### PR TITLE
ci: re-introduce VersionsFromDocs, move legacy-upgrade to tests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1062,16 +1062,6 @@ steps:
     agents:
       queue: linux-x86_64
 
-  - id: legacy-upgrade
-    label: Legacy upgrade tests
-    timeout_in_minutes: 60
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: legacy-upgrade
-    agents:
-      queue: linux-x86_64
-
   - group: "Language tests"
     key: language-tests
     steps:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -264,6 +264,16 @@ steps:
     agents:
       queue: linux-x86_64
 
+  - id: legacy-upgrade
+    label: Legacy upgrade tests
+    timeout_in_minutes: 60
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: legacy-upgrade
+    agents:
+      queue: linux-x86_64
+
   - group: "Debezium tests"
     key: debezium-tests
     steps:

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -14,6 +14,8 @@ import os
 from collections.abc import Callable
 from pathlib import Path
 
+import frontmatter
+
 from materialize import buildkite, docker, git
 from materialize.docker import (
     commit_to_image_tag,
@@ -246,7 +248,12 @@ def get_published_minor_mz_versions(
     limit: int | None = None,
     include_filter: Callable[[MzVersion], bool] | None = None,
 ) -> list[MzVersion]:
-    """Get the latest patch version for every minor version."""
+    """
+    Get the latest patch version for every minor version.
+    Use this version if it is NOT important whether a tag was introduced before or after creating this branch.
+
+    See also: #get_minor_mz_versions_listed_in_docs()
+    """
 
     # sorted in descending order
     all_versions = get_all_mz_versions(newest_first=True)
@@ -278,10 +285,24 @@ def get_published_minor_mz_versions(
     return sorted(minor_versions.values(), reverse=newest_first)
 
 
+def get_minor_mz_versions_listed_in_docs() -> list[MzVersion]:
+    """
+    Get the latest patch version for every minor version.
+    Use this version if it is important whether a tag was introduced before or after creating this branch.
+
+    See also: #get_published_minor_mz_versions()
+    """
+    return VersionsFromDocs().minor_versions()
+
+
 def get_all_mz_versions(
     newest_first: bool = True,
 ) -> list[MzVersion]:
-    """Get all mz versions based on git tags. Versions known to be invalid are excluded."""
+    """
+    Get all mz versions based on git tags. Versions known to be invalid are excluded.
+
+    See also: #get_all_mz_versions_listed_in_docs
+    """
     return [
         version
         for version in get_version_tags(
@@ -289,6 +310,15 @@ def get_all_mz_versions(
         )
         if version not in INVALID_VERSIONS
     ]
+
+
+def get_all_mz_versions_listed_in_docs() -> list[MzVersion]:
+    """
+    Get all mz versions based on docs. Versions known to be invalid are excluded.
+
+    See also: #get_all_mz_versions()
+    """
+    return VersionsFromDocs().all_versions()
 
 
 def get_all_published_mz_versions(
@@ -359,3 +389,67 @@ def is_valid_release_image(version: MzVersion) -> bool:
 
     # This is a potentially expensive operation which pulls an image if it hasn't been pulled yet.
     return docker.image_of_release_version_exists(version)
+
+
+class VersionsFromDocs:
+    """Materialize versions as listed in doc/user/content/versions
+
+    Only versions that declare `versiond: true` in their
+    frontmatter are considered.
+
+    >>> len(VersionsFromDocs().all_versions()) > 0
+    True
+
+    >>> len(VersionsFromDocs().minor_versions()) > 0
+    True
+
+    >>> len(VersionsFromDocs().patch_versions(minor_version=MzVersion.parse_mz("v0.52.0")))
+    4
+
+    >>> min(VersionsFromDocs().all_versions())
+    MzVersion(major=0, minor=27, patch=0, prerelease=None, build=None)
+    """
+
+    def __init__(self) -> None:
+        files = Path(MZ_ROOT / "doc" / "user" / "content" / "releases").glob("v*.md")
+        self.versions = []
+        for f in files:
+            base = f.stem
+            metadata = frontmatter.load(f)
+            if not metadata.get("released", False):
+                continue
+
+            current_patch = metadata.get("patch", 0)
+
+            for patch in range(current_patch + 1):
+                version = MzVersion.parse_mz(f"{base}.{patch}")
+                if version not in INVALID_VERSIONS:
+                    self.versions.append(version)
+
+        assert len(self.versions) > 0
+        self.versions.sort()
+
+    def all_versions(self) -> list[MzVersion]:
+        return self.versions
+
+    def minor_versions(self) -> list[MzVersion]:
+        """Return the latest patch version for every minor version."""
+        minor_versions = {}
+        for version in self.versions:
+            minor_versions[f"{version.major}.{version.minor}"] = version
+
+        assert len(minor_versions) > 0
+        return sorted(minor_versions.values())
+
+    def patch_versions(self, minor_version: MzVersion) -> list[MzVersion]:
+        """Return all patch versions within the given minor version."""
+        patch_versions = []
+        for version in self.versions:
+            if (
+                version.major == minor_version.major
+                and version.minor == minor_version.minor
+            ):
+                patch_versions.append(version)
+
+        assert len(patch_versions) > 0
+        return sorted(patch_versions)

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -23,10 +23,7 @@ from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.test_certs import TestCerts
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
-from materialize.version_list import (
-    get_all_published_mz_versions,
-    get_published_minor_mz_versions,
-)
+from materialize.version_list import VersionsFromDocs
 
 mz_options: dict[MzVersion, str] = {}
 
@@ -69,12 +66,14 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     args = parser.parse_args()
 
-    tested_versions = get_published_minor_mz_versions(limit=2)
-    all_versions_ascending = get_all_published_mz_versions(newest_first=False)
+    version_list = VersionsFromDocs()
+    all_versions = version_list.all_versions()
 
-    for tested_version in tested_versions:
-        priors = [v for v in all_versions_ascending if v <= tested_version]
-        test_upgrade_from_version(c, f"{tested_version}", priors, filter=args.filter)
+    tested_versions = version_list.minor_versions()[-2:]
+
+    for version in tested_versions:
+        priors = [v for v in all_versions if v <= version]
+        test_upgrade_from_version(c, f"{version}", priors, filter=args.filter)
 
     test_upgrade_from_version(c, "current_source", priors=[], filter=args.filter)
 


### PR DESCRIPTION
As discussed during the onsite: Only `VersionsFromDocs` is currently known to reliably provide a version that existed when creating the branch.