### PR TITLE
storage: make kafka timeouts configurable

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -170,6 +170,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             config.kafka_socket_keepalive(),
             config.kafka_socket_timeout(),
             config.kafka_socket_connection_setup_timeout(),
+            config.kafka_fetch_metadata_timeout(),
         ),
     }
 }

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -166,9 +166,10 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             connect_timeout: config.ssh_connect_timeout(),
             keepalives_idle: config.ssh_keepalives_idle(),
         },
-        kafka_timeout_config: mz_kafka_util::client::TcpTimeoutConfig::build(
+        kafka_timeout_config: mz_kafka_util::client::TimeoutConfig::build(
             config.kafka_socket_keepalive(),
             config.kafka_socket_timeout(),
+            config.kafka_transaction_timeout(),
             config.kafka_socket_connection_setup_timeout(),
             config.kafka_fetch_metadata_timeout(),
         ),

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -166,6 +166,11 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             connect_timeout: config.ssh_connect_timeout(),
             keepalives_idle: config.ssh_keepalives_idle(),
         },
+        kafka_timeout_config: mz_kafka_util::client::TcpTimeoutConfig::build(
+            config.kafka_socket_keepalive(),
+            config.kafka_socket_timeout(),
+            config.kafka_socket_connection_setup_timeout(),
+        ),
     }
 }
 

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -35,14 +35,12 @@ use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
 use tracing::{debug, error, info, warn, Level};
 
-/// A reasonable default timeout when refreshing topic metadata.
+/// A reasonable default timeout when refreshing topic metadata. This is configured
+/// at a source level.
 // 30s may seem infrequent, but the default is 5m. More frequent metadata
 // refresh rates are surprising to Kafka users, as topic partition counts hardly
 // ever change in production.
 pub const DEFAULT_TOPIC_METADATA_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
-
-/// A reasonable default timeout when fetching metadata or partitions.
-pub const DEFAULT_FETCH_METADATA_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A `ClientContext` implementation that uses `tracing` instead of `log`
 /// macros.
@@ -641,6 +639,9 @@ pub const DEFAULT_SOCKET_TIMEOUT: Duration = Duration::from_millis(60000);
 /// - <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
 pub const DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT: Duration = Duration::from_millis(30000);
 
+/// A reasonable default timeout when fetching metadata or partitions.
+pub const DEFAULT_FETCH_METADATA_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Configurable timeouts for Kafka connections.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TcpTimeoutConfig {
@@ -650,6 +651,8 @@ pub struct TcpTimeoutConfig {
     pub socket_timeout: Duration,
     /// The timeout for setting up network connections.
     pub socket_connection_setup_timeout: Duration,
+    /// The timeout for fetching metadata from upstream.
+    pub fetch_metadata_timeout: Duration,
 }
 
 impl Default for TcpTimeoutConfig {
@@ -658,6 +661,7 @@ impl Default for TcpTimeoutConfig {
             keepalive: DEFAULT_KEEPALIVE,
             socket_timeout: DEFAULT_SOCKET_TIMEOUT,
             socket_connection_setup_timeout: DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT,
+            fetch_metadata_timeout: DEFAULT_FETCH_METADATA_TIMEOUT,
         }
     }
 }
@@ -669,6 +673,7 @@ impl TcpTimeoutConfig {
         keepalive: bool,
         socket_timeout: Duration,
         socket_connection_setup_timeout: Duration,
+        fetch_metadata_timeout: Duration,
     ) -> TcpTimeoutConfig {
         // Constrain values based on ranges here:
         // <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
@@ -706,6 +711,7 @@ impl TcpTimeoutConfig {
             keepalive,
             socket_timeout,
             socket_connection_setup_timeout,
+            fetch_metadata_timeout,
         }
     }
 }

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -630,11 +630,14 @@ pub fn get_partitions<C: ClientContext>(
     Ok(partition_ids)
 }
 
