### PR TITLE
Chunked columnar stack

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -39,6 +39,7 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
         enable_mz_join_core: Some(config.enable_mz_join_core()),
         enable_jemalloc_profiling: Some(config.enable_jemalloc_profiling()),
         enable_columnation_lgalloc: Some(config.enable_columnation_lgalloc()),
+        enable_chunked_stack: Some(config.enable_compute_chunked_stack()),
         enable_operator_hydration_status_logging: Some(
             config.enable_compute_operator_hydration_status_logging(),
         ),

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -86,6 +86,7 @@ message ProtoComputeParameters {
     mz_compute_types.dataflows.ProtoYieldSpec linear_join_yielding = 9;
     optional bool enable_columnation_lgalloc = 10;
     optional bool enable_operator_hydration_status_logging = 11;
+    optional bool enable_chunked_stack = 12;
 }
 
 message ProtoComputeMaxInflightBytesConfig {

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -383,6 +383,8 @@ pub struct ComputeParameters {
     pub enable_jemalloc_profiling: Option<bool>,
     /// Enable lgalloc for columnation.
     pub enable_columnation_lgalloc: Option<bool>,
+    /// Enable the chunked stack implementation.
+    pub enable_chunked_stack: Option<bool>,
     /// Enable operator hydration status logging.
     pub enable_operator_hydration_status_logging: Option<bool>,
     /// Persist client configuration.
@@ -403,6 +405,7 @@ impl ComputeParameters {
             enable_mz_join_core,
             enable_jemalloc_profiling,
             enable_columnation_lgalloc,
+            enable_chunked_stack,
             enable_operator_hydration_status_logging,
             persist,
             tracing,
@@ -426,6 +429,9 @@ impl ComputeParameters {
         }
         if enable_columnation_lgalloc.is_some() {
             self.enable_columnation_lgalloc = enable_columnation_lgalloc;
+        }
+        if enable_chunked_stack.is_some() {
+            self.enable_chunked_stack = enable_chunked_stack;
         }
         if enable_operator_hydration_status_logging.is_some() {
             self.enable_operator_hydration_status_logging =
@@ -456,6 +462,7 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
             enable_mz_join_core: self.enable_mz_join_core.into_proto(),
             enable_jemalloc_profiling: self.enable_jemalloc_profiling.into_proto(),
             enable_columnation_lgalloc: self.enable_columnation_lgalloc.into_proto(),
+            enable_chunked_stack: self.enable_chunked_stack.into_proto(),
             enable_operator_hydration_status_logging: self
                 .enable_operator_hydration_status_logging
                 .into_proto(),
@@ -476,6 +483,7 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
             enable_mz_join_core: proto.enable_mz_join_core.into_rust()?,
             enable_jemalloc_profiling: proto.enable_jemalloc_profiling.into_rust()?,
             enable_columnation_lgalloc: proto.enable_columnation_lgalloc.into_rust()?,
+            enable_chunked_stack: proto.enable_chunked_stack.into_rust()?,
             enable_operator_hydration_status_logging: proto
                 .enable_operator_hydration_status_logging
                 .into_rust()?,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -235,6 +235,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             enable_mz_join_core,
             enable_jemalloc_profiling,
             enable_columnation_lgalloc,
+            enable_chunked_stack,
             enable_operator_hydration_status_logging,
             persist,
             tracing,
@@ -292,6 +293,10 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                 info!("Disabling lgalloc");
                 lgalloc::lgalloc_set_config(&lgalloc::LgAlloc::new())
             }
+            None => {}
+        }
+        match enable_chunked_stack {
+            Some(setting) => crate::containers::stack::use_chunked_stack(setting),
             None => {}
         }
         if let Some(v) = enable_operator_hydration_status_logging {

--- a/src/compute/src/containers/array.rs
+++ b/src/compute/src/containers/array.rs
@@ -1,0 +1,122 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! An array of fixed length, allocated from lgalloc if possible.
+
+use std::mem::{ManuallyDrop, MaybeUninit};
+use std::ops::Deref;
+
+/// A fixed-length region in memory, which is either allocated from heap or lgalloc.
+pub struct Array<T> {
+    /// A handle to lgalloc. None for heap allocations, Some if the memory comes from lgalloc.
+    handle: Option<lgalloc::Handle>,
+    /// Slice representation of the memory. Elements 0..self.length are valid.
+    elements: ManuallyDrop<Box<[MaybeUninit<T>]>>,
+    /// The number of valid elements in `elements`
+    length: usize,
+}
+
+impl<T> Array<T> {
+    /// Create a new [`Array`] with the specified capacity. The actual capacity of the returned
+    /// array is at least as big as the requested capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        // Allocate memory, fall-back to regular heap allocations if we cannot aquire memory through
+        // lgalloc.
+        let (handle, boxed) = if let Ok((ptr, actual_capacity, handle)) =
+            lgalloc::allocate::<MaybeUninit<T>>(capacity)
+        {
+            // We allocated sucessfully through lgalloc.
+            let handle = Some(handle);
+            // SAFETY: `ptr` is valid for constructing a slice:
+            // 1. Valid for reading and writing, and enough capacity.
+            // 2. Properly initialized (left for writing).
+            // 3. Not aliased.
+            // 4. Total size not longer than isize::MAX because lgalloc has a capacity limit.
+            let slice = unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), actual_capacity) };
+            // SAFETY: slice is valid, and we deallocate it usinge lgalloc.
+            (handle, unsafe { Box::from_raw(slice) })
+        } else {
+            // We failed to allocate through lgalloc, fall back to heap.
+            let mut vec = Vec::with_capacity(capacity);
+            // SAFETY: We treat all element as uninitialized and track initialized elements
+            // through `self.length`.
+            unsafe {
+                vec.set_len(vec.capacity());
+            }
+            (None, vec.into_boxed_slice())
+        };
+
+        let elements = ManuallyDrop::new(boxed);
+        Self {
+            handle,
+            elements,
+            length: 0,
+        }
+    }
+
+    /// Visit contained allocations to determine their size and capacity.
+    pub fn heap_size(&self, mut callback: impl FnMut(usize, usize)) {
+        let size_of_t = std::mem::size_of::<T>();
+        callback(self.len() * size_of_t, self.capacity() * size_of_t)
+    }
+
+    /// Move an element on the array. Panics if there is no more capacity.
+    pub fn push(&mut self, item: T) {
+        debug_assert!(
+            self.length < self.elements.len(),
+            "Failed to push: length {} not less than {} capacity",
+            self.length,
+            self.elements.len()
+        );
+        self.elements[self.length].write(item);
+        self.length += 1;
+    }
+
+    /// Update the length. Highly unsafe because it doesn't drop elements when reducing the length,
+    /// and doesn't initialize elements when increasing the length.
+    pub unsafe fn set_len(&mut self, length: usize) {
+        debug_assert!(length <= self.capacity());
+        self.length = length;
+    }
+
+    /// The number of elements this array can absorb.
+    pub fn capacity(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Remove all elements. Drops the contents, but leaves the allocation untouched.
+    pub fn clear(&mut self) {
+        for e in &mut self.elements[..self.length] {
+            // SAFETY: We know elements up to `length` are initialized.
+            unsafe {
+                e.assume_init_drop();
+            }
+        }
+        self.length = 0;
+    }
+}
+
+impl<T> Deref for Array<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { std::mem::transmute(&self.elements[..self.length]) }
+    }
+}
+
+impl<T> Drop for Array<T> {
+    fn drop(&mut self) {
+        self.clear();
+        if let Some(handle) = self.handle.take() {
+            // Memory allocated through lgalloc
+            lgalloc::deallocate(handle);
+        } else {
+            // Regular allocation
+            unsafe {
+                ManuallyDrop::drop(&mut self.elements);
+            }
+        }
+    }
+}

