### PR TITLE
Record the replication timeline_id in postgres sources to detect restores from backup at the upstream

### DIFF
--- a/misc/python/materialize/mzcompose/services/alpine.py
+++ b/misc/python/materialize/mzcompose/services/alpine.py
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.mzcompose.service import (
+    Service,
+)
+
+
+class Alpine(Service):
+    """
+    A basic alpine container, useful for running shell commands
+    on a mounted volume.
+    """
+
+    def __init__(
+        self,
+        name: str = "alpine",
+        image: str = "alpine",
+        volumes: list[str] | None = None,
+    ) -> None:
+        super().__init__(
+            name=name,
+            config={"image": image, "volumes": volumes or []},
+        )

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -16,6 +16,7 @@ use mz_ore::now::{EpochMillis, NowFn};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::Raw;
 use mz_storage_types::connections::ConnectionContext;
+use mz_storage_types::sources::GenericSourceConnection;
 use semver::Version;
 use tracing::info;
 
@@ -53,7 +54,7 @@ pub(crate) async fn migrate(
     state: &CatalogState,
     tx: &mut Transaction<'_>,
     _now: NowFn,
-    _connection_context: &ConnectionContext,
+    connection_context: &ConnectionContext,
 ) -> Result<(), anyhow::Error> {
     let catalog_version = tx.get_catalog_content_version();
     let catalog_version = match catalog_version {
@@ -95,6 +96,9 @@ pub(crate) async fn migrate(
     // Each migration should be a function that takes `tx` and `conn_cat` as
     // input and stages arbitrary transformations to the catalog on `tx`.
 
+    // This function blocks for at most 1 second per PG source.
+    ast_rewrite_postgres_source_timeline_id_0_80_0(tx, &conn_cat, connection_context).await?;
+
     info!(
         "migration from catalog version {:?} complete",
         catalog_version
@@ -111,6 +115,120 @@ pub(crate) async fn migrate(
 //
 // Please include the adapter team on any code reviews that add or edit
 // migrations.
+
+/// Attempt to connect to the upstream PostgreSQL server to get the
+/// publication's timeline ID.
+async fn ast_rewrite_postgres_source_timeline_id_0_80_0(
+    txn: &mut Transaction<'_>,
+    conn_catalog: &ConnCatalog<'_>,
+    connection_context: &ConnectionContext,
+) -> Result<(), anyhow::Error> {
+    use mz_postgres_util::PostgresError;
+    use mz_proto::RustType;
+    use mz_sql::catalog::SessionCatalog;
+    use mz_sql_parser::ast::{PgConfigOption, PgConfigOptionName, Value, WithOptionValue};
+    use mz_storage_types::connections::inline::IntoInlineConnection;
+    use mz_storage_types::connections::PostgresConnection;
+    use mz_storage_types::sources::{
+        PostgresSourcePublicationDetails, ProtoPostgresSourcePublicationDetails,
+    };
+    use prost::Message;
+
+    let mut updated_items = BTreeMap::new();
+    for mut item in txn.loaded_items() {
+        let catalog_item = conn_catalog.get_item(&item.id);
+        if let Ok(Some(source)) = catalog_item.source_desc() {
+            let pg_conn = match &source.connection {
+                GenericSourceConnection::Postgres(pg_conn) => {
+                    pg_conn.clone().into_inline_connection(&conn_catalog)
+                }
+                _ => continue,
+            };
+
+            let mut pg_source_create_stmt =
+                match mz_sql::parse::parse(&item.create_sql)?.into_element().ast {
+                    mz_sql::ast::Statement::CreateSource(c) => c,
+                    _ => unreachable!("PG sources are created w/ CreateSource"),
+                };
+
+            let source_options = match &mut pg_source_create_stmt.connection {
+                mz_sql::ast::CreateSourceConnection::Postgres {
+                    connection: _,
+                    options,
+                } => options,
+                _ => unreachable!("pg source must be pg conn"),
+            };
+
+            let details_pos = source_options
+                .iter()
+                .position(|o| o.name == PgConfigOptionName::Details)
+                .expect("pg source must have options");
+
+            let details = source_options.swap_remove(details_pos);
+            let details = match details.value.expect("details contains value") {
+                WithOptionValue::Value(Value::String(details)) => details,
+                _ => unreachable!("details encoded as string value"),
+            };
+
+            let details =
+                hex::decode(details).expect("PostgresSourcePublicationDetails must be decodable");
+            let mut details: ProtoPostgresSourcePublicationDetails =
+                ProtoPostgresSourcePublicationDetails::decode(&*details)
+                    .expect("corrupted PostgresSourcePublicationDetails");
+
+            if details.timeline_id.is_some() {
+                continue;
+            }
+
+            async fn get_timeline(
+                connection_context: &ConnectionContext,
+                connection: PostgresConnection,
+            ) -> Result<u64, PostgresError> {
+                let config = connection
+                    .config(&*connection_context.secrets_reader)
+                    .await?;
+
+                let replication_client = config
+                    .connect_replication(&connection_context.ssh_tunnel_manager)
+                    .await?;
+
+                mz_postgres_util::get_timeline_id(&replication_client).await
+            }
+
+            let result: Result<Result<u64, PostgresError>, tokio::time::error::Elapsed> =
+                tokio::time::timeout(
+                    std::time::Duration::from_secs(1),
+                    get_timeline(connection_context, pg_conn.connection),
+                )
+                .await;
+
+            let timeline_id = match result {
+                Ok(Ok(timeline_id)) => timeline_id,
+                _ => {
+                    tracing::info!("could not determine timeline ID for PG source {}", item.id);
+                    continue;
+                }
+            };
+
+            details.timeline_id = Some(timeline_id);
+
+            let publication_details = PostgresSourcePublicationDetails::from_proto(details)
+                .expect("proto to rust conversion succeeds for PostgresSourcePublicationDetails");
+
+            source_options.push(PgConfigOption {
+                name: PgConfigOptionName::Details,
+                value: Some(WithOptionValue::Value(Value::String(hex::encode(
+                    publication_details.into_proto().encode_to_vec(),
+                )))),
+            });
+
+            item.create_sql = pg_source_create_stmt.to_ast_string_stable();
+            updated_items.insert(item.id, item);
+        }
+    }
+    txn.update_items(updated_items)?;
+    Ok(())
+}
 
 fn _add_to_audit_log(
     tx: &mut Transaction,

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -92,7 +92,8 @@ macro_rules! bail_generic {
 pub mod replication;
 #[cfg(feature = "replication")]
 pub use replication::{
-    available_replication_slots, drop_replication_slots, get_max_wal_senders, get_wal_level,
+    available_replication_slots, drop_replication_slots, get_max_wal_senders, get_timeline_id,
+    get_wal_level,
 };
 #[cfg(feature = "schemas")]
 pub mod desc;
@@ -108,6 +109,9 @@ pub use tunnel::{
     DEFAULT_KEEPALIVE_INTERVAL, DEFAULT_KEEPALIVE_RETRIES, DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT,
     DEFAULT_TCP_USER_TIMEOUT,
 };
+
+pub mod query;
+pub use query::simple_query_opt;
 
 /// An error representing pg, ssh, ssl, and other failures.
 #[derive(Debug, thiserror::Error)]
@@ -128,4 +132,6 @@ pub enum PostgresError {
     /// Error setting up postgres ssl.
     #[error(transparent)]
     PostgresSsl(#[from] openssl::error::ErrorStack),
+    #[error("query returned more rows than expected")]
+    UnexpectedRow,
 }

--- a/src/postgres-util/src/query.rs
+++ b/src/postgres-util/src/query.rs
@@ -1,0 +1,29 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use tokio_postgres::{Client, SimpleQueryMessage, SimpleQueryRow};
+
+use crate::PostgresError;
+
+/// Runs the given query using the client and expects at most a single row to be returned.
+pub async fn simple_query_opt(
+    client: &Client,
+    query: &str,
+) -> Result<Option<SimpleQueryRow>, PostgresError> {
+    let result = client.simple_query(query).await?;
+    let mut rows = result.into_iter().filter_map(|msg| match msg {
+        SimpleQueryMessage::Row(row) => Some(row),
+        _ => None,
+    });
+    match (rows.next(), rows.next()) {
+        (Some(row), None) => Ok(Some(row)),
+        (None, None) => Ok(None),
+        _ => Err(PostgresError::UnexpectedRow),
+    }
+}

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -737,6 +737,13 @@ async fn purify_create_source(
             *referenced_subsources = Some(ReferencedSubsources::SubsetTables(targeted_subsources));
             subsources.extend(new_subsources);
 
+            // Record the active replication timeline_id to allow detection of a future upstream
+            // point-in-time-recovery that will put the source into an error state.
+            let replication_client = config
+                .connect_replication(&connection_context.ssh_tunnel_manager)
+                .await?;
+            let timeline_id = mz_postgres_util::get_timeline_id(&replication_client).await?;
+
             // Remove any old detail references
             options.retain(|PgConfigOption { name, .. }| name != &PgConfigOptionName::Details);
             let details = PostgresSourcePublicationDetails {
@@ -745,6 +752,7 @@ async fn purify_create_source(
                     "materialize_{}",
                     Uuid::new_v4().to_string().replace('-', "")
                 ),
+                timeline_id: Some(timeline_id),
             };
             options.push(PgConfigOption {
                 name: PgConfigOptionName::Details,
@@ -1127,6 +1135,7 @@ async fn purify_alter_source(
     let new_details = PostgresSourcePublicationDetails {
         tables: publication_tables,
         slot: pg_source_connection.publication_details.slot.clone(),
+        timeline_id: pg_source_connection.publication_details.timeline_id.clone(),
     };
 
     *details = Some(WithOptionValue::Value(Value::String(hex::encode(

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -203,6 +203,7 @@ message ProtoPostgresSourceConnection {
 message ProtoPostgresSourcePublicationDetails {
     repeated mz_postgres_util.desc.ProtoPostgresTableDesc tables = 1;
     string slot = 2;
+    optional uint64 timeline_id = 3;
 }
 
 message ProtoLoadGeneratorSourceConnection {

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -2227,6 +2227,10 @@ impl RustType<ProtoPostgresSourceConnection> for PostgresSourceConnection {
 pub struct PostgresSourcePublicationDetails {
     pub tables: Vec<mz_postgres_util::desc::PostgresTableDesc>,
     pub slot: String,
+    /// The active timeline_id when this source was created
+    /// The None value indicates an unknown timeline, to account for sources that existed
+    /// prior to this field being introduced
+    pub timeline_id: Option<u64>,
 }
 
 impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicationDetails {
@@ -2234,6 +2238,7 @@ impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicati
         ProtoPostgresSourcePublicationDetails {
             tables: self.tables.iter().map(|t| t.into_proto()).collect(),
             slot: self.slot.clone(),
+            timeline_id: self.timeline_id.clone(),
         }
     }
 
@@ -2245,6 +2250,7 @@ impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicati
                 .map(mz_postgres_util::desc::PostgresTableDesc::from_proto)
                 .collect::<Result<_, _>>()?,
             slot: proto.slot,
+            timeline_id: proto.timeline_id,
         })
     }
 }

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -150,6 +150,7 @@ use tracing::trace;
 use mz_expr::MirScalarExpr;
 use mz_ore::result::ResultExt;
 use mz_postgres_util::desc::PostgresTableDesc;
+use mz_postgres_util::simple_query_opt;
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_storage_types::connections::ConnectionContext;
@@ -160,7 +161,7 @@ use mz_timely_util::builder_async::{
 use mz_timely_util::operator::StreamExt as TimelyStreamExt;
 
 use crate::source::postgres::replication::RewindRequest;
-use crate::source::postgres::{simple_query_opt, verify_schema, DefiniteError, TransientError};
+use crate::source::postgres::{verify_schema, DefiniteError, TransientError};
 use crate::source::types::SourceReaderError;
 use crate::source::RawSourceCreationConfig;
 

--- a/test/pg-cdc-resumption/README.md
+++ b/test/pg-cdc-resumption/README.md
@@ -13,6 +13,11 @@ The following failures are injected:
 - restart of the Postgres server
 - restart of the Materialize instance
 
+This test suite additionally checks the failure logic for Postgres
+sources by verifying that a source is put into a failed state
+upon detecting a restore to a point-in-time backup of the Postgres
+server
+
 To run:
 
 ```bash

--- a/test/pg-cdc-resumption/verify-postgres-select.td
+++ b/test/pg-cdc-resumption/verify-postgres-select.td
@@ -1,0 +1,12 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+
+SELECT * FROM t1;

--- a/test/pg-cdc-resumption/verify-source-failed.td
+++ b/test/pg-cdc-resumption/verify-source-failed.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Ensure definite error is set for the source
+> SELECT COUNT(*) > 0 FROM mz_internal.mz_source_statuses WHERE status = 'stalled' AND error LIKE '%invalid timeline%';
+true
+
+! SELECT * FROM t1;
+contains:Source error


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug: Fixes https://github.com/MaterializeInc/materialize/issues/7869


<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I've left a couple of TODOs for improvements that I plan to do as follow ups. Feel free to call these out if you think I should include them in this review:
- This will only apply for newly created sources until we backfill the timeline-id on existing ones
- This currently only sets each subsource into a stalled state; the error does not propagate up to the postgres source itself:
```
materialize=> SELECT * FROM mz_internal.mz_source_statuses;
 id  |            name            |   type    |   last_status_change_at    | status  |
                  error                                  |                                           d
etails
-----+----------------------------+-----------+----------------------------+---------+----------------
---------------------------------------------------------+--------------------------------------------
-------------------------------------------------
 u5  | t1                         | subsource | 2023-12-07 20:49:06.148+00 | running |
                                                         |
 u6  | t2                         | subsource | 2023-12-07 20:49:06.38+00  | running |
                                                         |
 u3  | ten                        | subsource | 2023-12-07 20:49:06.144+00 | running |
                                                         |
 u9  | mz_source_progress         | progress  |                            | created |
                                                         |
 u10 | mz_source                  | postgres  | 2023-12-07 20:49:06.144+00 | running |
                                                         |
 u7  | alter_fail_drop_col        | subsource | 2023-12-07 20:49:06.151+00 | running |
                                                         |
 u4  | t0                         | subsource | 2023-12-07 20:49:06.141+00 | stalled | postgres: The r
eplication timeline id has changed. Expected 1 but got 2 | {"namespaced":{"postgres":"The replication
timeline id has changed. Expected 1 but got 2"}}
 u8  | alter_fail_drop_constraint | subsource | 2023-12-07 20:49:06.141+00 | stalled | postgres: The r
eplication timeline id has changed. Expected 1 but got 2 | {"namespaced":{"postgres":"The replication
timeline id has changed. Expected 1 but got 2"}}
(8 rows)

```

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
