### PR TITLE
MzArrange specifies the trace type itself

### DIFF
--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -41,7 +41,7 @@ use uuid::Uuid;
 use crate::extensions::arrange::MzArrange;
 use crate::logging::{ComputeLog, EventQueue, LogVariant, PermutedRowPacker, SharedLoggingState};
 use crate::metrics::LoggingMetrics;
-use crate::typedefs::{KeysValsHandle, RowSpine};
+use crate::typedefs::KeysValsHandle;
 
 /// Type alias for a logger of compute events.
 pub type Logger = timely::logging_core::Logger<ComputeEvent, WorkerIdentifier>;
@@ -374,9 +374,7 @@ pub(super) fn construct<A: Allocate + 'static>(
         for (variant, collection) in logs {
             let variant = LogVariant::Compute(variant);
             if config.index_logs.contains_key(&variant) {
-                let trace = collection
-                    .mz_arrange::<RowSpine<_, _, _, _>>(&format!("Arrange {variant:?}"))
-                    .trace;
+                let trace = collection.mz_arrange(&format!("Arrange {variant:?}")).trace;
                 traces.insert(variant, (trace, Rc::clone(&token)));
             }
         }

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -34,7 +34,7 @@ use crate::logging::compute::ComputeEvent;
 use crate::logging::{
     DifferentialLog, EventQueue, LogVariant, PermutedRowPacker, SharedLoggingState,
 };
-use crate::typedefs::{KeysValsHandle, RowSpine};
+use crate::typedefs::KeysValsHandle;
 
 /// Constructs the logging dataflow for differential logs.
 ///
@@ -117,7 +117,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(DifferentialLog::ArrangementBatches);
         let arrangement_batches = batches
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Differential batches")
+            .mz_arrange_core(Pipeline, "PreArrange Differential batches")
             .as_collection(move |op, ()| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*op)),
@@ -127,7 +127,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(DifferentialLog::ArrangementRecords);
         let arrangement_records = records
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Differential records")
+            .mz_arrange_core(Pipeline, "PreArrange Differential records")
             .as_collection(move |op, ()| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*op)),
@@ -138,7 +138,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(DifferentialLog::Sharing);
         let sharing = sharing
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Differential sharing")
+            .mz_arrange_core(Pipeline, "PreArrange Differential sharing")
             .as_collection(move |op, ()| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*op)),
@@ -158,9 +158,7 @@ pub(super) fn construct<A: Allocate>(
         for (variant, collection) in logs {
             let variant = LogVariant::Differential(variant);
             if config.index_logs.contains_key(&variant) {
-                let trace = collection
-                    .mz_arrange::<RowSpine<_, _, _, _>>(&format!("Arrange {variant:?}"))
-                    .trace;
+                let trace = collection.mz_arrange(&format!("Arrange {variant:?}")).trace;
                 traces.insert(variant, (trace, Rc::clone(&token)));
             }
         }

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -27,7 +27,7 @@ use timely::dataflow::operators::Filter;
 
 use crate::extensions::arrange::MzArrange;
 use crate::logging::{EventQueue, LogVariant, TimelyLog};
-use crate::typedefs::{KeysValsHandle, RowSpine};
+use crate::typedefs::KeysValsHandle;
 
 pub(super) type ReachabilityEvent = (
     Vec<usize>,
@@ -105,7 +105,7 @@ pub(super) fn construct<A: Allocate>(
 
         let updates = updates
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely reachability");
+            .mz_arrange_core(Pipeline, "PreArrange Timely reachability");
 
         let mut result = BTreeMap::new();
         for variant in logs_active {
@@ -146,9 +146,7 @@ pub(super) fn construct<A: Allocate>(
                         (key_row, value_row)
                     });
 
-                let trace = updates
-                    .mz_arrange::<RowSpine<_, _, _, _>>(&format!("Arrange {variant:?}"))
-                    .trace;
+                let trace = updates.mz_arrange(&format!("Arrange {variant:?}")).trace;
                 result.insert(variant.clone(), (trace, Rc::clone(&token)));
             }
         }

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -300,7 +300,7 @@ where
             // TODO(vmarcos): We should implement further arrangement specialization here (#22104).
             // By knowing how types propagate through joins we could specialize intermediate
             // arrangements as well, either in values or eventually in keys.
-            let arranged = keyed.mz_arrange::<RowSpine<_, _, _, _>>("JoinStage");
+            let arranged = keyed.mz_arrange("JoinStage");
             joined = JoinedFlavor::Local(SpecializedArrangement::RowRow(arranged));
         }
 

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -309,7 +309,7 @@ where
         let aggregate_types_err = aggregate_types.clone();
         use differential_dataflow::collection::concatenate;
         let (oks, errs) = concatenate(scope, to_concat)
-            .mz_arrange::<RowSpine<_, _, _, _>>("Arrange ReduceCollation")
+            .mz_arrange("Arrange ReduceCollation")
             .reduce_pair::<_, RowSpine<_, _, _, _>, _, ErrValSpine<_, _, _>>(
                 "ReduceCollation",
                 "ReduceCollation Errors",
@@ -485,7 +485,7 @@ where
         );
 
         let (output, errors) = collection
