### PR TITLE
[persist] Limit persist peek sizes and add some tests

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -366,6 +366,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                     peek,
                     Arc::clone(&self.compute_state.persist_clients),
                     metadata,
+                    usize::cast_from(self.compute_state.max_result_size),
                     self.timely_worker,
                 )
             }
@@ -701,6 +702,7 @@ impl PendingPeek {
         peek: Peek,
         persist_clients: Arc<PersistClientCache>,
         metadata: CollectionMetadata,
+        max_result_size: usize,
         timely_worker: &mut TimelyWorker<A>,
     ) -> Self {
         let active_worker = {
@@ -724,6 +726,7 @@ impl PendingPeek {
                     metadata,
                     timestamp,
                     mfp_plan,
+                    max_result_size,
                     max_results_needed,
                 )
                 .await
@@ -791,6 +794,7 @@ impl PersistPeek {
         metadata: CollectionMetadata,
         as_of: Timestamp,
         mfp_plan: SafeMfpPlan,
+        max_result_size: usize,
         mut limit_remaining: usize,
     ) -> Result<Vec<(Row, NonZeroUsize)>, String> {
         let client = persist_clients
@@ -826,6 +830,7 @@ impl PersistPeek {
         let mut datum_vec = DatumVec::new();
         let mut row_builder = Row::default();
         let arena = RowArena::new();
+        let mut total_size = 0usize;
 
         while limit_remaining > 0 {
             let Some(batch) = cursor.next().await else {
@@ -847,6 +852,15 @@ impl PersistPeek {
                     .evaluate_into(&mut datum_local, &arena, &mut row_builder)
                     .map_err(|e| e.to_string())?;
                 if let Some(row) = eval_result {
+                    total_size = total_size
+                        .saturating_add(row.byte_len())
+                        .saturating_add(std::mem::size_of::<NonZeroUsize>());
+                    if total_size > max_result_size {
+                        return Err(format!(
+                            "result exceeds max size of {}",
+                            ByteSize::b(u64::cast_from(max_result_size))
+                        ));
+                    }
                     result.push((row, count));
                     limit_remaining = limit_remaining.saturating_sub(count.get());
                     if limit_remaining == 0 {

--- a/test/sqllogictest/persist-fast-path.slt
+++ b/test/sqllogictest/persist-fast-path.slt
@@ -155,6 +155,26 @@ Source materialize.public.numbers
 
 EOF
 
+# Check that we bound result set size correctly
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET max_result_size TO 100;
+----
+COMPLETE 0
+
+query T
+SELECT * FROM numbers LIMIT 1;
+----
+1
+
+query error db error: ERROR: result exceeds max size of 100 B
+SELECT * FROM numbers LIMIT 99;
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET max_result_size
+----
+COMPLETE 0
+
 # Does not apply when an index exists.
 
 statement ok


### PR DESCRIPTION
### Motivation

This tackles the last couple things in our testing checklist: https://github.com/MaterializeInc/materialize/issues/22042

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
