### PR TITLE
ci: revert inclusion of closed cloud issues

### DIFF
--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -61,6 +61,8 @@ IGNORE_RE = re.compile(
     | \(\#1\)\ IS\ NULL
     # test/sqllogictest/cockroach/*.slt
     | cockroach\#
+    # cloud repo
+    | cloud\#
     # ci/test/lint-buf/README.md
     | Ignore\ because\ of\ #99999
     )

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -197,7 +197,7 @@ where
     }
 }
 
-// TODO(#23922): delete this
+// TODO(cloud#8196): delete this
 impl<C> DisplayText<C> for MapFilterProject
 where
     C: AsMut<Indent>,

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -619,7 +619,7 @@ pub struct Indices<'a>(pub &'a [usize]);
 ///
 /// Interval expressions are used only for runs of three or more elements.
 #[derive(Debug)]
-pub struct CompactScalarSeq<'a, T: ScalarOps>(pub &'a [T]); // TODO(#23922) remove this
+pub struct CompactScalarSeq<'a, T: ScalarOps>(pub &'a [T]); // TODO(cloud#8196) remove this
 
 /// Pretty-prints a list of scalar expressions that may have runs of column
 /// indices as a comma-separated list interleaved with interval expressions.


### PR DESCRIPTION
This reverts https://github.com/MaterializeInc/materialize/pull/23919 until https://github.com/MaterializeInc/materialize/issues/23932 is fixed.