### PR TITLE
adapter: make tunables of postgres TimestampOracle configurable via LD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5310,6 +5310,7 @@ dependencies = [
  "http",
  "itertools",
  "maplit",
+ "mz-adapter-types",
  "mz-build-info",
  "mz-ccsr",
  "mz-cloud-resources",

--- a/src/adapter-types/src/lib.rs
+++ b/src/adapter-types/src/lib.rs
@@ -79,3 +79,4 @@
 
 pub mod compaction;
 pub mod connection;
+pub mod timestamp_oracle;

--- a/src/adapter-types/src/timestamp_oracle.rs
+++ b/src/adapter-types/src/timestamp_oracle.rs
@@ -1,0 +1,28 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+/// Default value for `DynamicConfig::pg_connection_pool_max_size`.
+pub const DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE: usize = 50;
+
+/// Default value for `DynamicConfig::pg_connection_pool_max_wait`.
+pub const DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT: Duration = Duration::from_secs(60);
+
+/// Default value for `DynamicConfig::pg_connection_pool_ttl`.
+pub const DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL: Duration = Duration::from_secs(300);
+
+/// Default value for `DynamicConfig::pg_connection_pool_ttl_stagger`.
+pub const DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER: Duration = Duration::from_secs(6);
+
+/// Default value for `DynamicConfig::pg_connection_pool_connect_timeout`.
+pub const DEFAULT_PG_TIMESTAMP_ORACLE_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default value for `DynamicConfig::pg_connection_pool_tcp_user_timeout`.
+pub const DEFAULT_PG_TIMESTAMP_ORACLE_TCP_USER_TIMEOUT: Duration = Duration::from_secs(30);

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2359,6 +2359,13 @@ pub fn serve(
 
         let pg_timestamp_oracle_config = timestamp_oracle_url
             .map(|pg_url| PostgresTimestampOracleConfig::new(&pg_url, &metrics_registry));
+        if let Some(config) = pg_timestamp_oracle_config.as_ref() {
+            // Apply settings from system vars as early as possible because some
+            // of them are locked in right when an oracle is first opened!
+            let pg_timestamp_oracle_params =
+                flags::pg_timstamp_oracle_config(catalog.system_config());
+            pg_timestamp_oracle_params.apply(config);
+        }
 
         let initial_timestamps =
             get_initial_oracle_timestamps(&catalog, &pg_timestamp_oracle_config).await?;

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2357,11 +2357,8 @@ pub fn serve(
         // use the same impl!
         let timestamp_oracle_impl = catalog.system_config().timestamp_oracle_impl();
 
-        let timestamp_oracle_metrics =
-            Arc::new(timestamp_oracle::metrics::Metrics::new(&metrics_registry));
-        let pg_timestamp_oracle_config = timestamp_oracle_url.map(|pg_url| {
-            PostgresTimestampOracleConfig::new(&pg_url, Arc::clone(&timestamp_oracle_metrics))
-        });
+        let pg_timestamp_oracle_config = timestamp_oracle_url
+            .map(|pg_url| PostgresTimestampOracleConfig::new(&pg_url, &metrics_registry));
 
         let initial_timestamps =
             get_initial_oracle_timestamps(&catalog, &pg_timestamp_oracle_config).await?;

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1038,9 +1038,6 @@ pub struct Coordinator {
     /// Coordinator metrics.
     metrics: Metrics,
 
-    /// For registering new metrics.
-    timestamp_oracle_metrics: Arc<timestamp_oracle::metrics::Metrics>,
-
     /// Tracing handle.
     tracing_handle: TracingHandle,
 
@@ -1055,8 +1052,10 @@ pub struct Coordinator {
     /// use.
     timestamp_oracle_impl: vars::TimestampOracleImpl,
 
-    /// Postgres connection URL for the Postgres/CRDB-backed timestamp oracle.
-    timestamp_oracle_url: Option<String>,
+    /// Optional config for the Postgres-backed timestamp oracle. This is
+    /// _required_ when `postgres` is configured using the `timestamp_oracle`
+    /// system variable.
+    pg_timestamp_oracle_config: Option<PostgresTimestampOracleConfig>,
 }
 
 impl Coordinator {
@@ -2348,8 +2347,6 @@ pub fn serve(
 
         let metrics = Metrics::register_into(&metrics_registry);
         let metrics_clone = metrics.clone();
-        let timestamp_oracle_metrics =
-            Arc::new(timestamp_oracle::metrics::Metrics::new(&metrics_registry));
         let segment_client_clone = segment_client.clone();
         let span = tracing::Span::current();
         let coord_now = now.clone();
@@ -2360,12 +2357,14 @@ pub fn serve(
         // use the same impl!
         let timestamp_oracle_impl = catalog.system_config().timestamp_oracle_impl();
 
-        let initial_timestamps = get_initial_oracle_timestamps(
-            &catalog,
-            &timestamp_oracle_url,
-            &timestamp_oracle_metrics,
-        )
-        .await?;
+        let timestamp_oracle_metrics =
+            Arc::new(timestamp_oracle::metrics::Metrics::new(&metrics_registry));
+        let pg_timestamp_oracle_config = timestamp_oracle_url.map(|pg_url| {
+            PostgresTimestampOracleConfig::new(&pg_url, Arc::clone(&timestamp_oracle_metrics))
+        });
+
+        let initial_timestamps =
+            get_initial_oracle_timestamps(&catalog, &pg_timestamp_oracle_config).await?;
 
         let thread = thread::Builder::new()
             // The Coordinator thread tends to keep a lot of data on its stack. To
@@ -2387,8 +2386,7 @@ pub fn serve(
                         coord_now.clone(),
                         timestamp_oracle_impl,
                         persistence,
-                        timestamp_oracle_url.clone(),
-                        &timestamp_oracle_metrics,
+                        pg_timestamp_oracle_config.clone(),
                         &mut timestamp_oracles,
                     ));
                 }
@@ -2434,12 +2432,11 @@ pub fn serve(
                     storage_usage_collection_interval,
                     segment_client,
                     metrics,
-                    timestamp_oracle_metrics,
                     tracing_handle,
                     statement_logging: StatementLogging::new(),
                     webhook_concurrency_limit,
                     timestamp_oracle_impl,
-                    timestamp_oracle_url,
+                    pg_timestamp_oracle_config,
                 };
                 let bootstrap = handle.block_on(async {
                     coord
@@ -2512,8 +2509,7 @@ pub fn serve(
 // postgres/crdb-backed oracle.
 async fn get_initial_oracle_timestamps(
     catalog: &Catalog,
-    pg_timestamp_oracle_url: &Option<String>,
-    timestamp_oracle_metrics: &Arc<timestamp_oracle::metrics::Metrics>,
+    pg_timestamp_oracle_config: &Option<PostgresTimestampOracleConfig>,
 ) -> Result<BTreeMap<Timeline, Timestamp>, AdapterError> {
     let catalog_oracle_timestamps = catalog.get_all_persisted_timestamps().await?;
     let debug_msg = || {
@@ -2528,13 +2524,10 @@ async fn get_initial_oracle_timestamps(
     );
 
     let mut initial_timestamps = catalog_oracle_timestamps;
-    if let Some(timestamp_oracle_url) = pg_timestamp_oracle_url {
-        let oracle_config = PostgresTimestampOracleConfig::new(
-            timestamp_oracle_url,
-            Arc::clone(timestamp_oracle_metrics),
-        );
+    if let Some(pg_timestamp_oracle_config) = pg_timestamp_oracle_config {
         let postgres_oracle_timestamps =
-            PostgresTimestampOracle::<NowFn>::get_all_timelines(oracle_config).await?;
+            PostgresTimestampOracle::<NowFn>::get_all_timelines(pg_timestamp_oracle_config.clone())
+                .await?;
 
         let debug_msg = || {
             postgres_oracle_timestamps

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -216,6 +216,7 @@ impl Coordinator {
         let mut update_tracing_config = false;
         let mut update_compute_config = false;
         let mut update_storage_config = false;
+        let mut update_pg_timestamp_oracle_config = false;
         let mut update_metrics_retention = false;
         let mut update_secrets_caching_config = false;
         let mut update_cluster_scheduling_config = false;
@@ -312,6 +313,8 @@ impl Coordinator {
                     update_tracing_config |= vars::is_tracing_var(name);
                     update_compute_config |= vars::is_compute_config_var(name);
                     update_storage_config |= vars::is_storage_config_var(name);
+                    update_pg_timestamp_oracle_config |=
+                        vars::is_pg_timestamp_oracle_config_var(name);
                     update_metrics_retention |= name == vars::METRICS_RETENTION.name();
                     update_secrets_caching_config |= vars::is_secrets_caching_var(name);
                     update_cluster_scheduling_config |= vars::is_cluster_scheduling_var(name);
@@ -330,6 +333,7 @@ impl Coordinator {
                     update_tracing_config = true;
                     update_compute_config = true;
                     update_storage_config = true;
+                    update_pg_timestamp_oracle_config = true;
                     update_metrics_retention = true;
                     update_secrets_caching_config = true;
                     update_cluster_scheduling_config = true;
@@ -590,6 +594,9 @@ impl Coordinator {
             if update_storage_config {
                 self.update_storage_config();
             }
+            if update_pg_timestamp_oracle_config {
+                self.update_pg_timestamp_oracle_config();
+            }
             if update_metrics_retention {
                 self.update_metrics_retention();
             }
@@ -840,6 +847,13 @@ impl Coordinator {
     fn update_storage_config(&mut self) {
         let config_params = flags::storage_config(self.catalog().system_config());
         self.controller.storage.update_parameters(config_params);
+    }
+
+    fn update_pg_timestamp_oracle_config(&mut self) {
+        let config_params = flags::pg_timstamp_oracle_config(self.catalog().system_config());
+        if let Some(config) = self.pg_timestamp_oracle_config.as_ref() {
+            config_params.apply(config)
+        }
     }
 
     fn update_metrics_retention(&mut self) {

--- a/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
+++ b/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
@@ -407,7 +407,7 @@ where
         initially: Timestamp,
         next: N,
     ) -> Self {
-        info!(url = ?config.url, "opening PostgresTimestampOracle");
+        info!(config = ?config, "opening PostgresTimestampOracle");
 
         let fallible = || async {
             let metrics = Arc::clone(&config.metrics);

--- a/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
+++ b/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
@@ -66,7 +66,7 @@ where
 #[derive(Clone, Debug)]
 pub struct PostgresTimestampOracleConfig {
     url: String,
-    metrics: Arc<Metrics>,
+    pub metrics: Arc<Metrics>,
 
     /// Configurations that can be dynamically updated.
     pub dynamic: Arc<DynamicConfig>,

--- a/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
+++ b/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
@@ -29,7 +29,9 @@ use tracing::{debug, info};
 use crate::coord::timeline::WriteTimestamp;
 use crate::coord::timestamp_oracle::metrics::{Metrics, RetryMetrics};
 use crate::coord::timestamp_oracle::retry::Retry;
-use crate::coord::timestamp_oracle::{GenericNowFn, ShareableTimestampOracle, TimestampOracle};
+use crate::coord::timestamp_oracle::{
+    self, GenericNowFn, ShareableTimestampOracle, TimestampOracle,
+};
 
 // The timestamp columns are a `DECIMAL` that is big enough to hold
 // `18446744073709551615`, the maximum value of `u64` which is our underlying
@@ -84,7 +86,9 @@ impl PostgresTimestampOracleConfig {
     pub(crate) const EXTERNAL_TESTS_POSTGRES_URL: &'static str = "COCKROACH_URL";
 
     /// Returns a new instance of [`PostgresTimestampOracleConfig`] with default tuning.
-    pub fn new(url: &str, metrics: Arc<Metrics>) -> Self {
+    pub fn new(url: &str, metrics_registry: &MetricsRegistry) -> Self {
+        let metrics = Arc::new(timestamp_oracle::metrics::Metrics::new(metrics_registry));
+
         let dynamic = DynamicConfig {
             // TODO(aljoscha): These defaults are taken as is from the persist
             // Consensus tuning. Once we're sufficiently advanced we might want

--- a/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
+++ b/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
@@ -94,27 +94,7 @@ impl PostgresTimestampOracleConfig {
     pub fn new(url: &str, metrics_registry: &MetricsRegistry) -> Self {
         let metrics = Arc::new(timestamp_oracle::metrics::Metrics::new(metrics_registry));
 
-        let dynamic = DynamicConfig {
-            // TODO(aljoscha): These defaults are taken as is from the persist
-            // Consensus tuning. Once we're sufficiently advanced we might want
-            // to pick defaults that are different from the persist defaults.
-            pg_connection_pool_max_size: AtomicUsize::new(
-                DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE,
-            ),
-            pg_connection_pool_max_wait: RwLock::new(Some(
-                DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT,
-            )),
-            pg_connection_pool_ttl: RwLock::new(DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL),
-            pg_connection_pool_ttl_stagger: RwLock::new(
-                DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
-            ),
-            pg_connection_pool_connect_timeout: RwLock::new(
-                DEFAULT_PG_TIMESTAMP_ORACLE_CONNECT_TIMEOUT,
-            ),
-            pg_connection_pool_tcp_user_timeout: RwLock::new(
-                DEFAULT_PG_TIMESTAMP_ORACLE_TCP_USER_TIMEOUT,
-            ),
-        };
+        let dynamic = DynamicConfig::default();
 
         PostgresTimestampOracleConfig {
             url: url.to_string(),
@@ -142,14 +122,7 @@ impl PostgresTimestampOracleConfig {
             }
         };
 
-        let dynamic = DynamicConfig {
-            pg_connection_pool_max_size: AtomicUsize::new(2),
-            pg_connection_pool_max_wait: RwLock::new(None),
-            pg_connection_pool_ttl: RwLock::new(Duration::MAX),
-            pg_connection_pool_ttl_stagger: RwLock::new(Duration::MAX),
-            pg_connection_pool_connect_timeout: RwLock::new(Duration::MAX),
-            pg_connection_pool_tcp_user_timeout: RwLock::new(Duration::ZERO),
-        };
+        let dynamic = DynamicConfig::default();
 
         let config = PostgresTimestampOracleConfig {
             url: url.to_string(),
@@ -202,6 +175,32 @@ pub struct DynamicConfig {
     /// amount of time that transmitted data may remain unacknowledged before
     /// the TCP connection is forcibly closed.
     pg_connection_pool_tcp_user_timeout: RwLock<Duration>,
+}
+
+impl Default for DynamicConfig {
+    fn default() -> Self {
+        Self {
+            // TODO(aljoscha): These defaults are taken as is from the persist
+            // Consensus tuning. Once we're sufficiently advanced we might want
+            // to pick defaults that are different from the persist defaults.
+            pg_connection_pool_max_size: AtomicUsize::new(
+                DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE,
+            ),
+            pg_connection_pool_max_wait: RwLock::new(Some(
+                DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT,
+            )),
+            pg_connection_pool_ttl: RwLock::new(DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL),
+            pg_connection_pool_ttl_stagger: RwLock::new(
+                DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
+            ),
+            pg_connection_pool_connect_timeout: RwLock::new(
+                DEFAULT_PG_TIMESTAMP_ORACLE_CONNECT_TIMEOUT,
+            ),
+            pg_connection_pool_tcp_user_timeout: RwLock::new(
+                DEFAULT_PG_TIMESTAMP_ORACLE_TCP_USER_TIMEOUT,
+            ),
+        }
+    }
 }
 
 impl DynamicConfig {

--- a/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
+++ b/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
@@ -18,6 +18,11 @@ use std::time::{Duration, SystemTime};
 use async_trait::async_trait;
 use deadpool_postgres::{Object, PoolError};
 use dec::Decimal;
+use mz_adapter_types::timestamp_oracle::{
+    DEFAULT_PG_TIMESTAMP_ORACLE_CONNECT_TIMEOUT, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE,
+    DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL,
+    DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER, DEFAULT_PG_TIMESTAMP_ORACLE_TCP_USER_TIMEOUT,
+};
 use mz_ore::error::ErrorExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_pgrepr::Numeric;
@@ -92,15 +97,23 @@ impl PostgresTimestampOracleConfig {
         let dynamic = DynamicConfig {
             // TODO(aljoscha): These defaults are taken as is from the persist
             // Consensus tuning. Once we're sufficiently advanced we might want
-            // to a) make some of these configurable dynamically, as they are in
-            // persist, and b) pick defaults that are different from the persist
-            // defaults.
-            pg_connection_pool_max_size: AtomicUsize::new(50),
-            pg_connection_pool_max_wait: RwLock::new(Some(Duration::from_secs(60))),
-            pg_connection_pool_ttl: RwLock::new(Duration::from_secs(300)),
-            pg_connection_pool_ttl_stagger: RwLock::new(Duration::from_secs(6)),
-            pg_connection_pool_connect_timeout: RwLock::new(Duration::from_secs(5)),
-            pg_connection_pool_tcp_user_timeout: RwLock::new(Duration::from_secs(30)),
+            // to pick defaults that are different from the persist defaults.
+            pg_connection_pool_max_size: AtomicUsize::new(
+                DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE,
+            ),
+            pg_connection_pool_max_wait: RwLock::new(Some(
+                DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT,
+            )),
+            pg_connection_pool_ttl: RwLock::new(DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL),
+            pg_connection_pool_ttl_stagger: RwLock::new(
+                DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
+            ),
+            pg_connection_pool_connect_timeout: RwLock::new(
+                DEFAULT_PG_TIMESTAMP_ORACLE_CONNECT_TIMEOUT,
+            ),
+            pg_connection_pool_tcp_user_timeout: RwLock::new(
+                DEFAULT_PG_TIMESTAMP_ORACLE_TCP_USER_TIMEOUT,
+            ),
         };
 
         PostgresTimestampOracleConfig {

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -22,6 +22,8 @@ use mz_storage_types::parameters::{
 };
 use mz_tracing::params::TracingParameters;
 
+use crate::coord::timestamp_oracle::postgres_oracle::PostgresTimestampOracleParameters;
+
 /// Return the current compute configuration, derived from the system configuration.
 pub fn compute_config(config: &SystemVars) -> ComputeParameters {
     let linear_join_yielding = config.linear_join_yielding();
@@ -213,6 +215,22 @@ fn persist_config(config: &SystemVars) -> PersistParameters {
         pubsub_push_diff_enabled: Some(config.persist_pubsub_push_diff_enabled()),
         rollup_threshold: Some(config.persist_rollup_threshold()),
         feature_flags: config.persist_flags(),
+    }
+}
+
+pub fn pg_timstamp_oracle_config(config: &SystemVars) -> PostgresTimestampOracleParameters {
+    PostgresTimestampOracleParameters {
+        pg_connection_pool_max_size: Some(config.pg_timestamp_oracle_connection_pool_max_size()),
+        pg_connection_pool_max_wait: Some(config.pg_timestamp_oracle_connection_pool_max_wait()),
+        pg_connection_pool_ttl: Some(config.pg_timestamp_oracle_connection_pool_ttl()),
+        pg_connection_pool_ttl_stagger: Some(
+            config.pg_timestamp_oracle_connection_pool_ttl_stagger(),
+        ),
+        // We use a shared set of crdb flags for the basics, but the above flags
+        // for the connection pool are specific to the postgres/crdb timestamp
+        // oracle.
+        pg_connection_pool_connect_timeout: Some(config.crdb_connect_timeout()),
+        pg_connection_pool_tcp_user_timeout: Some(config.crdb_tcp_user_timeout()),
     }
 }
 

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -23,6 +23,7 @@ http = "0.2.8"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 maplit = "1.0.2"
+mz-adapter-types = { path = "../adapter-types" }
 mz-build-info = { path = "../build-info" }
 mz-ccsr = { path = "../ccsr" }
 mz-cloud-resources = { path = "../cloud-resources" }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -718,6 +718,38 @@ const TIMESTAMP_ORACLE_IMPL: ServerVar<TimestampOracleImpl> = ServerVar {
     internal: true,
 };
 
+/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_max_size`.
+const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_max_size"),
+    value: &50,
+    description: "Maximum size of the Postgres/CRDB connection pool, used by the Postgres/CRDB timestamp oracle.",
+    internal: true,
+};
+
+/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_max_wait`.
+const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT: ServerVar<Option<Duration>> = ServerVar {
+    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_max_wait"),
+    value: &None,
+    description: "The maximum time to wait when attempting to obtain a connection from the Postgres/CRDB connection pool, used by the Postgres/CRDB timestamp oracle.",
+    internal: true,
+};
+
+/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_ttl`.
+const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_ttl"),
+    value: &PersistConfig::DEFAULT_CONSENSUS_CONNPOOL_TTL,
+    description: "The minimum TTL of a Consensus connection to Postgres/CRDB before it is proactively terminated",
+    internal: true,
+};
+
+/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_ttl_stagger`.
+const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_ttl_stagger"),
+    value: &PersistConfig::DEFAULT_CONSENSUS_CONNPOOL_TTL_STAGGER,
+    description: "The minimum time between TTLing Consensus connections to Postgres/CRDB.",
+    internal: true,
+};
+
 /// The default for the `DISK` option when creating managed clusters and cluster replicas.
 const DISK_CLUSTER_REPLICAS_DEFAULT: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("disk_cluster_replicas_default"),
@@ -2850,7 +2882,11 @@ impl SystemVars {
             .with_var(&PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE)
             .with_var(&WEBHOOK_CONCURRENT_REQUEST_LIMIT)
             .with_var(&ENABLE_COLUMNATION_LGALLOC)
-            .with_var(&TIMESTAMP_ORACLE_IMPL);
+            .with_var(&TIMESTAMP_ORACLE_IMPL)
+            .with_var(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE)
+            .with_var(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT)
+            .with_var(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL)
+            .with_var(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER);
 
         for flag in PersistFeatureFlag::ALL {
             vars = vars.with_var(&flag.into())
@@ -3630,6 +3666,26 @@ impl SystemVars {
     /// Returns the `timestamp_oracle` configuration parameter.
     pub fn timestamp_oracle_impl(&self) -> TimestampOracleImpl {
         *self.expect_value(&TIMESTAMP_ORACLE_IMPL)
+    }
+
+    /// Returns the `pg_timestamp_oracle_connection_pool_max_size` configuration parameter.
+    pub fn pg_timestamp_oracle_connection_pool_max_size(&self) -> usize {
+        *self.expect_value(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE)
+    }
+
+    /// Returns the `pg_timestamp_oracle_connection_pool_max_wait` configuration parameter.
+    pub fn pg_timestamp_oracle_connection_pool_max_wait(&self) -> Option<Duration> {
+        *self.expect_value(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT)
+    }
+
+    /// Returns the `pg_timestamp_oracle_connection_pool_ttl` configuration parameter.
+    pub fn pg_timestamp_oracle_connection_pool_ttl(&self) -> Duration {
+        *self.expect_value(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL)
+    }
+
+    /// Returns the `pg_timestamp_oracle_connection_pool_ttl_stagger` configuration parameter.
+    pub fn pg_timestamp_oracle_connection_pool_ttl_stagger(&self) -> Duration {
+        *self.expect_value(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER)
     }
 }
 
@@ -5296,6 +5352,17 @@ fn is_persist_config_var(name: &str) -> bool {
         || name == PERSIST_PUBSUB_CLIENT_ENABLED.name()
         || name == PERSIST_PUBSUB_PUSH_DIFF_ENABLED.name()
         || PersistFeatureFlag::ALL.iter().any(|f| f.name == name)
+}
+
+/// Returns whether the named variable is a Postgres/CRDB timestamp oracle
+/// configuration parameter.
+pub fn is_pg_timestamp_oracle_config_var(name: &str) -> bool {
+    name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE.name()
+        || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT.name()
+        || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL.name()
+        || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER.name()
+        || name == CRDB_CONNECT_TIMEOUT.name()
+        || name == CRDB_TCP_USER_TIMEOUT.name()
 }
 
 /// Returns whether the named variable is a cluster scheduling config

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -76,6 +76,10 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
+use mz_adapter_types::timestamp_oracle::{
+    DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT,
+    DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
+};
 use mz_build_info::BuildInfo;
 use mz_ore::cast;
 use mz_ore::cast::CastFrom;
@@ -721,7 +725,7 @@ const TIMESTAMP_ORACLE_IMPL: ServerVar<TimestampOracleImpl> = ServerVar {
 /// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_max_size`.
 const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE: ServerVar<usize> = ServerVar {
     name: UncasedStr::new("pg_timestamp_oracle_connection_pool_max_size"),
-    value: &50,
+    value: &DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE,
     description: "Maximum size of the Postgres/CRDB connection pool, used by the Postgres/CRDB timestamp oracle.",
     internal: true,
 };
@@ -729,7 +733,7 @@ const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE: ServerVar<usize> = ServerVar
 /// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_max_wait`.
 const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT: ServerVar<Option<Duration>> = ServerVar {
     name: UncasedStr::new("pg_timestamp_oracle_connection_pool_max_wait"),
-    value: &None,
+    value: &Some(DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT),
     description: "The maximum time to wait when attempting to obtain a connection from the Postgres/CRDB connection pool, used by the Postgres/CRDB timestamp oracle.",
     internal: true,
 };
@@ -737,7 +741,7 @@ const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT: ServerVar<Option<Duration>> 
 /// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_ttl`.
 const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL: ServerVar<Duration> = ServerVar {
     name: UncasedStr::new("pg_timestamp_oracle_connection_pool_ttl"),
-    value: &PersistConfig::DEFAULT_CONSENSUS_CONNPOOL_TTL,
+    value: &DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL,
     description: "The minimum TTL of a Consensus connection to Postgres/CRDB before it is proactively terminated",
     internal: true,
 };
@@ -745,7 +749,7 @@ const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL: ServerVar<Duration> = ServerVar {
 /// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_ttl_stagger`.
 const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER: ServerVar<Duration> = ServerVar {
     name: UncasedStr::new("pg_timestamp_oracle_connection_pool_ttl_stagger"),
-    value: &PersistConfig::DEFAULT_CONSENSUS_CONNPOOL_TTL_STAGGER,
+    value: &DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
     description: "The minimum time between TTLing Consensus connections to Postgres/CRDB.",
     internal: true,
 };


### PR DESCRIPTION
### Motivation

Resolves https://github.com/MaterializeInc/materialize/issues/23405

### Tips for reviewer

Individual commits make sense and have meaningful comments.

@danhhz `max_size` and `max_wait` are not really dynamic, because these only get read when creating the pg connection pool. This is similar to persist, where these are among the non-dynamic configs. Also, the code should look very familiar because it's largely a port of persist code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
