### PR TITLE
persist: guarantee that every Batch's transmittable format is unique

### DIFF
--- a/src/persist-client/build.rs
+++ b/src/persist-client/build.rs
@@ -113,6 +113,7 @@ fn main() {
         .type_attribute(".", "#[allow(missing_docs)]")
         .btree_map(["."])
         .bytes([
+            ".mz_persist_client.batch.ProtoBatch",
             ".mz_persist_client.internal.diff.ProtoStateFieldDiffs",
             ".mz_persist_client.internal.state.ProtoHollowBatchPart",
             ".mz_persist_client.internal.state.ProtoVersionedData",

--- a/src/persist-client/src/batch.proto
+++ b/src/persist-client/src/batch.proto
@@ -14,6 +14,7 @@ import "persist-client/src/internal/state.proto";
 package mz_persist_client.batch;
 
 message ProtoBatch {
+    bytes batch_id = 4;
     string shard_id = 1;
     string version = 2;
     mz_persist_client.internal.state.ProtoHollowBatch batch = 3;

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -536,6 +536,7 @@ where
     /// to append it to this shard.
     pub fn batch_from_transmittable_batch(&self, batch: ProtoBatch) -> Batch<K, V, T, D> {
         let ret = Batch {
+            batch_id: batch.batch_id,
             batch_delete_enabled: self
                 .cfg
                 .dynamic

--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -440,9 +440,6 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64> TxnsCacheState
             );
             let idx = self.next_batch_id;
             self.next_batch_id += 1;
-            // TODO(txn): Pretty sure we could accidentally end up with a dup.
-            // Add some randomness to uncommitted batches before turning this on
-            // anywhere important.
             let prev = self.batch_idx.insert(batch.clone(), idx);
             assert_eq!(prev, None);
             let prev = self


### PR DESCRIPTION
This is added because persist-txn relies on batches being retractable. We could instead correctly handle non-1 diffs in persist-txn, but this seems more straightforward and less likely to go wrong.

Touches https://github.com/MaterializeInc/materialize/issues/22173
Touches https://github.com/MaterializeInc/materialize/issues/22801

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
