### PR TITLE
storage: add format columns to mz_sources and mz_sinks

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -406,6 +406,7 @@ Field            | Type     | Meaning
 `connection_id`  | [`text`] | The ID of the connection associated with the sink, if any. Corresponds to [`mz_connections.id`](/sql/system-catalog/mz_catalog/#mz_connections).
 `size`           | [`text`] | The size of the sink.
 `envelope_type`  | [`text`] | The [envelope](/sql/create-sink/kafka/#envelopes) of the sink: `upsert`, or `debezium`.
+`format`         | [`text`] | The [format](/sql/create-sink/kafka/#formats) of the sink's output: `avro` or `json`.
 `cluster_id`     | [`text`] | The ID of the cluster maintaining the sink. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters).
 `owner_id`       | [`text`] | The role ID of the owner of the sink. Corresponds to [`mz_roles.id`](/sql/system-catalog/mz_catalog/#mz_roles).
 `create_sql`     | [`text`] | The `CREATE` SQL statement for the sink.
@@ -426,6 +427,8 @@ Field            | Type                 | Meaning
 `connection_id`  | [`text`]             | The ID of the connection associated with the source, if any. Corresponds to [`mz_connections.id`](/sql/system-catalog/mz_catalog/#mz_connections).
 `size`           | [`text`]             | The [size](/sql/create-source/#sizing-a-source) of the source.
 `envelope_type`  | [`text`]             | The [envelope](/sql/create-source/#envelopes) of the source: `none`, `upsert`, or `debezium`.
+`key_format`     | [`text`]             | The [format](/sql/create-source/#formats) of the source's key, if any: `avro`, `protobuf`, `csv`, `regex`, `bytes`, `json`, `text`, or `NULL`.
+`value_format`     | [`text`]             | The [format](/sql/create-source/#formats) of the source, if any: `avro`, `protobuf`, `csv`, `regex`, `bytes`, `json`, `text`, or `NULL`.
 `cluster_id`     | [`text`]             | The ID of the cluster maintaining the source. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters).
 `owner_id`       | [`text`]             | The role ID of the owner of the source. Corresponds to [`mz_roles.id`](/sql/system-catalog/mz_catalog/#mz_roles).
 `privileges`     | [`mz_aclitem array`] | The privileges belonging to the source.

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2066,6 +2066,8 @@ pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("connection_id", ScalarType::String.nullable(true))
         .with_column("size", ScalarType::String.nullable(true))
         .with_column("envelope_type", ScalarType::String.nullable(true))
+        .with_column("key_format", ScalarType::String.nullable(true))
+        .with_column("value_format", ScalarType::String.nullable(true))
         .with_column("cluster_id", ScalarType::String.nullable(true))
         .with_column("owner_id", ScalarType::String.nullable(false))
         .with_column(
@@ -2089,6 +2091,7 @@ pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("connection_id", ScalarType::String.nullable(true))
         .with_column("size", ScalarType::String.nullable(true))
         .with_column("envelope_type", ScalarType::String.nullable(true))
+        .with_column("format", ScalarType::String.nullable(false))
         .with_column("cluster_id", ScalarType::String.nullable(false))
         .with_column("owner_id", ScalarType::String.nullable(false))
         .with_column("create_sql", ScalarType::String.nullable(false))

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use mz_adapter_types::compaction::DEFAULT_LOGICAL_COMPACTION_WINDOW;
 use mz_adapter_types::connection::ConnectionId;
+use mz_storage_types::sources::encoding::SourceDataEncoding;
 use once_cell::sync::Lazy;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
@@ -51,7 +52,7 @@ use mz_sql::rbac;
 use mz_sql::session::vars::OwnedVarInput;
 use mz_storage_client::controller::IntrospectionType;
 use mz_storage_types::connections::inline::ReferencedConnection;
-use mz_storage_types::sinks::{SinkEnvelope, StorageSinkConnection};
+use mz_storage_types::sinks::{KafkaSinkFormat, SinkEnvelope, StorageSinkConnection};
 use mz_storage_types::sources::{
     IngestionDescription, SourceConnection, SourceDesc, SourceEnvelope, SourceExport, Timeline,
 };
@@ -544,6 +545,20 @@ impl Source {
         }
     }
 
+    /// The key and value formats of the source.
+    pub fn formats(&self) -> (Option<&str>, Option<&str>) {
+        match &self.data_source {
+            DataSourceDesc::Ingestion(ingestion) => match &ingestion.desc.encoding {
+                SourceDataEncoding::Single(encoding) => (None, encoding.type_()),
+                SourceDataEncoding::KeyValue { key, value } => (key.type_(), value.type_()),
+            },
+            DataSourceDesc::Introspection(_)
+            | DataSourceDesc::Webhook { .. }
+            | DataSourceDesc::Progress
+            | DataSourceDesc::Source => (None, None),
+        }
+    }
+
     /// Envelope of the source.
     pub fn envelope(&self) -> Option<&str> {
         // Note how "none"/"append-only" is different from `None`. Source
@@ -551,7 +566,7 @@ impl Source {
         // other sources have an envelope that we call the "NONE"-envelope.
 
         match &self.data_source {
-            // NOTE(aljoscha): We could move the block for ingestsions into
+            // NOTE(aljoscha): We could move the block for ingestions into
             // `SourceEnvelope` itself, but that one feels more like an internal
             // thing and adapter should own how we represent envelopes as a
             // string? It would not be hard to convince me otherwise, though.
@@ -635,6 +650,7 @@ pub struct Sink {
     pub create_sql: String,
     pub from: GlobalId,
     pub connection: StorageSinkConnection<ReferencedConnection>,
+    // TODO(guswynn): this probably should just be in the `connection`.
     pub envelope: SinkEnvelope,
     pub with_snapshot: bool,
     pub resolved_ids: ResolvedIds,
@@ -651,6 +667,15 @@ impl Sink {
         match &self.envelope {
             SinkEnvelope::Debezium => Some("debezium"),
             SinkEnvelope::Upsert => Some("upsert"),
+        }
+    }
+
+    /// Output format of the sink.
+    pub fn format(&self) -> &str {
+        let StorageSinkConnection::Kafka(connection) = &self.connection;
+        match &connection.format {
+            KafkaSinkFormat::Avro { .. } => "avro",
+            KafkaSinkFormat::Json => "json",
         }
     }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1413,6 +1413,7 @@ pub struct Sink {
     pub create_sql: String,
     pub from: GlobalId,
     pub connection: StorageSinkConnection<ReferencedConnection>,
+    // TODO(guswynn): this probably should just be in the `connection`.
     pub envelope: SinkEnvelope,
 }
 

--- a/src/storage-types/src/sources/encoding.rs
+++ b/src/storage-types/src/sources/encoding.rs
@@ -279,6 +279,22 @@ impl<C: ConnectionAccess> DataEncoding<C> {
         }
     }
 
+    /// A human-readable name for the type of encoding
+    ///
+    /// This may be `None` if we don't actually render a decode operator (like for pg sources).
+    pub fn type_(&self) -> Option<&str> {
+        match &self.inner {
+            DataEncodingInner::Avro(_) => Some("avro"),
+            DataEncodingInner::Protobuf(_) => Some("protobuf"),
+            DataEncodingInner::Csv(_) => Some("csv"),
+            DataEncodingInner::Regex(_) => Some("regex"),
+            DataEncodingInner::Bytes => Some("bytes"),
+            DataEncodingInner::Json => Some("json"),
+            DataEncodingInner::Text => Some("text"),
+            DataEncodingInner::RowCodec(_) => None,
+        }
+    }
+
     /// Computes the [`RelationDesc`] for the relation specified by this
     /// data encoding and envelope.
     ///

--- a/test/sqllogictest/autogenerated/mz_catalog.slt
+++ b/test/sqllogictest/autogenerated/mz_catalog.slt
@@ -286,10 +286,11 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 6  connection_id  text
 7  size  text
 8  envelope_type  text
-9  cluster_id  text
-10  owner_id  text
-11  create_sql  text
-12  redacted_create_sql  text
+9  format  text
+10  cluster_id  text
+11  owner_id  text
+12  create_sql  text
+13  redacted_create_sql  text
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_sources' ORDER BY position
@@ -302,11 +303,13 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 6  connection_id  text
 7  size  text
 8  envelope_type  text
-9  cluster_id  text
-10  owner_id  text
-11  privileges  mz_aclitem[]
-12  create_sql  text
-13  redacted_create_sql  text
+9  key_format  text
+10  value_format  text
+11  cluster_id  text
+12  owner_id  text
+13  privileges  mz_aclitem[]
+14  create_sql  text
+15  redacted_create_sql  text
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_storage_usage' ORDER BY position

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -414,7 +414,7 @@ Explained Query:
           Negate
             Project (#0, #1, #3, #4, #6)
               Filter like["u%"](#0)
-                Join on=(#0 = #13) type=differential
+                Join on=(#0 = #15) type=differential
                   Get l0
                   ArrangeBy keys=[[#0]]
                     Distinct project=[#0]
@@ -426,9 +426,9 @@ Explained Query:
       Get l1
   With
     cte l1 =
-      Project (#0, #1, #3, #4, #6, #17, #18)
+      Project (#0, #1, #3, #4, #6, #19, #20)
         Filter like["u%"](#0)
-          Join on=(#0 = #13) type=differential
+          Join on=(#0 = #15) type=differential
             Get l0
             ArrangeBy keys=[[#0]]
               ReadIndex on=mz_source_statuses mz_source_statuses_ind=[differential join]

--- a/test/testdrive/mz-sinks.td
+++ b/test/testdrive/mz-sinks.td
@@ -38,3 +38,6 @@ debezium
 
 > SELECT envelope_type FROM mz_sinks WHERE name = 'mz_sinks_upsert'
 upsert
+
+> SELECT format FROM mz_sinks WHERE name = 'mz_sinks_upsert'
+avro

--- a/test/testdrive/mz-sources.td
+++ b/test/testdrive/mz-sources.td
@@ -25,6 +25,11 @@ $ kafka-create-topic topic=none-topic partitions=1
   INCLUDE KEY
   ENVELOPE NONE
 
+> CREATE SOURCE none_source_no_key
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-none-topic-${testdrive.seed}')
+  FORMAT TEXT
+  ENVELOPE NONE
+
 
 $ set keyschema={
     "type": "record",
@@ -145,3 +150,12 @@ debezium
 
 > SELECT envelope_type FROM mz_sources WHERE name = 'upsert_source'
 upsert
+
+> SELECT key_format, value_format FROM mz_sources WHERE name = 'none_source'
+text text
+
+> SELECT key_format, value_format FROM mz_sources WHERE name = 'none_source_no_key'
+<null> text
+
+> SELECT key_format, value_format FROM mz_sources WHERE name = 'debezium_source'
+avro avro


### PR DESCRIPTION
For storage metrics: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1702511680854199, we want to be able to label sources/sinks with the format they are using. This adds those to the `mz_sources` and `mz_sinks` table. I want people to take a look, and then ill update the docs in the same pr.

### Motivation


  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
