### PR TITLE
docs: Update webhook examples to use `try_parse_*`

### DIFF
--- a/doc/user/content/ingest-data/segment.md
+++ b/doc/user/content/ingest-data/segment.md
@@ -124,19 +124,19 @@ CREATE VIEW parse_segment AS SELECT
     body->>'anonymousId' AS anonymousId,
     body->>'channel' AS channel,
     body->'context'->>'ip' AS context_ip,
-    body->'context'->>'userAgent' AS context_userAgent,
-    (body->'integrations'->>'All')::bool AS integrations_All,
-    (body->'integrations'->>'Mixpanel')::bool AS integrations_Mixpanel,
-    (body->'integrations'->>'Salesforce')::bool AS integrations_Salesforce,
+    body->'context'->>'userAgent' AS context_user_agent,
+    (body->'integrations'->>'All')::bool AS integrations_all,
+    (body->'integrations'->>'Mixpanel')::bool AS integrations_mixpanel,
+    (body->'integrations'->>'Salesforce')::bool AS integrations_salesforce,
     body->>'messageId' AS messageId,
     body->>'name' AS name,
     body->'properties'->>'title' AS properties_title,
     body->'properties'->>'url' AS properties_url,
-    try_parse_monotonic_iso8601_timestamp(body->>'receivedAt') AS receivedAt,
-    try_parse_monotonic_iso8601_timestamp(body->>'sentAt') AS sentAt,
+    try_parse_monotonic_iso8601_timestamp(body->>'receivedAt') AS received_at,
+    try_parse_monotonic_iso8601_timestamp(body->>'sentAt') AS sent_at,
     try_parse_monotonic_iso8601_timestamp(body->>'timestamp') AS timestamp,
     body->>'type' AS type,
-    body->>'userId' AS userId,
+    body->>'userId' AS user_id,
     try_parse_monotonic_iso8601_timestamp(body->>'version') AS version
 FROM my_segment_source;
 ```
@@ -146,7 +146,7 @@ FROM my_segment_source;
 
 ```sql
 CREATE VIEW parse_segment AS SELECT
-    body->>'anonymousId' AS anonymousId,
+    body->>'anonymousId' AS anonymous_id,
     body->'context'->'library'->>'name' AS context_library_name,
     (body->'context'->'library'->>'version') AS context_library_version,
     body->'context'->'page'->>'path' AS context_page_path,
@@ -157,14 +157,14 @@ CREATE VIEW parse_segment AS SELECT
     body->'context'->>'userAgent' AS context_userAgent,
     body->'context'->>'ip' AS context_ip,
     body->>'event' AS event,
-    body->>'messageId' AS messageId,
+    body->>'messageId' AS message_id,
     body->'properties'->>'title' AS properties_title,
-    try_parse_monotonic_iso8601_timestamp(body->>'receivedAt') AS receivedAt,
-    try_parse_monotonic_iso8601_timestamp(body->>'sentAt') AS sentAt,
+    try_parse_monotonic_iso8601_timestamp(body->>'receivedAt') AS received_at,
+    try_parse_monotonic_iso8601_timestamp(body->>'sentAt') AS sent_at,
     try_parse_monotonic_iso8601_timestamp(body->>'timestamp') AS timestamp,
     body->>'type' AS type,
-    body->>'userId' AS userId,
-    try_parse_monotonic_iso8601_timestamp(body->>'originalTimestamp') AS originalTimestamp
+    body->>'userId' AS user_id,
+    try_parse_monotonic_iso8601_timestamp(body->>'originalTimestamp') AS original_timestamp
 FROM my_segment_source;
 ```
 
@@ -173,16 +173,16 @@ FROM my_segment_source;
 {{< tab "Identity">}}
 ```sql
 CREATE VIEW parse_segment AS SELECT
-    body->>'anonymousId' AS anonymousId,
+    body->>'anonymousId' AS anonymous_id,
     body->>'channel' AS channel,
     body->'context'->>'ip' AS context_ip,
