### PR TITLE
lint: align bin/lint with linting in CI

### DIFF
--- a/bin/pre-push
+++ b/bin/pre-push
@@ -16,7 +16,6 @@ set -euo pipefail
 . misc/shlib/shlib.bash
 
 try bin/lint
-try cargo fmt -- --check
 try cargo clippy --all-targets -- -D warnings
 try bin/doc --no-deps
 

--- a/bin/pre-push
+++ b/bin/pre-push
@@ -15,8 +15,13 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
+# this runs all of lint-fast.sh
 try bin/lint
+
+# part of lint-slow.sh because it requires building code
 try cargo clippy --all-targets -- -D warnings
+
+# part of lint-slow.sh because it requires building code
 try bin/doc --no-deps
 
 try_status_report

--- a/ci/test/lint-fast.sh
+++ b/ci/test/lint-fast.sh
@@ -11,15 +11,4 @@
 #
 # lint-fast.sh — fast linters that don't require building any code.
 
-set -euo pipefail
-
-. misc/shlib/shlib.bash
-
-try bin/lint
-try cargo --locked fmt -- --check
-try cargo --locked deny check licenses bans sources
-try cargo hakari generate --diff
-try cargo hakari manage-deps --dry-run
-try cargo deplint Cargo.lock ci/test/lint-deps.toml
-
-try_status_report
+bin/lint

--- a/ci/test/lint-main/checks/check-cargo.sh
+++ b/ci/test/lint-main/checks/check-cargo.sh
@@ -17,6 +17,23 @@ cd "$(dirname "$0")/../../../.."
 
 . misc/shlib/shlib.bash
 
+INSTALLED_CARGO_PACKAGES=$(cargo install --list)
+
+if ! echo $INSTALLED_CARGO_PACKAGES | grep --silent "cargo-about"; then
+  echo "lint: cargo-about is not installed"
+  echo "hint: install it with: cargo install cargo-about"
+fi
+
+if ! echo $INSTALLED_CARGO_PACKAGES | grep --silent "cargo-hakari"; then
+  echo "lint: cargo-hakari is not installed"
+  echo "hint: install it with: cargo install cargo-hakari"
+fi
+
+if ! echo $INSTALLED_CARGO_PACKAGES | grep --silent "cargo-deplint"; then
+  echo "lint: cargo-deplint is not installed"
+  echo "hint: install it with: cargo install cargo-deplint"
+fi
+
 try bin/lint-cargo
 
 try cargo --locked fmt -- --check

--- a/ci/test/lint-main/checks/check-cargo.sh
+++ b/ci/test/lint-main/checks/check-cargo.sh
@@ -19,4 +19,10 @@ cd "$(dirname "$0")/../../../.."
 
 try bin/lint-cargo
 
+try cargo --locked fmt -- --check
+try cargo --locked deny check licenses bans sources
+try cargo hakari generate --diff
+try cargo hakari manage-deps --dry-run
+try cargo deplint Cargo.lock ci/test/lint-deps.toml
+
 try_status_report

--- a/ci/test/lint-main/checks/check-cargo.sh
+++ b/ci/test/lint-main/checks/check-cargo.sh
@@ -9,7 +9,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# lint — complains about misformatted files and other problems.
+# check-cargo.sh — check for cargo issues (e.g., ensure that all crates use the same rust version).
 
 set -euo pipefail
 

--- a/ci/test/lint-main/checks/check-copyright.sh
+++ b/ci/test/lint-main/checks/check-copyright.sh
@@ -8,6 +8,8 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+#
+# check-copyright.sh — check copyright headers.
 
 set -euo pipefail
 

--- a/ci/test/lint-main/checks/check-crate-license-listing.sh
+++ b/ci/test/lint-main/checks/check-crate-license-listing.sh
@@ -9,17 +9,17 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# lint-fast.sh — fast linters that don't require building any code.
+# check-crate-license-listing.sh — check absence of failures in generating the license metadata page.
 
 set -euo pipefail
 
+cd "$(dirname "$0")/../../../.."
+
 . misc/shlib/shlib.bash
 
