### PR TITLE
tests: bounded memory: add 0.5Gb materialized_memory to accumulate-reductions

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -429,7 +429,7 @@ SCENARIOS = [
             10000001
             """
         ),
-        materialized_memory="9.0Gb",
+        materialized_memory="9.5Gb",
         clusterd_memory="3.5Gb",
     ),
     KafkaScenario(


### PR DESCRIPTION
This adds further memory as safety margin due to [build#5625](https://buildkite.com/materialize/nightlies/builds/5625#018c6d51-8a89-42e7-b962-fe368aa5705e) although I had a successful run with [build#5622](https://buildkite.com/materialize/nightlies/builds/5622).

Follow-up to https://github.com/MaterializeInc/materialize/pull/23891.