### PR TITLE
doc/user: add docs for AWS connections

### DIFF
--- a/doc/developer/design/20231110_aws_connections.md
+++ b/doc/developer/design/20231110_aws_connections.md
@@ -97,7 +97,7 @@ The AWS Connection create statement with all the options will now look like:
 CREATE CONNECTION <connector_name> TO AWS (
   ACCESS KEY ID [[=] <value>], -- existing
   SECRET ACCESS KEY [[=] SECRET <value>], -- existing
-  TOKEN [[=] SECRET <value>], -- existing
+  SESSION TOKEN [[=] SECRET <value>], -- rename existing from TOKEN
   ASSUME ROLE ARN [[=] <value>], -- rename existing from ROLE ARN
   ASSUME ROLE SESSION NAME [[=] <value>], -- new option
   ENDPOINT [[=] <value>], -- existing

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -21,6 +21,152 @@ certificates) can be specified as plain `text`, or also stored as secrets.
 
 ## Source and sink connections
 
+### AWS
+
+{{< private-preview />}}
+
+An Amazon Web Services (AWS) connection provides Materialize with access to an
+Identity and Access Management (IAM) user or role in your AWS account. In the
+future, you will be able to use AWS connections with sources and sinks that
+interact with AWS services, like Amazon Simple Storage Service (S3) and Amazon
+Relational Database Service (RDS).
+
+{{< diagram "create-connection-aws.svg" >}}
+
+#### Connection options {#aws-options}
+
+| <div style="min-width:240px">Field</div>  | Value            | Description
+|-------------------------------------------|------------------|------------------------------
+| `ENDPOINT`                                | `text`           | *Advanced.* Override the default AWS endpoint URL. Allows targeting AWS-compatible services like MinIO.
+| `REGION`                                  | `text`           | The AWS region to connect to.
+| `ACCESS KEY ID`                           | secret or `text` | The access key ID to connect with. Triggers credentials-based authentication.
+| `SECRET ACCESS KEY`                       | secret           | The secret access key corresponding to the specified access key ID.<br><br>Required and only valid when `ACCESS KEY ID` is specified.
+| `SESSION TOKEN`                           | secret or `text` | The session token corresponding to the specified access key ID.<br><br>Only valid when `ACCESS KEY ID` is specified.
+| `ASSUME ROLE ARN`                         | `text`           | The Amazon Resource Name (ARN) of the IAM role to assume. Triggers role assumption-based authentication.
+| `ASSUME ROLE SESSION NAME`                | `text`           | The session name to use when assuming the role.<br><br>Only valid when `ASSUME ROLE ARN` is specified.
+
+#### `WITH` options {#aws-with-options}
+
+Field         | Value     | Description
+--------------|-----------|-------------------------------------
+`VALIDATE`    | `boolean` | Whether [connection validation](#connection-validation) should be performed on connection creation.<br><br>Defaults to `false`.
+
+#### Permissions
+
+When using role assumption-based authentication, you must configure a [trust
+policy] on the IAM role that permits Materialize to assume the role.
+
+Materialize always uses the following IAM principal to assume the role:
+
+```
+arn:aws:iam::664411391173:role/MaterializeConnection
+```
+
+Materialize additionally generates an [external ID] which uniquely identifies
+your AWS connection across all Materialize regions. To ensure that other
+Materialize customers cannot assume your role, your IAM trust policy **must**
+constrain access to only the external ID that Materialize generates for the
+connection:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::664411391173:role/MaterializeConnection"
+            },
+            "Action": "sts:AssumeRole",
+            "Condition": {
+                "StringEquals": {
+                    "sts:ExternalId": "<EXTERNAL ID FOR CONNECTION>"
+                }
+            }
+        }
+    ]
+}
+```
+
+You can retrieve the external ID for the connection, as well as an example trust
+policy, by querying the
+[`mz_internal.mz_aws_connections`](/sql/system-catalog/mz_internal/#mz_aws_connections)
+table:
+
+```sql
+SELECT id, external_id, example_trust_policy FROM mz_internal.mz_aws_connections;
+```
+
+{{< warning >}}
+Failing to constrain the external ID in your role trust policy will allow
+other Materialize customers to assume your role and use AWS privileges you
+have granted the role!
+{{< /warning >}}
+
+#### Examples
+
+{{< tabs >}}
+{{< tab "Credentials">}}
+To create an AWS connection that uses static access key credentials:
+
+```sql
+CREATE SECRET aws_secret_access_key = '...';
+CREATE CONNECTION aws_credentials TO AWS (
+    ACCESS KEY ID = 'ASIAV2KIV5LPTG6HGXG6',
+    SECRET ACCESS KEY = SECRET aws_secret_access_key
+);
+```
+{{< /tab >}}
+
+{{< tab "Role assumption">}}
+
+In this example, we have created the following IAM role for Materialize to
+assume:
+
+<table>
+<tr>
+<th>Name</th>
+<th>AWS account ID</th>
+<th>Trust policy</th>
+<tr>
+<td><code>WarehouseExport</code></td>
+<td>400121260767</td>
+<td>
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::664411391173:role/MaterializeConnection"
+            },
+            "Action": "sts:AssumeRole",
+            "Condition": {
+                "StringEquals": {
+                    "sts:ExternalId": "mz_00000000-0000-0000-0000-000000000000_u0"
+                }
+            }
+        }
+    ]
+}
+```
+
+</td>
+</tr>
+</table>
+
+To create an AWS connection that will assume the `WarehouseExport` role:
+
+```sql
+CREATE CONNECTION aws_role_assumption TO AWS (
+    ASSUME ROLE ARN = 'arn:aws:iam::400121260767:role/WarehouseExport',
+);
+```
+{{< /tab >}}
+{{< /tabs >}}
+
 ### Kafka
 
 A Kafka connection establishes a link to a [Kafka] cluster. You can use Kafka
