### PR TITLE
Make `text_to_mz_timestamp` try harder

### DIFF
--- a/doc/user/content/sql/types/mz_timestamp.md
+++ b/doc/user/content/sql/types/mz_timestamp.md
@@ -28,7 +28,7 @@ Detail | Info
 For details about casting, including contexts, see [Functions:
 Cast](../../functions/cast).
 
-Integer, numeric, and text casts must be in the form of milliseconds since the Unix epoch.
+Integer and numeric casts must be in the form of milliseconds since the Unix epoch. Casting from `text` can be either also in the form of milliseconds since the Unix epoch or in a human-readable form that is the same as for the [`timestamp`](../timestamp) type.
 
 From | To | Required context
 -----|----|--------

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -92,6 +92,7 @@ pub enum Datum<'a> {
     /// A time.
     Time(NaiveTime),
     /// A date and time, without a timezone.
+    /// Note that this is not [`crate::Timestamp`]! That's in [`Datum::MzTimestamp`].
     Timestamp(CheckedTimestamp<NaiveDateTime>),
     /// A date and time, with a timezone.
     TimestampTz(CheckedTimestamp<DateTime<Utc>>),
@@ -1475,7 +1476,7 @@ pub enum ScalarType {
     /// A vector on small ints; this is a legacy type in PG used primarily in
     /// the catalog.
     Int2Vector,
-    /// A Materialize timestamp.
+    /// A Materialize timestamp. The type of [`Datum::MzTimestamp`].
     MzTimestamp,
     Range {
         element_type: Box<ScalarType>,

--- a/test/sqllogictest/mztimestamp.slt
+++ b/test/sqllogictest/mztimestamp.slt
@@ -43,3 +43,25 @@ CREATE MATERIALIZED VIEW valid AS
 SELECT *
 FROM intervals
 WHERE mz_now() BETWEEN a AND b;
+
+query TTBBB
+SELECT
+  '1702129950259'::mz_timestamp::text,
+  '1990-01-04 11:00'::mz_timestamp::text,
+  greatest('1990-01-04 11:00', mz_now()) > '1990-01-04 11:00'::mz_timestamp,
+     least('1990-01-04 11:00', mz_now()) > '1990-01-04 11:00'::mz_timestamp,
+  greatest(mz_now(), '1990-01-04 11:00') > '3000-01-04 11:00'::mz_timestamp
+----
+1702129950259
+631450800000
+true
+false
+false
+
+# Bad timestamp string
+query error db error: ERROR: invalid input syntax for type mz_timestamp: could not parse mz_timestamp: could not parse as number of milliseconds since epoch; could not parse as date and time: invalid input syntax for type timestamp: YEAR, MONTH, DAY are all required: "1990\-01": "1990\-01"
+SELECT '1990-01'::mz_timestamp;
+
+# This would be negative milliseconds since the Unix epoch
+query error db error: ERROR: invalid input syntax for type mz_timestamp: could not parse mz_timestamp: out of range for mz_timestamp: "1960\-01\-01 11:00"
+SELECT '1960-01-01 11:00'::mz_timestamp;


### PR DESCRIPTION
This makes the cast `text_to_mz_timestamp` try harder: if parsing the string as an `u64` fails, then try to also parse the string as date and time. In other words, it makes
`'1990-01-04 11:00'::mz_timestamp`
do the same as
`'1990-01-04 11:00'::timestamp::mz_timestamp`.

### Motivation
The motivation is that with the REFRESH options we’d like to make
`REFRESH AT greatest('1990-01-04 11:00', mz_now())`
ergonomic, but currently the user has to write it with 2 explicit casts:
`REFRESH AT greatest('1990-01-04 11:00'::timestamp::mz_timestamp, mz_now())`.
See [here](https://materializeinc.slack.com/archives/C063H5S7NKE/p1702125587550089?thread_ts=1699543250.405409&cid=C063H5S7NKE).

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
