### PR TITLE
ci/test: fix uploading of sources to PolarSignals

### DIFF
--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -152,7 +152,9 @@ def maybe_upload_debuginfo(
                         "--ignore-failed-read",
                     ],
                     stdin=p1.stdout,
-                    stdout=subprocess.PIPE,
+                    # Suppress noisy warnings about missing files.
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
                 )
 
                 # This causes p1 to receive SIGPIPE if p2 exits early,
@@ -161,7 +163,7 @@ def maybe_upload_debuginfo(
                 p1.stdout.close()
 
                 for p in [p1, p2]:
-                    if p.returncode:
+                    if p.wait():
                         raise subprocess.CalledProcessError(p.returncode, p.args)
 
                 print(f"Uploading source tarball for {bin} to Polar Signals...")


### PR DESCRIPTION
The code was not waiting for the `llvm-dwarfdump` and `tar` commands to complete, which meant we were trying to upload a zero-byte tarball.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug noticed in the last release.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
