### PR TITLE
adapter: remove ALTER CONNECTION + purification warning

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -374,8 +374,10 @@ impl Coordinator {
         // "unknown connector" error, or pick up a new connector that has
         // replaced the dropped connector.
         //
-        // WARNING: If we support `ALTER CONNECTION`, we'll need to also check
-        // for connectors that were altered while we were purifying.
+        // n.b. an `ALTER CONNECTION` occurring during purification is OK
+        // because we always look up/populate a connection's state after
+        // committing to the catalog, so are guaranteed to see the connection's
+        // most recent version.
         if !resolved_ids
             .0
             .iter()


### PR DESCRIPTION
Imagine this series of events:
1. CREATE CONNECTION begins, commits
2. CREATE SOURCE purification begins
3. ALTER CONNECTION begins, commits
4. CREATE SOURCE purification ends, commits

The source that gets rendered will have the connection's most- recent state as stored in the catalog because we inline the connection state as late as possible.

Sources:
https://github.com/MaterializeInc/materialize/blob/7fe3238070d167610b8fe3d8bc94c285b04b256d/src/adapter/src/coord/sequencer/inner.rs#L255

Sinks:
https://github.com/MaterializeInc/materialize/blob/7fe3238070d167610b8fe3d8bc94c285b04b256d/src/adapter/src/coord/ddl.rs#L952-L955

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
