### PR TITLE
persist: make listen_batch defaults match LaunchDarkly

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -343,9 +343,9 @@ impl PersistConfig {
 
     /// Default value for [`DynamicConfig::next_listen_batch_retry_params`].
     pub const DEFAULT_NEXT_LISTEN_BATCH_RETRYER: RetryParameters = RetryParameters {
-        initial_backoff: Duration::from_millis(4),
+        initial_backoff: Duration::from_millis(1200), // pubsub is on by default!
         multiplier: 2,
-        clamp: Duration::from_secs(16),
+        clamp: Duration::from_millis(100), // pubsub is on by default!
     };
 
     /// Default value for [`DynamicConfig::txns_data_shard_retry_params`].


### PR DESCRIPTION
With the rollout of Persist pubsub we changed the defaults we serve from LaunchDarkly. This makes the defaults in code match that, to make sure you get the same experience when running Materialize locally.