### PR TITLE
Idiomatic Arrangement GATs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,7 +1723,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#1bb6dc6d54a5e1f56f2e489cd8471b766d8caed5"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#f93f1de3c236bee04eff659f56fe65eb34858d3b"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1780,7 +1780,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#1bb6dc6d54a5e1f56f2e489cd8471b766d8caed5"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#f93f1de3c236bee04eff659f56fe65eb34858d3b"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/clippy.toml
+++ b/clippy.toml
@@ -52,6 +52,8 @@ disallowed-methods = [
     { path = "differential_dataflow::operators::arrange::arrangement::Arrange::arrange", reason = "use the `MzArrange::mz_arrange_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::Arrange::arrange_named", reason = "use the `MzArrange::mz_arrange_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::Arrange::arrange_core", reason = "use the `MzArrange::mz_arrange_core` function instead" },
+    { path = "differential_dataflow::operators::arrange::arrangement::Arranged::reduce_abelian", reason = "use the `MzArrange::mz_arrange_core` function instead" },
+    { path = "differential_dataflow::operators::arrange::arrangement::Arranged::reduce_core", reason = "use the `MzArrange::mz_arrange_core` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::ArrangeByKey::arrange_by_key", reason = "use the `MzArrange::mz_arrange_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::ArrangeByKey::arrange_by_key_named", reason = "use the `MzArrange::mz_arrange_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::ArrangeBySelf::arrange_by_self", reason = "use the `MzArrange::mz_arrange_named` function instead" },

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -23,7 +23,7 @@ version = "0.26.0"
 [[audits.differential-dataflow]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:1bb6dc6d54a5e1f56f2e489cd8471b766d8caed5"
+version = "0.12.0@git:f93f1de3c236bee04eff659f56fe65eb34858d3b"
 
 [[audits.futures-timer]]
 who = "Roshan Jobanputra <roshan@materialize.com>"

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -954,16 +954,32 @@ impl IndexPeek {
         let oks = self.trace_bundle.oks_mut();
         match oks {
             SpecializedTraceHandle::RowUnit(oks_handle) => {
-                Self::collect_ok_finished_data(peek, oks_handle, None, Some(&[]), max_result_size)
+                // Explicit types required due to Rust type inference limitations.
+                use crate::typedefs::RowKeySpine;
+                Self::collect_ok_finished_data::<RowKeySpine<Row, _, _>>(
+                    peek,
+                    oks_handle,
+                    None,
+                    Some(&[]),
+                    max_result_size,
+                )
             }
             SpecializedTraceHandle::RowRow(oks_handle) => {
-                Self::collect_ok_finished_data(peek, oks_handle, None, None, max_result_size)
+                // Explicit types required due to Rust type inference limitations.
+                use crate::typedefs::RowSpine;
+                Self::collect_ok_finished_data::<RowSpine<Row, Row, _, _>>(
+                    peek,
+                    oks_handle,
+                    None,
+                    None,
+                    max_result_size,
+                )
             }
         }
     }
 
     /// Collects data for a known-complete peek from the ok stream.
-    fn collect_ok_finished_data<Tr, K, V>(
+    fn collect_ok_finished_data<Tr>(
         peek: &mut Peek<Timestamp>,
         oks_handle: &mut TraceAgent<Tr>,
         key_types: Option<&[ColumnType]>,
@@ -971,14 +987,9 @@ impl IndexPeek {
         max_result_size: u32,
     ) -> Result<Vec<(Row, NonZeroUsize)>, String>
     where
-        Tr: for<'a> TraceReader<
-            Key<'a> = &'a K,
-            KeyOwned = K,
-            Val<'a> = &'a V,
-            ValOwned = V,
-            Time = Timestamp,
-            Diff = Diff,
-        >,
+        Tr: TraceReader<Time = Timestamp, Diff = Diff>,
+        for<'a> Tr::Key<'a>: IntoRowByTypes,
+        for<'a> Tr::Val<'a>: IntoRowByTypes,
         Tr::KeyOwned: Columnation + Data + FromRowByTypes + IntoRowByTypes,
         Tr::ValOwned: Columnation + Data + IntoRowByTypes,
     {
@@ -1004,7 +1015,7 @@ impl IndexPeek {
         let mut datum_vec = DatumVec::new();
         let mut l_datum_vec = DatumVec::new();
         let mut r_datum_vec = DatumVec::new();
-        let mut key_buf = K::default();
+        let mut key_buf = Tr::KeyOwned::default();
 
         // We have to sort the literal constraints because cursor.seek_key can seek only forward.
         peek.literal_constraints
@@ -1027,11 +1038,12 @@ impl IndexPeek {
                             // since we only perform as many of them as there are literals.
                             let current_literal =
                                 key_buf.from_row(current_literal.clone(), key_types);
-                            cursor.seek_key(&storage, &current_literal);
+                            cursor.seek_key_owned(&storage, &current_literal);
                             if !cursor.key_valid(&storage) {
                                 return Ok(results);
                             }
-                            if *cursor.get_key(&storage).unwrap() == current_literal {
+                            use differential_dataflow::trace::cursor::MyTrait;
+                            if cursor.get_key(&storage).unwrap().equals(&current_literal) {
                                 // The cursor found a record whose key matches the current literal.
                                 // We break from the inner loop, and process this key.
                                 break;
@@ -1051,8 +1063,10 @@ impl IndexPeek {
                 // from a performance perspective.
                 let arena = RowArena::new();
 
-                let key = cursor.key(&storage).into_datum_iter(key_types);
-                let row = cursor.val(&storage).into_datum_iter(val_types);
+                let key_item = cursor.key(&storage);
+                let key = key_item.into_datum_iter(key_types);
+                let row_item = cursor.val(&storage);
+                let row = row_item.into_datum_iter(val_types);
 
                 let mut borrow = datum_vec.borrow();
                 borrow.extend(key);

--- a/src/compute/src/extensions/reduce.rs
+++ b/src/compute/src/extensions/reduce.rs
@@ -46,7 +46,7 @@ where
     G::Timestamp: Lattice + Ord,
     G: Scope,
     T1: TraceReader<Time = G::Timestamp> + Clone + 'static,
-    T1::Diff: differential_dataflow::difference::Semigroup,
+    T1::Diff: Semigroup,
 {
     /// Applies `reduce` to arranged data, and returns an arrangement of output data.
     fn mz_reduce_abelian<L, T2>(&self, name: &str, logic: L) -> Arranged<G, TraceAgent<T2>>
@@ -61,7 +61,7 @@ where
             + 'static,
         Arranged<G, TraceAgent<T2>>: ArrangementSize,
     {
-        // Allow access to `reduce_abelian` since we're within Mz's wrapper.
+        // Allow access to `reduce_abelian` since we're within Mz's wrapper and force arrangement size logging.
         #[allow(clippy::disallowed_methods)]
         Arranged::<_, _>::reduce_abelian::<_, T2>(self, name, logic).log_arrangement_size()
     }

--- a/src/compute/src/extensions/reduce.rs
+++ b/src/compute/src/extensions/reduce.rs
@@ -16,7 +16,6 @@
 use differential_dataflow::difference::{Abelian, Semigroup};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
-use differential_dataflow::operators::reduce::ReduceCore;
 use differential_dataflow::trace::{Batch, Builder, Trace, TraceReader};
 use differential_dataflow::Data;
 use timely::dataflow::Scope;
@@ -24,53 +23,53 @@ use timely::dataflow::Scope;
 use crate::extensions::arrange::ArrangementSize;
 
 /// Extension trait for the `reduce_abelian` differential dataflow method.
-pub(crate) trait MzReduce<G: Scope, K: Data, V: Data, R: Semigroup>:
-    ReduceCore<G, K, V, R>
+pub(crate) trait MzReduce<G: Scope, T1: TraceReader<Time = G::Timestamp>>
 where
     G::Timestamp: Lattice + Ord,
 {
     /// Applies `reduce` to arranged data, and returns an arrangement of output data.
     fn mz_reduce_abelian<L, T2>(&self, name: &str, logic: L) -> Arranged<G, TraceAgent<T2>>
     where
-        T2: Trace
-            + for<'a> TraceReader<Key<'a> = &'a K, KeyOwned = K, Time = G::Timestamp>
-            + 'static,
+        T2: for<'a> Trace<Key<'a> = T1::Key<'a>, Time = G::Timestamp> + 'static,
         T2::ValOwned: Data,
         T2::Diff: Abelian,
         T2::Batch: Batch,
         T2::Builder:
-            Builder<Output = T2::Batch, Item = ((T2::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
-        L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::ValOwned, T2::Diff)>) + 'static,
+            Builder<Output = T2::Batch, Item = ((T1::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
+        L: FnMut(T1::Key<'_>, &[(T1::Val<'_>, T1::Diff)], &mut Vec<(T2::ValOwned, T2::Diff)>)
+            + 'static,
+        Arranged<G, TraceAgent<T2>>: ArrangementSize;
+}
+
+impl<G, T1> MzReduce<G, T1> for Arranged<G, T1>
+where
+    G::Timestamp: Lattice + Ord,
+    G: Scope,
+    T1: TraceReader<Time = G::Timestamp> + Clone + 'static,
+    T1::Diff: differential_dataflow::difference::Semigroup,
+{
+    /// Applies `reduce` to arranged data, and returns an arrangement of output data.
+    fn mz_reduce_abelian<L, T2>(&self, name: &str, logic: L) -> Arranged<G, TraceAgent<T2>>
+    where
+        T2: for<'a> Trace<Key<'a> = T1::Key<'a>, Time = G::Timestamp> + 'static,
+        T2::ValOwned: Data,
+        T2::Diff: Abelian,
+        T2::Batch: Batch,
+        T2::Builder:
+            Builder<Output = T2::Batch, Item = ((T1::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
+        L: FnMut(T1::Key<'_>, &[(T1::Val<'_>, T1::Diff)], &mut Vec<(T2::ValOwned, T2::Diff)>)
+            + 'static,
         Arranged<G, TraceAgent<T2>>: ArrangementSize,
     {
         // Allow access to `reduce_abelian` since we're within Mz's wrapper.
         #[allow(clippy::disallowed_methods)]
-        self.reduce_abelian::<_, T2>(name, logic)
-            .log_arrangement_size()
+        Arranged::<_, _>::reduce_abelian::<_, T2>(self, name, logic).log_arrangement_size()
     }
-}
-
-impl<G, K, V, T1, R> MzReduce<G, K, V, R> for Arranged<G, T1>
-where
-    G::Timestamp: Lattice + Ord,
-    G: Scope,
-    K: Data,
-    V: Data,
-    R: Semigroup,
-    T1: for<'a> TraceReader<
-            Key<'a> = &'a K,
-            KeyOwned = K,
-            Val<'a> = &'a V,
-            Time = G::Timestamp,
-            Diff = R,
-        > + Clone
-        + 'static,
-{
 }
 
 /// Extension trait for `ReduceCore`, currently providing a reduction based
 /// on an operator-pair approach.
-pub trait ReduceExt<G: Scope, K: Data, V: Data, R: Semigroup>
+pub trait ReduceExt<G: Scope, Tr: TraceReader<Time = G::Timestamp>>
 where
     G::Timestamp: Lattice + Ord,
 {
@@ -88,38 +87,34 @@ where
     ) -> (Arranged<G, TraceAgent<T1>>, Arranged<G, TraceAgent<T2>>)
     where
         T1: Trace
-            + for<'a> TraceReader<Key<'a> = &'a K, KeyOwned = K, Time = G::Timestamp>
+            + for<'a> TraceReader<Key<'a> = Tr::Key<'a>, KeyOwned = Tr::KeyOwned, Time = G::Timestamp>
             + 'static,
         T1::ValOwned: Data,
         T1::Diff: Abelian,
         T1::Batch: Batch,
         T1::Builder:
             Builder<Output = T1::Batch, Item = ((T1::KeyOwned, T1::ValOwned), T1::Time, T1::Diff)>,
-        L1: FnMut(&K, &[(&V, R)], &mut Vec<(T1::ValOwned, T1::Diff)>) + 'static,
+        L1: FnMut(Tr::Key<'_>, &[(Tr::Val<'_>, Tr::Diff)], &mut Vec<(T1::ValOwned, T1::Diff)>)
+            + 'static,
         T2: Trace
-            + for<'a> TraceReader<Key<'a> = &'a K, KeyOwned = K, Time = G::Timestamp>
+            + for<'a> TraceReader<Key<'a> = Tr::Key<'a>, KeyOwned = Tr::KeyOwned, Time = G::Timestamp>
             + 'static,
         T2::ValOwned: Data,
         T2::Diff: Abelian,
         T2::Batch: Batch,
         T2::Builder:
             Builder<Output = T2::Batch, Item = ((T2::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
-        L2: FnMut(&K, &[(&V, R)], &mut Vec<(T2::ValOwned, T2::Diff)>) + 'static,
+        L2: FnMut(Tr::Key<'_>, &[(Tr::Val<'_>, Tr::Diff)], &mut Vec<(T2::ValOwned, T2::Diff)>)
+            + 'static,
         Arranged<G, TraceAgent<T1>>: ArrangementSize,
         Arranged<G, TraceAgent<T2>>: ArrangementSize;
 }
 
-impl<G: Scope, K: Data, V: Data, Tr, R: Semigroup> ReduceExt<G, K, V, R> for Arranged<G, Tr>
+impl<G: Scope, Tr> ReduceExt<G, Tr> for Arranged<G, Tr>
 where
     G::Timestamp: Lattice + Ord,
-    Tr: for<'a> TraceReader<
-            Key<'a> = &'a K,
-            KeyOwned = K,
-            Val<'a> = &'a V,
-            Time = G::Timestamp,
-            Diff = R,
-        > + Clone
-        + 'static,
+    Tr: TraceReader<Time = G::Timestamp> + Clone + 'static,
+    Tr::Diff: Semigroup,
 {
     fn reduce_pair<L1, T1, L2, T2>(
         &self,
@@ -130,23 +125,25 @@ where
     ) -> (Arranged<G, TraceAgent<T1>>, Arranged<G, TraceAgent<T2>>)
     where
         T1: Trace
-            + for<'a> TraceReader<Key<'a> = &'a K, KeyOwned = K, Time = G::Timestamp>
+            + for<'a> TraceReader<Key<'a> = Tr::Key<'a>, KeyOwned = Tr::KeyOwned, Time = G::Timestamp>
             + 'static,
         T1::ValOwned: Data,
         T1::Diff: Abelian,
         T1::Batch: Batch,
         T1::Builder:
             Builder<Output = T1::Batch, Item = ((T1::KeyOwned, T1::ValOwned), T1::Time, T1::Diff)>,
-        L1: FnMut(&K, &[(&V, R)], &mut Vec<(T1::ValOwned, T1::Diff)>) + 'static,
+        L1: FnMut(Tr::Key<'_>, &[(Tr::Val<'_>, Tr::Diff)], &mut Vec<(T1::ValOwned, T1::Diff)>)
+            + 'static,
         T2: Trace
-            + for<'a> TraceReader<Key<'a> = &'a K, KeyOwned = K, Time = G::Timestamp>
+            + for<'a> TraceReader<Key<'a> = Tr::Key<'a>, KeyOwned = Tr::KeyOwned, Time = G::Timestamp>
             + 'static,
         T2::ValOwned: Data,
         T2::Diff: Abelian,
         T2::Batch: Batch,
         T2::Builder:
             Builder<Output = T2::Batch, Item = ((T2::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
-        L2: FnMut(&K, &[(&V, R)], &mut Vec<(T2::ValOwned, T2::Diff)>) + 'static,
+        L2: FnMut(Tr::Key<'_>, &[(Tr::Val<'_>, Tr::Diff)], &mut Vec<(T2::ValOwned, T2::Diff)>)
+            + 'static,
         Arranged<G, TraceAgent<T1>>: ArrangementSize,
         Arranged<G, TraceAgent<T2>>: ArrangementSize,
     {

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -650,8 +650,6 @@ where
     Tr: for<'a> TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
     for<'a> Tr::Key<'a>: IntoRowByTypes,
     for<'a> Tr::Val<'a>: IntoRowByTypes,
-    // K: Columnation + ExchangeData + FromRowByTypes + Hashable + IntoRowByTypes,
-    // V: Columnation + ExchangeData + IntoRowByTypes,
 {
     let mut inner_as_of = Antichain::new();
     for event_time in as_of.elements().iter() {

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -114,9 +114,7 @@ impl LinearJoinSpec {
             self.yielding.after_work,
             self.yielding.after_time,
         ) {
-            (DifferentialDataflow, _, _) => {
-                differential_dataflow::operators::JoinCore::join_core(arranged1, arranged2, result)
-            }
+            (DifferentialDataflow, _, _) => arranged1.join_core(arranged2, result),
             (Materialize, Some(work_limit), Some(time_limit)) => {
                 let yield_fn =
                     move |start: Instant, work| work >= work_limit || start.elapsed() >= time_limit;

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -35,7 +35,6 @@ use crate::render::context::{
     SpecializedArrangementImport,
 };
 use crate::render::join::mz_join_core::mz_join_core;
-use crate::typedefs::RowSpine;
 
 /// Available linear join implementations.
 ///
@@ -72,7 +71,7 @@ impl Default for LinearJoinSpec {
 
 impl LinearJoinSpec {
     /// Render a join operator according to this specification.
-    fn render<G, Tr1, Tr2, L, I, K, V1, V2>(
+    fn render<G, Tr1, Tr2, L, I>(
         &self,
         arranged1: &Arranged<G, Tr1>,
         arranged2: &Arranged<G, Tr2>,
@@ -82,30 +81,13 @@ impl LinearJoinSpec {
     where
         G: Scope,
         G::Timestamp: Lattice,
-        Tr1: for<'a> TraceReader<
-                Key<'a> = &'a K,
-                KeyOwned = K,
-                Val<'a> = &'a V1,
-                ValOwned = V1,
-                Time = G::Timestamp,
-                Diff = Diff,
-            > + Clone
-            + 'static,
-        Tr2: for<'a> TraceReader<
-                Key<'a> = &'a K,
-                KeyOwned = K,
-                Val<'a> = &'a V2,
-                ValOwned = V2,
-                Time = G::Timestamp,
-                Diff = Diff,
-            > + Clone
+        Tr1: TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
+        Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = G::Timestamp, Diff = Diff>
+            + Clone
             + 'static,
         L: FnMut(Tr1::Key<'_>, Tr1::Val<'_>, Tr2::Val<'_>) -> I + 'static,
         I: IntoIterator,
         I::Item: Data,
-        K: Data,
-        V1: Data,
-        V2: Data,
     {
         use LinearJoinImpl::*;
 
@@ -322,32 +304,11 @@ where
             joined = JoinedFlavor::Local(SpecializedArrangement::RowRow(arranged));
         }
 
-        macro_rules! dispatch {
-            ($A:tt, $B:tt, $prev_keyed:expr, $next_input:expr) => {{
-                let empty = Some(vec![]);
-                match ($prev_keyed, $next_input) {
-                    ($A::RowUnit(prev_keyed), $B::RowUnit(next_input)) => self
-                        .differential_join_inner(
-                            prev_keyed,
-                            next_input,
-                            None,
-                            empty.clone(),
-                            empty,
-                            closure,
-                        ),
-                    ($A::RowUnit(prev_keyed), $B::RowRow(next_input)) => self
-                        .differential_join_inner(
-                            prev_keyed, next_input, None, empty, None, closure,
-                        ),
-                    ($A::RowRow(prev_keyed), $B::RowUnit(next_input)) => self
-                        .differential_join_inner(
-                            prev_keyed, next_input, None, None, empty, closure,
-                        ),
-                    ($A::RowRow(prev_keyed), $B::RowRow(next_input)) => self
-                        .differential_join_inner(prev_keyed, next_input, None, None, None, closure),
-                }
-            }};
-        }
+        use crate::typedefs::{RowKeySpine, RowSpine};
+        use crate::typedefs::{TraceKeyHandle, TraceRowHandle};
+        use differential_dataflow::operators::arrange::TraceAgent;
+        use differential_dataflow::trace::wrappers::enter::TraceEnter;
+        use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
 
         // Demultiplex the four different cross products of arrangement types we might have.
         let arrangement = lookup_relation
@@ -359,19 +320,25 @@ where
             }
             JoinedFlavor::Local(local) => match arrangement {
                 ArrangementFlavor::Local(oks, errs1) => {
-                    let (oks, errs2) =
-                        dispatch!(SpecializedArrangement, SpecializedArrangement, local, oks);
+                    let (oks, errs2) = match (local, oks) {
+                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangement::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<RowKeySpine<Row, _, _>>,TraceAgent<RowKeySpine<Row, _, _>>>(prev_keyed, next_input, None, Some(vec![]), Some(vec![]), closure),
+                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangement::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowKeySpine<Row, _, _>>,TraceAgent<RowSpine<Row, Row, _, _>>>(prev_keyed, next_input, None, Some(vec![]), None, closure),
+                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangement::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<RowSpine<Row, Row, _, _>>,TraceAgent<RowKeySpine<Row, _, _>>>(prev_keyed, next_input, None, None, Some(vec![]), closure),
+                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangement::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowSpine<Row, Row, _, _>>,TraceAgent<RowSpine<Row, Row, _, _>>>(prev_keyed, next_input, None, None, None, closure),
+                    };
+
                     errors.push(errs1.as_collection(|k, _v| k.clone()));
                     errors.extend(errs2);
                     oks
                 }
                 ArrangementFlavor::Trace(_gid, oks, errs1) => {
-                    let (oks, errs2) = dispatch!(
-                        SpecializedArrangement,
-                        SpecializedArrangementImport,
-                        local,
-                        oks
-                    );
+                    let (oks, errs2) = match (local, oks) {
+                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangementImport::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<RowKeySpine<Row, _, _>>,TraceEnter<TraceFrontier<TraceKeyHandle<Row, T, Diff>>, G::Timestamp>>(prev_keyed, next_input, None, Some(vec![]), Some(vec![]), closure),
+                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangementImport::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowKeySpine<Row, _, _>>,TraceEnter<TraceFrontier<TraceRowHandle<Row, Row, T, Diff>>, G::Timestamp>>(prev_keyed, next_input, None, Some(vec![]), None, closure),
+                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangementImport::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<RowSpine<Row, Row, _, _>>,TraceEnter<TraceFrontier<TraceKeyHandle<Row, T, Diff>>, G::Timestamp>>(prev_keyed, next_input, None, None, Some(vec![]), closure),
+                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangementImport::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowSpine<Row, Row, _, _>>,TraceEnter<TraceFrontier<TraceRowHandle<Row, Row, T, Diff>>, G::Timestamp>>(prev_keyed, next_input, None, None, None, closure),
+                    };
+
                     errors.push(errs1.as_collection(|k, _v| k.clone()));
                     errors.extend(errs2);
                     oks
@@ -379,23 +346,121 @@ where
             },
             JoinedFlavor::Trace(trace) => match arrangement {
                 ArrangementFlavor::Local(oks, errs1) => {
-                    let (oks, errs2) = dispatch!(
-                        SpecializedArrangementImport,
-                        SpecializedArrangement,
-                        trace,
-                        oks
-                    );
+                    let (oks, errs2) = match (trace, oks) {
+                        (
+                            SpecializedArrangementImport::RowUnit(prev_keyed),
+                            SpecializedArrangement::RowUnit(next_input),
+                        ) => self.differential_join_inner::<_, TraceEnter<
+                            TraceFrontier<TraceKeyHandle<Row, T, Diff>>,
+                            G::Timestamp,
+                        >, TraceAgent<RowKeySpine<Row, _, _>>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            Some(vec![]),
+                            Some(vec![]),
+                            closure,
+                        ),
+                        (
+                            SpecializedArrangementImport::RowUnit(prev_keyed),
+                            SpecializedArrangement::RowRow(next_input),
+                        ) => self.differential_join_inner::<_, TraceEnter<
+                            TraceFrontier<TraceKeyHandle<Row, T, Diff>>,
+                            G::Timestamp,
+                        >, TraceAgent<RowSpine<Row, Row, _, _>>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            Some(vec![]),
+                            None,
+                            closure,
+                        ),
+                        (
+                            SpecializedArrangementImport::RowRow(prev_keyed),
+                            SpecializedArrangement::RowUnit(next_input),
+                        ) => self.differential_join_inner::<_, TraceEnter<
+                            TraceFrontier<TraceRowHandle<Row, Row, T, Diff>>,
+                            G::Timestamp,
+                        >, TraceAgent<RowKeySpine<Row, _, _>>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            None,
+                            Some(vec![]),
+                            closure,
+                        ),
+                        (
+                            SpecializedArrangementImport::RowRow(prev_keyed),
+                            SpecializedArrangement::RowRow(next_input),
+                        ) => self.differential_join_inner::<_, TraceEnter<
+                            TraceFrontier<TraceRowHandle<Row, Row, T, Diff>>,
+                            G::Timestamp,
+                        >, TraceAgent<RowSpine<Row, Row, _, _>>>(
+                            prev_keyed, next_input, None, None, None, closure,
+                        ),
+                    };
+
                     errors.push(errs1.as_collection(|k, _v| k.clone()));
                     errors.extend(errs2);
                     oks
                 }
                 ArrangementFlavor::Trace(_gid, oks, errs1) => {
-                    let (oks, errs2) = dispatch!(
-                        SpecializedArrangementImport,
-                        SpecializedArrangementImport,
-                        trace,
-                        oks
-                    );
+                    let (oks, errs2) = match (trace, oks) {
+                        (
+                            SpecializedArrangementImport::RowUnit(prev_keyed),
+                            SpecializedArrangementImport::RowUnit(next_input),
+                        ) => self.differential_join_inner::<_, TraceEnter<
+                            TraceFrontier<TraceKeyHandle<Row, T, Diff>>,
+                            G::Timestamp,
+                        >, TraceEnter<
+                            TraceFrontier<TraceKeyHandle<Row, T, Diff>>,
+                            G::Timestamp,
+                        >>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            Some(vec![]),
+                            Some(vec![]),
+                            closure,
+                        ),
+                        (
+                            SpecializedArrangementImport::RowUnit(prev_keyed),
+                            SpecializedArrangementImport::RowRow(next_input),
+                        ) => self.differential_join_inner::<_, TraceEnter<
+                            TraceFrontier<TraceKeyHandle<Row, T, Diff>>,
+                            G::Timestamp,
+                        >, TraceEnter<
+                            TraceFrontier<TraceRowHandle<Row, Row, T, Diff>>,
+                            G::Timestamp,
+                        >>(
+                            prev_keyed, next_input, None, Some(vec![]), None, closure
+                        ),
+                        (
+                            SpecializedArrangementImport::RowRow(prev_keyed),
+                            SpecializedArrangementImport::RowUnit(next_input),
+                        ) => self.differential_join_inner::<_, TraceEnter<
+                            TraceFrontier<TraceRowHandle<Row, Row, T, Diff>>,
+                            G::Timestamp,
+                        >, TraceEnter<
+                            TraceFrontier<TraceKeyHandle<Row, T, Diff>>,
+                            G::Timestamp,
+                        >>(
+                            prev_keyed, next_input, None, None, Some(vec![]), closure
+                        ),
+                        (
+                            SpecializedArrangementImport::RowRow(prev_keyed),
+                            SpecializedArrangementImport::RowRow(next_input),
+                        ) => self.differential_join_inner::<_, TraceEnter<
+                            TraceFrontier<TraceRowHandle<Row, Row, T, Diff>>,
+                            G::Timestamp,
+                        >, TraceEnter<
+                            TraceFrontier<TraceRowHandle<Row, Row, T, Diff>>,
+                            G::Timestamp,
+                        >>(
+                            prev_keyed, next_input, None, None, None, closure
+                        ),
+                    };
+
                     errors.push(errs1.as_collection(|k, _v| k.clone()));
                     errors.extend(errs2);
                     oks
@@ -410,7 +475,7 @@ where
     ///
     /// The return type includes an optional error collection, which may be
     /// `None` if we can determine that `closure` cannot error.
-    fn differential_join_inner<S, Tr1, Tr2, K, V1, V2>(
+    fn differential_join_inner<S, Tr1, Tr2>(
         &self,
         prev_keyed: Arranged<S, Tr1>,
         next_input: Arranged<S, Tr2>,
@@ -424,27 +489,13 @@ where
     )
     where
         S: Scope<Timestamp = G::Timestamp>,
-        Tr1: for<'a> TraceReader<
-                Key<'a> = &'a K,
-                KeyOwned = K,
-                Val<'a> = &'a V1,
-                ValOwned = V1,
-                Time = G::Timestamp,
-                Diff = Diff,
-            > + Clone
+        Tr1: TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
+        Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = G::Timestamp, Diff = Diff>
+            + Clone
             + 'static,
-        Tr2: for<'a> TraceReader<
-                Key<'a> = &'a K,
-                KeyOwned = K,
-                Val<'a> = &'a V2,
-                ValOwned = V2,
-                Time = G::Timestamp,
-                Diff = Diff,
-            > + Clone
-            + 'static,
-        K: Data + IntoRowByTypes,
-        V1: Data + IntoRowByTypes,
-        V2: Data + IntoRowByTypes,
+        for<'a> Tr1::Key<'a>: IntoRowByTypes,
+        for<'a> Tr1::Val<'a>: IntoRowByTypes,
+        for<'a> Tr2::Val<'a>: IntoRowByTypes,
     {
         // Reuseable allocation for unpacking.
         let mut datums = DatumVec::new();

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -599,30 +599,22 @@ where
 
     /// Rearranges an arrangement coming from an iterative scope into an arrangement
     /// in the outer timestamp scope.
-    fn rearrange_iterative<Tr, K, V, Tr2>(
+    fn rearrange_iterative<Tr1, Tr2>(
         &self,
-        oks: Arranged<Child<'g, G, T>, TraceAgent<Tr>>,
+        oks: Arranged<Child<'g, G, T>, TraceAgent<Tr1>>,
         name: &str,
     ) -> Arranged<G, TraceAgent<Tr2>>
     where
-        Tr: for<'a> TraceReader<
-            Key<'a> = &'a K,
-            KeyOwned = K,
-            Val<'a> = &'a V,
-            ValOwned = V,
-            Time = T,
-            Diff = Diff,
-        >,
-        Tr::KeyOwned: Columnation + ExchangeData + Hashable,
-        Tr::ValOwned: Columnation + ExchangeData,
-        Tr2: Trace
-            + for<'a> TraceReader<Key<'a> = &'a K, Val<'a> = &'a V, Time = G::Timestamp, Diff = Diff>
-            + 'static,
+        Tr1: TraceReader<Time = T, Diff = Diff>,
+        Tr1::KeyOwned: Columnation + ExchangeData + Hashable,
+        Tr1::ValOwned: Columnation + ExchangeData,
+        Tr2: Trace + TraceReader<Time = G::Timestamp, Diff = Diff> + 'static,
         Tr2::Batch: Batch,
-        Tr2::Batcher: Batcher<Item = ((K, V), G::Timestamp, Diff)>,
+        Tr2::Batcher: Batcher<Item = ((Tr1::KeyOwned, Tr1::ValOwned), G::Timestamp, Diff)>,
         Arranged<G, TraceAgent<Tr2>>: ArrangementSize,
     {
-        oks.as_collection(|k, v| (k.clone(), v.clone()))
+        use differential_dataflow::trace::cursor::MyTrait;
+        oks.as_collection(|k, v| (k.into_owned(), v.into_owned()))
             .leave()
             .mz_arrange(name)
     }

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -27,7 +27,6 @@ use mz_compute_types::plan::reduce::{
 };
 use mz_expr::{AggregateExpr, AggregateFunc, EvalError, MirScalarExpr};
 use mz_repr::adt::numeric::{self, Numeric, NumericAgg};
-use mz_repr::fixed_length::IntoRowByTypes;
 use mz_repr::{Datum, DatumList, DatumVec, Diff, Row, RowArena, SharedRow};
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
@@ -456,9 +455,9 @@ where
     }
 
     /// Build the dataflow to compute the set of distinct keys.
-    fn build_distinct<Tr, S, V>(
+    fn build_distinct<Tr, S>(
         &self,
-        collection: Collection<S, (Row, V), Diff>,
+        collection: Collection<S, (Row, Tr::ValOwned), Diff>,
         tag: &str,
     ) -> (
         Arranged<S, TraceAgent<Tr>>,
@@ -468,16 +467,14 @@ where
         S: Scope<Timestamp = G::Timestamp>,
         Tr: Trace
             + for<'a> TraceReader<
-                Key<'a> = &'a Row,
+                Key<'a> = &'a Row, // Required because of hardcoded use of `ErrValSpine`. TODO: remove requirement.
                 KeyOwned = Row,
-                Val<'a> = &'a V,
-                ValOwned = V,
                 Time = G::Timestamp,
                 Diff = Diff,
             > + 'static,
         Tr::Batch: Batch,
-        Tr::Batcher: Batcher<Item = ((Row, V), G::Timestamp, Diff)>,
-        V: Columnation + Default + ExchangeData + IntoRowByTypes,
+        Tr::Batcher: Batcher<Item = ((Row, Tr::ValOwned), G::Timestamp, Diff)>,
+        Tr::ValOwned: Columnation + ExchangeData + Default,
         Arranged<S, TraceAgent<Tr>>: ArrangementSize,
     {
         let error_logger = self.error_logger();
@@ -496,7 +493,7 @@ where
                     // We're pushing a unit value here because the key is implicitly added by the
                     // arrangement, and the permutation logic takes care of using the key part of the
                     // output.
-                    output.push((V::default(), 1));
+                    output.push((Tr::ValOwned::default(), 1));
                 },
                 move |key, input: &[(_, Diff)], output| {
                     for (_, count) in input.iter() {
@@ -602,10 +599,11 @@ where
 
         // If `distinct` is set, we restrict ourselves to the distinct `(key, val)`.
         if distinct {
+            use differential_dataflow::trace::cursor::MyTrait;
             if validating {
                 let (oks, errs) = self
-                    .build_reduce_inaccumulable_distinct::<_, Result<(), String>, RowSpine<_, _, _, _>>(partial, None)
-                    .as_collection(|k, v| (k.clone(), v.clone()))
+                    .build_reduce_inaccumulable_distinct::<_, RowSpine<_, Result<(), String>, _, _>>(partial, None)
+                    .as_collection(|k, v| (k.into_owned(), v.into_owned()))
                     .map_fallible("Demux Errors", move |(key, result)| match result {
                         Ok(()) => Ok(key),
                         Err(m) => Err(EvalError::Internal(m).into()),
@@ -614,11 +612,11 @@ where
                 partial = oks;
             } else {
                 partial = self
-                    .build_reduce_inaccumulable_distinct::<_, (), RowKeySpine<_, _, _>>(
+                    .build_reduce_inaccumulable_distinct::<_, RowKeySpine<_, _, _>>(
                         partial,
                         Some(" [val: empty]"),
                     )
-                    .as_collection(|k, _| k.clone());
+                    .as_collection(|k, _| k.into_owned());
             }
         }
 
@@ -678,25 +676,25 @@ where
         }
     }
 
-    fn build_reduce_inaccumulable_distinct<S, V, Tr>(
+    fn build_reduce_inaccumulable_distinct<S, Tr>(
         &self,
         input: Collection<S, (Row, Row), Diff>,
         name_tag: Option<&str>,
     ) -> Arranged<S, TraceAgent<Tr>>
     where
         S: Scope<Timestamp = G::Timestamp>,
-        V: MaybeValidatingRow<(), String>,
+        Tr::ValOwned: MaybeValidatingRow<(), String>,
         Tr: Trace
             + for<'a> TraceReader<
                 Key<'a> = &'a (Row, Row),
                 KeyOwned = (Row, Row),
-                Val<'a> = &'a V,
-                ValOwned = V,
+                // Val<'a> = &'a V,
+                // ValOwned = V,
                 Time = G::Timestamp,
                 Diff = Diff,
             > + 'static,
         Tr::Batch: Batch,
-        Tr::Batcher: Batcher<Item = (((Row, Row), V), G::Timestamp, Diff)>,
+        Tr::Batcher: Batcher<Item = (((Row, Row), Tr::ValOwned), G::Timestamp, Diff)>,
         Arranged<S, TraceAgent<Tr>>: ArrangementSize,
     {
         let error_logger = self.error_logger();
@@ -712,7 +710,7 @@ where
                 "Arranged ReduceInaccumulable Distinct [val: empty]",
             )
             .mz_reduce_abelian::<_, Tr>(&output_name, move |_, source, t| {
-                if let Some(err) = V::into_error() {
+                if let Some(err) = Tr::ValOwned::into_error() {
                     for (value, count) in source.iter() {
                         if count.is_positive() {
                             continue;
@@ -724,7 +722,7 @@ where
                         return;
                     }
                 }
-                t.push((V::ok(()), 1))
+                t.push((Tr::ValOwned::ok(()), 1))
             })
     }
 

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -688,8 +688,6 @@ where
             + for<'a> TraceReader<
                 Key<'a> = &'a (Row, Row),
                 KeyOwned = (Row, Row),
-                // Val<'a> = &'a V,
-                // ValOwned = V,
                 Time = G::Timestamp,
                 Diff = Diff,
             > + 'static,

--- a/src/repr/src/fixed_length.rs
+++ b/src/repr/src/fixed_length.rs
@@ -48,6 +48,13 @@ pub trait IntoRowByTypes: Sized {
     fn into_datum_iter<'a>(&'a self, types: Option<&[ColumnType]>) -> Self::DatumIter<'a>;
 }
 
+impl<'b, T: IntoRowByTypes> IntoRowByTypes for &'b T {
+    type DatumIter<'a> = T::DatumIter<'a> where T: 'a, Self: 'a;
+    fn into_datum_iter<'a>(&'a self, types: Option<&[ColumnType]>) -> Self::DatumIter<'a> {
+        (**self).into_datum_iter(types)
+    }
+}
+
 // Blanket identity implementation for Row.
 impl IntoRowByTypes for Row {
     /// Datum iterator for `Row`.


### PR DESCRIPTION
This PR updates MZ's use of arrangements to expose rather than constrain generic associated types. This generally amounts to removing generic parameters `K` and `V`, and allowing the arrangement's associated types fill their roles.

It seems Rust has a type inference limitation that requires a lot more type hinting than before, and this interacts badly with some of our use of macros. For example, in `linear_join.rs` which we should check. Additionally, there is a limitation in `build_distinct` based on how we are forcing an error arrangement, that we will need to revisit before engaging GATs (it has over-strong opinions on what the key reference type must be).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
