### PR TITLE
A container (and spines) specialized to hold `Row` data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,7 +1773,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#7596c843c745ef13ec7ea638be5e6b91b5fdf1a2"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#9d22bec650e80641bedfe1bcecbae27f31d17214"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1829,7 +1829,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#7596c843c745ef13ec7ea638be5e6b91b5fdf1a2"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#9d22bec650e80641bedfe1bcecbae27f31d17214"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -31,9 +31,9 @@ criteria = "safe-to-deploy"
 version = "1.2.6"
 
 [[audits.differential-dataflow]]
-who = "Moritz Hoffmann <mh@materialize.com>"
+who = "Frank McSherry <frank@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:7596c843c745ef13ec7ea638be5e6b91b5fdf1a2"
+version = "0.12.0@git:9d22bec650e80641bedfe1bcecbae27f31d17214"
 
 [[audits.futures-timer]]
 who = "Roshan Jobanputra <roshan@materialize.com>"

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -226,13 +226,13 @@ pub trait ArrangementSize {
 
 /// Helper to compute the size of an [`OffsetList`] in memory.
 #[inline]
-fn offset_list_size(data: &OffsetList, mut callback: impl FnMut(usize, usize)) {
+pub(crate) fn offset_list_size(data: &OffsetList, mut callback: impl FnMut(usize, usize)) {
     // Private `vec_size` because we should only use it where data isn't region-allocated.
     // `T: Copy` makes sure the implementation is correct even if types change!
     #[inline(always)]
     fn vec_size<T: Copy>(data: &Vec<T>, mut callback: impl FnMut(usize, usize)) {
         let size_of_t = std::mem::size_of::<T>();
-        callback(data.len() * size_of_t, data.len() * size_of_t);
+        callback(data.len() * size_of_t, data.capacity() * size_of_t);
     }
 
     vec_size(&data.smol, &mut callback);
@@ -391,7 +391,7 @@ where
                 allocations += usize::from(cap > 0);
             };
             trace.map_batches(|batch| {
-                // batch.storage.keys.heap_size(&mut callback);
+                batch.storage.keys.heap_size(&mut callback);
                 offset_list_size(&batch.storage.keys_offs, &mut callback);
                 batch.storage.vals.heap_size(&mut callback);
                 offset_list_size(&batch.storage.vals_offs, &mut callback);
@@ -418,9 +418,9 @@ where
                 allocations += usize::from(cap > 0);
             };
             trace.map_batches(|batch| {
-                // batch.storage.keys.heap_size(&mut callback);
+                batch.storage.keys.heap_size(&mut callback);
                 offset_list_size(&batch.storage.keys_offs, &mut callback);
-                // batch.storage.vals.heap_size(&mut callback);
+                batch.storage.vals.heap_size(&mut callback);
                 offset_list_size(&batch.storage.vals_offs, &mut callback);
                 batch.storage.updates.heap_size(&mut callback);
             });
@@ -445,7 +445,7 @@ where
                 allocations += usize::from(cap > 0);
             };
             trace.map_batches(|batch| {
-                // batch.storage.keys.heap_size(&mut callback);
+                batch.storage.keys.heap_size(&mut callback);
                 offset_list_size(&batch.storage.keys_offs, &mut callback);
                 batch.storage.updates.heap_size(&mut callback);
             });

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -84,6 +84,7 @@ pub(crate) mod extensions;
 pub(crate) mod logging;
 pub(crate) mod metrics;
 pub(crate) mod render;
+pub(crate) mod row_spine;
 pub mod server;
 pub(crate) mod sink;
 mod typedefs;

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -838,9 +838,11 @@ where
 
                         // We know that `mfp_after` can error if it exists, so try to evaluate it here.
                         let Some(mfp) = &mfp_after2 else { return };
-                        let iter = source.iter().flat_map(|(v, w)| {
+                        let iter = source.iter().flat_map(|(mut v, w)| {
                             let count = usize::try_from(*w).unwrap_or(0);
-                            std::iter::repeat(v.iter().next().unwrap()).take(count)
+                            // This would ideally use `into_datum_iter` but we cannot as it needs to
+                            // borrow `v` and only presents datums with that lifetime, not any longer.
+                            std::iter::repeat(v.next().unwrap()).take(count)
                         });
 
                         let temp_storage = RowArena::new();

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -1454,6 +1454,7 @@ where
                                 "Net-zero records with non-zero accumulation in ReduceAccumulable",
                                 &format!("aggr={aggr:?}, accum={accum:?}"),
                             );
+                            let key = key.into_owned();
                             let message = format!(
                                 "Invalid data in source, saw net-zero records for key {key} \
                                  with non-zero accumulation in accumulable aggregate"
@@ -1469,6 +1470,7 @@ where
                                     "Invalid negative unsigned aggregation in ReduceAccumulable",
                                     &format!("aggr={aggr:?}, accum={accum:?}"),
                                 );
+                                    let key = key.into_owned();
                                     let message = format!(
                                         "Invalid data in source, saw negative accumulation with \
                                          unsigned type for key {key}"

--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -1,3 +1,12 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
 pub use self::container::DatumContainer;
 pub use self::spines::{RowRowSpine, RowSpine, RowValSpine};
 

--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -1,0 +1,712 @@
+pub use self::codec::{BytesIter, Codec, ColumnsCodec, ColumnsIter, DictionaryCodec};
+pub use self::container::DatumContainer;
+pub use self::datum_seq::DatumSeq;
+pub use self::spines::{RowRowSpine, RowSpine, RowValSpine};
+
+// pub type CodecDuJour = DictionaryCodec;
+// pub type IterDuJour<'a> = BytesIter<'a>;
+
+pub type CodecDuJour = ColumnsCodec;
+pub type IterDuJour<'a> = ColumnsIter<'a>;
+
+/// Spines specialized to contain `Row` types in keys and values.
+mod spines {
+
+    use differential_dataflow::trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
+    use differential_dataflow::trace::implementations::ord_neu::{OrdKeyBatch, OrdKeyBuilder};
+    use differential_dataflow::trace::implementations::ord_neu::{OrdValBatch, OrdValBuilder};
+    use differential_dataflow::trace::implementations::spine_fueled::Spine;
+    use differential_dataflow::trace::implementations::Layout;
+    use differential_dataflow::trace::implementations::Update;
+    use differential_dataflow::trace::rc_blanket_impls::RcBuilder;
+    use std::rc::Rc;
+    use timely::container::columnation::{Columnation, TimelyStack};
+
+    use super::DatumContainer;
+    use mz_repr::Row;
+
+    pub type RowRowSpine<T, R> = Spine<
+        Rc<OrdValBatch<RowRowLayout<((Row, Row), T, R)>>>,
+        ColumnatedMergeBatcher<Row, Row, T, R>,
+        RcBuilder<OrdValBuilder<RowRowLayout<((Row, Row), T, R)>>>,
+    >;
+    pub type RowValSpine<V, T, R> = Spine<
+        Rc<OrdValBatch<RowValLayout<((Row, V), T, R)>>>,
+        ColumnatedMergeBatcher<Row, V, T, R>,
+        RcBuilder<OrdValBuilder<RowValLayout<((Row, V), T, R)>>>,
+    >;
+    pub type RowSpine<T, R> = Spine<
+        Rc<OrdKeyBatch<RowLayout<((Row, ()), T, R)>>>,
+        ColumnatedMergeBatcher<Row, (), T, R>,
+        RcBuilder<OrdKeyBuilder<RowLayout<((Row, ()), T, R)>>>,
+    >;
+
+    /// A layout based on timely stacks
+    pub struct RowRowLayout<U: Update<Key = Row, Val = Row>> {
+        phantom: std::marker::PhantomData<U>,
+    }
+    pub struct RowValLayout<U: Update<Key = Row>> {
+        phantom: std::marker::PhantomData<U>,
+    }
+    pub struct RowLayout<U: Update<Key = Row, Val = ()>> {
+        phantom: std::marker::PhantomData<U>,
+    }
+
+    impl<U: Update<Key = Row, Val = Row>> Layout for RowRowLayout<U>
+    where
+        U::Time: Columnation,
+        U::Diff: Columnation,
+    {
+        type Target = U;
+        type KeyContainer = DatumContainer;
+        type ValContainer = DatumContainer;
+        type UpdContainer = TimelyStack<(U::Time, U::Diff)>;
+    }
+    impl<U: Update<Key = Row>> Layout for RowValLayout<U>
+    where
+        U::Val: Columnation,
+        U::Time: Columnation,
+        U::Diff: Columnation,
+    {
+        type Target = U;
+        type KeyContainer = DatumContainer;
+        type ValContainer = TimelyStack<U::Val>;
+        type UpdContainer = TimelyStack<(U::Time, U::Diff)>;
+    }
+    impl<U: Update<Key = Row, Val = ()>> Layout for RowLayout<U>
+    where
+        U::Time: Columnation,
+        U::Diff: Columnation,
+    {
+        type Target = U;
+        type KeyContainer = DatumContainer;
+        type ValContainer = TimelyStack<()>;
+        type UpdContainer = TimelyStack<(U::Time, U::Diff)>;
+    }
+}
+
+/// A `Row`-specialized container using dictionary compression.
+mod container {
+
+    use differential_dataflow::trace::implementations::BatchContainer;
+    use timely::container::columnation::TimelyStack;
+
+    use mz_repr::Row;
+
+    use super::{Codec, CodecDuJour, DatumSeq};
+
+    #[derive(Default)]
+    pub struct DatumContainer {
+        /// DictionaryCodec with encoder, decoder, and stastistics.
+        codec: CodecDuJour,
+        /// A list of rows
+        inner: TimelyStack<Vec<u8>>,
+        /// Staging buffer for ingested `Row` types.
+        staging: Vec<u8>,
+    }
+
+    impl BatchContainer for DatumContainer {
+        type PushItem = Row;
+        type ReadItem<'a> = DatumSeq<'a>;
+
+        fn push(&mut self, item: Row) {
+            self.copy_push(&item);
+        }
+        fn copy_push(&mut self, item: &Row) {
+            use differential_dataflow::trace::cursor::MyTrait;
+            self.copy(MyTrait::borrow_as(item));
+        }
+        fn copy<'a>(&mut self, item: DatumSeq<'a>) {
+            self.staging.clear();
+            self.codec.encode(item.bytes_iter(), &mut self.staging);
+            self.inner.copy(&self.staging);
+        }
+        fn copy_slice(&mut self, slice: &[Row]) {
+            for item in slice.iter() {
+                self.copy_push(item);
+            }
+        }
+        fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
+            for index in start..end {
+                self.copy(other.index(index));
+            }
+        }
+        fn with_capacity(size: usize) -> Self {
+            Self {
+                codec: Default::default(),
+                inner: BatchContainer::with_capacity(size),
+                staging: Vec::new(),
+            }
+        }
+        fn reserve(&mut self, additional: usize) {
+            self.inner.reserve(additional);
+        }
+        fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
+            cont1.codec.report();
+            cont2.codec.report();
+
+            Self {
+                codec: CodecDuJour::new_from([&cont1.codec, &cont2.codec]),
+                inner: BatchContainer::merge_capacity(&cont1.inner, &cont2.inner),
+                staging: Vec::new(),
+            }
+        }
+        fn index(&self, index: usize) -> Self::ReadItem<'_> {
+            DatumSeq {
+                iter: self.codec.decode(self.inner.index(index)),
+            }
+        }
+        fn len(&self) -> usize {
+            self.inner.len()
+        }
+    }
+}
+
+/// A wrapper presenting as a sequence of `Datum` but backed by encoded state.
+mod datum_seq {
+
+    use super::{Codec, CodecDuJour, IterDuJour};
+    use differential_dataflow::trace::cursor::MyTrait;
+    use mz_repr::{read_datum, Datum, Row};
+
+    /// A reference that can be resolved to a sequence of `Datum`s.
+    ///
+    /// This type must "compare" as if decoded to a `Row`, which means it needs to track
+    /// various nuances of `Row::cmp`, which at the moment is first by length, and then by
+    /// the raw binary slice backing the row. Neither of those are explicit in this struct.
+    /// We will need to produce them in order to perform comparisons.
+    #[derive(Debug)]
+    pub struct DatumSeq<'a> {
+        pub iter: IterDuJour<'a>,
+    }
+
+    impl<'a> Copy for DatumSeq<'a> {}
+    impl<'a> Clone for DatumSeq<'a> {
+        fn clone(&self) -> Self {
+            *self
+        }
+    }
+
+    use std::cmp::Ordering;
+    impl<'a, 'b> PartialEq<DatumSeq<'a>> for DatumSeq<'b> {
+        fn eq(&self, other: &DatumSeq<'a>) -> bool {
+            Iterator::eq(self.iter, other.iter)
+        }
+    }
+    impl<'a> Eq for DatumSeq<'a> {}
+    impl<'a, 'b> PartialOrd<DatumSeq<'a>> for DatumSeq<'b> {
+        fn partial_cmp(&self, other: &DatumSeq<'a>) -> Option<Ordering> {
+            let len1: usize = self.iter.map(|b| b.len()).sum();
+            let len2: usize = other.iter.map(|b| b.len()).sum();
+            if len1 == len2 {
+                for (b1, b2) in self.iter.zip(other.iter) {
+                    let cmp = b1.cmp(b2);
+                    if cmp != Ordering::Equal {
+                        return Some(cmp);
+                    }
+                }
+                Some(Ordering::Equal)
+            } else {
+                Some(len1.cmp(&len2))
+            }
+        }
+    }
+    impl<'a> Ord for DatumSeq<'a> {
+        fn cmp(&self, other: &Self) -> Ordering {
+            self.partial_cmp(other).unwrap()
+        }
+    }
+
+    impl<'a> MyTrait<'a> for DatumSeq<'a> {
+        type Owned = Row;
+        fn into_owned(self) -> Self::Owned {
+            Row::pack(self)
+        }
+        fn clone_onto(&self, other: &mut Self::Owned) {
+            let mut packer = other.packer();
+            packer.extend(*self);
+        }
+        fn compare(&self, other: &Self::Owned) -> Ordering {
+            let mut other_bytes = other.data();
+            let len1: usize = self.iter.map(|b| b.len()).sum();
+            let len2: usize = other_bytes.len();
+            if len1 == len2 {
+                for bytes in self.iter {
+                    if other_bytes.len() >= bytes.len() && bytes.eq(&other_bytes[..bytes.len()]) {
+                        other_bytes = &other_bytes[bytes.len()..];
+                    } else {
+                        return bytes.cmp(other_bytes);
+                    }
+                }
+                if other_bytes.is_empty() {
+                    Ordering::Equal
+                } else {
+                    Ordering::Less // Shouldn't happen with equal lengths
+                }
+            } else {
+                len1.cmp(&len2)
+            }
+        }
+        fn borrow_as(other: &'a Self::Owned) -> Self {
+            Self {
+                iter: CodecDuJour::borrow_row(other),
+            }
+        }
+    }
+
+    impl<'a> DatumSeq<'a> {
+        pub fn bytes_iter(self) -> IterDuJour<'a> {
+            self.iter
+        }
+    }
+
+    impl<'a> Iterator for DatumSeq<'a> {
+        type Item = Datum<'a>;
+        fn next(&mut self) -> Option<Self::Item> {
+            self.iter
+                .next()
+                .map(|bytes| unsafe { read_datum(bytes, &mut 0) })
+        }
+    }
+
+    use mz_repr::fixed_length::IntoRowByTypes;
+    use mz_repr::ColumnType;
+    impl<'long> IntoRowByTypes for DatumSeq<'long> {
+        type DatumIter<'short> = DatumSeq<'short> where Self: 'short;
+        fn into_datum_iter<'short>(
+            &'short self,
+            _types: Option<&[ColumnType]>,
+        ) -> Self::DatumIter<'short> {
+            *self
+        }
+    }
+}
+
+/// Traits abstracting the processes of encoding and decoding byte sequences.
+mod codec {
+
+    use mz_repr::{read_datum, Row};
+
+    pub use self::misra_gries::MisraGries;
+    pub use dictionary::{BytesIter, DictionaryCodec};
+
+    pub trait Codec: Default + 'static {
+        /// The iterator type returned by decoding.
+        type DecodeIter<'a>: Iterator<Item = &'a [u8]> + Copy;
+        /// Decodes an input byte slice into a sequence of byte slices.
+        fn decode<'a>(&'a self, bytes: &'a [u8]) -> Self::DecodeIter<'a>;
+        /// Encodes a sequence of byte slices into an output byte slice.
+        fn encode<'a, I>(&mut self, iter: I, output: &mut Vec<u8>)
+        where
+            I: IntoIterator<Item = &'a [u8]>;
+        /// Constructs a new instance of `Self` from accumulated statistics.
+        /// These statistics should cover the data the output expects to see.
+        fn new_from(stats: [&Self; 2]) -> Self;
+        /// Diagnostic information about the state of the codec.
+        fn report(&self) {}
+
+        fn borrow_row<'a>(row: &'a Row) -> Self::DecodeIter<'a>;
+
+        fn shorten<'a, 'b>(iter: Self::DecodeIter<'a>) -> Self::DecodeIter<'b>
+        where
+            'a: 'b;
+    }
+
+    /// Independently encodes each column.
+    #[derive(Default, Debug)]
+    pub struct ColumnsCodec {
+        columns: Vec<DictionaryCodec>,
+        bytes: usize,
+        total: usize,
+    }
+
+    impl Codec for ColumnsCodec {
+        type DecodeIter<'a> = ColumnsIter<'a>;
+        fn decode<'a>(&'a self, bytes: &'a [u8]) -> Self::DecodeIter<'a> {
+            ColumnsIter {
+                index: Some(self),
+                column: 0,
+                data: bytes,
+                offset: 0,
+            }
+        }
+        fn encode<'a, I>(&mut self, iter: I, output: &mut Vec<u8>)
+        where
+            I: IntoIterator<Item = &'a [u8]>,
+        {
+            let mut iter = iter.into_iter();
+            let mut index = 0;
+            while let Some(bytes) = iter.next() {
+                self.total += bytes.len();
+                if self.columns.len() <= index {
+                    self.columns.push(Default::default());
+                }
+                self.columns[index].encode(std::iter::once(bytes), output);
+                index += 1;
+            }
+            self.bytes += output.len();
+        }
+
+        fn new_from(stats: [&Self; 2]) -> Self {
+            // Is it possible that one of the inputs has no stats?
+            let cols = std::cmp::max(stats[0].columns.len(), stats[1].columns.len());
+            let mut columns = Vec::with_capacity(cols);
+            let default: DictionaryCodec = Default::default();
+            for index in 0..cols {
+                columns.push(DictionaryCodec::new_from([
+                    stats[0].columns.get(index).unwrap_or(&default),
+                    stats[1].columns.get(index).unwrap_or(&default),
+                ]));
+            }
+            Self {
+                columns,
+                total: 0,
+                bytes: 0,
+            }
+        }
+        // fn report(&self) {
+        //     if self.total > 100000 && self.columns.iter().all(|c| c.decode.len() > 0) {
+        //         println!("REPORT: {:?} -> {:?} (x{:?})", self.total, self.bytes, self.total/self.bytes);
+        //         for column in self.columns.iter() { column.report() }
+        //     }
+        // }
+
+        fn borrow_row(row: &Row) -> Self::DecodeIter<'_> {
+            ColumnsIter {
+                index: None,
+                column: 0,
+                data: row.data(),
+                offset: 0,
+            }
+        }
+        fn shorten<'a, 'b>(iter: Self::DecodeIter<'a>) -> Self::DecodeIter<'b>
+        where
+            'a: 'b,
+        {
+            ColumnsIter {
+                index: iter.index,
+                column: iter.column,
+                data: iter.data,
+                offset: iter.offset,
+            }
+        }
+    }
+
+    #[derive(Debug, Copy, Clone)]
+    pub struct ColumnsIter<'a> {
+        // Optional only to support borrowing owned as this
+        pub index: Option<&'a ColumnsCodec>,
+        pub column: usize,
+        pub data: &'a [u8],
+        pub offset: usize,
+    }
+
+    impl<'a> Iterator for ColumnsIter<'a> {
+        type Item = &'a [u8];
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.offset >= self.data.len() {
+                None
+            } else if let Some(bytes) = self
+                .index
+                .as_ref()
+                .and_then(|i| i.columns.get(self.column))
+                .and_then(|i| i.decode.get(self.data[self.offset].into()))
+            {
+                self.offset += 1;
+                self.column += 1;
+                Some(bytes)
+            } else {
+                let offset = self.offset;
+                unsafe {
+                    read_datum(self.data, &mut self.offset);
+                }
+                self.column += 1;
+                Some(&self.data[offset..self.offset])
+            }
+        }
+    }
+
+    mod dictionary {
+
+        use mz_repr::{read_datum, Row};
+        use std::collections::BTreeMap;
+
+        pub use super::{BytesMap, Codec, MisraGries};
+
+        /// A type that can both encode and decode sequences of byte slices.
+        #[derive(Default, Debug)]
+        pub struct DictionaryCodec {
+            encode: BTreeMap<Vec<u8>, u8>,
+            pub decode: BytesMap,
+            stats: (MisraGries<Vec<u8>>, [u64; 4]),
+            bytes: usize,
+            total: usize,
+        }
+
+        impl Codec for DictionaryCodec {
+            type DecodeIter<'a> = BytesIter<'a>;
+
+            /// Decode a sequence of byte slices.
+            fn decode<'a>(&'a self, bytes: &'a [u8]) -> Self::DecodeIter<'a> {
+                BytesIter {
+                    index: Some(&self.decode),
+                    data: bytes,
+                    offset: 0,
+                }
+            }
+
+            /// Encode a sequence of byte slices.
+            ///
+            /// Encoding also records statistics about the structure of the input.
+            fn encode<'a, I>(&mut self, iter: I, output: &mut Vec<u8>)
+            where
+                I: IntoIterator<Item = &'a [u8]>,
+            {
+                let pre_len = output.len();
+                for bytes in iter.into_iter() {
+                    self.total += bytes.len();
+                    // If we have an index referencing `bytes`, use the index key.
+                    if let Some(b) = self.encode.get(bytes) {
+                        output.push(*b);
+                    } else {
+                        output.extend(bytes);
+                    }
+                    // Stats stuff.
+                    self.stats.0.insert(bytes.to_owned());
+                    let tag = bytes[0];
+                    let tag_idx: usize = (tag % 4).into();
+                    self.stats.1[tag_idx] |= 1 << (tag >> 2);
+                }
+                self.bytes += output.len() - pre_len;
+            }
+
+            /// Construct a new encoder from supplied statistics.
+            fn new_from(stats: [&Self; 2]) -> Self {
+                // Collect most popular bytes from combined containers.
+                let mut mg = MisraGries::default();
+                for (thing, count) in stats[0].stats.0.clone().done() {
+                    mg.update(thing, count);
+                }
+                for (thing, count) in stats[1].stats.0.clone().done() {
+                    mg.update(thing, count);
+                }
+                let mut mg = mg.done().into_iter();
+                // Establish encoding and decoding rules.
+                let mut encode = BTreeMap::new();
+                let mut decode = BytesMap::default();
+                for tag in 0..=255 {
+                    let tag_idx: usize = (tag % 4).into();
+                    let shift = tag >> 2;
+                    if ((stats[0].stats.1[tag_idx] | stats[1].stats.1[tag_idx]) >> shift) & 0x01
+                        != 0
+                    {
+                        decode.push(None);
+                    } else if let Some((next_bytes, _count)) = mg.next() {
+                        decode.push(Some(&next_bytes[..]));
+                        encode.insert(next_bytes, tag);
+                    }
+                }
+
+                Self {
+                    encode,
+                    decode,
+                    stats: (MisraGries::default(), [0u64; 4]),
+                    bytes: 0,
+                    total: 0,
+                }
+            }
+
+            fn report(&self) {
+                let mut tags_used = 0;
+                tags_used += self.stats.1[0].count_ones();
+                tags_used += self.stats.1[1].count_ones();
+                tags_used += self.stats.1[2].count_ones();
+                tags_used += self.stats.1[3].count_ones();
+                let mg = self.stats.0.clone().done();
+                let mut bytes = 0;
+                for (vec, _count) in mg.iter() {
+                    bytes += vec.len();
+                }
+                // if self.total > 10000 && !mg.is_empty() {
+                println!(
+                    "\t{:?}v{:?}: {:?} -> {:?} + {:?} = (x{:?})",
+                    tags_used,
+                    mg.len(),
+                    self.total,
+                    self.bytes,
+                    bytes,
+                    self.total / (self.bytes + bytes),
+                )
+                // }
+            }
+
+            fn borrow_row(row: &Row) -> Self::DecodeIter<'_> {
+                BytesIter {
+                    index: None,
+                    data: row.data(),
+                    offset: 0,
+                }
+            }
+
+            fn shorten<'a, 'b>(iter: Self::DecodeIter<'a>) -> Self::DecodeIter<'b>
+            where
+                'a: 'b,
+            {
+                BytesIter {
+                    index: iter.index,
+                    data: iter.data,
+                    offset: iter.offset,
+                }
+            }
+        }
+
+        #[derive(Debug, Copy, Clone)]
+        pub struct BytesIter<'a> {
+            // Optional only to support borrowing owned as this
+            pub index: Option<&'a BytesMap>,
+            pub data: &'a [u8],
+            pub offset: usize,
+        }
+
+        impl<'a> Iterator for BytesIter<'a> {
+            type Item = &'a [u8];
+            fn next(&mut self) -> Option<Self::Item> {
+                if self.offset >= self.data.len() {
+                    None
+                } else if let Some(bytes) = self
+                    .index
+                    .as_ref()
+                    .and_then(|i| i.get(self.data[self.offset].into()))
+                {
+                    self.offset += 1;
+                    Some(bytes)
+                } else {
+                    let offset = self.offset;
+                    unsafe {
+                        read_datum(self.data, &mut self.offset);
+                    }
+                    Some(&self.data[offset..self.offset])
+                }
+            }
+        }
+    }
+
+    /// A map from `0 .. something` to `Option<&[u8]>`.
+    ///
+    /// Non-empty slices are pushed in order, and can be retrieved by index.
+    /// Pushing an empty slice is equivalent to pushing `None`.
+    #[derive(Debug)]
+    pub struct BytesMap {
+        offsets: Vec<usize>,
+        bytes: Vec<u8>,
+    }
+    impl Default for BytesMap {
+        fn default() -> Self {
+            Self {
+                offsets: vec![0],
+                bytes: Vec::new(),
+            }
+        }
+    }
+    impl BytesMap {
+        fn push(&mut self, input: Option<&[u8]>) {
+            if let Some(bytes) = input {
+                self.bytes.extend(bytes);
+            }
+            self.offsets.push(self.bytes.len());
+        }
+        fn get(&self, index: usize) -> Option<&[u8]> {
+            if index < self.offsets.len() - 1 {
+                let lower = self.offsets[index];
+                let upper = self.offsets[index + 1];
+                if lower < upper {
+                    Some(&self.bytes[lower..upper])
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
+        #[allow(dead_code)]
+        fn len(&self) -> usize {
+            self.offsets.len() - 1
+        }
+    }
+
+    mod misra_gries {
+
+        /// Maintains a summary of "heavy hitters" in a presented collection of items.
+        #[derive(Clone, Debug)]
+        pub struct MisraGries<T> {
+            pub inner: Vec<(T, usize)>,
+        }
+
+        impl<T> Default for MisraGries<T> {
+            fn default() -> Self {
+                Self {
+                    inner: Vec::with_capacity(1024),
+                }
+            }
+        }
+
+        impl<T: Ord> MisraGries<T> {
+            /// Inserts an additional element to the summary.
+            pub fn insert(&mut self, element: T) {
+                self.update(element, 1);
+            }
+            /// Inserts multiple copies of an element to the summary.
+            pub fn update(&mut self, element: T, count: usize) {
+                self.inner.push((element, count));
+                if self.inner.len() == self.inner.capacity() {
+                    self.tidy();
+                }
+            }
+            // /// Allocates a Misra-Gries summary which intends to hold up to `k` examples.
+            // ///
+            // /// After `n` insertions it will contain only elements that were inserted at least `n/k` times.
+            // /// The actual memory use is proportional to `2 * k`, so that we can amortize the consolidation.
+            // pub fn with_capacity(k: usize) -> Self {
+            //     Self {
+            //         inner: Vec::with_capacity(2 * k),
+            //     }
+            // }
+
+            /// Completes the summary, and extracts the items and their counts.
+            pub fn done(mut self) -> Vec<(T, usize)> {
+                use differential_dataflow::consolidation::consolidate;
+                consolidate(&mut self.inner);
+                self.inner.sort_by(|x, y| y.1.cmp(&x.1));
+                self.inner
+            }
+
+            /// Internal method that reduces the summary down to at most `k-1` distinct items, by repeatedly
+            /// removing sets of `k` distinct items. The removal is biased towards the lowest counts, so as
+            /// to preserve fidelity around the larger counts, for whatever that is worth.
+            fn tidy(&mut self) {
+                use differential_dataflow::consolidation::consolidate;
+                consolidate(&mut self.inner);
+                self.inner.sort_by(|x, y| y.1.cmp(&x.1));
+                let k = self.inner.capacity() / 2;
+                if self.inner.len() > k {
+                    let sub_weight = self.inner[k].1 - 1;
+                    self.inner.truncate(k);
+                    for (_, weight) in self.inner.iter_mut() {
+                        *weight -= sub_weight;
+                    }
+                    while self.inner.last().map(|x| x.1) == Some(0) {
+                        self.inner.pop();
+                    }
+                }
+            }
+        }
+
+        impl<T: Ord> std::ops::AddAssign for MisraGries<T> {
+            fn add_assign(&mut self, rhs: Self) {
+                for (element, count) in rhs.done() {
+                    self.update(element, count);
+                }
+            }
+        }
+    }
+}

--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -1,13 +1,5 @@
-pub use self::codec::{BytesIter, Codec, ColumnsCodec, ColumnsIter, DictionaryCodec};
 pub use self::container::DatumContainer;
-pub use self::datum_seq::DatumSeq;
 pub use self::spines::{RowRowSpine, RowSpine, RowValSpine};
-
-// pub type CodecDuJour = DictionaryCodec;
-// pub type IterDuJour<'a> = BytesIter<'a>;
-
-pub type CodecDuJour = ColumnsCodec;
-pub type IterDuJour<'a> = ColumnsIter<'a>;
 
 /// Spines specialized to contain `Row` types in keys and values.
 mod spines {
@@ -88,38 +80,34 @@ mod spines {
 /// A `Row`-specialized container using dictionary compression.
 mod container {
 
+    use differential_dataflow::trace::cursor::MyTrait;
     use differential_dataflow::trace::implementations::BatchContainer;
-    use timely::container::columnation::TimelyStack;
+    use differential_dataflow::trace::implementations::OffsetList;
 
-    use mz_repr::Row;
+    use mz_repr::{read_datum, Datum, Row};
 
-    use super::{Codec, CodecDuJour, DatumSeq};
-
-    #[derive(Default)]
+    /// A slice container with four bytes overhead per slice.
     pub struct DatumContainer {
-        /// DictionaryCodec with encoder, decoder, and stastistics.
-        codec: CodecDuJour,
-        /// A list of rows
-        inner: TimelyStack<Vec<u8>>,
-        /// Staging buffer for ingested `Row` types.
-        staging: Vec<u8>,
+        batches: Vec<DatumBatch>,
+    }
+
+    impl Default for DatumContainer {
+        fn default() -> Self {
+            Self {
+                batches: Vec::new(),
+            }
+        }
     }
 
     impl BatchContainer for DatumContainer {
         type PushItem = Row;
         type ReadItem<'a> = DatumSeq<'a>;
 
-        fn push(&mut self, item: Row) {
+        fn push(&mut self, item: Self::PushItem) {
             self.copy_push(&item);
         }
-        fn copy_push(&mut self, item: &Row) {
-            use differential_dataflow::trace::cursor::MyTrait;
+        fn copy_push(&mut self, item: &Self::PushItem) {
             self.copy(MyTrait::borrow_as(item));
-        }
-        fn copy<'a>(&mut self, item: DatumSeq<'a>) {
-            self.staging.clear();
-            self.codec.encode(item.bytes_iter(), &mut self.staging);
-            self.inner.copy(&self.staging);
         }
         fn copy_slice(&mut self, slice: &[Row]) {
             for item in slice.iter() {
@@ -131,53 +119,97 @@ mod container {
                 self.copy(other.index(index));
             }
         }
+        fn reserve(&mut self, _additional: usize) {}
+
+        fn copy(&mut self, item: Self::ReadItem<'_>) {
+            if let Some(batch) = self.batches.last_mut() {
+                let success = batch.try_push(item.bytes);
+                if !success {
+                    let mut new_batch = DatumBatch::with_capacity(std::cmp::max(
+                        2 * batch.storage.capacity(),
+                        item.bytes.len(),
+                    ));
+                    new_batch.try_push(item.bytes);
+                    self.batches.push(new_batch);
+                }
+            }
+        }
+
         fn with_capacity(size: usize) -> Self {
             Self {
-                codec: Default::default(),
-                inner: BatchContainer::with_capacity(size),
-                staging: Vec::new(),
+                batches: vec![DatumBatch::with_capacity(size)],
             }
         }
-        fn reserve(&mut self, additional: usize) {
-            self.inner.reserve(additional);
-        }
-        fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
-            cont1.codec.report();
-            cont2.codec.report();
 
+        fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
             Self {
-                codec: CodecDuJour::new_from([&cont1.codec, &cont2.codec]),
-                inner: BatchContainer::merge_capacity(&cont1.inner, &cont2.inner),
-                staging: Vec::new(),
+                batches: vec![DatumBatch::with_capacity(cont1.len() + cont2.len())],
             }
         }
-        fn index(&self, index: usize) -> Self::ReadItem<'_> {
-            DatumSeq {
-                iter: self.codec.decode(self.inner.index(index)),
+
+        fn index(&self, mut index: usize) -> Self::ReadItem<'_> {
+            for batch in self.batches.iter() {
+                if index < batch.len() {
+                    return DatumSeq {
+                        bytes: batch.index(index),
+                    };
+                }
+                index -= batch.len();
             }
+            panic!("Index out of bounds");
         }
+
         fn len(&self) -> usize {
-            self.inner.len()
+            let mut result = 0;
+            for batch in self.batches.iter() {
+                result += batch.len();
+            }
+            result
         }
     }
-}
 
-/// A wrapper presenting as a sequence of `Datum` but backed by encoded state.
-mod datum_seq {
-
-    use super::{Codec, CodecDuJour, IterDuJour};
-    use differential_dataflow::trace::cursor::MyTrait;
-    use mz_repr::{read_datum, Datum, Row};
-
-    /// A reference that can be resolved to a sequence of `Datum`s.
+    /// A batch of slice storage.
     ///
-    /// This type must "compare" as if decoded to a `Row`, which means it needs to track
-    /// various nuances of `Row::cmp`, which at the moment is first by length, and then by
-    /// the raw binary slice backing the row. Neither of those are explicit in this struct.
-    /// We will need to produce them in order to perform comparisons.
+    /// The backing storage for this batch will not be resized.
+    pub struct DatumBatch {
+        offsets: OffsetList,
+        storage: Vec<u8>,
+    }
+
+    impl DatumBatch {
+        /// Either accepts the slice and returns true,
+        /// or does not and returns false.
+        fn try_push(&mut self, slice: &[u8]) -> bool {
+            if self.storage.len() + slice.len() <= self.storage.capacity() {
+                self.storage.extend(slice.iter().cloned());
+                self.offsets.push(self.storage.len());
+                true
+            } else {
+                false
+            }
+        }
+        fn index(&self, index: usize) -> &[u8] {
+            let lower = self.offsets.index(index);
+            let upper = self.offsets.index(index + 1);
+            &self.storage[lower..upper]
+        }
+        fn len(&self) -> usize {
+            self.offsets.len() - 1
+        }
+
+        fn with_capacity(cap: usize) -> Self {
+            let mut offsets = OffsetList::with_capacity(cap + 1);
+            offsets.push(0);
+            Self {
+                offsets,
+                storage: Vec::with_capacity(cap),
+            }
+        }
+    }
+
     #[derive(Debug)]
     pub struct DatumSeq<'a> {
-        pub iter: IterDuJour<'a>,
+        bytes: &'a [u8],
     }
 
     impl<'a> Copy for DatumSeq<'a> {}
@@ -190,33 +222,24 @@ mod datum_seq {
     use std::cmp::Ordering;
     impl<'a, 'b> PartialEq<DatumSeq<'a>> for DatumSeq<'b> {
         fn eq(&self, other: &DatumSeq<'a>) -> bool {
-            Iterator::eq(self.iter, other.iter)
+            self.bytes.eq(other.bytes)
         }
     }
     impl<'a> Eq for DatumSeq<'a> {}
     impl<'a, 'b> PartialOrd<DatumSeq<'a>> for DatumSeq<'b> {
         fn partial_cmp(&self, other: &DatumSeq<'a>) -> Option<Ordering> {
-            let len1: usize = self.iter.map(|b| b.len()).sum();
-            let len2: usize = other.iter.map(|b| b.len()).sum();
-            if len1 == len2 {
-                for (b1, b2) in self.iter.zip(other.iter) {
-                    let cmp = b1.cmp(b2);
-                    if cmp != Ordering::Equal {
-                        return Some(cmp);
-                    }
-                }
-                Some(Ordering::Equal)
-            } else {
-                Some(len1.cmp(&len2))
-            }
+            Some(self.cmp(other))
         }
     }
     impl<'a> Ord for DatumSeq<'a> {
         fn cmp(&self, other: &Self) -> Ordering {
-            self.partial_cmp(other).unwrap()
+            match self.bytes.len().cmp(&other.bytes.len()) {
+                std::cmp::Ordering::Less => std::cmp::Ordering::Less,
+                std::cmp::Ordering::Greater => std::cmp::Ordering::Greater,
+                std::cmp::Ordering::Equal => self.bytes.cmp(other.bytes),
+            }
         }
     }
-
     impl<'a> MyTrait<'a> for DatumSeq<'a> {
         type Owned = Row;
         fn into_owned(self) -> Self::Owned {
@@ -226,46 +249,27 @@ mod datum_seq {
             let mut packer = other.packer();
             packer.extend(*self);
         }
-        fn compare(&self, other: &Self::Owned) -> Ordering {
-            let mut other_bytes = other.data();
-            let len1: usize = self.iter.map(|b| b.len()).sum();
-            let len2: usize = other_bytes.len();
-            if len1 == len2 {
-                for bytes in self.iter {
-                    if other_bytes.len() >= bytes.len() && bytes.eq(&other_bytes[..bytes.len()]) {
-                        other_bytes = &other_bytes[bytes.len()..];
-                    } else {
-                        return bytes.cmp(other_bytes);
-                    }
-                }
-                if other_bytes.is_empty() {
-                    Ordering::Equal
-                } else {
-                    Ordering::Less // Shouldn't happen with equal lengths
-                }
-            } else {
-                len1.cmp(&len2)
-            }
+        fn compare(&self, other: &Self::Owned) -> std::cmp::Ordering {
+            self.cmp(&DatumSeq::borrow_as(other))
         }
         fn borrow_as(other: &'a Self::Owned) -> Self {
             Self {
-                iter: CodecDuJour::borrow_row(other),
+                bytes: other.data(),
             }
-        }
-    }
-
-    impl<'a> DatumSeq<'a> {
-        pub fn bytes_iter(self) -> IterDuJour<'a> {
-            self.iter
         }
     }
 
     impl<'a> Iterator for DatumSeq<'a> {
         type Item = Datum<'a>;
         fn next(&mut self) -> Option<Self::Item> {
-            self.iter
-                .next()
-                .map(|bytes| unsafe { read_datum(bytes, &mut 0) })
+            if self.bytes.is_empty() {
+                None
+            } else {
+                let mut offset = 0;
+                let result = unsafe { read_datum(self.bytes, &mut offset) };
+                self.bytes = &self.bytes[offset..];
+                Some(result)
+            }
         }
     }
 
@@ -278,435 +282,6 @@ mod datum_seq {
             _types: Option<&[ColumnType]>,
         ) -> Self::DatumIter<'short> {
             *self
-        }
-    }
-}
-
-/// Traits abstracting the processes of encoding and decoding byte sequences.
-mod codec {
-
-    use mz_repr::{read_datum, Row};
-
-    pub use self::misra_gries::MisraGries;
-    pub use dictionary::{BytesIter, DictionaryCodec};
-
-    pub trait Codec: Default + 'static {
-        /// The iterator type returned by decoding.
-        type DecodeIter<'a>: Iterator<Item = &'a [u8]> + Copy;
-        /// Decodes an input byte slice into a sequence of byte slices.
-        fn decode<'a>(&'a self, bytes: &'a [u8]) -> Self::DecodeIter<'a>;
-        /// Encodes a sequence of byte slices into an output byte slice.
-        fn encode<'a, I>(&mut self, iter: I, output: &mut Vec<u8>)
-        where
-            I: IntoIterator<Item = &'a [u8]>;
-        /// Constructs a new instance of `Self` from accumulated statistics.
-        /// These statistics should cover the data the output expects to see.
-        fn new_from(stats: [&Self; 2]) -> Self;
-        /// Diagnostic information about the state of the codec.
-        fn report(&self) {}
-
-        fn borrow_row<'a>(row: &'a Row) -> Self::DecodeIter<'a>;
-
-        fn shorten<'a, 'b>(iter: Self::DecodeIter<'a>) -> Self::DecodeIter<'b>
-        where
-            'a: 'b;
-    }
-
-    /// Independently encodes each column.
-    #[derive(Default, Debug)]
-    pub struct ColumnsCodec {
-        columns: Vec<DictionaryCodec>,
-        bytes: usize,
-        total: usize,
-    }
-
-    impl Codec for ColumnsCodec {
-        type DecodeIter<'a> = ColumnsIter<'a>;
-        fn decode<'a>(&'a self, bytes: &'a [u8]) -> Self::DecodeIter<'a> {
-            ColumnsIter {
-                index: Some(self),
-                column: 0,
-                data: bytes,
-                offset: 0,
-            }
-        }
-        fn encode<'a, I>(&mut self, iter: I, output: &mut Vec<u8>)
-        where
-            I: IntoIterator<Item = &'a [u8]>,
-        {
-            let mut iter = iter.into_iter();
-            let mut index = 0;
-            while let Some(bytes) = iter.next() {
-                self.total += bytes.len();
-                if self.columns.len() <= index {
-                    self.columns.push(Default::default());
-                }
-                self.columns[index].encode(std::iter::once(bytes), output);
-                index += 1;
-            }
-            self.bytes += output.len();
-        }
-
-        fn new_from(stats: [&Self; 2]) -> Self {
-            // Is it possible that one of the inputs has no stats?
-            let cols = std::cmp::max(stats[0].columns.len(), stats[1].columns.len());
-            let mut columns = Vec::with_capacity(cols);
-            let default: DictionaryCodec = Default::default();
-            for index in 0..cols {
-                columns.push(DictionaryCodec::new_from([
-                    stats[0].columns.get(index).unwrap_or(&default),
-                    stats[1].columns.get(index).unwrap_or(&default),
-                ]));
-            }
-            Self {
-                columns,
-                total: 0,
-                bytes: 0,
-            }
-        }
-        // fn report(&self) {
-        //     if self.total > 100000 && self.columns.iter().all(|c| c.decode.len() > 0) {
-        //         println!("REPORT: {:?} -> {:?} (x{:?})", self.total, self.bytes, self.total/self.bytes);
-        //         for column in self.columns.iter() { column.report() }
-        //     }
-        // }
-
-        fn borrow_row(row: &Row) -> Self::DecodeIter<'_> {
-            ColumnsIter {
-                index: None,
-                column: 0,
-                data: row.data(),
-                offset: 0,
-            }
-        }
-        fn shorten<'a, 'b>(iter: Self::DecodeIter<'a>) -> Self::DecodeIter<'b>
-        where
-            'a: 'b,
-        {
-            ColumnsIter {
-                index: iter.index,
-                column: iter.column,
-                data: iter.data,
-                offset: iter.offset,
-            }
-        }
-    }
-
-    #[derive(Debug, Copy, Clone)]
-    pub struct ColumnsIter<'a> {
-        // Optional only to support borrowing owned as this
-        pub index: Option<&'a ColumnsCodec>,
-        pub column: usize,
-        pub data: &'a [u8],
-        pub offset: usize,
-    }
-
-    impl<'a> Iterator for ColumnsIter<'a> {
-        type Item = &'a [u8];
-        fn next(&mut self) -> Option<Self::Item> {
-            if self.offset >= self.data.len() {
-                None
-            } else if let Some(bytes) = self
-                .index
-                .as_ref()
-                .and_then(|i| i.columns.get(self.column))
-                .and_then(|i| i.decode.get(self.data[self.offset].into()))
-            {
-                self.offset += 1;
-                self.column += 1;
-                Some(bytes)
-            } else {
-                let offset = self.offset;
-                unsafe {
-                    read_datum(self.data, &mut self.offset);
-                }
-                self.column += 1;
-                Some(&self.data[offset..self.offset])
-            }
-        }
-    }
-
-    mod dictionary {
-
-        use mz_repr::{read_datum, Row};
-        use std::collections::BTreeMap;
-
-        pub use super::{BytesMap, Codec, MisraGries};
-
-        /// A type that can both encode and decode sequences of byte slices.
-        #[derive(Default, Debug)]
-        pub struct DictionaryCodec {
-            encode: BTreeMap<Vec<u8>, u8>,
-            pub decode: BytesMap,
-            stats: (MisraGries<Vec<u8>>, [u64; 4]),
-            bytes: usize,
-            total: usize,
-        }
-
-        impl Codec for DictionaryCodec {
-            type DecodeIter<'a> = BytesIter<'a>;
-
-            /// Decode a sequence of byte slices.
-            fn decode<'a>(&'a self, bytes: &'a [u8]) -> Self::DecodeIter<'a> {
-                BytesIter {
-                    index: Some(&self.decode),
-                    data: bytes,
-                    offset: 0,
-                }
-            }
-
-            /// Encode a sequence of byte slices.
-            ///
-            /// Encoding also records statistics about the structure of the input.
-            fn encode<'a, I>(&mut self, iter: I, output: &mut Vec<u8>)
-            where
-                I: IntoIterator<Item = &'a [u8]>,
-            {
-                let pre_len = output.len();
-                for bytes in iter.into_iter() {
-                    self.total += bytes.len();
-                    // If we have an index referencing `bytes`, use the index key.
-                    if let Some(b) = self.encode.get(bytes) {
-                        output.push(*b);
-                    } else {
-                        output.extend(bytes);
-                    }
-                    // Stats stuff.
-                    self.stats.0.insert(bytes.to_owned());
-                    let tag = bytes[0];
-                    let tag_idx: usize = (tag % 4).into();
-                    self.stats.1[tag_idx] |= 1 << (tag >> 2);
-                }
-                self.bytes += output.len() - pre_len;
-            }
-
-            /// Construct a new encoder from supplied statistics.
-            fn new_from(stats: [&Self; 2]) -> Self {
-                // Collect most popular bytes from combined containers.
-                let mut mg = MisraGries::default();
-                for (thing, count) in stats[0].stats.0.clone().done() {
-                    mg.update(thing, count);
-                }
-                for (thing, count) in stats[1].stats.0.clone().done() {
-                    mg.update(thing, count);
-                }
-                let mut mg = mg.done().into_iter();
-                // Establish encoding and decoding rules.
-                let mut encode = BTreeMap::new();
-                let mut decode = BytesMap::default();
-                for tag in 0..=255 {
-                    let tag_idx: usize = (tag % 4).into();
-                    let shift = tag >> 2;
-                    if ((stats[0].stats.1[tag_idx] | stats[1].stats.1[tag_idx]) >> shift) & 0x01
-                        != 0
-                    {
-                        decode.push(None);
-                    } else if let Some((next_bytes, _count)) = mg.next() {
-                        decode.push(Some(&next_bytes[..]));
-                        encode.insert(next_bytes, tag);
-                    }
-                }
-
-                Self {
-                    encode,
-                    decode,
-                    stats: (MisraGries::default(), [0u64; 4]),
-                    bytes: 0,
-                    total: 0,
-                }
-            }
-
-            fn report(&self) {
-                let mut tags_used = 0;
-                tags_used += self.stats.1[0].count_ones();
-                tags_used += self.stats.1[1].count_ones();
-                tags_used += self.stats.1[2].count_ones();
-                tags_used += self.stats.1[3].count_ones();
-                let mg = self.stats.0.clone().done();
-                let mut bytes = 0;
-                for (vec, _count) in mg.iter() {
-                    bytes += vec.len();
-                }
-                // if self.total > 10000 && !mg.is_empty() {
-                println!(
-                    "\t{:?}v{:?}: {:?} -> {:?} + {:?} = (x{:?})",
-                    tags_used,
-                    mg.len(),
-                    self.total,
-                    self.bytes,
-                    bytes,
-                    self.total / (self.bytes + bytes),
-                )
-                // }
-            }
-
-            fn borrow_row(row: &Row) -> Self::DecodeIter<'_> {
-                BytesIter {
-                    index: None,
-                    data: row.data(),
-                    offset: 0,
-                }
-            }
-
-            fn shorten<'a, 'b>(iter: Self::DecodeIter<'a>) -> Self::DecodeIter<'b>
-            where
-                'a: 'b,
-            {
-                BytesIter {
-                    index: iter.index,
-                    data: iter.data,
-                    offset: iter.offset,
-                }
-            }
-        }
-
-        #[derive(Debug, Copy, Clone)]
-        pub struct BytesIter<'a> {
-            // Optional only to support borrowing owned as this
-            pub index: Option<&'a BytesMap>,
-            pub data: &'a [u8],
-            pub offset: usize,
-        }
-
-        impl<'a> Iterator for BytesIter<'a> {
-            type Item = &'a [u8];
-            fn next(&mut self) -> Option<Self::Item> {
-                if self.offset >= self.data.len() {
-                    None
-                } else if let Some(bytes) = self
-                    .index
-                    .as_ref()
-                    .and_then(|i| i.get(self.data[self.offset].into()))
-                {
-                    self.offset += 1;
-                    Some(bytes)
-                } else {
-                    let offset = self.offset;
-                    unsafe {
-                        read_datum(self.data, &mut self.offset);
-                    }
-                    Some(&self.data[offset..self.offset])
-                }
-            }
-        }
-    }
-
-    /// A map from `0 .. something` to `Option<&[u8]>`.
-    ///
-    /// Non-empty slices are pushed in order, and can be retrieved by index.
-    /// Pushing an empty slice is equivalent to pushing `None`.
-    #[derive(Debug)]
-    pub struct BytesMap {
-        offsets: Vec<usize>,
-        bytes: Vec<u8>,
-    }
-    impl Default for BytesMap {
-        fn default() -> Self {
-            Self {
-                offsets: vec![0],
-                bytes: Vec::new(),
-            }
-        }
-    }
-    impl BytesMap {
-        fn push(&mut self, input: Option<&[u8]>) {
-            if let Some(bytes) = input {
-                self.bytes.extend(bytes);
-            }
-            self.offsets.push(self.bytes.len());
-        }
-        fn get(&self, index: usize) -> Option<&[u8]> {
-            if index < self.offsets.len() - 1 {
-                let lower = self.offsets[index];
-                let upper = self.offsets[index + 1];
-                if lower < upper {
-                    Some(&self.bytes[lower..upper])
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        }
-        #[allow(dead_code)]
-        fn len(&self) -> usize {
-            self.offsets.len() - 1
-        }
-    }
-
-    mod misra_gries {
-
-        /// Maintains a summary of "heavy hitters" in a presented collection of items.
-        #[derive(Clone, Debug)]
-        pub struct MisraGries<T> {
-            pub inner: Vec<(T, usize)>,
-        }
-
-        impl<T> Default for MisraGries<T> {
-            fn default() -> Self {
-                Self {
-                    inner: Vec::with_capacity(1024),
-                }
-            }
-        }
-
-        impl<T: Ord> MisraGries<T> {
-            /// Inserts an additional element to the summary.
-            pub fn insert(&mut self, element: T) {
-                self.update(element, 1);
-            }
-            /// Inserts multiple copies of an element to the summary.
-            pub fn update(&mut self, element: T, count: usize) {
-                self.inner.push((element, count));
-                if self.inner.len() == self.inner.capacity() {
-                    self.tidy();
-                }
-            }
-            // /// Allocates a Misra-Gries summary which intends to hold up to `k` examples.
-            // ///
-            // /// After `n` insertions it will contain only elements that were inserted at least `n/k` times.
-            // /// The actual memory use is proportional to `2 * k`, so that we can amortize the consolidation.
-            // pub fn with_capacity(k: usize) -> Self {
-            //     Self {
-            //         inner: Vec::with_capacity(2 * k),
-            //     }
-            // }
-
-            /// Completes the summary, and extracts the items and their counts.
-            pub fn done(mut self) -> Vec<(T, usize)> {
-                use differential_dataflow::consolidation::consolidate;
-                consolidate(&mut self.inner);
-                self.inner.sort_by(|x, y| y.1.cmp(&x.1));
-                self.inner
-            }
-
-            /// Internal method that reduces the summary down to at most `k-1` distinct items, by repeatedly
-            /// removing sets of `k` distinct items. The removal is biased towards the lowest counts, so as
-            /// to preserve fidelity around the larger counts, for whatever that is worth.
-            fn tidy(&mut self) {
-                use differential_dataflow::consolidation::consolidate;
-                consolidate(&mut self.inner);
-                self.inner.sort_by(|x, y| y.1.cmp(&x.1));
-                let k = self.inner.capacity() / 2;
-                if self.inner.len() > k {
-                    let sub_weight = self.inner[k].1 - 1;
-                    self.inner.truncate(k);
-                    for (_, weight) in self.inner.iter_mut() {
-                        *weight -= sub_weight;
-                    }
-                    while self.inner.last().map(|x| x.1) == Some(0) {
-                        self.inner.pop();
-                    }
-                }
-            }
-        }
-
-        impl<T: Ord> std::ops::AddAssign for MisraGries<T> {
-            fn add_assign(&mut self, rhs: Self) {
-                for (element, count) in rhs.done() {
-                    self.update(element, count);
-                }
-            }
         }
     }
 }

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -17,8 +17,10 @@ use differential_dataflow::trace::wrappers::enter::TraceEnter;
 use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
 use timely::dataflow::ScopeParent;
 
-use mz_repr::{Diff, Row};
+use mz_repr::Diff;
 use mz_storage_types::errors::DataflowError;
+
+pub use crate::row_spine::{RowRowSpine, RowSpine, RowValSpine};
 
 // Spines are data structures that collect and maintain updates.
 // Agents are wrappers around spines that allow shared read access.
@@ -35,17 +37,14 @@ pub type KeyAgent<K, T, R> = TraceAgent<KeySpine<K, T, R>>;
 pub type KeyEnter<K, T, R, TEnter> = TraceEnter<TraceFrontier<KeyAgent<K, T, R>>, TEnter>;
 
 // Row specialized spines and agents.
-pub type RowValSpine<V, T, R> = ColValSpine<Row, V, T, R>;
 pub type RowValAgent<V, T, R> = TraceAgent<RowValSpine<V, T, R>>;
 pub type RowValArrangement<S, V> = Arranged<S, RowValAgent<V, <S as ScopeParent>::Timestamp, Diff>>;
 pub type RowValEnter<V, T, R, TEnter> = TraceEnter<TraceFrontier<RowValAgent<V, T, R>>, TEnter>;
 // Row specialized spines and agents.
-pub type RowRowSpine<T, R> = RowValSpine<Row, T, R>;
 pub type RowRowAgent<T, R> = TraceAgent<RowRowSpine<T, R>>;
 pub type RowRowArrangement<S> = Arranged<S, RowRowAgent<<S as ScopeParent>::Timestamp, Diff>>;
 pub type RowRowEnter<T, R, TEnter> = TraceEnter<TraceFrontier<RowRowAgent<T, R>>, TEnter>;
 // Row specialized spines and agents.
-pub type RowSpine<T, R> = ColKeySpine<Row, T, R>;
 pub type RowAgent<T, R> = TraceAgent<RowSpine<T, R>>;
 pub type RowArrangement<S> = Arranged<S, RowAgent<<S as ScopeParent>::Timestamp, Diff>>;
 pub type RowEnter<T, R, TEnter> = TraceEnter<TraceFrontier<RowAgent<T, R>>, TEnter>;

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -122,8 +122,8 @@ pub use crate::row::encoding::{
     RowEncoder,
 };
 pub use crate::row::{
-    datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, ProtoRow, Row,
-    RowArena, RowPacker, RowRef, SharedRow,
+    datum_list_size, datum_size, datums_size, read_datum, row_size, DatumList, DatumMap, ProtoRow,
+    Row, RowArena, RowPacker, RowRef, SharedRow,
 };
 pub use crate::scalar::{
     arb_datum, arb_range_type, ArrayRustType, AsColumnType, Datum, DatumType, PropArray, PropDatum,

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -678,7 +678,7 @@ pub(super) fn read_time(data: &[u8], offset: &mut usize) -> NaiveTime {
 ///
 /// This function is safe if a `Datum` was previously written at this offset by `push_datum`.
 /// Otherwise it could return invalid values, which is Undefined Behavior.
-unsafe fn read_datum<'a>(data: &'a [u8], offset: &mut usize) -> Datum<'a> {
+pub unsafe fn read_datum<'a>(data: &'a [u8], offset: &mut usize) -> Datum<'a> {
     let tag = Tag::try_from_primitive(read_byte(data, offset)).expect("unknown row tag");
     match tag {
         Tag::Null => Datum::Null,

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -275,7 +275,7 @@ true true true
 
 > CREATE DEFAULT INDEX ii_empty ON t3
 
-> SELECT records, batches, size < 1024, capacity < 1024, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_empty'
+> SELECT records, batches, size < 16 * 1024, capacity < 16 * 1024, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_empty'
 0 32 true true true
 
 # Tests that arrangement sizes are approximate
@@ -291,7 +291,7 @@ true true true
 
 > INSERT INTO t4 SELECT 1
 
-> SELECT records, batches, size < 1024, capacity > 0, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+> SELECT records, batches, size < 16 * 1024, capacity > 0, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
 1 32 true true true
 
 > INSERT INTO t4 SELECT generate_series(1, 1000)

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -284,7 +284,9 @@ true true true
 
 > CREATE INDEX ii_t4 ON t4(c)
 
-> SELECT records, batches, size < 1024, capacity < 1024, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+# We have 16 workers, and only want to ensure that the sizes are not egregious.
+
+> SELECT records, batches, size < 16 * 1024, capacity < 16 * 1024, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
 0 32 true true true
 
 > INSERT INTO t4 SELECT 1

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -265,7 +265,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 > CREATE DEFAULT INDEX ii_arr ON vv_arr
 
 # It's hard to come up with precise bounds because we might de-duplicate some data in arrangements.
-> SELECT records >= 300, size >= 0.25 * 10000, capacity >= 0.25 * 10000 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_arr' OR name LIKE '%mv_arr'
+> SELECT records >= 300, size > 0, capacity > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_arr' OR name LIKE '%mv_arr'
 true true true
 true true true
 
@@ -289,13 +289,13 @@ true true true
 
 > INSERT INTO t4 SELECT 1
 
-> SELECT records, batches, size < 1024, capacity > 96, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+> SELECT records, batches, size < 1024, capacity > 0, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
 1 32 true true true
 
 > INSERT INTO t4 SELECT generate_series(1, 1000)
 
 # Determining exact sizes is difficult because of deduplication in arrangements, so we just use safe values.
-> SELECT records >= 1000 AND records <= 1001, batches > 0, size > 0.25 * 30000 AND size < 4*30000, capacity > 0.25 * 30000, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+> SELECT records >= 1000 AND records <= 1001, batches > 0, size > 0 AND size < 4*30000, capacity > 0, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
 true true true true true
 
 > DROP INDEX ii_t4
@@ -349,9 +349,9 @@ true true true true true
 > SELECT
     records > 2 * 1000,
     records < 2 * 2 * 1000,
-    size > 0.25 * 130 * 1000,
+    size > 0,
     size < 4 * 130 * 1000,
-    capacity > 0.25 * 130 * 1000,
+    capacity > 0,
     capacity < 4 * 130 * 1000,
     allocations > 0
   FROM mz_internal.mz_dataflow_arrangement_sizes
@@ -361,9 +361,9 @@ true true true true true true true
 > SELECT
     records > 1000,
     records < 2 * 1000,
-    size > 0.025 * 100 * 1024,
+    size > 0,
     size < 4 * 100 * 1024,
-    capacity > 0.25 * 100 * 1024,
+    capacity > 0,
     capacity < 4 * 100 * 1024,
     allocations > 100
   FROM mz_internal.mz_dataflow_arrangement_sizes
@@ -390,9 +390,9 @@ true true true true true true true
 > SELECT
     records > 12 * 1000,
     records < 2 * 12 * 1000,
-    size > 0.25 * 1000 * 1000,
+    size > 0,
     size < 4 * 1000 * 1000,
-    capacity > 0.25 * 1000 * 1000,
+    capacity > 0,
     capacity < 4 * 1000 * 1000,
     allocations > 0
   FROM mz_internal.mz_dataflow_arrangement_sizes
@@ -424,9 +424,9 @@ true true true true true true true
 > SELECT
     records >= 2 * 1000,
     records < 1.1 * 2 * 1000,
-    size > 0.25 * 200 * 1000,
+    size > 0,
     size < 4 * 200 * 1000,
-    capacity > 0.25 * 200 * 1000,
+    capacity > 0,
     capacity < 4 * 200 * 1000,
     allocations > 100
   FROM mz_internal.mz_dataflow_arrangement_sizes
@@ -436,9 +436,9 @@ true true true true true true true
 > SELECT
     records >= 2 * 1000,
     records < 2 * 2 * 1000,
-    size > 0.25 * 172 * 1000,
+    size > 0,
     size < 4 * 172 * 1000,
-    capacity > 0.25 * 172 * 1000,
+    capacity > 0,
     capacity < 4 * 172 * 1000,
     allocations > 100
   FROM mz_internal.mz_dataflow_arrangement_sizes


### PR DESCRIPTION
This PR demonstrates how you can use Arrangement GATs to provide the appearance of `Row` data (`Datum` iterator, really) without maintaining `Row` data underneath.

This PR has a general `DatumContainer` that receives `Row` input data, and presents `DatumSeq<'a>` outputs, which reference underlying `&[u8]` data. Rather than shape that data as `Row` types, they are in a small number of larger `[u8]` allocations, with appropriately compact integers describing the boundaries of contained slices.

The intended (and observed) behavior is that the byte data backing a row plus four additional bytes is retained, without the 24 byte overhead of `Row`. This reduces memory substantially in some cases, and substantially reduces the non-`lg_alloc` memory from 24 bytes to 4 bytes by moving all binary data into `lg_alloc` regions.

cc: @antiguru, @ParkMyCar, @umanwizard 

### Motivation

  * This PR fixes a recognized bug.

      Materialize uses quite a lot of memory, and it should be reduced.


### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
