### PR TITLE
tests: create SSH setup for cloudtest upgrade

### DIFF
--- a/misc/python/materialize/checks/executors.py
+++ b/misc/python/materialize/checks/executors.py
@@ -31,7 +31,7 @@ class Executor:
 
     def testdrive(
         self, input: str, caller: Traceback | None = None, mz_service: str | None = None
-    ) -> Any:
+    ) -> None:
         assert False
 
     def mzcompose_composition(self) -> Composition:

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -22,7 +22,10 @@ from materialize.checks.all_checks.alter_connection import (
 from materialize.checks.all_checks.kafka_protocols import KafkaProtocols
 from materialize.checks.all_checks.ssh import SshKafka, SshPg
 from materialize.checks.checks import Check
-from materialize.checks.cloudtest_actions import ReplaceEnvironmentdStatefulSet
+from materialize.checks.cloudtest_actions import (
+    ReplaceEnvironmentdStatefulSet,
+    SetupSshTunnels,
+)
 from materialize.checks.executors import CloudtestExecutor
 from materialize.checks.scenarios import Scenario
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
@@ -42,6 +45,7 @@ class CloudtestUpgrade(Scenario):
 
     def actions(self) -> list[Action]:
         return [
+            SetupSshTunnels(self.executor.cloudtest_application()),
             Initialize(self),
             Manipulate(self, phase=1),
             ReplaceEnvironmentdStatefulSet(new_tag=None),
@@ -65,6 +69,7 @@ def test_upgrade(aws_region: str | None, log_filter: str | None, dev: bool) -> N
         log_filter=log_filter,
         release_mode=(not dev),
     )
+
     wait(
         condition="condition=Ready",
         resource="pod",

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -20,7 +20,6 @@ from materialize.checks.all_checks.alter_connection import (
     AlterConnectionToSsh,
 )
 from materialize.checks.all_checks.kafka_protocols import KafkaProtocols
-from materialize.checks.all_checks.ssh import SshKafka, SshPg
 from materialize.checks.checks import Check
 from materialize.checks.cloudtest_actions import (
     ReplaceEnvironmentdStatefulSet,
@@ -77,13 +76,11 @@ def test_upgrade(aws_region: str | None, log_filter: str | None, dev: bool) -> N
     )
 
     executor = CloudtestExecutor(application=mz, version=last_released_version)
-    # SshPg, SshKafka, alter connection tests: No SSH bastion host
     # KafkaProtocols: No shared secrets directory
+    # AlterConnection*: No second SSH host (other_ssh_bastion) set up
     checks = list(
         all_subclasses(Check)
         - {
-            SshPg,
-            SshKafka,
             KafkaProtocols,
             AlterConnectionToSsh,
             AlterConnectionToNonSsh,


### PR DESCRIPTION
Fix the test in cloudtest upgrade by providing it with the necessary setup.

Nightlies: https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Atests%2Ffix-alter-conn-in-cloudtest-upgrade