### PR TITLE
Amend RowSpine to use ColKeySpine vs ColValSpine

### DIFF
--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -45,7 +45,7 @@ pub type RowRowAgent<T, R> = TraceAgent<RowRowSpine<T, R>>;
 pub type RowRowArrangement<S> = Arranged<S, RowRowAgent<<S as ScopeParent>::Timestamp, Diff>>;
 pub type RowRowEnter<T, R, TEnter> = TraceEnter<TraceFrontier<RowRowAgent<T, R>>, TEnter>;
 // Row specialized spines and agents.
-pub type RowSpine<T, R> = RowValSpine<(), T, R>;
+pub type RowSpine<T, R> = ColKeySpine<Row, T, R>;
 pub type RowAgent<T, R> = TraceAgent<RowSpine<T, R>>;
 pub type RowArrangement<S> = Arranged<S, RowAgent<<S as ScopeParent>::Timestamp, Diff>>;
 pub type RowEnter<T, R, TEnter> = TraceEnter<TraceFrontier<RowAgent<T, R>>, TEnter>;


### PR DESCRIPTION
This PR fixes a regression in the types for `SpecializedArrangement::RowUnit` representations where we'd not use a `ColKeySpine` type to get rid of the value layer in the arrangement representation.

### Motivation

  * This PR fixes a previously unreported bug.

This is a regression introduced by https://github.com/MaterializeInc/materialize/pull/23787 that would reintroduce the issue described in https://github.com/MaterializeInc/materialize/issues/22880.

### Tips for reviewer

[Slack ref](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1702294515028929)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
