### PR TITLE
persist-txn: address another round of `TODO(txn)`

### DIFF
--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -134,8 +134,8 @@ impl Transactor {
                         debug!("read ts {}", read_ts);
                         write_ts = self.oracle.write_ts();
                         debug!("write ts {}", write_ts);
-                        // TODO(txn): Read this incrementally between the old
-                        // and new read timestamps, instead.
+                        // TODO: Read this incrementally between the old and new
+                        // read timestamps, instead.
                         reads = self.read_at(read_ts, read_ids.iter()).await;
                         continue;
                     }

--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -548,8 +548,9 @@ async fn apply_caa<K, V, T, D>(
             upper,
             commit_ts.step_forward(),
         );
-        // TODO(txn): We need to do all the batches for a given `(shard, ts)` at
-        // once.
+        // If we both spill to s3 in `Txn::write`` _and_ add the ability to
+        // merge two `Txn`s and then commit them together, then we need to do
+        // all the batches for a given `(shard, ts)` at once.
         let res = data_write
             .compare_and_append_batch(
                 &mut [&mut batch],

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -342,8 +342,8 @@ where
                     let _ = tx.send(res);
                 }
                 TxnsReadCmd::Wait { ts, tx } => {
-                    // TODO(txn): This could be arbitrarily far in the future.
-                    // Don't block other commands on this.
+                    // TODO(txn-lazy): This could be arbitrarily far in the
+                    // future. Don't block other commands on this.
                     let res = match &ts {
                         WaitTs::GreaterEqual(ts) => self.cache.update_ge(ts).await,
                         WaitTs::GreaterThan(ts) => self.cache.update_gt(ts).await,

--- a/src/persist-txn/src/txns.rs
+++ b/src/persist-txn/src/txns.rs
@@ -156,8 +156,8 @@ where
         let txns_since = client
             .open_critical_since(
                 txns_id,
-                // TODO(txn): We likely need to use a different critical reader
-                // id for this if we want to be able to introspect it via SQL.
+                // TODO: We likely need to use a different critical reader id
+                // for this if we want to be able to introspect it via SQL.
                 PersistClient::CONTROLLER_CRITICAL_SINCE,
                 Diagnostics {
                     shard_name: "txns".to_owned(),

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -171,9 +171,8 @@ pub trait Opaque: PartialEq + Clone + Sized + 'static {
 /// Advance a timestamp by the least amount possible such that
 /// `ts.less_than(ts.step_forward())` is true.
 ///
-/// TODO(txn): Unify this with repr's TimestampManipulation. Or, ideally, get
-/// rid of it entirely by making persist-txn methods take an `advance_to`
-/// argument.
+/// TODO: Unify this with repr's TimestampManipulation. Or, ideally, get rid of
+/// it entirely by making persist-txn methods take an `advance_to` argument.
 pub trait StepForward {
     /// Advance a timestamp by the least amount possible such that
     /// `ts.less_than(ts.step_forward())` is true. Panic if unable to do so.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1420,13 +1420,6 @@ where
                 // - This branch allows it to handle that advancing the physical upper of Table A to
                 //   10 (NB but only once we see it get past the write at 5!)
                 // - Then we can read it normally.
-                //
-                // TODO(txn): We do a series of snapshots at boot and then never again. It's
-                // wasteful to create this TxnsCache and then throw it away for each of them, but
-                // it's better than the alternative of keeping it alive for snapshot calls that will
-                // never come (worse, it's tricky to keep it making progress, which results in a
-                // stuck since). Replace this with the shared TxnsCache thing we'll have to do
-                // anyway for the dataflow operators.
                 let txns_read = self.txns.expect_enabled_lazy(txns_id);
                 txns_read.update_gt(as_of.clone()).await;
                 let data_snapshot = txns_read
@@ -1499,7 +1492,7 @@ where
         id: GlobalId,
         as_of: Antichain<Self::Timestamp>,
     ) -> Result<SnapshotStats<Self::Timestamp>, StorageError> {
-        // TODO(txn): Fix stats for persist-txn shards.
+        // TODO(txn-lazy): Fix stats for persist-txn shards.
         self.persist_read_handles.snapshot_stats(id, as_of).await
     }
 


### PR DESCRIPTION
Individual justifications as comments on the PR. This also introduces the distinction between things we need to turn persist-txn on with "eager" vs "lazy" by starting to use `TODO(txn-lazy)` as things that we only have to do to turn on the latter.

Touches https://github.com/MaterializeInc/materialize/issues/22173
Touches https://github.com/MaterializeInc/materialize/issues/22801

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
