### PR TITLE
[expr] Relax MFP evaluation semantics

### DIFF
--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -418,7 +418,7 @@ pub trait Interpreter {
             let result = mfp_eval.binary(&BinaryFunc::Gte, bound_range, mz_now.clone());
             results.push(result);
         }
-        self.variadic(&VariadicFunc::And, results)
+        mfp_eval.variadic(&VariadicFunc::And, results)
     }
 }
 

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -1340,6 +1340,52 @@ mod tests {
                 }
             }
 
+            // Munge our expr into a list of filters, so we can test MFP evaluation.
+            let predicates = if let MirScalarExpr::CallVariadic {
+                func: VariadicFunc::And,
+                exprs,
+            } = expr
+            {
+                exprs
+            } else if expr.typ(relation_type.columns()).scalar_type == ScalarType::Bool {
+                vec![expr]
+            } else {
+                vec![MirScalarExpr::CallUnary {
+                    func: UnaryFunc::IsNull(IsNull),
+                    expr: Box::new(expr),
+                }]
+            };
+
+            let mfp = MapFilterProject::new(relation_type.arity()).filter(predicates);
+            let spec = interpreter.mfp_filter(&mfp);
+            let safe_plan = mfp.into_plan().unwrap().into_nontemporal().unwrap();
+            let mut buffer = Row::default();
+            for row in &rows {
+                let mut datums: Vec<_> = row.iter().collect();
+                let eval_result = safe_plan.evaluate_into(&mut datums, &arena, &mut buffer);
+                match eval_result {
+                    Ok(None) => {
+                        assert!(
+                            spec.range.may_contain(Datum::False)
+                                || spec.range.may_contain(Datum::Null),
+                            "{spec:?} should allow for false/null when record is discarded"
+                        )
+                    }
+                    Ok(Some(_)) => {
+                        assert!(
+                            spec.range.may_contain(Datum::True),
+                            "{spec:?} should allow true when record is kept"
+                        )
+                    }
+                    Err(_) => {
+                        assert!(
+                            spec.range.may_fail(),
+                            "{spec:?} should allow for errors when MFP fails"
+                        );
+                    }
+                }
+            }
+
             Ok(())
         }
 

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -276,13 +276,7 @@ impl<'a> ResultSpec<'a> {
             // Since we only care about whether / not an error is possible, and not the specific
             // error, create an arbitrary error here.
             // NOTE! This assumes that functions do not discriminate on the type of the error.
-            let map_err = result_map(Err(EvalError::Internal(String::new())));
-            let raise_err = ResultSpec::fails();
-            // SQL has a very loose notion of evaluation order: https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-EXPRESS-EVAL
-            // Here, we account for the possibility that the expression is evaluated strictly,
-            // raising the error, or that it's evaluated lazily by the result_map function
-            // (which may return a non-error result even when given an error as input).
-            raise_err.union(map_err)
+            result_map(Err(EvalError::Internal(String::new())))
         } else {
             ResultSpec::nothing()
         };

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1524,21 +1524,36 @@ pub mod plan {
             datums: &'b mut Vec<Datum<'a>>,
             arena: &'a RowArena,
         ) -> Result<bool, EvalError> {
+            // NB: similar to the AND function, we prefer to return `false` instead of an error
+            // when we have the option. Buffer an error from evaluating our predicates and return
+            // it only if we don't exit early.
+            let mut null = false;
+            let mut err = None;
             let mut expression = 0;
             for (support, predicate) in self.mfp.predicates.iter() {
                 while self.mfp.input_arity + expression < *support {
                     datums.push(self.mfp.expressions[expression].eval(&datums[..], arena)?);
                     expression += 1;
                 }
-                if predicate.eval(&datums[..], arena)? != Datum::True {
-                    return Ok(false);
+                match predicate.eval(&datums[..], arena) {
+                    Ok(Datum::True) => {}
+                    Ok(Datum::Null) => {
+                        null = true;
+                    }
+                    Ok(_) => return Ok(false),
+                    Err(e) => {
+                        err = Some(match err {
+                            Some(e2) => e.min(e2),
+                            None => e,
+                        })
+                    }
                 }
             }
             while expression < self.mfp.expressions.len() {
                 datums.push(self.mfp.expressions[expression].eval(&datums[..], arena)?);
                 expression += 1;
             }
-            Ok(true)
+            err.map_or(Ok(!null), Err)
         }
 
         /// Returns true if evaluation could introduce an error on non-error inputs.


### PR DESCRIPTION
So! Here is the deal:
- Our abstract interpreter _must_ never return false positives. (ie. If our interpreter claims that an expression can't return a particular result, but it can, that is very bad.) In terms of filter pushdown in Persist, this means that pushing down a filter can never change the results of a query -- only the performance.
- In https://github.com/MaterializeInc/materialize/issues/23755, we're sad that `select * from <relation> where <expression that might error> and <expression that always returns false>` doesn't get filter pushdown. This is intentional: if the expression might error, this query might return an error, so pushing down that filter would change the results.

So: if we want filter pushdown to be able to prove the expression doesn't error, and it's really important for it to match the actual evaluation behaviour, the only option is to change the actual evaluation behaviour. This PR does that: evaluating filters now matches ANDs' error-swallowing evaluation semantics.

### Motivation

Known issue: https://github.com/MaterializeInc/materialize/issues/23755

### Tips for reviewer

I'm going to leave this in draft because I don't think we're quite there yet:
- The interleaving of map and filter isn't reflected in the interpreter. (For example: if a map fails, and that map runs before a filter, MFP execution won't run the filter... but the interpreter will still interpret it.) This probably requires changes to the interpreter.
- I suspect the behaviour doesn't match for temporal predicates right now.

Hopefully there's enough here to judge the approach, though.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