-try bin/lint
-try cargo --locked fmt -- --check
-try cargo --locked deny check licenses bans sources
-try cargo hakari generate --diff
-try cargo hakari manage-deps --dry-run
-try cargo deplint Cargo.lock ci/test/lint-deps.toml
+# Smoke out failures in generating the license metadata page, even though we
+# don't care about its output in the test pipeline, so that we don't only
+# discover the failures after a merge to main.
+try cargo --locked about generate ci/deploy/licenses.hbs > /dev/null
 
 try_status_report

--- a/ci/test/lint-main/checks/check-generation.sh
+++ b/ci/test/lint-main/checks/check-generation.sh
@@ -9,7 +9,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# lint — complains about misformatted files and other problems.
+# check-generation.sh — check code generation.
 
 set -euo pipefail
 

--- a/ci/test/lint-main/checks/check-new-line.sh
+++ b/ci/test/lint-main/checks/check-new-line.sh
@@ -8,6 +8,8 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+#
+# check-new-line.sh — check that files end with an empty line.
 
 set -euo pipefail
 

--- a/ci/test/lint-main/checks/check-protobuf.sh
+++ b/ci/test/lint-main/checks/check-protobuf.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# check-protobuf.sh — detect breaking changes in proto files.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../../../.."
+
+. misc/shlib/shlib.bash
+. misc/buildkite/git.bash
+
+CURRENT_GIT_BRANCH=$(try git branch --show-current)
+IN_BUILDKITE=in_ci
+IN_BUILDKITE_PR=0
+ON_MAIN_BRANCH=0
+IN_LOCAL_NON_MAIN_BRANCH=0
+
+if [[ ${BUILDKITE_PULL_REQUEST:-false} != "false" ]]; then
+  IN_BUILDKITE_PR=1
+fi
+
+if [[ "$CURRENT_GIT_BRANCH" == "main" ]]; then
+  ON_MAIN_BRANCH=1
+fi
+
+if [[ "$IN_BUILDKITE" != 1 && "$ON_MAIN_BRANCH" != 1 ]]; then
+  IN_LOCAL_NON_MAIN_BRANCH=1
+fi
+
+echo $IN_BUILDKITE_PR
+echo $IN_LOCAL_NON_MAIN_BRANCH
+
+if [[ $IN_BUILDKITE_PR || $IN_LOCAL_NON_MAIN_BRANCH ]]; then
+  # see ./ci/test/lint-buf/README.md
+
+  fetch_pr_target_branch
+
+  ci_collapsed_heading "Verify that protobuf config is up-to-date"
+  try bin/pyactivate ./ci/test/lint-buf/generate-buf-config.py
+  try yamllint src/buf.yaml
+  try git diff --name-only --exit-code src/buf.yaml
+
+  ci_collapsed_heading "Lint protobuf"
+  COMMON_ANCESTOR="$(get_common_ancestor_commit_of_pr_and_target)"
+  try buf breaking src --against ".git#ref=$COMMON_ANCESTOR,subdir=src" --verbose
+fi
+
+try_status_report

--- a/ci/test/lint-main/checks/check-protobuf.sh
+++ b/ci/test/lint-main/checks/check-protobuf.sh
@@ -18,6 +18,11 @@ cd "$(dirname "$0")/../../../.."
 . misc/shlib/shlib.bash
 . misc/buildkite/git.bash
 
+if ! buf --version >/dev/null 2>/dev/null; then
+  echo "lint: buf is not installed"
+  echo "hint: refer to https://buf.build/docs/installation for install instructions"
+fi
+
 CURRENT_GIT_BRANCH=$(try git branch --show-current)
 IN_BUILDKITE=in_ci
 IN_BUILDKITE_PR=0

--- a/ci/test/lint-main/checks/check-python-docs.sh
+++ b/ci/test/lint-main/checks/check-python-docs.sh
@@ -9,7 +9,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# lint — complains about misformatted files and other problems.
+# check-python-docs.sh — check Python docs.
 
 set -euo pipefail
 

--- a/ci/test/lint-main/checks/check-python-files.sh
+++ b/ci/test/lint-main/checks/check-python-files.sh
@@ -33,12 +33,6 @@ if [[ ! "${MZDEV_NO_PYTHON:-}" ]]; then
     try bin/pyactivate -m ruff --extend-exclude=misc/dbt-materialize .
     # We need to maintain compatibility with older Python versions for this
     try bin/pyactivate -m ruff --target-version=py38 misc/dbt-materialize
