### PR TITLE
ci: fix duplicate key

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -384,7 +384,7 @@ steps:
   - group: AWS
     key: aws
     steps:
-      - id: aws
+      - id: aws-checks
         label: AWS
         timeout_in_minutes: 30
         agents:


### PR DESCRIPTION
This fixes the nightly pipeline when triggering a manual run.

```
fatal: Failed to upload and process pipeline: Pipeline upload rejected: The key "aws" has already been used by another step in this build
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/var/lib/buildkite-agent/builds/buildkite-builders-d43b1b5-i-0aea1119dc6d8b4bb-1/materialize/nightlies/ci/mkpipeline.py", line 376, in <module>
    sys.exit(main())
             ^^^^^^
  File "/var/lib/buildkite-agent/builds/buildkite-builders-d43b1b5-i-0aea1119dc6d8b4bb-1/materialize/nightlies/ci/mkpipeline.py", line 162, in main
    spawn.runv(
  File "/var/lib/buildkite-agent/builds/buildkite-builders-d43b1b5-i-0aea1119dc6d8b4bb-1/materialize/nightlies/misc/python/materialize/spawn.py", line 72, in runv
    return subprocess.run(
           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['buildkite-agent', 'pipeline', 'upload']' returned non-zero exit status 1.
```

Nightly: https://buildkite.com/materialize/nightlies/builds/5606