### PR TITLE
Add `EXPLAIN WITH (redacted)` support for MIR plans

### DIFF
--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -61,6 +61,8 @@ IGNORE_RE = re.compile(
     | \(\#1\)\ IS\ NULL
     # test/sqllogictest/cockroach/*.slt
     | cockroach\#
+    # cloud repo
+    | cloud\#
     # ci/test/lint-buf/README.md
     | Ignore\ because\ of\ #99999
     )

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -25,15 +25,16 @@ use mz_compute_client::protocol::response::PeekResponse;
 use mz_compute_types::dataflows::{DataflowDescription, IndexImport};
 use mz_compute_types::ComputeInstanceId;
 use mz_controller_types::ClusterId;
+use mz_expr::explain::{fmt_text_constant_rows, HumanizedExplain, HumanizerMode};
 use mz_expr::{
     EvalError, Id, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing,
 };
 use mz_ore::cast::CastFrom;
 use mz_ore::str::{separated, StrExt};
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::explain::text::{fmt_text_constant_rows, DisplayText};
+use mz_repr::explain::text::DisplayText;
 use mz_repr::explain::{
-    CompactScalarSeq, IndexUsageType, Indices, PlanRenderingContext, UsedIndexes,
+    CompactScalars, IndexUsageType, Indices, PlanRenderingContext, UsedIndexes,
 };
 use mz_repr::{Diff, GlobalId, RelationType, Row};
 use serde::{Deserialize, Serialize};
@@ -117,6 +118,11 @@ impl<'a, T: 'a> DisplayText<PlanRenderingContext<'a, T>> for FastPathPlan {
         f: &mut fmt::Formatter<'_>,
         ctx: &mut PlanRenderingContext<'a, T>,
     ) -> fmt::Result {
+        let redacted = ctx.config.redacted;
+        let mode = HumanizedExplain::new(ctx.config.redacted);
+
+        // TODO(aalexandrov): factor out common PeekExisting and PeekPersist
+        // code.
         match self {
             FastPathPlan::Constant(Ok(rows), _) => {
                 if !rows.is_empty() {
@@ -126,6 +132,7 @@ impl<'a, T: 'a> DisplayText<PlanRenderingContext<'a, T>> for FastPathPlan {
                         f,
                         rows.iter().map(|(row, diff)| (row, diff)),
                         ctx.as_mut(),
+                        redacted,
                     )?;
                     *ctx.as_mut() -= 1;
                 } else {
@@ -134,11 +141,30 @@ impl<'a, T: 'a> DisplayText<PlanRenderingContext<'a, T>> for FastPathPlan {
                 Ok(())
             }
             FastPathPlan::Constant(Err(err), _) => {
-                writeln!(f, "{}Error {}", ctx.as_mut(), err.to_string().quoted())
+                if redacted {
+                    writeln!(f, "{}Error █", ctx.as_mut())
+                } else {
+                    writeln!(f, "{}Error {}", ctx.as_mut(), err.to_string().quoted())
+                }
             }
             FastPathPlan::PeekExisting(coll_id, idx_id, literal_constraints, mfp) => {
                 ctx.as_mut().set();
                 let (map, filter, project) = mfp.as_map_filter_project();
+
+                let (map_cols, filter_cols) = if !ctx.config.humanized_exprs {
+                    (None, None)
+                } else if let Some(cols) = ctx.humanizer.column_names_for_id(*coll_id) {
+                    let map_cols = itertools::chain(
+                        cols.iter().cloned(),
+                        std::iter::repeat(String::new()).take(map.len()),
+                    )
+                    .collect::<Vec<_>>();
+                    let filter_cols = map_cols.clone();
+                    (Some(map_cols), Some(filter_cols))
+                } else {
+                    (None, None)
+                };
+
                 if project.len() != mfp.input_arity + map.len()
                     || !project.iter().enumerate().all(|(i, o)| i == *o)
                 {
@@ -147,12 +173,13 @@ impl<'a, T: 'a> DisplayText<PlanRenderingContext<'a, T>> for FastPathPlan {
                     *ctx.as_mut() += 1;
                 }
                 if !filter.is_empty() {
-                    let predicates = separated(" AND ", filter);
+                    let predicates = separated(" AND ", mode.seq(&filter, filter_cols.as_ref()));
                     writeln!(f, "{}Filter {}", ctx.as_mut(), predicates)?;
                     *ctx.as_mut() += 1;
                 }
                 if !map.is_empty() {
-                    let scalars = CompactScalarSeq(&map);
+                    let scalars = mode.seq(&map, map_cols.as_ref());
+                    let scalars = CompactScalars(scalars);
                     writeln!(f, "{}Map ({})", ctx.as_mut(), scalars)?;
                     *ctx.as_mut() += 1;
                 }
@@ -171,6 +198,21 @@ impl<'a, T: 'a> DisplayText<PlanRenderingContext<'a, T>> for FastPathPlan {
             FastPathPlan::PeekPersist(gid, mfp) => {
                 ctx.as_mut().set();
                 let (map, filter, project) = mfp.as_map_filter_project();
+
+                let (map_cols, filter_cols) = if !ctx.config.humanized_exprs {
+                    (None, None)
+                } else if let Some(cols) = ctx.humanizer.column_names_for_id(*gid) {
+                    let map_cols = itertools::chain(
+                        cols.iter().cloned(),
+                        std::iter::repeat(String::new()).take(map.len()),
+                    )
+                    .collect::<Vec<_>>();
+                    let filter_cols = map_cols.clone();
+                    (Some(map_cols), Some(filter_cols))
+                } else {
+                    (None, None)
+                };
+
                 if project.len() != mfp.input_arity + map.len()
                     || !project.iter().enumerate().all(|(i, o)| i == *o)
                 {
@@ -179,12 +221,13 @@ impl<'a, T: 'a> DisplayText<PlanRenderingContext<'a, T>> for FastPathPlan {
                     *ctx.as_mut() += 1;
                 }
                 if !filter.is_empty() {
-                    let predicates = separated(" AND ", filter);
+                    let predicates = separated(" AND ", mode.seq(&filter, filter_cols.as_ref()));
                     writeln!(f, "{}Filter {}", ctx.as_mut(), predicates)?;
                     *ctx.as_mut() += 1;
                 }
                 if !map.is_empty() {
-                    let scalars = CompactScalarSeq(&map);
+                    let scalars = mode.seq(&map, map_cols.as_ref());
+                    let scalars = CompactScalars(scalars);
                     writeln!(f, "{}Map ({})", ctx.as_mut(), scalars)?;
                     *ctx.as_mut() += 1;
                 }
@@ -769,6 +812,7 @@ mod tests {
 
         let humanizer = DummyHumanizer;
         let config = ExplainConfig {
+            redacted: false,
             ..Default::default()
         };
         let ctx_gen = || {

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -96,15 +96,6 @@ pub struct GlobalMirPlan<T: Clone> {
 }
 
 impl<T: Clone> GlobalMirPlan<T> {
-    pub fn df_desc(&self) -> &MirDataflowDescription {
-        &self.df_desc
-    }
-
-    #[allow(dead_code)] // This will be needed for EXPLAIN SUBSCRIBE
-    pub fn df_meta(&self) -> &DataflowMetainfo {
-        &self.df_meta
-    }
-
     /// Computes the [`CollectionIdBundle`] of the wrapped dataflow.
     pub fn id_bundle(&self, compute_instance_id: ComputeInstanceId) -> CollectionIdBundle {
         dataflow_import_id_bundle(&self.df_desc, compute_instance_id)
@@ -120,14 +111,6 @@ pub struct GlobalLirPlan {
 }
 
 impl GlobalLirPlan {
-    pub fn df_desc(&self) -> &LirDataflowDescription {
-        &self.df_desc
-    }
-
-    pub fn df_meta(&self) -> &DataflowMetainfo {
-        &self.df_meta
-    }
-
     pub fn sink_id(&self) -> GlobalId {
         let sink_exports = &self.df_desc.sink_exports;
         let sink_id = sink_exports.keys().next().expect("valid sink");

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -25,9 +25,10 @@ use std::fmt;
 use std::ops::Deref;
 
 use itertools::{izip, Itertools};
+use mz_expr::explain::fmt_text_constant_rows;
 use mz_expr::{Id, MirScalarExpr};
 use mz_ore::str::{separated, IndentLike, StrExt};
-use mz_repr::explain::text::{fmt_text_constant_rows, DisplayText};
+use mz_repr::explain::text::DisplayText;
 use mz_repr::explain::{CompactScalarSeq, Indices, PlanRenderingContext};
 
 use crate::plan::join::delta_join::{DeltaPathPlan, DeltaStagePlan};
@@ -54,6 +55,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                                 f,
                                 rows.iter().map(|(data, _, diff)| (data, diff)),
                                 &mut ctx.indent,
+                                ctx.config.redacted,
                             )
                         })?;
                     } else {

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -29,9 +29,7 @@ use crate::{
     AccessStrategy, Id, LocalId, MapFilterProject, MirRelationExpr, MirScalarExpr, RowSetFinishing,
 };
 
-pub use crate::explain::text::{
-    display_singleton_row, HumanizedExplain, HumanizedExpr, HumanizedNotice, HumanizerMode,
-};
+pub use crate::explain::text::{HumanizedExplain, HumanizedExpr, HumanizedNotice, HumanizerMode};
 
 mod json;
 mod text;

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -69,12 +69,6 @@ pub struct PushdownInfo<'a> {
     pub pushdown: Vec<&'a MirScalarExpr>,
 }
 
-impl<'a, C: AsMut<Indent>> DisplayText<C> for PushdownInfo<'a> {
-    fn fmt_text(&self, f: &mut Formatter<'_>, ctx: &mut C) -> std::fmt::Result {
-        HumanizedExplain::new(self, None).fmt_text(f, ctx)
-    }
-}
-
 impl<'a, C, M> DisplayText<C> for HumanizedExpr<'a, PushdownInfo<'a>, M>
 where
     C: AsMut<Indent>,
@@ -127,15 +121,6 @@ impl<'a> ExplainSource<'a> {
     #[inline]
     pub fn is_identity(&self) -> bool {
         self.op.is_identity()
-    }
-}
-
-impl<'a, 'h, C> DisplayText<C> for ExplainSource<'a>
-where
-    C: AsMut<Indent> + AsRef<&'h dyn ExprHumanizer>,
-{
-    fn fmt_text(&self, f: &mut std::fmt::Formatter<'_>, ctx: &mut C) -> std::fmt::Result {
-        HumanizedExplain::new(self, None).fmt_text(f, ctx)
     }
 }
 

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -29,7 +29,9 @@ use crate::{
     AccessStrategy, Id, LocalId, MapFilterProject, MirRelationExpr, MirScalarExpr, RowSetFinishing,
 };
 
-pub use crate::explain::text::{HumanizedExplain, HumanizedExpr, HumanizedNotice, HumanizerMode};
+pub use crate::explain::text::{
+    fmt_text_constant_rows, HumanizedExplain, HumanizedExpr, HumanizedNotice, HumanizerMode,
+};
 
 mod json;
 mod text;
@@ -76,9 +78,7 @@ where
         let PushdownInfo { pushdown } = self.expr;
 
         if !pushdown.is_empty() {
-            let pushdown = pushdown
-                .iter()
-                .map(|e| HumanizedExplain::new(*e, self.cols));
+            let pushdown = pushdown.iter().map(|e| self.mode.expr(*e, self.cols));
             let pushdown = separated(" AND ", pushdown);
             writeln!(f, "{}pushdown=({})", ctx.as_mut(), pushdown)?;
         }

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -145,7 +145,7 @@ where
             self.context.used_indexes.fmt_text(f, &mut ctx)?;
         }
 
-        if !self.context.optimizer_notices.is_empty() {
+        if !(self.context.config.no_notices || self.context.optimizer_notices.is_empty()) {
             writeln!(f)?;
             writeln!(f, "Notices:")?;
             for notice in self.context.optimizer_notices.iter() {

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -19,7 +19,7 @@ use mz_ore::str::{closure_to_display, separated, Indent, IndentLike, StrExt};
 use mz_repr::explain::text::{fmt_text_constant_rows, DisplayText};
 use mz_repr::explain::{
     CompactScalarSeq, ExprHumanizer, HumanizedAttributes, IndexUsageType, Indices,
-    PlanRenderingContext, RenderingContext,
+    PlanRenderingContext, RenderingContext, ScalarOps,
 };
 use mz_repr::{Datum, GlobalId, Row};
 use mz_sql_parser::ast::Ident;
@@ -1203,6 +1203,16 @@ where
                 write!(f, "#{}", self.expr)
             }
         }
+    }
+}
+
+impl<'a, M> ScalarOps for HumanizedExpr<'a, MirScalarExpr, M> {
+    fn match_col_ref(&self) -> Option<usize> {
+        self.expr.match_col_ref()
+    }
+
+    fn references(&self, col_ref: usize) -> bool {
+        self.expr.references(col_ref)
     }
 }
 

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -35,7 +35,7 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use timely::container::columnation::{Columnation, CopyRegion};
 
-use crate::explain::HumanizedExpr;
+use crate::explain::{HumanizedExplain, HumanizedExpr, HumanizerMode};
 use crate::relation::func::{AggregateFunc, LagLeadType, TableFunc};
 use crate::visit::{Visit, VisitChildren};
 use crate::Id::Local;
@@ -2296,11 +2296,14 @@ impl RustType<ProtoColumnOrder> for ColumnOrder {
 
 impl fmt::Display for ColumnOrder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        HumanizedExpr::new(self, None).fmt(f)
+        HumanizedExplain::new(self, None).fmt(f)
     }
 }
 
-impl<'a> fmt::Display for HumanizedExpr<'a, ColumnOrder> {
+impl<'a, M> fmt::Display for HumanizedExpr<'a, ColumnOrder, M>
+where
+    M: HumanizerMode,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // If you modify this, then please also attend to Display for ColumnOrderWithExpr!
         write!(

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2296,7 +2296,8 @@ impl RustType<ProtoColumnOrder> for ColumnOrder {
 
 impl fmt::Display for ColumnOrder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        HumanizedExplain::new(self, None).fmt(f)
+        let mode = HumanizedExplain::default();
+        mode.expr(self, None).fmt(f)
     }
 }
 
@@ -3515,7 +3516,10 @@ mod tests {
             project: vec![1, 3, 4, 5],
         };
 
-        let act = text_string_at(&finishing, mz_ore::str::Indent::default);
+        let mode = HumanizedExplain::new(false);
+        let expr = mode.expr(&finishing, None);
+
+        let act = text_string_at(&expr, mz_ore::str::Indent::default);
 
         let exp = {
             use mz_ore::fmt::FormatBuffer;

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -429,6 +429,7 @@ impl<'a> AsRef<&'a dyn ExprHumanizer> for RenderingContext<'a> {
         &self.humanizer
     }
 }
+
 #[allow(missing_debug_implementations)]
 pub struct PlanRenderingContext<'a, T> {
     pub indent: Indent,
@@ -611,7 +612,17 @@ pub struct Indices<'a>(pub &'a [usize]);
 ///
 /// Interval expressions are used only for runs of three or more elements.
 #[derive(Debug)]
-pub struct CompactScalarSeq<'a, T: ScalarOps>(pub &'a [T]);
+pub struct CompactScalarSeq<'a, T: ScalarOps>(pub &'a [T]); // TODO(cloud#8196) remove this
+
+/// Pretty-prints a list of scalar expressions that may have runs of column
+/// indices as a comma-separated list interleaved with interval expressions.
+///
+/// Interval expressions are used only for runs of three or more elements.
+#[derive(Debug)]
+pub struct CompactScalars<T, I>(pub I)
+where
+    T: ScalarOps,
+    I: Iterator<Item = T> + Clone;
 
 pub trait ScalarOps {
     fn match_col_ref(&self) -> Option<usize>;

--- a/src/repr/src/explain/text.rs
+++ b/src/repr/src/explain/text.rs
@@ -14,8 +14,8 @@ use std::fmt;
 use mz_ore::str::{Indent, IndentLike};
 
 use crate::explain::{
-    CompactScalarSeq, ExprHumanizer, IndexUsageType, Indices, ScalarOps, UnsupportedFormat,
-    UsedIndexes,
+    CompactScalarSeq, CompactScalars, ExprHumanizer, IndexUsageType, Indices, ScalarOps,
+    UnsupportedFormat, UsedIndexes,
 };
 use crate::Row;
 
@@ -147,6 +147,105 @@ where
                 slice = &slice[1..];
             }
         }
