### PR TITLE
release: bump to version v0.81.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "mz-balancerd"
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "mz-catalog-debug"
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "mz-clusterd"
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 dependencies = [
  "anyhow",
  "axum",
@@ -4082,7 +4082,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 dependencies = [
  "anyhow",
  "askama",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "mz-persist-client"
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5513,7 +5513,7 @@ dependencies = [
 
 [[package]]
 name = "mz-stash-debug"
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "mz-testdrive"
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -218,9 +218,7 @@ class MaterializeAdapter(PostgresAdapter):
 
         if sql_header:
             self.connections.execute(sql_header)
-        self.connections.execute(
-            f"create temporary view {view_name} as {sql_view_def}"
-        )
+        self.connections.execute(f"create temporary view {view_name} as {sql_view_def}")
 
         # Fetch the names and types of each column in the view. Schema ID 0
         # indicates the temporary schema.

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-balancerd"
 description = "Balancer service."
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-catalog-debug"
 description = "Durable metadata storage debug tool."
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-clusterd"
 description = "Materialize's cluster server."
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition.workspace = true

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-persist-client"
 description = "Client for Materialize pTVC durability system"
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/stash-debug/Cargo.toml
+++ b/src/stash-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-stash-debug"
 description = "Durable metadata storage."
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-testdrive"
 description = "Integration test driver for Materialize."
-version = "0.80.0-dev"
+version = "0.81.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
This PR bumps the version in our repo to `v0.81.0-dev` and runs `bin/fmt`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