-    body->'context'->>'userAgent' AS context_userAgent,
-    (body->'integrations'->>'All')::bool AS integrations_All,
-    (body->'integrations'->>'Mixpanel')::bool AS integrations_Mixpanel,
-    (body->'integrations'->>'Salesforce')::bool AS integrations_Salesforce,
+    body->'context'->>'userAgent' AS context_user_agent,
+    (body->'integrations'->>'All')::bool AS integrations_all,
+    (body->'integrations'->>'Mixpanel')::bool AS integrations_mixpanel,
+    (body->'integrations'->>'Salesforce')::bool AS integrations_salesforce,
     body->>'messageId' AS messageId,
-    try_parse_monotonic_iso8601_timestamp(body->>'receivedAt') AS receivedAt,
-    try_parse_monotonic_iso8601_timestamp(body->>'sentAt') AS sentAt,
+    try_parse_monotonic_iso8601_timestamp(body->>'receivedAt') AS received_at,
+    try_parse_monotonic_iso8601_timestamp(body->>'sentAt') AS sent_at,
     try_parse_monotonic_iso8601_timestamp(body->>'timestamp') AS timestamp,
     body->'traits'->>'name' AS traits_name,
     body->'traits'->>'email' AS traits_email,
@@ -194,7 +194,7 @@ CREATE VIEW parse_segment AS SELECT
     (body->'traits'->'address'->>'postalCode') AS traits_address_postalCode,
     body->'traits'->'address'->>'country' AS traits_address_country,
     body->>'type' AS type,
-    body->>'userId' AS userId,
+    body->>'userId' AS user_id,
     (body->>'version') AS version
 FROM my_segment_source;
 ```

--- a/doc/user/content/ingest-data/segment.md
+++ b/doc/user/content/ingest-data/segment.md
@@ -132,12 +132,12 @@ CREATE VIEW parse_segment AS SELECT
     body->>'name' AS name,
     body->'properties'->>'title' AS properties_title,
     body->'properties'->>'url' AS properties_url,
-    (body->>'receivedAt')::timestamp AS receivedAt,
-    (body->>'sentAt')::timestamp AS sentAt,
-    (body->>'timestamp')::timestamp AS timestamp,
+    try_parse_monotonic_iso8601_timestamp(body->>'receivedAt') AS receivedAt,
+    try_parse_monotonic_iso8601_timestamp(body->>'sentAt') AS sentAt,
+    try_parse_monotonic_iso8601_timestamp(body->>'timestamp') AS timestamp,
     body->>'type' AS type,
     body->>'userId' AS userId,
-    (body->>'version')::timestamp AS version
+    try_parse_monotonic_iso8601_timestamp(body->>'version') AS version
 FROM my_segment_source;
 ```
 {{< /tab >}}
@@ -148,7 +148,7 @@ FROM my_segment_source;
 CREATE VIEW parse_segment AS SELECT
     body->>'anonymousId' AS anonymousId,
     body->'context'->'library'->>'name' AS context_library_name,
-    (body->'context'->'library'->>'version')::timestamp AS context_library_version,
+    (body->'context'->'library'->>'version') AS context_library_version,
     body->'context'->'page'->>'path' AS context_page_path,
     body->'context'->'page'->>'referrer' AS context_page_referrer,
     body->'context'->'page'->>'search' AS context_page_search,
@@ -159,12 +159,12 @@ CREATE VIEW parse_segment AS SELECT
     body->>'event' AS event,
     body->>'messageId' AS messageId,
     body->'properties'->>'title' AS properties_title,
-    (body->>'receivedAt')::timestamp AS receivedAt,
-    (body->>'sentAt')::timestamp AS sentAt,
-    (body->>'timestamp')::timestamp AS timestamp,
+    try_parse_monotonic_iso8601_timestamp(body->>'receivedAt') AS receivedAt,
+    try_parse_monotonic_iso8601_timestamp(body->>'sentAt') AS sentAt,
+    try_parse_monotonic_iso8601_timestamp(body->>'timestamp') AS timestamp,
     body->>'type' AS type,
     body->>'userId' AS userId,