-
-    try bin/pyfmt --check --diff
-    if try_last_failed; then
-        echo "lint: $(red error:) python formatting discrepancies found"
-        echo "hint: run bin/pyfmt" >&2
-    fi
 fi
 
 try_status_report

--- a/ci/test/lint-main/checks/check-python-files.sh
+++ b/ci/test/lint-main/checks/check-python-files.sh
@@ -9,7 +9,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# lint — complains about misformatted files and other problems.
+# check-python-files.sh — check Python files for issues.
 
 set -euo pipefail
 

--- a/ci/test/lint-main/checks/check-python-formatting.sh
+++ b/ci/test/lint-main/checks/check-python-formatting.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# check-python-formatting.sh — check Python formatting.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../../../.."
+
+. misc/shlib/shlib.bash
+
+if [[ ! "${MZDEV_NO_PYTHON:-}" ]]; then
+    try bin/pyfmt --check --diff
+    if try_last_failed; then
+        echo "lint: $(red error:) python formatting discrepancies found"
+        echo "hint: run bin/pyfmt" >&2
+    fi
+fi
+
+try_status_report

--- a/ci/test/lint-main/checks/check-rust-test-attributes.sh
+++ b/ci/test/lint-main/checks/check-rust-test-attributes.sh
@@ -9,7 +9,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# lint — complains about misformatted files and other problems.
+# check-rust-test-attributes.sh — checks usage of test/tokio::test attributes.
 
 set -euo pipefail
 

--- a/ci/test/lint-main/checks/check-rust-version.sh
+++ b/ci/test/lint-main/checks/check-rust-version.sh
@@ -9,7 +9,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# lint — complains about misformatted files and other problems.
+# check-rust-version.sh — checks the used rust version.
 
 set -euo pipefail
 

--- a/ci/test/lint-main/checks/check-shell-files.sh
+++ b/ci/test/lint-main/checks/check-shell-files.sh
@@ -8,6 +8,8 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+#
+# check-shell-files.sh — checks shell files.
 
 set -euo pipefail
 

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -302,6 +302,13 @@ We use the following tools to perform automatic code style checks:
 
 See the [style guide](style.md) for additional recommendations on code style.
 
