### PR TITLE
Add REFRESH options for MVs -- parsing, purification, planning

### DIFF
--- a/misc/dbt-materialize/tests/adapter/test_constraints.py
+++ b/misc/dbt-materialize/tests/adapter/test_constraints.py
@@ -131,7 +131,7 @@ class TestNullabilityAssertions:
             fetch="one",
         )
         assert (
-            'WITH (ASSERT NOT NULL = "a", ASSERT NOT NULL = "b")'
+            'ASSERT NOT NULL = "a", ASSERT NOT NULL = "b"'
             in nullability_assertions_ddl[1]
         )
 

--- a/misc/python/materialize/checks/all_checks/null_value.py
+++ b/misc/python/materialize/checks/all_checks/null_value.py
@@ -70,7 +70,7 @@ class NullValue(Check):
                 <null> <null> <null>
 
                 > SHOW CREATE MATERIALIZED VIEW null_value_view2;
-                materialize.public.null_value_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"null_value_view2\\" IN CLUSTER \\"{self._default_cluster()}\\" AS SELECT \\"f1\\", \\"f2\\", NULL FROM \\"materialize\\".\\"public\\".\\"null_value_table\\" WHERE \\"f1\\" IS NULL OR \\"f1\\" IS NOT NULL OR \\"f1\\" = NULL"
+                materialize.public.null_value_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"null_value_view2\\" IN CLUSTER \\"{self._default_cluster()}\\" WITH (REFRESH = ON COMMIT) AS SELECT \\"f1\\", \\"f2\\", NULL FROM \\"materialize\\".\\"public\\".\\"null_value_table\\" WHERE \\"f1\\" IS NULL OR \\"f1\\" IS NOT NULL OR \\"f1\\" = NULL"
 
                 > SELECT * FROM null_value_view2;
                 <null> <null> <null>

--- a/misc/python/materialize/checks/all_checks/text_bytea_types.py
+++ b/misc/python/materialize/checks/all_checks/text_bytea_types.py
@@ -53,7 +53,7 @@ class TextByteaTypes(Check):
             dedent(
                 f"""
                 > SHOW CREATE MATERIALIZED VIEW string_bytea_types_view1;
-                materialize.public.string_bytea_types_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"string_bytea_types_view1\\" IN CLUSTER \\"{self._default_cluster()}\\" AS SELECT \\"text_col\\", \\"bytea_col\\", 'това'::\\"pg_catalog\\".\\"text\\", '\\\\xAAAA'::\\"pg_catalog\\".\\"bytea\\" FROM \\"materialize\\".\\"public\\".\\"text_bytea_types_table\\" WHERE \\"text_col\\" >= ''::\\"pg_catalog\\".\\"text\\" AND \\"bytea_col\\" >= ''::\\"pg_catalog\\".\\"bytea\\""
+                materialize.public.string_bytea_types_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"string_bytea_types_view1\\" IN CLUSTER \\"{self._default_cluster()}\\" WITH (REFRESH = ON COMMIT) AS SELECT \\"text_col\\", \\"bytea_col\\", 'това'::\\"pg_catalog\\".\\"text\\", '\\\\xAAAA'::\\"pg_catalog\\".\\"bytea\\" FROM \\"materialize\\".\\"public\\".\\"text_bytea_types_table\\" WHERE \\"text_col\\" >= ''::\\"pg_catalog\\".\\"text\\" AND \\"bytea_col\\" >= ''::\\"pg_catalog\\".\\"bytea\\""
 
                 > SELECT text_col, text, LENGTH(bytea_col), LENGTH(bytea) FROM string_bytea_types_view1;
                 aaaa това 2 2

--- a/misc/python/materialize/checks/all_checks/top_k.py
+++ b/misc/python/materialize/checks/all_checks/top_k.py
@@ -60,14 +60,14 @@ class BasicTopK(Check):
             dedent(
                 f"""
                 > SHOW CREATE MATERIALIZED VIEW basic_topk_view1;
-                materialize.public.basic_topk_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"basic_topk_view1\\" IN CLUSTER \\"{self._default_cluster()}\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"basic_topk_table\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 2"
+                materialize.public.basic_topk_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"basic_topk_view1\\" IN CLUSTER \\"{self._default_cluster()}\\" WITH (REFRESH = ON COMMIT) AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"basic_topk_table\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 2"
 
                 > SELECT * FROM basic_topk_view1;
                 2 32
                 3 48
 
                 > SHOW CREATE MATERIALIZED VIEW basic_topk_view2;
-                materialize.public.basic_topk_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"basic_topk_view2\\" IN CLUSTER \\"{self._default_cluster()}\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"basic_topk_table\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 2"
+                materialize.public.basic_topk_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"basic_topk_view2\\" IN CLUSTER \\"{self._default_cluster()}\\" WITH (REFRESH = ON COMMIT) AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"basic_topk_table\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 2"
 
                 > SELECT * FROM basic_topk_view2;
                 1 16
@@ -123,14 +123,14 @@ class MonotonicTopK(Check):
             dedent(
                 f"""
                 > SHOW CREATE MATERIALIZED VIEW monotonic_topk_view1;
-                materialize.public.monotonic_topk_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_topk_view1\\" IN CLUSTER \\"{self._default_cluster()}\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_topk_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 2"
+                materialize.public.monotonic_topk_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_topk_view1\\" IN CLUSTER \\"{self._default_cluster()}\\" WITH (REFRESH = ON COMMIT) AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_topk_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 2"
 
                 > SELECT * FROM monotonic_topk_view1;
                 E 5
                 D 4
 
                 > SHOW CREATE MATERIALIZED VIEW monotonic_topk_view2;
-                materialize.public.monotonic_topk_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_topk_view2\\" IN CLUSTER \\"{self._default_cluster()}\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_topk_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 2"
+                materialize.public.monotonic_topk_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_topk_view2\\" IN CLUSTER \\"{self._default_cluster()}\\" WITH (REFRESH = ON COMMIT) AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_topk_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 2"
 
                 > SELECT * FROM monotonic_topk_view2;
                 A 1
@@ -186,13 +186,13 @@ class MonotonicTop1(Check):
             dedent(
                 f"""
                 > SHOW CREATE MATERIALIZED VIEW monotonic_top1_view1;
-                materialize.public.monotonic_top1_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_top1_view1\\" IN CLUSTER \\"{self._default_cluster()}\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_top1_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 1"
+                materialize.public.monotonic_top1_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_top1_view1\\" IN CLUSTER \\"{self._default_cluster()}\\" WITH (REFRESH = ON COMMIT) AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_top1_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 1"
 
                 > SELECT * FROM monotonic_top1_view1;
                 D 5
 
                 > SHOW CREATE MATERIALIZED VIEW monotonic_top1_view2;
-                materialize.public.monotonic_top1_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_top1_view2\\" IN CLUSTER \\"{self._default_cluster()}\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_top1_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 1"
+                materialize.public.monotonic_top1_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_top1_view2\\" IN CLUSTER \\"{self._default_cluster()}\\" WITH (REFRESH = ON COMMIT) AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_top1_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 1"
 
                 > SELECT * FROM monotonic_top1_view2;
                 A 1

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4217,6 +4217,10 @@ impl SessionCatalog for ConnCatalog<'_> {
         }
     }
 
