### PR TITLE
adapter: add `enable_mz_notices` feature flag

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1196,12 +1196,14 @@ impl Catalog {
 
         for id in drop_ids {
             if let Some(df_meta) = self.try_get_dataflow_metainfo(&id) {
-                // Generate retractions for the Builtin tables.
-                self.pack_optimizer_notices(
-                    &mut builtin_table_updates,
-                    df_meta.optimizer_notices.iter(),
-                    -1,
-                );
+                if self.state().system_config().enable_mz_notices() {
+                    // Generate retractions for the Builtin tables.
+                    self.pack_optimizer_notices(
+                        &mut builtin_table_updates,
+                        df_meta.optimizer_notices.iter(),
+                        -1,
+                    );
+                }
             }
             // Drop in-memory planning metadata.
             self.drop_plans_and_metainfos(id);

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1312,12 +1312,14 @@ impl Coordinator {
                             .try_get_dataflow_metainfo(&entry.id())
                             .expect("added in `bootstrap_dataflow_plans`");
 
-                        // Collect optimization hint updates.
-                        self.catalog().pack_optimizer_notices(
-                            &mut builtin_table_updates,
-                            df_meta.optimizer_notices.iter(),
-                            1,
-                        );
+                        if self.catalog().state().system_config().enable_mz_notices() {
+                            // Collect optimization hint updates.
+                            self.catalog().pack_optimizer_notices(
+                                &mut builtin_table_updates,
+                                df_meta.optimizer_notices.iter(),
+                                1,
+                            );
+                        }
 
                         // What follows is morally equivalent to `self.ship_dataflow(df, idx.cluster_id)`,
                         // but we cannot call that as it will also downgrade the read hold on the index.
@@ -1356,12 +1358,14 @@ impl Coordinator {
                         .try_get_dataflow_metainfo(&entry.id())
                         .expect("added in `bootstrap_dataflow_plans`");
 
-                    // Collect optimization hint updates.
-                    self.catalog().pack_optimizer_notices(
-                        &mut builtin_table_updates,
-                        df_meta.optimizer_notices.iter(),
-                        1,
-                    );
+                    if self.catalog().state().system_config().enable_mz_notices() {
+                        // Collect optimization hint updates.
+                        self.catalog().pack_optimizer_notices(
+                            &mut builtin_table_updates,
+                            df_meta.optimizer_notices.iter(),
+                            1,
+                        );
+                    }
 
                     self.ship_dataflow(df_desc, mview.cluster_id).await;
                 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2134,6 +2134,13 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: true,
     },
+    {
+        name: enable_mz_notices,
+        desc: "Populate the contents of `mz_internal.mz_notices`",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 /// Represents the input to a variable.

--- a/test/sqllogictest/transform/notice/index_key_empty.slt
+++ b/test/sqllogictest/transform/notice/index_key_empty.slt
@@ -12,6 +12,11 @@ ALTER SYSTEM SET enable_table_keys = true
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_mz_notices = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE t (
   a int,

--- a/test/sqllogictest/transform/notice/index_too_wide_for_literal_constraints.slt
+++ b/test/sqllogictest/transform/notice/index_too_wide_for_literal_constraints.slt
@@ -14,6 +14,11 @@ ALTER SYSTEM SET enable_table_keys = true
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_mz_notices = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE t6(x int, y int, z int, w text);
 


### PR DESCRIPTION
Gate tracking of optimizer notices in the catalog behind a feature flag.

[Design doc](https://github.com/MaterializeInc/materialize/pull/23562)

### Motivation

  * This PR adds a feature that has not yet been specified.

The bot in #23360 suggested to gate this behind a feature flag.

### Tips for reviewer

* The hard-coded default is `true`, otherwise we might not be able to pick all updates on the first deployment because the LD flag is synchronized after the `bootstrap` call.
* Currently only gates the packing of retractions / insertions.
* We should also add a change to `misc/python/materialize/mzcompose/__init__.py`, but as we saw earlier this week this doesn't quite work at the moment because regression tests picking up the last stable version and emit a `warn` if the `DEFAULT_SYSTEM_PARAMETERS` contain a parameter that is not supported by that version.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
