### PR TITLE
adapter: move `dataflows` from `coord` to `optimize`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,6 @@
 /src/adapter                        @MaterializeInc/adapter
 /src/adapter-types                  @MaterializeInc/adapter
 /src/adapter/src/optimizer          @MaterializeInc/compute
-/src/adapter/src/coord/dataflows.rs @MaterializeInc/compute
 # to track changes to feature flags
 /src/adapter/src/coord/ddl.rs       @MaterializeInc/testing
 # to track changes to feature flags

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4477,7 +4477,7 @@ mod tests {
     use mz_stash::DebugStashFactory;
 
     use crate::catalog::{Catalog, CatalogItem, Op, PrivilegeMap, SYSTEM_CONN_ID};
-    use crate::coord::dataflows::{prep_scalar_expr, EvalTime, ExprPrepStyle};
+    use crate::optimize::dataflows::{prep_scalar_expr, EvalTime, ExprPrepStyle};
     use crate::session::Session;
 
     /// System sessions have an empty `search_path` so it's necessary to

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -930,8 +930,6 @@ pub struct Coordinator {
     /// The controller for the storage and compute layers.
     #[derivative(Debug = "ignore")]
     controller: mz_controller::Controller,
-    /// Optimizer instance for logical optimization of views.
-    view_optimizer: Optimizer,
     /// The catalog in an Arc suitable for readonly references. The Arc allows
     /// us to hand out cheap copies of the catalog to functions that can use it
     /// off of the main coordinator thread. If the coordinator needs to mutate
@@ -2507,9 +2505,6 @@ pub fn serve(
                 let caching_secrets_reader = CachingSecretsReader::new(secrets_controller.reader());
                 let mut coord = Coordinator {
                     controller,
-                    view_optimizer: Optimizer::logical_optimizer(
-                        &mz_transform::typecheck::empty_context(),
-                    ),
                     catalog,
                     internal_cmd_tx,
                     group_commit_tx,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -89,6 +89,7 @@ use mz_build_info::BuildInfo;
 use mz_catalog::config::{AwsPrincipalContext, ClusterReplicaSizeMap};
 use mz_catalog::memory::objects::{CatalogEntry, CatalogItem, Connection, DataSourceDesc, Source};
 use mz_cloud_resources::{CloudResourceController, VpcEndpointConfig, VpcEndpointEvent};
+use mz_compute_client::controller::error::InstanceMissing;
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::Plan;
 use mz_compute_types::ComputeInstanceId;
@@ -139,7 +140,6 @@ use crate::client::{Client, Handle};
 use crate::command::{Canceled, Command, ExecuteResponse};
 use crate::config::{SynchronizedParameters, SystemParameterFrontend, SystemParameterSyncConfig};
 use crate::coord::appends::{Deferred, GroupCommitPermit, PendingWriteTxn};
-use crate::coord::dataflows::dataflow_import_id_bundle;
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::peek::PendingPeek;
 use crate::coord::timeline::{TimelineContext, TimelineState, WriteTimestamp};
@@ -150,6 +150,9 @@ use crate::coord::timestamp_oracle::postgres_oracle::{
 use crate::coord::timestamp_selection::TimestampContext;
 use crate::error::AdapterError;
 use crate::metrics::Metrics;
+use crate::optimize::dataflows::{
+    dataflow_import_id_bundle, ComputeInstanceSnapshot, DataflowBuilder,
+};
 use crate::optimize::{self, Optimize, OptimizerConfig};
 use crate::session::{EndTransactionAction, Session};
 use crate::statement_logging::StatementEndedExecutionReason;
@@ -160,7 +163,6 @@ use crate::{flags, AdapterNotice, TimestampProvider};
 use mz_catalog::builtin::BUILTINS;
 use mz_catalog::durable::DurableCatalogState;
 
-pub(crate) mod dataflows;
 use self::statement_logging::{StatementLogging, StatementLoggingId};
 
 pub(crate) mod id_bundle;
@@ -2276,6 +2278,58 @@ impl Coordinator {
         if let Some(uuid) = ctx_extra.retire() {
             self.end_statement_execution(uuid, reason);
         }
+    }
+
+    /// Creates a new dataflow builder from the catalog and indexes in `self`.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub fn dataflow_builder(&self, instance: ComputeInstanceId) -> DataflowBuilder {
+        let compute = self
+            .instance_snapshot(instance)
+            .expect("compute instance does not exist");
+        DataflowBuilder::new(self.catalog().state(), compute)
+    }
+
+    /// Return a reference-less snapshot to the indicated compute instance.
+    pub fn instance_snapshot(
+        &self,
+        id: ComputeInstanceId,
+    ) -> Result<ComputeInstanceSnapshot, InstanceMissing> {
+        ComputeInstanceSnapshot::new(&self.controller, id)
+    }
+
+    /// Call into the compute controller to install a finalized dataflow, and
+    /// initialize the read policies for its exported objects.
+    pub(crate) async fn ship_dataflow(
+        &mut self,
+        dataflow: DataflowDescription<Plan>,
+        instance: ComputeInstanceId,
+    ) {
+        let export_ids = dataflow.export_ids().collect();
+
+        self.controller
+            .active_compute()
+            .create_dataflow(instance, dataflow)
+            .unwrap_or_terminate("dataflow creation cannot fail");
+
+        self.initialize_compute_read_policies(export_ids, instance, CompactionWindow::Default)
+            .await;
+    }
+}
+
+#[cfg(test)]
+impl Coordinator {
+    #[allow(dead_code)]
+    async fn verify_ship_dataflow_no_error(&mut self, dataflow: DataflowDescription<Plan>) {
+        // `ship_dataflow_new` is not allowed to have a `Result` return because this function is
+        // called after `catalog_transact`, after which no errors are allowed. This test exists to
+        // prevent us from incorrectly teaching those functions how to return errors (which has
+        // happened twice and is the motivation for this test).
+
+        // An arbitrary compute instance ID to satisfy the function calls below. Note that
+        // this only works because this function will never run.
+        let compute_instance = ComputeInstanceId::User(1);
+
+        let _: () = self.ship_dataflow(dataflow, compute_instance).await;
     }
 }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -124,7 +124,6 @@ use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::controller::PersistTxnTablesImpl;
 use mz_storage_types::sources::Timeline;
-use mz_transform::Optimizer;
 use opentelemetry::trace::TraceContextExt;
 use timely::progress::Antichain;
 use timely::PartialOrder;

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -15,8 +15,8 @@ use mz_expr::{CollectionPlan, MirScalarExpr};
 use mz_repr::GlobalId;
 use mz_transform::IndexOracle;
 
-use crate::coord::dataflows::DataflowBuilder;
 use crate::coord::{CollectionIdBundle, Coordinator};
+use crate::optimize::dataflows::DataflowBuilder;
 
 impl Coordinator {
     /// Creates a new index oracle for the specified compute instance.

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -87,9 +87,6 @@ use tracing_core::callsite::rebuild_interest_cache;
 use crate::catalog::{self, Catalog, ConnCatalog, UpdatePrivilegeVariant};
 use crate::command::{ExecuteResponse, Response};
 use crate::coord::appends::{Deferred, DeferredPlan, PendingWriteTxn};
-use crate::coord::dataflows::{
-    dataflow_import_id_bundle, prep_scalar_expr, EvalTime, ExprPrepStyle,
-};
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::peek::{FastPathPlan, PeekDataflowPlan, PeekPlan, PlannedPeek};
 use crate::coord::timeline::TimelineContext;
@@ -106,6 +103,9 @@ use crate::error::AdapterError;
 use crate::explain::explain_dataflow;
 use crate::explain::optimizer_trace::OptimizerTrace;
 use crate::notice::{AdapterNotice, DroppedInUseIndex};
+use crate::optimize::dataflows::{
+    dataflow_import_id_bundle, prep_scalar_expr, EvalTime, ExprPrepStyle,
+};
 use crate::optimize::{self, Optimize, OptimizerConfig};
 use crate::session::{EndTransactionAction, Session, TransactionOps, TransactionStatus, WriteOp};
 use crate::subscribe::ActiveSubscribe;

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -28,10 +28,10 @@ use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 use tracing::{event, Level};
 
 use crate::catalog::CatalogState;
-use crate::coord::dataflows::{prep_scalar_expr, ExprPrepStyle};
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::timeline::TimelineContext;
 use crate::coord::Coordinator;
+use crate::optimize::dataflows::{prep_scalar_expr, ExprPrepStyle};
 use crate::session::Session;
 use crate::AdapterError;
 

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -37,7 +37,7 @@ use mz_transform::notice::IndexKeyEmpty;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
 
 use crate::catalog::Catalog;
-use crate::coord::dataflows::{
+use crate::optimize::dataflows::{
     prep_relation_expr, prep_scalar_expr, ComputeInstanceSnapshot, DataflowBuilder, ExprPrepStyle,
 };
 use crate::optimize::{

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -42,7 +42,7 @@ use timely::progress::Antichain;
 use tracing::{span, Level};
 
 use crate::catalog::Catalog;
-use crate::coord::dataflows::{
+use crate::optimize::dataflows::{
     prep_relation_expr, ComputeInstanceSnapshot, DataflowBuilder, ExprPrepStyle,
 };
 use crate::optimize::{

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -153,6 +153,7 @@ impl Optimize<HirRelationExpr> for Optimizer {
 
         // MIR ⇒ MIR optimization (local)
         let expr = span!(target: "optimizer", Level::DEBUG, "local").in_scope(|| {
+            #[allow(deprecated)]
             let optimizer = TransformOptimizer::logical_optimizer(&self.typecheck_ctx);
             let expr = optimizer.optimize(expr)?.into_inner();
 

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -69,8 +69,6 @@ use mz_sql::plan::PlanError;
 use mz_sql::session::vars::SystemVars;
 use mz_transform::TransformError;
 
-use crate::AdapterError;
-
 /// A trait that represents an optimization stage.
 ///
 /// The trait is implemented by structs that encapsulate the context needed to
@@ -183,9 +181,6 @@ type LirDataflowDescription = DataflowDescription<Plan>;
 /// Error types that can be generated during optimization.
 #[derive(Debug, thiserror::Error)]
 pub enum OptimizerError {
-    // TODO: change dataflows.rs error types and reverse this ownership.
-    #[error("{0}")]
-    AdapterError(#[from] AdapterError),
     #[error("{0}")]
     PlanError(#[from] PlanError),
     #[error("{0}")]
@@ -234,15 +229,5 @@ impl From<TimestampError> for OptimizerError {
 impl From<anyhow::Error> for OptimizerError {
     fn from(value: anyhow::Error) -> Self {
         OptimizerError::Internal(value.to_string())
-    }
-}
-
-// TODO: create a dedicated AdapterError::OptimizerError variant.
-impl From<OptimizerError> for AdapterError {
-    fn from(value: OptimizerError) -> Self {
-        match value {
-            OptimizerError::AdapterError(err) => err,
-            err => AdapterError::Internal(err.to_string()),
-        }
     }
 }

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -52,6 +52,7 @@
 //! For details, see the `20230714_optimizer_interface.md` design doc in this
 //! repository.
 
+pub mod dataflows;
 pub mod index;
 pub mod materialized_view;
 pub mod peek;
@@ -68,7 +69,6 @@ use mz_sql::plan::PlanError;
 use mz_sql::session::vars::SystemVars;
 use mz_transform::TransformError;
 
-use crate::coord::dataflows::DataflowBuilder;
 use crate::AdapterError;
 
 /// A trait that represents an optimization stage.
@@ -204,7 +204,8 @@ impl From<OptimizerError> for AdapterError {
     }
 }
 
-impl<'a> DataflowBuilder<'a> {
+// TODO(dataflows): move to dataflows mod
+impl<'a> dataflows::DataflowBuilder<'a> {
     // Re-optimize the imported view plans using the current optimizer
     // configuration if we are running in `EXPLAIN`.
     pub fn reoptimize_imported_views(

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -223,6 +223,7 @@ impl Optimize<MirRelationExpr> for Optimizer {
     fn optimize(&mut self, expr: MirRelationExpr) -> Result<Self::To, OptimizerError> {
         // MIR ⇒ MIR optimization (local)
         let expr = span!(target: "optimizer", Level::DEBUG, "local").in_scope(|| {
+            #[allow(deprecated)]
             let optimizer = TransformOptimizer::logical_optimizer(&self.typecheck_ctx);
             let expr = optimizer.optimize(expr)?.into_inner();
 

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -27,11 +27,11 @@ use timely::progress::Antichain;
 use tracing::{span, warn, Level};
 
 use crate::catalog::Catalog;
-use crate::coord::dataflows::{
+use crate::coord::peek::{create_fast_path_plan, FastPathPlan};
+use crate::optimize::dataflows::{
     prep_relation_expr, prep_scalar_expr, ComputeInstanceSnapshot, DataflowBuilder, EvalTime,
     ExprPrepStyle,
 };
-use crate::coord::peek::{create_fast_path_plan, FastPathPlan};
 use crate::optimize::{
     LirDataflowDescription, MirDataflowDescription, Optimize, OptimizeMode, OptimizerConfig,
     OptimizerError,

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -185,6 +185,7 @@ impl Optimize<SubscribeFrom> for Optimizer {
 
                 // MIR ⇒ MIR optimization (local)
                 let expr = span!(target: "optimizer", Level::DEBUG, "local").in_scope(|| {
+                    #[allow(deprecated)]
                     let optimizer = TransformOptimizer::logical_optimizer(&self.typecheck_ctx);
                     let expr = optimizer.optimize(expr)?;
 

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -29,7 +29,7 @@ use timely::progress::Antichain;
 use tracing::{span, Level};
 
 use crate::catalog::Catalog;
-use crate::coord::dataflows::{
+use crate::optimize::dataflows::{
     dataflow_import_id_bundle, ComputeInstanceSnapshot, DataflowBuilder,
 };
 use crate::optimize::{

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -43,6 +43,7 @@ impl Optimize<HirRelationExpr> for Optimizer {
 
         // MIR ⇒ MIR optimization (local)
         let expr = span!(target: "optimizer", Level::DEBUG, "local").in_scope(|| {
+            #[allow(deprecated)]
             let optimizer = TransformOptimizer::logical_optimizer(&self.typecheck_ctx);
             let expr = optimizer.optimize(expr)?;
 

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -20,7 +20,7 @@ use mz_sql::plan::{WebhookHeaders, WebhookValidation, WebhookValidationSecret};
 use mz_storage_client::controller::MonotonicAppender;
 use tokio::sync::Semaphore;
 
-use crate::coord::dataflows::{prep_scalar_expr, ExprPrepStyle};
+use crate::optimize::dataflows::{prep_scalar_expr, ExprPrepStyle};
 
 /// Errors returns when running validation of a webhook request.
 #[derive(thiserror::Error, Debug)]

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -59,6 +59,7 @@ pub fn optimize_dataflow(
         dataflow,
         indexes,
         stats,
+        #[allow(deprecated)]
         &Optimizer::logical_optimizer(&ctx),
         &mut dataflow_metainfo,
     )?;

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -452,6 +452,7 @@ pub struct Optimizer {
 
 impl Optimizer {
     /// Builds a logical optimizer that only performs logical transformations.
+    #[deprecated = "Create an Optimize instance and call `optimize` instead."]
     pub fn logical_optimizer(ctx: &crate::typecheck::SharedContext) -> Self {
         let transforms: Vec<Box<dyn crate::Transform>> = vec![
             Box::new(crate::typecheck::Typecheck::new(Arc::clone(ctx)).strict_join_equivalences()),

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -117,6 +117,7 @@ mod tests {
     thread_local! {
         static FULL_TRANSFORM_LIST: Vec<Box<dyn Transform>> = {
             let ctx = mz_transform::typecheck::empty_context();
+            #[allow(deprecated)]
             Optimizer::logical_optimizer(&ctx)
                 .transforms
                 .into_iter()
@@ -413,6 +414,7 @@ mod tests {
         }
         let mut out = String::new();
         if test_type == TestType::Opt {
+            #[allow(deprecated)]
             let optimizer = Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
             dataflow = dataflow
                 .into_iter()


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

This is the next step of the effort to consolidate all optimizer-related code in the `mz-adapter` crate into a single module that ultimately be split into its own crate.

### Tips for reviewer

This is just moving code.

The one discussion item that I have is how to model the `OptimizerError` embedding into `AdapterError`. Currently the `From` trait implementation maps every variant of the former to the same-named variant of the latter. I can also see if these variants are not needed anywhere else and replace `AdapterError::~` with `AdapterError::Optimizer(OptimizerError)`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