-    (body->>'originalTimestamp')::timestamp AS originalTimestamp
+    try_parse_monotonic_iso8601_timestamp(body->>'originalTimestamp') AS originalTimestamp
 FROM my_segment_source;
 ```
 
@@ -181,9 +181,9 @@ CREATE VIEW parse_segment AS SELECT
     (body->'integrations'->>'Mixpanel')::bool AS integrations_Mixpanel,
     (body->'integrations'->>'Salesforce')::bool AS integrations_Salesforce,
     body->>'messageId' AS messageId,
-    (body->>'receivedAt')::timestamp AS receivedAt,
-    (body->>'sentAt')::timestamp AS sentAt,
-    (body->>'timestamp')::timestamp AS timestamp,
+    try_parse_monotonic_iso8601_timestamp(body->>'receivedAt') AS receivedAt,
+    try_parse_monotonic_iso8601_timestamp(body->>'sentAt') AS sentAt,
+    try_parse_monotonic_iso8601_timestamp(body->>'timestamp') AS timestamp,
     body->'traits'->>'name' AS traits_name,
     body->'traits'->>'email' AS traits_email,
     body->'traits'->>'plan' AS traits_plan,
@@ -191,18 +191,20 @@ CREATE VIEW parse_segment AS SELECT
     body->'traits'->'address'->>'street' AS traits_address_street,
     body->'traits'->'address'->>'city' AS traits_address_city,
     body->'traits'->'address'->>'state' AS traits_address_state,
-    (body->'traits'->'address'->>'postalCode')::timestamp AS traits_address_postalCode,
+    (body->'traits'->'address'->>'postalCode') AS traits_address_postalCode,
     body->'traits'->'address'->>'country' AS traits_address_country,
     body->>'type' AS type,
     body->>'userId' AS userId,
-    (body->>'version')::timestamp AS version
+    (body->>'version') AS version
 FROM my_segment_source;
 ```
 {{< /tab >}}
 {{< /tabs >}}
 
 
