### PR TITLE
[persist peeks] Add a "type" tag to some peek-related collections in mz_internal

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -1152,10 +1152,11 @@ It distinguishes between individual records (`sent`, `received`) and batches of 
 The `mz_peek_durations_histogram` view describes a histogram of the duration in nanoseconds of read queries ("peeks") in the [dataflow] layer.
 
 <!-- RELATION_SPEC mz_internal.mz_peek_durations_histogram -->
-| Field          | Type        | Meaning                                            |
-| -------------- |-------------| --------                                           |
-| `duration_ns`  | [`uint8`]   | The upper bound of the bucket in nanoseconds.      |
-| `count`        | [`numeric`] | The (noncumulative) count of peeks in this bucket. |
+| Field         | Type        | Meaning                                            |
+|---------------|-------------|----------------------------------------------------|
+| `type`        | [`text`]    | The peek variant: `index` or `persist`.            |
+| `duration_ns` | [`uint8`]   | The upper bound of the bucket in nanoseconds.      |
+| `count`       | [`numeric`] | The (noncumulative) count of peeks in this bucket. |
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_peek_durations_histogram_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_peek_durations_histogram_raw -->

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -853,11 +853,12 @@ Per-worker relations expose the same data as their global counterparts, but have
 The `mz_active_peeks` view describes all read queries ("peeks") that are pending in the [dataflow] layer.
 
 <!-- RELATION_SPEC mz_internal.mz_active_peeks -->
-| Field       | Type               | Meaning                                                                                                                                              |
-| ----------- | ------------------ |------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`        | [`uuid`]           | The ID of the peek request.                                                                                                                          |
-| `index_id`  | [`text`]           | The ID of the collection the peek is targeting. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables). |
-| `time`      | [`mz_timestamp`]   | The timestamp the peek has requested.                                                                                                                |
+| Field       | Type             | Meaning                                                                                                                                                                                                                                                                                                               |
+|-------------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`        | [`uuid`]         | The ID of the peek request.                                                                                                                                                                                                                                                                                           |
+| `object_id` | [`text`]         | The ID of the collection the peek is targeting. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables). |
+| `type`      | [`text`]         | The type of the corresponding peek: `index` if targeting an index or temporary dataflow; `persist` for a source, materialized view, or table.                                                                                                                                                                         |
+| `time`      | [`mz_timestamp`] | The timestamp the peek has requested.                                                                                                                                                                                                                                                                                 |
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_active_peeks_per_worker -->
 

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -3804,11 +3804,11 @@ pub const MZ_PEEK_DURATIONS_HISTOGRAM_PER_WORKER: BuiltinView = BuiltinView {
     schema: MZ_INTERNAL_SCHEMA,
     column_defs: None,
     sql: "SELECT
-    worker_id, duration_ns, pg_catalog.count(*) AS count
+    worker_id, type, duration_ns, pg_catalog.count(*) AS count
 FROM
     mz_internal.mz_peek_durations_histogram_raw
 GROUP BY
-    worker_id, duration_ns",
+    worker_id, type, duration_ns",
     sensitivity: DataSensitivity::Public,
 };
 
