### PR TITLE
Add and use smarter HIR builders

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1888,13 +1888,13 @@ mod builtin_migration_tests {
                         create_sql: format!(
                             "CREATE MATERIALIZED VIEW mv AS SELECT * FROM {table_list}"
                         ),
-                        raw_expr: mz_sql::plan::HirRelationExpr::Constant {
-                            rows: Vec::new(),
-                            typ: RelationType {
+                        raw_expr: mz_sql::plan::HirRelationExpr::constant(
+                            Vec::new(),
+                            RelationType {
                                 column_types: Vec::new(),
                                 keys: Vec::new(),
                             },
-                        },
+                        ),
                         optimized_expr: OptimizedMirRelationExpr(MirRelationExpr::Constant {
                             rows: Ok(Vec::new()),
                             typ: RelationType {

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1329,7 +1329,7 @@ impl HirRelationExpr {
         }
     }
 
-    pub fn filter(mut self, preds: Vec<HirScalarExpr>) -> Self {
+    pub fn filter(mut self, mut preds: Vec<HirScalarExpr>) -> Self {
         if let HirRelationExpr::Filter {
             input: _,
             predicates,
@@ -1340,6 +1340,8 @@ impl HirRelationExpr {
             predicates.dedup();
             self
         } else {
+            preds.sort();
+            preds.dedup();
             HirRelationExpr::Filter {
                 input: Box::new(self),
                 predicates: preds,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1583,14 +1583,14 @@ pub fn plan_nested_query(
         group_size_hints,
     } = qcx.checked_recur_mut(|qcx| plan_query(qcx, q))?;
     if limit.is_some() || offset > 0 {
-        expr = HirRelationExpr::TopK {
-            input: Box::new(expr),
-            group_key: vec![],
-            order_key: order_by,
+        expr = HirRelationExpr::top_k(
+            expr,
+            vec![],
+            order_by,
             limit,
             offset,
-            expected_group_size: group_size_hints.limit_input_group_size,
-        };
+            group_size_hints.limit_input_group_size,
+        );
     }
     Ok((expr.project(project), scope))
 }
@@ -2455,14 +2455,15 @@ fn plan_view_select(
                 // columns in `ORDER BY` that are not part of the distinct key,
                 // if there are any, determine the ordering within each group,
                 // per PostgreSQL semantics.
-                relation_expr = HirRelationExpr::TopK {
-                    input: Box::new(relation_expr.map(map_exprs)),
-                    order_key: order_by.iter().skip(distinct_key.len()).cloned().collect(),
-                    group_key: distinct_key,
-                    limit: Some(HirScalarExpr::literal(Datum::Int64(1), ScalarType::Int64)),
-                    offset: 0,
-                    expected_group_size: group_size_hints.distinct_on_input_group_size,
-                }
+                let distinct_len = distinct_key.len();
+                relation_expr = HirRelationExpr::top_k(
+                    relation_expr.map(map_exprs),
+                    distinct_key,
+                    order_by.iter().skip(distinct_len).cloned().collect(),
+                    Some(HirScalarExpr::literal(Datum::Int64(1), ScalarType::Int64)),
+                    0,
+                    group_size_hints.distinct_on_input_group_size,
+                );
             }
         }
 
@@ -4299,14 +4300,14 @@ where
     let mut qcx = ecx.derived_query_context();
     let mut planned_query = plan_query(&mut qcx, query)?;
     if planned_query.limit.is_some() || planned_query.offset > 0 {
-        planned_query.expr = HirRelationExpr::TopK {
-            input: Box::new(planned_query.expr),
-            group_key: vec![],
-            order_key: planned_query.order_by.clone(),
-            limit: planned_query.limit,
-            offset: planned_query.offset,
-            expected_group_size: planned_query.group_size_hints.limit_input_group_size,
-        };
+        planned_query.expr = HirRelationExpr::top_k(
+            planned_query.expr,
+            vec![],
+            planned_query.order_by.clone(),
+            planned_query.limit,
+            planned_query.offset,
+            planned_query.group_size_hints.limit_input_group_size,
+        );
     }
 
     if planned_query.project.len() != 1 {

--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -154,132 +154,126 @@ EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
     "body": {
       "Union": {
         "base": {
-          "Union": {
-            "base": {
-              "Project": {
+          "Project": {
+            "input": {
+              "Map": {
                 "input": {
-                  "Map": {
-                    "input": {
-                      "Get": {
-                        "id": {
-                          "Local": 0
-                        },
-                        "typ": {
-                          "column_types": [],
-                          "keys": [
-                            []
-                          ]
-                        },
-                        "access_strategy": "UnknownOrLocal"
-                      }
+                  "Get": {
+                    "id": {
+                      "Local": 0
                     },
-                    "scalars": [
+                    "typ": {
+                      "column_types": [],
+                      "keys": [
+                        []
+                      ]
+                    },
+                    "access_strategy": "UnknownOrLocal"
+                  }
+                },
+                "scalars": [
+                  {
+                    "Literal": [
                       {
-                        "Literal": [
-                          {
-                            "Ok": {
-                              "data": [
-                                42,
-                                1
-                              ]
-                            }
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": false
-                          }
-                        ]
+                        "Ok": {
+                          "data": [
+                            42,
+                            1
+                          ]
+                        }
                       },
                       {
-                        "Literal": [
-                          {
-                            "Ok": {
-                              "data": [
-                                42,
-                                2
-                              ]
-                            }
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": false
-                          }
-                        ]
+                        "scalar_type": "Int32",
+                        "nullable": false
+                      }
+                    ]
+                  },
+                  {
+                    "Literal": [
+                      {
+                        "Ok": {
+                          "data": [
+                            42,
+                            2
+                          ]
+                        }
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": false
                       }
                     ]
                   }
-                },
-                "outputs": [
-                  0,
-                  1
                 ]
               }
             },
-            "inputs": [
-              {
-                "Project": {
-                  "input": {
-                    "Map": {
-                      "input": {
-                        "Get": {
-                          "id": {
-                            "Local": 0
-                          },
-                          "typ": {
-                            "column_types": [],
-                            "keys": [
-                              []
-                            ]
-                          },
-                          "access_strategy": "UnknownOrLocal"
-                        }
-                      },
-                      "scalars": [
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  42,
-                                  1
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": false
-                            }
-                          ]
-                        },
-                        {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  42,
-                                  2
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": false
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  },
-                  "outputs": [
-                    0,
-                    1
-                  ]
-                }
-              }
+            "outputs": [
+              0,
+              1
             ]
           }
         },
         "inputs": [
+          {
+            "Project": {
+              "input": {
+                "Map": {
+                  "input": {
+                    "Get": {
+                      "id": {
+                        "Local": 0
+                      },
+                      "typ": {
+                        "column_types": [],
+                        "keys": [
+                          []
+                        ]
+                      },
+                      "access_strategy": "UnknownOrLocal"
+                    }
+                  },
+                  "scalars": [
+                    {
+                      "Literal": [
+                        {
+                          "Ok": {
+                            "data": [
+                              42,
+                              1
+                            ]
+                          }
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        }
+                      ]
+                    },
+                    {
+                      "Literal": [
+                        {
+                          "Ok": {
+                            "data": [
+                              42,
+                              2
+                            ]
+                          }
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "outputs": [
+                0,
+                1
+              ]
+            }
+          },
           {
             "Project": {
               "input": {

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -57,15 +57,14 @@ EXPLAIN DECORRELATED PLAN AS TEXT FOR
 (SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
 ----
 Union
-  Union
-    Project (#0, #1)
-      Map (1, 2)
-        Constant
-          - ()
-    Project (#0, #1)
-      Map (1, 2)
-        Constant
-          - ()
+  Project (#0, #1)
+    Map (1, 2)
+      Constant
+        - ()
+  Project (#0, #1)
+    Map (1, 2)
+      Constant
+        - ()
   Project (#0, #1)
     Map (3, 4)
       Constant


### PR DESCRIPTION
Following a thought from @mjibson, I added a few that were missing here but present in MIR, and introduced a bit more use.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