-This view parses the incoming data, transforming the nested JSON structure into discernible columns, such as `type` or `userId`.
+This view parses the incoming data, transforming the nested JSON structure into discernible columns, such as `type` or `userId`. It uses
+the [`try_parse_monotonic_iso8601_timestamp`](/sql/functions/pushdown/) function when parsing timestamps, to enable
+[temporal filter pushdown](/transform-data/patterns/temporal-filters/#temporal-filter-pushdown).
 
 Furthermore, with the vast amount of data processed and potential network issues, it's not uncommon to receive duplicate records. You can use the
 `DISTINCT` clause to remove duplicates, for more details, refer to the webhook source [documentation](/sql/create-source/webhook/#handling-duplicated-and-partial-events).

--- a/doc/user/content/ingest-data/snowcatcloud.md
+++ b/doc/user/content/ingest-data/snowcatcloud.md
@@ -109,16 +109,19 @@ This will show you the last ten records ingested from SnowcatCloud. Note that wh
 
 ## Step 6. Parse Incoming Data
 
-The query below parses the incoming data, transforming the nested JSON structure into discernible columns on a materialized view. Refer to SnowcatCloud's [documentation](https://docs.snowcatcloud.com/) on which columns are available for your pipeline (enrichments).
+The query below parses the incoming data, transforming the nested JSON structure into discernible columns on a materialized view. It uses
+the [`try_parse_monotonic_iso8601_timestamp`](/sql/functions/pushdown/) function when parsing timestamps, to enable
+[temporal filter pushdown](/transform-data/patterns/temporal-filters/#temporal-filter-pushdown). Refer to SnowcatCloud's
+[documentation](https://docs.snowcatcloud.com/) on which columns are available for your pipeline (enrichments).
 
 ```sql
 CREATE MATERIALIZED VIEW events AS
 SELECT
     body ->> 'app_id' AS app_id,
     body ->> 'platform' AS platform,
-    (body ->> 'etl_tstamp')::timestamp AS etl_tstamp,
-    (body ->> 'collector_tstamp')::timestamp AS collector_tstamp,
-    (body ->> 'dvce_created_tstamp')::timestamp AS dvce_created_tstamp,
+    try_parse_monotonic_iso8601_timestamp(body ->> 'etl_tstamp') AS etl_tstamp,
+    try_parse_monotonic_iso8601_timestamp(body ->> 'collector_tstamp') AS collector_tstamp,
+    try_parse_monotonic_iso8601_timestamp(body ->> 'dvce_created_tstamp') AS dvce_created_tstamp,
     body ->> 'event' AS event,
     body ->> 'event_id' AS event_id,
     body ->> 'txn_id' AS txn_id,
@@ -230,11 +233,11 @@ SELECT
     body ->> 'mkt_clickid' AS mkt_clickid,
     body ->> 'mkt_network' AS mkt_network,
     body ->> 'etl_tags' AS etl_tags,
-    (body ->> 'dvce_sent_tstamp')::timestamp AS dvce_sent_tstamp,
+    try_parse_monotonic_iso8601_timestamp(body ->> 'dvce_sent_tstamp') AS dvce_sent_tstamp,
     body ->> 'refr_domain_userid' AS refr_domain_userid,
-    (body ->> 'refr_dvce_tstamp')::timestamp AS refr_dvce_tstamp,
+    try_parse_monotonic_iso8601_timestamp(body ->> 'refr_dvce_tstamp') AS refr_dvce_tstamp,
     body ->> 'domain_sessionid' AS domain_sessionid,
-    (body ->> 'derived_tstamp')::timestamp AS derived_tstamp,
+    try_parse_monotonic_iso8601_timestamp(body ->> 'derived_tstamp') AS derived_tstamp,
     body ->> 'event_vendor' AS event_vendor,
     body ->> 'event_name' AS event_name,
     body ->> 'event_format' AS event_format,

--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -238,8 +238,8 @@ CREATE MATERIALIZED VIEW my_build_jobs_merged IN CLUSTER my_compute_cluster AS (
   FROM (
     SELECT
       body->>'id' as id,
-      (body->>'started_at')::timestamptz as started_at,
-      (body->>'finished_at')::timestamptz as finished_at
+      try_parse_monotonic_iso8601_timestamp(body->>'started_at') as started_at,
+      try_parse_monotonic_iso8601_timestamp(body->>'finished_at') as finished_at
     FROM my_build_jobs_source
   )
   ORDER BY id, finished_at NULLS LAST, started_at NULLS LAST
@@ -248,9 +248,8 @@ CREATE MATERIALIZED VIEW my_build_jobs_merged IN CLUSTER my_compute_cluster AS (
 
 {{< note >}}
 
-If the feature is enabled, when casting from `text` to `timestamp` you should prefer to use the
-[`try_parse_monotonic_iso8601_timestamp`](/sql/functions/pushdown/) function, which enables
-[temporal filter pushdown](/transform-data/patterns/temporal-filters/#temporal-filter-pushdown).
+When casting from `text` to `timestamp` you should prefer to use the [`try_parse_monotonic_iso8601_timestamp`](/sql/functions/pushdown/)
+function, which enables [temporal filter pushdown](/transform-data/patterns/temporal-filters/#temporal-filter-pushdown).
 
 {{< /note >}}
 


### PR DESCRIPTION
Recently we moved `try_parse_monotonic_iso8601_timestamp` to public preview, users should prefer that over casting a string to timestamp, because this function enables filter pushdown.

[Preview Docs](https://preview.materialize.com/materialize/23781/)

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/23760

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Updates user documentation for webhook sources to recommend `try_parse_monotonic_iso8601_timestamp`.