### PR TITLE
docs: fix description of PG source inherited table workaround

### DIFF
--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -189,15 +189,11 @@ i.e. in Materialize, the data will not be returned when serving `SELECT`s from
 the inherited table.
 
 You can mimic PostgreSQL's `SELECT` behavior with inherited tables by creating a
-materialized view that `UNION`s data from the inherited and inheriting tables,
-though there are many caveats:
-
--   Materialized views are maintained in arrangements, which moves the tables'
-    data from being stored in relatively low-cost storage into being stored in
-    memory.
--   If new tables inherit from the table, data from the inheriting tables will
-    not be available in the view. You will need to add the inheriting tables via
-    `ADD SUBSOURCE` and create a new view that unions the new table.
+materialized view that unions data from the inherited and inheriting tables
+(using `UNION ALL`). However, if new tables inherit from the table, data from
+the inheriting tables will not be available in the view. You will need to add
+the inheriting tables via `ADD SUBSOURCE` and create a new view (materialized or
+non-) that unions the new table.
 
 ## Examples
 


### PR DESCRIPTION
`UNION` != `UNION ALL` and I meant `UNION ALL`

### Motivation

This PR fixes a recognized bug. [Slack](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1702598305974759)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
