### PR TITLE
cloudtest: Enable soft assertions

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -96,6 +96,7 @@ IGNORE_RE = re.compile(
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage(\ to\ set\ (default|configured)\ parameter)?
     | internal\ error:\ no\ AWS\ external\ ID\ prefix\ configured
     | failed\ writing\ row\ to\ mz_aws_connections.*no\ AWS\ external\ ID\ prefix\ configured
+    | failed\ writing\ row\ to\ mz_aws_connections.*no\ AWS\ connection\ role\ configured
     )
     """,
     re.VERBOSE | re.MULTILINE,

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -257,6 +257,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
         )
 
         env = [
+            V1EnvVar(name="MZ_SOFT_ASSERTIONS", value="1"),
             V1EnvVar(name="MZ_POD_NAME", value_from=value_from),
             V1EnvVar(name="AWS_REGION", value="minio"),
             V1EnvVar(name="AWS_ACCESS_KEY_ID", value="minio"),


### PR DESCRIPTION
This brings cloudtest in line with mzcompose

Relates to #23921

### Motivation

testdrive+cloudtest was failing in Nightly. Apparently the diff in the EXPLAIN plans was due to the absence of `--soft-assertions`.