+    fn get_system_type(&self, name: &str) -> &dyn mz_sql::catalog::CatalogItem {
+        self.state.get_system_type(name)
+    }
+
     fn try_get_item(&self, id: &GlobalId) -> Option<&dyn mz_sql::catalog::CatalogItem> {
         Some(self.state.try_get_entry(id)?)
     }

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -833,7 +833,12 @@ impl CatalogState {
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let create_stmt = mz_sql::parse::parse(&view.create_sql)
-            .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", view.create_sql))
+            .unwrap_or_else(|e| {
+                panic!(
+                    "create_sql cannot be invalid: `{}` --- error: `{}`",
+                    view.create_sql, e
+                )
+            })
             .into_element()
             .ast;
         let query = match &create_stmt {
@@ -875,7 +880,12 @@ impl CatalogState {
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let create_stmt = mz_sql::parse::parse(&mview.create_sql)
-            .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", mview.create_sql))
+            .unwrap_or_else(|e| {
+                panic!(
+                    "create_sql cannot be invalid: `{}` --- error: `{}`",
+                    mview.create_sql, e
+                )
+            })
             .into_element()
             .ast;
         let query = match &create_stmt {
@@ -975,7 +985,12 @@ impl CatalogState {
         let mut updates = vec![];
 
         let create_stmt = mz_sql::parse::parse(&index.create_sql)
-            .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", index.create_sql))
+            .unwrap_or_else(|e| {
+                panic!(
+                    "create_sql cannot be invalid: `{}` --- error: `{}`",
+                    index.create_sql, e
+                )
+            })
             .into_element()
             .ast;
 

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -17,7 +17,10 @@ use mz_ore::now::{EpochMillis, NowFn};
 use mz_repr::namespaces::PG_CATALOG_SCHEMA;
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::catalog::NameReference;
-use mz_sql_parser::ast::{visit_mut, Ident, Raw, RawDataType, Statement};
+use mz_sql_parser::ast::{
+    visit_mut, CreateMaterializedViewStatement, Ident, MaterializedViewOption,
+    MaterializedViewOptionName, Raw, RawDataType, RefreshOptionValue, Statement,
+};
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::sources::GenericSourceConnection;
@@ -94,6 +97,10 @@ pub(crate) async fn migrate(
                 ast_rewrite_create_sink_into_kafka_options_0_80_0(stmt)?;
             }
             ast_rewrite_rewrite_type_schemas_0_81_0(stmt);
+
+            if catalog_version <= Version::new(0, 81, u64::MAX) {
+                ast_rewrite_create_materialized_view_refresh_options_0_82_0(stmt)?;
+            }
 
             Ok(())
         })
@@ -344,6 +351,37 @@ fn persist_default_cluster_0_82_0(
     if !already_set {
         txn.upsert_system_config(CLUSTER_KEY, "default".to_string())?;
     }
+
+    Ok(())
+}
+
+fn ast_rewrite_create_materialized_view_refresh_options_0_82_0(
+    stmt: &mut Statement<Raw>,
+) -> Result<(), anyhow::Error> {
+    use mz_sql::ast::visit_mut::VisitMut;
+    use mz_sql::ast::WithOptionValue;
+
+    struct Rewriter;
+
+    impl<'ast> VisitMut<'ast, Raw> for Rewriter {
+        fn visit_create_materialized_view_statement_mut(
+            &mut self,
+            node: &'ast mut CreateMaterializedViewStatement<Raw>,
+        ) {
+            if !node
+                .with_options
+                .iter()
+                .any(|option| matches!(option.name, MaterializedViewOptionName::Refresh))
+            {
+                node.with_options.push(MaterializedViewOption {
+                    name: MaterializedViewOptionName::Refresh,
+                    value: Some(WithOptionValue::Refresh(RefreshOptionValue::OnCommit)),
+                })
+            }
+        }
+    }
+
+    Rewriter.visit_statement_mut(stmt);
 
     Ok(())
 }

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1921,6 +1921,7 @@ mod builtin_migration_tests {
                         cluster_id: ClusterId::User(1),
                         non_null_assertions: vec![],
                         custom_logical_compaction_window: None,
+                        refresh_schedule: None,
                     })
                 }
                 SimplifiedItem::Index { on } => {

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -571,7 +571,7 @@ impl CatalogState {
         self.entry_by_id.get_mut(id).expect("catalog out of sync")
     }
 
-    /// Gets an type named `name` from exactly one of the system schemas.
+    /// Gets a type named `name` from exactly one of the system schemas.
     ///
     /// # Panics
     /// - If `name` is not an entry in any system schema

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -942,6 +942,7 @@ impl CatalogState {
                     cluster_id: materialized_view.cluster_id,
                     non_null_assertions: materialized_view.non_null_assertions,
                     custom_logical_compaction_window: materialized_view.compaction_window,
+                    refresh_schedule: materialized_view.refresh_schedule,
                 })
             }
             Plan::CreateIndex(CreateIndexPlan { index, .. }) => CatalogItem::Index(Index {

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -26,9 +26,12 @@ use mz_sql::ast::{
     CopyRelation, CopyStatement, InsertSource, Query, Raw, SetExpr, Statement, SubscribeStatement,
 };
 use mz_sql::catalog::RoleAttributes;
-use mz_sql::names::{PartialItemName, ResolvedIds};
+use mz_sql::names::{Aug, PartialItemName, ResolvedIds};
 use mz_sql::plan::{
     AbortTransactionPlan, CommitTransactionPlan, CreateRolePlan, Params, Plan, TransactionType,
+};
+use mz_sql::pure::{
+    materialized_view_option_contains_temporal, purify_create_materialized_view_options,
 };
 use mz_sql::rbac;
 use mz_sql::rbac::CREATE_ITEM_USAGE;
@@ -36,6 +39,8 @@ use mz_sql::session::user::User;
 use mz_sql::session::vars::{
     EndTransactionAction, OwnedVarInput, Value, Var, STATEMENT_LOGGING_SAMPLE_RATE,
 };
+use mz_sql_parser::ast::CreateMaterializedViewStatement;
+use mz_storage_types::sources::Timeline;
 use opentelemetry::trace::TraceContextExt;
 use tokio::sync::{mpsc, oneshot, watch};
 use tracing::{debug_span, Instrument};
@@ -616,7 +621,7 @@ impl Coordinator {
         let original_stmt = Arc::clone(&stmt);
         // `resolved_ids` should be derivable from `stmt`. If `stmt` is transformed to remove/add
         // IDs, then `resolved_ids` should be updated to also remove/add those IDs.
-        let (stmt, resolved_ids) = match mz_sql::names::resolve(&catalog, (*stmt).clone()) {
+        let (stmt, mut resolved_ids) = match mz_sql::names::resolve(&catalog, (*stmt).clone()) {
             Ok(resolved) => resolved,
             Err(e) => return ctx.retire(Err(e.into())),
         };
@@ -684,6 +689,85 @@ impl Coordinator {
             Statement::CreateSubsource(_) => ctx.retire(Err(AdapterError::Unsupported(
                 "CREATE SUBSOURCE statements",
             ))),
+
+            Statement::CreateMaterializedView(mut cmvs) => {
+                // (This won't be the same timestamp as the system table inserts, unfortunately.)
+                let mz_now = if cmvs
+                    .with_options
+                    .iter()
+                    .any(materialized_view_option_contains_temporal)
+                {
+                    let timeline_context =
+                        match self.validate_timeline_context(resolved_ids.0.clone()) {
+                            Ok(tc) => tc,
+                            Err(e) => return ctx.retire(Err(e)),
+                        };
+
+                    // We default to EpochMilliseconds, similarly to `determine_timestamp_for`,
+                    // but even in the TimestampIndependent case.
+                    // Note that we didn't accurately decide whether we are TimestampDependent
+                    // or TimestampIndependent, because for this we'd need to also check whether
+                    // `query.contains_temporal()`, similarly to how `peek_stage_validate` does.
+                    // However, this doesn't matter here, as we are just going to default to
+                    // EpochMilliseconds in both cases.
+                    let timeline = timeline_context
+                        .timeline()
+                        .unwrap_or(&Timeline::EpochMilliseconds);
+                    Some(self.get_timestamp_oracle(timeline).read_ts().await)
+                    // TODO: It might be good to take into account `least_valid_read` in addition to
+                    // the oracle's `read_ts`, but there are two problems:
+                    // 1. At this point, we don't know which indexes would be used. We could do an
+                    // overestimation here by grabbing the ids of all indexes that are on ids
+                    // involved in the query. (We'd have to recursively follow view definitions,
+                    // similarly to `validate_timeline_context`.)
+                    // 2. For a peek, when the `least_valid_read` is later than the oracle's
+                    // `read_ts`, then the peek doesn't return before it completes at the chosen
+                    // timestamp. However, for a CRATE MATERIALIZED VIEW statement, it's not clear
+                    // whether we want to make it block until the chosen time. If it doesn't block,
+                    // then the initial refresh wouldn't be linearized with the CREATE MATERIALIZED
+                    // VIEW statement.
+                    //
+                    // Note: The Adapter is usually keeping a read hold of all objects at the oracle
+                    // read timestamp, so `least_valid_read` usually won't actually be later than
+                    // the oracle's `read_ts`. (see `Coordinator::advance_timelines`)
+                    //
+                    // Note 2: If we choose a timestamp here that is earlier than
+                    // `least_valid_read`, that is somewhat bad, but not catastrophic: The only
+                    // bad thing that happens is that we won't perform that refresh that was
+                    // specified to be at `mz_now()` (which is usually the initial refresh)
+                    // (similarly to how we don't perform refreshes that were specified to be in the
+                    // past).
+                } else {
+                    None
+                };
+
+                let owned_catalog = self.owned_catalog();
+                let catalog = owned_catalog.for_session(ctx.session());
+
+                purify_create_materialized_view_options(
+                    catalog,
+                    mz_now,
+                    &mut cmvs,
+                    &mut resolved_ids,
+                );
+
+                let purified_stmt =
+                    Statement::CreateMaterializedView(CreateMaterializedViewStatement::<Aug> {
+                        if_exists: cmvs.if_exists,
+                        name: cmvs.name,
+                        columns: cmvs.columns,
+                        in_cluster: cmvs.in_cluster,
+                        query: cmvs.query,
+                        with_options: cmvs.with_options,
+                    });
+
+                // (Purifying CreateMaterializedView doesn't happen async, so no need to send
+                // `Message::PurifiedStatementReady` here.)
+                match self.plan_statement(ctx.session(), purified_stmt, &params, &resolved_ids) {
+                    Ok(plan) => self.sequence_plan(ctx, plan, resolved_ids).await,
+                    Err(e) => ctx.retire(Err(e)),
+                }
+            }
 
             // All other statements are handled immediately.
             _ => match self.plan_statement(ctx.session(), stmt, &params, &resolved_ids) {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -22,6 +22,7 @@ use maplit::{btreemap, btreeset};
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_cloud_resources::VpcEndpointConfig;
 use mz_controller_types::{ClusterId, ReplicaId};
+use mz_expr::refresh_schedule::RefreshSchedule;
 use mz_expr::{
     permutation_for_arrangement, CollectionPlan, MirScalarExpr, OptimizedMirRelationExpr,
     RowSetFinishing,
@@ -2755,6 +2756,7 @@ impl Coordinator {
                 cluster_id,
                 broken,
                 non_null_assertions,
+                refresh_schedule,
             } => {
                 // Please see the docs on `explain_query_optimizer_pipeline` above.
                 self.explain_create_materialized_view_optimizer_pipeline(
@@ -2764,6 +2766,7 @@ impl Coordinator {
                     cluster_id,
                     broken,
                     non_null_assertions,
+                    refresh_schedule,
                     &config,
                     root_dispatch,
                 )
@@ -3095,6 +3098,7 @@ impl Coordinator {
         target_cluster_id: ClusterId,
         broken: bool,
         non_null_assertions: Vec<usize>,
+        _refresh_schedule: Option<RefreshSchedule>,
         explain_config: &mz_repr::explain::ExplainConfig,
         _root_dispatch: tracing::Dispatch,
     ) -> Result<

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -26,6 +26,7 @@ use mz_controller::clusters::{
     ClusterRole, ClusterStatus, ProcessId, ReplicaConfig, ReplicaLogging,
 };
 use mz_controller_types::{ClusterId, ReplicaId};
+use mz_expr::refresh_schedule::RefreshSchedule;
 use mz_expr::{CollectionPlan, MirScalarExpr, OptimizedMirRelationExpr};
 use mz_ore::collections::CollectionExt;
 use mz_repr::adt::mz_acl_item::{AclMode, PrivilegeMap};
@@ -706,6 +707,7 @@ pub struct MaterializedView {
     pub cluster_id: ClusterId,
     pub non_null_assertions: Vec<usize>,
     pub custom_logical_compaction_window: Option<CompactionWindow>,
+    pub refresh_schedule: Option<RefreshSchedule>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -92,6 +92,7 @@ mod relation;
 mod scalar;
 
 pub mod explain;
+pub mod refresh_schedule;
 pub mod virtual_syntax;
 pub mod visit;
 

--- a/src/expr/src/refresh_schedule.rs
+++ b/src/expr/src/refresh_schedule.rs
@@ -1,0 +1,36 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use mz_repr::Timestamp;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct RefreshSchedule {
+    // `REFRESH EVERY`s
+    pub everies: Vec<RefreshEvery>,
+    // `REFRESH AT`s
+    pub ats: Vec<Timestamp>,
+}
+
+impl RefreshSchedule {
+    pub fn empty() -> RefreshSchedule {
+        RefreshSchedule {
+            everies: Vec::new(),
+            ats: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct RefreshEvery {
+    pub interval: Duration,
+    pub aligned_to: Timestamp,
+}

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -27,6 +27,7 @@ Access
 Add
 Addresses
 Aggregate
+Aligned
 All
 Alter
 And
@@ -93,6 +94,7 @@ Create
 Createcluster
 Createdb
 Createrole
+Creation
 Cross
 Csv
 Current
@@ -133,6 +135,7 @@ Enforced
 Envelope
 Error
 Escape
+Every
 Except
 Execute
 Exists

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -31,6 +31,8 @@ pub enum MaterializedViewOptionName {
     /// The `ASSERT NOT NULL [=] <ident>` option.
     AssertNotNull,
     RetainHistory,
+    /// The `REFRESH [=] ...` option.
+    Refresh,
 }
 
 impl AstDisplay for MaterializedViewOptionName {
@@ -38,6 +40,7 @@ impl AstDisplay for MaterializedViewOptionName {
         match self {
             MaterializedViewOptionName::AssertNotNull => f.write_str("ASSERT NOT NULL"),
             MaterializedViewOptionName::RetainHistory => f.write_str("RETAIN HISTORY"),
+            MaterializedViewOptionName::Refresh => f.write_str("REFRESH"),
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -92,48 +92,59 @@ impl AstDisplay for Value {
                 f.write_str("'");
             }
             Value::Boolean(v) => f.write_str(v),
-            Value::Interval(IntervalValue {
-                value,
-                precision_high,
-                precision_low,
-                fsec_max_precision,
-            }) => {
+            Value::Interval(interval_value) => {
                 f.write_str("INTERVAL '");
-                f.write_node(&display::escape_single_quote_string(value));
-                f.write_str("'");
-                match (precision_high, precision_low, fsec_max_precision) {
-                    (DateTimeField::Year, DateTimeField::Second, None) => {}
-                    (DateTimeField::Year, DateTimeField::Second, Some(ns)) => {
-                        f.write_str(" SECOND(");
-                        f.write_str(ns);
-                        f.write_str(")");
-                    }
-                    (DateTimeField::Year, low, None) => {
-                        f.write_str(" ");
-                        f.write_str(low);
-                    }
-                    (high, low, None) => {
-                        f.write_str(" ");
-                        f.write_str(high);
-                        f.write_str(" TO ");
-                        f.write_str(low);
-                    }
-                    (high, low, Some(ns)) => {
-                        f.write_str(" ");
-                        f.write_str(high);
-                        f.write_str(" TO ");
-                        f.write_str(low);
-                        f.write_str("(");
-                        f.write_str(ns);
-                        f.write_str(")");
-                    }
-                }
+                f.write_node(interval_value);
             }
             Value::Null => f.write_str("NULL"),
         }
     }
 }
 impl_display!(Value);
+
+impl AstDisplay for IntervalValue {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        if f.redacted() {
+            f.write_str("<REDACTED>'");
+        } else {
+            let IntervalValue {
+                value,
+                precision_high,
+                precision_low,
+                fsec_max_precision,
+            } = self;
+            f.write_node(&display::escape_single_quote_string(value));
+            f.write_str("'");
+            match (precision_high, precision_low, fsec_max_precision) {
+                (DateTimeField::Year, DateTimeField::Second, None) => {}
+                (DateTimeField::Year, DateTimeField::Second, Some(ns)) => {
+                    f.write_str(" SECOND(");
+                    f.write_str(ns);
+                    f.write_str(")");
+                }
+                (DateTimeField::Year, low, None) => {
+                    f.write_str(" ");
+                    f.write_str(low);
+                }
+                (high, low, None) => {
+                    f.write_str(" ");
+                    f.write_str(high);
+                    f.write_str(" TO ");
+                    f.write_str(low);
+                }
+                (high, low, Some(ns)) => {
+                    f.write_str(" ");
+                    f.write_str(high);
+                    f.write_str(" TO ");
+                    f.write_str(low);
+                    f.write_str("(");
+                    f.write_str(ns);
+                    f.write_str(")");
+                }
+            }
+        }
+    }
+}
 
 impl From<Ident> for Value {
     fn from(ident: Ident) -> Self {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -381,6 +381,20 @@ CREATE MATERIALIZED VIEW v IN CLUSTER [1] AS SELECT 1
 =>
 CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("v")]), columns: [], in_cluster: Some(Resolved("1")), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, with_options: [] })
 
+parse-statement
+CREATE MATERIALIZED VIEW v WITH (REFRESH EVERY '1 day', ASSERT NOT NULL x) AS SELECT * FROM t;
+----
+CREATE MATERIALIZED VIEW v WITH (REFRESH = EVERY '1 day', ASSERT NOT NULL = x) AS SELECT * FROM t
+=>
+CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("v")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, with_options: [MaterializedViewOption { name: Refresh, value: Some(Refresh(Every(RefreshEveryOptionValue { interval: IntervalValue { value: "1 day", precision_high: Year, precision_low: Second, fsec_max_precision: None }, aligned_to: None }))) }, MaterializedViewOption { name: AssertNotNull, value: Some(Ident(Ident("x"))) }] })
+
+parse-statement
+CREATE OR REPLACE MATERIALIZED VIEW v IN CLUSTER [1] WITH (REFRESH EVERY '1 day' ALIGNED TO '2023-12-11 11:00', ASSERT NOT NULL x, REFRESH AT mz_now(), REFRESH ON COMMIT, REFRESH = AT CREATION) AS SELECT * FROM t;
+----
+CREATE OR REPLACE MATERIALIZED VIEW v IN CLUSTER [1] WITH (REFRESH = EVERY '1 day' ALIGNED TO '2023-12-11 11:00', ASSERT NOT NULL = x, REFRESH = AT mz_now(), REFRESH = ON COMMIT, REFRESH = AT CREATION) AS SELECT * FROM t
+=>
+CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Replace, name: UnresolvedItemName([Ident("v")]), columns: [], in_cluster: Some(Resolved("1")), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, with_options: [MaterializedViewOption { name: Refresh, value: Some(Refresh(Every(RefreshEveryOptionValue { interval: IntervalValue { value: "1 day", precision_high: Year, precision_low: Second, fsec_max_precision: None }, aligned_to: Some(Value(String("2023-12-11 11:00"))) }))) }, MaterializedViewOption { name: AssertNotNull, value: Some(Ident(Ident("x"))) }, MaterializedViewOption { name: Refresh, value: Some(Refresh(At(RefreshAtOptionValue { time: Function(Function { name: Name(UnresolvedItemName([Ident("mz_now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }) }))) }, MaterializedViewOption { name: Refresh, value: Some(Refresh(OnCommit)) }, MaterializedViewOption { name: Refresh, value: Some(Refresh(AtCreation)) }] })
+
 parse-statement roundtrip
 CREATE OR REPLACE MATERIALIZED VIEW v WITH (ASSERT NOT NULL a, ASSERT NOT NULL = b, RETAIN HISTORY = FOR '1s') AS SELECT 1
 ----

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -232,6 +232,13 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync + ConnectionR
         self.resolve_item(name)
     }
 
+    /// Gets a type named `name` from exactly one of the system schemas.
+    ///
+    /// # Panics
+    /// - If `name` is not an entry in any system schema
+    /// - If more than one system schema has an entry named `name`.
+    fn get_system_type(&self, name: &str) -> &dyn CatalogItem;
+
     /// Gets an item by its ID.
     fn try_get_item(&self, id: &GlobalId) -> Option<&dyn CatalogItem>;
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -196,7 +196,9 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync + ConnectionR
         cluster_replica_name: &'b QualifiedReplica,
     ) -> Result<&dyn CatalogClusterReplica<'a>, CatalogError>;
 
-    /// Resolves a partially-specified item name.
+    /// Resolves a partially-specified item name, that is NOT a function or
+    /// type. (For resolving functions or types, please use
+    /// [SessionCatalog::resolve_function] or [SessionCatalog::resolve_type].)
     ///
     /// If the partial name has a database component, it searches only the
     /// specified database; otherwise, it searches the active database. If the

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1784,6 +1784,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
             ),
             ConnectionKafkaBroker(broker) => ConnectionKafkaBroker(self.fold_kafka_broker(broker)),
             RetainHistoryFor(value) => RetainHistoryFor(self.fold_value(value)),
+            Refresh(refresh) => Refresh(self.fold_refresh_option_value(refresh)),
         }
     }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -35,6 +35,7 @@ use enum_kinds::EnumKind;
 use maplit::btreeset;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_controller_types::{ClusterId, ReplicaId};
+use mz_expr::refresh_schedule::RefreshSchedule;
 use mz_expr::{CollectionPlan, ColumnOrder, MirRelationExpr, MirScalarExpr, RowSetFinishing};
 use mz_ore::now::{self, NOW_ZERO};
 use mz_pgcopy::CopyFormatParams;
@@ -864,6 +865,7 @@ pub enum ExplaineeStatement {
         /// Broken flag (see [`ExplaineeStatement::broken()`]).
         broken: bool,
         non_null_assertions: Vec<usize>,
+        refresh_schedule: Option<RefreshSchedule>,
     },
     /// The object to be explained is a CREATE INDEX.
     CreateIndex {
@@ -1438,6 +1440,7 @@ pub struct MaterializedView {
     pub cluster_id: ClusterId,
     pub non_null_assertions: Vec<usize>,
     pub compaction_window: Option<CompactionWindow>,
+    pub refresh_schedule: Option<RefreshSchedule>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -228,6 +228,8 @@ pub enum PlanError {
     LoadGeneratorSourcePurification(LoadGeneratorSourcePurificationError),
     CsrPurification(CsrPurificationError),
     MissingName(CatalogItemType),
+    InvalidRefreshAt,
+    InvalidRefreshEveryAlignedTo,
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -370,6 +372,10 @@ impl PlanError {
             }
             Self::RecursiveTypeMismatch(..) => {
                 Some("You will need to rewrite or cast the query's expressions.".into())
+            },
+            Self::InvalidRefreshAt
+            | Self::InvalidRefreshEveryAlignedTo => {
+                Some("Calling `mz_now()` is allowed.".into())
             },
             _ => None,
         }
@@ -598,6 +604,14 @@ impl fmt::Display for PlanError {
             }
             Self::MissingName(item_type) => {
                 write!(f, "unspecified name for {item_type}")
+            }
+            Self::InvalidRefreshAt => {
+                write!(f, "REFRESH AT argument must be an expression that can be simplified \
+                           and/or cast to a constant whose type is mz_timestamp")
+            }
+            Self::InvalidRefreshEveryAlignedTo => {
+                write!(f, "REFRESH EVERY ... ALIGNED TO argument must be an expression that can be simplified \
+                           and/or cast to a constant whose type is mz_timestamp")
             }
         }
     }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -3071,6 +3071,28 @@ impl HirScalarExpr {
             }
         })
     }
+
+    /// Attempts to simplify this expression to a literal MzTimestamp.
+    ///
+    /// Returns `None` if this expression cannot be simplified, e.g. because it
+    /// contains non-literal values.
+    ///
+    /// TODO: Make this (and the other similar fns above) return Result, so that we can show the
+    /// error when it fails. (E.g., there can be non-trivial cast errors.)
+    ///
+    /// # Panics
+    ///
+    /// Panics if this expression does not have type [`ScalarType::MzTimestamp`].
+    pub fn into_literal_mz_timestamp(self) -> Option<Timestamp> {
+        self.simplify_to_literal().and_then(|row| {
+            let datum = row.unpack_first();
+            if datum.is_null() {
+                None
+            } else {
+                Some(datum.unwrap_mz_timestamp())
+            }
+        })
+    }
 }
 
 impl VisitChildren<Self> for HirScalarExpr {

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -241,7 +241,8 @@ pub fn describe(
 /// Planning is a pure, synchronous function and so requires that the provided
 /// `stmt` does does not depend on any external state. Statements that rely on
 /// external state must remove that state prior to calling this function via
-/// [`crate::pure::purify_statement`].
+/// [`crate::pure::purify_statement`] or
+/// [`crate::pure::purify_create_materialized_view_options`].
 ///
 /// TODO: sinks do not currently obey this rule, which is a bug
 /// <https://github.com/MaterializeInc/materialize/issues/20019>

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -364,6 +364,7 @@ pub fn plan_explain_plan(
                         column_names,
                         cluster_id,
                         non_null_assertions,
+                        refresh_schedule,
                         ..
                     },
                 ..
@@ -379,6 +380,7 @@ pub fn plan_explain_plan(
                 cluster_id,
                 broken,
                 non_null_assertions,
+                refresh_schedule,
             })
         }
         Explainee::CreateIndex(mut stmt, broken) => {

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -9,12 +9,13 @@
 
 //! Provides tooling to handle `WITH` options.
 
+use std::time::Duration;
+
 use mz_repr::adt::interval::Interval;
 use mz_repr::{strconv, GlobalId};
-use mz_sql_parser::ast::{Ident, KafkaBroker, ReplicaDefinition};
+use mz_sql_parser::ast::{Ident, KafkaBroker, RefreshOptionValue, ReplicaDefinition};
 use mz_storage_types::connections::StringOrSecret;
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
 
 use crate::ast::{AstInfo, UnresolvedItemName, Value, WithOptionValue};
 use crate::names::{ResolvedDataType, ResolvedItemName};
@@ -434,15 +435,21 @@ impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOpti
         match v {
             WithOptionValue::Value(v) => V::try_from_value(v),
             WithOptionValue::Ident(i) => V::try_from_value(Value::String(i.into_string())),
+            WithOptionValue::RetainHistoryFor(v) => V::try_from_value(v),
             WithOptionValue::Sequence(_)
             | WithOptionValue::Item(_)
             | WithOptionValue::UnresolvedItemName(_)
             | WithOptionValue::Secret(_)
             | WithOptionValue::DataType(_)
             | WithOptionValue::ClusterReplicas(_)
-            | WithOptionValue::ConnectionKafkaBroker(_) => sql_bail!(
+            | WithOptionValue::ConnectionKafkaBroker(_)
+            | WithOptionValue::Refresh(_) => sql_bail!(
                 "incompatible value types: cannot convert {} to {}",
                 match v {
+                    // The first few are unreachable because they are handled at the top of the outer match.
+                    WithOptionValue::Value(_) => unreachable!(),
+                    WithOptionValue::Ident(_) => unreachable!(),
+                    WithOptionValue::RetainHistoryFor(_) => unreachable!(),
                     WithOptionValue::Sequence(_) => "sequences",
                     WithOptionValue::Item(_) => "object references",
                     WithOptionValue::UnresolvedItemName(_) => "object names",
@@ -450,11 +457,10 @@ impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOpti
                     WithOptionValue::DataType(_) => "data types",
                     WithOptionValue::ClusterReplicas(_) => "cluster replicas",
                     WithOptionValue::ConnectionKafkaBroker(_) => "connection kafka brokers",
-                    _ => unreachable!(),
+                    WithOptionValue::Refresh(_) => "refresh option values",
                 },
                 V::name()
             ),
-            WithOptionValue::RetainHistoryFor(v) => V::try_from_value(v),
         }
     }
     fn name() -> String {
@@ -516,5 +522,25 @@ impl TryFromValue<WithOptionValue<Aug>> for Vec<KafkaBroker<Aug>> {
 impl ImpliedValue for Vec<KafkaBroker<Aug>> {
     fn implied_value() -> Result<Self, PlanError> {
         sql_bail!("must provide a kafka broker")
+    }
+}
+
+impl TryFromValue<WithOptionValue<Aug>> for RefreshOptionValue<Aug> {
+    fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
+        if let WithOptionValue::Refresh(r) = v {
+            Ok(r)
+        } else {
+            sql_bail!("cannot use value `{}` for a refresh option", v)
+        }
+    }
+
+    fn name() -> String {
+        "refresh option value".to_string()
+    }
+}
+
+impl ImpliedValue for RefreshOptionValue<Aug> {
+    fn implied_value() -> Result<Self, PlanError> {
+        sql_bail!("must provide a refresh option value")
     }
 }

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -25,15 +25,20 @@ use mz_ore::str::StrExt;
 use mz_postgres_util::replication::WalLevel;
 use mz_postgres_util::PostgresError;
 use mz_proto::RustType;
-use mz_repr::{strconv, GlobalId};
+use mz_repr::{strconv, GlobalId, Timestamp};
 use mz_sql_parser::ast::display::AstDisplay;
+use mz_sql_parser::ast::visit::{visit_function, Visit};
+use mz_sql_parser::ast::visit_mut::{visit_expr_mut, VisitMut};
 use mz_sql_parser::ast::{
     AlterSourceAction, AlterSourceAddSubsourceOptionName, AlterSourceStatement, AvroDocOn,
-    CreateSinkConnection, CreateSinkStatement, CreateSubsourceOption, CreateSubsourceOptionName,
-    CsrConfigOption, CsrConfigOptionName, CsrConnection, CsrSeedAvro, CsrSeedProtobuf,
-    CsrSeedProtobufSchema, DbzMode, DeferredItemName, DocOnIdentifier, DocOnSchema, Envelope,
-    Ident, KafkaSourceConfigOption, KafkaSourceConfigOptionName, PgConfigOption,
-    PgConfigOptionName, RawItemName, ReaderSchemaSelectionStrategy, Statement, UnresolvedItemName,
+    CreateMaterializedViewStatement, CreateSinkConnection, CreateSinkStatement,
+    CreateSubsourceOption, CreateSubsourceOptionName, CsrConfigOption, CsrConfigOptionName,
+    CsrConnection, CsrSeedAvro, CsrSeedProtobuf, CsrSeedProtobufSchema, DbzMode, DeferredItemName,
+    DocOnIdentifier, DocOnSchema, Envelope, Expr, Function, FunctionArgs, Ident,
+    KafkaSourceConfigOption, KafkaSourceConfigOptionName, MaterializedViewOption,
+    MaterializedViewOptionName, PgConfigOption, PgConfigOptionName, RawItemName,
+    ReaderSchemaSelectionStrategy, RefreshAtOptionValue, RefreshEveryOptionValue,
+    RefreshOptionValue, Statement, UnresolvedItemName,
 };
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::connections::inline::IntoInlineConnection;
@@ -54,7 +59,10 @@ use crate::ast::{
 };
 use crate::catalog::{CatalogItemType, ErsatzCatalog, SessionCatalog};
 use crate::kafka_util::{KafkaSinkConfigOptionExtracted, KafkaSourceConfigOptionExtracted};
-use crate::names::{Aug, ResolvedColumnName, ResolvedItemName};
+use crate::names::{
+    Aug, FullItemName, PartialItemName, ResolvedColumnName, ResolvedDataType, ResolvedIds,
+    ResolvedItemName,
+};
 use crate::plan::error::PlanError;
 use crate::plan::statement::ddl::load_generator_ast_to_generator;
 use crate::plan::StatementContext;
@@ -139,6 +147,11 @@ fn subsource_name_gen(
 ///
 /// See the section on [purification](crate#purification) in the crate
 /// documentation for details.
+///
+/// Note that this doesn't handle CREATE MATERIALIZED VIEW, which is
+/// handled by [purify_create_materialized_view_options] instead.
+/// This could be made more consistent by a refactoring discussed here:
+/// <https://github.com/MaterializeInc/materialize/pull/23870#discussion_r1435922709>
 pub async fn purify_statement(
     catalog: impl SessionCatalog,
     now: u64,
@@ -1476,4 +1489,249 @@ async fn compile_proto(
         schema,
         message_name,
     })
+}
+
+const MZ_NOW_NAME: &str = "mz_now";
+const MZ_NOW_SCHEMA: &str = "mz_catalog";
+
+/// Purifies a CREATE MATERIALIZED VIEW statement. Additionally, it adjusts `resolved_ids` if
+/// references to ids appear or disappear during the purification.
+///
+/// Note that in contrast with [`purify_statement`], this doesn't need to be async, because
+/// this function is not making any network calls. Furthermore, there is a good reason for it
+/// to be sync: if this were async, then the `mz_now` that our caller selected could become
+/// invalid by the time the async result message is handled by the coordinator main loop, in
+/// the sense that we might no longer be able to read our inputs at the selected timestamp.
+/// If it is sync, then there is no gap between observing the oracle read timestamp and
+/// installing the materialized view in the catalog, at which point it will install its own
+/// read holds for the refresh at `mz_now`.
+pub fn purify_create_materialized_view_options(
+    catalog: impl SessionCatalog,
+    mz_now: Option<Timestamp>,
+    cmvs: &mut CreateMaterializedViewStatement<Aug>,
+    resolved_ids: &mut ResolvedIds,
+) {
+    // 0. Preparations:
+    // Prepare an expression that calls `mz_now()`, which we can insert in various later steps.
+    let (mz_now_id, mz_now_expr) = {
+        let item = catalog
+            .resolve_function(&PartialItemName {
+                database: None,
+                schema: Some(MZ_NOW_SCHEMA.to_string()),
+                item: MZ_NOW_NAME.to_string(),
+            })
+            .expect("we should be able to resolve mz_now");
+        (
+            item.id(),
+            Expr::Function(Function {
+                name: ResolvedItemName::Item {
+                    id: item.id(),
+                    qualifiers: item.name().qualifiers.clone(),
+                    full_name: catalog.resolve_full_name(item.name()),
+                    print_id: false,
+                },
+                args: FunctionArgs::Args {
+                    args: Vec::new(),
+                    order_by: Vec::new(),
+                },
+                filter: None,
+                over: None,
+                distinct: false,
+            }),
+        )
+    };
+    // Prepare the `mz_timestamp` type.
+    let (mz_timestamp_id, mz_timestamp_type) = {
+        let item = catalog.get_system_type("mz_timestamp");
+        let full_name = catalog.resolve_full_name(item.name());
+        (
+            item.id(),
+            ResolvedDataType::Named {
+                id: item.id(),
+                qualifiers: item.name().qualifiers.clone(),
+                full_name,
+                modifiers: vec![],
+                print_id: true,
+            },
+        )
+    };
+
+    let mut introduced_mz_timestamp = false;
+
+    for option in cmvs.with_options.iter_mut() {
+        // 1. Purify `REFRESH AT CREATION` to `REFRESH AT mz_now()`.
+        if matches!(
+            option.value,
+            Some(WithOptionValue::Refresh(RefreshOptionValue::AtCreation))
+        ) {
+            option.value = Some(WithOptionValue::Refresh(RefreshOptionValue::At(
+                RefreshAtOptionValue {
+                    time: mz_now_expr.clone(),
+                },
+            )));
+        }
+
+        // 2. If `REFRESH EVERY` doesn't have an `ALIGNED TO`, then add `ALIGNED TO mz_now()`.
+        if let Some(WithOptionValue::Refresh(RefreshOptionValue::Every(
+            RefreshEveryOptionValue { aligned_to, .. },
+        ))) = &mut option.value
+        {
+            if aligned_to.is_none() {
+                *aligned_to = Some(mz_now_expr.clone());
+            }
+        }
+
+        // 3. Substitute `mz_now()` with the timestamp chosen for the CREATE MATERIALIZED VIEW
+        // statement. (This has to happen after the above steps, which might introduce `mz_now()`.)
+        match &mut option.value {
+            Some(WithOptionValue::Refresh(RefreshOptionValue::At(RefreshAtOptionValue {
+                time,
+            }))) => {
+                let mut visitor = MzNowPurifierVisitor::new(mz_now, mz_timestamp_type.clone());
+                visitor.visit_expr_mut(time);
+                introduced_mz_timestamp |= visitor.introduced_mz_timestamp;
+            }
+            Some(WithOptionValue::Refresh(RefreshOptionValue::Every(
+                RefreshEveryOptionValue {
+                    interval: _,
+                    aligned_to: Some(aligned_to),
+                },
+            ))) => {
+                let mut visitor = MzNowPurifierVisitor::new(mz_now, mz_timestamp_type.clone());
+                visitor.visit_expr_mut(aligned_to);
+                introduced_mz_timestamp |= visitor.introduced_mz_timestamp;
+            }
+            _ => {}
+        }
+    }
+
+    // 4. If the user didn't give any REFRESH option, then default to ON COMMIT.
+    if !cmvs.with_options.iter().any(|o| {
+        matches!(
+            o,
+            MaterializedViewOption {
+                value: Some(WithOptionValue::Refresh(..)),
+                ..
+            }
+        )
+    }) {
+        cmvs.with_options.push(MaterializedViewOption {
+            name: MaterializedViewOptionName::Refresh,
+            value: Some(WithOptionValue::Refresh(RefreshOptionValue::OnCommit)),
+        })
+    }
+
+    // 5. Attend to `resolved_ids`: The purification might have
+    // - added references to `mz_timestamp`;
+    // - removed references to `mz_now`.
+    if introduced_mz_timestamp {
+        resolved_ids.0.insert(mz_timestamp_id);
+    }
+    // Even though we always remove `mz_now()` from the `with_options`, there might be `mz_now()`
+    // remaining in the main query expression of the MV, so let's visit the entire statement to look
+    // for `mz_now()` everywhere.
+    let mut visitor = ExprContainsTemporalVisitor::new();
+    visitor.visit_create_materialized_view_statement(cmvs);
+    if !visitor.contains_temporal {
+        resolved_ids.0.remove(&mz_now_id);
+    }
+}
+
+/// Returns true if the [MaterializedViewOption] either already involves `mz_now()` or will involve
+/// after purification.
+pub fn materialized_view_option_contains_temporal(mvo: &MaterializedViewOption<Aug>) -> bool {
+    match &mvo.value {
+        Some(WithOptionValue::Refresh(RefreshOptionValue::At(RefreshAtOptionValue { time }))) => {
+            let mut visitor = ExprContainsTemporalVisitor::new();
+            visitor.visit_expr(time);
+            visitor.contains_temporal
+        }
+        Some(WithOptionValue::Refresh(RefreshOptionValue::Every(RefreshEveryOptionValue {
+            interval: _,
+            aligned_to: Some(aligned_to),
+        }))) => {
+            let mut visitor = ExprContainsTemporalVisitor::new();
+            visitor.visit_expr(aligned_to);
+            visitor.contains_temporal
+        }
+        Some(WithOptionValue::Refresh(RefreshOptionValue::Every(RefreshEveryOptionValue {
+            interval: _,
+            aligned_to: None,
+        }))) => {
+            // For a `REFRESH EVERY` without an `ALIGNED TO`, purification will default the
+            // `ALIGNED TO` to `mz_now()`.
+            true
+        }
+        Some(WithOptionValue::Refresh(RefreshOptionValue::AtCreation)) => {
+            // `REFRESH AT CREATION` will be purified to `REFRESH AT mz_now()`.
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Determines whether the AST involves `mz_now()`.
+struct ExprContainsTemporalVisitor {
+    pub contains_temporal: bool,
+}
+
+impl ExprContainsTemporalVisitor {
+    pub fn new() -> ExprContainsTemporalVisitor {
+        ExprContainsTemporalVisitor {
+            contains_temporal: false,
+        }
+    }
+}
+
+impl Visit<'_, Aug> for ExprContainsTemporalVisitor {
+    fn visit_function(&mut self, func: &Function<Aug>) {
+        self.contains_temporal |= func.name.full_item_name().item == MZ_NOW_NAME;
+        visit_function(self, func);
+    }
+}
+
+struct MzNowPurifierVisitor {
+    pub mz_now: Option<Timestamp>,
+    pub mz_timestamp_type: ResolvedDataType,
+    pub introduced_mz_timestamp: bool,
+}
+
+impl MzNowPurifierVisitor {
+    pub fn new(
+        mz_now: Option<Timestamp>,
+        mz_timestamp_type: ResolvedDataType,
+    ) -> MzNowPurifierVisitor {
+        MzNowPurifierVisitor {
+            mz_now,
+            mz_timestamp_type,
+            introduced_mz_timestamp: false,
+        }
+    }
+}
+
+impl VisitMut<'_, Aug> for MzNowPurifierVisitor {
+    fn visit_expr_mut(&mut self, expr: &'_ mut Expr<Aug>) {
+        match expr {
+            Expr::Function(Function {
+                name:
+                    ResolvedItemName::Item {
+                        full_name: FullItemName { item, .. },
+                        ..
+                    },
+                ..
+            }) if item == &MZ_NOW_NAME.to_string() => {
+                let mz_now = self.mz_now.expect(
+                    "we should have chosen a timestamp if the expression contains mz_now()",
+                );
+                // We substitute `mz_now()` with number + a cast to `mz_timestamp`. The cast is to
+                // not alter the type of the expression.
+                *expr = Expr::Cast {
+                    expr: Box::new(Expr::Value(Value::Number(mz_now.to_string()))),
+                    data_type: self.mz_timestamp_type.clone(),
+                };
+                self.introduced_mz_timestamp = true;
+            }
+            _ => visit_expr_mut(self, expr),
+        }
+    }
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2197,6 +2197,13 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_refresh_every_mvs,
+        desc: "REFRESH EVERY materialized views",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
 );
 
 /// Represents the input to a variable.

--- a/test/legacy-upgrade/check-from-v0.27.0-json.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-json.td
@@ -8,4 +8,4 @@
 # by the Apache License, Version 2.0.
 
 > SHOW CREATE MATERIALIZED VIEW json_view;
-"materialize.public.json_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"json_view\" IN CLUSTER \"json_compute_cluster\" AS SELECT \"a\" -> 1 AS \"c1\", \"a\" ->> 'b' AS \"c2\", \"a\" #> '{b,1}' AS \"c3\", \"a\" #>> '{b, 1}' AS \"c4\", \"a\" - 'b' AS \"c5\", \"a\" @> '{b, 1}' AS \"c6\", \"a\" <@ '{b, 1}'::\"pg_catalog\".\"jsonb\" AS \"c7\", \"a\" ? 'b' AS \"c8\" FROM \"materialize\".\"public\".\"json_table\""
+"materialize.public.json_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"json_view\" IN CLUSTER \"json_compute_cluster\" WITH (REFRESH = ON COMMIT) AS SELECT \"a\" -> 1 AS \"c1\", \"a\" ->> 'b' AS \"c2\", \"a\" #> '{b,1}' AS \"c3\", \"a\" #>> '{b, 1}' AS \"c4\", \"a\" - 'b' AS \"c5\", \"a\" @> '{b, 1}' AS \"c6\", \"a\" <@ '{b, 1}'::\"pg_catalog\".\"jsonb\" AS \"c7\", \"a\" ? 'b' AS \"c8\" FROM \"materialize\".\"public\".\"json_table\""

--- a/test/legacy-upgrade/check-from-v0.27.0-regexp.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-regexp.td
@@ -11,4 +11,4 @@ $ skip-if
 SELECT mz_version_num() >= 6100;
 
 > SHOW CREATE MATERIALIZED VIEW regexp_view;
-"materialize.public.regexp_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"regexp_view\" IN CLUSTER \"default\" AS SELECT \"a\" !~~ 'b' AS \"c1\", \"a\" ~~* 'b' AS \"c2\", \"a\" ~ 'b' AS \"c3\", \"a\" ~* 'b' AS \"c4\", \"a\" !~ 'b' AS \"c5\", \"a\" !~* 'b' AS \"c6\" FROM \"materialize\".\"public\".\"regexp_table\""
+"materialize.public.regexp_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"regexp_view\" IN CLUSTER \"default\" WITH (REFRESH = ON COMMIT) AS SELECT \"a\" !~~ 'b' AS \"c1\", \"a\" ~~* 'b' AS \"c2\", \"a\" ~ 'b' AS \"c3\", \"a\" ~* 'b' AS \"c4\", \"a\" !~ 'b' AS \"c5\", \"a\" !~* 'b' AS \"c6\" FROM \"materialize\".\"public\".\"regexp_table\""

--- a/test/legacy-upgrade/check-from-v0.27.0-special-functions.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-special-functions.td
@@ -14,4 +14,4 @@
 #
 
 > SHOW CREATE MATERIALIZED VIEW special_functions_view;
-"materialize.public.special_functions_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"special_functions_view\" IN CLUSTER \"${arg.created-cluster}\" AS SELECT * FROM \"materialize\".\"public\".\"special_functions\" WHERE \"mz_catalog\".\"mz_now\"() > \"f1\""
+"materialize.public.special_functions_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"special_functions_view\" IN CLUSTER \"${arg.created-cluster}\" WITH (REFRESH = ON COMMIT) AS SELECT * FROM \"materialize\".\"public\".\"special_functions\" WHERE \"mz_catalog\".\"mz_now\"() > \"f1\""

--- a/test/legacy-upgrade/check-from-v0.27.0-subquery.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-subquery.td
@@ -11,4 +11,4 @@
 # CREATE a view containing subqueries/derived tables of various types
 
 > SHOW CREATE MATERIALIZED VIEW subquery_view;
-"materialize.public.subquery_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"subquery_view\" IN CLUSTER \"${arg.created-cluster}\" AS SELECT (SELECT 1) FROM (SELECT 2) AS \"derived\" WHERE 2 NOT IN (SELECT 3) AND NOT EXISTS (SELECT 4) AND 5 >= ALL (SELECT 6) AND 7 < ANY (SELECT 8)"
+"materialize.public.subquery_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"subquery_view\" IN CLUSTER \"${arg.created-cluster}\" WITH (REFRESH = ON COMMIT) AS SELECT (SELECT 1) FROM (SELECT 2) AS \"derived\" WHERE 2 NOT IN (SELECT 3) AND NOT EXISTS (SELECT 4) AND 5 >= ALL (SELECT 6) AND 7 < ANY (SELECT 8)"

--- a/test/legacy-upgrade/check-from-v0.61.0-regexp.td
+++ b/test/legacy-upgrade/check-from-v0.61.0-regexp.td
@@ -11,4 +11,4 @@ $ skip-if
 SELECT mz_version_num() < 6100;
 
 > SHOW CREATE MATERIALIZED VIEW regexp_view;
-"materialize.public.regexp_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"regexp_view\" IN CLUSTER \"${arg.created-cluster}\" AS SELECT \"a\" NOT LIKE 'b' AS \"c1\", \"a\" ILIKE 'b' AS \"c2\", \"a\" ~ 'b' AS \"c3\", \"a\" ~* 'b' AS \"c4\", \"a\" !~ 'b' AS \"c5\", \"a\" !~* 'b' AS \"c6\" FROM \"materialize\".\"public\".\"regexp_table\""
+"materialize.public.regexp_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"regexp_view\" IN CLUSTER \"${arg.created-cluster}\" WITH (REFRESH = ON COMMIT) AS SELECT \"a\" NOT LIKE 'b' AS \"c1\", \"a\" ILIKE 'b' AS \"c2\", \"a\" ~ 'b' AS \"c3\", \"a\" ~* 'b' AS \"c4\", \"a\" !~ 'b' AS \"c5\", \"a\" !~* 'b' AS \"c6\" FROM \"materialize\".\"public\".\"regexp_table\""

--- a/test/legacy-upgrade/check-from-v0.67.0-object-with-avg.td
+++ b/test/legacy-upgrade/check-from-v0.67.0-object-with-avg.td
@@ -11,11 +11,11 @@
 "materialize.public.view_with_avg_internal" "CREATE VIEW \"materialize\".\"public\".\"view_with_avg_internal\" (\"a\") AS SELECT \"mz_catalog\".\"avg_internal_v1\"(\"position\") FROM \"mz_catalog\".\"mz_columns\""
 
 > SHOW CREATE MATERIALIZED VIEW mat_view_with_avg_internal;
-"materialize.public.mat_view_with_avg_internal" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"mat_view_with_avg_internal\" (\"a\") IN CLUSTER \"${arg.created-cluster}\" AS SELECT \"mz_catalog\".\"avg_internal_v1\"(\"position\") FROM \"mz_catalog\".\"mz_columns\""
+"materialize.public.mat_view_with_avg_internal" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"mat_view_with_avg_internal\" (\"a\") IN CLUSTER \"${arg.created-cluster}\" WITH (REFRESH = ON COMMIT) AS SELECT \"mz_catalog\".\"avg_internal_v1\"(\"position\") FROM \"mz_catalog\".\"mz_columns\""
 
 
 > SHOW CREATE VIEW view_with_avg_post_v0_67;
 "materialize.public.view_with_avg_post_v0_67" "CREATE VIEW \"materialize\".\"public\".\"view_with_avg_post_v0_67\" (\"a\") AS SELECT \"pg_catalog\".\"avg\"(\"position\") FROM \"mz_catalog\".\"mz_columns\""
 
 > SHOW CREATE MATERIALIZED VIEW mat_view_with_avg_post_v0_67;
-"materialize.public.mat_view_with_avg_post_v0_67" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"mat_view_with_avg_post_v0_67\" (\"a\") IN CLUSTER \"${arg.created-cluster}\" AS SELECT \"pg_catalog\".\"avg\"(\"position\") FROM \"mz_catalog\".\"mz_columns\""
+"materialize.public.mat_view_with_avg_post_v0_67" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"mat_view_with_avg_post_v0_67\" (\"a\") IN CLUSTER \"${arg.created-cluster}\" WITH (REFRESH = ON COMMIT) AS SELECT \"pg_catalog\".\"avg\"(\"position\") FROM \"mz_catalog\".\"mz_columns\""

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -370,14 +370,14 @@ query TT colnames
 SHOW CREATE MATERIALIZED VIEW mv
 ----
 name                  create_sql
-materialize.public.mv CREATE␠MATERIALIZED␠VIEW␠"materialize"."public"."mv"␠IN␠CLUSTER␠"quickstart"␠AS␠SELECT␠1
+materialize.public.mv CREATE␠MATERIALIZED␠VIEW␠"materialize"."public"."mv"␠IN␠CLUSTER␠"quickstart"␠WITH␠(REFRESH␠=␠ON␠COMMIT)␠AS␠SELECT␠1
 
 # Test: SHOW CREATE MATERIALIZED VIEW as mz_support
 
 simple conn=mz_introspection,user=mz_support
 SHOW CREATE MATERIALIZED VIEW mv
 ----
-materialize.public.mv,CREATE MATERIALIZED VIEW "materialize"."public"."mv" IN CLUSTER "quickstart" AS SELECT 1
+materialize.public.mv,CREATE MATERIALIZED VIEW "materialize"."public"."mv" IN CLUSTER "quickstart" WITH (REFRESH = ON COMMIT) AS SELECT 1
 COMPLETE 1
 
 # Test: SHOW MATERIALIZED VIEWS
@@ -645,7 +645,126 @@ SELECT * FROM mv_assertion_at_begin ORDER BY x;
 4 NULL 6
 7 8 NULL
 
-# More Cleanup
+# ------------------------------------------------------------------
+# REFRESH options (see also in materialized-view-refresh-options.td)
+# ------------------------------------------------------------------
+
+# Planning/parsing errors
+
+# Should be disabled by default.
+query error db error: ERROR: REFRESH EVERY materialized views is not supported
+CREATE MATERIALIZED VIEW mv_bad WITH (ASSERT NOT NULL x, REFRESH EVERY '8 seconds') AS SELECT * FROM t2;
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_refresh_every_mvs = true
+----
+COMPLETE 0
+
+query error Expected one of ON or AT or EVERY, found number "5"
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH 5) AS SELECT 1;
+
+query error db error: ERROR: REFRESH ON COMMIT cannot be specified multiple times
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH ON COMMIT, REFRESH ON COMMIT) AS SELECT 1;
+
+query error db error: ERROR: REFRESH ON COMMIT is not compatible with any of the other REFRESH options
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH ON COMMIT, REFRESH EVERY '1 day') AS SELECT 1;
+
+query error db error: ERROR: REFRESH AT does not support casting from record\(f1: integer,f2: integer\) to mz_timestamp
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH AT row(1,2)) AS SELECT 1;
+
+query error db error: ERROR: REFRESH AT argument must be an expression that can be simplified and/or cast to a constant whose type is mz_timestamp
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH AT 'aaaa') AS SELECT 1;
+
+query error db error: ERROR: column "ccc" does not exist
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH AT ccc) AS SELECT 1 as ccc;
+
+query error db error: ERROR: REFRESH AT argument must be an expression that can be simplified and/or cast to a constant whose type is mz_timestamp
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH AT now()) AS SELECT 1;
+
+query error db error: ERROR: REFRESH AT argument must be an expression that can be simplified and/or cast to a constant whose type is mz_timestamp
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH AT now()::mz_timestamp) AS SELECT 1;
+
+query error db error: ERROR: greatest types mz_timestamp and timestamp with time zone cannot be matched
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH AT greatest(mz_now(), now())) AS SELECT 1;
+
+query error db error: ERROR: REFRESH AT argument must be an expression that can be simplified and/or cast to a constant whose type is mz_timestamp
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH AT greatest(mz_now(), now()::mz_timestamp)) AS SELECT 1;
+
+query error db error: ERROR: aggregate functions are not allowed in REFRESH AT \(function pg_catalog\.sum\)
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH AT sum(5)) AS SELECT 1;
+
+query error db error: ERROR: REFRESH AT does not allow subqueries
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH AT (SELECT 1)) AS SELECT 1;
+
+query error db error: ERROR: window functions are not allowed in REFRESH AT \(function pg_catalog\.lag\)
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH AT lag(7) OVER ()) AS SELECT 1;
+
+query error Expected literal string, found number "42"
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY 42) AS SELECT 1;
+
+query error db error: ERROR: invalid input syntax for type interval: unknown units dayy: "1 dayy"
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '1 dayy') AS SELECT 1;
+
+query error Expected literal string, found INTERVAL
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY INTERVAL '1 day') AS SELECT 1;
+
+query error db error: ERROR: REFRESH interval must be positive; got: \-00:01:00
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '-1 minutes') AS SELECT 1;
+
+query error db error: ERROR: REFRESH interval must not involve units larger than days
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '1 month') AS SELECT 1;
+
+query error db error: ERROR: REFRESH interval must not involve units larger than days
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '1 year') AS SELECT 1;
+
+query error db error: ERROR: REFRESH EVERY \.\.\. ALIGNED TO argument must be an expression that can be simplified and/or cast to a constant whose type is mz_timestamp
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '1 day' ALIGNED TO now()) AS SELECT 1;
+
+query error db error: ERROR: REFRESH EVERY \.\.\. ALIGNED TO argument must be an expression that can be simplified and/or cast to a constant whose type is mz_timestamp
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '1 day' ALIGNED TO now()::mz_timestamp) AS SELECT 1;
+
+query error db error: ERROR: greatest types mz_timestamp and timestamp with time zone cannot be matched
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '1 day' ALIGNED TO greatest(mz_now(), now())) AS SELECT 1;
+
+query error db error: ERROR: REFRESH EVERY \.\.\. ALIGNED TO argument must be an expression that can be simplified and/or cast to a constant whose type is mz_timestamp
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '1 day' ALIGNED TO greatest(mz_now(), now()::mz_timestamp)) AS SELECT 1;
+
+query error db error: ERROR: aggregate functions are not allowed in REFRESH EVERY \.\.\. ALIGNED TO \(function pg_catalog\.sum\)
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '1 day' ALIGNED TO sum(5)) AS SELECT 1;
+
+query error db error: ERROR: REFRESH EVERY \.\.\. ALIGNED TO does not allow subqueries
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '1 day' ALIGNED TO (SELECT 1)) AS SELECT 1;
+
+query error db error: ERROR: window functions are not allowed in REFRESH EVERY \.\.\. ALIGNED TO \(function pg_catalog\.lag\)
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY '1 day' ALIGNED TO lag(7) OVER ()) AS SELECT 1;
+
+query error Expected literal string, found right parenthesis
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY) AS SELECT * FROM t2;
+
+query error Expected literal string, found comma
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY, ASSERT NOT NULL x) AS SELECT * FROM t2;
+
+query error Expected right parenthesis, found REFRESH
+CREATE MATERIALIZED VIEW mv_bad WITH (ASSERT NOT NULL x REFRESH EVERY '8 seconds') AS SELECT * FROM t2;
+
+query error Expected literal string, found ASSERT
+CREATE MATERIALIZED VIEW mv_bad WITH (REFRESH EVERY ASSERT NOT NULL x) AS SELECT * FROM t2;
+
+# Test that we call `transform_ast::transform`. (This has an `Expr::Nested`, which needs to be desugared, or we panic.)
+query error db error: ERROR: REFRESH options other than ON COMMIT are not supported
+CREATE MATERIALIZED VIEW mv_desugar1 WITH (REFRESH AT (mz_now())) AS SELECT * FROM t2;
+
+# Same with ALIGNED TO
+query error db error: ERROR: REFRESH options other than ON COMMIT are not supported
+CREATE MATERIALIZED VIEW mv_desugar2 WITH (REFRESH EVERY '1 day' ALIGNED TO (mz_now())) AS SELECT * FROM t2;
 
 statement ok