@@ -674,6 +820,7 @@ Connection type             | Validated by default |
 PostgreSQL                  | ✓                    |
 Kafka                       | ✓                    |
 Confluent Schema Registry   | ✓                    |
+AWS                         |                      |
 SSH Tunnel                  |                      |
 AWS PrivateLink             |                      |
 
@@ -683,10 +830,10 @@ returned. You can disable connection validation by setting the `VALIDATE`
 option to `false`. This is useful, for example, when the parameters are known
 to be correct but the external system is unavailable at the time of creation.
 
-Connection types that require additional setup steps after creation, like SSH
-tunnel and AWS PrivateLink connections, can be **manually validated** using the
-[`VALIDATE CONNECTION`](/sql/validate-connection) syntax once all setup steps
-are completed.
+Connection types that require additional setup steps after creation, like AWS
+and SSH tunnel connections, can be **manually validated** using the [`VALIDATE
+CONNECTION`](/sql/validate-connection) syntax once all setup steps are
+completed.
 
 ## Privileges
 
@@ -715,3 +862,5 @@ The privileges required to execute this statement are:
 [`mz_ssh_tunnel_connections`]: /sql/system-catalog/mz_catalog/#mz_ssh_tunnel_connections
 [Ed25519 algorithm]: https://ed25519.cr.yp.to
 [latacora-crypto]: https://latacora.micro.blog/2018/04/03/cryptographic-right-answers.html
+[trust policy]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#term_trust-policy
+[external ID]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -75,6 +75,40 @@ sampling rate than the one set in this variable.
 | `prepared_at`             | [`timestamp with time zone`] | The time at which the statement was prepared.                                                                                                                                                                                                                                 |
 | `statement_kind`          | [`text`]                     | The _kind_ of the statement, e.g. `select` for a `SELECT` query, or `NULL` if the statement was empty.                                                                                                                                                                        |
 
