### PR TITLE
sql: Support setting global defaults for some Session variables

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -194,7 +194,6 @@ impl Client {
             role_id,
             write_notify,
             session_defaults,
-            role_defaults,
             catalog,
         } = response;
 
@@ -207,13 +206,10 @@ impl Client {
         session.initialize_role_metadata(role_id);
         let vars_mut = session.vars_mut();
         for (name, val) in session_defaults {
-            vars_mut.set_default(&name, val);
-        }
-        for (name, val) in role_defaults {
-            if let Err(err) = vars_mut.set_role_default(&name, val.borrow()) {
+            if let Err(err) = vars_mut.set_default(&name, val.borrow()) {
                 // Note: erroring here is unexpected, but we don't want to panic if somehow our
                 // assumptions are wrong.
-                tracing::error!("failed to set peristed role default, {err:?}");
+                tracing::error!("failed to set peristed default, {err:?}");
             }
         }
         session

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::pin::Pin;
@@ -181,10 +180,8 @@ pub struct StartupResponse {
     /// A future that completes when all necessary Builtin Table writes have completed.
     #[derivative(Debug = "ignore")]
     pub write_notify: BoxFuture<'static, ()>,
-    /// Vec of (name, VarInput::Flat) tuples of session default variables that should be set.
-    pub session_defaults: Vec<(String, Box<dyn Any + Send + Sync>)>,
-    /// Vec of (name, VarInput::Flat) tuples of Role default variables that should be set.
-    pub role_defaults: Vec<(String, OwnedVarInput)>,
+    /// Map of (name, VarInput::Flat) tuples of session default variables that should be set.
+    pub session_defaults: BTreeMap<String, OwnedVarInput>,
     pub catalog: Arc<Catalog>,
 }
 

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -10,8 +10,7 @@
 //! Logic for  processing client [`Command`]s. Each [`Command`] is initiated by a
 //! client via some external Materialize API (ex: HTTP and psql).
 
-use std::any::Any;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -35,7 +34,7 @@ use mz_sql::rbac;
 use mz_sql::rbac::CREATE_ITEM_USAGE;
 use mz_sql::session::user::User;
 use mz_sql::session::vars::{
-    EndTransactionAction, OwnedVarInput, Var, STATEMENT_LOGGING_SAMPLE_RATE,
+    EndTransactionAction, OwnedVarInput, Value, Var, STATEMENT_LOGGING_SAMPLE_RATE,
 };
 use opentelemetry::trace::TraceContextExt;
 use tokio::sync::{mpsc, oneshot, watch};
@@ -233,22 +232,32 @@ impl Coordinator {
         // Early return if successful, otherwise cleanup any possible state.
         match self.handle_startup_inner(&user, &conn_id).await {
             Ok(role_id) => {
-                let mut session_defaults: Vec<(_, Box<dyn Any + Send + Sync>)> = Vec::new();
-                let default = self
-                    .catalog()
-                    .state()
-                    .system_config()
-                    .statement_logging_default_sample_rate();
-                session_defaults.push((
+                let mut session_defaults = BTreeMap::new();
+                let system_config = self.catalog().state().system_config();
+
+                // Override the session with any system defaults.
+                session_defaults.extend(
+                    system_config
+                        .iter_session()
+                        .map(|v| (v.name().to_string(), OwnedVarInput::Flat(v.value()))),
+                );
+
+                // Special case.
+                let statement_logging_default = system_config
+                    .statement_logging_default_sample_rate()
+                    .format();
+                session_defaults.insert(
                     STATEMENT_LOGGING_SAMPLE_RATE.name().to_string(),
-                    Box::new(default),
-                ));
-                let role_defaults = self
-                    .catalog()
-                    .get_role(&role_id)
-                    .vars()
-                    .map(|(name, val)| (name.to_owned(), val.clone()))
-                    .collect();
+                    OwnedVarInput::Flat(statement_logging_default),
+                );
+
+                // Override system defaults with role defaults.
+                session_defaults.extend(
+                    self.catalog()
+                        .get_role(&role_id)
+                        .vars()
+                        .map(|(name, val)| (name.to_string(), val.clone())),
+                );
 
                 let session_type = metrics::session_type_label_value(&user);
                 self.metrics
@@ -279,7 +288,6 @@ impl Coordinator {
                     role_id,
                     write_notify: Box::pin(notify),
                     session_defaults,
-                    role_defaults,
                     catalog: self.owned_catalog(),
                 });
                 if tx.send(resp).is_err() {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -59,9 +59,10 @@ use mz_sql::plan::{
     PlannedAlterRoleOption, PlannedRoleVariable, QueryWhen, SideEffectingFunc,
     SourceSinkClusterConfig, UpdatePrivilege, VariableValue,
 };
+use mz_sql::session::user::UserKind;
 use mz_sql::session::vars::{
-    IsolationLevel, OwnedVarInput, SessionVars, Var, VarInput, CLUSTER_VAR_NAME, DATABASE_VAR_NAME,
-    ENABLE_RBAC_CHECKS, SCHEMA_ALIAS, TRANSACTION_ISOLATION_VAR_NAME,
+    IsolationLevel, OwnedVarInput, SessionVars, VarInput, CLUSTER_VAR_NAME, DATABASE_VAR_NAME,
+    SCHEMA_ALIAS, TRANSACTION_ISOLATION_VAR_NAME,
 };
 use mz_sql::{plan, rbac};
 use mz_sql_parser::ast::display::AstDisplay;
@@ -5673,34 +5674,36 @@ impl Coordinator {
         session: &Session,
         var_name: Option<&str>,
     ) -> Result<(), AdapterError> {
-        if session.user().is_system_user()
-            || (var_name == Some(ENABLE_RBAC_CHECKS.name()) && session.is_superuser())
-        {
-            match var_name {
-                Some(name) => {
-                    // In lieu of plumbing the user to all system config functions, just check that the var is
-                    // visible.
-                    let var = self.catalog().system_config().get(name)?;
-                    var.visible(session.user(), Some(self.catalog().system_config()))?;
-                    Ok(())
-                }
-                None => Ok(()),
+        match (session.user().kind(), var_name) {
+            // Only internal superusers can reset all system variables.
+            (UserKind::Superuser, None) if session.user().is_internal() => Ok(()),
+            // Whether or not a variable can be modified depends if we're an internal superuser.
+            (UserKind::Superuser, Some(name))
+                if session.user().is_internal()
+                    || self.catalog().system_config().user_modifiable(name) =>
+            {
+                // In lieu of plumbing the user to all system config functions, just check that
+                // the var is visible.
+                let var = self.catalog().system_config().get(name)?;
+                var.visible(session.user(), Some(self.catalog().system_config()))?;
+                Ok(())
             }
-        } else if var_name == Some(ENABLE_RBAC_CHECKS.name()) {
-            Err(AdapterError::Unauthorized(
-                rbac::UnauthorizedError::Superuser {
-                    action: format!(
-                        "toggle the '{}' system configuration parameter",
-                        ENABLE_RBAC_CHECKS.name()
-                    ),
-                },
-            ))
-        } else {
-            Err(AdapterError::Unauthorized(
+            // If we're not a superuser, but the variable is user modifiable, indicate they can use
+            // session variables.
+            (UserKind::Regular, Some(name))
+                if self.catalog().system_config().user_modifiable(name) =>
+            {
+                Err(AdapterError::Unauthorized(
+                    rbac::UnauthorizedError::Superuser {
+                        action: format!("toggle the '{name}' system configuration parameter"),
+                    },
+                ))
+            }
+            _ => Err(AdapterError::Unauthorized(
                 rbac::UnauthorizedError::MzSystem {
                     action: "alter system".into(),
                 },
-            ))
+            )),
         }
     }
 

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -50,7 +50,9 @@ use mz_server_core::{ConnectionHandler, Server};
 use mz_sql::session::user::{
     User, HTTP_DEFAULT_USER, SUPPORT_USER, SUPPORT_USER_NAME, SYSTEM_USER, SYSTEM_USER_NAME,
 };
-use mz_sql::session::vars::{ConnectionCounter, DropConnection, VarInput};
+use mz_sql::session::vars::{
+    ConnectionCounter, DropConnection, Value, Var, VarInput, WELCOME_MESSAGE,
+};
 use openssl::ssl::{Ssl, SslContext};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -622,7 +624,8 @@ where
             |session| {
                 session
                     .vars_mut()
-                    .set_default("welcome_message", Box::new(false))
+                    .set_default(WELCOME_MESSAGE.name(), VarInput::Flat(&false.format()))
+                    .expect("known to exist")
             },
             options,
         )

--- a/src/sql/src/session/user.rs
+++ b/src/sql/src/session/user.rs
@@ -80,7 +80,7 @@ impl User {
 
     /// Returns whether this user is a superuser.
     pub fn is_superuser(&self) -> bool {
-        self.is_external_admin() || self.name == SYSTEM_USER.name
+        matches!(self.kind(), UserKind::Superuser)
     }
 
     /// Returns whether this is user is the `mz_system` user.
@@ -92,6 +92,21 @@ impl User {
     pub fn limit_max_connections(&self) -> bool {
         !self.is_internal() && !self.is_external_admin()
     }
+
+    /// Returns the kind of user this is.
+    pub fn kind(&self) -> UserKind {
+        if self.is_external_admin() || self.is_system_user() {
+            UserKind::Superuser
+        } else {
+            UserKind::Regular
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum UserKind {
+    Regular,
+    Superuser,
 }
 
 pub const MZ_SYSTEM_ROLE_ID: RoleId = RoleId::System(1);

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -3071,6 +3071,11 @@ impl SystemVars {
             .filter(|v| Self::SESSION_VARS.contains_key(UncasedStr::new(v.name())))
     }
 
+    /// Returns whether or not this parameter can be modified by a superuser.
+    pub fn user_modifiable(&self, name: &str) -> bool {
+        Self::SESSION_VARS.contains_key(UncasedStr::new(name)) || name == ENABLE_RBAC_CHECKS.name()
+    }
+
     /// Returns a [`Var`] representing the configuration parameter with the
     /// specified name.
     ///

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2237,27 +2237,11 @@ impl SessionVars {
             user,
         };
 
-        s.with_var(&APPLICATION_NAME)
-            .with_var(&CLIENT_ENCODING)
-            .with_var(&CLIENT_MIN_MESSAGES)
-            .with_var(&CLUSTER)
-            .with_var(&CLUSTER_REPLICA)
-            .with_var(&DATABASE)
-            .with_var(&DATE_STYLE)
-            .with_var(&EXTRA_FLOAT_DIGITS)
+        s.with_system_vars(&*SystemVars::SESSION_VARS)
             .with_var(&FAILPOINTS)
-            .with_value_constrained_var(&INTEGER_DATETIMES, ValueConstraint::Fixed)
-            .with_var(&INTERVAL_STYLE)
-            .with_var(&SEARCH_PATH)
             .with_value_constrained_var(&SERVER_VERSION, ValueConstraint::ReadOnly)
             .with_value_constrained_var(&SERVER_VERSION_NUM, ValueConstraint::ReadOnly)
-            .with_var(&SEARCH_PATH)
             .with_var(&SQL_SAFE_UPDATES)
-            .with_value_constrained_var(&STANDARD_CONFORMING_STRINGS, ValueConstraint::Fixed)
-            .with_var(&STATEMENT_TIMEOUT)
-            .with_var(&IDLE_IN_TRANSACTION_SESSION_TIMEOUT)
-            .with_var(&TIMEZONE)
-            .with_var(&TRANSACTION_ISOLATION)
             .with_feature_gated_var(&REAL_TIME_RECENCY, &ALLOW_REAL_TIME_RECENCY)
             .with_var(&EMIT_TIMESTAMP_NOTICE)
             .with_var(&EMIT_TRACE_ID_NOTICE)
@@ -2294,7 +2278,7 @@ impl SessionVars {
     ) -> Self
     where
         V: Value + Debug + PartialEq + Clone + 'static,
-        V::Owned: Debug + PartialEq + Send + Clone + Sync,
+        V::Owned: Debug + Send + Clone + Sync,
     {
         self.vars.insert(
             var.name,
@@ -2310,12 +2294,22 @@ impl SessionVars {
     ) -> Self
     where
         V: Value + Debug + PartialEq + Clone + 'static,
-        V::Owned: Debug + PartialEq + Send + Clone + Sync,
+        V::Owned: Debug + Send + Clone + Sync,
     {
         self.vars.insert(
             var.name,
             Box::new(SessionVar::new(var).add_feature_flag(flag)),
         );
+        self
+    }
+
+    fn with_system_vars<'a>(
+        mut self,
+        vars: impl IntoIterator<Item = (&'a &'static UncasedStr, &'a Box<dyn SystemVarMut>)>,
+    ) -> Self {
+        for (name, var) in vars {
+            self.vars.insert(name, var.to_session_var());
+        }
         self
     }
 
@@ -2444,26 +2438,14 @@ impl SessionVars {
 
     /// Sets the default value for the parameter named `name` to the value
     /// represented by `value`.
-    pub fn set_default(&mut self, name: &str, input: Box<dyn Any>) {
-        let name = UncasedStr::new(name);
-        let var = self.vars.get_mut(name).unwrap_or_else(|| {
-            panic!("SessionVars::set_default called with unknown variable {name}")
-        });
-        var.set_default(input);
-    }
-
-    /// Sets the "role default" parameter named `name` to the value represented by `value`.
-    ///
-    /// A role default only takes effect at the start of a Session, so running
-    /// `ALTER ROLE ... SET ...` has no visible impact until a new connection is started.
-    pub fn set_role_default(&mut self, name: &str, input: VarInput) -> Result<(), VarError> {
+    pub fn set_default(&mut self, name: &str, input: VarInput) -> Result<(), VarError> {
         let name = UncasedStr::new(name);
         self.check_read_only(name)?;
 
         self.vars
             .get_mut(name)
             // Note: visibility is checked when persisting a role default.
-            .map(|v| v.set_role_default(input))
+            .map(|v| v.set_default(input))
             .transpose()?
             .ok_or_else(|| VarError::UnknownParameter(name.to_string()))
     }
@@ -2805,6 +2787,39 @@ impl Default for SystemVars {
 }
 
 impl SystemVars {
+    /// Set of [`SystemVar`]s that can also get set at a per-Session level.
+    const SESSION_VARS: Lazy<BTreeMap<&'static UncasedStr, Box<dyn SystemVarMut>>> =
+        Lazy::new(|| {
+            #[allow(clippy::as_conversions)]
+            [
+                Box::new(SystemVar::new(&APPLICATION_NAME)) as Box<dyn SystemVarMut>,
+                Box::new(SystemVar::new(&CLIENT_ENCODING)),
+                Box::new(SystemVar::new(&CLIENT_MIN_MESSAGES)),
+                Box::new(SystemVar::new(&CLUSTER)),
+                Box::new(SystemVar::new(&CLUSTER_REPLICA)),
+                Box::new(SystemVar::new(&DATABASE)),
+                Box::new(SystemVar::new(&DATE_STYLE)),
+                Box::new(SystemVar::new(&EXTRA_FLOAT_DIGITS)),
+                Box::new(
+                    SystemVar::new(&INTEGER_DATETIMES)
+                        .with_value_constraint(ValueConstraint::Fixed),
+                ),
+                Box::new(SystemVar::new(&INTERVAL_STYLE)),
+                Box::new(SystemVar::new(&SEARCH_PATH)),
+                Box::new(
+                    SystemVar::new(&STANDARD_CONFORMING_STRINGS)
+                        .with_value_constraint(ValueConstraint::Fixed),
+                ),
+                Box::new(SystemVar::new(&STATEMENT_TIMEOUT)),
+                Box::new(SystemVar::new(&IDLE_IN_TRANSACTION_SESSION_TIMEOUT)),
+                Box::new(SystemVar::new(&TIMEZONE)),
+                Box::new(SystemVar::new(&TRANSACTION_ISOLATION)),
+            ]
+            .into_iter()
+            .map(|var| (UncasedStr::new(var.name()), var))
+            .collect()
+        });
+
     pub fn new(active_connection_count: Arc<Mutex<ConnectionCounter>>) -> Self {
         let vars = SystemVars {
             vars: Default::default(),
@@ -2813,6 +2828,7 @@ impl SystemVars {
         };
 
         let mut vars = vars
+            .with_session_vars(&Self::SESSION_VARS)
             .with_feature_flags()
             .with_var(&MAX_KAFKA_CONNECTIONS)
             .with_var(&MAX_POSTGRES_CONNECTIONS)
@@ -2973,15 +2989,6 @@ impl SystemVars {
         self
     }
 
-    pub fn set_unsafe(mut self, allow_unsafe: bool) -> Self {
-        self.allow_unsafe = allow_unsafe;
-        self
-    }
-
-    pub fn allow_unsafe(&self) -> bool {
-        self.allow_unsafe
-    }
-
     fn with_value_constrained_var<V>(
         mut self,
         var: &'static ServerVar<V>,
@@ -2996,6 +3003,25 @@ impl SystemVars {
             Box::new(SystemVar::new(var).with_value_constraint(c)),
         );
         self
+    }
+
+    fn with_session_vars(
+        mut self,
+        vars: &BTreeMap<&'static UncasedStr, Box<dyn SystemVarMut>>,
+    ) -> Self {
+        for (name, var) in vars {
+            self.vars.insert(*name, var.clone_var());
+        }
+        self
+    }
+
+    pub fn set_unsafe(mut self, allow_unsafe: bool) -> Self {
+        self.allow_unsafe = allow_unsafe;
+        self
+    }
+
+    pub fn allow_unsafe(&self) -> bool {
+        self.allow_unsafe
     }
 
     fn expect_value<V>(&self, var: &ServerVar<V>) -> &V
@@ -3024,7 +3050,10 @@ impl SystemVars {
     /// Returns an iterator over the configuration parameters and their current
     /// values on disk.
     pub fn iter(&self) -> impl Iterator<Item = &dyn Var> {
-        self.vars.values().map(|v| v.as_var())
+        self.vars
+            .values()
+            .map(|v| v.as_var())
+            .filter(|v| !Self::SESSION_VARS.contains_key(UncasedStr::new(v.name())))
     }
 
     /// Returns an iterator over the configuration parameters and their current
@@ -3032,6 +3061,14 @@ impl SystemVars {
     /// that shouldn't be synced by SystemParameterFrontend.
     pub fn iter_synced(&self) -> impl Iterator<Item = &dyn Var> {
         self.iter().filter(|v| v.name() != ENABLE_LAUNCHDARKLY.name)
+    }
+
+    /// Returns an iterator over the configuration parameters that can be overriden per-Session.
+    pub fn iter_session(&self) -> impl Iterator<Item = &dyn Var> {
+        self.vars
+            .values()
+            .map(|v| v.as_var())
+            .filter(|v| Self::SESSION_VARS.contains_key(UncasedStr::new(v.name())))
     }
 
     /// Returns a [`Var`] representing the configuration parameter with the
@@ -3829,6 +3866,9 @@ pub trait SystemVarMut: Var + Send + Sync {
     /// Upcast to Var, for use with `dyn`.
     fn as_var(&self) -> &dyn Var;
 
+    /// Creates a [`SessionVarMut`] from this [`SystemVarMut`].
+    fn to_session_var(&self) -> Box<dyn SessionVarMut>;
+
     /// Return the value as `dyn Any`.
     fn value_any(&self) -> &(dyn Any + 'static);
 
@@ -4021,6 +4061,14 @@ where
         self
     }
 
+    fn to_session_var(&self) -> Box<dyn SessionVarMut> {
+        let mut var = SessionVar::new(&self.parent);
+        for constraint in &self.constraints {
+            var = var.with_value_constraint(constraint.clone());
+        }
+        Box::new(var)
+    }
+
     fn value_any(&self) -> &(dyn Any + 'static) {
         let value = SystemVar::value(self);
         value
@@ -4127,17 +4175,16 @@ struct SessionVar<V>
 where
     V: Value + ToOwned + Debug + PartialEq + 'static,
 {
-    /// Default value.
+    /// Value compiled into the binary.
+    parent: ServerVar<V>,
+    /// Sysetm or Role default value.
     default_value: Option<V::Owned>,
-    /// Value persisted with the current role.
-    role_value: Option<V::Owned>,
     /// Value `LOCAL` to a transaction, will be unset at the completion of the transaction.
     local_value: Option<V::Owned>,
     /// Value set during a transaction, will be set if the transaction is committed.
     staged_value: Option<V::Owned>,
     /// Value that overrides the default.
     session_value: Option<V::Owned>,
-    parent: &'static ServerVar<V>,
     feature_flag: Option<&'static FeatureFlag>,
     constraints: Vec<ValueConstraint<V>>,
 }
@@ -4200,17 +4247,16 @@ where
 
 impl<V> SessionVar<V>
 where
-    V: Value + ToOwned + Debug + PartialEq + 'static,
+    V: Value + Clone + Debug + PartialEq + 'static,
     V::Owned: Debug + Send + Sync,
 {
-    fn new(parent: &'static ServerVar<V>) -> SessionVar<V> {
+    fn new(parent: &ServerVar<V>) -> SessionVar<V> {
         SessionVar {
             default_value: None,
-            role_value: None,
             local_value: None,
             staged_value: None,
             session_value: None,
-            parent,
+            parent: parent.clone(),
             feature_flag: None,
             constraints: vec![],
         }
@@ -4248,7 +4294,6 @@ where
             .map(|v| v.borrow())
             .or_else(|| self.staged_value.as_ref().map(|v| v.borrow()))
             .or_else(|| self.session_value.as_ref().map(|v| v.borrow()))
-            .or_else(|| self.role_value.as_ref().map(|v| v.borrow()))
             .or_else(|| self.default_value.as_ref().map(|v| v.borrow()))
             .unwrap_or(&self.parent.value)
     }
@@ -4256,7 +4301,7 @@ where
 
 impl<V> Var for SessionVar<V>
 where
-    V: Value + ToOwned + Debug + PartialEq + 'static,
+    V: Value + Clone + Debug + PartialEq + 'static,
     V::Owned: Debug + Send + Sync,
 {
     fn name(&self) -> &'static str {
@@ -4296,13 +4341,7 @@ pub trait SessionVarMut: Var + Send + Sync {
     fn set(&mut self, input: VarInput, local: bool) -> Result<(), VarError>;
 
     /// Sets the default value for the variable.
-    fn set_default(&mut self, value: Box<dyn Any>);
-
-    /// Parse the input and update the default Role value.
-    ///
-    /// Note: these only get set on Session start. Updating the default value for a role will not
-    /// have any effect until your Session restarts, i.e. you reconnect.
-    fn set_role_default(&mut self, input: VarInput) -> Result<(), VarError>;
+    fn set_default(&mut self, value: VarInput) -> Result<(), VarError>;
 
     /// Reset the stored value to the default.
     fn reset(&mut self, local: bool);
@@ -4312,8 +4351,8 @@ pub trait SessionVarMut: Var + Send + Sync {
 
 impl<V> SessionVarMut for SessionVar<V>
 where
-    V: Value + Debug + PartialEq + 'static,
-    V::Owned: Debug + Send + Sync + PartialEq,
+    V: Value + Clone + Debug + PartialEq + 'static,
+    V::Owned: Debug + Clone + Send + Sync,
 {
     /// Upcast to Var, for use with `dyn`.
     fn as_var(&self) -> &dyn Var {
@@ -4340,33 +4379,20 @@ where
         Ok(())
     }
 
-    /// Sets the default value.
-    fn set_default(&mut self, input: Box<dyn Any>) {
-        let v = input.downcast().unwrap_or_else(|input| {
-            panic!(
-                "SessionVar::set_default called with invalid value {:?} for {}",
-                input,
-                self.name()
-            )
-        });
-        self.default_value = Some(*v);
-    }
-
-    /// Parse the input and set the default Role value.
-    fn set_role_default(&mut self, input: VarInput) -> Result<(), VarError> {
+    /// Sets the default value for the variable.
+    fn set_default(&mut self, input: VarInput) -> Result<(), VarError> {
         let v = V::parse(self, input)?;
         self.check_constraints(&v)?;
-        self.role_value = Some(v);
+        self.default_value = Some(v);
         Ok(())
     }
 
     /// Reset the stored value to the default.
     fn reset(&mut self, local: bool) {
         let value = self
-            .role_value
+            .default_value
             .as_ref()
             .map(|v| v.borrow())
-            .or_else(|| self.default_value.as_ref().map(|v| v.borrow()))
             .unwrap_or(&self.parent.value)
             .to_owned();
         if local {

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -659,3 +659,28 @@ simple conn=mz_system,user=mz_system
 ALTER ROLE parker SET metrics_retention TO 10;
 ----
 db error: ERROR: unrecognized configuration parameter "metrics_retention"
+
+# Role defaults should override a change to the system default.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET cluster TO new_system_default
+----
+COMPLETE 0
+
+simple conn=joe_1,user=joe
+SHOW cluster;
+----
+will_work
+COMPLETE 1
+
+# Reset the role default, so new sessions should get the system default.
+simple conn=joe_1,user=joe
+ALTER ROLE joe RESET cluster;
+----
+COMPLETE 0
+
+simple conn=joe_2,user=joe
+SHOW cluster;
+----
+new_system_default
+COMPLETE 1

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -684,3 +684,69 @@ SHOW cluster;
 ----
 new_system_default
 COMPLETE 1
+
+simple conn=joe_2,user=joe
+BEGIN;
+----
+COMPLETE 0
+
+simple conn=joe_2,user=joe
+SET LOCAL cluster TO 'txn_specific_cluster';
+----
+COMPLETE 0
+
+simple conn=joe_2,user=joe
+SHOW cluster;
+----
+txn_specific_cluster
+COMPLETE 1
+
+simple conn=joe_2,user=joe
+COMMIT;
+----
+COMPLETE 0
+
+simple conn=joe_2,user=joe
+SHOW cluster;
+----
+new_system_default
+COMPLETE 1
+
+simple conn=joe_2,user=joe
+BEGIN;
+----
+COMPLETE 0
+
+simple conn=joe_2,user=joe
+SET cluster TO 'foo_bar';
+----
+COMPLETE 0
+
+simple conn=joe_2,user=joe
+SHOW cluster;
+----
+foo_bar
+COMPLETE 1
+
+simple conn=joe_2,user=joe
+ROLLBACK;
+----
+COMPLETE 0
+
+simple conn=joe_2,user=joe
+SHOW cluster;
+----
+new_system_default
+COMPLETE 1
+
+# Not all session variables can be overriden.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET server_version TO this_wont_work
+----
+db error: ERROR: unrecognized configuration parameter "server_version"
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET emit_trace_id_notice TO true
+----
+db error: ERROR: unrecognized configuration parameter "emit_trace_id_notice"


### PR DESCRIPTION
This PR enables setting some system-wide defaults for a subset of all session variables. Specifically, a user with the correct permissions could now run:

```
ALTER SYSTEM SET cluster TO 'our_own_default_cluster';
```

It works by sharing a set of variables between `SystemVars` and `SessionVars`, then it uses the existing plumbing in the Coordinator message `StartupResponse` to provide system overrides at the start of a `Session`.

I don't love the changes made to `vars.rs`, but I couldn't find a better way to share a set of variables between `SystemVars` and `SessionVars`. In my ideal world we'd have three static lists of `ServerVar`s (what I think of as `VarDefinition`s):

1. `SESSION_ONLY_VARS`
2. `SYSTEM_ONLY_VARS`
3. `SESSION_AND_SYSTEM_VARS`

We can't do this today because `ServerVar` is generic over a type `V`, i.e. `ServerVar<V>`, and you can't make a list of generic types. I have an idea of how to get rid of the generic parameter, [Rust Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=cd799eaf7ca07aa8f2ce5c214d95839d), but given the size of the change I'm going to surface it in Slack first.

### Motivation

Fixes: https://github.com/MaterializeInc/materialize/issues/23754

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds the ability to change the system default for a subset of session variables.