+        Ok(())
+    }
+}
+
+impl<T, I> fmt::Display for CompactScalars<T, I>
+where
+    T: ScalarOps + fmt::Display,
+    I: Iterator<Item = T> + Clone,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        enum State<T> {
+            Start,
+            FoundOne(T, usize),    // (x, x_col)
+            FoundTwo(T, T, usize), // (x, y, y_col)
+            FoundRun(T, T, usize), // (x, y, y_col)
+        }
+
+        let mut state = State::Start;
+
+        let mut is_first = true;
+        let mut prefix = || {
+            if std::mem::replace(&mut is_first, false) {
+                ""
+            } else {
+                ", "
+            }
+        };
+
+        for n in self.0.clone() {
+            state = match state {
+                State::Start => match n.match_col_ref() {
+                    Some(n_col) => {
+                        State::FoundOne(n, n_col) // Next state
+                    }
+                    None => {
+                        write!(f, "{}{n}", prefix())?;
+                        State::Start // New match
+                    }
+                },
+                State::FoundOne(x, x_col) => match n.match_col_ref() {
+                    Some(n_col) => {
+                        if x_col + 1 == n_col {
+                            State::FoundTwo(x, n, n_col) // Next state
+                        } else {
+                            write!(f, "{}{x}", prefix())?;
+                            State::FoundOne(n, n_col) // Reset match
+                        }
+                    }
+                    None => {
+                        write!(f, "{}{x}, {n}", prefix())?;
+                        State::Start // New match
+                    }
+                },
+                State::FoundTwo(x, y, y_col) => match n.match_col_ref() {
+                    Some(n_col) => {
+                        if y_col + 1 == n_col {
+                            State::FoundRun(x, n, n_col) // Next state
+                        } else {
+                            write!(f, "{}{x}, {y}", prefix())?;
+                            State::FoundOne(n, n_col) // Reset match
+                        }
+                    }
+                    None => {
+                        write!(f, "{}{x}, {y}, {n}", prefix())?;
+                        State::Start // New match
+                    }
+                },
+                State::FoundRun(x, y, y_col) => match n.match_col_ref() {
+                    Some(n_col) => {
+                        if y_col + 1 == n_col {
+                            State::FoundRun(x, n, n_col) // Extend run
+                        } else {
+                            write!(f, "{}{x}..={y}", prefix())?;
+                            State::FoundOne(n, n_col) // Reset match
+                        }
+                    }
+                    None => {
+                        write!(f, "{}{x}..={y}, {n}", prefix())?;
+                        State::Start // Reset state
+                    }
+                },
+            };
+        }
+
+        match state {
+            State::Start => {
+                // Do nothing
+            }
+            State::FoundOne(x, _) => {
+                write!(f, "{}{x}", prefix())?;
+            }
+            State::FoundTwo(x, y, _) => {
+                write!(f, "{}{x}, {y}", prefix())?;
+            }
+            State::FoundRun(x, y, _) => {
+                write!(f, "{}{x}..={y}", prefix())?;
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/sql/src/plan/explain/text.rs
+++ b/src/sql/src/plan/explain/text.rs
@@ -21,10 +21,11 @@
 use itertools::Itertools;
 use std::fmt;
 
+use mz_expr::explain::fmt_text_constant_rows;
 use mz_expr::virtual_syntax::{AlgExcept, Except};
 use mz_expr::{Id, WindowFrame};
 use mz_ore::str::{separated, IndentLike};
-use mz_repr::explain::text::{fmt_text_constant_rows, DisplayText};
+use mz_repr::explain::text::DisplayText;
 use mz_repr::explain::{CompactScalarSeq, Indices, PlanRenderingContext};
 
 use crate::plan::{AggregateExpr, Hir, HirRelationExpr, HirScalarExpr, JoinKind, WindowExprType};
@@ -79,7 +80,12 @@ impl HirRelationExpr {
                 if !rows.is_empty() {
                     writeln!(f, "{}Constant", ctx.indent)?;
                     ctx.indented(|ctx| {
-                        fmt_text_constant_rows(f, rows.iter().map(|row| (row, &1)), &mut ctx.indent)
+                        fmt_text_constant_rows(
+                            f,
+                            rows.iter().map(|row| (row, &1)),
+                            &mut ctx.indent,
+                            ctx.config.redacted,
+                        )
                     })?;
                 } else {
                     writeln!(f, "{}Constant <empty>", ctx.indent)?;

--- a/src/transform/src/optimizer_notices.rs
+++ b/src/transform/src/optimizer_notices.rs
@@ -13,7 +13,7 @@ use std::fmt::{self, Error, Write};
 
 use itertools::zip_eq;
 
-use mz_expr::explain::{display_singleton_row, HumanizedExpr};
+use mz_expr::explain::{display_singleton_row, HumanizedNotice, HumanizerMode};
 use mz_expr::MirScalarExpr;
 use mz_ore::str::separated;
 use mz_repr::explain::ExprHumanizer;
@@ -149,7 +149,7 @@ impl<'a> fmt::Display for HumanizedNoticeMsg<'a> {
                     .humanize_id_unqualified(*index_on_id)
                     .unwrap_or_else(|| index_on_id.to_string());
 
-                let index_key = separated(", ", HumanizedExpr::seq(index_key, col_names));
+                let index_key = separated(", ", HumanizedNotice::seq(index_key, col_names));
 
                 write!(f, "Index {index_name} on {index_on_id_name}({index_key}) is too wide to use for literal equalities `")?;
                 {
@@ -158,14 +158,14 @@ impl<'a> fmt::Display for HumanizedNoticeMsg<'a> {
                             write!(
                                 f,
                                 "{} = {}",
-                                HumanizedExpr::new(&usable_subset[0], col_names),
+                                HumanizedNotice::new(&usable_subset[0], col_names),
                                 display_singleton_row(literal_values[0].clone())
                             )?;
                         } else {
                             write!(
                                 f,
                                 "{} IN ({})",
-                                HumanizedExpr::new(&usable_subset[0], col_names),
+                                HumanizedNotice::new(&usable_subset[0], col_names),
                                 separated(
                                     ", ",
                                     literal_values
@@ -196,7 +196,7 @@ impl<'a> fmt::Display for HumanizedNoticeMsg<'a> {
                             write!(
                                 f,
                                 "({}) IN ({})",
-                                separated(", ", HumanizedExpr::seq(usable_subset, col_names)),
+                                separated(", ", HumanizedNotice::seq(usable_subset, col_names)),
                                 separated(", ", literal_values)
                             )?;
                         }
@@ -240,7 +240,7 @@ impl<'a> fmt::Display for HumanizedNoticeHint<'a> {
                         ", ",
                         recommended_key
                             .iter()
-                            .map(|expr| HumanizedExpr::new(expr, col_names)),
+                            .map(|expr| HumanizedNotice::new(expr, col_names)),
                     )
                 };
 

--- a/test/sqllogictest/attributes/mir_unique_keys.slt
+++ b/test/sqllogictest/attributes/mir_unique_keys.slt
@@ -135,8 +135,8 @@ Used Indexes:
   - materialize.public.v_primary_idx (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.v_primary_idx on v(#0{c}, #1{d}) is too wide to use for literal equalities `#0{c} = 1`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{c}).
+  - Notice: Index materialize.public.v_primary_idx on v(c, d) is too wide to use for literal equalities `c = 1`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (c).
 
 EOF
 

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1320,8 +1320,8 @@ Used Indexes:
   - materialize.public.fk_orderline_item (differential join)
 
 Notices:
-  - Notice: Index materialize.public.fk_orderline_order on orderline(#2{ol_w_id}, #1{ol_d_id}, #0{ol_o_id}) is too wide to use for literal equalities `#2{ol_w_id} IN (1, 2, 3, 4, 5)`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#2{ol_w_id}).
+  - Notice: Index materialize.public.fk_orderline_order on orderline(ol_w_id, ol_d_id, ol_o_id) is too wide to use for literal equalities `ol_w_id IN (1, 2, 3, 4, 5)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (ol_w_id).
 
 EOF
 

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -1,0 +1,941 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_table_keys = true
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE t (
+  a int,
+  b int
+);
+
+statement ok
+CREATE TABLE u (
+  c int,
+  d int
+);
+
+statement ok
+CREATE TABLE v (
+  e int,
+  f int
+);
+
+statement ok
+CREATE INDEX t_a_idx ON t(a);
+
+statement ok
+CREATE VIEW ov AS SELECT * FROM t ORDER BY b asc, a desc LIMIT 5;
+
+statement ok
+CREATE VIEW iv AS
+SELECT * FROM t WHERE a IS NOT NULL;
+
+statement ok
+CREATE INDEX iv_a_idx ON iv(a);
+
+statement ok
+CREATE INDEX iv_b_idx ON iv(b);
+
+# This is an identical index to the above (on the same object, on the same key)
+statement ok
+CREATE INDEX iv_b_idx_2 ON iv(b);
+
+statement ok
+CREATE MATERIALIZED VIEW mv AS
+SELECT * FROM t WHERE a IS NOT NULL;
+
+mode cockroach
+
+# Test constant error.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+SELECT 1 / 0
+----
+Explained Query (fast path):
+  Error █
+
+EOF
+
+# Test constant with two elements.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+(SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
+----
+Explained Query (fast path):
+  Constant
+    - ((█, █) x 2)
+    - (█, █)
+
+EOF
+
+# Test introspection queries (index found based on cluster auto-routing).
+query T multiline
+EXPLAIN SELECT * FROM mz_internal.mz_source_status_history
+----
+Explained Query (fast path):
+  Project (#1, #0, #2..=#4)
+    ReadIndex on=mz_internal.mz_source_status_history mz_source_status_history_ind=[*** full scan ***]
+
+Used Indexes:
+  - mz_internal.mz_source_status_history_ind (*** full scan ***)
+
+EOF
+
+# Test basic linear chains (fast path).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+SELECT 1, a + b as c FROM t WHERE a = 5 and b < 0 and a + b > 0
+----
+Explained Query (fast path):
+  Project (#4, #3)
+    Filter (#1{b} < █) AND ((#0{a} + #1{b}) > █)
+      Map ((█ + #1{b}), █)
+        ReadIndex on=materialize.public.t t_a_idx=[lookup value=(█)]
+
+Used Indexes:
+  - materialize.public.t_a_idx (lookup)
+
+EOF
+
+# Test basic linear chains (slow path).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
+----
+Explained Query:
+  Project (#3, #2)
+    Filter (#1{b} < █) AND (#0{a} > █) AND (#2 > █)
+      Map ((#0{a} + #1{b}), █)
+        ReadStorage materialize.public.mv
+
+Source materialize.public.mv
+  filter=((#0{a} > █) AND (#1{b} < █) AND ((#0{a} + #1{b}) > █))
+
+EOF
+
+# Test table functions in the select clause (FlatMap).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+SELECT generate_series(a, b) from t
+----
+Explained Query:
+  Project (#2)
+    FlatMap generate_series(#0{a}, #1{b}, █)
+      ReadIndex on=t t_a_idx=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test TopK.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+SELECT * FROM ov
+----
+Explained Query:
+  TopK order_by=[#1{b} asc nulls_last, #0{a} desc nulls_first] limit=█
+    ReadIndex on=t t_a_idx=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Finish.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
+----
+Explained Query (fast path):
+  Finish order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 output=[#0, #1]
+    ReadIndex on=materialize.public.t t_a_idx=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce (global).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+SELECT abs(min(a) - max(a)) FROM t
+----
+Explained Query:
+  Return
+    Project (#2)
+      Map (abs((#0 - #1)))
+        Union
+          Get l0
+          Map (█, █)
+            Union
+              Negate
+                Project ()
+                  Get l0
+              Constant
+                - ()
+  With
+    cte l0 =
+      Reduce aggregates=[min(#0{a}), max(#0{a})]
+        Project (#0)
+          ReadIndex on=t t_a_idx=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce (local).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+SELECT abs(min(a) - max(a)) FROM t GROUP BY b
+----
+Explained Query:
+  Project (#3)
+    Map (abs((#1 - #2)))
+      Reduce group_by=[#1{b}] aggregates=[min(#0{a}), max(#0{a})]
+        ReadIndex on=t t_a_idx=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test EXISTS subqueries.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
+----
+Explained Query:
+  Return
+    Project (#0, #1)
+      Join on=(#1{b} = #2{b}) type=differential
+        ArrangeBy keys=[[#1{b}]]
+          Get l0
+        ArrangeBy keys=[[#0{b}]]
+          Distinct project=[#0{b}]
+            Project (#0)
+              Filter (#0{b} > #1{b})
+                CrossJoin type=differential
+                  ArrangeBy keys=[[]]
+                    Distinct project=[#0{b}]
+                      Project (#1)
+                        Get l0
+                  ArrangeBy keys=[[]]
+                    Project (#1)
+                      ReadStorage materialize.public.mv
+  With
+    cte l0 =
+      Project (#0, #1)
+        Join on=(#0{a} = #2{a}) type=differential
+          ArrangeBy keys=[[#0{a}]]
+            ReadIndex on=t t_a_idx=[differential join]
+          ArrangeBy keys=[[#0{a}]]
+            Distinct project=[#0{a}]
+              Project (#0)
+                Filter (#0{a} < #1{a})
+                  CrossJoin type=differential
+                    ArrangeBy keys=[[]]
+                      Distinct project=[#0{a}]
+                        Project (#0)
+                          ReadIndex on=t t_a_idx=[*** full scan ***]
+                    ArrangeBy keys=[[]]
+                      Project (#0)
+                        ReadStorage materialize.public.mv
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***, differential join)
+
+EOF
+
+# Test SELECT subqueries.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
+----
+Explained Query:
+  Return
+    Project (#2, #4)
+      Join on=(#0{b} = #1{b} = #3{b}) type=delta
+        ArrangeBy keys=[[#0{b}]]
+          Get l0
+        ArrangeBy keys=[[#0{b}]]
+          Union
+            Get l3
+            Map (█)
+              Union
+                Negate
+                  Project (#0)
+                    Get l3
+                Get l1
+        ArrangeBy keys=[[#0{b}]]
+          Union
+            Get l4
+            Map (█)
+              Union
+                Negate
+                  Project (#0)
+                    Get l4
+                Get l1
+  With
+    cte l4 =
+      TopK group_by=[#0{b}] limit=█
+        Project (#0, #1)
+          Filter (#0{b}) IS NOT NULL
+            Join on=(#0{b} = #2{b}) type=differential
+              Get l2
+              ArrangeBy keys=[[#1{b}]]
+                Filter (#1{b}) IS NOT NULL
+                  ReadStorage materialize.public.mv
+    cte l3 =
+      TopK group_by=[#0{b}] limit=█
+        Project (#0, #1)
+          Filter (#0{b}) IS NOT NULL
+            Join on=(#0{b} = #2{b}) type=differential
+              Get l2
+              ArrangeBy keys=[[#1{b}]]
+                ReadIndex on=iv iv_b_idx=[differential join]
+    cte l2 =
+      ArrangeBy keys=[[#0{b}]]
+        Get l1
+    cte l1 =
+      Distinct project=[#0{b}]
+        Get l0
+    cte l0 =
+      Project (#1)
+        ReadIndex on=t t_a_idx=[*** full scan ***]
+
+Source materialize.public.mv
+  filter=((#1{b}) IS NOT NULL)
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+  - materialize.public.iv_b_idx (differential join)
+
+EOF
+
+# Test outer joins (ON syntax).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+SELECT t1.a, t2.a
+FROM t as t1
+LEFT JOIN t as t2 ON t1.b = t2.b
+RIGHT JOIN t as t3 ON t2.b = t3.b
+----
+Explained Query:
+  Return
+    Union
+      Map (█, █)
+        Union
+          Negate
+            Project ()
+              Join on=(#0{b} = #1{b}) type=differential
+                ArrangeBy keys=[[#0{b}]]
+                  Project (#1)
+                    ReadIndex on=t t_a_idx=[*** full scan ***]
+                ArrangeBy keys=[[#0{b}]]
+                  Distinct project=[#0{b}]
+                    Project (#1)
+                      Get l2
+          Project ()
+            ReadIndex on=t t_a_idx=[*** full scan ***]
+      Project (#0, #2)
+        Get l2
+  With
+    cte l2 =
+      Project (#0..=#2)
+        Join on=(#1{b} = #3{b} = #4{b}) type=delta
+          Get l1
+          Get l1
+          ArrangeBy keys=[[#0{b}]]
+            Project (#1)
+              Get l0
+    cte l1 =
+      ArrangeBy keys=[[#1{b}]]
+        Get l0
+    cte l0 =
+      Filter (#1{b}) IS NOT NULL
+        ReadIndex on=t t_a_idx=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test an IndexedFilter join.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, redacted) AS TEXT FOR
+SELECT a, max(b)
+FROM t
+WHERE a = 0
+GROUP BY a
+----
+Explained Query:
+  Project (#1, #0)
+    Map (█)
+      Reduce aggregates=[max(#0{b})]
+        Project (#1)
+          ReadIndex on=materialize.public.t t_a_idx=[lookup value=(█)]
+
+Used Indexes:
+  - materialize.public.t_a_idx (lookup)
+
+EOF
+
+# Create index for IndexedFilter test
+
+statement ok
+CREATE INDEX t_a_b_idx ON T(a,b)
+
+# Test an IndexedFilter join WITH(join_impls).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(join_impls) AS TEXT FOR
+SELECT a, max(b)
+FROM t
+WHERE (a = 0 AND b = 1) OR (a = 3 AND b = 4) OR (a = 7 AND b = 8)
+GROUP BY a
+----
+Explained Query:
+  Reduce group_by=[#0] aggregates=[max(#1)]
+    Project (#0, #1)
+      ReadIndex on=materialize.public.t t_a_b_idx=[lookup values=[(0, 1); (3, 4); (7, 8)]]
+
+Used Indexes:
+  - materialize.public.t_a_b_idx (lookup)
+
+EOF
+
+# Test an IndexedFilter join on fast path WITH(join_impls).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(join_impls) AS TEXT FOR
+SELECT *
+FROM t
+WHERE (a = 0 AND b = 1) OR (a = 3 AND b = 4) OR (a = 7 AND b = 8)
+----
+Explained Query (fast path):
+  Project (#0, #1)
+    ReadIndex on=materialize.public.t t_a_b_idx=[lookup values=[(0, 1); (3, 4); (7, 8)]]
+
+Used Indexes:
+  - materialize.public.t_a_b_idx (lookup)
+
+EOF
+
+# Test #17348.
+
+statement ok
+CREATE TABLE r(f0 INT, f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT, f9 INT, f10 INT, f11 INT, f12 INT, f13 INT, f14 INT, f15 INT, f16 INT);
+
+query T multiline
+EXPLAIN SELECT *
+FROM r AS r0, r AS r1
+WHERE
+  r0.f0=r1.f0 AND
+  r0.f2=r1.f2 AND
+  r0.f3=r1.f3 AND
+  r0.f4=r1.f4 AND
+  r0.f6=r1.f6 AND
+  r0.f8=r1.f8 AND
+  r0.f9=r1.f9 AND
+  r0.f11=r1.f11 AND
+  r0.f12=r1.f12 AND
+  r0.f13=r1.f13 AND
+  r0.f15=r1.f15 AND
+  r0.f16=r1.f16;
+----
+Explained Query:
+  Return
+    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
+      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
+        Get l0
+        Get l0
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0, #2..=#4, #6, #8, #9, #11..=#13, #15, #16]]
+        Filter (#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL
+          ReadStorage materialize.public.r
+
+Source materialize.public.r
+  filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)
+
+EOF
+
+## linear_chains is currently disabled for WMR.
+statement error not supported
+EXPLAIN WITH(linear_chains)
+WITH MUTUALLY RECURSIVE
+    foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
+    bar (a int) as (SELECT a FROM foo)
+SELECT * FROM bar;
+
+# Regression test for #19148: support mz_now() on select from indexed table
+# ---
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_rbac_checks TO false;
+----
+COMPLETE 0
+
+statement ok
+DROP SCHEMA IF EXISTS public CASCADE;
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET enable_rbac_checks;
+----
+COMPLETE 0
+
+statement ok
+CREATE SCHEMA public;
+
+statement ok
+CREATE TABLE t(a TIMESTAMP);
+
+statement ok
+CREATE DEFAULT INDEX ON t;
+
+# EXPLAIN output is time-dependent, so we don't want show the output here, just
+# assert that the query doesn't fail.
+statement ok
+EXPLAIN SELECT * FROM t WHERE a < mz_now();
+
+# Regression test for #19177
+# ---
+
+statement ok
+DROP SCHEMA IF EXISTS public CASCADE;
+
+statement ok
+CREATE SCHEMA public;
+
+statement ok
+CREATE TABLE t1(x text);
+
+statement ok
+CREATE TABLE t2(x text);
+
+statement ok
+EXPLAIN SELECT * FROM t1, t2 WHERE t1.x || mz_internal.mz_session_id()  = t2.x || mz_internal.mz_session_id();
+
+# Regression test for the join visitation part of #19177
+statement ok
+EXPLAIN SELECT * FROM t1, t2 WHERE t1.x || mz_now()  = t2.x || mz_now();
+
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+SELECT lag(x, 3, 'default') IGNORE NULLS OVER (ORDER BY x || x)
+FROM t1;
+----
+Explained Query:
+  Project (#2)
+    Map (record_get[0](#1))
+      FlatMap unnest_list(#0)
+        Reduce aggregates=[lag[ignore_nulls=true, order_by=[#0 asc nulls_last]](row(row(row(#0{x}), row(#0{x}, █, █)), (#0{x} || #0{x})))]
+          ReadStorage materialize.public.t1
+
+EOF
+
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+SELECT first_value(x) OVER (ORDER BY x || x ROWS BETWEEN 5 preceding AND CURRENT ROW)
+FROM t1;
+----
+Explained Query:
+  Project (#2)
+    Map (record_get[0](#1))
+      FlatMap unnest_list(#0)
+        Reduce aggregates=[first_value[order_by=[#0 asc nulls_last] rows between 5 preceding and current row](row(row(row(#0{x}), #0{x}), (#0{x} || #0{x})))]
+          ReadStorage materialize.public.t1
+
+EOF
+
+## "Used indexes" tests
+
+statement ok
+CREATE TABLE t (
+  a int,
+  b int
+);
+
+statement ok
+CREATE TABLE u (
+  c int,
+  d int
+);
+
+# If two indexes exist on the same table, then "Used indexes" should print the one that we are actually going to use
+
+statement ok
+CREATE INDEX u_c ON u(c);
+
+statement ok
+CREATE INDEX u_d ON u(d);
+
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+SELECT *
+FROM t, u
+WHERE t.b = u.c;
+----
+Explained Query:
+  Project (#0, #1, #1, #3)
+    Filter (#1{b}) IS NOT NULL
+      Join on=(#1{b} = #2{c}) type=differential
+        ArrangeBy keys=[[#1{b}]]
+          Filter (#1{b}) IS NOT NULL
+            ReadStorage materialize.public.t
+        ArrangeBy keys=[[#0{c}]]
+          ReadIndex on=u u_c=[differential join]
+
+Source materialize.public.t
+  filter=((#1{b}) IS NOT NULL)
+
+Used Indexes:
+  - materialize.public.u_c (differential join)
+
+EOF
+
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+SELECT *
+FROM t, u
+WHERE t.b = u.d;
+----
+Explained Query:
+  Project (#0..=#2, #1)
+    Filter (#1{b}) IS NOT NULL
+      Join on=(#1{b} = #3{d}) type=differential
+        ArrangeBy keys=[[#1{b}]]
+          Filter (#1{b}) IS NOT NULL
+            ReadStorage materialize.public.t
+        ArrangeBy keys=[[#1{d}]]
+          ReadIndex on=u u_d=[differential join]
+
+Source materialize.public.t
+  filter=((#1{b}) IS NOT NULL)
+
+Used Indexes:
+  - materialize.public.u_d (differential join)
+
+EOF
+
+statement ok
+DROP INDEX u_c;
+
+# Let's test the weird situation that two identical indexes exist.
+
+statement ok
+CREATE INDEX t_a_idx_1 ON t(a);
+
+statement ok
+CREATE INDEX t_a_idx_2 ON t(a);
+
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+SELECT *
+FROM t, u
+WHERE t.a = u.c
+----
+Explained Query:
+  Project (#0, #1, #0, #3)
+    Filter (#0{a}) IS NOT NULL
+      Join on=(#0{a} = #2{c}) type=differential
+        ArrangeBy keys=[[#0{a}]]
+          ReadIndex on=t t_a_idx_1=[differential join]
+        ArrangeBy keys=[[#0{c}]]
+          Filter (#0{c}) IS NOT NULL
+            ReadIndex on=u u_d=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.u_d (*** full scan ***)
+  - materialize.public.t_a_idx_1 (differential join)
+
+EOF
+
+# An index is used two times by the same (self) join. We should show a 1st input and a non-1st input usage.
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+SELECT *
+FROM t AS t1, t AS t2, t AS t3
+WHERE t1.a = t2.a AND t2.a = t3.a;
+----
+Explained Query:
+  Return
+    Project (#0, #1, #0, #3, #0, #5)
+      Filter (#0{a}) IS NOT NULL
+        Join on=(#0{a} = #2{a} = #4{a}) type=delta
+          Get l0
+          Get l0
+          Get l0
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{a}]]
+        ReadIndex on=t t_a_idx_1=[delta join lookup, delta join 1st input (full scan)]
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (delta join lookup, delta join 1st input (full scan))
+
+EOF
+
+# An index is used in both a join and a full scan.
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+(SELECT t1.a + t2.a AS a, t1.b + t2.b AS b
+ FROM t AS t1, t AS t2
+ WHERE t1.a = t2.a)
+UNION
+(SELECT *
+ FROM t
+ WHERE b > 5)
+----
+Explained Query:
+  Return
+    Distinct project=[#0{a}, #1{b}]
+      Union
+        Project (#4, #5)
+          Filter (#0{a}) IS NOT NULL
+            Map ((#0{a} + #0{a}), (#1{b} + #3{b}))
+              Join on=(#0{a} = #2{a}) type=differential
+                Get l0
+                Get l0
+        Filter (#1{b} > █)
+          ReadIndex on=t t_a_idx_1=[*** full scan ***]
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0{a}]]
+        ReadIndex on=t t_a_idx_1=[differential join]
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (*** full scan ***, differential join)
+
+EOF
+
+# An index exists that can't be used for the join because of having the wrong key.
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+(SELECT t1.a + t2.a AS a, t1.b + t2.b AS b
+ FROM t AS t1, t AS t2
+ WHERE t1.b = t2.b)
+UNION
+(SELECT *
+ FROM t
+ WHERE b > 5)
+----
+Explained Query:
+  Return
+    Distinct project=[#0{a}, #1{b}]
+      Union
+        Project (#4, #5)
+          Map ((#0{a} + #2{a}), (#1{b} + #1{b}))
+            Join on=(#1{b} = #3{b}) type=differential
+              Get l0
+              Get l0
+        Filter (#1{b} > █)
+          ReadIndex on=t t_a_idx_1=[*** full scan ***]
+  With
+    cte l0 =
+      ArrangeBy keys=[[#1{b}]]
+        Filter (#1{b}) IS NOT NULL
+          ReadIndex on=t t_a_idx_1=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (*** full scan ***)
+
+EOF
+
+# Similar to the previous test, but exercises the full scan code inside the context loop of the Get case in
+# `collect_index_reqs_inner`, where we don't have an index for the requested key.
+
+statement ok
+CREATE TABLE t_non_null (
+  a int NOT NULL,
+  b int NOT NULL
+);
+
+statement ok
+CREATE INDEX t_non_null_a_idx ON t_non_null(a);
+
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+(SELECT t1.a + t2.a AS a, t1.b + t2.b AS b
+ FROM t_non_null AS t1, t_non_null AS t2
+ WHERE t1.b = t2.b)
+UNION
+(SELECT *
+ FROM t_non_null
+ WHERE b > 5)
+----
+Explained Query:
+  Return
+    Distinct project=[#0{a}, #1{b}]
+      Union
+        Project (#4, #5)
+          Map ((#0{a} + #2{a}), (#1{b} + #1{b}))
+            Join on=(#1{b} = #3{b}) type=differential
+              Get l0
+              Get l0
+        Filter (#1{b} > █)
+          ReadIndex on=t_non_null t_non_null_a_idx=[*** full scan ***]
+  With
+    cte l0 =
+      ArrangeBy keys=[[#1{b}]]
+        ReadIndex on=t_non_null t_non_null_a_idx=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_non_null_a_idx (*** full scan ***)
+
+EOF
+
+# This has 1 more full scan than the previous test, because the join needs 2 different arrangements.
+# (But we print only one full scan due to deduplication.)
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+(SELECT t1.a + t2.a AS a, t1.b + t2.b AS b
+ FROM t_non_null AS t1, t_non_null AS t2
+ WHERE t1.b = t2.b + 1)
+UNION
+(SELECT *
+ FROM t_non_null
+ WHERE b > 5)
+----
+Explained Query:
+  Distinct project=[#0{a}, #1{b}]
+    Union
+      Project (#4, #5)
+        Map ((#0{a} + #2{a}), (#1{b} + #3{b}))
+          Join on=(#1{b} = (#3{b} + █)) type=differential
+            ArrangeBy keys=[[#1{b}]]
+              ReadIndex on=t_non_null t_non_null_a_idx=[*** full scan ***]
+            ArrangeBy keys=[[(#1{b} + █)]]
+              ReadIndex on=t_non_null t_non_null_a_idx=[*** full scan ***]
+      Filter (#1{b} > █)
+        ReadIndex on=t_non_null t_non_null_a_idx=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_non_null_a_idx (*** full scan ***)
+
+EOF
+
+# An index is used in both a lookup and a full scan.
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+SELECT * FROM t
+UNION
+SELECT * FROM t WHERE a = 5;
+----
+Explained Query:
+  Distinct project=[#0{a}, #1{b}]
+    Union
+      ReadIndex on=t t_a_idx_2=[*** full scan ***]
+      Project (#0, #1)
+        ReadIndex on=materialize.public.t t_a_idx_2=[lookup value=(█)]
+
+Used Indexes:
+  - materialize.public.t_a_idx_2 (*** full scan ***, lookup)
+
+EOF
+
+# Several lookups using different indexes
+
+statement ok
+CREATE INDEX t_b_idx ON t(b);
+
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+SELECT * FROM t
+UNION ALL
+SELECT * FROM t WHERE b = 7
+UNION ALL
+SELECT * FROM t WHERE a = 5
+UNION ALL
+SELECT * FROM u WHERE c = 3
+UNION ALL
+SELECT * FROM u WHERE d = 1;
+----
+Explained Query:
+  Union
+    ReadIndex on=t t_b_idx=[*** full scan ***]
+    Project (#0, #1)
+      ReadIndex on=materialize.public.t t_b_idx=[lookup value=(█)]
+    Project (#0, #1)
+      ReadIndex on=materialize.public.t t_a_idx_2=[lookup value=(█)]
+    Filter (#0{c} = █)
+      ReadIndex on=u u_d=[*** full scan ***]
+    Project (#0, #1)
+      ReadIndex on=materialize.public.u u_d=[lookup value=(█)]
+
+Used Indexes:
+  - materialize.public.u_d (*** full scan ***, lookup)
+  - materialize.public.t_a_idx_2 (lookup)
+  - materialize.public.t_b_idx (*** full scan ***, lookup)
+
+EOF
+
+# Fast path with a LIMIT and no ORDER BY. This is not a full scan.
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+SELECT a+b as x
+FROM t
+WHERE a < 7
+LIMIT 3;
+----
+Explained Query (fast path):
+  Finish limit=3 output=[#0]
+    Project (#2)
+      Filter (#0{a} < █)
+        Map ((#0{a} + #1{b}))
+          ReadIndex on=materialize.public.t t_a_idx_1=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (fast path limit)
+
+EOF
+
+# Same query without a LIMIT, so full scan
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+SELECT a+b as x
+FROM t
+WHERE a < 7;
+----
+Explained Query (fast path):
+  Project (#2)
+    Filter (#0{a} < █)
+      Map ((#0{a} + #1{b}))
+        ReadIndex on=materialize.public.t t_a_idx_1=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (*** full scan ***)
+
+EOF
+
+# Same query with a LIMIT + ORDER BY, so full scan
+query T multiline
+EXPLAIN WITH(humanized_exprs, redacted)
+SELECT a+b as x
+FROM t
+WHERE a < 7
+ORDER BY x
+LIMIT 3;
+----
+Explained Query (fast path):
+  Finish order_by=[#0 asc nulls_last] limit=3 output=[#0]
+    Project (#2)
+      Filter (#0{a} < █)
+        Map ((#0{a} + #1{b}))
+          ReadIndex on=materialize.public.t t_a_idx_1=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (*** full scan ***)
+
+EOF
+

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -444,7 +444,7 @@ Explained Query:
     Return // { arity: 7 }
       Project (#0..=#2, #4, #7, #5, #8) // { arity: 7 }
         Map ((#5 / bigint_to_numeric(case when (#6 = 0) then null else #6 end)), (bigint_to_numeric(#4) / #3)) // { arity: 9 }
-          Reduce group_by=[#1, #2, #3, #4] aggregates=[count(*), sum(integer_to_bigint(#0{length})), count(integer_to_bigint(#0{length}))] // { arity: 7 }
+          Reduce group_by=[#1..=#4] aggregates=[count(*), sum(integer_to_bigint(#0{length})), count(integer_to_bigint(#0{length}))] // { arity: 7 }
             CrossJoin type=differential // { arity: 5 }
               implementation
                 %1[×]U » %0:message[×]if
@@ -738,7 +738,7 @@ LIMIT 100
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
-      Reduce group_by=[#1{id}, #2{firstname}, #3{lastname}, #0{creationdate}] aggregates=[count(#4{messageid})] // { arity: 5 }
+      Reduce group_by=[#1{id}..=#3{lastname}, #0{creationdate}] aggregates=[count(#4{messageid})] // { arity: 5 }
         Union // { arity: 5 }
           Map (null) // { arity: 5 }
             Union // { arity: 4 }
@@ -1589,7 +1589,7 @@ SELECT Person.id AS "person.id"
 ----
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
-    Reduce group_by=[#0{id}, #1{firstname}, #2{lastname}] aggregates=[count(*), sum(#3)] // { arity: 5 }
+    Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3)] // { arity: 5 }
       Project (#1..=#3, #25) // { arity: 4 }
         Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 26 }
           Join on=(#1{id} = #20{creatorpersonid} AND #12{messageid} = #24{rootpostid}) type=delta // { arity: 26 }
@@ -2004,15 +2004,15 @@ Explained Query:
                   Join on=(#0{creationdate} = #11{creationdate} AND #1{id} = #12{id} AND #2{firstname} = #13{firstname} AND #3{lastname} = #14{lastname} AND #4{gender} = #15{gender} AND #5{birthday} = #16{birthday} AND #6{locationip} = #17{locationip} AND #7{browserused} = #18{browserused} AND #8{locationcityid} = #19{locationcityid} AND #9{speaks} = #20{speaks} AND #10{email} = #21{email}) type=differential // { arity: 22 }
                     implementation
                       %0[#0..=#10]KKKKKKKKKKK » %1:person[#0..=#10]KKKKKKKKKKK
-                    ArrangeBy keys=[[#0{creationdate}, #1{id}, #2{firstname}, #3{lastname}, #4{gender}, #5{birthday}, #6{locationip}, #7{browserused}, #8{locationcityid}, #9{speaks}, #10{email}]] // { arity: 11 }
+                    ArrangeBy keys=[[#0{creationdate}..=#10{email}]] // { arity: 11 }
                       Union // { arity: 11 }
                         Negate // { arity: 11 }
-                          Distinct project=[#0{creationdate}, #1{id}, #2{firstname}, #3{lastname}, #4{gender}, #5{birthday}, #6{locationip}, #7{browserused}, #8{locationcityid}, #9{speaks}, #10{email}] // { arity: 11 }
+                          Distinct project=[#0{creationdate}..=#10{email}] // { arity: 11 }
                             Project (#0..=#10) // { arity: 11 }
                               Get l1 // { arity: 12 }
-                        Distinct project=[#0{creationdate}, #1{id}, #2{firstname}, #3{lastname}, #4{gender}, #5{birthday}, #6{locationip}, #7{browserused}, #8{locationcityid}, #9{speaks}, #10{email}] // { arity: 11 }
+                        Distinct project=[#0{creationdate}..=#10{email}] // { arity: 11 }
                           ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
-                    ArrangeBy keys=[[#0{creationdate}, #1{id}, #2{firstname}, #3{lastname}, #4{gender}, #5{birthday}, #6{locationip}, #7{browserused}, #8{locationcityid}, #9{speaks}, #10{email}]] // { arity: 11 }
+                    ArrangeBy keys=[[#0{creationdate}..=#10{email}]] // { arity: 11 }
                       ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
     With
       cte l1 =
@@ -2173,17 +2173,17 @@ Explained Query:
                     Join on=(#0{id} = #16{id} AND #1{url} = #17{url} AND #2{partofcontinentid} = #18{partofcontinentid} AND #3{id} = #19{id} AND #4{name} = #20{name} AND #5{url} = #21{url} AND #6{creationdate} = #22{creationdate} AND #7{id} = #23{id} AND #8{firstname} = #24{firstname} AND #9{lastname} = #25{lastname} AND #10{gender} = #26{gender} AND #11{birthday} = #27{birthday} AND #12{locationip} = #28{locationip} AND #13{browserused} = #29{browserused} AND #14{speaks} = #30{speaks} AND #15{email} = #31{email}) type=differential // { arity: 32 }
                       implementation
                         %0[#0..=#15]KKKKKKKKKKKKKKKK » %1:l0[#0..=#15]KKKKKKKKKKKKKKKK
-                      ArrangeBy keys=[[#0{id}, #1{url}, #2{partofcontinentid}, #3{id}, #4{name}, #5{url}, #6{creationdate}, #7{id}, #8{firstname}, #9{lastname}, #10{gender}, #11{birthday}, #12{locationip}, #13{browserused}, #14{speaks}, #15{email}]] // { arity: 16 }
+                      ArrangeBy keys=[[#0{id}..=#15{email}]] // { arity: 16 }
                         Union // { arity: 16 }
                           Negate // { arity: 16 }
-                            Distinct project=[#0{id}, #1{url}, #2{partofcontinentid}, #3{id}, #4{name}, #5{url}, #6{creationdate}, #7{id}, #8{firstname}, #9{lastname}, #10{gender}, #11{birthday}, #12{locationip}, #13{browserused}, #14{speaks}, #15{email}] // { arity: 16 }
+                            Distinct project=[#0{id}..=#15{email}] // { arity: 16 }
                               Project (#0..=#15) // { arity: 16 }
                                 Filter (#0{id} = #0{id}) AND (#3{id} = #3{id}) // { arity: 17 }
                                   Get l1 // { arity: 17 }
-                          Distinct project=[#0{id}, #1{url}, #2{partofcontinentid}, #3{id}, #4{name}, #5{url}, #6{creationdate}, #7{id}, #8{firstname}, #9{lastname}, #10{gender}, #11{birthday}, #12{locationip}, #13{browserused}, #14{speaks}, #15{email}] // { arity: 16 }
+                          Distinct project=[#0{id}..=#15{email}] // { arity: 16 }
                             Filter (#0{id} = #0{id}) AND (#3{id} = #3{id}) // { arity: 16 }
                               Get l0 // { arity: 16 }
-                      ArrangeBy keys=[[#0{id}, #1{url}, #2{partofcontinentid}, #3{id}, #4{name}, #5{url}, #6{creationdate}, #7{id}, #8{firstname}, #9{lastname}, #10{gender}, #11{birthday}, #12{locationip}, #13{browserused}, #14{speaks}, #15{email}]] // { arity: 16 }
+                      ArrangeBy keys=[[#0{id}..=#15{email}]] // { arity: 16 }
                         Get l0 // { arity: 16 }
       cte l1 =
         Project (#0..=#15, #17) // { arity: 17 }
@@ -2773,7 +2773,7 @@ Explained Query:
                     Get l17 // { arity: 6 }
   With Mutually Recursive
     cte l17 =
-      Distinct project=[#0, #1, #2{person2id}, #3, #4, #5] // { arity: 6 }
+      Distinct project=[#0..=#5] // { arity: 6 }
         Union // { arity: 6 }
           Map (0) // { arity: 6 }
             Union // { arity: 5 }
@@ -2855,11 +2855,11 @@ Explained Query:
               Join on=(#0 = #6 = #12 AND #1 = #7 = #13 AND #2 = #8 = #14 AND #3 = #9 AND #4 = #10 AND #5 = #11) type=differential // { arity: 16 }
                 implementation
                   %1:l10[#0..=#5]UKKKKKK » %0:l17[#0..=#5]KKKKKK » %2[#0..=#2]KKK
-                ArrangeBy keys=[[#0, #1, #2, #3, #4, #5]] // { arity: 6 }
+                ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
                   Get l17 // { arity: 6 }
-                ArrangeBy keys=[[#0, #1, #2, #3, #4, #5]] // { arity: 6 }
+                ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
                   Get l10 // { arity: 6 }
-                ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+                ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                   Union // { arity: 4 }
                     Map (true) // { arity: 4 }
                       Get l12 // { arity: 3 }
@@ -2868,30 +2868,30 @@ Explained Query:
                         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                           implementation
                             %1:l11[#0..=#2]UKKK » %0[#0..=#2]KKK
-                          ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+                          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                             Union // { arity: 3 }
                               Negate // { arity: 3 }
                                 Get l12 // { arity: 3 }
                               Get l11 // { arity: 3 }
-                          ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+                          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                             Get l11 // { arity: 3 }
     cte l12 =
       Project (#0..=#2) // { arity: 3 }
         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
           implementation
             %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
-          ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
             Get l11 // { arity: 3 }
-          ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
-            Distinct project=[#0, #1, #2] // { arity: 3 }
+          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+            Distinct project=[#0..=#2] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
                 Get l9 // { arity: 5 }
     cte l11 =
-      Distinct project=[#0, #1, #2] // { arity: 3 }
+      Distinct project=[#0..=#2] // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
           Get l10 // { arity: 6 }
     cte l10 =
-      Distinct project=[#0, #1, #2, #3, #4, #5] // { arity: 6 }
+      Distinct project=[#0..=#5] // { arity: 6 }
         Get l17 // { arity: 6 }
     cte l9 =
       TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
@@ -3564,7 +3564,7 @@ Explained Query:
   With Mutually Recursive
     cte l0 =
       Reduce group_by=[#0{id}, #1{id}] aggregates=[min(#2)] // { arity: 3 }
-        Distinct project=[#0{id}, #1{id}, #2] // { arity: 3 }
+        Distinct project=[#0{id}..=#2] // { arity: 3 }
           Union // { arity: 3 }
             Project (#1, #1, #12) // { arity: 3 }
               Map (0) // { arity: 13 }
@@ -3867,7 +3867,7 @@ Explained Query:
                       Get l8 // { arity: 6 }
     With Mutually Recursive
       cte l8 =
-        Distinct project=[#0, #1{id}, #2{id}, #3, #4, #5] // { arity: 6 }
+        Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
             Map (0) // { arity: 6 }
               Union // { arity: 5 }
@@ -3931,7 +3931,7 @@ Explained Query:
                     Get l4 // { arity: 5 }
       cte l4 =
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-          Distinct project=[#0, #1, #2{dst}, #3, #4] // { arity: 5 }
+          Distinct project=[#0..=#4] // { arity: 5 }
             Union // { arity: 5 }
               Project (#3, #4, #1, #7, #8) // { arity: 5 }
                 Map ((#6 + bigint_to_double(#2{w})), false) // { arity: 9 }
@@ -3949,11 +3949,11 @@ Explained Query:
                   Join on=(#0 = #6 = #12 AND #1 = #7 = #13 AND #2 = #8 = #14 AND #3 = #9 AND #4 = #10 AND #5 = #11) type=differential // { arity: 16 }
                     implementation
                       %1:l1[#0..=#5]UKKKKKK » %0:l8[#0..=#5]KKKKKK » %2[#0..=#2]KKK
-                    ArrangeBy keys=[[#0, #1, #2, #3, #4, #5]] // { arity: 6 }
+                    ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
                       Get l8 // { arity: 6 }
-                    ArrangeBy keys=[[#0, #1, #2, #3, #4, #5]] // { arity: 6 }
+                    ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
                       Get l1 // { arity: 6 }
-                    ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+                    ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                       Union // { arity: 4 }
                         Map (true) // { arity: 4 }
                           Get l3 // { arity: 3 }
@@ -3962,32 +3962,32 @@ Explained Query:
                             Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                               implementation
                                 %1:l2[#0..=#2]UKKK » %0[#0..=#2]KKK
-                              ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                                 Union // { arity: 3 }
                                   Negate // { arity: 3 }
                                     Get l3 // { arity: 3 }
                                   Get l2 // { arity: 3 }
-                              ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                                 Get l2 // { arity: 3 }
       cte l3 =
         Project (#0..=#2) // { arity: 3 }
           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
             implementation
               %1[#0..=#2]UKKKA » %0:l2[#0..=#2]UKKK
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
               Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
                 Get l2 // { arity: 3 }
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
-              Distinct project=[#0, #1, #2] // { arity: 3 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+              Distinct project=[#0..=#2] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
                   Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
       cte l2 =
-        Distinct project=[#0, #1, #2] // { arity: 3 }
+        Distinct project=[#0..=#2] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Get l1 // { arity: 6 }
       cte l1 =
-        Distinct project=[#0, #1, #2, #3, #4, #5] // { arity: 6 }
+        Distinct project=[#0..=#5] // { arity: 6 }
           Get l8 // { arity: 6 }
       cte l0 =
         TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
@@ -4317,7 +4317,7 @@ Explained Query:
           Map (10995116285979) // { arity: 4 }
             Reduce group_by=[#0{dst}, #2] aggregates=[min(#1)] // { arity: 3 }
               Reduce group_by=[#0{dst}, #2] aggregates=[min(#1)] // { arity: 3 }
-                Distinct project=[#0{dst}, #1, #2] // { arity: 3 }
+                Distinct project=[#0{dst}..=#2] // { arity: 3 }
                   Union // { arity: 3 }
                     Project (#4, #6, #7) // { arity: 3 }
                       Map ((#1 + integer_to_bigint(#5{w})), (#2 + 1)) // { arity: 8 }
@@ -4464,11 +4464,11 @@ Explained Query:
                       Get l11 // { arity: 6 }
     With Mutually Recursive
       cte l11 =
-        Distinct project=[#0, #1{personid}, #2{personid}, #3, #4, #5] // { arity: 6 }
+        Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
             Project (#0..=#2, #4, #3, #5) // { arity: 6 }
               Map (false, 0, 0) // { arity: 6 }
-                Distinct project=[#0, #1{personid}, #2{personid}] // { arity: 3 }
+                Distinct project=[#0..=#2{personid}] // { arity: 3 }
                   Union // { arity: 3 }
                     Project (#1, #0, #0) // { arity: 3 }
                       Map (10995116285979, false) // { arity: 2 }
@@ -4559,11 +4559,11 @@ Explained Query:
                 Join on=(#0 = #6 = #12 AND #1 = #7 = #13 AND #2 = #8 = #14 AND #3 = #9 AND #4 = #10 AND #5 = #11) type=differential // { arity: 16 }
                   implementation
                     %1:l4[#0..=#5]UKKKKKK » %0:l11[#0..=#5]KKKKKK » %2[#0..=#2]KKK
-                  ArrangeBy keys=[[#0, #1, #2, #3, #4, #5]] // { arity: 6 }
+                  ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
                     Get l11 // { arity: 6 }
-                  ArrangeBy keys=[[#0, #1, #2, #3, #4, #5]] // { arity: 6 }
+                  ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
                     Get l4 // { arity: 6 }
-                  ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+                  ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                     Union // { arity: 4 }
                       Map (true) // { arity: 4 }
                         Get l6 // { arity: 3 }
@@ -4572,30 +4572,30 @@ Explained Query:
                           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                             implementation
                               %1:l5[#0..=#2]UKKK » %0[#0..=#2]KKK
-                            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                               Union // { arity: 3 }
                                 Negate // { arity: 3 }
                                   Get l6 // { arity: 3 }
                                 Get l5 // { arity: 3 }
-                            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                               Get l5 // { arity: 3 }
       cte l6 =
         Project (#0..=#2) // { arity: 3 }
           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
             implementation
               %1[#0..=#2]UKKKA » %0:l5[#0..=#2]UKKK
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
               Get l5 // { arity: 3 }
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
-              Distinct project=[#0, #1, #2] // { arity: 3 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+              Distinct project=[#0..=#2] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
                   Get l3 // { arity: 5 }
       cte l5 =
-        Distinct project=[#0, #1, #2] // { arity: 3 }
+        Distinct project=[#0..=#2] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Get l4 // { arity: 6 }
       cte l4 =
-        Distinct project=[#0, #1, #2, #3, #4, #5] // { arity: 6 }
+        Distinct project=[#0..=#5] // { arity: 6 }
           Get l11 // { arity: 6 }
       cte l3 =
         TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -114,9 +114,9 @@ Return // { arity: 4 }
           Join on=(#0{facts_k01} = #9{facts_k01} AND #1{dim01_k01} = #10{dim01_k01} AND #2{dim02_k01} = #11{dim02_k01} AND #3{dim03_k01} = #12{dim03_k01} AND #4{facts_d01} = #13{facts_d01} AND #5{facts_d02} = #14{facts_d02} AND #6{facts_d03} = #15{facts_d03} AND #7{facts_d04} = #16{facts_d04} AND #8{facts_d05} = #17{facts_d05}) // { arity: 18 }
             Union // { arity: 9 }
               Negate // { arity: 9 }
-                Distinct project=[#0{facts_k01}, #1{dim01_k01}, #2{dim02_k01}, #3{dim03_k01}, #4{facts_d01}, #5{facts_d02}, #6{facts_d03}, #7{facts_d04}, #8{facts_d05}] // { arity: 9 }
+                Distinct project=[#0{facts_k01}..=#8{facts_d05}] // { arity: 9 }
                   Get l1 // { arity: 15 }
-              Distinct project=[#0{facts_k01}, #1{dim01_k01}, #2{dim02_k01}, #3{dim03_k01}, #4{facts_d01}, #5{facts_d02}, #6{facts_d03}, #7{facts_d04}, #8{facts_d05}] // { arity: 9 }
+              Distinct project=[#0{facts_k01}..=#8{facts_d05}] // { arity: 9 }
                 Get l0 // { arity: 9 }
             Get l0 // { arity: 9 }
         Constant // { arity: 6 }
@@ -222,9 +222,9 @@ Return // { arity: 6 }
                 Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
                   Union // { arity: 11 }
                     Negate // { arity: 11 }
-                      Distinct project=[#0{x}, #1{y}, #2{facts_k01}, #3{dim01_k01}, #4{dim02_k01}, #5{dim03_k01}, #6{facts_d01}, #7{facts_d02}, #8{facts_d03}, #9{facts_d04}, #10{facts_d05}] // { arity: 11 }
+                      Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
                         Get l3 // { arity: 17 }
-                    Distinct project=[#0{x}, #1{y}, #2{facts_k01}, #3{dim01_k01}, #4{dim02_k01}, #5{dim03_k01}, #6{facts_d01}, #7{facts_d02}, #8{facts_d03}, #9{facts_d04}, #10{facts_d05}] // { arity: 11 }
+                    Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
                       Get l2 // { arity: 11 }
                   Get l2 // { arity: 11 }
               Constant // { arity: 6 }
@@ -281,7 +281,7 @@ Return // { arity: 6 }
                   Project (#0..=#10) // { arity: 11 }
                     Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
                       Get l2 // { arity: 11 }
-                      Distinct project=[#0{x}, #1{y}, #2] // { arity: 3 }
+                      Distinct project=[#0{x}..=#2] // { arity: 3 }
                         Project (#17..=#19) // { arity: 3 }
                           Map (#0{x}, #1{y}, (#3{dim01_k01} + #0{x})) // { arity: 20 }
                             Get l3 // { arity: 17 }
@@ -340,7 +340,7 @@ Return // { arity: 6 }
                     Project (#0..=#10) // { arity: 11 }
                       Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
                         Get l2 // { arity: 11 }
-                        Distinct project=[#0{x}, #1{y}, #2] // { arity: 3 }
+                        Distinct project=[#0{x}..=#2] // { arity: 3 }
                           Project (#17..=#19) // { arity: 3 }
                             Map (#0{x}, #1{y}, (#2{dim01_k01} + #1{y})) // { arity: 20 }
                               Get l3 // { arity: 17 }
@@ -402,9 +402,9 @@ Return // { arity: 6 }
                 Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
                   Union // { arity: 11 }
                     Negate // { arity: 11 }
-                      Distinct project=[#0{x}, #1{y}, #2{facts_k01}, #3{dim01_k01}, #4{dim02_k01}, #5{dim03_k01}, #6{facts_d01}, #7{facts_d02}, #8{facts_d03}, #9{facts_d04}, #10{facts_d05}] // { arity: 11 }
+                      Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
                         Get l3 // { arity: 17 }
-                    Distinct project=[#0{x}, #1{y}, #2{facts_k01}, #3{dim01_k01}, #4{dim02_k01}, #5{dim03_k01}, #6{facts_d01}, #7{facts_d02}, #8{facts_d03}, #9{facts_d04}, #10{facts_d05}] // { arity: 11 }
+                    Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
                       Get l2 // { arity: 11 }
                   Get l2 // { arity: 11 }
               Constant // { arity: 6 }
@@ -466,7 +466,7 @@ Return // { arity: 6 }
                     Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
                       Filter (#7{facts_d02} = 42) // { arity: 11 }
                         Get l2 // { arity: 11 }
-                      Distinct project=[#0{x}, #1{y}, #2] // { arity: 3 }
+                      Distinct project=[#0{x}..=#2] // { arity: 3 }
                         Project (#17..=#19) // { arity: 3 }
                           Map (#0{x}, #1{y}, (#3{dim01_k01} + #0{x})) // { arity: 20 }
                             Get l3 // { arity: 17 }
@@ -530,7 +530,7 @@ Return // { arity: 6 }
                       Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
                         Filter (#7{facts_d02} = 42) // { arity: 11 }
                           Get l2 // { arity: 11 }
-                        Distinct project=[#0{x}, #1{y}, #2] // { arity: 3 }
+                        Distinct project=[#0{x}..=#2] // { arity: 3 }
                           Project (#17..=#19) // { arity: 3 }
                             Map (#0{x}, #1{y}, (#2{dim01_k01} + #1{y})) // { arity: 20 }
                               Get l3 // { arity: 17 }
@@ -607,7 +607,7 @@ Return // { arity: 6 }
             Get l4 // { arity: 14 }
 With
   cte l5 =
-    Distinct project=[#0{x}, #1{y}, #2] // { arity: 3 }
+    Distinct project=[#0{x}..=#2] // { arity: 3 }
       Project (#14..=#16) // { arity: 3 }
         Map (#0{x}, #1{y}, coalesce(#2{dim01_k01}, #0{x})) // { arity: 17 }
           Get l4 // { arity: 14 }
@@ -668,9 +668,9 @@ Return // { arity: 6 }
                 Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
                   Union // { arity: 11 }
                     Negate // { arity: 11 }
-                      Distinct project=[#0{x}, #1{y}, #2{facts_k01}, #3{dim01_k01}, #4{dim02_k01}, #5{dim03_k01}, #6{facts_d01}, #7{facts_d02}, #8{facts_d03}, #9{facts_d04}, #10{facts_d05}] // { arity: 11 }
+                      Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
                         Get l8 // { arity: 17 }
-                    Distinct project=[#0{x}, #1{y}, #2{facts_k01}, #3{dim01_k01}, #4{dim02_k01}, #5{dim03_k01}, #6{facts_d01}, #7{facts_d02}, #8{facts_d03}, #9{facts_d04}, #10{facts_d05}] // { arity: 11 }
+                    Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
                       Get l2 // { arity: 11 }
                   Get l2 // { arity: 11 }
               Constant // { arity: 6 }

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -261,7 +261,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q02;
 ----
 materialize.public.q02_primary_idx:
-  ArrangeBy keys=[[#0{s_acctbal}, #1{s_name}, #2{n_name}, #3{p_partkey}, #4{p_mfgr}, #5{s_address}, #6{s_phone}, #7{s_comment}]] // { arity: 8 }
+  ArrangeBy keys=[[#0{s_acctbal}..=#7{s_comment}]] // { arity: 8 }
     ReadGlobalFromSameDataflow materialize.public.q02 // { arity: 8 }
 
 materialize.public.q02:
@@ -372,7 +372,7 @@ materialize.public.q03_primary_idx:
 
 materialize.public.q03:
   Project (#0, #3, #1, #2) // { arity: 4 }
-    Reduce group_by=[#0{o_orderkey}, #1{o_orderdate}, #2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
+    Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
       Project (#8, #12, #15, #22, #23) // { arity: 5 }
         Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) AND (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
@@ -628,7 +628,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q07;
 ----
 materialize.public.q07_primary_idx:
-  ArrangeBy keys=[[#0{supp_nation}, #1{cust_nation}, #2{l_year}]] // { arity: 4 }
+  ArrangeBy keys=[[#0{supp_nation}..=#2{l_year}]] // { arity: 4 }
     ReadGlobalFromSameDataflow materialize.public.q07 // { arity: 4 }
 
 materialize.public.q07:
@@ -905,7 +905,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q10;
 ----
 materialize.public.q10_primary_idx:
-  ArrangeBy keys=[[#0{c_custkey}, #1{c_name}, #3{c_acctbal}, #4{n_name}, #5{c_address}, #6{c_phone}, #7{c_comment}]] // { arity: 8 }
+  ArrangeBy keys=[[#0{c_custkey}, #1{c_name}, #3{c_acctbal}..=#7{c_comment}]] // { arity: 8 }
     ReadGlobalFromSameDataflow materialize.public.q10 // { arity: 8 }
 
 materialize.public.q10:
@@ -1259,7 +1259,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q15;
 ----
 materialize.public.q15_primary_idx:
-  ArrangeBy keys=[[#0{s_suppkey}, #1{s_name}, #2{s_address}, #3{s_phone}, #4{total_revenue}]] // { arity: 5 }
+  ArrangeBy keys=[[#0{s_suppkey}..=#4{total_revenue}]] // { arity: 5 }
     ReadGlobalFromSameDataflow materialize.public.q15 // { arity: 5 }
 
 materialize.public.q15:
@@ -1332,12 +1332,12 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q16;
 ----
 materialize.public.q16_primary_idx:
-  ArrangeBy keys=[[#0{p_brand}, #1{p_type}, #2{p_size}]] // { arity: 4 }
+  ArrangeBy keys=[[#0{p_brand}..=#2{p_size}]] // { arity: 4 }
     ReadGlobalFromSameDataflow materialize.public.q16 // { arity: 4 }
 
 materialize.public.q16:
   Return // { arity: 4 }
-    Reduce group_by=[#1{p_brand}, #2{p_type}, #3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
+    Reduce group_by=[#1{p_brand}..=#3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
       Project (#0..=#3) // { arity: 4 }
         Join on=(#0{ps_suppkey} = #4{ps_suppkey}) type=differential // { arity: 5 }
           implementation
@@ -1512,7 +1512,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q18;
 ----
 materialize.public.q18_primary_idx:
-  ArrangeBy keys=[[#0{c_name}, #1{c_custkey}, #2{o_orderkey}, #3{o_orderdate}, #4{o_totalprice}]] // { arity: 6 }
+  ArrangeBy keys=[[#0{c_name}..=#4{o_totalprice}]] // { arity: 6 }
     ReadGlobalFromSameDataflow materialize.public.q18 // { arity: 6 }
 
 materialize.public.q18:

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -342,7 +342,7 @@ ORDER BY
 ----
 materialize.public.q03:
   Project (#0, #3, #1, #2) // { arity: 4 }
-    Reduce group_by=[#0{o_orderkey}, #1{o_orderdate}, #2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
+    Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
       Project (#8, #12, #15, #22, #23) // { arity: 5 }
         Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) AND (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
@@ -1193,7 +1193,7 @@ ORDER BY
 ----
 materialize.public.q16:
   Return // { arity: 4 }
-    Reduce group_by=[#1{p_brand}, #2{p_type}, #3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
+    Reduce group_by=[#1{p_brand}..=#3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
       Project (#0..=#3) // { arity: 4 }
         Join on=(#0{ps_suppkey} = #4{ps_suppkey}) type=differential // { arity: 5 }
           implementation

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -341,7 +341,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#1 desc nulls_first, #2{o_orderdate} asc nulls_last] output=[#0..=#3]
     Project (#0, #3, #1, #2) // { arity: 4 }
-      Reduce group_by=[#0{o_orderkey}, #1{o_orderdate}, #2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
+      Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
         Project (#8, #12, #15, #22, #23) // { arity: 5 }
           Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) AND (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
             Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
@@ -1190,7 +1190,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{p_brand} asc nulls_last, #1{p_type} asc nulls_last, #2{p_size} asc nulls_last] output=[#0..=#3]
     Return // { arity: 4 }
-      Reduce group_by=[#1{p_brand}, #2{p_type}, #3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
+      Reduce group_by=[#1{p_brand}..=#3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
         Project (#0..=#3) // { arity: 4 }
           Join on=(#0{ps_suppkey} = #4{ps_suppkey}) type=differential // { arity: 5 }
             implementation

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -48,8 +48,8 @@ Used Indexes:
   - materialize.public.idx_t1_a_b (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.idx_t1_a_b on t1(#0{a}, #1{b}) is too wide to use for literal equalities `#0{a} IN (1, 2)`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{a}).
+  - Notice: Index materialize.public.idx_t1_a_b on t1(a, b) is too wide to use for literal equalities `a IN (1, 2)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (a).
 
 EOF
 
@@ -1359,8 +1359,8 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(#0{x}, #1{y}) is too wide to use for literal equalities `#0{x} = 5`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{x}).
+  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `x = 5`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (x).
 
 EOF
 
@@ -1382,10 +1382,10 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(#0{x}, #1{y}) is too wide to use for literal equalities `#0{x} = 5`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{x}).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `#0{x} = 5`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{x}).
+  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `x = 5`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (x).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `x = 5`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (x).
 
 EOF
 
@@ -1455,10 +1455,10 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(#0{x}, #1{y}) is too wide to use for literal equalities `#1{y} = 6`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `#1{y} = 6`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}).
+  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y = 6`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y = 6`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
 
 EOF
 
@@ -1494,8 +1494,8 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `#2{z} = 7`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#2{z}).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `z = 7`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (z).
 
 EOF
 
@@ -1517,10 +1517,10 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(#0{x}, #1{y}) is too wide to use for literal equalities `#1{y} = 5`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `#1{y} = 5`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}).
+  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y = 5`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y = 5`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
 
 EOF
 
@@ -1539,10 +1539,10 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(#0{x}, #1{y}) is too wide to use for literal equalities `#1{y} IN (4, 8)`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `#1{y} IN (4, 8)`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}).
+  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y IN (4, 8)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y IN (4, 8)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
 
 EOF
 
@@ -1561,10 +1561,10 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(#0{x}, #1{y}) is too wide to use for literal equalities `#1{y} IN (2, 5)`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}, #2{z}).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `(#1{y}, #2{z}) IN ((2, 3), (5, 7))`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}, #2{z}).
+  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y IN (2, 5)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y, z).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `(y, z) IN ((2, 3), (5, 7))`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y, z).
 
 EOF
 
@@ -1583,7 +1583,7 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `#2{z} = 9`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#2{z}, #3{w}).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `z = 9`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (z, w).
 
 EOF

--- a/test/testdrive/primary-key-optimizations.td
+++ b/test/testdrive/primary-key-optimizations.td
@@ -57,64 +57,64 @@ $ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys
 
 # Optimization is possible - no distinct is mentioned in the plan
 
-> EXPLAIN SELECT DISTINCT key1, key2 FROM t1;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1, key2 FROM t1;
 "Explained Query (fast path):  Project (#0, #1)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT DISTINCT key2, key1 FROM t1;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key2, key1 FROM t1;
 "Explained Query (fast path):  Project (#1, #0)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT DISTINCT key2, key1, key2 FROM t1;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key2, key1, key2 FROM t1;
 "Explained Query (fast path):  Project (#1, #0, #1)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT key2, key1 FROM t1 GROUP BY key1, key2;
+> EXPLAIN WITH(no_notices) SELECT key2, key1 FROM t1 GROUP BY key1, key2;
 "Explained Query (fast path):  Project (#1, #0)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT key2, key1 FROM t1 GROUP BY key1, key2, key2 || 'a';
+> EXPLAIN WITH(no_notices) SELECT key2, key1 FROM t1 GROUP BY key1, key2, key2 || 'a';
 "Explained Query (fast path):  Project (#1, #0)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT DISTINCT key1, key2, nokey FROM t1;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1, key2, nokey FROM t1;
 "Explained Query (fast path):  ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT key1, key2, nokey FROM t1 GROUP BY key1, key2, nokey;
+> EXPLAIN WITH(no_notices) SELECT key1, key2, nokey FROM t1 GROUP BY key1, key2, nokey;
 "Explained Query (fast path):  ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT key1, key2 FROM t1 GROUP BY key1, key2 HAVING key1 = 'a';
-"Explained Query (fast path):  Project (#3, #1)    Filter (#0 = \"a\")      Map (\"a\")        ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(#0{key1}, #1{key2}) is too wide to use for literal equalities `#0{key1} = \"a\"`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{key1})."
+> EXPLAIN WITH(no_notices) SELECT key1, key2 FROM t1 GROUP BY key1, key2 HAVING key1 = 'a';
+"Explained Query (fast path):  Project (#3, #1)    Filter (#0 = \"a\")      Map (\"a\")        ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # Optimization not possible - explicit distinct is present in planFor certain types of tests the 
 
-> EXPLAIN SELECT DISTINCT key1 FROM t1;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1 FROM t1;
 "Explained Query:  Distinct project=[#0]    Project (#0)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT DISTINCT key2 FROM t1;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key2 FROM t1;
 "Explained Query:  Distinct project=[#0]    Project (#1)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT DISTINCT key1, upper(key2) FROM t1;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1, upper(key2) FROM t1;
 "Explained Query:  Distinct project=[#0, upper(#1)]    Project (#0, #1)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT DISTINCT key1, key2 || 'a' FROM t1;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1, key2 || 'a' FROM t1;
 "Explained Query:  Distinct project=[#0, (#1 || \"a\")]    Project (#0, #1)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT key1 FROM t1 GROUP BY key1;
+> EXPLAIN WITH(no_notices) SELECT key1 FROM t1 GROUP BY key1;
 "Explained Query:  Distinct project=[#0]    Project (#0)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT key2 FROM t1 GROUP BY key2;
+> EXPLAIN WITH(no_notices) SELECT key2 FROM t1 GROUP BY key2;
 "Explained Query:  Distinct project=[#0]    Project (#1)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT COUNT(DISTINCT key1) FROM t1;
+> EXPLAIN WITH(no_notices) SELECT COUNT(DISTINCT key1) FROM t1;
 "Explained Query:  Return    Union      Get l0      Map (0)        Union          Negate            Project ()              Get l0          Constant            - ()  With    cte l0 =      Reduce aggregates=[count(distinct #0)]        Project (#0)          ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # Make sure that primary key information is inherited from the source
 
 > CREATE VIEW v1 AS SELECT * FROM t1;
 
-> EXPLAIN SELECT DISTINCT key1, key2 FROM v1;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1, key2 FROM v1;
 "Explained Query (fast path):  Project (#0, #1)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 > CREATE VIEW v2 AS SELECT * FROM t1;
 > CREATE DEFAULT INDEX ON v2;
 
-> EXPLAIN SELECT DISTINCT key1, key2 FROM v2;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1, key2 FROM v2;
 "Explained Query (fast path):  Project (#0, #1)    ReadIndex on=v2 v2_primary_idx=[*** full scan ***]Used Indexes:  - v2_primary_idx (*** full scan ***)"
 
 # Make sure that having a DISTINCT or GROUP BY confers PK semantics on upstream views
@@ -122,24 +122,24 @@ $ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys
 > CREATE VIEW distinct_view AS SELECT DISTINCT nokey FROM t1;
 > CREATE DEFAULT INDEX ON distinct_view;
 
-> EXPLAIN SELECT DISTINCT nokey FROM distinct_view
+> EXPLAIN WITH(no_notices) SELECT DISTINCT nokey FROM distinct_view
 "Explained Query (fast path):  ReadIndex on=distinct_view distinct_view_primary_idx=[*** full scan ***]Used Indexes:  - distinct_view_primary_idx (*** full scan ***)"
 
 > CREATE VIEW group_by_view AS SELECT nokey || 'a' AS f1 , nokey || 'b' AS f2 FROM t1 GROUP BY nokey || 'a', nokey || 'b';
 > CREATE DEFAULT INDEX ON group_by_view;
 
-> EXPLAIN SELECT DISTINCT f1, f2 FROM group_by_view;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT f1, f2 FROM group_by_view;
 "Explained Query (fast path):  ReadIndex on=group_by_view group_by_view_primary_idx=[*** full scan ***]Used Indexes:  - group_by_view_primary_idx (*** full scan ***)"
 
 # Redundant table is eliminated from an inner join using PK information
 
-> EXPLAIN SELECT a1.* FROM t1 AS a1, t1 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
+> EXPLAIN WITH(no_notices) SELECT a1.* FROM t1 AS a1, t1 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
 "Explained Query (fast path):  ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT a1.* FROM v1 AS a1, v1 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
+> EXPLAIN WITH(no_notices) SELECT a1.* FROM v1 AS a1, v1 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
 "Explained Query (fast path):  ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT a1.* FROM v2 AS a1, v2 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
+> EXPLAIN WITH(no_notices) SELECT a1.* FROM v2 AS a1, v2 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
 "Explained Query (fast path):  ReadIndex on=v2 v2_primary_idx=[*** full scan ***]Used Indexes:  - v2_primary_idx (*** full scan ***)"
 
 # Declare a key constraint (PRIMARY KEY NOT ENFORCED); otherwise identical tests as above.
@@ -168,64 +168,64 @@ $ kafka-ingest format=avro topic=t1-pkne schema=${schema}
 
 # Optimization is possible - no distinct is mentioned in the plan
 
-> EXPLAIN SELECT DISTINCT key1, key2 FROM t1_pkne;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1, key2 FROM t1_pkne;
 "Explained Query (fast path):  Project (#0, #1)    ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT DISTINCT key2, key1 FROM t1_pkne;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key2, key1 FROM t1_pkne;
 "Explained Query (fast path):  Project (#1, #0)    ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT DISTINCT key2, key1, key2 FROM t1_pkne;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key2, key1, key2 FROM t1_pkne;
 "Explained Query (fast path):  Project (#1, #0, #1)    ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT key2, key1 FROM t1_pkne GROUP BY key1, key2;
+> EXPLAIN WITH(no_notices) SELECT key2, key1 FROM t1_pkne GROUP BY key1, key2;
 "Explained Query (fast path):  Project (#1, #0)    ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT key2, key1 FROM t1_pkne GROUP BY key1, key2, key2 || 'a';
+> EXPLAIN WITH(no_notices) SELECT key2, key1 FROM t1_pkne GROUP BY key1, key2, key2 || 'a';
 "Explained Query (fast path):  Project (#1, #0)    ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT DISTINCT key1, key2, nokey FROM t1_pkne;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1, key2, nokey FROM t1_pkne;
 "Explained Query (fast path):  ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT key1, key2, nokey FROM t1_pkne GROUP BY key1, key2, nokey;
+> EXPLAIN WITH(no_notices) SELECT key1, key2, nokey FROM t1_pkne GROUP BY key1, key2, nokey;
 "Explained Query (fast path):  ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT key1, key2 FROM t1_pkne GROUP BY key1, key2 HAVING key1 = 'a';
-"Explained Query (fast path):  Project (#3, #1)    Filter (#0 = \"a\")      Map (\"a\")        ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_pkne_primary_idx on t1_pkne(#0{key1}, #1{key2}) is too wide to use for literal equalities `#0{key1} = \"a\"`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{key1})."
+> EXPLAIN WITH(no_notices) SELECT key1, key2 FROM t1_pkne GROUP BY key1, key2 HAVING key1 = 'a';
+"Explained Query (fast path):  Project (#3, #1)    Filter (#0 = \"a\")      Map (\"a\")        ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
 # Optimization not possible - explicit distinct is present in plan
 
-> EXPLAIN SELECT DISTINCT key1 FROM t1_pkne;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1 FROM t1_pkne;
 "Explained Query:  Distinct project=[#0] monotonic    Project (#0)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT DISTINCT key2 FROM t1_pkne;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key2 FROM t1_pkne;
 "Explained Query:  Distinct project=[#0] monotonic    Project (#1)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT DISTINCT key1, upper(key2) FROM t1_pkne;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1, upper(key2) FROM t1_pkne;
 "Explained Query:  Distinct project=[#0, upper(#1)] monotonic    Project (#0, #1)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT DISTINCT key1, key2 || 'a' FROM t1_pkne;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1, key2 || 'a' FROM t1_pkne;
 "Explained Query:  Distinct project=[#0, (#1 || \"a\")] monotonic    Project (#0, #1)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT key1 FROM t1_pkne GROUP BY key1;
+> EXPLAIN WITH(no_notices) SELECT key1 FROM t1_pkne GROUP BY key1;
 "Explained Query:  Distinct project=[#0] monotonic    Project (#0)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT key2 FROM t1_pkne GROUP BY key2;
+> EXPLAIN WITH(no_notices) SELECT key2 FROM t1_pkne GROUP BY key2;
 "Explained Query:  Distinct project=[#0] monotonic    Project (#1)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT COUNT(DISTINCT key1) FROM t1_pkne;
+> EXPLAIN WITH(no_notices) SELECT COUNT(DISTINCT key1) FROM t1_pkne;
 "Explained Query:  Return    Union      Get l0      Map (0)        Union          Negate            Project ()              Get l0          Constant            - ()  With    cte l0 =      Reduce aggregates=[count(distinct #0)] monotonic        Project (#0)          ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
 # Make sure that primary key information is inherited from the source
 
 > CREATE VIEW v1_pkne AS SELECT * FROM t1_pkne;
 
-> EXPLAIN SELECT DISTINCT key1, key2 FROM v1_pkne;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1, key2 FROM v1_pkne;
 "Explained Query (fast path):  Project (#0, #1)    ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
 > CREATE VIEW v2_pkne AS SELECT * FROM t1_pkne;
 > CREATE DEFAULT INDEX ON v2_pkne;
 
-> EXPLAIN SELECT DISTINCT key1, key2 FROM v2_pkne;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT key1, key2 FROM v2_pkne;
 "Explained Query (fast path):  Project (#0, #1)    ReadIndex on=v2_pkne v2_pkne_primary_idx=[*** full scan ***]Used Indexes:  - v2_pkne_primary_idx (*** full scan ***)"
 
 # Make sure that having a DISTINCT or GROUP BY confers PK semantics on upstream views
@@ -233,22 +233,22 @@ $ kafka-ingest format=avro topic=t1-pkne schema=${schema}
 > CREATE VIEW distinct_view_pkne AS SELECT DISTINCT nokey FROM t1_pkne;
 > CREATE DEFAULT INDEX ON distinct_view_pkne;
 
-> EXPLAIN SELECT DISTINCT nokey FROM distinct_view_pkne
+> EXPLAIN WITH(no_notices) SELECT DISTINCT nokey FROM distinct_view_pkne
 "Explained Query (fast path):  ReadIndex on=distinct_view_pkne distinct_view_pkne_primary_idx=[*** full scan ***]Used Indexes:  - distinct_view_pkne_primary_idx (*** full scan ***)"
 
 > CREATE VIEW group_by_view_pkne AS SELECT nokey || 'a' AS f1 , nokey || 'b' AS f2 FROM t1_pkne GROUP BY nokey || 'a', nokey || 'b';
 > CREATE DEFAULT INDEX ON group_by_view_pkne;
 
-> EXPLAIN SELECT DISTINCT f1, f2 FROM group_by_view_pkne;
+> EXPLAIN WITH(no_notices) SELECT DISTINCT f1, f2 FROM group_by_view_pkne;
 "Explained Query (fast path):  ReadIndex on=group_by_view_pkne group_by_view_pkne_primary_idx=[*** full scan ***]Used Indexes:  - group_by_view_pkne_primary_idx (*** full scan ***)"
 
 # Redundant table is eliminated from an inner join using PK information
 
-> EXPLAIN SELECT a1.* FROM t1_pkne AS a1, t1_pkne AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
+> EXPLAIN WITH(no_notices) SELECT a1.* FROM t1_pkne AS a1, t1_pkne AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
 "Explained Query (fast path):  ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT a1.* FROM v1_pkne AS a1, v1_pkne AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
+> EXPLAIN WITH(no_notices) SELECT a1.* FROM v1_pkne AS a1, v1_pkne AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
 "Explained Query (fast path):  ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT a1.* FROM v2_pkne AS a1, v2_pkne AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
+> EXPLAIN WITH(no_notices) SELECT a1.* FROM v2_pkne AS a1, v2_pkne AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
 "Explained Query (fast path):  ReadIndex on=v2_pkne v2_pkne_primary_idx=[*** full scan ***]Used Indexes:  - v2_pkne_primary_idx (*** full scan ***)"

--- a/test/testdrive/subexpression-replacement.td
+++ b/test/testdrive/subexpression-replacement.td
@@ -24,99 +24,99 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 
 # The simplest expression there could be
 
-> EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL AND (col_null IS NULL AND col_not_null = 5);
-"Explained Query (fast path):  Filter (#0) IS NULL AND (#1 = 5)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(#0{col_null}, #1{col_not_null}) is too wide to use for literal equalities `#1{col_not_null} = 5`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{col_not_null})."
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_null IS NULL AND (col_null IS NULL AND col_not_null = 5);
+"Explained Query (fast path):  Filter (#0) IS NULL AND (#1 = 5)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT * FROM t1 WHERE col_not_null = 1 AND (col_not_null = 1 AND col_null = 5);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_not_null = 1 AND (col_not_null = 1 AND col_null = 5);
 "Explained Query (fast path):  Project (#0, #1)    ReadIndex on=t1 t1_primary_idx=[lookup value=(5, 1)]Used Indexes:  - t1_primary_idx (lookup)"
 
 # NULL-able expressions are dedupped
-> EXPLAIN SELECT * FROM t1 WHERE col_null = 1 AND (col_null = 1 AND col_not_null = 5);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_null = 1 AND (col_null = 1 AND col_not_null = 5);
 "Explained Query (fast path):  Project (#0, #1)    ReadIndex on=t1 t1_primary_idx=[lookup value=(1, 5)]Used Indexes:  - t1_primary_idx (lookup)"
 
 # OR/disjunction at the top level
 
-> EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL OR (col_null IS NULL AND col_not_null = 5);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_null IS NULL OR (col_null IS NULL AND col_not_null = 5);
 "Explained Query (fast path):  Filter (#0) IS NULL    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL OR col_null IS NULL OR (col_null IS NULL AND col_not_null = 5);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_null IS NULL OR col_null IS NULL OR (col_null IS NULL AND col_not_null = 5);
 "Explained Query (fast path):  Filter (#0) IS NULL    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 
-> EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL OR (col_null IS NULL AND col_not_null = 5) OR (col_null IS NULL AND col_not_null = 6);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_null IS NULL OR (col_null IS NULL AND col_not_null = 5) OR (col_null IS NULL AND col_not_null = 6);
 "Explained Query (fast path):  Filter (#0) IS NULL    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # OR/disjunction at the lower level
 
-> EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL AND (col_null IS NULL OR col_not_null = 5);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_null IS NULL AND (col_null IS NULL OR col_not_null = 5);
 "Explained Query (fast path):  Filter (#0) IS NULL    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # Nested OR/disjunction
 
-> EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL OR (col_null IS NULL OR col_not_null = 5);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_null IS NULL OR (col_null IS NULL OR col_not_null = 5);
 "Explained Query (fast path):  Filter ((#0) IS NULL OR (#1 = 5))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # A more complex expression
 
-> EXPLAIN SELECT * FROM t1 WHERE (col_not_null + 1 / col_not_null) = 5 AND ((col_not_null + 1 / col_not_null) = 5 AND col_null = 6);
-"Explained Query (fast path):  Filter (#0 = 6) AND (5 = (#1 + (1 / #1)))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(#0{col_null}, #1{col_not_null}) is too wide to use for literal equalities `#0{col_null} = 6`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{col_null}, (#1{col_not_null} + (1 / #1{col_not_null})))."
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE (col_not_null + 1 / col_not_null) = 5 AND ((col_not_null + 1 / col_not_null) = 5 AND col_null = 6);
+"Explained Query (fast path):  Filter (#0 = 6) AND (5 = (#1 + (1 / #1)))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # More nesting
 
-> EXPLAIN SELECT * FROM t1 WHERE col_not_null + col_not_null + col_not_null = 5 AND (col_not_null + col_not_null + col_not_null = 5);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_not_null + col_not_null + col_not_null = 5 AND (col_not_null + col_not_null + col_not_null = 5);
 "Explained Query (fast path):  Filter (5 = ((#1 + #1) + #1))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # The common expression contains an AND/conjunction itself
 
-> EXPLAIN SELECT * FROM t1 WHERE ((col_not_null > 3) AND (col_not_null < 5)) AND ((col_not_null > 3) AND (col_not_null < 5) OR col_not_null = 10);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE ((col_not_null > 3) AND (col_not_null < 5)) AND ((col_not_null > 3) AND (col_not_null < 5) OR col_not_null = 10);
 "Explained Query (fast path):  Filter (#1 < 5) AND (#1 > 3)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # The common expression contains an OR/disjunction
 
-> EXPLAIN SELECT * FROM t1 WHERE ((col_not_null > 3) OR (col_not_null < 5)) OR ((col_not_null > 3) OR (col_not_null < 5));
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE ((col_not_null > 3) OR (col_not_null < 5)) OR ((col_not_null > 3) OR (col_not_null < 5));
 "Explained Query (fast path):  Filter ((#1 < 5) OR (#1 > 3))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # Use of a deterministic function
 
-> EXPLAIN SELECT * FROM t1 WHERE col_not_null % 2 = 5 AND (col_not_null % 2 = 5 IS NULL);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_not_null % 2 = 5 AND (col_not_null % 2 = 5 IS NULL);
 "Explained Query (fast path):  Constant <empty>"
 
 # This is not optimized
-> EXPLAIN SELECT * FROM t1 WHERE (col_not_null % 2) = 1 AND (((col_not_null % 2) = 1) = TRUE);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE (col_not_null % 2) = 1 AND (((col_not_null % 2) = 1) = TRUE);
 "Explained Query (fast path):  Filter (1 = (#1 % 2))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # Column used on both sides of the expression
-> EXPLAIN SELECT * FROM t1 WHERE (col_not_null = col_not_null + 1) AND (col_not_null = col_not_null + 1);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE (col_not_null = col_not_null + 1) AND (col_not_null = col_not_null + 1);
 "Explained Query (fast path):  Filter (#1 = (#1 + 1))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # TODO (https://github.com/MaterializeInc/materialize/issues/6262):  Avoid simplifying mz_sleep.
 
-> EXPLAIN SELECT * FROM t1
+> EXPLAIN WITH(no_notices) SELECT * FROM t1
   WHERE mz_unsafe.mz_sleep(col_not_null) > mz_unsafe.mz_sleep(col_not_null)
   AND (mz_unsafe.mz_sleep(col_not_null) > mz_unsafe.mz_sleep(col_not_null) = true);
 "Explained Query (fast path):  Project (#0, #1)    Filter (#2 > #2)      Map (mz_sleep(integer_to_double(#1)))        ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # IN list inside the expression
 
-> EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (2, 3);
-"Explained Query (fast path):  Filter ((#1 = 2) OR (#1 = 3))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(#0{col_null}, #1{col_not_null}) is too wide to use for literal equalities `#1{col_not_null} IN (2, 3)`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{col_not_null})."
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (2, 3);
+"Explained Query (fast path):  Filter ((#1 = 2) OR (#1 = 3))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # Partial matches
 
-> EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (3, 4);
-"Explained Query (fast path):  Filter (#1 = 3)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(#0{col_null}, #1{col_not_null}) is too wide to use for literal equalities `#1{col_not_null} = 3`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{col_not_null})."
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (3, 4);
+"Explained Query (fast path):  Filter (#1 = 3)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
-> EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (4, 5);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (4, 5);
 "Explained Query (fast path):  Constant <empty>"
 
 # Expression inside an IN list
 
 # Optimized in AND/conjunctions
 
-> EXPLAIN SELECT * FROM t1 WHERE col_not_null = 1 AND TRUE IN (col_not_null = 1, col_not_null = 2);
-"Explained Query (fast path):  Filter (#1 = 1)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(#0{col_null}, #1{col_not_null}) is too wide to use for literal equalities `#1{col_not_null} = 1`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{col_not_null})."
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_not_null = 1 AND TRUE IN (col_not_null = 1, col_not_null = 2);
+"Explained Query (fast path):  Filter (#1 = 1)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # Not optimized in OR/disjunctions
 
-> EXPLAIN SELECT * FROM t1 WHERE col_not_null = 1 OR TRUE IN (col_not_null = 1, col_not_null = 2);
+> EXPLAIN WITH(no_notices) SELECT * FROM t1 WHERE col_not_null = 1 OR TRUE IN (col_not_null = 1, col_not_null = 2);
 "Explained Query (fast path):  Project (#0, #1)    Filter (#2 OR (#2 = true) OR (true = (#1 = 2)))      Map ((#1 = 1))        ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"


### PR DESCRIPTION
**Note**: This is a clone of #23683 because I accidentally deleted the original PR branch.

Add support for `EXPLAIN WITH(redacted)` output which replaces literals with █.

The flag should be auto-set for `mz_support` when the `CollectionPlan::depends_on` for the source expression contains a source for which `mz_support` only has `USAGE` (and no `SELECT` privileges). Since the flag is only implemented for `EXPLAIN AS TEXT`, all other output formats should be done with the regular RBAC check (asserting `SELECT` on all dependencies).

### Motivation

  * This PR adds a known-desirable feature.

Fixes MaterializeInc/cloud#8196.

### Tips for reviewer

#### Reviewed in #23360

- adapter: don't add `CatalogPlans` entries for `SUBSCRIBE`
- adapter: implement `ExprHumanizer` for `CatalogState`
- explain: add `no_notices` flag
- explain: fix `OptimizerNotice` rendering

#### New in this PR

- fix context type in `DisplayText` for `FastPathPlan`
  - This just simplifies some of the existing code. See commit message for details.
- explain: evolve `HumanizedExpr` / `HumanizerMode` API
  - This is the main API change that facilitates emitting
    redacted literals. See commit message for details.
- explain: add `CompactScalars` and `fmt::Display` implementation
  - Another code simplification.  See commit message for details.
- explain: redacted text output
  - Fix broken code and implement `EXPLAIN WITH(redacted)` for MIR-based plans.
- test: fix broken tests, add `EXPLAIN WITH(redacted)` tests
  - Fix broken tests and add a dedicated test file for redacted MIR output.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
