### PR TITLE
adapter: adjust warn message regarding unknown system parameter

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -93,7 +93,7 @@ IGNORE_RE = re.compile(
     # Old versions won't support new parameters
     | (platform-checks|legacy-upgrade|upgrade-matrix|feature-benchmark)-materialized-.* \| .*cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
     # For platform-checks upgrade tests
-    | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage\ name=enable_dangerous_functions
+    | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage(\ to\ set\ (default|configured)\ parameter)?\ name=enable_dangerous_functions
     )
     """,
     re.VERBOSE | re.MULTILINE,

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1119,7 +1119,7 @@ impl Catalog {
             match state.set_system_configuration_default(name, VarInput::Flat(value)) {
                 Ok(_) => (),
                 Err(AdapterError::VarError(VarError::UnknownParameter(name))) => {
-                    warn!(%name, "cannot load unknown system parameter from catalog storage");
+                    warn!(%name, "cannot load unknown system parameter from catalog storage to set default parameter");
                 }
                 Err(e) => return Err(e),
             };
@@ -1128,7 +1128,7 @@ impl Catalog {
             match state.insert_system_configuration(&name, VarInput::Flat(&value)) {
                 Ok(_) => (),
                 Err(AdapterError::VarError(VarError::UnknownParameter(name))) => {
-                    warn!(%name, "cannot load unknown system parameter from catalog storage");
+                    warn!(%name, "cannot load unknown system parameter from catalog storage to set configured parameter");
                 }
                 Err(e) => return Err(e),
             };


### PR DESCRIPTION
This is to 

> somehow disambiguate the two ```warn!(%name, "cannot load unknown system parameter from catalog storage");``` entries in load_system_configuration so we can differentiate whether they are coming from the first or the second loop.

(https://materializeinc.slack.com/archives/C01LKF361MZ/p1702308656490319?thread_ts=1702052753.700419&cid=C01LKF361MZ)

Nightlies: https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Afeature%2Fdistinct-unknown-sys-param-warning