### PR TITLE
catalog: Add tombstone config

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -130,6 +130,9 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// Get the deployment generation of this instance.
     async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError>;
 
+    /// Get the tombstone value of this instance.
+    async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError>;
+
     /// Generate an unconsolidated [`Trace`] of catalog contents.
     async fn trace(&mut self) -> Result<Trace, CatalogError>;
 
@@ -188,6 +191,9 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
     async fn get_persist_txn_tables(
         &mut self,
     ) -> Result<Option<PersistTxnTablesImpl>, CatalogError>;
+
+    /// Get the tombstone value of this instance.
+    async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError>;
 
     /// Get a snapshot of the catalog.
     async fn snapshot(&mut self) -> Result<Snapshot, CatalogError>;

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -529,6 +529,10 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
         self.get_current_config(DEPLOY_GENERATION).await
     }
 
+    async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {
+        panic!("Persist implementation does not have a tombstone")
+    }
+
     #[tracing::instrument(level = "info", skip_all)]
     async fn trace(&mut self) -> Result<Trace, CatalogError> {
         let (persist_shard_readable, current_upper) = self.is_persist_shard_readable().await;
@@ -908,6 +912,10 @@ impl ReadOnlyDurableCatalogState for PersistCatalogState {
                 DurableCatalogError::from(TryFromProtoError::UnknownEnumVariant(err.to_string()))
                     .into()
             })
+    }
+
+    async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {
+        panic!("Persist implementation does not have a tombstone")
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/src/catalog/src/durable/impls/shadow.rs
+++ b/src/catalog/src/durable/impls/shadow.rs
@@ -153,6 +153,10 @@ where
         compare_and_return_async!(self, get_deployment_generation)
     }
 
+    async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {
+        compare_and_return_async!(self, get_tombstone)
+    }
+
     async fn trace(&mut self) -> Result<Trace, CatalogError> {
         panic!("ShadowCatalog is not used for catalog-debug tool");
     }
@@ -344,6 +348,10 @@ impl ReadOnlyDurableCatalogState for ShadowCatalogState {
 
     async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError> {
         compare_and_return_async!(self, has_system_config_synced_once)
+    }
+
+    async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {
+        compare_and_return_async!(self, get_tombstone)
     }
 
     async fn snapshot(&mut self) -> Result<Snapshot, CatalogError> {

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -41,7 +41,7 @@ use crate::durable::{
 pub(crate) const DEPLOY_GENERATION: &str = "deploy_generation";
 /// The key within the "config" Collection that stores the version of the catalog.
 pub(crate) const USER_VERSION_KEY: &str = "user_version";
-/// The key within the "config" Collection that stores whether the remote configuration was
+/// The key within the "config" collection that stores whether the remote configuration was
 /// synchronized at least once.
 pub(crate) const SYSTEM_CONFIG_SYNCED_KEY: &str = "system_config_synced";
 
@@ -50,6 +50,10 @@ pub(crate) const SYSTEM_CONFIG_SYNCED_KEY: &str = "system_config_synced";
 /// can toggle the flag with Launch Darkly, but use it in boot before Launch
 /// Darkly is available.
 pub(crate) const PERSIST_TXN_TABLES: &str = "persist_txn_tables";
+
+/// The key within the "config" collection that stores whether the current durable store is actively
+/// being used for the catalog. This is used to implement migrations/rollbacks to/from persist.
+pub(crate) const TOMBSTONE_KEY: &str = "tombstone";
 
 const USER_ID_ALLOC_KEY: &str = "user";
 const SYSTEM_ID_ALLOC_KEY: &str = "system";

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -30,7 +30,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
 use crate::builtin::BuiltinLog;
-use crate::durable::initialize::{PERSIST_TXN_TABLES, SYSTEM_CONFIG_SYNCED_KEY};
+use crate::durable::initialize::{PERSIST_TXN_TABLES, SYSTEM_CONFIG_SYNCED_KEY, TOMBSTONE_KEY};
 use crate::durable::objects::serialization::proto;
 use crate::durable::objects::{
     AuditLogKey, Cluster, ClusterConfig, ClusterIntrospectionSourceIndexKey,
@@ -1062,6 +1062,12 @@ impl<'a> Transaction<'a> {
     /// Updates the catalog `system_config_synced` "config" value to true.
     pub fn set_system_config_synced_once(&mut self) -> Result<(), CatalogError> {
         self.set_config(SYSTEM_CONFIG_SYNCED_KEY.into(), 1)
+    }
+
+    /// Updates the catalog `tombstone` "config" value.
+    pub fn set_tombstone(&mut self, value: bool) -> Result<(), CatalogError> {
+        self.set_config(TOMBSTONE_KEY.into(), if value { 1 } else { 0 })?;
+        Ok(())
     }
 
     pub fn update_comment(


### PR DESCRIPTION
This commit adds the "tombstone" config value to the stash catalog only. This is required for migrating an environment from one catalog implementation to another.

Works towards resolving #23779

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