-            .mz_arrange::<Tr>(&input_name)
+            .mz_arrange(&input_name)
             .reduce_pair::<_, Tr, _, ErrValSpine<_, _, _>>(
                 &output_name,
                 "DistinctByErrorCheck",
@@ -545,7 +545,7 @@ where
                 .push(result.as_collection(move |key, val| (key.clone(), (index, val.clone()))));
         }
         let output = differential_dataflow::collection::concatenate(&mut input.scope(), to_collect)
-            .mz_arrange::<RowSpine<_, _, _, _>>("Arranged ReduceFuseBasic input")
+            .mz_arrange("Arranged ReduceFuseBasic input")
             .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceFuseBasic", {
                 move |_key, input, output| {
                     let binding = SharedRow::get();
@@ -620,7 +620,7 @@ where
             }
         }
 
-        let arranged = partial.mz_arrange::<RowSpine<_, Row, _, _>>("Arranged ReduceInaccumulable");
+        let arranged = partial.mz_arrange("Arranged ReduceInaccumulable");
         let oks = arranged.mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceInaccumulable", {
             move |_key, source, target| {
                 // We respect the multiplicity here (unlike in hierarchical aggregation)
@@ -704,9 +704,7 @@ where
 
         let input: KeyCollection<_, _, _> = input.into();
         input
-            .mz_arrange::<RowKeySpine<(Row, Row), _, _>>(
-                "Arranged ReduceInaccumulable Distinct [val: empty]",
-            )
+            .mz_arrange("Arranged ReduceInaccumulable Distinct [val: empty]")
             .mz_reduce_abelian::<_, Tr>(&output_name, move |_, source, t| {
                 if let Some(err) = Tr::ValOwned::into_error() {
                     for (value, count) in source.iter() {
@@ -819,8 +817,7 @@ where
             let error_logger = self.error_logger();
             // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
             // view mz_internal.mz_expected_group_size_advice.
-            let arranged =
-                partial.mz_arrange::<RowSpine<_, Vec<Row>, _, _>>("Arrange ReduceMinsMaxes");
+            let arranged = partial.mz_arrange("Arrange ReduceMinsMaxes");
             // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
             // but we then wouldn't be able to do this error check conditionally.  See its documentation
             // for the rationale around using a second reduction here.
@@ -890,8 +887,7 @@ where
         let error_logger = self.error_logger();
         // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
         // view mz_internal.mz_expected_group_size_advice.
-        let arranged_input =
-            input.mz_arrange::<RowSpine<_, Vec<Row>, _, _>>("Arranged MinsMaxesHierarchical input");
+        let arranged_input = input.mz_arrange("Arranged MinsMaxesHierarchical input");
 
         arranged_input
             .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>(
@@ -996,7 +992,7 @@ where
         });
         let partial: KeyCollection<_, _, _> = partial.into();
         let output = partial
-            .mz_arrange::<RowKeySpine<_, _, Vec<ReductionMonoid>>>("ArrangeMonotonic [val: empty]")
+            .mz_arrange("ArrangeMonotonic [val: empty]")
             .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceMonotonic", {
                 move |_key, input, output| {
                     let binding = SharedRow::get();
@@ -1101,9 +1097,7 @@ where
                     (key, row_builder.clone())
                 })
                 .map(|k| (k, ()))
-                .mz_arrange::<RowKeySpine<(Row, Row), _, _>>(
-                    "Arranged Accumulable Distinct [val: empty]",
-                )
+                .mz_arrange("Arranged Accumulable Distinct [val: empty]")
                 .mz_reduce_abelian::<_, RowKeySpine<_, _, _>>(
                     "Reduced Accumulable Distinct [val: empty]",
                     move |_k, _s, t| t.push(((), 1)),
@@ -1132,7 +1126,7 @@ where
         let error_logger = self.error_logger();
         let err_full_aggrs = full_aggrs.clone();
         let (arranged_output, arranged_errs) = collection
-            .mz_arrange::<RowKeySpine<_, _, (Vec<Accum>, Diff)>>("ArrangeAccumulable [val: empty]")
+            .mz_arrange("ArrangeAccumulable [val: empty]")
             .reduce_pair::<_, RowSpine<_, _, _, _>, _, ErrValSpine<_, _, _>>(
                 "ReduceAccumulable",
                 "AccumulableErrorCheck",

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -362,7 +362,7 @@ where
             })
             .into();
         let result = partial
-            .mz_arrange::<RowKeySpine<Row, _, _>>("Arranged MonotonicTop1 partial [val: empty]")
+            .mz_arrange("Arranged MonotonicTop1 partial [val: empty]")
             .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("MonotonicTop1", {
                 move |_key, input, output| {
                     let accum: &monoids::Top1Monoid = &input[0].1;
@@ -391,7 +391,7 @@ where
     // NOTE(vmarcos): The arranged input operator name below is used in the tuning advice
     // built-in view mz_internal.mz_expected_group_size_advice.
     input
-        .mz_arrange::<RowSpine<(Row, u64), _, _, _>>("Arranged TopK input")
+        .mz_arrange("Arranged TopK input")
         .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("Reduced TopK input", {
             move |_key, source, target: &mut Vec<(R, Diff)>| {
                 if let Some(err) = R::into_error() {


### PR DESCRIPTION
This is a switch from letting the caller determine the trace type. Most of the changes are mechanical, but there are some places where we used the trace in an unexpected way, and those have been corrected.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
