### PR TITLE
dbt-materialize: unblock UUID type usage for data contracts

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Remove the dependency of data contracts pre-flight checks on the existence of
   the pre-installed `default` cluster. Fixes [#23600](https://github.com/MaterializeInc/materialize/issues/23600).
 
+* Work around [dbt-core #8353](https://github.com/dbt-labs/dbt-core/issues/8353)
+  while a permanent fix doesn't land in dbt Core to unblock users using UUID
+  types.
+
 ## 1.7.0 - 2023-11-20
 
 * Support specifying the materialization type used to store test failures via

--- a/misc/dbt-materialize/dbt/adapters/materialize/connections.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/connections.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import psycopg2
+from psycopg2.extras import register_uuid
 
 import dbt.adapters.postgres.connections
 import dbt.exceptions
@@ -48,6 +49,11 @@ def connect(**kwargs):
         *(kwargs.get("options") or []),
     ]
     kwargs["options"] = " ".join(options)
+
+    # NOTE(morsapaes): work around dbt-core #8353 while #8900 doesn't land to
+    # unblock users using UUID types.
+    register_uuid()
+
     return _connect(**kwargs)
 
 


### PR DESCRIPTION
Users using `UUID` types with data contracts currently run into the following error:

```bash
❯ dbt run
05:12:28  Running with dbt=1.7.3
05:12:28  Registered adapter: materialize=1.7.0
05:12:28  Found 2 tests, 4 seeds, 1 model, 2 sources, 0 exposures, 0 metrics, 426 macros, 0 groups, 0 semantic models
05:12:28
05:12:31  Concurrency: 1 threads (target='dev')
05:12:31
05:12:31  1 of 1 START sql materialized_view model public.content_tags_model ............. [RUN]
05:12:32  Unhandled error while executing
2950
05:12:32  1 of 1 ERROR creating sql materialized_view model public.content_tags_model .... [ERROR in 1.12s]
05:12:32
05:12:32  Finished running 1 materialized_view model in 0 hours 0 minutes and 4.58 seconds (4.58s).
05:12:32
05:12:32  Completed with 1 error and 0 warnings:
05:12:32
05:12:32    2950
05:12:32
05:12:32  Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
```

This is a known limitation in `dbt-core` ([#8353](https://github.com/dbt-labs/dbt-core/issues/8353)) that has been generically fixed, but is still pending an adapter-specific fix. Since it won't be uncommon for users to need this, patching `dbt-materialize` with a workaround that calls `register_uuid()` on connection, to avoid requiring users to define a type mapping macro.

Based on [dbt-core #8357](https://github.com/dbt-labs/dbt-core/pull/8357).