### PR TITLE
ci: check existence of docker images without pulling

### DIFF
--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -47,12 +47,11 @@ def mz_image_tag_exists(image_tag: str) -> bool:
         EXISTENCE_OF_IMAGE_NAMES_FROM_EARLIER_CHECK[image_name] = True
         return True
     except subprocess.CalledProcessError as e:
-        print(f"Failed to fetch image manifest: {image_name}")
-
         if "no such manifest:" in e.output:
+            print(f"Failed to fetch image manifest '{image_name}' (does not exist)")
             EXISTENCE_OF_IMAGE_NAMES_FROM_EARLIER_CHECK[image_name] = False
         else:
-            print(f"Error when checking image manifest was: {e.output}")
+            print(f"Failed to fetch image manifest '{image_name}' ({e.output})")
             # do not cache the result of unknown error messages
 
         return False

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -35,23 +35,24 @@ def mz_image_tag_exists(image_tag: str) -> bool:
 
     command = [
         "docker",
-        "pull",
+        "manifest",
+        "inspect",
         image_name,
     ]
 
-    print(f"Trying to pull image: {image_name}")
+    print(f"Checking existence of image manifest: {image_name}")
 
     try:
         subprocess.check_output(command, stderr=subprocess.STDOUT, text=True)
         EXISTENCE_OF_IMAGE_NAMES_FROM_EARLIER_CHECK[image_name] = True
         return True
     except subprocess.CalledProcessError as e:
-        print(f"Failed to pull image: {image_name}")
+        print(f"Failed to fetch image manifest: {image_name}")
 
-        if "not found: manifest unknown: manifest unknown" in e.output:
+        if "no such manifest:" in e.output:
             EXISTENCE_OF_IMAGE_NAMES_FROM_EARLIER_CHECK[image_name] = False
         else:
-            print(f"Error when pulling image was: {e.output}")
+            print(f"Error when checking image manifest was: {e.output}")
             # do not cache the result of unknown error messages
 
         return False


### PR DESCRIPTION
Try to determine whether a Docker image exists without pulling.

Nightlies: https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Aci%2Fimage-check-without-pull

### Potential downsides
* This uses an experimental feature: https://docs.docker.com/engine/reference/commandline/manifest_inspect/
* It seemed rather slow locally, let's see how it performs in CI. Could have been my internet connection.

### Alternatives
If this does not work, other solutions exist:
* https://stackoverflow.com/a/65826563/584532
* https://stackoverflow.com/a/69088157/584532