### PR TITLE
adapter: log redacted SQL if stuck on execute command

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -29,6 +29,7 @@ use mz_sql::plan::{
 use mz_sql::rbac;
 use mz_sql_parser::ast::{Raw, Statement};
 use mz_storage_types::connections::inline::IntoInlineConnection;
+use std::sync::Arc;
 use tokio::sync::oneshot;
 use tracing::{event, Instrument, Level, Span};
 
@@ -603,7 +604,7 @@ impl Coordinator {
     pub(crate) async fn sequence_execute_single_statement_transaction(
         &mut self,
         ctx: ExecuteContext,
-        stmt: Statement<Raw>,
+        stmt: Arc<Statement<Raw>>,
         params: Params,
     ) {
         // Put the session into single statement implicit so anything can execute.

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -145,7 +145,7 @@ impl Coordinator {
         if let Some(revision) = Self::verify_statement_revision(
             self.catalog(),
             session,
-            portal.stmt.as_ref(),
+            portal.stmt.as_deref(),
             &portal.desc,
             portal.catalog_revision,
         )? {

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -584,7 +584,7 @@ impl<T: TimestampManipulation> Session<T> {
         self.portals.insert(
             portal_name,
             Portal {
-                stmt,
+                stmt: stmt.map(Arc::new),
                 desc,
                 catalog_revision,
                 parameters: Params {
@@ -638,7 +638,7 @@ impl<T: TimestampManipulation> Session<T> {
                 Entry::Occupied(_) => continue,
                 Entry::Vacant(entry) => {
                     entry.insert(Portal {
-                        stmt,
+                        stmt: stmt.map(Arc::new),
                         desc,
                         catalog_revision,
                         parameters,
@@ -819,7 +819,7 @@ impl PreparedStatement {
 #[derivative(Debug)]
 pub struct Portal {
     /// The statement that is bound to this portal.
-    pub stmt: Option<Statement<Raw>>,
+    pub stmt: Option<Arc<Statement<Raw>>>,
     /// The statement description.
     pub desc: StatementDesc,
     /// The most recent catalog revision that has verified this statement.
@@ -1285,7 +1285,7 @@ pub enum TransactionOps<T> {
     /// This transaction has a prospective statement that will execute during commit.
     SingleStatement {
         /// The prospective statement.
-        stmt: Statement<Raw>,
+        stmt: Arc<Statement<Raw>>,
         /// The statement params.
         params: mz_sql::plan::Params,
     },

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1003,7 +1003,7 @@ where
             };
 
             // In an aborted transaction, reject all commands except COMMIT/ROLLBACK.
-            let txn_exit_stmt = is_txn_exit_stmt(portal.stmt.as_ref());
+            let txn_exit_stmt = is_txn_exit_stmt(portal.stmt.as_deref());
             if aborted_txn && !txn_exit_stmt {
                 if let Some(outer_ctx_extra) = outer_ctx_extra {
                     self.adapter_client.retire_execute(


### PR DESCRIPTION
We had an incident today in which the coordinator got stuck due to a pathological SQL query. We were lucky that the customer was able to provide us with the query that caused the hang. In the future, we might not be so lucky.

So, this commit teaches the coordinator watchdog to log the redacted SQL that caused it to get stuck, if its stuck on a SQL execution command. Careful introduction of an `Arc` here means the coordinator is net neutral on deep clones of the SQL statement during command execution, so there should be no observable performance impact to this change.

Fix #23938.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
