### PR TITLE
dbt-materialize: simplify SQL header splitting code

### DIFF
--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -214,17 +214,13 @@ class MaterializeAdapter(PostgresAdapter):
         # statement, we split the input based on the string appended to the
         # header in materialize__get_empty_subquery_sql.
 
-        sql_part1, _, sql_part2 = sql.partition("#__dbt_sbq_parse_header__#")
+        sql_header, sql_view_def = sql.split("#__dbt_sbq_parse_header__#")
 
-        if sql_part2:
-            self.connections.execute(sql_part1)
-            self.connections.execute(
-                f"create temporary view {view_name} as {sql_part2}"
-            )
-        else:
-            self.connections.execute(
-                f"create temporary view {view_name} as {sql_part1}"
-            )
+        if sql_header:
+            self.connections.execute(sql_header)
+        self.connections.execute(
+            f"create temporary view {view_name} as {sql_view_def}"
+        )
 
         # Fetch the names and types of each column in the view. Schema ID 0
         # indicates the temporary schema.

--- a/misc/dbt-materialize/dbt/include/materialize/macros/columns.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/columns.sql
@@ -15,8 +15,9 @@
 
 {% macro materialize__get_empty_subquery_sql(select_sql, select_sql_header=none) %}
     {%- if select_sql_header is not none -%}
-    {{ select_sql_header + '#__dbt_sbq_parse_header__#' }}
+    {{ select_sql_header }}
     {%- endif -%}
+    #__dbt_sbq_parse_header__#
     select * from (
         {{ select_sql }}
     ) as __dbt_sbq


### PR DESCRIPTION
Follow up from #23712.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
