### PR TITLE
adapter: RETAIN HISTORY for SOURCES

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -889,7 +889,9 @@ impl CatalogState {
                 desc: source.desc,
                 timeline,
                 resolved_ids,
-                custom_logical_compaction_window,
+                custom_logical_compaction_window: source
+                    .compaction_window
+                    .or(custom_logical_compaction_window),
                 is_retained_metrics_object,
             }),
             Plan::CreateView(CreateViewPlan { view, .. }) => {

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -518,7 +518,10 @@ impl Source {
             desc: plan.source.desc,
             timeline: plan.timeline,
             resolved_ids,
-            custom_logical_compaction_window,
+            custom_logical_compaction_window: plan
+                .source
+                .compaction_window
+                .or(custom_logical_compaction_window),
             is_retained_metrics_object,
         }
     }

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1221,6 +1221,7 @@ pub enum CreateSourceOptionName {
     Size,
     Timeline,
     TimestampInterval,
+    RetainHistory,
 }
 
 impl AstDisplay for CreateSourceOptionName {
@@ -1230,6 +1231,7 @@ impl AstDisplay for CreateSourceOptionName {
             CreateSourceOptionName::Size => "SIZE",
             CreateSourceOptionName::Timeline => "TIMELINE",
             CreateSourceOptionName::TimestampInterval => "TIMESTAMP INTERVAL",
+            CreateSourceOptionName::RetainHistory => "RETAIN HISTORY",
         })
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1144,7 +1144,7 @@ ALTER INDEX name RESET (property = true)
 parse-statement
 ALTER SOURCE name SET (property = true)
 ----
-error: Expected one of IGNORE or SIZE or TIMELINE or TIMESTAMP, found identifier "property"
+error: Expected one of IGNORE or SIZE or TIMELINE or TIMESTAMP or RETAIN, found identifier "property"
 ALTER SOURCE name SET (property = true)
                        ^
 
@@ -2120,7 +2120,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (START OFFSET=1, START TIMESTAMP=
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 WITH (START OFFSET="hmm") TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
 ----
-error: Expected one of IGNORE or SIZE or TIMELINE or TIMESTAMP, found START
+error: Expected one of IGNORE or SIZE or TIMELINE or TIMESTAMP or RETAIN, found START
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 WITH (START OFFSET="hmm") TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
                                                      ^
 
@@ -2837,3 +2837,10 @@ CREATE SOURCE header2 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT 
 CREATE SOURCE header2 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON INCLUDE HEADER 'header1' AS h1, HEADER 'header2' AS h2 BYTES ENVELOPE UPSERT
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header2")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [Header { key: "header1", alias: Ident("h1"), use_bytes: false }, Header { key: "header2", alias: Ident("h2"), use_bytes: true }], format: KeyValue { key: Text, value: Json }, envelope: Some(Upsert), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+
+parse-statement
+CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (SIZE '1', RETAIN HISTORY FOR '1s');
+----
+CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (SIZE = '1', RETAIN HISTORY = FOR '1s')
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("s")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("1"))) }, CreateSourceOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1s"))) }], referenced_subsources: None, progress_subsource: None })

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1290,6 +1290,7 @@ pub struct Source {
     pub create_sql: String,
     pub data_source: DataSourceDesc,
     pub desc: RelationDesc,
+    pub compaction_window: Option<CompactionWindow>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -387,7 +387,8 @@ generate_extracted_config!(
     (IgnoreKeys, bool),
     (Size, String),
     (Timeline, String),
-    (TimestampInterval, Duration)
+    (TimestampInterval, Duration),
+    (RetainHistory, Duration)
 );
 
 generate_extracted_config!(
@@ -543,6 +544,7 @@ pub fn plan_create_webhook_source(
                 headers,
             },
             desc,
+            compaction_window: None,
         },
         if_not_exists,
         timeline,
@@ -574,6 +576,7 @@ pub fn plan_create_source(
     let allowed_with_options = vec![
         CreateSourceOptionName::Size,
         CreateSourceOptionName::TimestampInterval,
+        CreateSourceOptionName::RetainHistory,
     ];
     if let Some(op) = with_options
         .iter()
@@ -1064,6 +1067,7 @@ pub fn plan_create_source(
         timeline,
         timestamp_interval,
         ignore_keys,
+        retain_history,
         seen: _,
     } = CreateSourceOptionExtracted::try_from(with_options.clone())?;
 
@@ -1259,6 +1263,13 @@ pub fn plan_create_source(
         Some(timeline) => Timeline::User(timeline),
     };
 
+    let compaction_window = retain_history
+        .map(|cw| {
+            scx.require_feature_flag(&vars::ENABLE_LOGICAL_COMPACTION_WINDOW)?;
+            Ok::<_, PlanError>(cw.try_into()?)
+        })
+        .transpose()?;
+
     let source = Source {
         create_sql,
         data_source: DataSourceDesc::Ingestion(Ingestion {
@@ -1269,6 +1280,7 @@ pub fn plan_create_source(
             progress_subsource,
         }),
         desc,
+        compaction_window,
     };
 
     Ok(Plan::CreateSource(CreateSourcePlan {
@@ -1428,6 +1440,7 @@ pub fn plan_create_subsource(
             unreachable!("state prohibited above")
         },
         desc,
+        compaction_window: None,
     };
 
     Ok(Plan::CreateSource(CreateSourcePlan {


### PR DESCRIPTION
Webhooks and subsources not yet supported.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add `RETAIN HISTORY` option for `SOURCE`s.