### PR TITLE
adapter: Move mz_aclitem to mz_catalog

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -1589,7 +1589,7 @@ pub const TYPE_TSTZ_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
 
 pub const TYPE_MZ_ACL_ITEM: BuiltinType<NameReference> = BuiltinType {
     name: "mz_aclitem",
-    schema: MZ_INTERNAL_SCHEMA,
+    schema: MZ_CATALOG_SCHEMA,
     oid: mz_pgrepr::oid::TYPE_MZ_ACL_ITEM_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::MzAclItem,
@@ -1600,7 +1600,7 @@ pub const TYPE_MZ_ACL_ITEM: BuiltinType<NameReference> = BuiltinType {
 
 pub const TYPE_MZ_ACL_ITEM_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_mz_aclitem",
-    schema: MZ_INTERNAL_SCHEMA,
+    schema: MZ_CATALOG_SCHEMA,
     oid: mz_pgrepr::oid::TYPE_MZ_ACL_ITEM_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {


### PR DESCRIPTION
This commit updates the schema of mz_aclitem from mz_internal to mz_catalog. Due to
https://github.com/MaterializeInc/materialize/issues/23833, mz_aclitem has actually always been in the pg_catalog schema, and will remain in the pg_catalog schema after this change. However, the type has pretended to be in the mz_internal schema for long enough that it is now stable, so it's ready to pretend to be in the mz_catalog schema.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
