### PR TITLE
DNM: GAT demonstration

### DIFF
--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -337,39 +337,39 @@ where
                 allocations += usize::from(cap > 0);
             };
             trace.map_batches(|batch| {
-                batch.storage.keys.heap_size(&mut callback);
+                // batch.storage.keys.heap_size(&mut callback);
                 offset_list_size(&batch.storage.keys_offs, &mut callback);
-                batch.storage.vals.heap_size(&mut callback);
+                // batch.storage.vals.heap_size(&mut callback);
                 offset_list_size(&batch.storage.vals_offs, &mut callback);
-                batch.storage.updates.heap_size(&mut callback);
+                // batch.storage.updates.heap_size(&mut callback);
             });
             (size, capacity, allocations)
         })
     }
 }
 
-impl<G, K, T, R> ArrangementSize for Arranged<G, TraceAgent<RowKeySpine<K, T, R>>>
-where
-    G: Scope<Timestamp = T>,
-    G::Timestamp: Lattice + Ord,
-    K: Data + Columnation,
-    T: Lattice + Timestamp + Columnation,
-    R: Semigroup + Columnation,
-{
-    fn log_arrangement_size(self) -> Self {
-        log_arrangement_size_inner(self, |trace| {
-            let (mut size, mut capacity, mut allocations) = (0, 0, 0);
-            let mut callback = |siz, cap| {
-                size += siz;
-                capacity += cap;
-                allocations += usize::from(cap > 0);
-            };
-            trace.map_batches(|batch| {
-                batch.storage.keys.heap_size(&mut callback);
-                offset_list_size(&batch.storage.keys_offs, &mut callback);
-                batch.storage.updates.heap_size(&mut callback);
-            });
-            (size, capacity, allocations)
-        })
-    }
-}
+// impl<G, K, T, R> ArrangementSize for Arranged<G, TraceAgent<RowKeySpine<K, T, R>>>
+// where
+//     G: Scope<Timestamp = T>,
+//     G::Timestamp: Lattice + Ord,
+//     K: Data + Columnation,
+//     T: Lattice + Timestamp + Columnation,
+//     R: Semigroup + Columnation,
+// {
+//     fn log_arrangement_size(self) -> Self {
+//         log_arrangement_size_inner(self, |trace| {
+//             let (mut size, mut capacity, mut allocations) = (0, 0, 0);
+//             let mut callback = |siz, cap| {
+//                 size += siz;
+//                 capacity += cap;
+//                 allocations += usize::from(cap > 0);
+//             };
+//             trace.map_batches(|batch| {
+//                 // batch.storage.keys.heap_size(&mut callback);
+//                 offset_list_size(&batch.storage.keys_offs, &mut callback);
+//                 // batch.storage.updates.heap_size(&mut callback);
+//             });
+//             (size, capacity, allocations)
+//         })
+//     }
+// }

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -118,7 +118,7 @@ pub(super) fn construct<A: Allocate>(
         let arrangement_batches = batches
             .as_collection()
             .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Differential batches")
-            .as_collection(move |op, ()| {
+            .as_collection(move |op, _| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*op)),
                     Datum::UInt64(u64::cast_from(worker_id)),
@@ -128,7 +128,7 @@ pub(super) fn construct<A: Allocate>(
         let arrangement_records = records
             .as_collection()
             .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Differential records")
-            .as_collection(move |op, ()| {
+            .as_collection(move |op, _| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*op)),
                     Datum::UInt64(u64::cast_from(worker_id)),
@@ -139,7 +139,7 @@ pub(super) fn construct<A: Allocate>(
         let sharing = sharing
             .as_collection()
             .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Differential sharing")
-            .as_collection(move |op, ()| {
+            .as_collection(move |op, _| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*op)),
                     Datum::UInt64(u64::cast_from(worker_id)),

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -156,14 +156,14 @@ pub(super) fn construct<A: Allocate>(
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*id)),
                     Datum::UInt64(u64::cast_from(worker_id)),
-                    Datum::String(name),
+                    Datum::String(&name),
                 ])
             });
         let mut packer = PermutedRowPacker::new(TimelyLog::Channels);
         let channels = channels
             .as_collection()
             .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely operates")
-            .as_collection(move |datum, ()| {
+            .as_collection(move |datum, _| {
                 let (source_node, source_port) = datum.source;
                 let (target_node, target_port) = datum.target;
                 packer.pack_slice(&[
@@ -195,7 +195,7 @@ pub(super) fn construct<A: Allocate>(
         let parks = parks
             .as_collection()
             .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely parks")
-            .as_collection(move |datum, ()| {
+            .as_collection(move |datum, _| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(worker_id)),
                     Datum::UInt64(u64::try_from(datum.duration_pow).expect("duration too big")),
@@ -209,7 +209,7 @@ pub(super) fn construct<A: Allocate>(
         let batches_sent = batches_sent
             .as_collection()
             .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely batches sent")
-            .as_collection(move |datum, ()| {
+            .as_collection(move |datum, _| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(datum.channel)),
                     Datum::UInt64(u64::cast_from(worker_id)),
@@ -223,7 +223,7 @@ pub(super) fn construct<A: Allocate>(
                 Pipeline,
                 "PreArrange Timely batches received",
             )
-            .as_collection(move |datum, ()| {
+            .as_collection(move |datum, _| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(datum.channel)),
                     Datum::UInt64(u64::cast_from(datum.worker)),
@@ -234,7 +234,7 @@ pub(super) fn construct<A: Allocate>(
         let messages_sent = messages_sent
             .as_collection()
             .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely messages sent")
-            .as_collection(move |datum, ()| {
+            .as_collection(move |datum, _| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(datum.channel)),
                     Datum::UInt64(u64::cast_from(worker_id)),
@@ -248,7 +248,7 @@ pub(super) fn construct<A: Allocate>(
                 Pipeline,
                 "PreArrange Timely messages received",
             )
-            .as_collection(move |datum, ()| {
+            .as_collection(move |datum, _| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(datum.channel)),
                     Datum::UInt64(u64::cast_from(datum.worker)),

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -17,6 +17,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
+use differential_dataflow::trace::cursor::MyTrait;
 use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
 use differential_dataflow::{AsCollection, Collection, ExchangeData, Hashable};
 use mz_compute_types::plan::join::delta_join::{DeltaJoinPlan, DeltaPathPlan, DeltaStagePlan};
@@ -90,7 +91,7 @@ where
                                     if err_dedup.insert((lookup_idx, lookup_key)) {
                                         inner_errs.push(
                                             errs.enter_region(inner)
-                                                .as_collection(|k, _v| k.clone()),
+                                                .as_collection(|k, _v| k.into_owned()),
                                         );
                                     }
                                     Ok(oks.enter_region(inner))
@@ -99,7 +100,7 @@ where
                                     if err_dedup.insert((lookup_idx, lookup_key)) {
                                         inner_errs.push(
                                             errs.enter_region(inner)
-                                                .as_collection(|k, _v| k.clone()),
+                                                .as_collection(|k, _v| k.into_owned()),
                                         );
                                     }
                                     Err(oks.enter_region(inner))

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -15,6 +15,7 @@ use std::time::Instant;
 
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::arrangement::Arranged;
+use differential_dataflow::trace::cursor::MyTrait;
 use differential_dataflow::trace::TraceReader;
 use differential_dataflow::{AsCollection, Collection, Data};
 use mz_compute_types::dataflows::YieldSpec;
@@ -158,11 +159,17 @@ where
             // We can use an arrangement if it exists and an initial closure does not.
             let mut joined = match (arrangement, linear_plan.initial_closure) {
                 (Some(ArrangementFlavor::Local(oks, errs)), None) => {
-                    errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
+                    errors.push(
+                        errs.as_collection(|k, _v| k.into_owned())
+                            .enter_region(inner),
+                    );
                     JoinedFlavor::Local(oks.enter_region(inner))
                 }
                 (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
-                    errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
+                    errors.push(
+                        errs.as_collection(|k, _v| k.into_owned())
+                            .enter_region(inner),
+                    );
                     JoinedFlavor::Trace(oks.enter_region(inner))
                 }
                 (_, initial_closure) => {
@@ -327,7 +334,7 @@ where
                         (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangement::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowSpine<Row, Row, _, _>>,TraceAgent<RowSpine<Row, Row, _, _>>>(prev_keyed, next_input, None, None, None, closure),
                     };
 
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
+                    errors.push(errs1.as_collection(|k, _v| k.into_owned()));
                     errors.extend(errs2);
                     oks
                 }
@@ -339,7 +346,7 @@ where
                         (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangementImport::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowSpine<Row, Row, _, _>>,TraceEnter<TraceFrontier<TraceRowHandle<Row, Row, T, Diff>>, G::Timestamp>>(prev_keyed, next_input, None, None, None, closure),
                     };
 
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
+                    errors.push(errs1.as_collection(|k, _v| k.into_owned()));
                     errors.extend(errs2);
                     oks
                 }
@@ -400,7 +407,7 @@ where
                         ),
                     };
 
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
+                    errors.push(errs1.as_collection(|k, _v| k.into_owned()));
                     errors.extend(errs2);
                     oks
                 }
@@ -461,7 +468,7 @@ where
                         ),
                     };
 
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
+                    errors.push(errs1.as_collection(|k, _v| k.into_owned()));
                     errors.extend(errs2);
                     oks
                 }

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -108,6 +108,7 @@ use std::sync::Arc;
 use differential_dataflow::dynamic::pointstamp::PointStamp;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
+use differential_dataflow::trace::cursor::MyTrait;
 use differential_dataflow::trace::{Batch, Batcher, Trace, TraceReader};
 use differential_dataflow::{AsCollection, Collection, Data, ExchangeData, Hashable};
 use itertools::izip;
@@ -542,7 +543,7 @@ where
                 let oks_trace = oks.trace_handle();
 
                 let errs = errs
-                    .as_collection(|k, v| (k.clone(), v.clone()))
+                    .as_collection(|k, v| (k.into_owned(), v.into_owned()))
                     .leave()
                     .mz_arrange("Arrange export iterative err");
 
@@ -613,7 +614,6 @@ where
         Tr2::Batcher: Batcher<Item = ((Tr1::KeyOwned, Tr1::ValOwned), G::Timestamp, Diff)>,
         Arranged<G, TraceAgent<Tr2>>: ArrangementSize,
     {
-        use differential_dataflow::trace::cursor::MyTrait;
         oks.as_collection(|k, v| (k.into_owned(), v.into_owned()))
             .leave()
             .mz_arrange(name)
@@ -716,7 +716,7 @@ where
                         "Distinct recursive err",
                         move |_k, _s, t| t.push(((), 1)),
                     )
-                    .as_collection(|k, _| k.clone());
+                    .as_collection(|k, _| k.into_owned());
                 if let Some(token) = &self.shutdown_token.get_inner() {
                     errs = errs.with_token(Weak::clone(token));
                 }

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -17,12 +17,183 @@ use differential_dataflow::trace::implementations::ord_neu::{ColKeySpine, ColVal
 use mz_repr::{Diff, Row, Timestamp};
 use mz_storage_types::errors::DataflowError;
 
-pub type RowSpine<K, V, T, R> = ColValSpine<K, V, T, R>;
-pub type RowKeySpine<K, T, R> = ColKeySpine<K, T, R>;
-pub type ErrSpine<K, T, R> = ColKeySpine<K, T, R>;
-pub type ErrValSpine<K, T, R> = ColValSpine<K, DataflowError, T, R>;
+pub type RowRowSpine<K, V, T, R> = WrappedSpine<K, V, T, R>;
+
+// pub type RowSpine<K, V, T, R> = ColValSpine<K, V, T, R>;
+// pub type RowKeySpine<K, T, R> = ColKeySpine<K, T, R>;
+// pub type ErrSpine<K, T, R> = ColKeySpine<K, T, R>;
+// pub type ErrValSpine<K, T, R> = ColValSpine<K, DataflowError, T, R>;
+pub type RowSpine<K, V, T, R> = WrappedSpine<K, V, T, R>;
+pub type RowKeySpine<K, T, R> = WrappedSpine<K, (), T, R>;
+pub type ErrSpine<K, T, R> = WrappedSpine<K, (), T, R>;
+pub type ErrValSpine<K, T, R> = WrappedSpine<K, DataflowError, T, R>;
+
 pub type TraceRowHandle<K, V, T, R> = TraceAgent<RowSpine<K, V, T, R>>;
+// pub type TraceRowHandle<K, V, T, R> = TraceAgent<RowRowSpine<K, V, T, R>>;
 pub type TraceKeyHandle<K, T, R> = TraceAgent<RowKeySpine<K, T, R>>;
 pub type TraceErrHandle<K, T, R> = TraceAgent<ErrSpine<K, T, R>>;
 pub type KeysValsHandle = TraceRowHandle<Row, Row, Timestamp, Diff>;
 pub type ErrsHandle = TraceErrHandle<DataflowError, Timestamp, Diff>;
+
+use differential_dataflow::trace::implementations::BatchContainer;
+
+pub struct WrappedVec<T> {
+    inner: Vec<T>,
+}
+
+impl<T> Default for WrappedVec<T> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct WrappedRef<'a, T: ?Sized> {
+    pub inner: &'a T,
+}
+
+impl<'a, T: std::fmt::Display> std::fmt::Display for WrappedRef<'a, T> {
+    /// Debug representation using the internal datums
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.inner, f)
+    }
+}
+
+// All `T: Clone` also implement `ToOwned<Owned = T>`, but without the constraint Rust
+// struggles to understand why the owned type must be `T` (i.e. the one blanket impl).
+impl<T: Ord + Clone + 'static> BatchContainer for WrappedVec<T> {
+    type PushItem = T;
+    type ReadItem<'a> = WrappedRef<'a, T>;
+
+    fn push(&mut self, item: T) {
+        self.inner.push(item);
+    }
+    fn copy_push(&mut self, item: &T) {
+        self.inner.copy(item);
+    }
+    fn copy<'a>(&mut self, item: WrappedRef<'a, T>) {
+        self.inner.push(item.inner.clone());
+    }
+    fn copy_slice(&mut self, slice: &[T]) {
+        self.inner.extend_from_slice(slice);
+    }
+    fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
+        self.inner.extend_from_slice(&other.inner[start..end]);
+    }
+    fn with_capacity(size: usize) -> Self {
+        Self {
+            inner: Vec::with_capacity(size),
+        }
+    }
+    fn reserve(&mut self, additional: usize) {
+        self.inner.reserve(additional);
+    }
+    fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
+        Self {
+            inner: Vec::with_capacity(cont1.inner.len() + cont2.inner.len()),
+        }
+    }
+    fn index(&self, index: usize) -> Self::ReadItem<'_> {
+        WrappedRef {
+            inner: &self.inner[index],
+        }
+    }
+    fn len(&self) -> usize {
+        self.inner[..].len()
+    }
+}
+
+impl<'a, T> Copy for WrappedRef<'a, T> {}
+impl<'a, T> Clone for WrappedRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+use std::cmp::Ordering;
+impl<'a, 'b, B: Ord> PartialEq<WrappedRef<'a, B>> for WrappedRef<'b, B> {
+    fn eq(&self, other: &WrappedRef<'a, B>) -> bool {
+        self.inner.eq(other.inner)
+    }
+}
+impl<'a, B: Ord> Eq for WrappedRef<'a, B> {}
+impl<'a, 'b, B: Ord> PartialOrd<WrappedRef<'a, B>> for WrappedRef<'b, B> {
+    fn partial_cmp(&self, other: &WrappedRef<'a, B>) -> Option<Ordering> {
+        self.inner.partial_cmp(other.inner)
+    }
+}
+impl<'a, B: Ord> Ord for WrappedRef<'a, B> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+use differential_dataflow::trace::cursor::MyTrait;
+impl<'a, T: Ord + ToOwned> MyTrait<'a> for WrappedRef<'a, T> {
+    type Owned = T::Owned;
+    fn into_owned(self) -> Self::Owned {
+        self.inner.to_owned()
+    }
+    fn clone_onto(&self, other: &mut Self::Owned) {
+        <T as ToOwned>::clone_into(self.inner, other)
+    }
+    fn compare(&self, other: &Self::Owned) -> Ordering {
+        use std::borrow::Borrow;
+        self.inner.cmp(&other.borrow())
+    }
+    fn borrow_as(other: &'a Self::Owned) -> Self {
+        use std::borrow::Borrow;
+        Self {
+            inner: other.borrow(),
+        }
+    }
+}
+
+impl<'a, T> std::ops::Deref for WrappedRef<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        println!("BOO!");
+        self.inner
+    }
+}
+
+use differential_dataflow::trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
+use differential_dataflow::trace::implementations::ord_neu::{OrdValBatch, OrdValBuilder};
+use differential_dataflow::trace::implementations::spine_fueled::Spine;
+use differential_dataflow::trace::implementations::Layout;
+use differential_dataflow::trace::implementations::Update;
+use differential_dataflow::trace::rc_blanket_impls::RcBuilder;
+use std::rc::Rc;
+
+pub type WrappedSpine<K, V, T, R> = Spine<
+    Rc<OrdValBatch<Wrap<((K, V), T, R)>>>,
+    ColumnatedMergeBatcher<K, V, T, R>,
+    RcBuilder<OrdValBuilder<Wrap<((K, V), T, R)>>>,
+>;
+
+/// A layout based on timely stacks
+pub struct Wrap<U: Update> {
+    phantom: std::marker::PhantomData<U>,
+}
+
+impl<U: Update> Layout for Wrap<U>
+where
+    U::Key: 'static,
+    U::Val: 'static,
+{
+    type Target = U;
+    type KeyContainer = WrappedVec<U::Key>;
+    type ValContainer = WrappedVec<U::Val>;
+    type UpdContainer = Vec<(U::Time, U::Diff)>;
+}
+
+use mz_repr::fixed_length::IntoRowByTypes;
+use mz_repr::ColumnType;
+impl<'b, T: IntoRowByTypes> IntoRowByTypes for WrappedRef<'b, T> {
+    type DatumIter<'a> = T::DatumIter<'a> where T: 'a, Self: 'a;
+    fn into_datum_iter<'a>(&'a self, types: Option<&[ColumnType]>) -> Self::DatumIter<'a> {
+        self.inner.into_datum_iter(types)
+    }
+}

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -233,7 +233,7 @@ where
         R: Semigroup + differential_dataflow::ExchangeData,
         G::Timestamp: Lattice,
         Tr: Trace
-            + for<'a> TraceReader<Key<'a> = &'a D1, Val<'a> = &'a (), Time = G::Timestamp, Diff = R>
+            + TraceReader<KeyOwned = D1, ValOwned = (), Time = G::Timestamp, Diff = R>
             + 'static,
         Tr::Batch: Batch,
         Tr::Batcher: Batcher<Item = ((D1, ()), G::Timestamp, R), Time = G::Timestamp>,
@@ -551,7 +551,7 @@ where
         R: Semigroup + differential_dataflow::ExchangeData,
         G::Timestamp: Lattice + Ord,
         Tr: Trace
-            + for<'a> TraceReader<Key<'a> = &'a D1, Val<'a> = &'a (), Time = G::Timestamp, Diff = R>
+            + TraceReader<KeyOwned = D1, ValOwned = (), Time = G::Timestamp, Diff = R>
             + 'static,
         Tr::Batch: Batch,
         Tr::Batcher: Batcher<Item = ((D1, ()), G::Timestamp, R), Time = G::Timestamp>,
@@ -588,10 +588,11 @@ where
                 data.hash(&mut h);
                 h.finish()
             });
+            use differential_dataflow::trace::cursor::MyTrait;
             // Access to `arrange_core` is OK because we specify the trace and don't hold on to it.
             #[allow(clippy::disallowed_methods)]
             self.arrange_core::<_, Tr>(exchange, name)
-                .as_collection(|k, _v| k.clone())
+                .as_collection(|k, _v| k.into_owned())
         } else {
             self
         }


### PR DESCRIPTION
These are changes that get us to a state where one can use a GAT-oriented spine. This is not meant to be merged, and just comments out some complicated code to make things work. We have to chase down several issues, and there is still a fair bit to explore.

cc: @antiguru, @ParkMyCar 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
