### PR TITLE
catalog: make the persist impl's schema a single jsonb column Row

### DIFF
--- a/src/catalog/build.rs
+++ b/src/catalog/build.rs
@@ -221,6 +221,12 @@ fn main() -> anyhow::Result<()> {
         .enum_attribute("SchemaSpecifier.spec", ATTR)
         .enum_attribute("RoleVars.Entry.val", ATTR)
         .enum_attribute("StateUpdateKind.kind", ATTR)
+        // Serialize/deserialize the top-level enum in the persist-backed
+        // catalog as "internally tagged"[^1] to set up persist pushdown
+        // statistics for success.
+        //
+        // [^1]: https://serde.rs/enum-representations.html#internally-tagged
+        .enum_attribute("StateUpdateKind.kind", "#[serde(tag = \"kind\")]")
         // We derive Arbitrary for all protobuf types for wire compatibility testing.
         .message_attribute(".", ARBITRARY_ATTR)
         .enum_attribute(".", ARBITRARY_ATTR)

--- a/src/catalog/src/durable/objects/serialization.rs
+++ b/src/catalog/src/durable/objects/serialization.rs
@@ -30,10 +30,9 @@ use mz_sql::names::{
 };
 use mz_sql::session::vars::OwnedVarInput;
 use mz_storage_types::instances::StorageInstanceId;
-use prost::Message;
 use std::time::Duration;
 
-use crate::durable::impls::persist::state_update::StateUpdateKindBinary;
+use crate::durable::impls::persist::state_update::StateUpdateKindRaw;
 use crate::durable::objects::{
     AuditLogKey, ClusterIntrospectionSourceIndexKey, ClusterIntrospectionSourceIndexValue,
     ClusterKey, ClusterReplicaKey, ClusterReplicaValue, ClusterValue, CommentKey, CommentValue,
@@ -51,17 +50,17 @@ pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/objects.rs"));
 }
 
-impl From<proto::StateUpdateKind> for StateUpdateKindBinary {
+impl From<proto::StateUpdateKind> for StateUpdateKindRaw {
     fn from(value: proto::StateUpdateKind) -> Self {
-        Self(value.encode_to_vec())
+        StateUpdateKindRaw::from_serde(&value)
     }
 }
 
-impl TryFrom<StateUpdateKindBinary> for proto::StateUpdateKind {
+impl TryFrom<StateUpdateKindRaw> for proto::StateUpdateKind {
     type Error = String;
 
-    fn try_from(value: StateUpdateKindBinary) -> Result<Self, Self::Error> {
-        proto::StateUpdateKind::decode(value.0.as_slice()).map_err(|err| err.to_string())
+    fn try_from(value: StateUpdateKindRaw) -> Result<Self, Self::Error> {
+        Ok(value.to_serde::<Self>())
     }
 }
 

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -94,7 +94,7 @@ use crate::{strconv, Datum, Row, RowPacker};
 /// All numbers are represented as [`f64`]s. It is not possible to construct a
 /// `Jsonb` from a JSON object that contains integers that cannot be represented
 /// exactly as `f64`s.
-#[derive(Debug, Clone, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub struct Jsonb {
     row: Row,
 }


### PR DESCRIPTION
Technically not a Row, but rather a SourceData with no Errs, like we do
for tables.

This sets us up to expose the raw catalog shard as a queryable source in
mz SQL. This in turn would allow us to model something like
`mz_databases` as a `VIEW` (or `MATERIALIZED VIEW`) instead of manually
denormalize-ing catalog changes into a second place when committing DDL
changes.

There are a number of tweaks we could make to the proto->json mapping to
make it easier to actually defining these views in SQL, but the catalog
migration framework means we can "easily" punt that for a later time.

For now, start by modeling the top-level "kind" enum as [internally
tagged] to try to set persist pushdown statistics up for success. We
might later want to use [untagged] for all the proto oneofs, to make the
json more ergonomic, but this would require tweaking the protos a bit
(e.g. replace the GlobalId proto or its innards with the canonical
GlobalId string representation).

[internally tagged]: https://serde.rs/enum-representations.html#internally-tagged
[untagged]: https://serde.rs/enum-representations.html#untagged

Closes #23871

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