+### Required Tools
+Linting requires the following tools and Cargo packages to be installed:
+* buf ([installation guide](https://buf.build/docs/installation))
+* cargo-about (`cargo install cargo-about`)
+* cargo-hakari (`cargo install cargo-hakari`)
+* cargo-deplint (`cargo install cargo-deplint`)
+
 ## Submitting and reviewing changes
 
 See [Developer guide: submitting and reviewing changes](guide-changes.md).

--- a/misc/python/materialize/lint/lint.py
+++ b/misc/python/materialize/lint/lint.py
@@ -83,16 +83,19 @@ class LintManager:
         Runs checks in the given directory and validates their outcome.
         :return: names of failed checks
         """
-        print(f"--- Running checks in {checks_path}")
 
-        paths = os.listdir(checks_path)
-
+        lint_files = [
+            lint_file
+            for lint_file in os.listdir(checks_path)
+            if not self.is_ignore_file(checks_path / lint_file)
+        ]
         threads = []
 
-        for lint_file in paths:
-            if self.is_ignore_file(checks_path / lint_file):
-                continue
+        print(
+            f"--- Running {len(lint_files)} check(s) in {checks_path.relative_to(MZ_ROOT)}"
+        )
 
+        for lint_file in lint_files:
             thread = LintingThread(checks_path, lint_file)
             thread.start()
             threads.append(thread)

--- a/misc/python/materialize/lint/lint.py
+++ b/misc/python/materialize/lint/lint.py
@@ -89,6 +89,7 @@ class LintManager:
             for lint_file in os.listdir(checks_path)
             if not self.is_ignore_file(checks_path / lint_file)
         ]
+        lint_files.sort()
         threads = []
 
         print(


### PR DESCRIPTION
This makes sure that `lint-fast.sh` and `bin/lint` do the same. It is a follow-up to https://github.com/MaterializeInc/materialize/pull/23802.

Note that CI additionally runs `lint-slow.sh`, which requires building the code.

### Commits
89574b15c5 lint: complete and update docs of checks
b5a3c3ebf7 lint: extract check-protobuf.sh
5eb28d7079 lint: extract failures in check-crate-license-listing.sh
82e1e08e1c lint: move further cargo checks to check-cargo.sh
8a7dea3b06 lint: improve output
1b96938d01 lint: bin/pre-push: remove command already executed in bin/lint
37501320bc lint: bin/pre-push: add comments
80e5242ccc lint: extract check-python-formatting.sh from check-python-formatting.sh
d43d0da3d2 lint: order checks by name

### Overview of checks after the changes
```
ci/test/lint-main
├── after
│   └── check-no-diff.sh
├── before
│   └── can-lint.sh
└── checks
    ├── check-cargo.sh
    ├── check-copyright.sh
    ├── check-crate-license-listing.sh
    ├── check-generation.sh
    ├── check-new-line.sh
    ├── check-protobuf.sh
    ├── check-python-docs.sh
    ├── check-python-files.sh
    ├── check-python-formatting.sh
    ├── check-rust-test-attributes.sh
    ├── check-rust-version.sh
    └── check-shell-files.sh
```

### Performance impact

Performance of `bin/lint` deteriorated from 9 seconds to 14 seconds compared to the introduction of parallel linting with https://github.com/MaterializeInc/materialize/pull/23802. Linting is still faster than it was before the introduction of parallel linting (26 seconds).

The slowest steps are `check-python-files.sh`, `check-crate-license-listing.sh`, and `check-new-line.sh`, which take over 12 seconds. Interestingly, `check-python-files.sh` and `check-new-line.sh` are slower a bit since this PR, possibly due to much concurrent IO access.

#### Before
9 seconds (multiple measurements conducted).

```
--- Running checks in /Users/nrainer/Workspaces/mz-repo/ci/test/lint-main/before
--- can-lint.sh (SUCCEEDED in 0.03s)
--- Running checks in /Users/nrainer/Workspaces/mz-repo/ci/test/lint-main/checks
--- check-python-docs.sh (SUCCEEDED in 3.40s)
--- check-shell-files.sh (SUCCEEDED in 2.68s)
--- check-copyright.sh (SUCCEEDED in 6.34s)
--- check-python-files.sh (SUCCEEDED in 10.16s)
--- check-rust-files.sh (SUCCEEDED in 5.01s)
--- check-cargo.sh (SUCCEEDED in 0.21s)
--- check-rust-version.sh (SUCCEEDED in 0.03s)
--- check-new-line.sh (SUCCEEDED in 7.97s)
--- check-generation.sh (SUCCEEDED in 0.94s)
--- Running checks in /Users/nrainer/Workspaces/mz-repo/ci/test/lint-main/after
--- check-no-diff.sh (SUCCEEDED in 0.06s)
+++ Linting result
All checks successful.
```

#### After
14 seconds (multiple measurements conducted).

```
--- Running 1 check(s) in ci/test/lint-main/before
--- can-lint.sh (SUCCEEDED in 0.03s)
--- Running 11 check(s) in ci/test/lint-main/checks
--- check-python-docs.sh (SUCCEEDED in 4.65s)
--- check-shell-files.sh (SUCCEEDED in 2.95s)
--- check-protobuf.sh (SUCCEEDED in 4.32s)
--- check-copyright.sh (SUCCEEDED in 11.62s)
--- check-python-files.sh (SUCCEEDED in 13.84s)
--- check-cargo.sh (SUCCEEDED in 6.54s)
--- check-crate-license-listing.sh (SUCCEEDED in 12.64s)
--- check-rust-version.sh (SUCCEEDED in 0.03s)
--- check-new-line.sh (SUCCEEDED in 13.30s)
--- check-rust-test-attributes.sh (SUCCEEDED in 7.02s)
--- check-generation.sh (SUCCEEDED in 1.18s)
--- Running 1 check(s) in ci/test/lint-main/after
--- check-no-diff.sh (SUCCEEDED in 0.07s)
+++ Linting result
All checks successful.
```

#### Other

I further extracted `check-python-formatting.sh` from `check-python-formatting.sh`:
```
--- check-python-files.sh (SUCCEEDED in 10.65s)
--- check-python-formatting.sh (SUCCEEDED in 5.39s)
```

However, the overall duration remains 14 seconds due to step `check-crate-license-listing.sh`, which cannot be split.