-DROP TABLE t2 CASCADE
+CREATE MATERIALIZED VIEW mv_on_commit WITH (REFRESH ON COMMIT) AS SELECT * FROM t2;
+
+query III
+SELECT 1000*x, 1000*y, 1000*z
+FROM mv_on_commit;
+----
+7000  8000  NULL
+4000  NULL  6000
+1000  2000  3000

--- a/test/sqllogictest/rename.slt
+++ b/test/sqllogictest/rename.slt
@@ -159,7 +159,7 @@ query TT
 SHOW CREATE MATERIALIZED VIEW grand_friend.mv1;
 ----
 materialize.grand_friend.mv1
-CREATE MATERIALIZED VIEW "materialize"."grand_friend"."mv1" IN CLUSTER "quickstart" AS SELECT "x" FROM "materialize"."enemy"."v1"
+CREATE MATERIALIZED VIEW "materialize"."grand_friend"."mv1" IN CLUSTER "quickstart" WITH (REFRESH = ON COMMIT) AS SELECT "x" FROM "materialize"."enemy"."v1"
 
 statement ok
 CREATE TABLE a1.t (y text);

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -79,7 +79,7 @@ data_view
 > SHOW CREATE MATERIALIZED VIEW test1
 name                      create_sql
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.test1  "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"test1\" IN CLUSTER \"quickstart\" AS SELECT \"b\", \"pg_catalog\".\"sum\"(\"a\") FROM \"materialize\".\"public\".\"data\" GROUP BY \"b\""
+materialize.public.test1  "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"test1\" IN CLUSTER \"quickstart\" WITH (REFRESH = ON COMMIT) AS SELECT \"b\", \"pg_catalog\".\"sum\"(\"a\") FROM \"materialize\".\"public\".\"data\" GROUP BY \"b\""
 
 # Materialized view can be built on a not-materialized view.
 > CREATE MATERIALIZED VIEW test2 AS


### PR DESCRIPTION
This is the parsing, purification, planning of REFRESH options on materialized views. [This is the full PR, which includes the Compute part.](https://github.com/MaterializeInc/materialize/pull/23819)

[Design document.](https://github.com/ggevay/materialize/blob/refresh-every-design-doc/doc/developer/design/20231027_refresh_every_mv.md#solution-proposal)

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
