### PR TITLE
Spine rationalization

### DIFF
--- a/src/compute/src/arrangement/manager.rs
+++ b/src/compute/src/arrangement/manager.rs
@@ -27,7 +27,7 @@ use timely::progress::timestamp::Refines;
 use crate::logging::compute::{LogImportFrontiers, Logger};
 use crate::metrics::TraceMetrics;
 use crate::render::context::SpecializedArrangementImport;
-use crate::typedefs::{ErrsHandle, TraceKeyHandle, TraceRowHandle};
+use crate::typedefs::{ErrAgent, KeyAgent, KeyValAgent};
 
 /// A `TraceManager` stores maps from global identifiers to the primary arranged
 /// representation of that collection.
@@ -111,8 +111,8 @@ impl TraceManager {
 /// arrangements.
 #[derive(Clone)]
 pub enum SpecializedTraceHandle {
-    RowUnit(TraceKeyHandle<Row, Timestamp, Diff>),
-    RowRow(TraceRowHandle<Row, Row, Timestamp, Diff>),
+    RowUnit(KeyAgent<Row, Timestamp, Diff>),
+    RowRow(KeyValAgent<Row, Row, Timestamp, Diff>),
 }
 
 impl SpecializedTraceHandle {
@@ -204,13 +204,13 @@ impl SpecializedTraceHandle {
 #[derive(Clone)]
 pub struct TraceBundle {
     oks: SpecializedTraceHandle,
-    errs: ErrsHandle,
+    errs: ErrAgent<Timestamp, Diff>,
     to_drop: Option<Rc<dyn Any>>,
 }
 
 impl TraceBundle {
     /// Constructs a new trace bundle out of an `oks` trace and `errs` trace.
-    pub fn new(oks: SpecializedTraceHandle, errs: ErrsHandle) -> TraceBundle {
+    pub fn new(oks: SpecializedTraceHandle, errs: ErrAgent<Timestamp, Diff>) -> TraceBundle {
         TraceBundle {
             oks,
             errs,
@@ -235,7 +235,7 @@ impl TraceBundle {
     }
 
     /// Returns a mutable reference to the `errs` trace.
-    pub fn errs_mut(&mut self) -> &mut ErrsHandle {
+    pub fn errs_mut(&mut self) -> &mut ErrAgent<Timestamp, Diff> {
         &mut self.errs
     }
 

--- a/src/compute/src/arrangement/manager.rs
+++ b/src/compute/src/arrangement/manager.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 use differential_dataflow::lattice::{antichain_join, Lattice};
 use differential_dataflow::operators::arrange::ShutdownButton;
 use differential_dataflow::trace::TraceReader;
-use mz_repr::{Diff, GlobalId, Row, Timestamp};
+use mz_repr::{Diff, GlobalId, Timestamp};
 use timely::dataflow::operators::CapabilitySet;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
@@ -27,7 +27,7 @@ use timely::progress::timestamp::Refines;
 use crate::logging::compute::{LogImportFrontiers, Logger};
 use crate::metrics::TraceMetrics;
 use crate::render::context::SpecializedArrangementImport;
-use crate::typedefs::{ErrAgent, KeyAgent, KeyValAgent};
+use crate::typedefs::{ErrAgent, RowAgent, RowRowAgent};
 
 /// A `TraceManager` stores maps from global identifiers to the primary arranged
 /// representation of that collection.
@@ -111,8 +111,8 @@ impl TraceManager {
 /// arrangements.
 #[derive(Clone)]
 pub enum SpecializedTraceHandle {
-    RowUnit(KeyAgent<Row, Timestamp, Diff>),
-    RowRow(KeyValAgent<Row, Row, Timestamp, Diff>),
+    RowUnit(RowAgent<Timestamp, Diff>),
+    RowRow(RowRowAgent<Timestamp, Diff>),
 }
 
 impl SpecializedTraceHandle {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -955,8 +955,8 @@ impl IndexPeek {
         match oks {
             SpecializedTraceHandle::RowUnit(oks_handle) => {
                 // Explicit types required due to Rust type inference limitations.
-                use crate::typedefs::RowKeySpine;
-                Self::collect_ok_finished_data::<RowKeySpine<Row, _, _>>(
+                use crate::typedefs::KeySpine;
+                Self::collect_ok_finished_data::<KeySpine<Row, _, _>>(
                     peek,
                     oks_handle,
                     None,
@@ -966,8 +966,8 @@ impl IndexPeek {
             }
             SpecializedTraceHandle::RowRow(oks_handle) => {
                 // Explicit types required due to Rust type inference limitations.
-                use crate::typedefs::RowSpine;
-                Self::collect_ok_finished_data::<RowSpine<Row, Row, _, _>>(
+                use crate::typedefs::KeyValSpine;
+                Self::collect_ok_finished_data::<KeyValSpine<Row, Row, _, _>>(
                     peek,
                     oks_handle,
                     None,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -955,8 +955,8 @@ impl IndexPeek {
         match oks {
             SpecializedTraceHandle::RowUnit(oks_handle) => {
                 // Explicit types required due to Rust type inference limitations.
-                use crate::typedefs::KeySpine;
-                Self::collect_ok_finished_data::<KeySpine<Row, _, _>>(
+                use crate::typedefs::RowSpine;
+                Self::collect_ok_finished_data::<RowSpine<_, _>>(
                     peek,
                     oks_handle,
                     None,
@@ -966,8 +966,8 @@ impl IndexPeek {
             }
             SpecializedTraceHandle::RowRow(oks_handle) => {
                 // Explicit types required due to Rust type inference limitations.
-                use crate::typedefs::KeyValSpine;
-                Self::collect_ok_finished_data::<KeyValSpine<Row, Row, _, _>>(
+                use crate::typedefs::RowRowSpine;
+                Self::collect_ok_finished_data::<RowRowSpine<_, _>>(
                     peek,
                     oks_handle,
                     None,

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -22,7 +22,7 @@ use timely::dataflow::{Scope, ScopeParent};
 use timely::progress::Timestamp;
 
 use crate::logging::compute::ComputeEvent;
-use crate::typedefs::{KeySpine, KeyValSpine};
+use crate::typedefs::{KeyAgent, KeyValAgent};
 
 /// Extension trait to arrange data.
 pub trait MzArrange
@@ -319,7 +319,7 @@ where
     }
 }
 
-impl<G, K, V, T, R> ArrangementSize for Arranged<G, TraceAgent<KeyValSpine<K, V, T, R>>>
+impl<G, K, V, T, R> ArrangementSize for Arranged<G, KeyValAgent<K, V, T, R>>
 where
     G: Scope<Timestamp = T>,
     G::Timestamp: Lattice + Ord + Columnation,
@@ -348,7 +348,7 @@ where
     }
 }
 
-impl<G, K, T, R> ArrangementSize for Arranged<G, TraceAgent<KeySpine<K, T, R>>>
+impl<G, K, T, R> ArrangementSize for Arranged<G, KeyAgent<K, T, R>>
 where
     G: Scope<Timestamp = T>,
     G::Timestamp: Lattice + Ord,

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -22,7 +22,7 @@ use timely::dataflow::{Scope, ScopeParent};
 use timely::progress::Timestamp;
 
 use crate::logging::compute::ComputeEvent;
-use crate::typedefs::{RowKeySpine, RowSpine};
+use crate::typedefs::{KeySpine, KeyValSpine};
 
 /// Extension trait to arrange data.
 pub trait MzArrange
@@ -319,7 +319,7 @@ where
     }
 }
 
-impl<G, K, V, T, R> ArrangementSize for Arranged<G, TraceAgent<RowSpine<K, V, T, R>>>
+impl<G, K, V, T, R> ArrangementSize for Arranged<G, TraceAgent<KeyValSpine<K, V, T, R>>>
 where
     G: Scope<Timestamp = T>,
     G::Timestamp: Lattice + Ord + Columnation,
@@ -348,7 +348,7 @@ where
     }
 }
 
-impl<G, K, T, R> ArrangementSize for Arranged<G, TraceAgent<RowKeySpine<K, T, R>>>
+impl<G, K, T, R> ArrangementSize for Arranged<G, TraceAgent<KeySpine<K, T, R>>>
 where
     G: Scope<Timestamp = T>,
     G::Timestamp: Lattice + Ord,

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -41,7 +41,7 @@ use uuid::Uuid;
 use crate::extensions::arrange::MzArrange;
 use crate::logging::{ComputeLog, EventQueue, LogVariant, PermutedRowPacker, SharedLoggingState};
 use crate::metrics::LoggingMetrics;
-use crate::typedefs::{KeyValSpine, RowRowAgent};
+use crate::typedefs::{RowRowAgent, RowRowSpine};
 
 /// Type alias for a logger of compute events.
 pub type Logger = timely::logging_core::Logger<ComputeEvent, WorkerIdentifier>;
@@ -375,7 +375,7 @@ pub(super) fn construct<A: Allocate + 'static>(
             let variant = LogVariant::Compute(variant);
             if config.index_logs.contains_key(&variant) {
                 let trace = collection
-                    .mz_arrange::<KeyValSpine<_, _, _, _>>(&format!("Arrange {variant:?}"))
+                    .mz_arrange::<RowRowSpine<_, _>>(&format!("Arrange {variant:?}"))
                     .trace;
                 traces.insert(variant, (trace, Rc::clone(&token)));
             }

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -21,7 +21,7 @@ use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
 use differential_dataflow::Collection;
 use mz_ore::cast::CastFrom;
-use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
+use mz_repr::{Datum, Diff, GlobalId, Timestamp};
 use mz_timely_util::replay::MzReplay;
 use prometheus::core::{AtomicF64, GenericCounter};
 use timely::communication::Allocate;
@@ -41,7 +41,7 @@ use uuid::Uuid;
 use crate::extensions::arrange::MzArrange;
 use crate::logging::{ComputeLog, EventQueue, LogVariant, PermutedRowPacker, SharedLoggingState};
 use crate::metrics::LoggingMetrics;
-use crate::typedefs::{KeyValAgent, KeyValSpine};
+use crate::typedefs::{KeyValSpine, RowRowAgent};
 
 /// Type alias for a logger of compute events.
 pub type Logger = timely::logging_core::Logger<ComputeEvent, WorkerIdentifier>;
@@ -155,7 +155,7 @@ pub(super) fn construct<A: Allocate + 'static>(
     metrics: LoggingMetrics,
     event_queue: EventQueue<ComputeEvent>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
-) -> BTreeMap<LogVariant, (KeyValAgent<Row, Row, Timestamp, Diff>, Rc<dyn Any>)> {
+) -> BTreeMap<LogVariant, (RowRowAgent<Timestamp, Diff>, Rc<dyn Any>)> {
     let logging_interval_ms = std::cmp::max(1, config.interval.as_millis());
     let worker_id = worker.index();
     let worker2 = worker.clone();

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -20,7 +20,7 @@ use differential_dataflow::logging::{
     BatchEvent, DifferentialEvent, DropEvent, MergeEvent, TraceShare,
 };
 use mz_ore::cast::CastFrom;
-use mz_repr::{Datum, Diff, Row, Timestamp};
+use mz_repr::{Datum, Diff, Timestamp};
 use mz_timely_util::buffer::ConsolidateBuffer;
 use mz_timely_util::replay::MzReplay;
 use timely::communication::Allocate;
@@ -34,7 +34,7 @@ use crate::logging::compute::ComputeEvent;
 use crate::logging::{
     DifferentialLog, EventQueue, LogVariant, PermutedRowPacker, SharedLoggingState,
 };
-use crate::typedefs::{KeyValAgent, KeyValSpine};
+use crate::typedefs::{KeyValSpine, RowRowAgent};
 
 /// Constructs the logging dataflow for differential logs.
 ///
@@ -49,7 +49,7 @@ pub(super) fn construct<A: Allocate>(
     config: &mz_compute_client::logging::LoggingConfig,
     event_queue: EventQueue<DifferentialEvent>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
-) -> BTreeMap<LogVariant, (KeyValAgent<Row, Row, Timestamp, Diff>, Rc<dyn Any>)> {
+) -> BTreeMap<LogVariant, (RowRowAgent<Timestamp, Diff>, Rc<dyn Any>)> {
     let logging_interval_ms = std::cmp::max(1, config.interval.as_millis());
     let worker_id = worker.index();
 

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -34,7 +34,7 @@ use crate::logging::compute::ComputeEvent;
 use crate::logging::{
     DifferentialLog, EventQueue, LogVariant, PermutedRowPacker, SharedLoggingState,
 };
-use crate::typedefs::{KeyValSpine, RowRowAgent};
+use crate::typedefs::{KeyValSpine, RowRowAgent, RowRowSpine};
 
 /// Constructs the logging dataflow for differential logs.
 ///
@@ -168,7 +168,7 @@ pub(super) fn construct<A: Allocate>(
             let variant = LogVariant::Differential(variant);
             if config.index_logs.contains_key(&variant) {
                 let trace = collection
-                    .mz_arrange::<KeyValSpine<_, _, _, _>>(&format!("Arrange {variant:?}"))
+                    .mz_arrange::<RowRowSpine<_, _>>(&format!("Arrange {variant:?}"))
                     .trace;
                 traces.insert(variant, (trace, Rc::clone(&token)));
             }

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -27,7 +27,7 @@ use timely::dataflow::operators::Filter;
 
 use crate::extensions::arrange::MzArrange;
 use crate::logging::{EventQueue, LogVariant, TimelyLog};
-use crate::typedefs::{KeyValSpine, RowRowAgent};
+use crate::typedefs::{KeyValSpine, RowRowAgent, RowRowSpine};
 
 pub(super) type ReachabilityEvent = (
     Vec<usize>,
@@ -150,7 +150,7 @@ pub(super) fn construct<A: Allocate>(
                     });
 
                 let trace = updates
-                    .mz_arrange::<KeyValSpine<_, _, _, _>>(&format!("Arrange {variant:?}"))
+                    .mz_arrange::<RowRowSpine<_, _>>(&format!("Arrange {variant:?}"))
                     .trace;
                 result.insert(variant.clone(), (trace, Rc::clone(&token)));
             }

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -19,7 +19,7 @@ use mz_compute_client::logging::LoggingConfig;
 use mz_expr::{permutation_for_arrangement, MirScalarExpr};
 use mz_ore::cast::CastFrom;
 use mz_ore::iter::IteratorExt;
-use mz_repr::{Datum, Diff, Row, RowArena, SharedRow, Timestamp};
+use mz_repr::{Datum, Diff, RowArena, SharedRow, Timestamp};
 use mz_timely_util::buffer::ConsolidateBuffer;
 use mz_timely_util::replay::MzReplay;
 use timely::communication::Allocate;
@@ -27,7 +27,7 @@ use timely::dataflow::operators::Filter;
 
 use crate::extensions::arrange::MzArrange;
 use crate::logging::{EventQueue, LogVariant, TimelyLog};
-use crate::typedefs::{KeyValAgent, KeyValSpine};
+use crate::typedefs::{KeyValSpine, RowRowAgent};
 
 pub(super) type ReachabilityEvent = (
     Vec<usize>,
@@ -47,7 +47,7 @@ pub(super) fn construct<A: Allocate>(
     worker: &mut timely::worker::Worker<A>,
     config: &LoggingConfig,
     event_queue: EventQueue<ReachabilityEvent>,
-) -> BTreeMap<LogVariant, (KeyValAgent<Row, Row, Timestamp, Diff>, Rc<dyn Any>)> {
+) -> BTreeMap<LogVariant, (RowRowAgent<Timestamp, Diff>, Rc<dyn Any>)> {
     let interval_ms = std::cmp::max(1, config.interval.as_millis());
     let worker_index = worker.index();
 

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -19,7 +19,7 @@ use mz_compute_client::logging::LoggingConfig;
 use mz_expr::{permutation_for_arrangement, MirScalarExpr};
 use mz_ore::cast::CastFrom;
 use mz_ore::iter::IteratorExt;
-use mz_repr::{Datum, Diff, RowArena, SharedRow, Timestamp};
+use mz_repr::{Datum, Diff, Row, RowArena, SharedRow, Timestamp};
 use mz_timely_util::buffer::ConsolidateBuffer;
 use mz_timely_util::replay::MzReplay;
 use timely::communication::Allocate;
@@ -27,7 +27,7 @@ use timely::dataflow::operators::Filter;
 
 use crate::extensions::arrange::MzArrange;
 use crate::logging::{EventQueue, LogVariant, TimelyLog};
-use crate::typedefs::{KeysValsHandle, RowSpine};
+use crate::typedefs::{KeyValAgent, KeyValSpine};
 
 pub(super) type ReachabilityEvent = (
     Vec<usize>,
@@ -47,7 +47,7 @@ pub(super) fn construct<A: Allocate>(
     worker: &mut timely::worker::Worker<A>,
     config: &LoggingConfig,
     event_queue: EventQueue<ReachabilityEvent>,
-) -> BTreeMap<LogVariant, (KeysValsHandle, Rc<dyn Any>)> {
+) -> BTreeMap<LogVariant, (KeyValAgent<Row, Row, Timestamp, Diff>, Rc<dyn Any>)> {
     let interval_ms = std::cmp::max(1, config.interval.as_millis());
     let worker_index = worker.index();
 
@@ -105,7 +105,10 @@ pub(super) fn construct<A: Allocate>(
 
         let updates = updates
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely reachability");
+            .mz_arrange_core::<_, KeyValSpine<_, _, _, _>>(
+                Pipeline,
+                "PreArrange Timely reachability",
+            );
 
         let mut result = BTreeMap::new();
         for variant in logs_active {
@@ -147,7 +150,7 @@ pub(super) fn construct<A: Allocate>(
                     });
 
                 let trace = updates
-                    .mz_arrange::<RowSpine<_, _, _, _>>(&format!("Arrange {variant:?}"))
+                    .mz_arrange::<KeyValSpine<_, _, _, _>>(&format!("Arrange {variant:?}"))
                     .trace;
                 result.insert(variant.clone(), (trace, Rc::clone(&token)));
             }

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use differential_dataflow::collection::AsCollection;
 use mz_compute_client::logging::LoggingConfig;
 use mz_ore::cast::CastFrom;
-use mz_repr::{Datum, Diff, Row, Timestamp};
+use mz_repr::{Datum, Diff, Timestamp};
 use mz_timely_util::buffer::ConsolidateBuffer;
 use mz_timely_util::replay::MzReplay;
 use serde::{Deserialize, Serialize};
@@ -38,7 +38,7 @@ use crate::extensions::arrange::MzArrange;
 use crate::logging::compute::ComputeEvent;
 use crate::logging::PermutedRowPacker;
 use crate::logging::{EventQueue, LogVariant, SharedLoggingState, TimelyLog};
-use crate::typedefs::{KeyValAgent, KeyValSpine};
+use crate::typedefs::{KeyValSpine, RowRowAgent};
 
 /// Constructs the logging dataflow for timely logs.
 ///
@@ -53,7 +53,7 @@ pub(super) fn construct<A: Allocate>(
     config: &LoggingConfig,
     event_queue: EventQueue<TimelyEvent>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
-) -> BTreeMap<LogVariant, (KeyValAgent<Row, Row, Timestamp, Diff>, Rc<dyn Any>)> {
+) -> BTreeMap<LogVariant, (RowRowAgent<Timestamp, Diff>, Rc<dyn Any>)> {
     let logging_interval_ms = std::cmp::max(1, config.interval.as_millis());
     let worker_id = worker.index();
     let peers = worker.peers();

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -38,7 +38,7 @@ use crate::extensions::arrange::MzArrange;
 use crate::logging::compute::ComputeEvent;
 use crate::logging::PermutedRowPacker;
 use crate::logging::{EventQueue, LogVariant, SharedLoggingState, TimelyLog};
-use crate::typedefs::{KeyValSpine, RowRowAgent};
+use crate::typedefs::{KeyValSpine, RowRowAgent, RowRowSpine};
 
 /// Constructs the logging dataflow for timely logs.
 ///
@@ -303,7 +303,7 @@ pub(super) fn construct<A: Allocate>(
             let variant = LogVariant::Timely(variant);
             if config.index_logs.contains_key(&variant) {
                 let trace = collection
-                    .mz_arrange::<KeyValSpine<_, _, _, _>>(&format!("Arrange {variant:?}"))
+                    .mz_arrange::<RowRowSpine<_, _>>(&format!("Arrange {variant:?}"))
                     .trace;
                 traces.insert(variant, (trace, Rc::clone(&token)));
             }

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use differential_dataflow::collection::AsCollection;
 use mz_compute_client::logging::LoggingConfig;
 use mz_ore::cast::CastFrom;
-use mz_repr::{Datum, Diff, Timestamp};
+use mz_repr::{Datum, Diff, Row, Timestamp};
 use mz_timely_util::buffer::ConsolidateBuffer;
 use mz_timely_util::replay::MzReplay;
 use serde::{Deserialize, Serialize};
@@ -38,7 +38,7 @@ use crate::extensions::arrange::MzArrange;
 use crate::logging::compute::ComputeEvent;
 use crate::logging::PermutedRowPacker;
 use crate::logging::{EventQueue, LogVariant, SharedLoggingState, TimelyLog};
-use crate::typedefs::{KeysValsHandle, RowSpine};
+use crate::typedefs::{KeyValAgent, KeyValSpine};
 
 /// Constructs the logging dataflow for timely logs.
 ///
@@ -53,7 +53,7 @@ pub(super) fn construct<A: Allocate>(
     config: &LoggingConfig,
     event_queue: EventQueue<TimelyEvent>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
-) -> BTreeMap<LogVariant, (KeysValsHandle, Rc<dyn Any>)> {
+) -> BTreeMap<LogVariant, (KeyValAgent<Row, Row, Timestamp, Diff>, Rc<dyn Any>)> {
     let logging_interval_ms = std::cmp::max(1, config.interval.as_millis());
     let worker_id = worker.index();
     let peers = worker.peers();
@@ -151,7 +151,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::Operates);
         let operates = operates
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely operates")
+            .mz_arrange_core::<_, KeyValSpine<_, _, _, _>>(Pipeline, "PreArrange Timely operates")
             .as_collection(move |id, name| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*id)),
@@ -162,7 +162,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::Channels);
         let channels = channels
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely operates")
+            .mz_arrange_core::<_, KeyValSpine<_, _, _, _>>(Pipeline, "PreArrange Timely operates")
             .as_collection(move |datum, ()| {
                 let (source_node, source_port) = datum.source;
                 let (target_node, target_port) = datum.target;
@@ -179,7 +179,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::Addresses);
         let addresses = addresses
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely addresses")
+            .mz_arrange_core::<_, KeyValSpine<_, _, _, _>>(Pipeline, "PreArrange Timely addresses")
             .as_collection({
                 move |id, address| {
                     packer.pack_by_index(|packer, index| match index {
@@ -194,7 +194,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::Parks);
         let parks = parks
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely parks")
+            .mz_arrange_core::<_, KeyValSpine<_, _, _, _>>(Pipeline, "PreArrange Timely parks")
             .as_collection(move |datum, ()| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(worker_id)),
@@ -208,7 +208,10 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::BatchesSent);
         let batches_sent = batches_sent
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely batches sent")
+            .mz_arrange_core::<_, KeyValSpine<_, _, _, _>>(
+                Pipeline,
+                "PreArrange Timely batches sent",
+            )
             .as_collection(move |datum, ()| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(datum.channel)),
@@ -219,7 +222,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::BatchesReceived);
         let batches_received = batches_received
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
+            .mz_arrange_core::<_, KeyValSpine<_, _, _, _>>(
                 Pipeline,
                 "PreArrange Timely batches received",
             )
@@ -233,7 +236,10 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::MessagesSent);
         let messages_sent = messages_sent
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely messages sent")
+            .mz_arrange_core::<_, KeyValSpine<_, _, _, _>>(
+                Pipeline,
+                "PreArrange Timely messages sent",
+            )
             .as_collection(move |datum, ()| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(datum.channel)),
@@ -244,7 +250,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::MessagesReceived);
         let messages_received = messages_received
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
+            .mz_arrange_core::<_, KeyValSpine<_, _, _, _>>(
                 Pipeline,
                 "PreArrange Timely messages received",
             )
@@ -258,7 +264,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::Elapsed);
         let elapsed = schedules_duration
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely duration")
+            .mz_arrange_core::<_, KeyValSpine<_, _, _, _>>(Pipeline, "PreArrange Timely duration")
             .as_collection(move |operator, _| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*operator)),
@@ -268,7 +274,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::Histogram);
         let histogram = schedules_histogram
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely histogram")
+            .mz_arrange_core::<_, KeyValSpine<_, _, _, _>>(Pipeline, "PreArrange Timely histogram")
             .as_collection(move |datum, _| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(datum.operator)),
@@ -297,7 +303,7 @@ pub(super) fn construct<A: Allocate>(
             let variant = LogVariant::Timely(variant);
             if config.index_logs.contains_key(&variant) {
                 let trace = collection
-                    .mz_arrange::<RowSpine<_, _, _, _>>(&format!("Arrange {variant:?}"))
+                    .mz_arrange::<KeyValSpine<_, _, _, _>>(&format!("Arrange {variant:?}"))
                     .trace;
                 traces.insert(variant, (trace, Rc::clone(&token)));
             }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -40,7 +40,7 @@ use crate::render::errors::ErrorLogger;
 use crate::render::join::LinearJoinSpec;
 use crate::render::RenderTimestamp;
 use crate::typedefs::{
-    ErrAgent, ErrImport, ErrSpine, RowAgent, RowImport, RowRowAgent, RowRowImport, RowRowSpine,
+    ErrAgent, ErrEnter, ErrSpine, RowAgent, RowEnter, RowRowAgent, RowRowEnter, RowRowSpine,
     RowSpine,
 };
 
@@ -356,8 +356,8 @@ where
     T: Timestamp + Lattice + Columnation,
     <S as ScopeParent>::Timestamp: Lattice + Refines<T>,
 {
-    RowUnit(Arranged<S, RowImport<T, Diff, <S as ScopeParent>::Timestamp>>),
-    RowRow(Arranged<S, RowRowImport<T, Diff, <S as ScopeParent>::Timestamp>>),
+    RowUnit(Arranged<S, RowEnter<T, Diff, <S as ScopeParent>::Timestamp>>),
+    RowRow(Arranged<S, RowRowEnter<T, Diff, <S as ScopeParent>::Timestamp>>),
 }
 
 impl<S: Scope, T> SpecializedArrangementImport<S, T>
@@ -425,7 +425,7 @@ where
         let mut datums = DatumVec::new();
         match self {
             SpecializedArrangementImport::RowUnit(inner) => {
-                CollectionBundle::<S, T>::flat_map_core::<RowImport<T, Diff, S::Timestamp>, _, _>(
+                CollectionBundle::<S, T>::flat_map_core::<RowEnter<T, Diff, S::Timestamp>, _, _>(
                     inner,
                     key,
                     move |k, v, t, d| {
@@ -438,7 +438,7 @@ where
                 )
             }
             SpecializedArrangementImport::RowRow(inner) => {
-                CollectionBundle::<S, T>::flat_map_core::<RowRowImport<T, Diff, S::Timestamp>, _, _>(
+                CollectionBundle::<S, T>::flat_map_core::<RowRowEnter<T, Diff, S::Timestamp>, _, _>(
                     inner,
                     key,
                     move |k, v, t, d| {
@@ -491,7 +491,7 @@ where
     Trace(
         GlobalId,
         SpecializedArrangementImport<S, T>,
-        Arranged<S, ErrImport<T, <S as ScopeParent>::Timestamp>>,
+        Arranged<S, ErrEnter<T, <S as ScopeParent>::Timestamp>>,
     ),
 }
 

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -41,23 +41,10 @@ use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::render::errors::ErrorLogger;
 use crate::render::join::LinearJoinSpec;
 use crate::render::RenderTimestamp;
-use crate::typedefs::{ErrAgent, ErrSpine, KeyAgent, KeySpine, KeyValAgent, KeyValSpine};
-
-// Local type definition to avoid the horror in signatures.
-pub(crate) type KeyValArrangement<S, K, V> =
-    Arranged<S, KeyValAgent<K, V, <S as ScopeParent>::Timestamp, Diff>>;
-pub(crate) type Arrangement<S, V> = KeyValArrangement<S, V, V>;
-pub(crate) type KeyArrangement<S, K> =
-    Arranged<S, KeyAgent<K, <S as ScopeParent>::Timestamp, Diff>>;
-pub(crate) type ErrArrangement<S> = Arranged<S, ErrAgent<<S as ScopeParent>::Timestamp, Diff>>;
-pub(crate) type KeyValArrangementImport<S, K, V, T> = Arranged<
-    S,
-    TraceEnter<TraceFrontier<KeyValAgent<K, V, T, Diff>>, <S as ScopeParent>::Timestamp>,
->;
-pub(crate) type KeyArrangementImport<S, K, T> =
-    Arranged<S, TraceEnter<TraceFrontier<KeyAgent<K, T, Diff>>, <S as ScopeParent>::Timestamp>>;
-pub(crate) type ErrArrangementImport<S, T> =
-    Arranged<S, TraceEnter<TraceFrontier<ErrAgent<T, Diff>>, <S as ScopeParent>::Timestamp>>;
+use crate::typedefs::{
+    ErrArrangement, ErrArrangementImport, ErrSpine, KeyAgent, KeyArrangement, KeyArrangementImport,
+    KeySpine, KeyValAgent, KeyValArrangement, KeyValArrangementImport, KeyValSpine,
+};
 
 /// Dataflow-local collections and arrangements.
 ///

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -254,14 +254,14 @@ where
         match self {
             SpecializedArrangement::RowUnit(inner) => inner.as_collection(move |k, v| {
                 let mut datums_borrow = datums.borrow();
-                datums_borrow.extend(&**k);
+                datums_borrow.extend(k.into_datum_iter(None));
                 datums_borrow.extend(v.into_datum_iter(Some(&[])));
                 logic(&datums_borrow)
             }),
             SpecializedArrangement::RowRow(inner) => inner.as_collection(move |k, v| {
                 let mut datums_borrow = datums.borrow();
-                datums_borrow.extend(&**k);
-                datums_borrow.extend(&**v);
+                datums_borrow.extend(k.into_datum_iter(None));
+                datums_borrow.extend(v.into_datum_iter(None));
                 logic(&datums_borrow)
             }),
         }
@@ -290,7 +290,7 @@ where
                     key,
                     move |k, v, t, d| {
                         let mut datums_borrow = datums.borrow();
-                        datums_borrow.extend(&**k);
+                        datums_borrow.extend(k.into_datum_iter(None));
                         datums_borrow.extend(v.into_datum_iter(Some(&[])));
                         logic(&mut datums_borrow, t, d)
                     },
@@ -303,8 +303,8 @@ where
                     key,
                     move |k, v, t, d| {
                         let mut datums_borrow = datums.borrow();
-                        datums_borrow.extend(&**k);
-                        datums_borrow.extend(&**v);
+                        datums_borrow.extend(k.into_datum_iter(None));
+                        datums_borrow.extend(v.into_datum_iter(None));
                         logic(&mut datums_borrow, t, d)
                     },
                     refuel,
@@ -397,14 +397,14 @@ where
         match self {
             SpecializedArrangementImport::RowUnit(inner) => inner.as_collection(move |k, v| {
                 let mut datums_borrow = datums.borrow();
-                datums_borrow.extend(&**k);
+                datums_borrow.extend(k.into_datum_iter(None));
                 datums_borrow.extend(v.into_datum_iter(Some(&[])));
                 logic(&datums_borrow)
             }),
             SpecializedArrangementImport::RowRow(inner) => inner.as_collection(move |k, v| {
                 let mut datums_borrow = datums.borrow();
-                datums_borrow.extend(&**k);
-                datums_borrow.extend(&**v);
+                datums_borrow.extend(k.into_datum_iter(None));
+                datums_borrow.extend(v.into_datum_iter(None));
                 logic(&datums_borrow)
             }),
         }
@@ -430,7 +430,7 @@ where
                     key,
                     move |k, v, t, d| {
                         let mut datums_borrow = datums.borrow();
-                        datums_borrow.extend(&**k);
+                        datums_borrow.extend(k.into_datum_iter(None));
                         datums_borrow.extend(v.into_datum_iter(Some(&[])));
                         logic(&mut datums_borrow, t, d)
                     },
@@ -443,8 +443,8 @@ where
                     key,
                     move |k, v, t, d| {
                         let mut datums_borrow = datums.borrow();
-                        datums_borrow.extend(&**k);
-                        datums_borrow.extend(&**v);
+                        datums_borrow.extend(k.into_datum_iter(None));
+                        datums_borrow.extend(v.into_datum_iter(None));
                         logic(&mut datums_borrow, t, d)
                     },
                     refuel,

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -375,10 +375,10 @@ where
     G::Timestamp: Lattice + crate::render::RenderTimestamp + Refines<T> + Columnation,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
 {
-    use crate::typedefs::{RowImport, RowRowImport};
+    use crate::typedefs::{RowEnter, RowRowEnter};
     match trace {
         SpecializedArrangementImport::RowUnit(inner) => {
-            build_halfjoin::<_, RowImport<T, Diff, G::Timestamp>, _>(
+            build_halfjoin::<_, RowEnter<T, Diff, G::Timestamp>, _>(
                 updates,
                 inner,
                 None,
@@ -391,7 +391,7 @@ where
             )
         }
         SpecializedArrangementImport::RowRow(inner) => {
-            build_halfjoin::<_, RowRowImport<T, Diff, G::Timestamp>, _>(
+            build_halfjoin::<_, RowRowEnter<T, Diff, G::Timestamp>, _>(
                 updates,
                 inner,
                 None,
@@ -596,10 +596,10 @@ where
     T: Timestamp + Lattice + Columnation,
     G::Timestamp: Lattice + crate::render::RenderTimestamp + Refines<T> + Columnation,
 {
-    use crate::typedefs::{RowImport, RowRowImport};
+    use crate::typedefs::{RowEnter, RowRowEnter};
     match trace {
         SpecializedArrangementImport::RowUnit(inner) => {
-            build_update_stream::<_, RowImport<T, Diff, G::Timestamp>>(
+            build_update_stream::<_, RowEnter<T, Diff, G::Timestamp>>(
                 inner,
                 None,
                 Some(vec![]),
@@ -609,7 +609,7 @@ where
             )
         }
         SpecializedArrangementImport::RowRow(inner) => {
-            build_update_stream::<_, RowRowImport<T, Diff, G::Timestamp>>(
+            build_update_stream::<_, RowRowEnter<T, Diff, G::Timestamp>>(
                 inner,
                 None,
                 None,

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -324,11 +324,11 @@ where
     G::Timestamp: crate::render::RenderTimestamp,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
 {
-    use crate::typedefs::{RowKeySpine, RowSpine};
+    use crate::typedefs::{KeySpine, KeyValSpine};
     use differential_dataflow::operators::arrange::TraceAgent;
     match trace {
         SpecializedArrangement::RowUnit(inner) => {
-            build_halfjoin::<_, TraceAgent<RowKeySpine<Row, _, _>>, _>(
+            build_halfjoin::<_, TraceAgent<KeySpine<Row, _, _>>, _>(
                 updates,
                 inner,
                 None,
@@ -341,7 +341,7 @@ where
             )
         }
         SpecializedArrangement::RowRow(inner) => {
-            build_halfjoin::<_, TraceAgent<RowSpine<Row, Row, _, _>>, _>(
+            build_halfjoin::<_, TraceAgent<KeyValSpine<Row, Row, _, _>>, _>(
                 updates,
                 inner,
                 None,
@@ -375,28 +375,26 @@ where
     G::Timestamp: Lattice + crate::render::RenderTimestamp + Refines<T> + Columnation,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
 {
-    use crate::typedefs::{TraceKeyHandle, TraceRowHandle};
+    use crate::typedefs::{KeyAgent, KeyValAgent};
     use differential_dataflow::trace::wrappers::enter::TraceEnter;
     use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
     match trace {
-        SpecializedArrangementImport::RowUnit(inner) => build_halfjoin::<
-            _,
-            TraceEnter<TraceFrontier<TraceKeyHandle<Row, T, Diff>>, G::Timestamp>,
-            _,
-        >(
-            updates,
-            inner,
-            None,
-            Some(vec![]),
-            prev_key,
-            prev_thinning,
-            comparison,
-            closure,
-            shutdown_token,
-        ),
+        SpecializedArrangementImport::RowUnit(inner) => {
+            build_halfjoin::<_, TraceEnter<TraceFrontier<KeyAgent<Row, T, Diff>>, G::Timestamp>, _>(
+                updates,
+                inner,
+                None,
+                Some(vec![]),
+                prev_key,
+                prev_thinning,
+                comparison,
+                closure,
+                shutdown_token,
+            )
+        }
         SpecializedArrangementImport::RowRow(inner) => build_halfjoin::<
             _,
-            TraceEnter<TraceFrontier<TraceRowHandle<Row, Row, T, Diff>>, G::Timestamp>,
+            TraceEnter<TraceFrontier<KeyValAgent<Row, Row, T, Diff>>, G::Timestamp>,
             _,
         >(
             updates,
@@ -569,11 +567,11 @@ where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
 {
-    use crate::typedefs::{RowKeySpine, RowSpine};
+    use crate::typedefs::{KeySpine, KeyValSpine};
     use differential_dataflow::operators::arrange::TraceAgent;
     match trace {
         SpecializedArrangement::RowUnit(inner) => {
-            build_update_stream::<_, TraceAgent<RowKeySpine<Row, _, _>>>(
+            build_update_stream::<_, TraceAgent<KeySpine<Row, _, _>>>(
                 inner,
                 None,
                 Some(vec![]),
@@ -583,7 +581,7 @@ where
             )
         }
         SpecializedArrangement::RowRow(inner) => {
-            build_update_stream::<_, TraceAgent<RowSpine<Row, Row, _, _>>>(
+            build_update_stream::<_, TraceAgent<KeyValSpine<Row, Row, _, _>>>(
                 inner,
                 None,
                 None,
@@ -607,25 +605,24 @@ where
     T: Timestamp + Lattice + Columnation,
     G::Timestamp: Lattice + crate::render::RenderTimestamp + Refines<T> + Columnation,
 {
-    use crate::typedefs::{TraceKeyHandle, TraceRowHandle};
+    use crate::typedefs::{KeyAgent, KeyValAgent};
     use differential_dataflow::trace::wrappers::enter::TraceEnter;
     use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
     match trace {
-        SpecializedArrangementImport::RowUnit(inner) => build_update_stream::<
-            _,
-            TraceEnter<TraceFrontier<TraceKeyHandle<Row, T, Diff>>, G::Timestamp>,
-        >(
-            inner,
-            None,
-            Some(vec![]),
-            as_of,
-            source_relation,
-            initial_closure,
-        ),
+        SpecializedArrangementImport::RowUnit(inner) => {
+            build_update_stream::<_, TraceEnter<TraceFrontier<KeyAgent<Row, T, Diff>>, G::Timestamp>>(
+                inner,
+                None,
+                Some(vec![]),
+                as_of,
+                source_relation,
+                initial_closure,
+            )
+        }
         SpecializedArrangementImport::RowRow(inner) => {
             build_update_stream::<
                 _,
-                TraceEnter<TraceFrontier<TraceRowHandle<Row, Row, T, Diff>>, G::Timestamp>,
+                TraceEnter<TraceFrontier<KeyValAgent<Row, Row, T, Diff>>, G::Timestamp>,
             >(inner, None, None, as_of, source_relation, initial_closure)
         }
     }

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -304,8 +304,10 @@ where
             joined = JoinedFlavor::Local(SpecializedArrangement::RowRow(arranged));
         }
 
-        use crate::typedefs::{KeyAgent, KeyValAgent};
-        use crate::typedefs::{KeySpine, KeyValSpine};
+        use crate::typedefs::KeyValSpine;
+        use crate::typedefs::{
+            RowAgent, RowImport, RowRowAgent, RowRowImport, RowRowSpine, RowSpine,
+        };
         use differential_dataflow::operators::arrange::TraceAgent;
         use differential_dataflow::trace::wrappers::enter::TraceEnter;
         use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
@@ -321,10 +323,10 @@ where
             JoinedFlavor::Local(local) => match arrangement {
                 ArrangementFlavor::Local(oks, errs1) => {
                     let (oks, errs2) = match (local, oks) {
-                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangement::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<KeySpine<Row, _, _>>,TraceAgent<KeySpine<Row, _, _>>>(prev_keyed, next_input, None, Some(vec![]), Some(vec![]), closure),
-                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangement::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<KeySpine<Row, _, _>>,TraceAgent<KeyValSpine<Row, Row, _, _>>>(prev_keyed, next_input, None, Some(vec![]), None, closure),
-                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangement::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<KeyValSpine<Row, Row, _, _>>,TraceAgent<KeySpine<Row, _, _>>>(prev_keyed, next_input, None, None, Some(vec![]), closure),
-                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangement::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<KeyValSpine<Row, Row, _, _>>,TraceAgent<KeyValSpine<Row, Row, _, _>>>(prev_keyed, next_input, None, None, None, closure),
+                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangement::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<RowSpine<_, _>>,TraceAgent<RowSpine<_, _>>>(prev_keyed, next_input, None, Some(vec![]), Some(vec![]), closure),
+                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangement::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowSpine<_, _>>,TraceAgent<RowRowSpine<_, _>>>(prev_keyed, next_input, None, Some(vec![]), None, closure),
+                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangement::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<RowRowSpine<_, _>>,TraceAgent<RowSpine<_, _>>>(prev_keyed, next_input, None, None, Some(vec![]), closure),
+                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangement::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowRowSpine<_, _>>,TraceAgent<RowRowSpine<_, _>>>(prev_keyed, next_input, None, None, None, closure),
                     };
 
                     errors.push(errs1.as_collection(|k, _v| k.clone()));
@@ -333,10 +335,10 @@ where
                 }
                 ArrangementFlavor::Trace(_gid, oks, errs1) => {
                     let (oks, errs2) = match (local, oks) {
-                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangementImport::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<KeySpine<Row, _, _>>,TraceEnter<TraceFrontier<KeyAgent<Row, T, Diff>>, G::Timestamp>>(prev_keyed, next_input, None, Some(vec![]), Some(vec![]), closure),
-                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangementImport::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<KeySpine<Row, _, _>>,TraceEnter<TraceFrontier<KeyValAgent<Row, Row, T, Diff>>, G::Timestamp>>(prev_keyed, next_input, None, Some(vec![]), None, closure),
-                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangementImport::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<KeyValSpine<Row, Row, _, _>>,TraceEnter<TraceFrontier<KeyAgent<Row, T, Diff>>, G::Timestamp>>(prev_keyed, next_input, None, None, Some(vec![]), closure),
-                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangementImport::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<KeyValSpine<Row, Row, _, _>>,TraceEnter<TraceFrontier<KeyValAgent<Row, Row, T, Diff>>, G::Timestamp>>(prev_keyed, next_input, None, None, None, closure),
+                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangementImport::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<RowSpine<_, _>>,RowImport<T, Diff, G::Timestamp>>(prev_keyed, next_input, None, Some(vec![]), Some(vec![]), closure),
+                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangementImport::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowSpine<_, _>>,RowRowImport<T, Diff, G::Timestamp>>(prev_keyed, next_input, None, Some(vec![]), None, closure),
+                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangementImport::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<RowRowSpine<_, _>>,RowImport<T, Diff, G::Timestamp>>(prev_keyed, next_input, None, None, Some(vec![]), closure),
+                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangementImport::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowRowSpine<_, _>>,RowRowImport<T, Diff, G::Timestamp>>(prev_keyed, next_input, None, None, None, closure),
                     };
 
                     errors.push(errs1.as_collection(|k, _v| k.clone()));
@@ -344,17 +346,16 @@ where
                     oks
                 }
             },
-            JoinedFlavor::Trace(trace) => {
-                match arrangement {
-                    ArrangementFlavor::Local(oks, errs1) => {
-                        let (oks, errs2) = match (trace, oks) {
+            JoinedFlavor::Trace(trace) => match arrangement {
+                ArrangementFlavor::Local(oks, errs1) => {
+                    let (oks, errs2) = match (trace, oks) {
                             (
                                 SpecializedArrangementImport::RowUnit(prev_keyed),
                                 SpecializedArrangement::RowUnit(next_input),
                             ) => self.differential_join_inner::<_, TraceEnter<
-                                TraceFrontier<KeyAgent<Row, T, Diff>>,
+                                TraceFrontier<RowAgent<T, Diff>>,
                                 G::Timestamp,
-                            >, TraceAgent<KeySpine<Row, _, _>>>(
+                            >, TraceAgent<RowSpine<_, _>>>(
                                 prev_keyed,
                                 next_input,
                                 None,
@@ -366,9 +367,9 @@ where
                                 SpecializedArrangementImport::RowUnit(prev_keyed),
                                 SpecializedArrangement::RowRow(next_input),
                             ) => self.differential_join_inner::<_, TraceEnter<
-                                TraceFrontier<KeyAgent<Row, T, Diff>>,
+                                TraceFrontier<RowAgent<T, Diff>>,
                                 G::Timestamp,
-                            >, TraceAgent<KeyValSpine<Row, Row, _, _>>>(
+                            >, TraceAgent<RowRowSpine<_, _>>>(
                                 prev_keyed,
                                 next_input,
                                 None,
@@ -380,9 +381,9 @@ where
                                 SpecializedArrangementImport::RowRow(prev_keyed),
                                 SpecializedArrangement::RowUnit(next_input),
                             ) => self.differential_join_inner::<_, TraceEnter<
-                                TraceFrontier<KeyValAgent<Row, Row, T, Diff>>,
+                                TraceFrontier<RowRowAgent<T, Diff>>,
                                 G::Timestamp,
-                            >, TraceAgent<KeySpine<Row, _, _>>>(
+                            >, TraceAgent<RowSpine<_, _>>>(
                                 prev_keyed,
                                 next_input,
                                 None,
@@ -394,27 +395,27 @@ where
                                 SpecializedArrangementImport::RowRow(prev_keyed),
                                 SpecializedArrangement::RowRow(next_input),
                             ) => self.differential_join_inner::<_, TraceEnter<
-                                TraceFrontier<KeyValAgent<Row, Row, T, Diff>>,
+                                TraceFrontier<RowRowAgent<T, Diff>>,
                                 G::Timestamp,
-                            >, TraceAgent<KeyValSpine<Row, Row, _, _>>>(
+                            >, TraceAgent<RowRowSpine<_, _>>>(
                                 prev_keyed, next_input, None, None, None, closure,
                             ),
                         };
 
-                        errors.push(errs1.as_collection(|k, _v| k.clone()));
-                        errors.extend(errs2);
-                        oks
-                    }
-                    ArrangementFlavor::Trace(_gid, oks, errs1) => {
-                        let (oks, errs2) = match (trace, oks) {
+                    errors.push(errs1.as_collection(|k, _v| k.clone()));
+                    errors.extend(errs2);
+                    oks
+                }
+                ArrangementFlavor::Trace(_gid, oks, errs1) => {
+                    let (oks, errs2) = match (trace, oks) {
                             (
                                 SpecializedArrangementImport::RowUnit(prev_keyed),
                                 SpecializedArrangementImport::RowUnit(next_input),
                             ) => self.differential_join_inner::<_, TraceEnter<
-                                TraceFrontier<KeyAgent<Row, T, Diff>>,
+                                TraceFrontier<RowAgent<T, Diff>>,
                                 G::Timestamp,
                             >, TraceEnter<
-                                TraceFrontier<KeyAgent<Row, T, Diff>>,
+                                TraceFrontier<RowAgent<T, Diff>>,
                                 G::Timestamp,
                             >>(
                                 prev_keyed,
@@ -428,10 +429,10 @@ where
                                 SpecializedArrangementImport::RowUnit(prev_keyed),
                                 SpecializedArrangementImport::RowRow(next_input),
                             ) => self.differential_join_inner::<_, TraceEnter<
-                                TraceFrontier<KeyAgent<Row, T, Diff>>,
+                                TraceFrontier<RowAgent<T, Diff>>,
                                 G::Timestamp,
                             >, TraceEnter<
-                                TraceFrontier<KeyValAgent<Row, Row, T, Diff>>,
+                                TraceFrontier<RowRowAgent<T, Diff>>,
                                 G::Timestamp,
                             >>(
                                 prev_keyed, next_input, None, Some(vec![]), None, closure
@@ -440,10 +441,10 @@ where
                                 SpecializedArrangementImport::RowRow(prev_keyed),
                                 SpecializedArrangementImport::RowUnit(next_input),
                             ) => self.differential_join_inner::<_, TraceEnter<
-                                TraceFrontier<KeyValAgent<Row, Row, T, Diff>>,
+                                TraceFrontier<RowRowAgent<T, Diff>>,
                                 G::Timestamp,
                             >, TraceEnter<
-                                TraceFrontier<KeyAgent<Row, T, Diff>>,
+                                TraceFrontier<RowAgent<T, Diff>>,
                                 G::Timestamp,
                             >>(
                                 prev_keyed, next_input, None, None, Some(vec![]), closure
@@ -452,22 +453,21 @@ where
                                 SpecializedArrangementImport::RowRow(prev_keyed),
                                 SpecializedArrangementImport::RowRow(next_input),
                             ) => self.differential_join_inner::<_, TraceEnter<
-                                TraceFrontier<KeyValAgent<Row, Row, T, Diff>>,
+                                TraceFrontier<RowRowAgent<T, Diff>>,
                                 G::Timestamp,
                             >, TraceEnter<
-                                TraceFrontier<KeyValAgent<Row, Row, T, Diff>>,
+                                TraceFrontier<RowRowAgent<T, Diff>>,
                                 G::Timestamp,
                             >>(
                                 prev_keyed, next_input, None, None, None, closure
                             ),
                         };
 
-                        errors.push(errs1.as_collection(|k, _v| k.clone()));
-                        errors.extend(errs2);
-                        oks
-                    }
+                    errors.push(errs1.as_collection(|k, _v| k.clone()));
+                    errors.extend(errs2);
+                    oks
                 }
-            }
+            },
         }
     }
 

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -300,11 +300,10 @@ where
             // TODO(vmarcos): We should implement further arrangement specialization here (#22104).
             // By knowing how types propagate through joins we could specialize intermediate
             // arrangements as well, either in values or eventually in keys.
-            let arranged = keyed.mz_arrange::<KeyValSpine<_, _, _, _>>("JoinStage");
+            let arranged = keyed.mz_arrange::<RowRowSpine<_, _>>("JoinStage");
             joined = JoinedFlavor::Local(SpecializedArrangement::RowRow(arranged));
         }
 
-        use crate::typedefs::KeyValSpine;
         use crate::typedefs::{
             RowAgent, RowEnter, RowRowAgent, RowRowEnter, RowRowSpine, RowSpine,
         };

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -306,7 +306,7 @@ where
 
         use crate::typedefs::KeyValSpine;
         use crate::typedefs::{
-            RowAgent, RowImport, RowRowAgent, RowRowImport, RowRowSpine, RowSpine,
+            RowAgent, RowEnter, RowRowAgent, RowRowEnter, RowRowSpine, RowSpine,
         };
         use differential_dataflow::operators::arrange::TraceAgent;
         use differential_dataflow::trace::wrappers::enter::TraceEnter;
@@ -335,10 +335,10 @@ where
                 }
                 ArrangementFlavor::Trace(_gid, oks, errs1) => {
                     let (oks, errs2) = match (local, oks) {
-                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangementImport::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<RowSpine<_, _>>,RowImport<T, Diff, G::Timestamp>>(prev_keyed, next_input, None, Some(vec![]), Some(vec![]), closure),
-                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangementImport::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowSpine<_, _>>,RowRowImport<T, Diff, G::Timestamp>>(prev_keyed, next_input, None, Some(vec![]), None, closure),
-                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangementImport::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<RowRowSpine<_, _>>,RowImport<T, Diff, G::Timestamp>>(prev_keyed, next_input, None, None, Some(vec![]), closure),
-                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangementImport::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowRowSpine<_, _>>,RowRowImport<T, Diff, G::Timestamp>>(prev_keyed, next_input, None, None, None, closure),
+                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangementImport::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<RowSpine<_, _>>,RowEnter<T, Diff, G::Timestamp>>(prev_keyed, next_input, None, Some(vec![]), Some(vec![]), closure),
+                        (SpecializedArrangement::RowUnit(prev_keyed), SpecializedArrangementImport::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowSpine<_, _>>,RowRowEnter<T, Diff, G::Timestamp>>(prev_keyed, next_input, None, Some(vec![]), None, closure),
+                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangementImport::RowUnit(next_input)) => self.differential_join_inner::<_,TraceAgent<RowRowSpine<_, _>>,RowEnter<T, Diff, G::Timestamp>>(prev_keyed, next_input, None, None, Some(vec![]), closure),
+                        (SpecializedArrangement::RowRow(prev_keyed),  SpecializedArrangementImport::RowRow(next_input))  => self.differential_join_inner::<_,TraceAgent<RowRowSpine<_, _>>,RowRowEnter<T, Diff, G::Timestamp>>(prev_keyed, next_input, None, None, None, closure),
                     };
 
                     errors.push(errs1.as_collection(|k, _v| k.clone()));

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -40,11 +40,11 @@ use tracing::warn;
 
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::{MzReduce, ReduceExt};
-use crate::render::context::{Arrangement, CollectionBundle, Context, SpecializedArrangement};
+use crate::render::context::{CollectionBundle, Context, SpecializedArrangement};
 use crate::render::errors::MaybeValidatingRow;
 use crate::render::reduce::monoids::{get_monoid, ReductionMonoid};
 use crate::render::ArrangementFlavor;
-use crate::typedefs::{KeyErrSpine, KeySpine, KeyValSpine};
+use crate::typedefs::{KeyErrSpine, KeySpine, KeyValArrangement, KeyValSpine};
 
 impl<G, T> Context<G, T>
 where
@@ -272,10 +272,13 @@ where
     /// so we can do a linear merge to form the output.
     fn build_collation<S>(
         &self,
-        arrangements: Vec<(ReductionType, Arrangement<S, Row>)>,
+        arrangements: Vec<(ReductionType, KeyValArrangement<S, Row, Row>)>,
         aggregate_types: Vec<ReductionType>,
         scope: &mut S,
-    ) -> (Arrangement<S, Row>, Collection<S, DataflowError, Diff>)
+    ) -> (
+        KeyValArrangement<S, Row, Row>,
+        Collection<S, DataflowError, Diff>,
+    )
     where
         S: Scope<Timestamp = G::Timestamp>,
     {
@@ -521,7 +524,10 @@ where
         &self,
         input: Collection<S, (Row, Row), Diff>,
         aggrs: Vec<(usize, AggregateExpr)>,
-    ) -> (Arrangement<S, Row>, Collection<S, DataflowError, Diff>)
+    ) -> (
+        KeyValArrangement<S, Row, Row>,
+        Collection<S, DataflowError, Diff>,
+    )
     where
         S: Scope<Timestamp = G::Timestamp>,
     {
@@ -574,7 +580,7 @@ where
         aggr: &AggregateExpr,
         validating: bool,
     ) -> (
-        Arrangement<S, Row>,
+        KeyValArrangement<S, Row, Row>,
         Option<Collection<S, DataflowError, Diff>>,
     )
     where
@@ -746,7 +752,7 @@ where
             buckets,
         }: BucketedPlan,
     ) -> (
-        Arrangement<S, Row>,
+        KeyValArrangement<S, Row, Row>,
         Option<Collection<S, DataflowError, Diff>>,
     )
     where
@@ -949,7 +955,10 @@ where
             skips,
             must_consolidate,
         }: MonotonicPlan,
-    ) -> (Arrangement<S, Row>, Collection<S, DataflowError, Diff>)
+    ) -> (
+        KeyValArrangement<S, Row, Row>,
+        Collection<S, DataflowError, Diff>,
+    )
     where
         S: Scope<Timestamp = G::Timestamp>,
     {
@@ -1026,7 +1035,10 @@ where
             simple_aggrs,
             distinct_aggrs,
         }: AccumulablePlan,
-    ) -> (Arrangement<S, Row>, Collection<S, DataflowError, Diff>)
+    ) -> (
+        KeyValArrangement<S, Row, Row>,
+        Collection<S, DataflowError, Diff>,
+    )
     where
         S: Scope<Timestamp = G::Timestamp>,
     {

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -44,7 +44,7 @@ use crate::render::context::{CollectionBundle, Context, SpecializedArrangement};
 use crate::render::errors::MaybeValidatingRow;
 use crate::render::reduce::monoids::{get_monoid, ReductionMonoid};
 use crate::render::ArrangementFlavor;
-use crate::typedefs::{KeyErrSpine, KeySpine, KeyValArrangement, KeyValSpine};
+use crate::typedefs::{KeyErrSpine, KeySpine, KeyValSpine, RowRowArrangement};
 
 impl<G, T> Context<G, T>
 where
@@ -272,13 +272,10 @@ where
     /// so we can do a linear merge to form the output.
     fn build_collation<S>(
         &self,
-        arrangements: Vec<(ReductionType, KeyValArrangement<S, Row, Row>)>,
+        arrangements: Vec<(ReductionType, RowRowArrangement<S>)>,
         aggregate_types: Vec<ReductionType>,
         scope: &mut S,
-    ) -> (
-        KeyValArrangement<S, Row, Row>,
-        Collection<S, DataflowError, Diff>,
-    )
+    ) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
     where
         S: Scope<Timestamp = G::Timestamp>,
     {
@@ -524,10 +521,7 @@ where
         &self,
         input: Collection<S, (Row, Row), Diff>,
         aggrs: Vec<(usize, AggregateExpr)>,
-    ) -> (
-        KeyValArrangement<S, Row, Row>,
-        Collection<S, DataflowError, Diff>,
-    )
+    ) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
     where
         S: Scope<Timestamp = G::Timestamp>,
     {
@@ -580,7 +574,7 @@ where
         aggr: &AggregateExpr,
         validating: bool,
     ) -> (
-        KeyValArrangement<S, Row, Row>,
+        RowRowArrangement<S>,
         Option<Collection<S, DataflowError, Diff>>,
     )
     where
@@ -752,7 +746,7 @@ where
             buckets,
         }: BucketedPlan,
     ) -> (
-        KeyValArrangement<S, Row, Row>,
+        RowRowArrangement<S>,
         Option<Collection<S, DataflowError, Diff>>,
     )
     where
@@ -955,10 +949,7 @@ where
             skips,
             must_consolidate,
         }: MonotonicPlan,
-    ) -> (
-        KeyValArrangement<S, Row, Row>,
-        Collection<S, DataflowError, Diff>,
-    )
+    ) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
     where
         S: Scope<Timestamp = G::Timestamp>,
     {
@@ -1035,10 +1026,7 @@ where
             simple_aggrs,
             distinct_aggrs,
         }: AccumulablePlan,
-    ) -> (
-        KeyValArrangement<S, Row, Row>,
-        Collection<S, DataflowError, Diff>,
-    )
+    ) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
     where
         S: Scope<Timestamp = G::Timestamp>,
     {

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -649,7 +649,8 @@ where
                     // Note that in the non-positive case, this is wrong, but harmless because
                     // our other reduction will produce an error.
                     let count = usize::try_from(*w).unwrap_or(0);
-                    std::iter::repeat(v.iter().next().unwrap()).take(count)
+                    use mz_repr::fixed_length::IntoRowByTypes;
+                    std::iter::repeat(v.into_datum_iter(None).next().unwrap()).take(count)
                 });
                 let binding = SharedRow::get();
                 let mut row_builder = binding.borrow_mut();

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -35,7 +35,7 @@ use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::extensions::reduce::MzReduce;
 use crate::render::context::{CollectionBundle, Context};
 use crate::render::errors::MaybeValidatingRow;
-use crate::typedefs::{KeySpine, KeyValSpine};
+use crate::typedefs::{KeySpine, KeyValSpine, RowSpine};
 
 // The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.
 impl<G> Context<G>
@@ -362,7 +362,7 @@ where
             })
             .into();
         let result = partial
-            .mz_arrange::<KeySpine<Row, _, _>>("Arranged MonotonicTop1 partial [val: empty]")
+            .mz_arrange::<RowSpine<_, _>>("Arranged MonotonicTop1 partial [val: empty]")
             .mz_reduce_abelian::<_, KeyValSpine<_, _, _, _>>("MonotonicTop1", {
                 move |_key, input, output| {
                     let accum: &monoids::Top1Monoid = &input[0].1;

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -35,7 +35,7 @@ use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::extensions::reduce::MzReduce;
 use crate::render::context::{CollectionBundle, Context};
 use crate::render::errors::MaybeValidatingRow;
-use crate::typedefs::{RowKeySpine, RowSpine};
+use crate::typedefs::{KeySpine, KeyValSpine};
 
 // The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.
 impl<G> Context<G>
@@ -91,7 +91,7 @@ where
                             };
                             (group_row, row)
                         })
-                        .consolidate_named_if::<RowKeySpine<_, _, _>>(
+                        .consolidate_named_if::<KeySpine<_, _, _>>(
                             must_consolidate,
                             "Consolidated MonotonicTopK input",
                         );
@@ -301,7 +301,7 @@ where
         (
             oks.negate()
                 .concat(&input)
-                .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated TopK"),
+                .consolidate_named::<KeySpine<_, _, _>>("Consolidated TopK"),
             errs,
         )
     }
@@ -335,7 +335,7 @@ where
                     (group_key, row)
                 }
             })
-            .consolidate_named_if::<RowKeySpine<_, _, _>>(
+            .consolidate_named_if::<KeySpine<_, _, _>>(
                 must_consolidate,
                 "Consolidated MonotonicTop1 input",
             );
@@ -362,8 +362,8 @@ where
             })
             .into();
         let result = partial
-            .mz_arrange::<RowKeySpine<Row, _, _>>("Arranged MonotonicTop1 partial [val: empty]")
-            .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("MonotonicTop1", {
+            .mz_arrange::<KeySpine<Row, _, _>>("Arranged MonotonicTop1 partial [val: empty]")
+            .mz_reduce_abelian::<_, KeyValSpine<_, _, _, _>>("MonotonicTop1", {
                 move |_key, input, output| {
                     let accum: &monoids::Top1Monoid = &input[0].1;
                     output.push((accum.row.clone(), 1));
@@ -391,8 +391,8 @@ where
     // NOTE(vmarcos): The arranged input operator name below is used in the tuning advice
     // built-in view mz_internal.mz_expected_group_size_advice.
     input
-        .mz_arrange::<RowSpine<(Row, u64), _, _, _>>("Arranged TopK input")
-        .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("Reduced TopK input", {
+        .mz_arrange::<KeyValSpine<(Row, u64), _, _, _>>("Arranged TopK input")
+        .mz_reduce_abelian::<_, KeyValSpine<_, _, _, _>>("Reduced TopK input", {
             move |_key, source, target: &mut Vec<(R, Diff)>| {
                 if let Some(err) = R::into_error() {
                     for (row, diff) in source.iter() {

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -14,15 +14,18 @@
 use differential_dataflow::operators::arrange::TraceAgent;
 use differential_dataflow::trace::implementations::ord_neu::{ColKeySpine, ColValSpine};
 
-use mz_repr::{Diff, Row, Timestamp};
 use mz_storage_types::errors::DataflowError;
 
-pub type RowSpine<K, V, T, R> = ColValSpine<K, V, T, R>;
-pub type RowKeySpine<K, T, R> = ColKeySpine<K, T, R>;
-pub type ErrSpine<K, T, R> = ColKeySpine<K, T, R>;
-pub type ErrValSpine<K, T, R> = ColValSpine<K, DataflowError, T, R>;
-pub type TraceRowHandle<K, V, T, R> = TraceAgent<RowSpine<K, V, T, R>>;
-pub type TraceKeyHandle<K, T, R> = TraceAgent<RowKeySpine<K, T, R>>;
-pub type TraceErrHandle<K, T, R> = TraceAgent<ErrSpine<K, T, R>>;
-pub type KeysValsHandle = TraceRowHandle<Row, Row, Timestamp, Diff>;
-pub type ErrsHandle = TraceErrHandle<DataflowError, Timestamp, Diff>;
+// Spines are data structures that collect and maintain updates.
+// Agents are wrappers around spines that allow shared read access.
+
+// Fully generic spines and agents.
+pub type KeyValSpine<K, V, T, R> = ColValSpine<K, V, T, R>;
+pub type KeyValAgent<K, V, T, R> = TraceAgent<KeyValSpine<K, V, T, R>>;
+pub type KeySpine<K, T, R> = ColKeySpine<K, T, R>;
+pub type KeyAgent<K, T, R> = TraceAgent<KeySpine<K, T, R>>;
+
+// Error specialized spines and agents.
+pub type ErrSpine<T, R> = ColKeySpine<DataflowError, T, R>;
+pub type ErrAgent<T, R> = TraceAgent<ErrSpine<T, R>>;
+pub type KeyErrSpine<K, T, R> = ColValSpine<K, DataflowError, T, R>;

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -35,17 +35,17 @@ pub type KeyAgent<K, T, R> = TraceAgent<KeySpine<K, T, R>>;
 pub type KeyEnter<K, T, R, TEnter> = TraceEnter<TraceFrontier<KeyAgent<K, T, R>>, TEnter>;
 
 // Row specialized spines and agents.
-pub type RowRowSpine<T, R> = ColValSpine<Row, Row, T, R>;
+pub type RowValSpine<V, T, R> = ColValSpine<Row, V, T, R>;
+pub type RowValAgent<V, T, R> = TraceAgent<RowValSpine<V, T, R>>;
+pub type RowValArrangement<S, V> = Arranged<S, RowValAgent<V, <S as ScopeParent>::Timestamp, Diff>>;
+pub type RowValEnter<V, T, R, TEnter> = TraceEnter<TraceFrontier<RowValAgent<V, T, R>>, TEnter>;
+// Row specialized spines and agents.
+pub type RowRowSpine<T, R> = RowValSpine<Row, T, R>;
 pub type RowRowAgent<T, R> = TraceAgent<RowRowSpine<T, R>>;
 pub type RowRowArrangement<S> = Arranged<S, RowRowAgent<<S as ScopeParent>::Timestamp, Diff>>;
 pub type RowRowEnter<T, R, TEnter> = TraceEnter<TraceFrontier<RowRowAgent<T, R>>, TEnter>;
 // Row specialized spines and agents.
-pub type RowValSpine<V, T, R> = ColValSpine<Row, V, T, R>;
-pub type RowValAgent<V, T, R> = TraceAgent<RowValSpine<V, T, R>>;
-pub type RowValArrangement<S, V> = Arranged<S, RowValAgent<V, <S as ScopeParent>::Timestamp, Diff>>;
-pub type RowValImport<V, T, R, TEnter> = TraceEnter<TraceFrontier<RowValAgent<V, T, R>>, TEnter>;
-// Row specialized spines and agents.
-pub type RowSpine<T, R> = ColKeySpine<Row, T, R>;
+pub type RowSpine<T, R> = RowValSpine<(), T, R>;
 pub type RowAgent<T, R> = TraceAgent<RowSpine<T, R>>;
 pub type RowArrangement<S> = Arranged<S, RowAgent<<S as ScopeParent>::Timestamp, Diff>>;
 pub type RowEnter<T, R, TEnter> = TraceEnter<TraceFrontier<RowAgent<T, R>>, TEnter>;
@@ -55,3 +55,4 @@ pub type ErrSpine<T, R> = ColKeySpine<DataflowError, T, R>;
 pub type ErrAgent<T, R> = TraceAgent<ErrSpine<T, R>>;
 pub type ErrEnter<T, TEnter> = TraceEnter<TraceFrontier<ErrAgent<T, Diff>>, TEnter>;
 pub type KeyErrSpine<K, T, R> = ColValSpine<K, DataflowError, T, R>;
+pub type RowErrSpine<T, R> = RowValSpine<DataflowError, T, R>;

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -26,19 +26,19 @@ use mz_storage_types::errors::DataflowError;
 // Fully generic spines and agents.
 pub type KeyValSpine<K, V, T, R> = ColValSpine<K, V, T, R>;
 pub type KeyValAgent<K, V, T, R> = TraceAgent<KeyValSpine<K, V, T, R>>;
-pub type KeyValImport<K, V, T, R, TEnter> =
+pub type KeyValEnter<K, V, T, R, TEnter> =
     TraceEnter<TraceFrontier<KeyValAgent<K, V, T, R>>, TEnter>;
 
 // Fully generic key-only spines and agents
 pub type KeySpine<K, T, R> = ColKeySpine<K, T, R>;
 pub type KeyAgent<K, T, R> = TraceAgent<KeySpine<K, T, R>>;
-pub type KeyImport<K, T, R, TEnter> = TraceEnter<TraceFrontier<KeyAgent<K, T, R>>, TEnter>;
+pub type KeyEnter<K, T, R, TEnter> = TraceEnter<TraceFrontier<KeyAgent<K, T, R>>, TEnter>;
 
 // Row specialized spines and agents.
 pub type RowRowSpine<T, R> = ColValSpine<Row, Row, T, R>;
 pub type RowRowAgent<T, R> = TraceAgent<RowRowSpine<T, R>>;
 pub type RowRowArrangement<S> = Arranged<S, RowRowAgent<<S as ScopeParent>::Timestamp, Diff>>;
-pub type RowRowImport<T, R, TEnter> = TraceEnter<TraceFrontier<RowRowAgent<T, R>>, TEnter>;
+pub type RowRowEnter<T, R, TEnter> = TraceEnter<TraceFrontier<RowRowAgent<T, R>>, TEnter>;
 // Row specialized spines and agents.
 pub type RowValSpine<V, T, R> = ColValSpine<Row, V, T, R>;
 pub type RowValAgent<V, T, R> = TraceAgent<RowValSpine<V, T, R>>;
@@ -48,10 +48,10 @@ pub type RowValImport<V, T, R, TEnter> = TraceEnter<TraceFrontier<RowValAgent<V,
 pub type RowSpine<T, R> = ColKeySpine<Row, T, R>;
 pub type RowAgent<T, R> = TraceAgent<RowSpine<T, R>>;
 pub type RowArrangement<S> = Arranged<S, RowAgent<<S as ScopeParent>::Timestamp, Diff>>;
-pub type RowImport<T, R, TEnter> = TraceEnter<TraceFrontier<RowAgent<T, R>>, TEnter>;
+pub type RowEnter<T, R, TEnter> = TraceEnter<TraceFrontier<RowAgent<T, R>>, TEnter>;
 
 // Error specialized spines and agents.
 pub type ErrSpine<T, R> = ColKeySpine<DataflowError, T, R>;
 pub type ErrAgent<T, R> = TraceAgent<ErrSpine<T, R>>;
-pub type ErrImport<T, TEnter> = TraceEnter<TraceFrontier<ErrAgent<T, Diff>>, TEnter>;
+pub type ErrEnter<T, TEnter> = TraceEnter<TraceFrontier<ErrAgent<T, Diff>>, TEnter>;
 pub type KeyErrSpine<K, T, R> = ColValSpine<K, DataflowError, T, R>;

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -10,10 +10,14 @@
 //! Convience typedefs for differential types.
 
 #![allow(missing_docs)]
-
+use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::operators::arrange::TraceAgent;
 use differential_dataflow::trace::implementations::ord_neu::{ColKeySpine, ColValSpine};
+use differential_dataflow::trace::wrappers::enter::TraceEnter;
+use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
+use timely::dataflow::ScopeParent;
 
+use mz_repr::Diff;
 use mz_storage_types::errors::DataflowError;
 
 // Spines are data structures that collect and maintain updates.
@@ -22,10 +26,25 @@ use mz_storage_types::errors::DataflowError;
 // Fully generic spines and agents.
 pub type KeyValSpine<K, V, T, R> = ColValSpine<K, V, T, R>;
 pub type KeyValAgent<K, V, T, R> = TraceAgent<KeyValSpine<K, V, T, R>>;
+pub type KeyValArrangement<S, K, V> =
+    Arranged<S, KeyValAgent<K, V, <S as ScopeParent>::Timestamp, Diff>>;
+pub type KeyValImport<K, V, T, R, TEnter> =
+    TraceEnter<TraceFrontier<KeyValAgent<K, V, T, R>>, TEnter>;
+pub type KeyValArrangementImport<S, K, V, T> =
+    Arranged<S, KeyValImport<K, V, T, Diff, <S as ScopeParent>::Timestamp>>;
+
+// Fully generic key-only spines and agents
 pub type KeySpine<K, T, R> = ColKeySpine<K, T, R>;
 pub type KeyAgent<K, T, R> = TraceAgent<KeySpine<K, T, R>>;
+pub type KeyArrangement<S, K> = Arranged<S, KeyAgent<K, <S as ScopeParent>::Timestamp, Diff>>;
+pub type KeyImport<K, T, R, TEnter> = TraceEnter<TraceFrontier<KeyAgent<K, T, R>>, TEnter>;
+pub type KeyArrangementImport<S, K, T> =
+    Arranged<S, KeyImport<K, T, Diff, <S as ScopeParent>::Timestamp>>;
 
 // Error specialized spines and agents.
 pub type ErrSpine<T, R> = ColKeySpine<DataflowError, T, R>;
 pub type ErrAgent<T, R> = TraceAgent<ErrSpine<T, R>>;
+pub type ErrImport<T, TEnter> = TraceEnter<TraceFrontier<ErrAgent<T, Diff>>, TEnter>;
+pub type ErrArrangementImport<S, T> = Arranged<S, ErrImport<T, <S as ScopeParent>::Timestamp>>;
+pub type ErrArrangement<S> = Arranged<S, ErrAgent<<S as ScopeParent>::Timestamp, Diff>>;
 pub type KeyErrSpine<K, T, R> = ColValSpine<K, DataflowError, T, R>;

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -9,7 +9,7 @@
 
 //! Convience typedefs for differential types.
 
-#![allow(missing_docs)]
+#![allow(dead_code, missing_docs)]
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::operators::arrange::TraceAgent;
 use differential_dataflow::trace::implementations::ord_neu::{ColKeySpine, ColValSpine};
@@ -17,7 +17,7 @@ use differential_dataflow::trace::wrappers::enter::TraceEnter;
 use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
 use timely::dataflow::ScopeParent;
 
-use mz_repr::Diff;
+use mz_repr::{Diff, Row};
 use mz_storage_types::errors::DataflowError;
 
 // Spines are data structures that collect and maintain updates.
@@ -26,25 +26,32 @@ use mz_storage_types::errors::DataflowError;
 // Fully generic spines and agents.
 pub type KeyValSpine<K, V, T, R> = ColValSpine<K, V, T, R>;
 pub type KeyValAgent<K, V, T, R> = TraceAgent<KeyValSpine<K, V, T, R>>;
-pub type KeyValArrangement<S, K, V> =
-    Arranged<S, KeyValAgent<K, V, <S as ScopeParent>::Timestamp, Diff>>;
 pub type KeyValImport<K, V, T, R, TEnter> =
     TraceEnter<TraceFrontier<KeyValAgent<K, V, T, R>>, TEnter>;
-pub type KeyValArrangementImport<S, K, V, T> =
-    Arranged<S, KeyValImport<K, V, T, Diff, <S as ScopeParent>::Timestamp>>;
 
 // Fully generic key-only spines and agents
 pub type KeySpine<K, T, R> = ColKeySpine<K, T, R>;
 pub type KeyAgent<K, T, R> = TraceAgent<KeySpine<K, T, R>>;
-pub type KeyArrangement<S, K> = Arranged<S, KeyAgent<K, <S as ScopeParent>::Timestamp, Diff>>;
 pub type KeyImport<K, T, R, TEnter> = TraceEnter<TraceFrontier<KeyAgent<K, T, R>>, TEnter>;
-pub type KeyArrangementImport<S, K, T> =
-    Arranged<S, KeyImport<K, T, Diff, <S as ScopeParent>::Timestamp>>;
+
+// Row specialized spines and agents.
+pub type RowRowSpine<T, R> = ColValSpine<Row, Row, T, R>;
+pub type RowRowAgent<T, R> = TraceAgent<RowRowSpine<T, R>>;
+pub type RowRowArrangement<S> = Arranged<S, RowRowAgent<<S as ScopeParent>::Timestamp, Diff>>;
+pub type RowRowImport<T, R, TEnter> = TraceEnter<TraceFrontier<RowRowAgent<T, R>>, TEnter>;
+// Row specialized spines and agents.
+pub type RowValSpine<V, T, R> = ColValSpine<Row, V, T, R>;
+pub type RowValAgent<V, T, R> = TraceAgent<RowValSpine<V, T, R>>;
+pub type RowValArrangement<S, V> = Arranged<S, RowValAgent<V, <S as ScopeParent>::Timestamp, Diff>>;
+pub type RowValImport<V, T, R, TEnter> = TraceEnter<TraceFrontier<RowValAgent<V, T, R>>, TEnter>;
+// Row specialized spines and agents.
+pub type RowSpine<T, R> = ColKeySpine<Row, T, R>;
+pub type RowAgent<T, R> = TraceAgent<RowSpine<T, R>>;
+pub type RowArrangement<S> = Arranged<S, RowAgent<<S as ScopeParent>::Timestamp, Diff>>;
+pub type RowImport<T, R, TEnter> = TraceEnter<TraceFrontier<RowAgent<T, R>>, TEnter>;
 
 // Error specialized spines and agents.
 pub type ErrSpine<T, R> = ColKeySpine<DataflowError, T, R>;
 pub type ErrAgent<T, R> = TraceAgent<ErrSpine<T, R>>;
 pub type ErrImport<T, TEnter> = TraceEnter<TraceFrontier<ErrAgent<T, Diff>>, TEnter>;
-pub type ErrArrangementImport<S, T> = Arranged<S, ErrImport<T, <S as ScopeParent>::Timestamp>>;
-pub type ErrArrangement<S> = Arranged<S, ErrAgent<<S as ScopeParent>::Timestamp, Diff>>;
 pub type KeyErrSpine<K, T, R> = ColValSpine<K, DataflowError, T, R>;


### PR DESCRIPTION
This PR restructures our spine type aliases to have a common structure of `XYSpine` or `XSpine`, where `X` and `Y` are drawn from `{ Key, Row, Err }` and `{ Val, Row, Err }` respectively. Our existing naming scheme used similar terms but with varying meaning. Also, centralize type aliases in `typedefs.rs` (including some from `context.rs`). Identifies uses of "general" spines with `Row` hardcoding, and replaces them with `RowSpine` variants (the same types at the moment, behind aliases, but now pivotable to new types).

### Motivation

   * This PR refactors existing code.

There should be no behavioral changes; only changes to type aliases.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