--- a/src/compute/src/containers/mod.rs
+++ b/src/compute/src/containers/mod.rs
@@ -7,18 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![warn(missing_docs)]
+//! Reusable containers.
 
-//! Materialize's compute layer.
-
-pub(crate) mod arrangement;
-pub mod compute_state;
-pub(crate) mod containers;
-pub(crate) mod extensions;
-pub(crate) mod logging;
-pub(crate) mod metrics;
-pub(crate) mod render;
-pub(crate) mod row_spine;
-pub mod server;
-pub(crate) mod sink;
-mod typedefs;
+pub mod array;
+pub mod stack;

--- a/src/compute/src/containers/stack.rs
+++ b/src/compute/src/containers/stack.rs
@@ -12,49 +12,11 @@
 
 use std::collections::Bound;
 use std::ops::{Index, RangeBounds};
-use std::rc::Rc;
 
-use differential_dataflow::trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
-use differential_dataflow::trace::implementations::ord_neu::{OrdKeyBatch, OrdKeyBuilder};
-use differential_dataflow::trace::implementations::ord_neu::{OrdValBatch, OrdValBuilder};
-use differential_dataflow::trace::implementations::spine_fueled::Spine;
-use differential_dataflow::trace::implementations::{BatchContainer, Layout, Update};
-use differential_dataflow::trace::rc_blanket_impls::RcBuilder;
+use differential_dataflow::trace::implementations::BatchContainer;
 use timely::container::columnation::{Columnation, Region};
 
 use crate::containers::array::Array;
