### PR TITLE
docs: Add lodash

### DIFF
--- a/doc/user/content/transform-data/json.md
+++ b/doc/user/content/transform-data/json.md
@@ -16,7 +16,7 @@ individual fields mapped to columns.
 <div class="json_widget">
     <div class="json">
         <textarea title="JSON Sample" id="json_sample" placeholder="JSON Sample">
-            { "payload": "materialize", "event": { "kind": 1, "success": true }, "ts": "2023-02-01T17:00:00.000Z" }
+            { "payload": "materialize", "event": { "kind": 1, "success": true, "createdAt": "2023-02-01T17:00:00.000Z" }, "ts": "2023-02-01T17:00:00.000Z" }
         </textarea>
         <div id="error_span" class="error">
             <p id="error_text"></p>
@@ -131,7 +131,7 @@ function formSql(selectItems, viewName, sourceName, objectType) {
 
     let selects = selectItems.map(([name, wrapping_function, cast, parents]) => {
         // Note: The first "parent" is the JSON column.
-        const formattedName = [...parents.slice(1), name].join("_").toLowerCase();
+        const formattedName = [...parents.slice(1), _.snakeCase(name)].join("_").toLowerCase();
 
         const parentPath = [parents[0], ...parents.slice(1).map((p) => `'${p}'`)].join("->");
         const formattedPath = parentPath.concat(`->>'${name}'`);

--- a/doc/user/content/transform-data/json.md
+++ b/doc/user/content/transform-data/json.md
@@ -45,10 +45,7 @@ individual fields mapped to columns.
 
 <script>
 
-/* Helper Methods
-
-If this wasn't a simple script these would be in a `utils.js` or come from lodash.
-*/
+/* Helper Methods */
 
 function escapeString(s) {
     return s.replace(`'`, `''`);
@@ -56,19 +53,6 @@ function escapeString(s) {
 
 function escapeIdent(s) {
     return s.replace(`"`, `""`);
-}
-
-function clone(x) {
-    return JSON.parse(JSON.stringify(x))
-}
-
-function debounce(callback, wait) {
-    let timeout;
-    return (...args) => {
-        const context = this;
-        clearTimeout(timeout);
-        timeout = setTimeout(() => callback.apply(context, args), wait);
-    }
 }
 
 /* JSON Parsing and SQL conversion */
@@ -125,7 +109,7 @@ function expandObject(object, parents, columns) {
                 continue;
         }
 
-        columns.push([name, wrapping_function, cast, clone(parents)]);
+        columns.push([name, wrapping_function, cast, _.clone(parents)]);
     }
 }
 
@@ -223,12 +207,12 @@ function render() {
 render();
 
 // Debounce at a quicker rate since these generally cannot generate errors.
-$("#view_name").keyup(debounce(render, 200));
-$("#source_name").keyup(debounce(render, 200));
-$("#column_name").keyup(debounce(render, 200));
+$("#view_name").keyup(_.debounce(render, 200));
+$("#source_name").keyup(_.debounce(render, 200));
+$("#column_name").keyup(_.debounce(render, 200));
 $("input[name='type_view']").change(render);
 
 // Debounce relatively slowly on the JSON sample since it can generate parsing errors.
-$("#json_sample").keyup(debounce(render, 600));
+$("#json_sample").keyup(_.debounce(render, 600));
 
 </script>

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -62,6 +62,7 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/anchor-js/anchor.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/simple-scrollspy@2.0.3/dist/simple-scrollspy.min.js"></script>
+<script src=" https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js "></script>
 
 {{/* Sass processing here */}} {{ $style := resources.Get "sass/main.scss" |
 toCSS | fingerprint }}


### PR DESCRIPTION
This PR adds the `lodash` Javascript library to our docs. Looking at the network tools is adds ~28Kb of JS that needs to get loaded. I think using Hugo's [js.Build](https://gohugo.io/hugo-pipes/js/) pipe we could get tree shaking to reduce this further, but my timebox ran out so I wasn't able to get that to work.

### Motivation

The JSON to SQL widget has a few util functions that would be better served by just using the lodash implementations. And as we make the widget more complex, e.g. https://github.com/MaterializeInc/materialize/pull/23820, it would make it a lot easier to just use lodash instead of implementing our own.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
