### PR TITLE
webhook: Cache "webhook appender" from Coordinator 

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -309,23 +309,22 @@ Issue a SQL query to get started. Need help?
         to_datetime((self.now)())
     }
 
-    pub async fn append_webhook(
+    /// Get a metadata and a channel that can be used to append to a webhook source.
+    pub async fn get_webhook_appender(
         &self,
         database: String,
         schema: String,
         name: String,
         conn_id: ConnectionId,
-        received_at: DateTime<Utc>,
     ) -> Result<AppendWebhookResponse, AdapterError> {
         let (tx, rx) = oneshot::channel();
 
         // Send our request.
-        self.send(Command::AppendWebhook {
+        self.send(Command::GetWebhook {
             database,
             schema,
             name,
             conn_id,
-            received_at,
             tx,
         });
 
@@ -762,7 +761,7 @@ impl SessionClient {
             // - execute reports success of dataflow execution
             match cmd {
                 Command::Execute { .. } => typ = Some("execute"),
-                Command::AppendWebhook { .. } => typ = Some("webhook"),
+                Command::GetWebhook { .. } => typ = Some("webhook"),
                 Command::Startup { .. }
                 | Command::CatalogSnapshot { .. }
                 | Command::Commit { .. }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -315,7 +315,6 @@ Issue a SQL query to get started. Need help?
         database: String,
         schema: String,
         name: String,
-        conn_id: ConnectionId,
     ) -> Result<AppendWebhookResponse, AdapterError> {
         let (tx, rx) = oneshot::channel();
 
@@ -324,7 +323,6 @@ Issue a SQL query to get started. Need help?
             database,
             schema,
             name,
-            conn_id,
             tx,
         });
 

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -90,7 +90,6 @@ pub enum Command {
         database: String,
         schema: String,
         name: String,
-        conn_id: ConnectionId,
         tx: oneshot::Sender<Result<AppendWebhookResponse, AdapterError>>,
     },
 

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -12,7 +12,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use enum_kinds::EnumKind;
 use futures::future::BoxFuture;
@@ -87,12 +86,11 @@ pub enum Command {
         conn_id: ConnectionId,
     },
 
-    AppendWebhook {
+    GetWebhook {
         database: String,
         schema: String,
         name: String,
         conn_id: ConnectionId,
-        received_at: DateTime<Utc>,
         tx: oneshot::Sender<Result<AppendWebhookResponse, AdapterError>>,
     },
 
@@ -136,7 +134,7 @@ impl Command {
             | Command::Startup { .. }
             | Command::CatalogSnapshot { .. }
             | Command::PrivilegedCancelRequest { .. }
-            | Command::AppendWebhook { .. }
+            | Command::GetWebhook { .. }
             | Command::Terminate { .. }
             | Command::GetSystemVars { .. }
             | Command::SetSystemVars { .. }
@@ -152,7 +150,7 @@ impl Command {
             | Command::Startup { .. }
             | Command::CatalogSnapshot { .. }
             | Command::PrivilegedCancelRequest { .. }
-            | Command::AppendWebhook { .. }
+            | Command::GetWebhook { .. }
             | Command::Terminate { .. }
             | Command::GetSystemVars { .. }
             | Command::SetSystemVars { .. }

--- a/src/adapter/src/coord/consistency.rs
+++ b/src/adapter/src/coord/consistency.rs
@@ -11,6 +11,7 @@
 
 use super::Coordinator;
 use crate::catalog::consistency::CatalogInconsistencies;
+use mz_catalog::memory::objects::{CatalogItem, DataSourceDesc, Source};
 use mz_repr::GlobalId;
 use serde::Serialize;
 
@@ -20,11 +21,15 @@ pub struct CoordinatorInconsistencies {
     catalog_inconsistencies: Box<CatalogInconsistencies>,
     /// Inconsistencies found in read capabilities.
     read_capabilities: Vec<ReadCapabilitiesInconsistency>,
+    /// Inconsistencies found with our map of active webhooks.
+    active_webhooks: Vec<ActiveWebhookInconsistency>,
 }
 
 impl CoordinatorInconsistencies {
     pub fn is_empty(&self) -> bool {
-        self.catalog_inconsistencies.is_empty() && self.read_capabilities.is_empty()
+        self.catalog_inconsistencies.is_empty()
+            && self.read_capabilities.is_empty()
+            && self.active_webhooks.is_empty()
     }
 }
 
@@ -39,6 +44,10 @@ impl Coordinator {
 
         if let Err(read_capabilities) = self.check_read_capabilities() {
             inconsistencies.read_capabilities = read_capabilities;
+        }
+
+        if let Err(active_webhooks) = self.check_active_webhooks() {
+            inconsistencies.active_webhooks = active_webhooks;
         }
 
         if inconsistencies.is_empty() {
@@ -73,10 +82,45 @@ impl Coordinator {
             Err(read_capabilities_inconsistencies)
         }
     }
+
+    /// # Invariants
+    ///
+    /// * All [`GlobalId`]s in the `active_webhooks` map should reference known webhook sources.
+    ///
+    fn check_active_webhooks(&self) -> Result<(), Vec<ActiveWebhookInconsistency>> {
+        let mut inconsistencies = vec![];
+        for (id, _) in &self.active_webhooks {
+            let is_webhook = self
+                .catalog()
+                .try_get_entry(id)
+                .map(|entry| entry.item())
+                .and_then(|item| {
+                    let CatalogItem::Source(Source { data_source, .. }) = &item else {
+                        return None;
+                    };
+                    Some(matches!(data_source, DataSourceDesc::Webhook { .. }))
+                })
+                .unwrap_or(false);
+            if !is_webhook {
+                inconsistencies.push(ActiveWebhookInconsistency::NonExistentWebhook(*id));
+            }
+        }
+
+        if inconsistencies.is_empty() {
+            Ok(())
+        } else {
+            Err(inconsistencies)
+        }
+    }
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
 enum ReadCapabilitiesInconsistency {
     Storage(GlobalId),
     Compute(GlobalId),
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+enum ActiveWebhookInconsistency {
+    NonExistentWebhook(GlobalId),
 }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -33,7 +33,7 @@ use mz_ore::str::StrExt;
 use mz_ore::task;
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::{GlobalId, Timestamp};
-use mz_sql::catalog::CatalogCluster;
+use mz_sql::catalog::{CatalogCluster, CatalogSchema};
 use mz_sql::names::{ObjectId, ResolvedDatabaseSpecifier};
 use mz_sql::session::vars::{
     self, SystemVars, Var, MAX_AWS_PRIVATELINK_CONNECTIONS, MAX_CLUSTERS,
@@ -203,6 +203,7 @@ impl Coordinator {
         event!(Level::TRACE, ops = format!("{:?}", ops));
 
         let mut sources_to_drop = vec![];
+        let mut webhook_sources_to_restart = BTreeSet::new();
         let mut tables_to_drop = vec![];
         let mut storage_sinks_to_drop = vec![];
         let mut indexes_to_drop = vec![];
@@ -341,6 +342,34 @@ impl Coordinator {
                     update_jemalloc_profiling_config = true;
                     update_default_arrangement_merge_options = true;
                     update_http_config = true;
+                }
+                catalog::Op::AlterSource { id, .. } | catalog::Op::RenameItem { id, .. } => {
+                    let item = self.catalog().get_entry(id);
+                    let is_webhook_source = item
+                        .source()
+                        .map(|s| matches!(s.data_source, DataSourceDesc::Webhook { .. }))
+                        .unwrap_or(false);
+                    if is_webhook_source {
+                        webhook_sources_to_restart.insert(*id);
+                    }
+                }
+                catalog::Op::RenameSchema {
+                    database_spec,
+                    schema_spec,
+                    ..
+                } => {
+                    let schema = self.catalog().get_schema(
+                        database_spec,
+                        schema_spec,
+                        conn_id.unwrap_or(&SYSTEM_CONN_ID),
+                    );
+                    let webhook_sources = schema.item_ids().filter(|id| {
+                        let item = self.catalog().get_entry(id);
+                        item.source()
+                            .map(|s| matches!(s.data_source, DataSourceDesc::Webhook { .. }))
+                            .unwrap_or(false)
+                    });
+                    webhook_sources_to_restart.extend(webhook_sources);
                 }
                 _ => (),
             }
@@ -496,6 +525,9 @@ impl Coordinator {
             }
             if !tables_to_drop.is_empty() {
                 self.drop_sources(tables_to_drop);
+            }
+            if !webhook_sources_to_restart.is_empty() {
+                self.restart_webhook_sources(webhook_sources_to_restart);
             }
             if !storage_sinks_to_drop.is_empty() {
                 self.drop_storage_sinks(storage_sinks_to_drop);
@@ -679,12 +711,19 @@ impl Coordinator {
 
     fn drop_sources(&mut self, sources: Vec<GlobalId>) {
         for id in &sources {
+            self.active_webhooks.remove(id);
             self.drop_storage_read_policy(id);
         }
         self.controller
             .storage
             .drop_sources(sources)
             .unwrap_or_terminate("cannot fail to drop sources");
+    }
+
+    fn restart_webhook_sources(&mut self, sources: impl IntoIterator<Item = GlobalId>) {
+        for id in sources {
+            self.active_webhooks.remove(&id);
+        }
     }
 
     pub(crate) fn drop_compute_sinks(&mut self, sinks: impl IntoIterator<Item = ComputeSinkId>) {

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -139,4 +139,6 @@ pub use crate::coord::ExecuteContextExtra;
 pub use crate::coord::{serve, Config};
 pub use crate::error::AdapterError;
 pub use crate::notice::AdapterNotice;
-pub use crate::webhook::{AppendWebhookError, AppendWebhookResponse, AppendWebhookValidator};
+pub use crate::webhook::{
+    AppendWebhookError, AppendWebhookResponse, AppendWebhookValidator, WebhookAppenderCache,
+};

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -13,7 +13,7 @@ use mz_ore::stats::{histogram_milliseconds_buckets, histogram_seconds_buckets};
 use mz_sql::ast::{AstInfo, Statement, StatementKind, SubscribeOutput};
 use mz_sql::session::user::User;
 use mz_sql_parser::ast::statement_kind_label_value;
-use prometheus::{HistogramVec, IntCounterVec, IntGaugeVec};
+use prometheus::{HistogramVec, IntCounter, IntCounterVec, IntGaugeVec};
 
 #[derive(Debug, Clone)]
 pub struct Metrics {
@@ -35,6 +35,7 @@ pub struct Metrics {
     pub optimization_notices: IntCounterVec,
     pub append_table_duration_seconds: HistogramVec,
     pub webhook_validation_reduce_failures: IntCounterVec,
+    pub webhook_get_appender: IntCounter,
 }
 
 impl Metrics {
@@ -131,7 +132,11 @@ impl Metrics {
                 name: "mz_webhook_validation_reduce_failures",
                 help: "Count of how many times we've failed to reduce a webhook source's CHECK statement.",
                 var_labels: ["reason"],
-            ))
+            )),
+            webhook_get_appender: registry.register(metric!(
+                name: "mz_webhook_get_appender_count",
+                help: "Count of getting a webhook appender from the Coordinator.",
+            )),
         }
     }
 }

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -241,7 +241,7 @@ pub struct WebhookAppender {
 }
 
 impl WebhookAppender {
-    /// Checks if the [`WebhookAppender`] or underlying channel have closed.
+    /// Checks if the [`WebhookAppender`] has closed.
     pub fn is_closed(&self) -> bool {
         self.guard.is_closed()
     }

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -277,6 +277,9 @@ impl WebhookAppenderGuard {
 
 /// A handle to invalidate [`WebhookAppender`]s. See the comment on [`WebhookAppenderGuard`] for
 /// more detail.
+///
+/// Note: to invalidate the associated [`WebhookAppender`]s, you must drop the corresponding
+/// [`WebhookAppenderInvalidator`].
 #[derive(Debug)]
 pub struct WebhookAppenderInvalidator {
     is_closed: Arc<AtomicBool>,
@@ -295,15 +298,11 @@ impl WebhookAppenderInvalidator {
             is_closed: Arc::clone(&self.is_closed),
         }
     }
-
-    pub fn close(&self) {
-        self.is_closed.store(true, Ordering::SeqCst);
-    }
 }
 
 impl Drop for WebhookAppenderInvalidator {
     fn drop(&mut self) {
-        self.close()
+        self.is_closed.store(true, Ordering::SeqCst);
     }
 }
 

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -8,21 +8,23 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::BTreeMap;
-use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use anyhow::Context;
 use chrono::{DateTime, Utc};
-use mz_repr::{ColumnType, Datum, Row, RowArena};
+use derivative::Derivative;
+use mz_repr::{ColumnType, Datum, Diff, Row, RowArena};
 use mz_secrets::cache::CachingSecretsReader;
 use mz_secrets::SecretsReader;
 use mz_sql::plan::{WebhookHeaders, WebhookValidation, WebhookValidationSecret};
 use mz_storage_client::controller::MonotonicAppender;
+use mz_storage_types::controller::StorageError;
 use tokio::sync::Semaphore;
 
 use crate::optimize::dataflows::{prep_scalar_expr, ExprPrepStyle};
 
-/// Errors returns when running validation of a webhook request.
+/// Errors returns when attempting to append to a webhook.
 #[derive(thiserror::Error, Debug)]
 pub enum AppendWebhookError {
     // A secret that we need for validation has gone missing.
@@ -36,6 +38,10 @@ pub enum AppendWebhookError {
     // including any more detail we might accidentally expose SECRETs.
     #[error("validation failed")]
     ValidationError,
+    #[error("temporary error, please retry")]
+    TemporaryError,
+    #[error("internal storage failure! {0:?}")]
+    StorageError(#[from] StorageError),
     // Note: we should _NEVER_ add more detail to this error, see above as to why.
     #[error("internal error when validating request")]
     InternalError,
@@ -44,22 +50,17 @@ pub enum AppendWebhookError {
 /// Contains all of the components necessary for running webhook validation.
 ///
 /// To actually validate a webhook request call [`AppendWebhookValidator::eval`].
+#[derive(Clone)]
 pub struct AppendWebhookValidator {
     validation: WebhookValidation,
     secrets_reader: CachingSecretsReader,
-    received_at: DateTime<Utc>,
 }
 
 impl AppendWebhookValidator {
-    pub fn new(
-        validation: WebhookValidation,
-        secrets_reader: CachingSecretsReader,
-        received_at: DateTime<Utc>,
-    ) -> Self {
+    pub fn new(validation: WebhookValidation, secrets_reader: CachingSecretsReader) -> Self {
         AppendWebhookValidator {
             validation,
             secrets_reader,
-            received_at,
         }
     }
 
@@ -67,11 +68,11 @@ impl AppendWebhookValidator {
         self,
         body: bytes::Bytes,
         headers: Arc<BTreeMap<String, String>>,
+        received_at: DateTime<Utc>,
     ) -> Result<bool, AppendWebhookError> {
         let AppendWebhookValidator {
             validation,
             secrets_reader,
-            received_at,
         } = self;
 
         let WebhookValidation {
@@ -217,21 +218,111 @@ impl AppendWebhookValidator {
     }
 }
 
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub struct AppendWebhookResponse {
-    pub tx: MonotonicAppender,
+    /// Channel to monotonically append rows to a webhook source.
+    pub tx: WebhookAppender,
+    /// Column type for the `body` column.
     pub body_ty: ColumnType,
+    /// Types of the columns for the headers of a request.
     pub header_tys: WebhookHeaders,
+    /// Expression used to validate a webhook request.
+    #[derivative(Debug = "ignore")]
     pub validator: Option<AppendWebhookValidator>,
 }
 
-impl fmt::Debug for AppendWebhookResponse {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AppendWebhookResponse")
-            .field("tx", &self.tx)
-            .field("body_ty", &self.body_ty)
-            .field("header_tys", &self.header_tys)
-            .field("validate_expr", &"(...)")
-            .finish()
+/// A wrapper around [`MonotonicAppender`] that can get closed by the `Coordinator` if the webhook
+/// gets modified.
+#[derive(Clone, Debug)]
+pub struct WebhookAppender {
+    tx: MonotonicAppender,
+    guard: WebhookAppenderGuard,
+}
+
+impl WebhookAppender {
+    /// Checks if the [`WebhookAppender`] or underlying channel have closed.
+    pub fn is_closed(&self) -> bool {
+        self.guard.is_closed()
+    }
+
+    /// Appends updates to the linked webhook source.
+    pub async fn append(&self, updates: Vec<(Row, Diff)>) -> Result<(), AppendWebhookError> {
+        if self.is_closed() {
+            return Err(AppendWebhookError::TemporaryError);
+        }
+        self.tx.append(updates).await?;
+        Ok(())
+    }
+
+    pub(crate) fn new(tx: MonotonicAppender, guard: WebhookAppenderGuard) -> Self {
+        WebhookAppender { tx, guard }
+    }
+}
+
+/// When a webhook, or it's containing schema and database, get modified we need to invalidate any
+/// outstanding [`WebhookAppender`]s. This is because `Adapter`s will cache [`WebhookAppender`]s to
+/// increase performance, and the (database, schema, name) tuple they cached an appender for is now
+/// incorrect.
+#[derive(Clone, Debug)]
+pub struct WebhookAppenderGuard {
+    is_closed: Arc<AtomicBool>,
+}
+
+impl WebhookAppenderGuard {
+    pub fn is_closed(&self) -> bool {
+        self.is_closed.load(Ordering::SeqCst)
+    }
+}
+
+/// A handle to invalidate [`WebhookAppender`]s. See the comment on [`WebhookAppenderGuard`] for
+/// more detail.
+#[derive(Debug)]
+pub struct WebhookAppenderInvalidator {
+    is_closed: Arc<AtomicBool>,
+}
+// We want to enforce unique ownership over the ability to invalidate a `WebhookAppender`.
+static_assertions::assert_not_impl_all!(WebhookAppenderInvalidator: Clone);
+
+impl WebhookAppenderInvalidator {
+    pub(crate) fn new() -> WebhookAppenderInvalidator {
+        let is_closed = Arc::new(AtomicBool::new(false));
+        WebhookAppenderInvalidator { is_closed }
+    }
+
+    pub fn guard(&self) -> WebhookAppenderGuard {
+        WebhookAppenderGuard {
+            is_closed: Arc::clone(&self.is_closed),
+        }
+    }
+
+    pub fn close(&self) {
+        self.is_closed.store(true, Ordering::SeqCst);
+    }
+}
+
+impl Drop for WebhookAppenderInvalidator {
+    fn drop(&mut self) {
+        self.close()
+    }
+}
+
+pub type WebhookAppenderName = (String, String, String);
+
+/// A cache of [`WebhookAppender`]s and other metadata required for appending to a wbhook source.
+///
+/// Entries in the cache get invalidated when a [`WebhookAppender`] closes, at which point the
+/// entry should be dropped from the cache and a request made to the `Coordinator` for a new one.
+#[derive(Debug, Clone)]
+pub struct WebhookAppenderCache {
+    pub entries: Arc<tokio::sync::Mutex<BTreeMap<WebhookAppenderName, AppendWebhookResponse>>>,
+}
+
+impl WebhookAppenderCache {
+    pub fn new() -> Self {
+        WebhookAppenderCache {
+            entries: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
+        }
     }
 }
 

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -38,8 +38,8 @@ pub enum AppendWebhookError {
     // including any more detail we might accidentally expose SECRETs.
     #[error("validation failed")]
     ValidationError,
-    #[error("temporary error, please retry")]
-    TemporaryError,
+    #[error("internal channel closed")]
+    ChannelClosed,
     #[error("internal storage failure! {0:?}")]
     StorageError(#[from] StorageError),
     // Note: we should _NEVER_ add more detail to this error, see above as to why.
@@ -249,7 +249,7 @@ impl WebhookAppender {
     /// Appends updates to the linked webhook source.
     pub async fn append(&self, updates: Vec<(Row, Diff)>) -> Result<(), AppendWebhookError> {
         if self.is_closed() {
-            return Err(AppendWebhookError::TemporaryError);
+            return Err(AppendWebhookError::ChannelClosed);
         }
         self.tx.append(updates).await?;
         Ok(())

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -20,7 +20,6 @@ use mz_repr::{ColumnType, Datum, Row, ScalarType};
 use mz_sql::plan::{WebhookHeaderFilters, WebhookHeaders};
 use mz_storage_types::controller::StorageError;
 
-use anyhow::Context;
 use axum::extract::{Path, State};
 use axum::response::IntoResponse;
 use bytes::Bytes;
@@ -44,9 +43,6 @@ pub async fn handle_webhook(
 ) -> impl IntoResponse {
     // Record the time we receive the request, for use if validation checks the current timestamp.
     let received_at = adapter_client.now();
-    let conn_id = adapter_client
-        .new_conn_id()
-        .context("allocate connection id")?;
 
     // Collect headers into a map, while converting them into strings.
     let mut headers_s = BTreeMap::new();
@@ -86,7 +82,7 @@ pub async fn handle_webhook(
 
                 // Acquire and cache a new appender.
                 let appender = adapter_client
-                    .get_webhook_appender(database.clone(), schema.clone(), name.clone(), conn_id)
+                    .get_webhook_appender(database.clone(), schema.clone(), name.clone())
                     .await?;
 
                 guard.insert((database, schema, name), appender.clone());

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -376,7 +376,7 @@ pub trait StorageController: Debug {
         commands: Vec<(GlobalId, Vec<TimestamplessUpdate>)>,
     ) -> Result<tokio::sync::oneshot::Receiver<Result<(), StorageError>>, StorageError>;
 
-    /// Returns a [`MonotonicAppender`] which is a channel that can be used to  monotonically
+    /// Returns a [`MonotonicAppender`] which is a channel that can be used to monotonically
     /// append to the specified [`GlobalId`].
     fn monotonic_appender(&self, id: GlobalId) -> Result<MonotonicAppender, StorageError>;
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1856,7 +1856,7 @@ where
             if let Some(CollectionState { description, .. }) = collection {
                 if description.data_source == DataSource::Webhook && frontier.is_empty() {
                     // Unregister our collection from the manager so writes should no longer occur.
-                    self.collection_manager.unregsiter_collection(id).await;
+                    self.collection_manager.unregister_collection(id).await;
 
                     pending_source_drops.push(id);
                     // Normally `clusterd` will emit this StorageResponse when it knows we can

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -356,6 +356,73 @@ $ webhook-append name=webhook_for_batch_events
 > SELECT COUNT(*) FROM webhook_for_batch_events_flattened
 8
 
+# Renaming a webhook source.
+
+> CREATE SOURCE webhook_foo IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT TEXT
+
+$ webhook-append name=webhook_foo
+aaa_1
+
+> SELECT body FROM webhook_foo;
+aaa_1
+
+> ALTER SOURCE webhook_foo RENAME TO webhook_bar
+
+$ webhook-append name=webhook_foo status=404
+aaa_2
+
+$ webhook-append name=webhook_bar
+bbb_1
+
+> SELECT body FROM webhook_bar;
+aaa_1
+bbb_1
+
+# Renaming the schema that contains a webhook source.
+
+> CREATE SCHEMA my_webhooks;
+
+> CREATE SOURCE my_webhooks.foo IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT TEXT
+
+> CREATE SOURCE my_webhooks.bar IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT TEXT
+
+$ webhook-append schema=my_webhooks name=foo
+foo-foo
+
+$ webhook-append schema=my_webhooks name=bar
+bar-bar
+
+> SELECT body FROM my_webhooks.foo
+foo-foo
+
+> SELECT body FROM my_webhooks.bar
+bar-bar
+
+> BEGIN;
+
+> ALTER SCHEMA my_webhooks RENAME TO other_webhooks;
+
+> ALTER SOURCE other_webhooks.bar RENAME TO baz;
+
+> COMMIT;
+
+$ webhook-append schema=other_webhooks name=foo
+foo-after
+
+$ webhook-append schema=other_webhooks name=baz
+baz-after
+
+> SELECT body FROM other_webhooks.foo
+foo-foo
+foo-after
+
+> SELECT body FROM other_webhooks.baz
+bar-bar
+baz-after
+
 # Dropping a webhook source should drop the underlying persist shards.
 
 $ set-from-sql var=webhook-source-id


### PR DESCRIPTION
This PR refactors our webhook HTTP handler to cache the necessary info for appending to a webhook source.

Previously for every webhook request we would send a message to the Coordinator and get back the necessary metadata for appending to a webhook, i.e. a channel to push updates and an expression to run validation. Webhook sources rarely change (if ever) so sending a message to the Coordinator on _every_ append is unnecessary, and effectively serialized all webhook requests. In this PR we add a cache to the HTTP server where for a given `(database, schema, name)` tuple, we store a channel for appending and the expression for validation. The channel in the cache gets closed if the underlying webhook source ever changes, at which point we call into the Coordinator to get a new channel.

This removes the Coordinator from the critical path for webhook appends, which reduces CPU load on `environmentd` and increases our throughput for webhooks. Benchmarking with the same setup as https://github.com/MaterializeInc/materialize/pull/21766, we are able to sustain ~2,000 writes per-second at ~30% CPU usage, with spikes to 80%.

Note: I validated this approach with @mjibson to make sure we stay aligned with the Platform V2 vision.
Note2: I didn't do any profiling, but the CPU spikes seem to follow a similar shape as memory spikes, I have a branch stacked on top of this one which should improve this.

### Race Conditions

Given we have multiple async components running concurrently, operations can get interleaved. I believe we retain correctness though because before any `ALTER` command would return, e.g. `ALTER SOURCE ... RENAME TO ...` we invalidate the `MonotonicAppender`s. And the only way for `Adapter` clients to obtain new `MonotonicAppender`s, is to go through the Coordinator. 

For example, the following scenario is impossible:

1. Run `ALTER SOURCE foo RENAME TO bar`... wait to return success.
2. HTTP POST, append to webhook source `foo` <- this is guaranteed to return a 404.

### Motivation

Webhook sources are getting used more frequently now, so I wanted to increase their supported throughput and thus stability.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improves the throughput of webhook sources.