-use crate::row_spine::OffsetOptimized;
-
-pub type ColValSpine<K, V, T, R> = Spine<
-    Rc<OrdValBatch<MzStack<((K, V), T, R)>>>,
-    ColumnatedMergeBatcher<K, V, T, R>,
-    RcBuilder<OrdValBuilder<MzStack<((K, V), T, R)>>>,
->;
-
-pub type ColKeySpine<K, T, R> = Spine<
-    Rc<OrdKeyBatch<MzStack<((K, ()), T, R)>>>,
-    ColumnatedMergeBatcher<K, (), T, R>,
-    RcBuilder<OrdKeyBuilder<MzStack<((K, ()), T, R)>>>,
->;
-
-/// A layout based on chunked timely stacks
-pub struct MzStack<U: Update> {
-    phantom: std::marker::PhantomData<U>,
-}
-
-impl<U: Update> Layout for MzStack<U>
-where
-    U::Key: Columnation + 'static,
-    U::Val: Columnation + 'static,
-    U::Time: Columnation,
-    U::Diff: Columnation,
-{
-    type Target = U;
-    type KeyContainer = ChunkedStack<U::Key>;
-    type ValContainer = ChunkedStack<U::Val>;
-    type UpdContainer = ChunkedStack<(U::Time, U::Diff)>;
-    type OffsetContainer = OffsetOptimized;
-}
 
 /// An append-only vector that store records as columns.
 ///

