### PR TITLE
[sinks] Restore the original / default timeout and comment

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -297,8 +297,10 @@ impl KafkaTxProducer {
                     // big difference.
                     "queue.buffering.max.ms" => format!("{}", 10),
                     "transactional.id" => format!("mz-producer-{sink_id}-0"),
-                    // Time out transactions after 10 seconds
-                    "transaction.timeout.ms" => format!("{}", 10_000),
+                    // Use the default transaction timeout. (At time of writing: 60s.)
+                    // The Kafka sink may have long-running transactions, since it expects
+                    // to be able to write all data at the same timestamp in a single
+                    // transaction... including the initial snapshot.
                 },
             )
             .await?;


### PR DESCRIPTION
We recently lowered the transaction timeout to 10s. Since then, we've updated the sink to avoid the problem that our shorter timeout was solving... and since a shorter timeout limits our ability to write large initial snapshots out to Kafka, let's roll it back.

### Motivation

Previously-unreported bug: https://buildkite.com/materialize/release-qualification/builds/387#018c464a-ead0-4f5c-a0f2-3fa1d560b702

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
