### PR TITLE
dbt-materialize: ensure `get_empty_subquery_sql` is valid SQL

### DIFF
--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -214,7 +214,7 @@ class MaterializeAdapter(PostgresAdapter):
         # statement, we split the input based on the string appended to the
         # header in materialize__get_empty_subquery_sql.
 
-        sql_header, sql_view_def = sql.split("#__dbt_sbq_parse_header__#")
+        sql_header, sql_view_def = sql.split("--#dbt_sbq_parse_header#--")
 
         if sql_header:
             self.connections.execute(sql_header)

--- a/misc/dbt-materialize/dbt/include/materialize/macros/columns.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/columns.sql
@@ -17,7 +17,7 @@
     {%- if select_sql_header is not none -%}
     {{ select_sql_header }}
     {%- endif -%}
-    #__dbt_sbq_parse_header__#
+    --#dbt_sbq_parse_header#--
     select * from (
         {{ select_sql }}
     ) as __dbt_sbq


### PR DESCRIPTION
@morsapaes check my math here, but it just spontaneously occurred to me that the `#dbt_sbq_parse_header#`, I think, results in`get_empty_subquery_sql` returning invalid SQL when called directly.

----

Follow up to cb172dfa1, which in turn was a follow up to #23712. The get_empty_subquery_sql macro is technically public API that users can call directly, so we need to ensure that our hack to be able to split the header from the body doesn't result in invalid SQL if the macro is called directly.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