--- a/src/compute/src/containers/stack.rs
+++ b/src/compute/src/containers/stack.rs
@@ -1,0 +1,306 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A chunked columnar container based on the columnation library. It stores the local
+//! portion in region-allocated data, too, which is different to the `TimelyStack` type.
+
+use std::collections::Bound;
+use std::ops::{Index, RangeBounds};
+use std::rc::Rc;
+
+use differential_dataflow::trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
+use differential_dataflow::trace::implementations::ord_neu::{OrdKeyBatch, OrdKeyBuilder};
+use differential_dataflow::trace::implementations::ord_neu::{OrdValBatch, OrdValBuilder};
+use differential_dataflow::trace::implementations::spine_fueled::Spine;
+use differential_dataflow::trace::implementations::{BatchContainer, Layout, Update};
+use differential_dataflow::trace::rc_blanket_impls::RcBuilder;
+use timely::container::columnation::{Columnation, Region};
+
+use crate::containers::array::Array;
+use crate::row_spine::OffsetOptimized;
+
+pub type ColValSpine<K, V, T, R> = Spine<
+    Rc<OrdValBatch<MzStack<((K, V), T, R)>>>,
+    ColumnatedMergeBatcher<K, V, T, R>,
+    RcBuilder<OrdValBuilder<MzStack<((K, V), T, R)>>>,
+>;
+
+pub type ColKeySpine<K, T, R> = Spine<
+    Rc<OrdKeyBatch<MzStack<((K, ()), T, R)>>>,
+    ColumnatedMergeBatcher<K, (), T, R>,
+    RcBuilder<OrdKeyBuilder<MzStack<((K, ()), T, R)>>>,
+>;
+
+/// A layout based on chunked timely stacks
+pub struct MzStack<U: Update> {
+    phantom: std::marker::PhantomData<U>,
+}
+
+impl<U: Update> Layout for MzStack<U>
+where
+    U::Key: Columnation + 'static,
+    U::Val: Columnation + 'static,
+    U::Time: Columnation,
+    U::Diff: Columnation,
+{
+    type Target = U;
+    type KeyContainer = ChunkedStack<U::Key>;
+    type ValContainer = ChunkedStack<U::Val>;
+    type UpdContainer = ChunkedStack<(U::Time, U::Diff)>;
+    type OffsetContainer = OffsetOptimized;
+}
+
+/// An append-only vector that store records as columns.
+///
+/// This container maintains elements that might conventionally own
+/// memory allocations, but instead the pointers to those allocations
+/// reference larger regions of memory shared with multiple instances
+/// of the type. Elements can be retrieved as references, and care is
+/// taken when this type is dropped to ensure that the correct memory
+/// is returned (rather than the incorrect memory, from running the
+/// elements `Drop` implementations).
+pub struct ChunkedStack<T: Columnation> {
+    local: Vec<Array<T>>,
+    inner: T::InnerRegion,
+    length: usize,
+}
+
+impl<T: Columnation> ChunkedStack<T> {
+    /// The capacity of each individual chunk, in number of elements. Should be a power of two.
+    const CHUNK: usize = 64 << 10;
+
+    /// Construct a [`ChunkedStack`], reserving space for `capacity` elements
+    ///
+    /// Note that the associated region is not initialized to a specific capacity
+    /// because we can't generally know how much space would be required.
+    pub fn with_capacity(capacity: usize) -> Self {
+        let local = Vec::with_capacity((capacity + Self::CHUNK - 1) / Self::CHUNK);
+        Self {
+            local,
+            inner: T::InnerRegion::default(),
+            length: 0,
+        }
+    }
+
+    /// Ensures `Self` can absorb `items` without further allocations.
+    ///
+    /// The argument `items` may be cloned and iterated multiple times.
+    /// Please be careful if it contains side effects.
+    #[inline(always)]
+    pub fn reserve_items<'a, I>(&'a mut self, items: I)
+    where
+        I: Iterator<Item = &'a T> + Clone,
+    {
+        self.inner.reserve_items(items);
+    }
+
+    /// Ensures `Self` can absorb `items` without further allocations.
+    ///
+    /// The argument `items` may be cloned and iterated multiple times.
+    /// Please be careful if it contains side effects.
+    #[inline(always)]
+    pub fn reserve_regions<'a, I>(&mut self, regions: I)
+    where
+        Self: 'a,
+        I: Iterator<Item = &'a Self> + Clone,
+    {
+        self.inner.reserve_regions(regions.map(|cs| &cs.inner));
+    }
+
+    /// Copies an element in to the region.
+    ///
+    /// The element can be read by indexing
+    #[inline(always)]
+    pub fn copy(&mut self, item: &T) {
+        let copy = unsafe { self.inner.copy(item) };
+        self.push(copy);
+    }
+
+    /// Internal helper to push a copied item onto the local storage. The `item` must be allocated
+    /// in the region, because it will not be dropped.
+    fn push(&mut self, item: T) {
+        if Some(true) != self.local.last().map(|last| last.len() < Self::CHUNK) {
+            self.local.push(Array::with_capacity(Self::CHUNK));
+        }
+        let chunk = self.local.last_mut().unwrap();
+        chunk.push(item);
+        self.length += 1;
+    }
+
+    /// Estimate the memory capacity in bytes.
+    #[inline]
+    pub fn heap_size(&self, mut callback: impl FnMut(usize, usize)) {
+        let size_of = std::mem::size_of::<T>();
+        callback(self.local.len() * size_of, self.local.capacity() * size_of);
+        for local in &self.local {
+            local.heap_size(&mut callback);
+        }
+        self.inner.heap_size(callback);
+    }
+
+    /// Iterate over a range of elements. Panics if the range mentions non-existent elements,
+    /// i.e., its end is past the last element of this container.
+    #[inline(always)]
+    pub fn range(&self, r: impl RangeBounds<usize> + std::fmt::Debug) -> Iter<'_, T> {
+        let offset = match r.start_bound() {
+            Bound::Included(x) => *x,
+            Bound::Excluded(x) => x.checked_add(1).unwrap(),
+            Bound::Unbounded => 0,
+        };
+        let limit = match r.end_bound() {
+            Bound::Included(x) => x.checked_sub(1).unwrap(),
+            Bound::Excluded(x) => *x,
+            Bound::Unbounded => self.length,
+        };
+        debug_assert!(offset <= limit, "Incorrect range bounds: {r:?}");
+        debug_assert!(
+            limit <= self.length,
+            "Limit {limit} exceeds length {}",
+            self.length
+        );
+
+        Iter {
+            stack: self,
+            offset,
+            limit,
+        }
+    }
+
+    /// Lookup a specific element.
+    #[inline(always)]
+    fn index(&self, index: usize) -> &T {
+        let chunk = index / Self::CHUNK;
+        let offset = index & (Self::CHUNK - 1);
+        &self.local[chunk][offset]
+    }
+
+    /// The number of elements we store.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.length
+    }
+
+    /// Test if this container is empty.
+    pub fn is_empty(&self) -> bool {
+        self.local.is_empty()
+    }
+}
+
+// The `ToOwned` requirement exists to satisfy `self.reserve_items`, who must for now
+// be presented with the actual contained type, rather than a type that borrows into it.
+impl<T: Ord + Columnation + ToOwned<Owned = T> + 'static> BatchContainer for ChunkedStack<T> {
+    type PushItem = T;
+    type ReadItem<'a> = &'a Self::PushItem;
+
+    #[inline]
+    fn copy(&mut self, item: &T) {
+        self.copy(item);
+    }
+    #[inline]
+    fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
+        let range = other.range(start..end);
+        self.reserve_items(range);
+        for item in range {
+            self.copy(item);
+        }
+    }
+
+    #[inline]
+    fn with_capacity(size: usize) -> Self {
+        Self::with_capacity(size)
+    }
+
+    fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
+        let mut new = Self::with_capacity(cont1.length + cont2.length);
+        new.reserve_regions(std::iter::once(cont1).chain(std::iter::once(cont2)));
+        new
+    }
+
+    #[inline]
+    fn index(&self, index: usize) -> Self::ReadItem<'_> {
+        self.index(index)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T: Columnation> Index<usize> for ChunkedStack<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        ChunkedStack::index(self, index)
+    }
+}
+
+impl<T: Columnation> Default for ChunkedStack<T> {
+    fn default() -> Self {
+        Self::with_capacity(0)
+    }
+}
+
+impl<A: Columnation, B: Columnation, C: Columnation> ChunkedStack<(A, B, C)> {
+    /// Copies a destructured tuple `(A, B, C)` into this column stack.
+    ///
+    /// This serves situations where a tuple should be constructed from its constituents but
+    /// not all elements are available as owned data.
+    ///
+    /// The element can be read by indexing
+    pub fn copy_destructured(&mut self, r0: &A, r1: &B, r2: &C) {
+        let copy = unsafe { self.inner.copy_destructured(r0, r1, r2) };
+        self.push(copy);
+    }
+}
+
+/// An iterator of a [`ChunkedStack`].
+pub struct Iter<'a, T: Columnation> {
+    stack: &'a ChunkedStack<T>,
+    offset: usize,
+    limit: usize,
+}
+
+impl<'a, T: Columnation> Clone for Iter<'a, T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T: Columnation> Copy for Iter<'a, T> {}
+
+impl<'a, T: Columnation> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.offset >= self.limit {
+            None
+        } else {
+            let next = self.stack.index(self.offset);
+            self.offset = self.offset.saturating_add(1);
+            Some(next)
+        }
+    }
+}
+
+impl<T: Columnation> Drop for ChunkedStack<T> {
+    fn drop(&mut self) {
+        for array in &mut self.local {
+            // SAFETY: All elements in `array` have their allocations in a region. We drop the
+            // region and forget the immediate values.
+            unsafe {
+                array.set_len(0);
+            }
+        }
+        // Important: Clear the region before dropping it to avoid double frees.
+        self.inner.clear();
+    }
+}

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -338,9 +338,9 @@ where
             };
             trace.map_batches(|batch| {
                 batch.storage.keys.heap_size(&mut callback);
-                offset_list_size(&batch.storage.keys_offs, &mut callback);
+                batch.storage.keys_offs.heap_size(&mut callback);
                 batch.storage.vals.heap_size(&mut callback);
-                offset_list_size(&batch.storage.vals_offs, &mut callback);
+                batch.storage.vals_offs.heap_size(&mut callback);
                 batch.storage.updates.heap_size(&mut callback);
             });
             (size, capacity, allocations)
