### PR TITLE
docs: convert camelCase to snake_case in the SQL / JSON widget

### DIFF
--- a/doc/user/content/transform-data/json.md
+++ b/doc/user/content/transform-data/json.md
@@ -71,6 +71,10 @@ function debounce(callback, wait) {
     }
 }
 
+function camelToSnakeCase(s) {
+    return s.split(/(?=[A-Z])/).map(word => word.toLowerCase()).join("_");
+}
+
 /* JSON Parsing and SQL conversion */
 
 const errorSpan = $("#error_span");
@@ -147,7 +151,7 @@ function formSql(selectItems, viewName, sourceName, objectType) {
 
     let selects = selectItems.map(([name, wrapping_function, cast, parents]) => {
         // Note: The first "parent" is the JSON column.
-        const formattedName = [...parents.slice(1), name].join("_").toLowerCase();
+        const formattedName = [...parents.slice(1), name].map(camelToSnakeCase).join("_");
 
         const parentPath = [parents[0], ...parents.slice(1).map((p) => `'${p}'`)].join("->");
         const formattedPath = parentPath.concat(`->>'${name}'`);


### PR DESCRIPTION
### Motivation

Convert camelCase to snake_case in the JSON widget, which is easier to use based on postgres' capitalization normalization rules. 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
