### PR TITLE
lint: improve output

### DIFF
--- a/ci/test/lint-fast.sh
+++ b/ci/test/lint-fast.sh
@@ -11,4 +11,4 @@
 #
 # lint-fast.sh — fast linters that don't require building any code.
 
-bin/lint
+bin/lint --verbose

--- a/misc/python/materialize/lint/lint.py
+++ b/misc/python/materialize/lint/lint.py
@@ -15,6 +15,13 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from materialize import MZ_ROOT, buildkite
+from materialize.terminal import (
+    COLOR_ERROR,
+    COLOR_OK,
+    STYLE_BOLD,
+    with_formatting,
+    with_formattings,
+)
 
 MAIN_PATH = MZ_ROOT / "ci" / "test" / "lint-main"
 MAIN_CHECKS_PATH = MAIN_PATH / "checks"
@@ -120,9 +127,13 @@ class LintManager:
                 else ""
             )
             if thread.success:
-                print(f"--- {thread.name} (SUCCEEDED{formatted_duration})")
+                status = (
+                    f"({with_formatting('SUCCEEDED', COLOR_OK)}{formatted_duration})"
+                )
+                print(f"--- {thread.name} {status}")
             else:
-                print(f"+++ {thread.name} (FAILED{formatted_duration})")
+                status = f"({with_formattings('FAILED', [COLOR_ERROR, STYLE_BOLD])}{formatted_duration})"
+                print(f"+++ {thread.name} {status}")
                 failed_checks.append(thread.name)
 
             if thread.has_output() and (not thread.success or self.verbose_output):

--- a/misc/python/materialize/terminal.py
+++ b/misc/python/materialize/terminal.py
@@ -1,0 +1,27 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Terminal utilities."""
+
+
+COLOR_GREEN = "\033[92m"
+COLOR_RED = "\033[91m"
+COLOR_OK = COLOR_GREEN
+COLOR_ERROR = COLOR_RED
+STYLE_BOLD = "\033[1m"
+_END_FORMATTING = "\033[0m"
+
+
+def with_formatting(text: str, formatting: str) -> str:
+    return with_formattings(text, [formatting])
+
+
+def with_formattings(text: str, formattings: list[str]) -> str:
+    formatting = "".join(formattings)
+    return f"{formatting}{text}{_END_FORMATTING}"


### PR DESCRIPTION
### Changes
af10b92219 lint: show that it is running
2178368765 ci: run bin/lint in verbose mode
31e3de6903 lint: colored result status

### Before
<img width="1008" alt="Bildschirmfoto 2023-12-18 um 14 26 55" src="https://github.com/MaterializeInc/materialize/assets/129728240/136d8436-da24-4ee6-9fe7-875b8a464c44">

### After

<img width="974" alt="Bildschirmfoto 2023-12-18 um 10 26 51" src="https://github.com/MaterializeInc/materialize/assets/129728240/9884d362-f588-4c6e-ab1f-8f9b89c3fa44">