@@ -366,7 +366,7 @@ where
             };
             trace.map_batches(|batch| {
                 batch.storage.keys.heap_size(&mut callback);
-                offset_list_size(&batch.storage.keys_offs, &mut callback);
+                batch.storage.keys_offs.heap_size(&mut callback);
                 batch.storage.updates.heap_size(&mut callback);
             });
             (size, capacity, allocations)

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -12,7 +12,6 @@ use std::rc::Rc;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arrange, Arranged, TraceAgent};
-use differential_dataflow::trace::implementations::OffsetList;
 use differential_dataflow::trace::{Batch, Batcher, Builder, Trace, TraceReader};
 use differential_dataflow::{Collection, Data, ExchangeData, Hashable};
 use timely::container::columnation::Columnation;
@@ -222,21 +221,6 @@ where
 pub trait ArrangementSize {
     /// Install a logger to track the heap size of the target.
     fn log_arrangement_size(self) -> Self;
-}
-
-/// Helper to compute the size of an [`OffsetList`] in memory.
-#[inline]
-pub(crate) fn offset_list_size(data: &OffsetList, mut callback: impl FnMut(usize, usize)) {
-    // Private `vec_size` because we should only use it where data isn't region-allocated.
-    // `T: Copy` makes sure the implementation is correct even if types change!
-    #[inline(always)]
-    fn vec_size<T: Copy>(data: &Vec<T>, mut callback: impl FnMut(usize, usize)) {
-        let size_of_t = std::mem::size_of::<T>();
-        callback(data.len() * size_of_t, data.capacity() * size_of_t);
-    }
-
-    vec_size(&data.smol, &mut callback);
-    vec_size(&data.chonk, callback);
 }
 
 /// Helper for [`ArrangementSize`] to install a common operator holding on to a trace.

