### PR TITLE
tests: version resolution: allow use-case specific commit overrides

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -15,6 +15,7 @@ import uuid
 from textwrap import dedent
 
 from materialize.version_list import (
+    ANCESTOR_OVERRIDES_FOR_PERFORMANCE_REGRESSIONS,
     get_latest_published_version,
     resolve_ancestor_image_tag,
 )
@@ -134,7 +135,9 @@ def run_one_scenario(
         )
 
         if tag == "common-ancestor":
-            tag = resolve_ancestor_image_tag()
+            tag = resolve_ancestor_image_tag(
+                ANCESTOR_OVERRIDES_FOR_PERFORMANCE_REGRESSIONS
+            )
 
         entrypoint_host = "balancerd" if balancerd else "materialized"
 

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -45,7 +45,10 @@ from materialize.scalability.workload import Workload, WorkloadSelfTest
 from materialize.scalability.workloads import *  # noqa: F401 F403
 from materialize.scalability.workloads_test import *  # noqa: F401 F403
 from materialize.util import YesNoOnce, all_subclasses
-from materialize.version_list import resolve_ancestor_image_tag
+from materialize.version_list import (
+    ANCESTOR_OVERRIDES_FOR_SCALABILITY_REGRESSIONS,
+    resolve_ancestor_image_tag,
+)
 
 SERVICES = [
     Materialized(
@@ -252,7 +255,9 @@ def get_baseline_and_other_endpoints(
             )
         else:
             if target == "common-ancestor":
-                target = resolve_ancestor_image_tag()
+                target = resolve_ancestor_image_tag(
+                    ANCESTOR_OVERRIDES_FOR_SCALABILITY_REGRESSIONS
+                )
             endpoint = MaterializeContainer(
                 composition=c,
                 specified_target=original_target,

--- a/test/version-consistency/mzcompose.py
+++ b/test/version-consistency/mzcompose.py
@@ -16,7 +16,10 @@ from materialize.version_consistency.version_consistency_test import (
     EVALUATION_STRATEGY_NAMES,
     VersionConsistencyTest,
 )
-from materialize.version_list import resolve_ancestor_image_tag
+from materialize.version_list import (
+    ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS,
+    resolve_ancestor_image_tag,
+)
 
 SERVICES = [
     Cockroach(setup_materialize=True),
@@ -53,7 +56,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     name_mz_this, name_mz_other = "mz_this", "mz_other"
     port_mz_internal, port_mz_this, port_mz_other = 6875, 6875, 16875
-    tag_mz_other = resolve_ancestor_image_tag()
+    tag_mz_other = resolve_ancestor_image_tag(
+        ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS
+    )
 
     print(f"Using {tag_mz_other} as tag for other mz version")
 


### PR DESCRIPTION
Basically split `MIN_ANCESTOR_MZ_VERSION_PER_COMMIT` into
* `ANCESTOR_OVERRIDES_FOR_PERFORMANCE_REGRESSIONS`,
* `ANCESTOR_OVERRIDES_FOR_SCALABILITY_REGRESSIONS`,
*  and `ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS`.