### PR TITLE
[persist] Tombstone followup

### DIFF
--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -188,15 +188,16 @@ where
             })
     }
 
-    /// A point-in-time read of `is_tombstone` from the current state.
+    /// A point-in-time read from the current state. (We declare a shard 'finalized' if it's
+    /// both become an unreadable tombstone and the state itself is has been emptied out.)
     ///
     /// Due to sharing state with other handles, successive reads to this fn or any other may
     /// see a different version of state, even if this Applier has not explicitly fetched and
     /// updated to the latest state. Once this fn returns true, it will always return true.
-    pub fn is_tombstone(&self) -> bool {
+    pub fn is_finalized(&self) -> bool {
         self.state
             .read_lock(&self.metrics.locks.applier_read_cacheable, |state| {
-                state.collections.is_tombstone()
+                state.collections.is_tombstone() && state.collections.is_single_empty_batch()
             })
     }
 

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -640,8 +640,8 @@ where
         (seqno, maintenance)
     }
 
-    pub fn is_tombstone(&self) -> bool {
-        self.applier.is_tombstone()
+    pub fn is_finalized(&self) -> bool {
+        self.applier.is_finalized()
     }
 
     async fn tombstone_step(&mut self) -> Result<(bool, RoutineMaintenance), InvalidUsage<T>> {
@@ -2015,7 +2015,7 @@ pub mod datadriven {
         _args: DirectiveArgs<'_>,
     ) -> anyhow::Result<String> {
         let seqno = datadriven.machine.seqno();
-        let tombstone = datadriven.machine.is_tombstone();
+        let tombstone = datadriven.machine.is_finalized();
         Ok(format!("{seqno} {tombstone}\n"))
     }
 

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -918,6 +918,16 @@ where
             && self.critical_readers.is_empty()
     }
 
+    pub(crate) fn is_single_empty_batch(&self) -> bool {
+        let mut batch_count = 0;
+        let mut is_empty = true;
+        self.trace.map_batches(|b| {
+            batch_count += 1;
+            is_empty &= b.parts.is_empty()
+        });
+        batch_count <= 1 && is_empty
+    }
+
     pub fn become_tombstone_and_shrink(&mut self) -> ControlFlow<NoOpStateTransition<()>, ()> {
         assert_eq!(self.trace.upper(), &Antichain::new());
         assert_eq!(self.trace.since(), &Antichain::new());

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -645,7 +645,8 @@ impl PersistClient {
     }
 
     /// Check if the given shard is in a finalized state; ie. it can no longer be
-    /// read and any data that was written to it is no longer accessible.
+    /// read, any data that was written to it is no longer accessible, and we've
+    /// discarded references to that data from state.
     pub async fn is_finalized<K, V, T, D>(
         &self,
         shard_id: ShardId,
@@ -660,7 +661,7 @@ impl PersistClient {
         let machine = self
             .make_machine::<K, V, T, D>(shard_id, diagnostics)
             .await?;
-        Ok(machine.is_tombstone())
+        Ok(machine.is_finalized())
     }
 
     /// If a shard is guaranteed to never be used again, finalize it to delete

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -892,7 +892,7 @@ where
                 .machine
                 .heartbeat_leased_reader(&self.reader_id, heartbeat_ts)
                 .await;
-            if !existed && !self.machine.applier.is_tombstone() {
+            if !existed && !self.machine.applier.is_finalized() {
                 // It's probably surprising to the caller that the shard
                 // becoming a tombstone expired this reader. Possibly the right
                 // thing to do here is pass up a bool to the caller indicating


### PR DESCRIPTION
Historically, we failed to distinguish between a shard that was unreadable and unwritable and one that had had all of its state cleaned up. #23756 made some progress here, but it still failed to distinguish between the two: `is_finalized` could return true even if eg. a shard still referenced parts. This would not happen in normal operation, but could happen if eg. a process died in the middle of the finalization process.

This adds a new `is_empty` method to state, and ensure `PersistClient::is_finalized` only returns true once the trace is also empty. This should keep things from being removed from the finalization WAL too early, even in the face of crashes.

### Motivation

https://github.com/MaterializeInc/materialize/issues/20222

### Tips for reviewer
This PR still doesn't handle ensuring that GC runs to completion; `is_finalized` is only based on the current state.

To test this I think I'd have to pull the loop out of `machine` so datadriven can run it one step at a time. Seems a bit invasive, and I'm on the fence, but happy to do it if you like the cost/benefit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