+### `mz_aws_connections`
+
+The `mz_aws_connections` table contains a row for each AWS connection in the
+system.
+
+<!-- RELATION_SPEC mz_internal.mz_aws_connections -->
+| Field                         | Type      | Meaning
+|-------------------------------|-----------|--------
+| `id`                          | [`text`]  | The ID of the connection.
+| `endpoint`                    | [`text`]  | The value of the `ENDPOINT` option, if set.
+| `region`                      | [`text`]  | The value of the `REGION` option, if set.
+| `access_key_id`               | [`text`]  | The value of the `ACCESS KEY ID` option, if provided in line.
+| `access_key_id_secret_id`     | [`text`]  | The ID of the secret referenced by the `ACCESS KEY ID` option, if provided via a secret.
+| `secret_access_key_secret_id` | [`text`]  | The ID of the secret referenced by the `SECRET ACCESS KEY` option, if set.
+| `session_token`               | [`text`]  | The value of the `SESSION TOKEN` option, if provided in line.
+| `session_token_secret_id`     | [`text`]  | The ID of the secret referenced by the `SESSION TOKEN` option, if provided via a secret.
+| `assume_role_arn`             | [`text`]  | The value of the `ASSUME ROLE ARN` option, if set.
+| `assume_role_session_name`    | [`text`]  | The value of the `ASSUME ROLE SESSION NAME` option, if set.
+| `principal`                   | [`text`]  | The ARN of the AWS principal Materialize will use when assuming the provided role, if the connection is configured to use role assumption.
+| `external_id`                 | [`text`]  | The external ID Materialize will use when assuming the provided role, if the connection is configured to use role assumption.
+| `example_trust_policy`        | [`jsonb`] | An example of an IAM role trust policy that allows this connection's principal and external ID to assume the role.
+
+### `mz_aws_privatelink_connection_status_history`
+
+The `mz_aws_privatelink_connection_status_history` table contains a row describing
+the historical status for each AWS PrivateLink connection in the system.
+
+<!-- RELATION_SPEC mz_internal.mz_aws_privatelink_connection_status_history -->
+| Field             | Type                       | Meaning                                                    |
+|-------------------|----------------------------|------------------------------------------------------------|
+| `occurred_at`     | `timestamp with time zone` | Wall-clock timestamp of the status change.       |
+| `connection_id`   | `text`                     | The unique identifier of the AWS PrivateLink connection. Corresponds to [`mz_catalog.mz_connections.id`](../mz_catalog#mz_connections).   |
+| `status`          | `text`                     | The status of the connection: one of `pending-service-discovery`, `creating-endpoint`, `recreating-endpoint`, `updating-endpoint`, `available`, `deleted`, `deleting`, `expired`, `failed`, `pending`, `pending-acceptance`, `rejected`, or `unknown`.                        |
+
 ### `mz_cluster_replica_frontiers`
 
 The `mz_cluster_replica_frontiers` table describes the per-replica frontiers of
@@ -767,20 +801,6 @@ messages and additional metadata helpful for debugging.
 | `error`        | [`text`]                        | If the source is in an error state, the error message.                                                             |
 | `details`      | [`jsonb`]                       | Additional metadata provided by the source. In case of error, may contain a `hint` field with helpful suggestions. |
 
-
-### `mz_aws_privatelink_connection_status_history`
-
-The `mz_aws_privatelink_connection_status_history` table contains a row describing
-the historical status for each AWS PrivateLink connection in the system.
-
-<!-- RELATION_SPEC mz_internal.mz_aws_privatelink_connection_status_history -->
-| Field             | Type                       | Meaning                                                    |
-|-------------------|----------------------------|------------------------------------------------------------|
-| `occurred_at`     | `timestamp with time zone` | Wall-clock timestamp of the status change.       |
-| `connection_id`   | `text`                     | The unique identifier of the AWS PrivateLink connection. Corresponds to [`mz_catalog.mz_connections.id`](../mz_catalog#mz_connections).   |
-| `status`          | `text`                     | The status of the connection: one of `pending-service-discovery`, `creating-endpoint`, `recreating-endpoint`, `updating-endpoint`, `available`, `deleted`, `deleting`, `expired`, `failed`, `pending`, `pending-acceptance`, `rejected`, or `unknown`.                        |
-
-
 <!--
 ### `mz_statement_execution_history`
 
@@ -1244,7 +1264,6 @@ The `mz_scheduling_parks_histogram` view describes a histogram of [dataflow] wor
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_activity_log_redacted -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_aggregates -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_aws_connections -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_dataflow_operator_reachability -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_dataflow_operator_reachability_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_dataflow_operator_reachability_raw -->

--- a/doc/user/layouts/partials/sql-grammar/create-connection-aws.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-connection-aws.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="601" height="297">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="76" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">CREATE</text>
+   <rect x="127" y="3" width="116" height="32" rx="10"/>
+   <rect x="125"
+         y="1"
+         width="116"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="135" y="21">CONNECTION</text>
+   <rect x="283" y="35" width="120" height="32" rx="10"/>
+   <rect x="281"
+         y="33"
+         width="120"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="291" y="53">IF NOT EXISTS</text>
+   <rect x="443" y="3" width="136" height="32"/>
+   <rect x="441" y="1" width="136" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="451" y="21">connection_name</text>
+   <rect x="72" y="145" width="40" height="32" rx="10"/>
+   <rect x="70"
+         y="143"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="80" y="163">TO</text>
+   <rect x="132" y="145" width="54" height="32" rx="10"/>
+   <rect x="130"
+         y="143"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="140" y="163">AWS</text>
+   <rect x="206" y="145" width="26" height="32" rx="10"/>
+   <rect x="204"
+         y="143"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="214" y="163">(</text>
+   <rect x="272" y="145" width="48" height="32"/>
+   <rect x="270" y="143" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="280" y="163">field</text>
+   <rect x="360" y="177" width="28" height="32" rx="10"/>
+   <rect x="358"
+         y="175"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="368" y="195">=</text>
+   <rect x="428" y="145" width="38" height="32"/>
+   <rect x="426" y="143" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="436" y="163">val</text>
+   <rect x="272" y="101" width="24" height="32" rx="10"/>
+   <rect x="270"
+         y="99"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="280" y="119">,</text>
+   <rect x="506" y="145" width="26" height="32" rx="10"/>
+   <rect x="504"
+         y="143"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="514" y="163">)</text>
+   <rect x="373" y="263" width="58" height="32" rx="10"/>
+   <rect x="371"
+         y="261"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="381" y="281">WITH</text>
+   <rect x="451" y="263" width="102" height="32"/>
+   <rect x="449" y="261" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="459" y="281">with_options</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m116 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m136 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-551 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m40 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m20 0 h10 m0 0 h38 m-68 0 h20 m48 0 h20 m-88 0 q10 0 10 10 m68 0 q0 -10 10 -10 m-78 10 v12 m68 0 v-12 m-68 12 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m28 0 h10 m20 -32 h10 m38 0 h10 m-234 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m214 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-214 0 h10 m24 0 h10 m0 0 h170 m20 44 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-223 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h190 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v12 m220 0 v-12 m-220 12 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m58 0 h10 m0 0 h10 m102 0 h10 m23 -32 h-3"/>
+   <polygon points="591 245 599 241 599 249"/>
+   <polygon points="591 245 583 241 583 249"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -87,6 +87,10 @@ cluster_replica_def ::=
   replica_name '(' replica_option '=' value ( ',' replica_option '=' value )* ')'
 create_cluster_replica ::=
   'CREATE' 'CLUSTER' 'REPLICA' cluster_name '.' replica_name (option '=' value ( ',' option '=' value )*)?
+create_connection_aws ::=
+  'CREATE' 'CONNECTION' 'IF NOT EXISTS'? connection_name 'TO' 'AWS'
+  '(' field '='? val ( ',' field '='? val )* ')'
+  ('WITH' with_options)?
 create_connection_kafka ::=
   'CREATE' 'CONNECTION' 'IF NOT EXISTS'? connection_name 'TO' 'KAFKA'
   '(' field '='? val ( ',' field '='? val )* ')'

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -754,18 +754,29 @@ impl CatalogState {
 
         let mut access_key_id = None;
         let mut access_key_id_secret_id = None;
+        let mut secret_access_key_secret_id = None;
+        let mut session_token = None;
+        let mut session_token_secret_id = None;
         let mut assume_role_arn = None;
         let mut assume_role_session_name = None;
         let mut principal = None;
         let mut external_id = None;
         let mut example_trust_policy = None;
         match &aws_config.auth {
-            AwsAuth::Credentials(credentials) => match &credentials.access_key_id {
-                StringOrSecret::String(access_key) => access_key_id = Some(access_key.as_str()),
-                StringOrSecret::Secret(secret_id) => {
-                    access_key_id_secret_id = Some(secret_id.to_string())
+            AwsAuth::Credentials(credentials) => {
+                match &credentials.access_key_id {
+                    StringOrSecret::String(s) => access_key_id = Some(s.as_str()),
+                    StringOrSecret::Secret(s) => access_key_id_secret_id = Some(s.to_string()),
                 }
-            },
+                secret_access_key_secret_id = Some(credentials.secret_access_key.to_string());
+                match credentials.session_token.as_ref() {
+                    None => (),
+                    Some(StringOrSecret::String(s)) => session_token = Some(s.as_str()),
+                    Some(StringOrSecret::Secret(s)) => {
+                        session_token_secret_id = Some(s.to_string())
+                    }
+                }
+            }
             AwsAuth::AssumeRole(assume_role) => {
                 assume_role_arn = Some(assume_role.arn.as_str());
                 assume_role_session_name = assume_role.session_name.as_deref();
@@ -791,6 +802,9 @@ impl CatalogState {
             Datum::from(aws_config.region.as_deref()),
             Datum::from(access_key_id),
             Datum::from(access_key_id_secret_id.as_deref()),
+            Datum::from(secret_access_key_secret_id.as_deref()),
+            Datum::from(session_token),
+            Datum::from(session_token_secret_id.as_deref()),
             Datum::from(assume_role_arn),
             Datum::from(assume_role_session_name),
             Datum::from(principal),

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2660,6 +2660,12 @@ pub static MZ_AWS_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("region", ScalarType::String.nullable(true))
         .with_column("access_key_id", ScalarType::String.nullable(true))
         .with_column("access_key_id_secret_id", ScalarType::String.nullable(true))
+        .with_column(
+            "secret_access_key_secret_id",
+            ScalarType::String.nullable(true),
+        )
+        .with_column("session_token", ScalarType::String.nullable(true))
+        .with_column("session_token_secret_id", ScalarType::String.nullable(true))
         .with_column("assume_role_arn", ScalarType::String.nullable(true))
         .with_column(
             "assume_role_session_name",

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -695,7 +695,7 @@ pub enum ConnectionOptionName {
     SslCertificateAuthority,
     SslKey,
     SslMode,
-    Token,
+    SessionToken,
     Url,
     User,
 }
@@ -728,7 +728,7 @@ impl AstDisplay for ConnectionOptionName {
             ConnectionOptionName::SslCertificateAuthority => "SSL CERTIFICATE AUTHORITY",
             ConnectionOptionName::SslKey => "SSL KEY",
             ConnectionOptionName::SslMode => "SSL MODE",
-            ConnectionOptionName::Token => "TOKEN",
+            ConnectionOptionName::SessionToken => "SESSION TOKEN",
             ConnectionOptionName::Url => "URL",
             ConnectionOptionName::User => "USER",
         })

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2420,9 +2420,9 @@ impl<'a> Parser<'a> {
                 SECRET,
                 SECURITY,
                 SERVICE,
+                SESSION,
                 SSH,
                 SSL,
-                TOKEN,
                 URL,
                 USER,
                 USERNAME,
@@ -2480,6 +2480,10 @@ impl<'a> Parser<'a> {
                     self.expect_keyword(NAME)?;
                     ConnectionOptionName::ServiceName
                 }
+                SESSION => {
+                    self.expect_keyword(TOKEN)?;
+                    ConnectionOptionName::SessionToken
+                }
                 SSH => {
                     self.expect_keyword(TUNNEL)?;
                     ConnectionOptionName::SshTunnel
@@ -2496,7 +2500,6 @@ impl<'a> Parser<'a> {
                     MODE => ConnectionOptionName::SslMode,
                     _ => unreachable!(),
                 },
-                TOKEN => ConnectionOptionName::Token,
                 URL => ConnectionOptionName::Url,
                 USER | USERNAME => ConnectionOptionName::User,
                 _ => unreachable!(),

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -387,11 +387,11 @@ CREATE OR REPLACE MATERIALIZED VIEW v WITH (ASSERT NOT NULL a, ASSERT NOT NULL =
 CREATE OR REPLACE MATERIALIZED VIEW v WITH (ASSERT NOT NULL = a, ASSERT NOT NULL = b, RETAIN HISTORY = FOR '1s') AS SELECT 1
 
 parse-statement
-CREATE CONNECTION awsconn TO AWS (ACCESS KEY ID 'id', ENDPOINT 'endpoint', REGION 'region', SECRET ACCESS KEY 'key', TOKEN 'token')
+CREATE CONNECTION awsconn TO AWS (ACCESS KEY ID 'id', ENDPOINT 'endpoint', REGION 'region', SECRET ACCESS KEY 'key', SESSION TOKEN 'token')
 ----
-CREATE CONNECTION awsconn TO AWS (ACCESS KEY ID = 'id', ENDPOINT = 'endpoint', REGION = 'region', SECRET ACCESS KEY = 'key', TOKEN = 'token')
+CREATE CONNECTION awsconn TO AWS (ACCESS KEY ID = 'id', ENDPOINT = 'endpoint', REGION = 'region', SECRET ACCESS KEY = 'key', SESSION TOKEN = 'token')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("awsconn")]), connection_type: Aws, if_not_exists: false, values: [ConnectionOption { name: AccessKeyId, value: Some(Value(String("id"))) }, ConnectionOption { name: Endpoint, value: Some(Value(String("endpoint"))) }, ConnectionOption { name: Region, value: Some(Value(String("region"))) }, ConnectionOption { name: SecretAccessKey, value: Some(Value(String("key"))) }, ConnectionOption { name: Token, value: Some(Value(String("token"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("awsconn")]), connection_type: Aws, if_not_exists: false, values: [ConnectionOption { name: AccessKeyId, value: Some(Value(String("id"))) }, ConnectionOption { name: Endpoint, value: Some(Value(String("endpoint"))) }, ConnectionOption { name: Region, value: Some(Value(String("region"))) }, ConnectionOption { name: SecretAccessKey, value: Some(Value(String("key"))) }, ConnectionOption { name: SessionToken, value: Some(Value(String("token"))) }], with_options: [] })
 
 parse-statement
 CREATE CONNECTION awsconn TO AWS (ASSUME ROLE ARN 'role-arn', ASSUME ROLE SESSION NAME 'session-name')
@@ -401,11 +401,11 @@ CREATE CONNECTION awsconn TO AWS (ASSUME ROLE ARN = 'role-arn', ASSUME ROLE SESS
 CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("awsconn")]), connection_type: Aws, if_not_exists: false, values: [ConnectionOption { name: AssumeRoleArn, value: Some(Value(String("role-arn"))) }, ConnectionOption { name: AssumeRoleSessionName, value: Some(Value(String("session-name"))) }], with_options: [] })
 
 parse-statement
-CREATE CONNECTION awsconn TO AWS (ACCESS KEY ID 'id', ENDPOINT 'endpoint', REGION 'region', ASSUME ROLE ARN 'role-arn', SECRET ACCESS KEY 'key', TOKEN 'token')
+CREATE CONNECTION awsconn TO AWS (ACCESS KEY ID 'id', ENDPOINT 'endpoint', REGION 'region', ASSUME ROLE ARN 'role-arn', SECRET ACCESS KEY 'key', SESSION TOKEN 'token')
 ----
-CREATE CONNECTION awsconn TO AWS (ACCESS KEY ID = 'id', ENDPOINT = 'endpoint', REGION = 'region', ASSUME ROLE ARN = 'role-arn', SECRET ACCESS KEY = 'key', TOKEN = 'token')
+CREATE CONNECTION awsconn TO AWS (ACCESS KEY ID = 'id', ENDPOINT = 'endpoint', REGION = 'region', ASSUME ROLE ARN = 'role-arn', SECRET ACCESS KEY = 'key', SESSION TOKEN = 'token')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("awsconn")]), connection_type: Aws, if_not_exists: false, values: [ConnectionOption { name: AccessKeyId, value: Some(Value(String("id"))) }, ConnectionOption { name: Endpoint, value: Some(Value(String("endpoint"))) }, ConnectionOption { name: Region, value: Some(Value(String("region"))) }, ConnectionOption { name: AssumeRoleArn, value: Some(Value(String("role-arn"))) }, ConnectionOption { name: SecretAccessKey, value: Some(Value(String("key"))) }, ConnectionOption { name: Token, value: Some(Value(String("token"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("awsconn")]), connection_type: Aws, if_not_exists: false, values: [ConnectionOption { name: AccessKeyId, value: Some(Value(String("id"))) }, ConnectionOption { name: Endpoint, value: Some(Value(String("endpoint"))) }, ConnectionOption { name: Region, value: Some(Value(String("region"))) }, ConnectionOption { name: AssumeRoleArn, value: Some(Value(String("role-arn"))) }, ConnectionOption { name: SecretAccessKey, value: Some(Value(String("key"))) }, ConnectionOption { name: SessionToken, value: Some(Value(String("token"))) }], with_options: [] })
 
 parse-statement
 CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES ('use1-az1', 'use1-az4'))

--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -60,7 +60,7 @@ generate_extracted_config!(
     (SslCertificateAuthority, StringOrSecret),
     (SslKey, with_options::Secret),
     (SslMode, String),
-    (Token, StringOrSecret),
+    (SessionToken, StringOrSecret),
     (Url, String),
     (User, StringOrSecret)
 );
@@ -86,7 +86,7 @@ pub(super) fn validate_options_per_connection_type(
         CreateConnectionType::Aws => [
             AccessKeyId,
             SecretAccessKey,
-            Token,
+            SessionToken,
             Endpoint,
             Region,
             AssumeRoleArn,
@@ -166,7 +166,11 @@ impl ConnectionOptionExtracted {
 
         let connection: Connection<ReferencedConnection> = match connection_type {
             CreateConnectionType::Aws => {
-                let credentials = match (self.access_key_id, self.secret_access_key, self.token) {
+                let credentials = match (
+                    self.access_key_id,
+                    self.secret_access_key,
+                    self.session_token,
+                ) {
                     (Some(access_key_id), Some(secret_access_key), session_token) => {
                         Some(AwsCredentials {
                             access_key_id,

--- a/test/aws/aws-connection/aws-connection.td
+++ b/test/aws/aws-connection/aws-connection.td
@@ -18,13 +18,13 @@ ALTER SYSTEM SET enable_connection_validation_syntax = true;
 > CREATE CONNECTION aws_assume_role
   TO AWS (ASSUME ROLE ARN 'assume-role', ASSUME ROLE SESSION NAME 'session-name');
 
-$ set-from-sql var=conn_id
+$ set-from-sql var=conn-id
 SELECT id FROM mz_connections WHERE name = 'aws_assume_role';
 
-> SELECT * FROM mz_internal.mz_aws_connections WHERE id = '${conn_id}';
-id           endpoint  region  access_key_id  access_key_id_secret_id  assume_role_arn  assume_role_session_name  principal                                            external_id                                          example_trust_policy
+> SELECT * FROM mz_internal.mz_aws_connections WHERE id = '${conn-id}';
+id           endpoint  region  access_key_id  access_key_id_secret_id  secret_access_key_secret_id  session_token  session_token_secret_id  assume_role_arn  assume_role_session_name  principal                                   external_id                                          example_trust_policy
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-"${conn_id}" <null>    <null>  <null>         <null>                   assume-role      session-name              arn:aws:iam::123456789000:role/MaterializeConnection "mz_eb5cb59b-e2fe-41f3-87ca-d2176a495345_${conn_id}" "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Condition\":{\"StringEquals\":{\"sts:ExternalId\":\"mz_eb5cb59b-e2fe-41f3-87ca-d2176a495345_${conn_id}\"}},\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789000:role/MaterializeConnection\"}}],\"Version\":\"2012-10-17\"}"
+"${conn-id}" <null>    <null>  <null>         <null>                   <null>                       <null>         <null>                   assume-role      session-name              arn:aws:iam::123456789000:role/MaterializeConnection "mz_eb5cb59b-e2fe-41f3-87ca-d2176a495345_${conn-id}" "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Condition\":{\"StringEquals\":{\"sts:ExternalId\":\"mz_eb5cb59b-e2fe-41f3-87ca-d2176a495345_${conn-id}\"}},\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789000:role/MaterializeConnection\"}}],\"Version\":\"2012-10-17\"}"
 
 # Test access credentials connections.
 
@@ -33,13 +33,16 @@ id           endpoint  region  access_key_id  access_key_id_secret_id  assume_ro
 > CREATE CONNECTION aws_credentials
   TO AWS (ACCESS KEY ID = 'access_key', SECRET ACCESS KEY = SECRET aws_secret_access_key);
 
-$ set-from-sql var=conn_id
+$ set-from-sql var=conn-id
 SELECT id FROM mz_connections WHERE name = 'aws_credentials';
 
-> SELECT * FROM mz_internal.mz_aws_connections WHERE id = '${conn_id}';
-id           endpoint  region  access_key_id  access_key_id_secret_id  assume_role_arn  assume_role_session_name  principal external_id example_trust_policy
--------------------------------------------------------------------------------------------------------------------------------------------------------------
-"${conn_id}" <null>   <null>   access_key     <null>                   <null>           <null>                    <null>    <null>      <null>
+$ set-from-sql var=secret-key-secret-id
+SELECT id FROM mz_secrets WHERE name = 'aws_secret_access_key';
+
+> SELECT * FROM mz_internal.mz_aws_connections WHERE id = '${conn-id}';
+id           endpoint  region  access_key_id  access_key_id_secret_id  secret_access_key_secret_id  session_token  session_token_secret_id  assume_role_arn  assume_role_session_name  principal  external_id  example_trust_policy
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+\${conn-id}  <null>   <null>   access_key     <null>                   ${secret-key-secret-id}      <null>         <null>                   <null>           <null>                    <null>     <null>       <null>
 
 # Test access credentials connections where the access key ID is also a secret.
 
@@ -48,16 +51,16 @@ id           endpoint  region  access_key_id  access_key_id_secret_id  assume_ro
 > CREATE CONNECTION aws_credentials_with_secret
   TO AWS (ACCESS KEY ID = SECRET aws_access_key_id, SECRET ACCESS KEY = SECRET aws_secret_access_key);
 
-$ set-from-sql var=conn_id
+$ set-from-sql var=conn-id
 SELECT id FROM mz_connections WHERE name = 'aws_credentials_with_secret';
 
-$ set-from-sql var=secret_id
+$ set-from-sql var=access-key-secret-id
 SELECT id FROM mz_secrets WHERE name = 'aws_access_key_id';
 
-> SELECT * FROM mz_internal.mz_aws_connections WHERE id = '${conn_id}';
-id           endpoint  region  access_key_id  access_key_id_secret_id  assume_role_arn  assume_role_session_name  principal external_id example_trust_policy
--------------------------------------------------------------------------------------------------------------------------------------------------------------
-"${conn_id}" <null>   <null>   <null>         "${secret_id}"           <null>           <null>                    <null>    <null>      <null>
+> SELECT * FROM mz_internal.mz_aws_connections WHERE id = '${conn-id}';
+id           endpoint  region  access_key_id  access_key_id_secret_id  secret_access_key_secret_id  session_token  session_token_secret_id  assume_role_arn  assume_role_session_name  principal  external_id  example_trust_policy
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+\${conn-id}  <null>   <null>   <null>         ${access-key-secret-id}  ${secret-key-secret-id}      <null>         <null>                   <null>           <null>                    <null>     <null>       <null>
 
 # TODO: tests for validating connections.
 
@@ -72,7 +75,7 @@ contains:must specify both ACCESS KEY ID and SECRET ACCESS KEY with optional SES
 contains:must specify both ACCESS KEY ID and SECRET ACCESS KEY with optional SESSION TOKEN
 
 ! CREATE CONNECTION conn
-  TO AWS (TOKEN = 'token');
+  TO AWS (SESSION TOKEN = 'token');
 contains:must specify both ACCESS KEY ID and SECRET ACCESS KEY with optional SESSION TOKEN
 
 ! CREATE CONNECTION conn

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -57,6 +57,30 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 23  statement_kind  text
 
 query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_aws_connections' ORDER BY position
+----
+1  id  text
+2  endpoint  text
+3  region  text
+4  access_key_id  text
+5  access_key_id_secret_id  text
+6  secret_access_key_secret_id  text
+7  session_token  text
+8  session_token_secret_id  text
+9  assume_role_arn  text
+10  assume_role_session_name  text
+11  principal  text
+12  external_id  text
+13  example_trust_policy  jsonb
+
+query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_aws_privatelink_connection_status_history' ORDER BY position
+----
+1  occurred_at  timestamp␠with␠time␠zone
+2  connection_id  text
+3  status  text
+
+query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_frontiers' ORDER BY position
 ----
 1  object_id  text
@@ -433,13 +457,6 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 3  status  text
 4  error  text
 5  details  jsonb
-
-query ITT
-SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_aws_privatelink_connection_status_history' ORDER BY position
-----
-1  occurred_at  timestamp␠with␠time␠zone
-2  connection_id  text
-3  status  text
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_subscriptions' ORDER BY position

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -160,9 +160,9 @@ $ kafka-ingest format=avro topic=csr_test key-format=avro key-schema=${keyschema
 
 ! CREATE CONNECTION csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}',
-    TOKEN = 'abc'
+    SESSION TOKEN = 'abc'
   );
-contains:CONFLUENT SCHEMA REGISTRY connections do not support TOKEN values
+contains:CONFLUENT SCHEMA REGISTRY connections do not support SESSION TOKEN values
 
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);


### PR DESCRIPTION
I added to the original documentation PR with a commit that tweaks the implementation:

> **sql: rename TOKEN to SESSION TOKEN in AWS connections**
> 
> To better align with what AWS calls this parameter in its upstream SDKs.
> Also add columns for the secret key and session token to the
> `aws_connections` table.

(The documentation was documenting the new shape of the `mz_aws_connections` table and the tests were complaining.)

----

Touches #23055.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR adds documentation for a new feature.

### Tips for reviewers

Docs preview:

  * `CREATE CONNECTION`: https://preview.materialize.com/materialize/23958/sql/create-connection/#aws
  * `mz_aws_connections`: https://preview.materialize.com/materialize/23958/sql/system-catalog/mz_internal/#mz_aws_connections

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