--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -26,7 +26,7 @@ mod spines {
     use mz_repr::Row;
     use timely::container::columnation::Columnation;
 
-    use crate::containers::stack::ChunkedStack;
+    use crate::containers::stack::StackWrapper;
     use crate::row_spine::{DatumContainer, OffsetOptimized};
     use crate::typedefs::{KeyBatcher, KeyValBatcher};
 
@@ -65,7 +65,7 @@ mod spines {
         type Target = U;
         type KeyContainer = DatumContainer;
         type ValContainer = DatumContainer;
-        type UpdContainer = ChunkedStack<(U::Time, U::Diff)>;
+        type UpdContainer = StackWrapper<(U::Time, U::Diff)>;
         type OffsetContainer = OffsetOptimized;
     }
     impl<U: Update<Key = Row>> Layout for RowValLayout<U>
@@ -76,8 +76,8 @@ mod spines {
     {
         type Target = U;
         type KeyContainer = DatumContainer;
-        type ValContainer = ChunkedStack<U::Val>;
-        type UpdContainer = ChunkedStack<(U::Time, U::Diff)>;
+        type ValContainer = StackWrapper<U::Val>;
+        type UpdContainer = StackWrapper<(U::Time, U::Diff)>;
         type OffsetContainer = OffsetOptimized;
     }
     impl<U: Update<Key = Row, Val = ()>> Layout for RowLayout<U>
@@ -87,8 +87,8 @@ mod spines {
     {
         type Target = U;
         type KeyContainer = DatumContainer;
-        type ValContainer = ChunkedStack<()>;
-        type UpdContainer = ChunkedStack<(U::Time, U::Diff)>;
+        type ValContainer = StackWrapper<()>;
+        type UpdContainer = StackWrapper<(U::Time, U::Diff)>;
         type OffsetContainer = OffsetOptimized;
     }
 }

--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -16,7 +16,6 @@ pub use self::spines::{RowRowSpine, RowSpine, RowValSpine};
 mod spines {
     use std::rc::Rc;
 
-    use differential_dataflow::trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
     use differential_dataflow::trace::implementations::ord_neu::{OrdKeyBatch, OrdKeyBuilder};
     use differential_dataflow::trace::implementations::ord_neu::{OrdValBatch, OrdValBuilder};
     use differential_dataflow::trace::implementations::spine_fueled::Spine;
@@ -28,20 +27,21 @@ mod spines {
 
     use crate::containers::stack::ChunkedStack;
     use crate::row_spine::{DatumContainer, OffsetOptimized};
+    use crate::typedefs::{KeyBatcher, KeyValBatcher};
 
     pub type RowRowSpine<T, R> = Spine<
         Rc<OrdValBatch<RowRowLayout<((Row, Row), T, R)>>>,
-        ColumnatedMergeBatcher<Row, Row, T, R>,
+        KeyValBatcher<Row, Row, T, R>,
         RcBuilder<OrdValBuilder<RowRowLayout<((Row, Row), T, R)>>>,
     >;
     pub type RowValSpine<V, T, R> = Spine<
         Rc<OrdValBatch<RowValLayout<((Row, V), T, R)>>>,
-        ColumnatedMergeBatcher<Row, V, T, R>,
+        KeyValBatcher<Row, V, T, R>,
         RcBuilder<OrdValBuilder<RowValLayout<((Row, V), T, R)>>>,
     >;
     pub type RowSpine<T, R> = Spine<
         Rc<OrdKeyBatch<RowLayout<((Row, ()), T, R)>>>,
-        ColumnatedMergeBatcher<Row, (), T, R>,
+        KeyBatcher<Row, T, R>,
         RcBuilder<OrdKeyBuilder<RowLayout<((Row, ()), T, R)>>>,
     >;
 

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -13,13 +13,13 @@
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::operators::arrange::TraceAgent;
 use differential_dataflow::trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
-use differential_dataflow::trace::implementations::ord_neu::{ColKeySpine, ColValSpine};
 use differential_dataflow::trace::wrappers::enter::TraceEnter;
 use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
-use timely::dataflow::ScopeParent;
-
 use mz_repr::Diff;
 use mz_storage_types::errors::DataflowError;
+use timely::dataflow::ScopeParent;
+
+use crate::containers::stack::{ColKeySpine, ColValSpine};
 
 pub use crate::row_spine::{RowRowSpine, RowSpine, RowValSpine};
 

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -34,7 +34,7 @@ pub(crate) mod spines {
     use differential_dataflow::trace::rc_blanket_impls::RcBuilder;
     use timely::container::columnation::Columnation;
 
-    use crate::containers::stack::ChunkedStack;
+    use crate::containers::stack::StackWrapper;
     use crate::row_spine::OffsetOptimized;
     use crate::typedefs::{KeyBatcher, KeyValBatcher};
 
@@ -65,9 +65,9 @@ pub(crate) mod spines {
         U::Diff: Columnation,
     {
         type Target = U;
-        type KeyContainer = ChunkedStack<U::Key>;
-        type ValContainer = ChunkedStack<U::Val>;
-        type UpdContainer = ChunkedStack<(U::Time, U::Diff)>;
+        type KeyContainer = StackWrapper<U::Key>;
+        type ValContainer = StackWrapper<U::Val>;
+        type UpdContainer = StackWrapper<(U::Time, U::Diff)>;
         type OffsetContainer = OffsetOptimized;
     }
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1501,6 +1501,13 @@ pub const ENABLE_COLUMNATION_LGALLOC: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
+pub const ENABLE_COMPUTE_CHUNKED_STACK: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_compute_chunked_stack"),
+    value: false,
+    description: "Enable the chunked stack implementation in compute",
+    internal: true,
+};
+
 pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("enable_statement_lifecycle_logging"),
     value: false,
@@ -2978,6 +2985,7 @@ impl SystemVars {
             .with_var(&PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE)
             .with_var(&WEBHOOK_CONCURRENT_REQUEST_LIMIT)
             .with_var(&ENABLE_COLUMNATION_LGALLOC)
+            .with_var(&ENABLE_COMPUTE_CHUNKED_STACK)
             .with_var(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
             .with_var(&ENABLE_DEPENDENCY_READ_HOLD_ASSERTS)
             .with_var(&TIMESTAMP_ORACLE_IMPL)
@@ -3848,6 +3856,11 @@ impl SystemVars {
     /// Returns the `enable_columnation_lgalloc` configuration parameter.
     pub fn enable_columnation_lgalloc(&self) -> bool {
         *self.expect_value(&ENABLE_COLUMNATION_LGALLOC)
+    }
+
+    /// Returns the `enable_compute_chunked_stack` configuration parameter.
+    pub fn enable_compute_chunked_stack(&self) -> bool {
+        *self.expect_value(&ENABLE_COMPUTE_CHUNKED_STACK)
     }
 
     pub fn enable_statement_lifecycle_logging(&self) -> bool {

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -265,9 +265,9 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 > CREATE DEFAULT INDEX ii_arr ON vv_arr
 
 # It's hard to come up with precise bounds because we might de-duplicate some data in arrangements.
-> SELECT records >= 300, size > 0, capacity > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_arr' OR name LIKE '%mv_arr'
-true true true
-true true true
+> SELECT records >= 300, size > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_arr' OR name LIKE '%mv_arr'
+true true
+true true
 
 # Test that non-arranging dataflows show up in `mz_dataflow_arrangement_sizes`
 
@@ -275,8 +275,8 @@ true true true
 
 > CREATE DEFAULT INDEX ii_empty ON t3
 
-> SELECT records, batches, size < 16 * 1024, capacity < 16 * 1024, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_empty'
-0 32 true true true
+> SELECT records, batches, size < 16 * 1024, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_empty'
+0 32 true true
 
 # Tests that arrangement sizes are approximate
 
@@ -286,13 +286,13 @@ true true true
 
 # We have 16 workers, and only want to ensure that the sizes are not egregious.
 
-> SELECT records, batches, size < 16 * 1024, capacity < 16 * 1024, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
-0 32 true true true
+> SELECT records, batches, size < 16 * 1024, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+0 32 true true
 
 > INSERT INTO t4 SELECT 1
 
-> SELECT records, batches, size < 16 * 1024, capacity > 0, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
-1 32 true true true
+> SELECT records, batches, size < 16 * 1024, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+1 32 true true
 
 > INSERT INTO t4 SELECT generate_series(1, 1000)
 
@@ -353,24 +353,20 @@ true true true true true
     records < 2 * 2 * 1000,
     size > 0,
     size < 4 * 130 * 1000,
-    capacity > 0,
-    capacity < 4 * 130 * 1000,
-    allocations > 0
+    allocations < 2 * 2 * 1000
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%c1%';
-true true true true true true true
+true true true true true
 
 > SELECT
     records > 1000,
     records < 2 * 1000,
     size > 0,
     size < 4 * 100 * 1024,
-    capacity > 0,
-    capacity < 4 * 100 * 1024,
-    allocations > 100
+    allocations < 2 * 1000
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%c2%';
-true true true true true true true
+true true true true true
 
 # For coverage, we also include a recursive materialized view to account for dynamic timestamps.
 > CREATE MATERIALIZED VIEW rec AS
@@ -394,12 +390,10 @@ true true true true true true true
     records < 2 * 12 * 1000,
     size > 0,
     size < 4 * 1000 * 1000,
-    capacity > 0,
-    capacity < 4 * 1000 * 1000,
-    allocations > 0
+    allocations < 2 * 12 * 1000
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%rec%';
-true true true true true true true
+true true true true true
 
 > DROP TABLE ten CASCADE;
 
@@ -428,24 +422,20 @@ true true true true true true true
     records < 1.1 * 2 * 1000,
     size > 0,
     size < 4 * 200 * 1000,
-    capacity > 0,
-    capacity < 4 * 200 * 1000,
-    allocations > 100
+    allocations < 2 * 2 * 1000
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%m_minmax%';
-true true true true true true true
+true true true true true
 
 > SELECT
     records >= 2 * 1000,
     records < 2 * 2 * 1000,
     size > 0,
     size < 4 * 172 * 1000,
-    capacity > 0,
-    capacity < 4 * 172 * 1000,
-    allocations > 100
+    allocations < 2 * 2 * 1000
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%m_top1%';
-true true true true true true true
+true true true true true
 
 > DROP SOURCE counter CASCADE;
 


### PR DESCRIPTION
Chunked and fixed-length columnar containers.

This PR tries to replace `TimelyStack` with a type that regions-allocates the `local` portion of the timely stack to allow it being paged to disk. Currently, `TimelyStack` only allows regions that explicitly get their allocations from `lgalloc` to be spilled to disk, but nothing else. The types introduced in the PR additionally allow the local portion of the stack to go to disk.

For this, it introduces several new types:
* A *FixedStack* is similar to a TimelyStack, but can only absorb a fixed number of copies. We use it within the merge batcher.
* A *ChunkedStack* is similar to a TimelyStack but stores the local portion in *Array*, moving the local vector to spillable memory.

Additionally, we upgrade `lgalloc` and cease using its `Region` implementation, so we inline the implementation into Materialize.

TODO: This PR has unknown performance implications, which we need to measure separately.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
