### PR TITLE
sql: resolve types separately from other objects

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1069,7 +1069,7 @@ impl CatalogState {
             let arg_type_ids = func_impl_details
                 .arg_typs
                 .iter()
-                .map(|typ| self.get_entry_in_system_schemas(typ).id().to_string())
+                .map(|typ| self.get_system_type(typ).id().to_string())
                 .collect::<Vec<_>>();
 
             let mut row = Row::default();
@@ -1097,13 +1097,13 @@ impl CatalogState {
                     Datum::from(
                         func_impl_details
                             .variadic_typ
-                            .map(|typ| self.get_entry_in_system_schemas(typ).id().to_string())
+                            .map(|typ| self.get_system_type(typ).id().to_string())
                             .as_deref(),
                     ),
                     Datum::from(
                         func_impl_details
                             .return_typ
-                            .map(|typ| self.get_entry_in_system_schemas(typ).id().to_string())
+                            .map(|typ| self.get_system_type(typ).id().to_string())
                             .as_deref(),
                     ),
                     func_impl_details.return_is_set.into(),
@@ -1137,7 +1137,7 @@ impl CatalogState {
         let arg_type_ids = func_impl_details
             .arg_typs
             .iter()
-            .map(|typ| self.get_entry_in_system_schemas(typ).id().to_string())
+            .map(|typ| self.get_system_type(typ).id().to_string())
             .collect::<Vec<_>>();
 
         let mut row = Row::default();
@@ -1161,7 +1161,7 @@ impl CatalogState {
                 Datum::from(
                     func_impl_details
                         .return_typ
-                        .map(|typ| self.get_entry_in_system_schemas(typ).id().to_string())
+                        .map(|typ| self.get_system_type(typ).id().to_string())
                         .as_deref(),
                 ),
             ]),

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -373,6 +373,7 @@ impl Catalog {
                         oid,
                         items: BTreeMap::new(),
                         functions: BTreeMap::new(),
+                        types: BTreeMap::new(),
                         owner_id,
                         privileges: PrivilegeMap::from_mz_acl_items(privileges),
                     },
@@ -950,6 +951,9 @@ impl Catalog {
                 for (_item_name, function_id) in &schema.functions {
                     builtin_table_updates.extend(catalog.state.pack_item_update(*function_id, 1));
                 }
+                for (_item_name, type_id) in &schema.types {
+                    builtin_table_updates.extend(catalog.state.pack_item_update(*type_id, 1));
+                }
             }
             for (_id, db) in &catalog.state.database_by_id {
                 builtin_table_updates.push(catalog.state.pack_database_update(db, 1));
@@ -963,6 +967,9 @@ impl Catalog {
                     for (_item_name, function_id) in &schema.functions {
                         builtin_table_updates
                             .extend(catalog.state.pack_item_update(*function_id, 1));
+                    }
+                    for (_item_name, type_id) in &schema.types {
+                        builtin_table_updates.extend(catalog.state.pack_item_update(*type_id, 1));
                     }
                 }
             }

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -91,6 +91,7 @@ pub struct Schema {
     pub oid: u32,
     pub items: BTreeMap<String, GlobalId>,
     pub functions: BTreeMap<String, GlobalId>,
+    pub types: BTreeMap<String, GlobalId>,
     pub owner_id: RoleId,
     pub privileges: PrivilegeMap,
 }
@@ -1846,8 +1847,14 @@ impl mz_sql::catalog::CatalogSchema for Schema {
         !self.items.is_empty()
     }
 
-    fn item_ids(&self) -> &BTreeMap<String, GlobalId> {
-        &self.items
+    fn item_ids(&self) -> Box<dyn Iterator<Item = GlobalId> + '_> {
+        Box::new(
+            self.items
+                .values()
+                .chain(self.functions.values())
+                .chain(self.types.values())
+                .copied(),
+        )
     }
 
     fn owner_id(&self) -> RoleId {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -4117,7 +4117,7 @@ pub enum CommentObjectType<T: AstInfo> {
     Index { name: T::ItemName },
     Func { name: T::ItemName },
     Connection { name: T::ItemName },
-    Type { name: T::ItemName },
+    Type { ty: T::DataType },
     Secret { name: T::ItemName },
     Role { name: T::RoleName },
     Database { name: T::DatabaseName },
@@ -4167,9 +4167,9 @@ impl<T: AstInfo> AstDisplay for CommentObjectType<T> {
                 f.write_str("CONNECTION ");
                 f.write_node(name);
             }
-            Type { name } => {
+            Type { ty } => {
                 f.write_str("TYPE ");
-                f.write_node(name);
+                f.write_node(ty);
             }
             Secret { name } => {
                 f.write_str("SECRET ");

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -7972,8 +7972,8 @@ impl<'a> Parser<'a> {
                 CommentObjectType::Connection { name }
             }
             TYPE => {
-                let name = self.parse_raw_name()?;
-                CommentObjectType::Type { name }
+                let ty = self.parse_data_type()?;
+                CommentObjectType::Type { ty }
             }
             SECRET => {
                 let name = self.parse_raw_name()?;

--- a/src/sql-parser/tests/testdata/comment
+++ b/src/sql-parser/tests/testdata/comment
@@ -144,7 +144,7 @@ COMMENT ON TYPE special_int IS 'not enough bits'
 ----
 COMMENT ON TYPE special_int IS 'not enough bits'
 =>
-Comment(CommentStatement { object: Type { name: Name(UnresolvedItemName([Ident("special_int")])) }, comment: Some("not enough bits") })
+Comment(CommentStatement { object: Type { ty: Other { name: Name(UnresolvedItemName([Ident("special_int")])), typ_mod: [] } }, comment: Some("not enough bits") })
 
 parse-statement
 COMMENT ON SECRET api_key IS 'shhhhhh'

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -5445,10 +5445,14 @@ pub fn scalar_type_from_catalog(
     let entry = catalog.get_item(&id);
     let type_details = match entry.type_details() {
         Some(type_details) => type_details,
-        None => sql_bail!(
-            "{} does not refer to a type",
-            catalog.resolve_full_name(entry.name()).to_string().quoted()
-        ),
+        None => {
+            // Resolution should never produce a `ResolvedDataType::Named` with
+            // an ID of a non-type, but we error gracefully just in case.
+            sql_bail!(
+                "internal error: {} does not refer to a type",
+                catalog.resolve_full_name(entry.name()).to_string().quoted()
+            );
+        }
     };
     match &type_details.typ {
         CatalogType::Numeric => {

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -681,10 +681,6 @@ impl<'a> StatementContext<'a> {
         self.catalog.get_schema(database_spec, schema_spec)
     }
 
-    pub fn item_exists(&self, name: &QualifiedItemName) -> bool {
-        self.catalog.item_exists(name)
-    }
-
     pub fn resolve_item(&self, name: RawItemName) -> Result<&dyn CatalogItem, PlanError> {
         match name {
             RawItemName::Name(name) => {

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -79,7 +79,7 @@ impl<'a> FuncRewriter<'a> {
         let item = self
             .scx
             .catalog
-            .resolve_item(name)
+            .resolve_type(name)
             .expect("data type known to be valid");
         let full_name = self.scx.catalog.resolve_full_name(item.name());
         ResolvedDataType::Named {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -851,7 +851,9 @@ async fn purify_create_source(
 
                 let partial = normalize::unresolved_item_name(UnresolvedItemName(suggested_name))?;
                 let qualified = scx.allocate_qualified_name(partial)?;
-                Ok::<_, PlanError>(!scx.item_exists(&qualified))
+                let item_exists = scx.catalog.get_item_by_name(&qualified).is_some();
+                let type_exists = scx.catalog.get_type_by_name(&qualified).is_some();
+                Ok::<_, PlanError>(!item_exists && !type_exists)
             })?;
 
             let mut full_name = prefix.to_vec();

--- a/test/pg-cdc/types-temporal-with-tz.td
+++ b/test/pg-cdc/types-temporal-with-tz.td
@@ -68,4 +68,4 @@ INSERT INTO timestamp_table SELECT * FROM timestamp_table;
 ! CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source_time')
   FOR ALL TABLES;
-contains:unknown catalog item 'pg_catalog.timetz'
+contains:type "pg_catalog.timetz" does not exist

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -1173,7 +1173,7 @@ ORDER BY company_id;
 3  C
 4  D
 
-query error unknown catalog item 'b'
+query error type "b" does not exist
 SELECT company_id, string_agg(employee::BYTEA, b',')
 FROM string_agg_test
 GROUP BY company_id
@@ -1190,7 +1190,7 @@ ORDER BY company_id;
 3  CCC
 4  DDDD
 
-query error unknown catalog item 'b'
+query error type "b" does not exist
 SELECT company_id, string_agg(employee::BYTEA, b'')
 FROM string_agg_test
 GROUP BY company_id
@@ -1277,7 +1277,7 @@ ORDER BY company_id, id;
 4  D,D,D
 4  D,D,D,D
 
-query error unknown catalog item 'b'
+query error type "b" does not exist
 SELECT company_id, string_agg(employee::BYTEA, b',')
 OVER (PARTITION BY company_id ORDER BY id)
 FROM string_agg_test
@@ -1300,7 +1300,7 @@ ORDER BY company_id, id;
 4  DDD
 4  DDDD
 
-query error unknown catalog item 'b'
+query error type "b" does not exist
 SELECT company_id, string_agg(employee::BYTEA, b'')
 OVER (PARTITION BY company_id ORDER BY id)
 FROM string_agg_test
@@ -1487,7 +1487,7 @@ ORDER BY e.company_id;
 ----
 1  A,␠B,␠C,␠D
 
-query error unknown catalog item 'b'
+query error type "b" does not exist
 SELECT e.company_id, string_agg(e.employee, b', ')
 FROM (
   SELECT employee::BYTEA, company_id
@@ -1510,7 +1510,7 @@ ORDER BY e.company_id;
 ----
 1  A,␠B,␠C,␠D
 
-query error unknown catalog item 'b'
+query error type "b" does not exist
 SELECT e.company_id, string_agg(e.employee, b', ')
 FROM (
   SELECT employee::BYTEA, company_id

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1983,7 +1983,7 @@ SELECT '{1}'::float4 list = '{2}'::float8 list
 
 # 🔬 CREATE TYPE .. AS LIST
 
-query error ELEMENT TYPE must be of class type, but received pg_catalog.pg_enum which is of class view
+query error type "pg_enum" does not exist
 CREATE TYPE tbl_list AS LIST (ELEMENT TYPE=pg_enum)
 
 query error CREATE TYPE ... AS LIST option ELEMENT TYPE can only use named data types, but found unnamed data type pg_catalog.int4 list. Use CREATE TYPE to create a named type first
@@ -2020,7 +2020,7 @@ SELECT '{{1,2}}'::int4_list_list_c::text;
 ----
 {{1,2}}
 
-query error unknown catalog item 'bool list'
+query error type "bool list" does not exist
 CREATE TYPE nested_list AS LIST (ELEMENT TYPE = "bool list")
 
 query error db error: ERROR: cannot reference pseudo type pg_catalog\.list

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -27,10 +27,10 @@ CREATE TYPE custom AS MAP (VALUE TYPE = bool)
 query error Expected one of KEY or VALUE, found identifier "extra_type"
 CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool, extra_type=customthing)
 
-query error KEY TYPE must be of class type, but received pg_catalog.pg_enum which is of class view
+query error type "pg_enum" does not exist
 CREATE TYPE tbl_map AS MAP (KEY TYPE = pg_enum, VALUE TYPE = text)
 
-query error VALUE TYPE must be of class type, but received pg_catalog.pg_enum which is of class view
+query error type "pg_enum" does not exist
 CREATE TYPE tbl_map AS MAP (KEY TYPE = text, VALUE TYPE = pg_enum)
 
 query error CREATE TYPE ... AS MAP option VALUE TYPE can only use named data types, but found unnamed data type pg_catalog.int4 list. Use CREATE TYPE to create a named type first

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -33,7 +33,7 @@ SELECT pg_typeof('true'::boolean)
 ----
 boolean
 
-query error unknown catalog item 'pg_catalog.boolean'
+query error type "pg_catalog.boolean" does not exist
 SELECT 'true'::pg_catalog.boolean
 
 # 🔬🔬 bytea
@@ -55,7 +55,7 @@ SELECT 'a'::bytes
 ----
 a
 
-query error unknown catalog item 'pg_catalog.bytes'
+query error type "pg_catalog.bytes" does not exist
 SELECT ''::pg_catalog.bytes
 
 # 🔬🔬 date
@@ -89,7 +89,7 @@ SELECT '1.2'::float(1)
 ----
 1.200
 
-query error unknown catalog item 'pg_catalog.float'
+query error type "pg_catalog.float" does not exist
 SELECT '1.2'::pg_catalog.float(1)
 
 query T
@@ -102,7 +102,7 @@ SELECT '1.2'::real
 ----
 1.200
 
-query error unknown catalog item 'pg_catalog.real'
+query error type "pg_catalog.real" does not exist
 SELECT '1.2'::pg_catalog.real
 
 query T
@@ -129,7 +129,7 @@ SELECT '1.2'::float(53)
 ----
 1.200
 
-query error unknown catalog item 'pg_catalog.float'
+query error type "pg_catalog.float" does not exist
 SELECT '1.2'::pg_catalog.float(53)
 
 query T
@@ -142,7 +142,7 @@ SELECT '1.2'::double
 ----
 1.200
 
-query error unknown catalog item 'pg_catalog.double'
+query error type "pg_catalog.double" does not exist
 SELECT '1.2'::pg_catalog.double
 
 query T
@@ -169,7 +169,7 @@ SELECT '1'::smallint
 ----
 1
 
-query error unknown catalog item 'pg_catalog.smallint'
+query error type "pg_catalog.smallint" does not exist
 SELECT '1'::pg_catalog.smallint
 
 query T
@@ -196,7 +196,7 @@ SELECT '1'::int
 ----
 1
 
-query error unknown catalog item 'pg_catalog.int'
+query error type "pg_catalog.int" does not exist
 SELECT '1'::pg_catalog.int
 
 query T
@@ -209,7 +209,7 @@ SELECT '1'::integer
 ----
 1
 
-query error unknown catalog item 'pg_catalog.integer'
+query error type "pg_catalog.integer" does not exist
 SELECT '1'::pg_catalog.integer
 
 query T
@@ -236,7 +236,7 @@ SELECT '1'::bigint
 ----
 1
 
-query error unknown catalog item 'pg_catalog.bigint'
+query error type "pg_catalog.bigint" does not exist
 SELECT '1'::pg_catalog.bigint
 
 query T
@@ -291,7 +291,7 @@ SELECT '{"1":2,"3":4}'::json
 ----
 {"1":2,"3":4}
 
-query error unknown catalog item 'pg_catalog.json'
+query error type "pg_catalog.json" does not exist
 SELECT '{"1":2,"3":4}'::pg_catalog.json
 
 # 🔬🔬 numeric
@@ -314,7 +314,7 @@ SELECT '1'::decimal(38,0)
 ----
 1
 
-query error unknown catalog item 'pg_catalog.decimal'
+query error type "pg_catalog.decimal" does not exist
 SELECT '1'::pg_catalog.decimal(38,0)
 
 query T
@@ -322,7 +322,7 @@ SELECT '1'::dec(38,0)
 ----
 1
 
-query error unknown catalog item 'pg_catalog.dec'
+query error type "pg_catalog.dec" does not exist
 SELECT '1'::pg_catalog.dec(38,0)
 
 # 🔬🔬 oid
@@ -596,8 +596,106 @@ SELECT '1'::materialize.pg_catalog.int4
 1
 
 # tables are not types yet
-query error "pg_catalog.pg_enum" does not refer to a type
+query error type "pg_catalog.pg_enum" does not exist
 SELECT '1'::pg_catalog.pg_enum
+
+# relations can have the same name as built-in types
+statement ok
+CREATE VIEW int4 AS VALUES (1)
+
+query I
+SELECT * FROM int4
+----
+1
+
+# but within the same schema, types cannot have the same name as a relation
+statement error view "materialize.public.int4" already exists
+CREATE TYPE int4 AS (a int)
+
+# creating relations with the same name as an existing type is not allowed
+# (see #23789)...
+
+statement ok
+CREATE TYPE rectype AS (a int)
+
+statement error type "materialize.public.rectype" already exists
+CREATE VIEW rectype AS VALUES (1)
+
+statement error type "materialize.public.rectype" already exists
+CREATE MATERIALIZED VIEW rectype AS VALUES (1)
+
+statement error type "materialize.public.rectype" already exists
+CREATE TABLE rectype (a int)
+
+statement error type "materialize.public.rectype" already exists
+CREATE SOURCE rectype FROM LOAD GENERATOR COUNTER
+
+statement error type "materialize.public.rectype" already exists
+CREATE INDEX rectype ON int4 (column1)
+
+# ...not even via rename...
+
+statement ok
+CREATE VIEW rectype_sneaky_v AS VALUES (1)
+
+statement error catalog item 'rectype' already exists
+ALTER VIEW rectype_sneaky_v RENAME TO rectype
+
+statement ok
+CREATE MATERIALIZED VIEW rectype_sneaky_mv AS VALUES (1)
+
+statement error catalog item 'rectype' already exists
+ALTER MATERIALIZED VIEW rectype_sneaky_mv RENAME TO rectype
+
+statement ok
+CREATE TABLE rectype_sneaky_t (a int)
+
+statement error catalog item 'rectype' already exists
+ALTER TABLE rectype_sneaky_t RENAME TO rectype
+
+statement ok
+CREATE SOURCE rectype_sneaky_s FROM LOAD GENERATOR COUNTER
+
+statement error catalog item 'rectype' already exists
+ALTER SOURCE rectype_sneaky_s RENAME TO rectype
+
+statement ok
+CREATE INDEX rectype_sneaky_i ON int4 (column1)
+
+statement error catalog item 'rectype' already exists
+ALTER INDEX rectype_sneaky_i RENAME TO rectype
+
+# creating secrets with the same name as a type is ok though...
+
+statement ok
+CREATE SECRET rectype AS 'ignored'
+
+statement ok
+DROP SECRET rectype
+
+statement ok
+CREATE SECRET rectype_sneaky AS 'ignored'
+
+statement ok
+ALTER SECRET rectype_sneaky RENAME TO rectype
+
+statement ok
+DROP SECRET rectype
+
+statement ok
+CREATE CONNECTION rectype TO SSH TUNNEL (HOST 'localhost', USER 'ignored')
+
+statement ok
+DROP CONNECTION rectype
+
+statement ok
+CREATE CONNECTION rectype_sneaky TO SSH TUNNEL (HOST 'localhost', USER 'ignored')
+
+statement ok
+ALTER CONNECTION rectype_sneaky RENAME TO rectype
+
+statement ok
+DROP CONNECTION rectype
 
 # 🔬 format_type
 

--- a/test/testdrive/type_char_quoted.td
+++ b/test/testdrive/type_char_quoted.td
@@ -16,7 +16,7 @@
 97
 
 ! SELECT 'a'::"char(5)"
-contains: unknown catalog item 'char(5)'
+contains:type "char(5)" does not exist
 
 ! SELECT 'a'::"char"(5)
 contains: pg_catalog.char does not support type modifiers


### PR DESCRIPTION
Like functions, types in PostgreSQL exist in a namespace that is parallel to the namespace for tables, views, indexes, etc.

Fix #23770.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow bare references to tables, views, and sources whose name matches the name of a type.
