### PR TITLE
catalog: Add set_catalog functionality

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -194,7 +194,7 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
 
     /// Get a full snapshot of all data in the catalog. This includes all audit logs and storage
     /// usages that isn't included in [`Self::snapshot`].
-    async fn full_snapshot(
+    async fn whole_migration_snapshot(
         &mut self,
     ) -> Result<(Snapshot, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError>;
 }
@@ -211,7 +211,7 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     /// Creates a new durable catalog state transaction. Also returns all the audit logs and storage
     /// usages that exist at the start of the transaction, which isn't included in
     /// [`Self::transaction`].
-    async fn full_transaction(
+    async fn whole_migration_transaction(
         &mut self,
     ) -> Result<(Transaction, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError>;
 

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -191,6 +191,12 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
 
     /// Get a snapshot of the catalog.
     async fn snapshot(&mut self) -> Result<Snapshot, CatalogError>;
+
+    /// Get a full snapshot of all data in the catalog. This includes all audit logs and storage
+    /// usages that isn't included in [`Self::snapshot`].
+    async fn full_snapshot(
+        &mut self,
+    ) -> Result<(Snapshot, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError>;
 }
 
 /// A read-write API for the durable catalog state.
@@ -201,6 +207,13 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
 
     /// Creates a new durable catalog state transaction.
     async fn transaction(&mut self) -> Result<Transaction, CatalogError>;
+
+    /// Creates a new durable catalog state transaction. Also returns all the audit logs and storage
+    /// usages that exist at the start of the transaction, which isn't included in
+    /// [`Self::transaction`].
+    async fn full_transaction(
+        &mut self,
+    ) -> Result<(Transaction, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError>;
 
     /// Commits a durable catalog state transaction.
     async fn commit_transaction(&mut self, txn_batch: TransactionBatch)

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -916,7 +916,7 @@ impl ReadOnlyDurableCatalogState for PersistCatalogState {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn full_snapshot(
+    async fn whole_migration_snapshot(
         &mut self,
     ) -> Result<(Snapshot, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
         self.sync_to_current_upper().await?;
@@ -957,11 +957,11 @@ impl DurableCatalogState for PersistCatalogState {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn full_transaction(
+    async fn whole_migration_transaction(
         &mut self,
     ) -> Result<(Transaction, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
         self.metrics.transactions_started.inc();
-        let (snapshot, audit_events, storage_usages) = self.full_snapshot().await?;
+        let (snapshot, audit_events, storage_usages) = self.whole_migration_snapshot().await?;
         let transaction = Transaction::new(self, snapshot)?;
         Ok((transaction, audit_events, storage_usages))
     }

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -914,6 +914,33 @@ impl ReadOnlyDurableCatalogState for PersistCatalogState {
     async fn snapshot(&mut self) -> Result<Snapshot, CatalogError> {
         self.with_snapshot(|snapshot| Ok(snapshot.clone())).await
     }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn full_snapshot(
+        &mut self,
+    ) -> Result<(Snapshot, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
+        self.sync_to_current_upper().await?;
+        let snapshot = self.snapshot.clone();
+        let mut audit_events = Vec::new();
+        let mut storage_usages = Vec::new();
+        for StateUpdate { kind, ts: _, diff } in self.persist_snapshot().await {
+            soft_assert_eq!(1, diff, "updates should be consolidated");
+            match kind {
+                StateUpdateKind::AuditLog(audit_event, ()) => {
+                    let audit_event = AuditLogKey::from_proto(audit_event)?.event;
+                    audit_events.push(audit_event);
+                }
+                StateUpdateKind::StorageUsage(storage_usage, ()) => {
+                    let storage_usage = StorageUsageKey::from_proto(storage_usage)?.metric;
+                    storage_usages.push(storage_usage);
+                }
+                _ => {
+                    // Everything else is already cached in `self.snapshot`.
+                }
+            }
+        }
+        Ok((snapshot, audit_events, storage_usages))
+    }
 }
 
 #[async_trait]
@@ -927,6 +954,16 @@ impl DurableCatalogState for PersistCatalogState {
         self.metrics.transactions_started.inc();
         let snapshot = self.snapshot().await?;
         Transaction::new(self, snapshot)
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn full_transaction(
+        &mut self,
+    ) -> Result<(Transaction, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
+        self.metrics.transactions_started.inc();
+        let (snapshot, audit_events, storage_usages) = self.full_snapshot().await?;
+        let transaction = Transaction::new(self, snapshot)?;
+        Ok((transaction, audit_events, storage_usages))
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/src/catalog/src/durable/impls/shadow.rs
+++ b/src/catalog/src/durable/impls/shadow.rs
@@ -437,7 +437,7 @@ impl ReadOnlyDurableCatalogState for ShadowCatalogState {
         }
     }
 
-    async fn full_snapshot(
+    async fn whole_migration_snapshot(
         &mut self,
     ) -> Result<(Snapshot, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
         panic!("Shadow catalog should never get a full snapshot")
@@ -479,7 +479,7 @@ impl DurableCatalogState for ShadowCatalogState {
         Transaction::new(self, snapshot)
     }
 
-    async fn full_transaction(
+    async fn whole_migration_transaction(
         &mut self,
     ) -> Result<(Transaction, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
         panic!("Shadow catalog should never get a full transaction")

--- a/src/catalog/src/durable/impls/shadow.rs
+++ b/src/catalog/src/durable/impls/shadow.rs
@@ -436,6 +436,12 @@ impl ReadOnlyDurableCatalogState for ShadowCatalogState {
             compare_and_return_async!(self, snapshot)
         }
     }
+
+    async fn full_snapshot(
+        &mut self,
+    ) -> Result<(Snapshot, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
+        panic!("Shadow catalog should never get a full snapshot")
+    }
 }
 
 #[async_trait]
@@ -471,6 +477,12 @@ impl DurableCatalogState for ShadowCatalogState {
         // both implementations.
         let snapshot = self.snapshot().await?;
         Transaction::new(self, snapshot)
+    }
+
+    async fn full_transaction(
+        &mut self,
+    ) -> Result<(Transaction, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
+        panic!("Shadow catalog should never get a full transaction")
     }
 
     async fn commit_transaction(

--- a/src/catalog/src/durable/impls/stash.rs
+++ b/src/catalog/src/durable/impls/stash.rs
@@ -707,6 +707,121 @@ impl ReadOnlyDurableCatalogState for Connection {
             system_privileges,
         })
     }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn full_snapshot(
+        &mut self,
+    ) -> Result<(Snapshot, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
+        let (
+            databases,
+            schemas,
+            roles,
+            items,
+            comments,
+            clusters,
+            cluster_replicas,
+            introspection_sources,
+            id_allocator,
+            configs,
+            settings,
+            timestamps,
+            system_gid_mapping,
+            system_configurations,
+            default_privileges,
+            system_privileges,
+            audit_events,
+            storage_usages,
+        ): (
+            BTreeMap<proto::DatabaseKey, proto::DatabaseValue>,
+            BTreeMap<proto::SchemaKey, proto::SchemaValue>,
+            BTreeMap<proto::RoleKey, proto::RoleValue>,
+            BTreeMap<proto::ItemKey, proto::ItemValue>,
+            BTreeMap<proto::CommentKey, proto::CommentValue>,
+            BTreeMap<proto::ClusterKey, proto::ClusterValue>,
+            BTreeMap<proto::ClusterReplicaKey, proto::ClusterReplicaValue>,
+            BTreeMap<
+                proto::ClusterIntrospectionSourceIndexKey,
+                proto::ClusterIntrospectionSourceIndexValue,
+            >,
+            BTreeMap<proto::IdAllocKey, proto::IdAllocValue>,
+            BTreeMap<proto::ConfigKey, proto::ConfigValue>,
+            BTreeMap<proto::SettingKey, proto::SettingValue>,
+            BTreeMap<proto::TimestampKey, proto::TimestampValue>,
+            BTreeMap<proto::GidMappingKey, proto::GidMappingValue>,
+            BTreeMap<proto::ServerConfigurationKey, proto::ServerConfigurationValue>,
+            BTreeMap<proto::DefaultPrivilegesKey, proto::DefaultPrivilegesValue>,
+            BTreeMap<proto::SystemPrivilegesKey, proto::SystemPrivilegesValue>,
+            BTreeMap<proto::AuditLogKey, ()>,
+            BTreeMap<proto::StorageUsageKey, ()>,
+        ) = self
+            .stash
+            .with_transaction(|tx| {
+                Box::pin(async move {
+                    // Peek the catalog collections in any order and a single transaction.
+                    futures::try_join!(
+                        tx.peek_one(tx.collection(DATABASES_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(SCHEMAS_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(ROLES_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(ITEM_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(COMMENTS_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(CLUSTER_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(CLUSTER_REPLICA_COLLECTION.name()).await?),
+                        tx.peek_one(
+                            tx.collection(CLUSTER_INTROSPECTION_SOURCE_INDEX_COLLECTION.name())
+                                .await?,
+                        ),
+                        tx.peek_one(tx.collection(ID_ALLOCATOR_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(CONFIG_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(SETTING_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(TIMESTAMP_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(SYSTEM_GID_MAPPING_COLLECTION.name()).await?),
+                        tx.peek_one(
+                            tx.collection(SYSTEM_CONFIGURATION_COLLECTION.name())
+                                .await?
+                        ),
+                        tx.peek_one(tx.collection(DEFAULT_PRIVILEGES_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(SYSTEM_PRIVILEGES_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(AUDIT_LOG_COLLECTION.name()).await?),
+                        tx.peek_one(tx.collection(STORAGE_USAGE_COLLECTION.name()).await?),
+                    )
+                })
+            })
+            .await?;
+
+        let audit_events = audit_events
+            .into_keys()
+            .map(RustType::from_proto)
+            .map_ok(|key: AuditLogKey| key.event)
+            .collect::<Result<_, _>>()?;
+        let storage_usages = storage_usages
+            .into_keys()
+            .map(RustType::from_proto)
+            .map_ok(|key: StorageUsageKey| key.metric)
+            .collect::<Result<_, _>>()?;
+
+        Ok((
+            Snapshot {
+                databases,
+                schemas,
+                roles,
+                items,
+                comments,
+                clusters,
+                cluster_replicas,
+                introspection_sources,
+                id_allocator,
+                configs,
+                settings,
+                timestamps,
+                system_object_mappings: system_gid_mapping,
+                system_configurations,
+                default_privileges,
+                system_privileges,
+            },
+            audit_events,
+            storage_usages,
+        ))
+    }
 }
 
 #[async_trait]
@@ -719,6 +834,15 @@ impl DurableCatalogState for Connection {
     async fn transaction(&mut self) -> Result<Transaction, CatalogError> {
         let snapshot = self.snapshot().await?;
         Transaction::new(self, snapshot)
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn full_transaction(
+        &mut self,
+    ) -> Result<(Transaction, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
+        let (snapshot, audit_events, storage_usages) = self.full_snapshot().await?;
+        let transaction = Transaction::new(self, snapshot)?;
+        Ok((transaction, audit_events, storage_usages))
     }
 
     #[tracing::instrument(name = "storage::transaction", level = "debug", skip_all)]

--- a/src/catalog/src/durable/impls/stash.rs
+++ b/src/catalog/src/durable/impls/stash.rs
@@ -709,7 +709,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn full_snapshot(
+    async fn whole_migration_snapshot(
         &mut self,
     ) -> Result<(Snapshot, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
         let (
@@ -837,10 +837,10 @@ impl DurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn full_transaction(
+    async fn whole_migration_transaction(
         &mut self,
     ) -> Result<(Transaction, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
-        let (snapshot, audit_events, storage_usages) = self.full_snapshot().await?;
+        let (snapshot, audit_events, storage_usages) = self.whole_migration_snapshot().await?;
         let transaction = Transaction::new(self, snapshot)?;
         Ok((transaction, audit_events, storage_usages))
     }

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -555,7 +555,8 @@ async fn test_set_catalog(openable_state: impl OpenableDurableCatalogState) {
     txn.commit().await.unwrap();
 
     // Set the contents of the catalog.
-    let (mut txn, old_audit_logs, old_storage_usages) = state.full_transaction().await.unwrap();
+    let (mut txn, old_audit_logs, old_storage_usages) =
+        state.whole_migration_transaction().await.unwrap();
     txn.set_catalog(
         new_snapshot.clone(),
         old_audit_logs,
@@ -567,7 +568,8 @@ async fn test_set_catalog(openable_state: impl OpenableDurableCatalogState) {
     txn.commit().await.unwrap();
 
     // Check the current state of the catalog.
-    let (mut snapshot, audit_logs, storage_usages) = state.full_snapshot().await.unwrap();
+    let (mut snapshot, audit_logs, storage_usages) =
+        state.whole_migration_snapshot().await.unwrap();
     let items = std::mem::take(&mut snapshot.items);
     assert_eq!(items, new_items);
     assert_eq!(audit_logs, new_audit_logs);

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -893,4 +893,12 @@ where
         soft_assert!(self.verify().is_ok());
         deleted
     }
+
+    /// Deletes all items.
+    pub fn clear(&mut self) {
+        self.for_values_mut(|p, k, _v| {
+            p.insert(k.clone(), None);
+        });
+        soft_assert!(self.verify().is_ok());
+    }
 }


### PR DESCRIPTION
This commit adds the ability to transactionally clear the entire contents of a catalog and set it to something else. This is required for migrating an environment from one catalog implementation to another.

Works towards resolving #23779

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