@@ -3818,10 +3818,10 @@ pub const MZ_PEEK_DURATIONS_HISTOGRAM: BuiltinView = BuiltinView {
     column_defs: None,
     sql: "
 SELECT
-    duration_ns,
+    type, duration_ns,
     pg_catalog.sum(count) AS count
 FROM mz_internal.mz_peek_durations_histogram_per_worker
-GROUP BY duration_ns",
+GROUP BY type, duration_ns",
     sensitivity: DataSensitivity::Public,
 };
 

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -4093,7 +4093,7 @@ pub const MZ_ACTIVE_PEEKS: BuiltinView = BuiltinView {
     schema: MZ_INTERNAL_SCHEMA,
     column_defs: None,
     sql: "
-SELECT id, index_id, time
+SELECT id, object_id, type, time
 FROM mz_internal.mz_active_peeks_per_worker
 WHERE worker_id = 0",
     sensitivity: DataSensitivity::Public,

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -469,7 +469,8 @@ impl LogVariant {
             LogVariant::Compute(ComputeLog::PeekCurrent) => RelationDesc::empty()
                 .with_column("id", ScalarType::Uuid.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
-                .with_column("index_id", ScalarType::String.nullable(false))
+                .with_column("object_id", ScalarType::String.nullable(false))
+                .with_column("type", ScalarType::String.nullable(false))
                 .with_column("time", ScalarType::MzTimestamp.nullable(false))
                 .with_key(vec![0, 1]),
 

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -476,6 +476,7 @@ impl LogVariant {
 
             LogVariant::Compute(ComputeLog::PeekDuration) => RelationDesc::empty()
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
+                .with_column("type", ScalarType::String.nullable(false))
                 .with_column("duration_ns", ScalarType::UInt64.nullable(false)),
 
             LogVariant::Compute(ComputeLog::ShutdownDuration) => RelationDesc::empty()

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -671,17 +671,17 @@ pub enum PendingPeek {
 
 impl PendingPeek {
     /// Produces a corresponding log event.
-    pub fn as_log_event(&self, install: bool) -> ComputeEvent {
+    pub fn as_log_event(&self, installed: bool) -> ComputeEvent {
         let peek = self.peek();
         let peek_type = match self {
             PendingPeek::Index(_) => logging::compute::PeekType::Index,
             PendingPeek::Persist(_) => logging::compute::PeekType::Persist,
         };
-        ComputeEvent::Peek(
-            logging::compute::Peek::new(peek.target.id(), peek.timestamp, peek.uuid),
+        ComputeEvent::Peek {
+            peek: logging::compute::Peek::new(peek.target.id(), peek.timestamp, peek.uuid),
             peek_type,
-            install,
-        )
+            installed,
+        }
     }
 
     fn index(peek: Peek, mut trace_bundle: TraceBundle) -> Self {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -673,7 +673,11 @@ impl PendingPeek {
     /// Produces a corresponding log event.
     pub fn as_log_event(&self) -> logging::compute::Peek {
         let peek = self.peek();
-        logging::compute::Peek::new(peek.target.id(), peek.timestamp, peek.uuid)
+        let peek_type = match self {
+            PendingPeek::Index(_) => "index",
+            PendingPeek::Persist(_) => "persist",
+        };
+        logging::compute::Peek::new(peek.target.id(), peek.timestamp, peek_type, peek.uuid)
     }
 
     fn index(peek: Peek, mut trace_bundle: TraceBundle) -> Self {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -375,7 +375,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
 
         // Log the receipt of the peek.
         if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-            logger.log(ComputeEvent::Peek(pending.as_log_event(), true));
+            logger.log(pending.as_log_event(true));
         }
 
         self.process_peek(&mut Antichain::new(), pending);
@@ -578,7 +578,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
     /// meant to prevent multiple responses to the same peek.
     #[tracing::instrument(level = "debug", skip(self, peek))]
     fn send_peek_response(&mut self, peek: PendingPeek, response: PeekResponse) {
-        let log_event = peek.as_log_event();
+        let log_event = peek.as_log_event(false);
         // Respond with the response.
         self.send_compute_response(ComputeResponse::PeekResponse(
             peek.peek().uuid,
@@ -588,7 +588,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
 
         // Log responding to the peek request.
         if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-            logger.log(ComputeEvent::Peek(log_event, false));
+            logger.log(log_event);
         }
     }
 
@@ -671,13 +671,17 @@ pub enum PendingPeek {
 
 impl PendingPeek {
     /// Produces a corresponding log event.
-    pub fn as_log_event(&self) -> logging::compute::Peek {
+    pub fn as_log_event(&self, install: bool) -> ComputeEvent {
         let peek = self.peek();
         let peek_type = match self {
-            PendingPeek::Index(_) => "index",
-            PendingPeek::Persist(_) => "persist",
+            PendingPeek::Index(_) => logging::compute::PeekType::Index,
+            PendingPeek::Persist(_) => logging::compute::PeekType::Persist,
         };
-        logging::compute::Peek::new(peek.target.id(), peek.timestamp, peek_type, peek.uuid)
+        ComputeEvent::Peek(
+            logging::compute::Peek::new(peek.target.id(), peek.timestamp, peek.uuid),
+            peek_type,
+            install,
+        )
     }
 
     fn index(peek: Peek, mut trace_bundle: TraceBundle) -> Self {

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -308,6 +308,7 @@ pub(super) fn construct<A: Allocate + 'static>(
                     Datum::Uuid(datum.uuid),
                     Datum::UInt64(u64::cast_from(worker_id)),
                     make_string_datum(datum.id, &mut scratch),
+                    Datum::String(datum.peek_type),
                     Datum::MzTimestamp(datum.time),
                 ])
             }

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -62,8 +62,16 @@ pub enum ComputeEvent {
         /// Identifier of the export.
         id: GlobalId,
     },
-    /// Peek command, true for install and false for retire.
-    Peek(Peek, PeekType, bool),
+    /// Peek command.
+    Peek {
+        /// The data for the peek itself.
+        peek: Peek,
+        /// The relevant _type_ of peek: index or persist.
+        // Note that this is not stored on the Peek event for data-packing reasons only.
+        peek_type: PeekType,
+        /// True if the peek is being installed; false if it's being removed.
+        installed: bool,
+    },
     /// Available frontier information for dataflow exports.
     Frontier {
         id: GlobalId,
@@ -124,7 +132,6 @@ pub enum ComputeEvent {
     },
 }
 
-#[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub enum PeekType {
     Index,
@@ -312,26 +319,27 @@ pub(super) fn construct<A: Allocate + 'static>(
         let mut packer = PermutedRowPacker::new(ComputeLog::PeekCurrent);
         let peek_current = peek.as_collection().map({
             let mut scratch = String::new();
-            move |(typ, datum)| {
+            move |PeekDatum { peek, peek_type }| {
                 packer.pack_slice(&[
-                    Datum::Uuid(datum.uuid),
+                    Datum::Uuid(peek.uuid),
                     Datum::UInt64(u64::cast_from(worker_id)),
-                    make_string_datum(datum.id, &mut scratch),
-                    typ.name().into(),
-                    Datum::MzTimestamp(datum.time),
+                    make_string_datum(peek.id, &mut scratch),
+                    Datum::String(peek_type.name()),
+                    Datum::MzTimestamp(peek.time),
                 ])
             }
         });
         let mut packer = PermutedRowPacker::new(ComputeLog::PeekDuration);
-        let peek_duration = peek_duration
-            .as_collection()
-            .map(move |(peek_type, bucket)| {
-                packer.pack_slice(&[
-                    Datum::UInt64(u64::cast_from(worker_id)),
-                    Datum::String(peek_type.name()),
-                    Datum::UInt64(bucket.try_into().expect("bucket too big")),
-                ])
-            });
+        let peek_duration =
+            peek_duration
+                .as_collection()
+                .map(move |PeekDurationDatum { peek_type, bucket }| {
+                    packer.pack_slice(&[
+                        Datum::UInt64(u64::cast_from(worker_id)),
+                        Datum::String(peek_type.name()),
+                        Datum::UInt64(bucket.try_into().expect("bucket too big")),
+                    ])
+                });
         let mut packer = PermutedRowPacker::new(ComputeLog::ShutdownDuration);
         let shutdown_duration = shutdown_duration.as_collection().map(move |bucket| {
             packer.pack_slice(&[
@@ -564,8 +572,8 @@ struct DemuxOutput<'a> {
     frontier: OutputSession<'a, FrontierDatum>,
     import_frontier: OutputSession<'a, ImportFrontierDatum>,
     frontier_delay: OutputSession<'a, FrontierDelayDatum>,
-    peek: OutputSession<'a, (PeekType, Peek)>,
-    peek_duration: OutputSession<'a, (PeekType, u128)>,
+    peek: OutputSession<'a, PeekDatum>,
+    peek_duration: OutputSession<'a, PeekDurationDatum>,
     shutdown_duration: OutputSession<'a, u128>,
     arrangement_heap_size: OutputSession<'a, ArrangementHeapDatum>,
     arrangement_heap_capacity: OutputSession<'a, ArrangementHeapDatum>,
@@ -597,6 +605,18 @@ struct FrontierDelayDatum {
     export_id: GlobalId,
     import_id: GlobalId,
     delay_pow: u128,
+}
+
+#[derive(Clone)]
+struct PeekDatum {
+    peek: Peek,
+    peek_type: PeekType,
+}
+
+#[derive(Clone)]
+struct PeekDurationDatum {
+    peek_type: PeekType,
+    bucket: u128,
 }
 
 #[derive(Clone)]
@@ -644,8 +664,16 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
         match event {
             Export { id, dataflow_index } => self.handle_export(id, dataflow_index),
             ExportDropped { id } => self.handle_export_dropped(id),
-            Peek(peek, typ, true) => self.handle_peek_install(peek, typ),
-            Peek(peek, typ, false) => self.handle_peek_retire(peek, typ),
+            Peek {
+                peek,
+                peek_type,
+                installed: true,
+            } => self.handle_peek_install(peek, peek_type),
+            Peek {
+                peek,
+                peek_type,
+                installed: false,
+            } => self.handle_peek_retire(peek, peek_type),
             Frontier { id, time, diff } => self.handle_frontier(id, time, diff),
             ImportFrontier {
                 import_id,
@@ -805,10 +833,12 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
         export.error_count = new_count;
     }
 
-    fn handle_peek_install(&mut self, peek: Peek, typ: PeekType) {
+    fn handle_peek_install(&mut self, peek: Peek, peek_type: PeekType) {
         let uuid = peek.uuid;
         let ts = self.ts();
-        self.output.peek.give(((typ, peek), ts, 1));
+        self.output
+            .peek
+            .give((PeekDatum { peek, peek_type }, ts, 1));
 
         let existing = self.state.peek_stash.insert(uuid, self.time);
         if existing.is_some() {
@@ -819,15 +849,19 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
         }
     }
 
-    fn handle_peek_retire(&mut self, peek: Peek, typ: PeekType) {
+    fn handle_peek_retire(&mut self, peek: Peek, peek_type: PeekType) {
         let uuid = peek.uuid;
         let ts = self.ts();
-        self.output.peek.give(((typ, peek), ts, -1));
+        self.output
+            .peek
+            .give((PeekDatum { peek, peek_type }, ts, -1));
 
         if let Some(start) = self.state.peek_stash.remove(&uuid) {
             let elapsed_ns = self.time.saturating_sub(start).as_nanos();
-            let elapsed_pow = elapsed_ns.next_power_of_two();
-            self.output.peek_duration.give(((typ, elapsed_pow), ts, 1));
+            let bucket = elapsed_ns.next_power_of_two();
+            self.output
+                .peek_duration
+                .give((PeekDurationDatum { peek_type, bucket }, ts, 1));
         } else {
             error!(
                 uuid = ?uuid,

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -131,14 +131,21 @@ pub struct Peek {
     id: GlobalId,
     /// The logical timestamp requested.
     time: Timestamp,
+    /// The type of the peek: currently 'index' or 'persist'.
+    peek_type: &'static str,
     /// The ID of the peek.
     uuid: Uuid,
 }
 
 impl Peek {
     /// Create a new peek from its arguments.
-    pub fn new(id: GlobalId, time: Timestamp, uuid: Uuid) -> Self {
-        Self { id, time, uuid }
+    pub fn new(id: GlobalId, time: Timestamp, peek_type: &'static str, uuid: Uuid) -> Self {
+        Self {
+            id,
+            time,
+            peek_type,
+            uuid,
+        }
     }
 }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -645,7 +645,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             for (_, peek) in std::mem::take(&mut compute_state.pending_peeks) {
                 // Log dropping the peek request.
                 if let Some(logger) = compute_state.compute_logger.as_mut() {
-                    logger.log(ComputeEvent::Peek(peek.as_log_event(), false));
+                    logger.log(peek.as_log_event(false));
                 }
             }
 

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -3509,7 +3509,7 @@ fn test_peek_on_dropped_indexed_view() {
             let count: i64 = ddl_client
                 .query_one(
                     &format!(
-                "SELECT COUNT(*) FROM mz_internal.mz_active_peeks WHERE index_id = '{index_id}'"
+                "SELECT COUNT(*) FROM mz_internal.mz_active_peeks WHERE object_id = '{index_id}'"
             ),
                     &[],
                 )
@@ -3541,7 +3541,7 @@ fn test_peek_on_dropped_indexed_view() {
             let count: i64 = ddl_client
                 .query_one(
                     &format!(
-                        "SELECT COUNT(*) FROM mz_internal.mz_active_peeks WHERE index_id = '{index_id}'"
+                        "SELECT COUNT(*) FROM mz_internal.mz_active_peeks WHERE object_id = '{index_id}'"
                     ),
                     &[],
                 )

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -461,8 +461,9 @@ query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_active_peeks' ORDER BY position
 ----
 1  id  uuid
-2  index_id  text
-3  time  mz_timestamp
+2  object_id  text
+3  type  text
+4  time  mz_timestamp
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_arrangement_sharing' ORDER BY position

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -612,8 +612,9 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_peek_durations_histogram' ORDER BY position
 ----
-1  duration_ns  uint8
-2  count  numeric
+1  type  text
+2  duration_ns  uint8
+3  count  numeric
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_records_per_dataflow' ORDER BY position

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -249,7 +249,8 @@ bar  mz_message_counts_sent_raw  mz_message_counts_sent_raw_u7_primary_idx  1  c
 bar  mz_message_counts_sent_raw  mz_message_counts_sent_raw_u7_primary_idx  2  from_worker_id  NULL  false
 bar  mz_message_counts_sent_raw  mz_message_counts_sent_raw_u7_primary_idx  3  to_worker_id  NULL  false
 bar  mz_peek_durations_histogram_raw  mz_peek_durations_histogram_raw_u7_primary_idx  1  worker_id  NULL  false
-bar  mz_peek_durations_histogram_raw  mz_peek_durations_histogram_raw_u7_primary_idx  2  duration_ns  NULL  false
+bar  mz_peek_durations_histogram_raw  mz_peek_durations_histogram_raw_u7_primary_idx  2  type  NULL  false
+bar  mz_peek_durations_histogram_raw  mz_peek_durations_histogram_raw_u7_primary_idx  3  duration_ns  NULL  false
 bar  mz_scheduling_elapsed_raw  mz_scheduling_elapsed_raw_u7_primary_idx  1  id  NULL  false
 bar  mz_scheduling_elapsed_raw  mz_scheduling_elapsed_raw_u7_primary_idx  2  worker_id  NULL  false
 bar  mz_scheduling_parks_histogram_raw  mz_scheduling_parks_histogram_raw_u7_primary_idx  1  worker_id  NULL  false

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -327,7 +327,7 @@ mz_object_dependencies_ind                                  mz_object_dependenci
 mz_object_lifetimes_ind                                     mz_object_lifetimes                          mz_introspection    {id}
 mz_object_transitive_dependencies_ind                       mz_object_transitive_dependencies            mz_introspection    {object_id}
 mz_notices_ind                                              mz_notices                                   mz_introspection    {object_id}
-mz_peek_durations_histogram_raw_s2_primary_idx              mz_peek_durations_histogram_raw              mz_introspection    {worker_id,duration_ns}
+mz_peek_durations_histogram_raw_s2_primary_idx              mz_peek_durations_histogram_raw              mz_introspection    {worker_id,type,duration_ns}
 mz_roles_ind                                                mz_roles                                     mz_introspection    {id}
 mz_scheduling_elapsed_raw_s2_primary_idx                    mz_scheduling_elapsed_raw                    mz_introspection    {id,worker_id}
 mz_scheduling_parks_histogram_raw_s2_primary_idx            mz_scheduling_parks_histogram_raw            mz_introspection    {worker_id,slept_for_ns,requested_ns}

--- a/test/testdrive/logging.td
+++ b/test/testdrive/logging.td
@@ -103,8 +103,9 @@ contains:cannot drop source mz_internal.mz_compute_delays_histogram_raw because 
 id      name        position    type
 --------------------------------------
 SID   worker_id   1           uint8
-SID   duration_ns 2           uint8
-SID   count       3           bigint
+SID   type        2           text
+SID   duration_ns 3           uint8
+SID   count       4           bigint
 
 > SELECT mz_columns.id, mz_columns.name, position, type
   FROM mz_views JOIN mz_columns USING (id)


### PR DESCRIPTION
### Motivation

In #23248, we talked about tagging metrics in `mz_internal` as followup work. This is that!

### Tips for reviewer

Should probably be one of the last fast-path things to merge: while `mz_internal` is free to change at any time, we don't want to do _too_ much thrashing there. As a consequence, I might not merge this until the new year. Wanted to have it ready to go ahead of time though!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
