### PR TITLE
persist-txn: rewrite data_snapshot and data_listen_next unit tests

### DIFF
--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -264,6 +264,8 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64> TxnsCacheState
             }
         };
 
+        // Figure out the most recent timestamp that had a physical write to
+        // the data shard.
         let last_reg = data_times.last_reg();
         let mut physical_ts = last_reg.register_ts.clone();
         if let Some(forget_ts) = &last_reg.forget_ts {

--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -1098,6 +1098,10 @@ mod tests {
         testcase(&mut c, 0, d0, ds(None, 0, 1), ReadDataTo(1));
 
         // ts 1 (direct write)
+        // - The cache knows everything < 2.
+        // - d0 is not registered in the cache.
+        // - We know the shard can't be written to via txn < 2.
+        // - So go read the shard normally up to 2.
         testcase(&mut c, 1, d0, ds(None, 1, 2), ReadDataTo(2));
 
         // ts 2 (register)
@@ -1163,6 +1167,7 @@ mod tests {
         assert_eq!(c.data_listen_next(&d0, 11), ReadDataTo(12));
         assert_eq!(c.data_listen_next(&d0, 12), EmitLogicalProgress(13));
         assert_eq!(c.data_listen_next(&d0, 13), EmitLogicalProgress(14));
+        assert_eq!(c.data_listen_next(&d0, 13), WaitForTxnsProgress);
     }
 
     #[mz_ore::test(tokio::test)]

--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -1091,7 +1091,7 @@ mod tests {
 
         // empty
         assert_eq!(c.progress_exclusive, 0);
-        assert!(std::panic::catch_unwind(|| c.data_snapshot(d0, 0)).is_err());
+        assert!(mz_ore::panic::catch_unwind(|| c.data_snapshot(d0, 0)).is_err());
         assert_eq!(c.data_listen_next(&d0, 0), WaitForTxnsProgress);
 
         // ts 0 (never registered)

--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -286,10 +286,6 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64> TxnsCacheState
                 return EmitLogicalProgress(forget_ts.step_forward());
             } else if ts < self.progress_exclusive {
                 return ReadDataTo(self.progress_exclusive.clone());
-            } else {
-                // TODO(txn): Make sure to add a regression test for this when
-                // we redo the data_listen_next unit test.
-                return WaitForTxnsProgress;
             }
         }
 

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -40,8 +40,9 @@ use crate::TxnsCodecDefault;
 /// A token exchangeable for a data shard snapshot.
 ///
 /// - Invariant: `latest_write <= as_of < empty_to`
-/// - Invariant: `(latest_write, empty_to)` has no committed writes (which means
-///   we can do an empty CaA of those times if we like).
+/// - Invariant: `(latest_write, empty_to)` and `(as_of, empty_to)` have no
+///   committed writes (which means we can do an empty CaA of those times if we
+///   like).
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct DataSnapshot<T> {
@@ -268,7 +269,7 @@ pub enum DataListenNext<T> {
     /// Read the data shard normally, until this timestamp is less_equal what
     /// has been read.
     ReadDataTo(T),
-    /// It is known there there are no writes between the progress given to the
+    /// It is known that there are no writes between the progress given to the
     /// `data_listen_next` call and this timestamp. Advance the data shard
     /// listen progress to this (exclusive) frontier.
     EmitLogicalProgress(T),


### PR DESCRIPTION
Using the example history I came up with to try to exercise all the interesting edge cases.

Touches https://github.com/MaterializeInc/materialize/issues/22173
Touches https://github.com/MaterializeInc/materialize/issues/22801

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

I'd love to go over the answers in this test with the two of you before trying to fix up the impl to pass it :D. (I think all the disagreements with the current impl are places where we're being too conservative, plus "eager" doesn't use this.)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
