### PR TITLE
postgres consistency: extend ignores regarding regex groups

### DIFF
--- a/misc/python/materialize/output_consistency/expression/expression_characteristics.py
+++ b/misc/python/materialize/output_consistency/expression/expression_characteristics.py
@@ -34,6 +34,7 @@ class ExpressionCharacteristics(Enum):
     TEXT_EMPTY = 140
     TEXT_WITH_SPECIAL_SPACE_CHARS = 141
     """Lines with tabulators, newlines, and further whitespace types"""
+    TEXT_WITH_BACKSLASH_CHAR = 142
 
     JSON_EMPTY = 150
     JSON_ARRAY = 151

--- a/misc/python/materialize/output_consistency/ignore_filter/param_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/param_matchers.py
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from collections.abc import Callable
+
+from materialize.output_consistency.operation.operation_param import OperationParam
+
+
+def index_of_param_by_type(
+    params: list[OperationParam], type_to_match: type[OperationParam]
+) -> int | None:
+    return index_of_param(params, lambda p: isinstance(p, type_to_match))
+
+
+def index_of_param_by_equality(
+    params: list[OperationParam], param_to_match: OperationParam
+) -> int | None:
+    return index_of_param(params, lambda p: p == param_to_match)
+
+
+def index_of_param(
+    params: list[OperationParam], match_fn: Callable[[OperationParam], bool]
+) -> int | None:
+    for i, param in enumerate(params):
+        if match_fn(param):
+            return i
+
+    return None

--- a/misc/python/materialize/output_consistency/input_data/operations/bytea_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/bytea_operations_provider.py
@@ -80,9 +80,12 @@ encode_function = DbFunction(
     [ByteaOperationParam(), TEXT_FORMAT_PARAM],
     TextReturnTypeSpec(),
 )
-# encode may introduce new lines
+# encode may introduce new lines and backslashes
 encode_function.added_characteristics.add(
     ExpressionCharacteristics.TEXT_WITH_SPECIAL_SPACE_CHARS
+)
+encode_function.added_characteristics.add(
+    ExpressionCharacteristics.TEXT_WITH_BACKSLASH_CHAR
 )
 BYTEA_OPERATION_TYPES.append(encode_function)
 

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -153,6 +153,11 @@ class PgPreExecutionInconsistencyIgnoreFilter(
             ):
                 return YesIgnore("#22000: regexp with linebreak")
 
+            if expression.args[regex_param_index].has_any_characteristic(
+                {ExpressionCharacteristics.TEXT_WITH_BACKSLASH_CHAR}
+            ):
+                return YesIgnore("#23605: regexp with backslash")
+
         if db_function.function_name_in_lower_case == "replace":
             # replace is not working properly with empty text; however, it is not possible to reliably determine if an
             # expression is an empty text, we therefore need to exclude the function completely

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -40,6 +40,12 @@ from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter im
     PostExecutionInconsistencyIgnoreFilterBase,
     PreExecutionInconsistencyIgnoreFilterBase,
 )
+from materialize.output_consistency.ignore_filter.param_matchers import (
+    index_of_param_by_equality,
+)
+from materialize.output_consistency.input_data.params.enum_constant_operation_params import (
+    REGEX_PARAM,
+)
 from materialize.output_consistency.input_data.return_specs.date_time_return_spec import (
     DateTimeReturnTypeSpec,
 )
@@ -136,13 +142,16 @@ class PgPreExecutionInconsistencyIgnoreFilter(
             if isinstance(return_type_spec, TextReturnTypeSpec):
                 return YesIgnore("#22002: min/max on text")
 
-        if db_function.function_name_in_lower_case in {
-            "regexp_match",
-            "regexp_replace",
-        } and expression.args[0].has_any_characteristic(
-            {ExpressionCharacteristics.TEXT_WITH_SPECIAL_SPACE_CHARS}
-        ):
-            return YesIgnore("#22000: regexp with linebreak")
+        if db_function.function_name_in_lower_case.startswith("regexp"):
+            regex_param_index = index_of_param_by_equality(
+                db_function.params, REGEX_PARAM
+            )
+            assert regex_param_index is not None
+
+            if expression.args[regex_param_index].has_any_characteristic(
+                {ExpressionCharacteristics.TEXT_WITH_SPECIAL_SPACE_CHARS}
+            ):
+                return YesIgnore("#22000: regexp with linebreak")
 
         if db_function.function_name_in_lower_case == "replace":
             # replace is not working properly with empty text; however, it is not possible to reliably determine if an
@@ -160,14 +169,6 @@ class PgPreExecutionInconsistencyIgnoreFilter(
             ):
                 # Postgres returns a double for nullif(int, double), which does not seem better
                 return YesIgnore("not considered worse")
-
-        if (
-            db_function.function_name_in_lower_case == "regexp_split_to_array"
-            and expression.args[0].has_any_characteristic(
-                {ExpressionCharacteristics.TEXT_WITH_SPECIAL_SPACE_CHARS}
-            )
-        ):
-            return YesIgnore("#22000: regexp_split_to_array with linebreaks")
 
         if db_function.function_name_in_lower_case in [
             "length",


### PR DESCRIPTION
This addresses one build failure in https://buildkite.com/materialize/nightlies/builds/5563#018c5a25-97fd-4e12-a018-93795e8ce39a:

```
-- Test with query #41.1.1 FAILED.
-- Durations: 0.020, 0.001
-- Errors:
-- * ValidationErrorType.CONTENT_MISMATCH: Value differs at row index 0, column index 0 ('regexp_replace(text_val_1, '[ab]', encode(bytea_val_2, 'escape'))').
--   Value 1 (Materialize evaluation): 'hello \360\237\221\213' (type: <class 'str'>)
--   Value 2 (Postgres evaluation): 'hello 60372113' (type: <class 'str'>)
--   Query 1: SELECT regexp_replace(text_val_1, '[ab]', encode(bytea_val_2, 'escape')), (text_val_2 = text_val_3), (position(text_val_2 IN text_val_w_spaces)), left(text_empty, int2_zero) FROM t_dfr_horiz;
--   Query 2: SELECT regexp_replace(text_val_1, '[ab]', encode(bytea_val_2, 'escape')), (text_val_2 = text_val_3), (position(text_val_2 IN text_val_w_spaces)), left(text_empty, int2_zero) FROM t_pg_horiz;
```

The fix itself is in 9f71470637.

### Commits
f2d70c8312 output consistency: add param matcher
19b07830d0 postgres consistency: merge and rework regex ignore entries
9f71470637 postgres consistency: add ignore for regex with backslash