-/// Default to true as they hey have no downsides <https://github.com/confluentinc/librdkafka/issues/283>.
+/// Default to true as they have no downsides <https://github.com/confluentinc/librdkafka/issues/283>.
 pub const DEFAULT_KEEPALIVE: bool = true;
 /// The `rdkafka` default.
 /// - <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
 pub const DEFAULT_SOCKET_TIMEOUT: Duration = Duration::from_millis(60000);
+/// The `rdkafka` default.
+/// - <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
+pub const DEFAULT_TRANSACTION_TIMEOUT: Duration = Duration::from_millis(60000);
 /// The `rdkafka` default.
 /// - <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
 pub const DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT: Duration = Duration::from_millis(30000);
@@ -644,72 +647,112 @@ pub const DEFAULT_FETCH_METADATA_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Configurable timeouts for Kafka connections.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TcpTimeoutConfig {
+pub struct TimeoutConfig {
     /// Whether or not to enable
     pub keepalive: bool,
-    /// The timeout for network requests.
+    /// The timeout for network requests. Can't be more than 100ms longer than
+    /// `transaction_timeout.
     pub socket_timeout: Duration,
+    /// The timeout for transactions.
+    pub transaction_timeout: Duration,
     /// The timeout for setting up network connections.
     pub socket_connection_setup_timeout: Duration,
     /// The timeout for fetching metadata from upstream.
     pub fetch_metadata_timeout: Duration,
 }
 
-impl Default for TcpTimeoutConfig {
+impl Default for TimeoutConfig {
     fn default() -> Self {
-        TcpTimeoutConfig {
+        TimeoutConfig {
             keepalive: DEFAULT_KEEPALIVE,
             socket_timeout: DEFAULT_SOCKET_TIMEOUT,
+            transaction_timeout: DEFAULT_TRANSACTION_TIMEOUT,
             socket_connection_setup_timeout: DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT,
             fetch_metadata_timeout: DEFAULT_FETCH_METADATA_TIMEOUT,
         }
     }
 }
 
-impl TcpTimeoutConfig {
+impl TimeoutConfig {
     /// Build a `TcpTimeoutConfig` from the given parameters. Parameters outside the supported
     /// range are defaulted and cause an error log.
     pub fn build(
         keepalive: bool,
         socket_timeout: Duration,
+        transaction_timeout: Duration,
         socket_connection_setup_timeout: Duration,
         fetch_metadata_timeout: Duration,
-    ) -> TcpTimeoutConfig {
+    ) -> TimeoutConfig {
         // Constrain values based on ranges here:
         // <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
         //
         // Note we error log but do not fail as this is called in a non-fallible
         // LD-sync in the adapter.
 
-        // The documented max here is `300000`, but rdkafka bans `socket.timeout.ms` being more
-        // than `transaction.timeout.ms` + 100ms. We don't currently allow configuring
-        // `transaction.timeout.ms`, so we use its default + 100 here.
-        let socket_timeout = if socket_timeout.as_millis() > 60100 {
-            error!("socket_timeout ({socket_timeout:?}) greater than max of 60100ms, defaulting to the default of {DEFAULT_SOCKET_TIMEOUT:?}");
-            DEFAULT_SOCKET_TIMEOUT
-        } else if socket_timeout.as_millis() < 10 {
-            error!("socket_timeout ({socket_timeout:?}) less than max of 10ms, defaulting to the default of {DEFAULT_SOCKET_TIMEOUT:?}");
-            DEFAULT_SOCKET_TIMEOUT
-        } else {
-            socket_timeout
-        };
-
-        let socket_connection_setup_timeout = if socket_connection_setup_timeout.as_millis()
-            > 2147483647
+        let transaction_timeout = if transaction_timeout.as_millis() > i32::MAX.try_into().unwrap()
         {
-            error!("socket_timeout ({socket_connection_setup_timeout:?}) greater than max of 2147483647ms, \
-            defaulting to the default of {DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT:?}");
-            DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT
+            error!(
+                "transaction_timeout ({transaction_timeout:?}) greater than max \
+                of {}, defaulting to the default of {DEFAULT_TRANSACTION_TIMEOUT:?}",
+                i32::MAX
+            );
+            DEFAULT_TRANSACTION_TIMEOUT
+        } else if socket_timeout.as_millis() < 1000 {
+            error!(
+                "transaction_timeout ({transaction_timeout:?}) less than max \
+                of 1000ms, defaulting to the default of {DEFAULT_TRANSACTION_TIMEOUT:?}"
+            );
+            DEFAULT_TRANSACTION_TIMEOUT
+        } else {
+            transaction_timeout
+        };
+
+        // The documented max here is `300000`, but rdkafka bans `socket.timeout.ms` being more
+        // than `transaction.timeout.ms` + 100ms.
+        let socket_timeout = if socket_timeout.as_millis()
+            > (std::cmp::min(transaction_timeout.as_millis() + 100, 300000))
+        {
+            error!(
+                "socket_timeout ({socket_timeout:?}) greater than max \
+                of min(30000, transaction.timeout.ms + 100 ({})), \
+                defaulting to the default of {DEFAULT_SOCKET_TIMEOUT:?}",
+                transaction_timeout.as_millis() + 100
+            );
+            DEFAULT_SOCKET_TIMEOUT
         } else if socket_timeout.as_millis() < 10 {
-            error!("socket_timeout ({socket_timeout:?}) less than max of 10ms, defaulting to the default of {DEFAULT_SOCKET_TIMEOUT:?}");
-            DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT
+            error!(
+                "socket_timeout ({socket_timeout:?}) less than max \
+                of 10ms, defaulting to the default of {DEFAULT_SOCKET_TIMEOUT:?}"
+            );
+            DEFAULT_SOCKET_TIMEOUT
         } else {
             socket_timeout
         };
 
-        TcpTimeoutConfig {
+        let socket_connection_setup_timeout =
+            if socket_connection_setup_timeout.as_millis() > i32::MAX.try_into().unwrap() {
+                error!(
+                    "socket_connection_setup_timeout ({socket_connection_setup_timeout:?}) \
+                    greater than max of {}ms, defaulting to the default \
+                    of {DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT:?}",
+                    i32::MAX,
+                );
+                DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT
+            } else if socket_timeout.as_millis() < 10 {
+                error!(
+                    "socket_connection_setup_timeout ({socket_connection_setup_timeout:?}) \
+                    less than max of 10ms, defaulting to the default of \
+                {DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT:?}"
+                );
+                DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT
+            } else {
+                socket_connection_setup_timeout
+            };
+
+        TimeoutConfig {
             keepalive,
             socket_timeout,
+            transaction_timeout,
             socket_connection_setup_timeout,
             fetch_metadata_timeout,
         }
@@ -727,7 +770,7 @@ pub fn create_new_client_config_simple() -> ClientConfig {
 /// determined for `target: "librdkafka"`.
 pub fn create_new_client_config(
     tracing_level: Level,
-    timeout_config: TcpTimeoutConfig,
+    timeout_config: TimeoutConfig,
 ) -> ClientConfig {
     #[allow(clippy::disallowed_methods)]
     let mut config = ClientConfig::new();
@@ -776,6 +819,10 @@ pub fn create_new_client_config(
     config.set(
         "socket.timeout.ms",
         timeout_config.socket_timeout.as_millis().to_string(),
+    );
+    config.set(
+        "transaction.timeout.ms",
+        timeout_config.transaction_timeout.as_millis().to_string(),
     );
     config.set(
         "socket.connection.setup.timeout.ms",

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -31,6 +31,7 @@ use rdkafka::producer::{DefaultProducerContext, DeliveryResult, ProducerContext}
 use rdkafka::types::RDKafkaRespErr;
 use rdkafka::util::Timeout;
 use rdkafka::{ClientContext, Statistics, TopicPartitionList};
+use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
 use tracing::{debug, error, info, warn, Level};
 
@@ -631,16 +632,97 @@ pub fn get_partitions<C: ClientContext>(
     Ok(partition_ids)
 }
 
+/// Default to true as they hey have no downsides <https://github.com/confluentinc/librdkafka/issues/283>.
+pub const DEFAULT_KEEPALIVE: bool = true;
+/// The `rdkafka` default.
+/// - <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
+pub const DEFAULT_SOCKET_TIMEOUT: Duration = Duration::from_millis(60000);
+/// The `rdkafka` default.
+/// - <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
+pub const DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT: Duration = Duration::from_millis(30000);
+
+/// Configurable timeouts for Kafka connections.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TcpTimeoutConfig {
+    /// Whether or not to enable
+    pub keepalive: bool,
+    /// The timeout for network requests.
+    pub socket_timeout: Duration,
+    /// The timeout for setting up network connections.
+    pub socket_connection_setup_timeout: Duration,
+}
+
+impl Default for TcpTimeoutConfig {
+    fn default() -> Self {
+        TcpTimeoutConfig {
+            keepalive: DEFAULT_KEEPALIVE,
+            socket_timeout: DEFAULT_SOCKET_TIMEOUT,
+            socket_connection_setup_timeout: DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT,
+        }
+    }
+}
+
+impl TcpTimeoutConfig {
+    /// Build a `TcpTimeoutConfig` from the given parameters. Parameters outside the supported
+    /// range are defaulted and cause an error log.
+    pub fn build(
+        keepalive: bool,
+        socket_timeout: Duration,
+        socket_connection_setup_timeout: Duration,
+    ) -> TcpTimeoutConfig {
+        // Constrain values based on ranges here:
+        // <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
+        //
+        // Note we error log but do not fail as this is called in a non-fallible
+        // LD-sync in the adapter.
+
+        // The documented max here is `300000`, but rdkafka bans `socket.timeout.ms` being more
+        // than `transaction.timeout.ms` + 100ms. We don't currently allow configuring
+        // `transaction.timeout.ms`, so we use its default + 100 here.
+        let socket_timeout = if socket_timeout.as_millis() > 60100 {
+            error!("socket_timeout ({socket_timeout:?}) greater than max of 60100ms, defaulting to the default of {DEFAULT_SOCKET_TIMEOUT:?}");
+            DEFAULT_SOCKET_TIMEOUT
+        } else if socket_timeout.as_millis() < 10 {
+            error!("socket_timeout ({socket_timeout:?}) less than max of 10ms, defaulting to the default of {DEFAULT_SOCKET_TIMEOUT:?}");
+            DEFAULT_SOCKET_TIMEOUT
+        } else {
+            socket_timeout
+        };
+
+        let socket_connection_setup_timeout = if socket_connection_setup_timeout.as_millis()
+            > 2147483647
+        {
+            error!("socket_timeout ({socket_connection_setup_timeout:?}) greater than max of 2147483647ms, \
+            defaulting to the default of {DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT:?}");
+            DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT
+        } else if socket_timeout.as_millis() < 10 {
+            error!("socket_timeout ({socket_timeout:?}) less than max of 10ms, defaulting to the default of {DEFAULT_SOCKET_TIMEOUT:?}");
+            DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT
+        } else {
+            socket_timeout
+        };
+
+        TcpTimeoutConfig {
+            keepalive,
+            socket_timeout,
+            socket_connection_setup_timeout,
+        }
+    }
+}
+
 /// A simpler version of [`create_new_client_config`] that defaults
 /// the `log_level` to `INFO` and should only be used in tests.
 pub fn create_new_client_config_simple() -> ClientConfig {
-    create_new_client_config(tracing::Level::INFO)
+    create_new_client_config(tracing::Level::INFO, Default::default())
 }
 
 /// Build a new [`rdkafka`] [`ClientConfig`] with its `log_level` set correctly
 /// based on the passed through [`tracing::Level`]. This level should be
 /// determined for `target: "librdkafka"`.
-pub fn create_new_client_config(tracing_level: Level) -> ClientConfig {
+pub fn create_new_client_config(
+    tracing_level: Level,
+    timeout_config: TcpTimeoutConfig,
+) -> ClientConfig {
     #[allow(clippy::disallowed_methods)]
     let mut config = ClientConfig::new();
 
@@ -680,6 +762,22 @@ pub fn create_new_client_config(tracing_level: Level) -> ClientConfig {
         tracing::debug!(target: "librdkafka", "Enabling debug logs for rdkafka");
         config.set("debug", "all");
     }
+
+    if timeout_config.keepalive {
+        config.set("socket.keepalive.enable", "true");
+    }
+
+    config.set(
+        "socket.timeout.ms",
+        timeout_config.socket_timeout.as_millis().to_string(),
+    );
+    config.set(
+        "socket.connection.setup.timeout.ms",
+        timeout_config
+            .socket_connection_setup_timeout
+            .as_millis()
+            .to_string(),
+    );
 
     config
 }

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -11,9 +11,7 @@
 
 use std::sync::Arc;
 
-use mz_kafka_util::client::{
-    DEFAULT_FETCH_METADATA_TIMEOUT, DEFAULT_TOPIC_METADATA_REFRESH_INTERVAL,
-};
+use mz_kafka_util::client::DEFAULT_TOPIC_METADATA_REFRESH_INTERVAL;
 use mz_ore::task;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
@@ -102,6 +100,7 @@ pub async fn lookup_start_offsets<C>(
     topic: &str,
     time_offset: i64,
     now: u64,
+    fetch_metadata_timeout: Duration,
 ) -> Result<Vec<i64>, PlanError>
 where
     C: ConsumerContext + 'static,
@@ -127,7 +126,7 @@ where
             let num_partitions = mz_kafka_util::client::get_partitions(
                 consumer.as_ref().client(),
                 &topic,
-                DEFAULT_FETCH_METADATA_TIMEOUT,
+                fetch_metadata_timeout,
             )
             .map_err(|e| sql_err!("{}", e))?
             .len();
@@ -195,6 +194,7 @@ pub async fn validate_start_offsets<C>(
     consumer: Arc<BaseConsumer<C>>,
     topic: &str,
     start_offsets: Vec<i64>,
+    fetch_metadata_timeout: Duration,
 ) -> Result<(), PlanError>
 where
     C: ConsumerContext + 'static,
@@ -206,7 +206,7 @@ where
             let num_partitions = mz_kafka_util::client::get_partitions(
                 consumer.as_ref().client(),
                 &topic,
-                DEFAULT_FETCH_METADATA_TIMEOUT,
+                fetch_metadata_timeout,
             )
             .map_err(|e| sql_err!("{}", e))?
             .len();

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1103,6 +1103,33 @@ const SSH_KEEPALIVES_IDLE: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
+/// Enables `socket.keepalive.enable` for rdkafka client connections. Defaults to true.
+const KAFKA_SOCKET_KEEPALIVE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("kafka_socket_keepalive"),
+    value: &mz_kafka_util::client::DEFAULT_KEEPALIVE,
+    description:
+        "Enables `socket.keepalive.enable` for rdkafka client connections. Defaults to true.",
+    internal: true,
+};
+
+/// Controls `socket.timeout.ms` for rdkafka client connections. Defaults to the rdkafka default.
+const KAFKA_SOCKET_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("kafka_socket_timeout"),
+    value: &mz_kafka_util::client::DEFAULT_SOCKET_TIMEOUT,
+    description: "Controls `socket.timeout.ms` for rdkafka \
+        client connections. Defaults to the rdkafka default.",
+    internal: true,
+};
+
+/// Controls `socket.connection.setup.timeout.ms` for rdkafka client connections. Defaults to the rdkafka default.
+const KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("kafka_socket_connection_setup_timeout"),
+    value: &mz_kafka_util::client::DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT,
+    description: "Controls `socket.connection.setup.timeout.ms` for rdkafka \
+        client connections. Defaults to the rdkafka default.",
+    internal: true,
+};
+
 /// Controls the connection timeout to Cockroach.
 ///
 /// Used by persist as [`mz_persist_client::cfg::DynamicConfig::consensus_connect_timeout`].
@@ -2869,6 +2896,9 @@ impl SystemVars {
             .with_var(&SSH_CHECK_INTERVAL)
             .with_var(&SSH_CONNECT_TIMEOUT)
             .with_var(&SSH_KEEPALIVES_IDLE)
+            .with_var(&KAFKA_SOCKET_KEEPALIVE)
+            .with_var(&KAFKA_SOCKET_TIMEOUT)
+            .with_var(&KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT)
             .with_var(&ENABLE_LAUNCHDARKLY)
             .with_var(&MAX_CONNECTIONS)
             .with_var(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
@@ -3423,6 +3453,21 @@ impl SystemVars {
     /// Returns the `ssh_keepalives_idle` configuration parameter.
     pub fn ssh_keepalives_idle(&self) -> Duration {
         *self.expect_value(&SSH_KEEPALIVES_IDLE)
+    }
+
+    /// Returns the `kafka_socket_keepalive` configuration parameter.
+    pub fn kafka_socket_keepalive(&self) -> bool {
+        *self.expect_value(&KAFKA_SOCKET_KEEPALIVE)
+    }
+
+    /// Returns the `kafka_socket_timeout` configuration parameter.
+    pub fn kafka_socket_timeout(&self) -> Duration {
+        *self.expect_value(&KAFKA_SOCKET_TIMEOUT)
+    }
+
+    /// Returns the `kafka_socket_connection_setup_timeout` configuration parameter.
+    pub fn kafka_socket_connection_setup_timeout(&self) -> Duration {
+        *self.expect_value(&KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT)
     }
 
     /// Returns the `crdb_connect_timeout` configuration parameter.
@@ -5342,6 +5387,9 @@ pub fn is_storage_config_var(name: &str) -> bool {
         || name == SSH_CHECK_INTERVAL.name()
         || name == SSH_CONNECT_TIMEOUT.name()
         || name == SSH_KEEPALIVES_IDLE.name()
+        || name == KAFKA_SOCKET_KEEPALIVE.name()
+        || name == KAFKA_SOCKET_TIMEOUT.name()
+        || name == KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY.name()

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1130,6 +1130,14 @@ const KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
+/// Controls the timeout when fetching kafka metadata.
+const KAFKA_FETCH_METADATA_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("kafka_fetch_metadata_timeout"),
+    value: &mz_kafka_util::client::DEFAULT_FETCH_METADATA_TIMEOUT,
+    description: "Controls the timeout when fetching kafka metadata.",
+    internal: true,
+};
+
 /// Controls the connection timeout to Cockroach.
 ///
 /// Used by persist as [`mz_persist_client::cfg::DynamicConfig::consensus_connect_timeout`].
@@ -2899,6 +2907,7 @@ impl SystemVars {
             .with_var(&KAFKA_SOCKET_KEEPALIVE)
             .with_var(&KAFKA_SOCKET_TIMEOUT)
             .with_var(&KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT)
+            .with_var(&KAFKA_FETCH_METADATA_TIMEOUT)
             .with_var(&ENABLE_LAUNCHDARKLY)
             .with_var(&MAX_CONNECTIONS)
             .with_var(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
@@ -3468,6 +3477,11 @@ impl SystemVars {
     /// Returns the `kafka_socket_connection_setup_timeout` configuration parameter.
     pub fn kafka_socket_connection_setup_timeout(&self) -> Duration {
         *self.expect_value(&KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT)
+    }
+
+    /// Returns the `kafka_fetch_metadata_timeout` configuration parameter.
+    pub fn kafka_fetch_metadata_timeout(&self) -> Duration {
+        *self.expect_value(&KAFKA_FETCH_METADATA_TIMEOUT)
     }
 
     /// Returns the `crdb_connect_timeout` configuration parameter.
@@ -5390,6 +5404,7 @@ pub fn is_storage_config_var(name: &str) -> bool {
         || name == KAFKA_SOCKET_KEEPALIVE.name()
         || name == KAFKA_SOCKET_TIMEOUT.name()
         || name == KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT.name()
+        || name == KAFKA_FETCH_METADATA_TIMEOUT.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY.name()

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -464,15 +464,11 @@ impl KafkaConnection {
             );
         }
 
-        // We don't override any socket timeouts (like `socket.timeout.ms`) as we allow rdkafka
-        // to choose a reasonably default for us, but we do enable keepalives, as
-        // they have no downsides <https://github.com/confluentinc/librdkafka/issues/283>.
-        options.insert("socket.keepalive.enable".into(), "true".into());
-
         let mut config = mz_kafka_util::client::create_new_client_config(
             storage_configuration
                 .connection_context
                 .librdkafka_log_level,
+            storage_configuration.parameters.kafka_timeout_config,
         );
         for (k, v) in options {
             config.set(

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -36,7 +36,7 @@ message ProtoStorageParameters {
     bool record_namespaced_errors = 18;
     uint64 keep_n_privatelink_status_history_entries = 19;
     ProtoSshTimeoutConfig ssh_timeout_config = 20;
-    ProtoKafkaSourceTcpTimeouts kafka_timeout_config = 21;
+    ProtoKafkaTimeouts kafka_timeout_config = 21;
 }
 
 
@@ -48,9 +48,10 @@ message ProtoPgSourceTcpTimeouts {
     optional mz_proto.ProtoDuration tcp_user_timeout = 5;
 }
 
-message ProtoKafkaSourceTcpTimeouts {
+message ProtoKafkaTimeouts {
     bool keepalive = 1;
     mz_proto.ProtoDuration socket_timeout = 2;
+    mz_proto.ProtoDuration transaction_timeout = 5;
     mz_proto.ProtoDuration socket_connection_setup_timeout = 3;
     mz_proto.ProtoDuration fetch_metadata_timeout = 4;
 }

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -52,6 +52,7 @@ message ProtoKafkaSourceTcpTimeouts {
     bool keepalive = 1;
     mz_proto.ProtoDuration socket_timeout = 2;
     mz_proto.ProtoDuration socket_connection_setup_timeout = 3;
+    mz_proto.ProtoDuration fetch_metadata_timeout = 4;
 }
 message ProtoSshTimeoutConfig {
     mz_proto.ProtoDuration check_interval = 1;

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -36,6 +36,7 @@ message ProtoStorageParameters {
     bool record_namespaced_errors = 18;
     uint64 keep_n_privatelink_status_history_entries = 19;
     ProtoSshTimeoutConfig ssh_timeout_config = 20;
+    ProtoKafkaSourceTcpTimeouts kafka_timeout_config = 21;
 }
 
 
@@ -47,9 +48,14 @@ message ProtoPgSourceTcpTimeouts {
     optional mz_proto.ProtoDuration tcp_user_timeout = 5;
 }
 
+message ProtoKafkaSourceTcpTimeouts {
+    bool keepalive = 1;
+    mz_proto.ProtoDuration socket_timeout = 2;
+    mz_proto.ProtoDuration socket_connection_setup_timeout = 3;
+}
 message ProtoSshTimeoutConfig {
     mz_proto.ProtoDuration check_interval = 1;
-    mz_proto.ProtoDuration connect_timeout= 2;
+    mz_proto.ProtoDuration connect_timeout = 2;
     mz_proto.ProtoDuration keepalives_idle = 3;
 }
 

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -320,6 +320,7 @@ impl RustType<ProtoKafkaSourceTcpTimeouts> for mz_kafka_util::client::TcpTimeout
             socket_connection_setup_timeout: Some(
                 self.socket_connection_setup_timeout.into_proto(),
             ),
+            fetch_metadata_timeout: Some(self.fetch_metadata_timeout.into_proto()),
         }
     }
 
@@ -334,6 +335,9 @@ impl RustType<ProtoKafkaSourceTcpTimeouts> for mz_kafka_util::client::TcpTimeout
                 .into_rust_if_some(
                     "ProtoKafkaSourceTcpTimeouts::socket_connection_setup_timeout",
                 )?,
+            fetch_metadata_timeout: proto
+                .fetch_metadata_timeout
+                .into_rust_if_some("ProtoKafkaSourceTcpTimeouts::fetch_metadata_timeout")?,
         })
     }
 }

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -58,7 +58,7 @@ pub struct StorageParameters {
     /// Networking configuration for ssh connections.
     pub ssh_timeout_config: SshTimeoutConfig,
     /// Networking configuration for kafka connections.
-    pub kafka_timeout_config: mz_kafka_util::client::TcpTimeoutConfig,
+    pub kafka_timeout_config: mz_kafka_util::client::TimeoutConfig,
 }
 
 // Implement `Default` manually, so that the default can match the
@@ -312,11 +312,12 @@ impl RustType<ProtoPgSourceTcpTimeouts> for mz_postgres_util::TcpTimeoutConfig {
     }
 }
 
-impl RustType<ProtoKafkaSourceTcpTimeouts> for mz_kafka_util::client::TcpTimeoutConfig {
-    fn into_proto(&self) -> ProtoKafkaSourceTcpTimeouts {
-        ProtoKafkaSourceTcpTimeouts {
+impl RustType<ProtoKafkaTimeouts> for mz_kafka_util::client::TimeoutConfig {
+    fn into_proto(&self) -> ProtoKafkaTimeouts {
+        ProtoKafkaTimeouts {
             keepalive: self.keepalive,
             socket_timeout: Some(self.socket_timeout.into_proto()),
+            transaction_timeout: Some(self.transaction_timeout.into_proto()),
             socket_connection_setup_timeout: Some(
                 self.socket_connection_setup_timeout.into_proto(),
             ),
@@ -324,12 +325,15 @@ impl RustType<ProtoKafkaSourceTcpTimeouts> for mz_kafka_util::client::TcpTimeout
         }
     }
 
-    fn from_proto(proto: ProtoKafkaSourceTcpTimeouts) -> Result<Self, TryFromProtoError> {
-        Ok(mz_kafka_util::client::TcpTimeoutConfig {
+    fn from_proto(proto: ProtoKafkaTimeouts) -> Result<Self, TryFromProtoError> {
+        Ok(mz_kafka_util::client::TimeoutConfig {
             keepalive: proto.keepalive,
             socket_timeout: proto
                 .socket_timeout
                 .into_rust_if_some("ProtoKafkaSourceTcpTimeouts::socket_timeout")?,
+            transaction_timeout: proto
+                .transaction_timeout
+                .into_rust_if_some("ProtoKafkaSourceTcpTimeouts::transaction_timeout")?,
             socket_connection_setup_timeout: proto
                 .socket_connection_setup_timeout
                 .into_rust_if_some(


### PR DESCRIPTION
Closes https://github.com/MaterializeInc/materialize/issues/18683

see https://github.com/MaterializeInc/materialize/issues/18683#issuecomment-1835317032

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
