### PR TITLE
*: update various feature flag defaults

### DIFF
--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -11,7 +11,7 @@
 //!
 //! Consult [LinearJoinPlan] documentation for details.
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::arrangement::Arranged;
@@ -63,7 +63,7 @@ impl Default for LinearJoinSpec {
             implementation: LinearJoinImpl::Materialize,
             yielding: YieldSpec {
                 after_work: Some(1_000_000),
-                after_time: None,
+                after_time: Some(Duration::from_millis(100)),
             },
         }
     }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1457,7 +1457,8 @@ const ENABLE_MZ_JOIN_CORE: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
-pub static DEFAULT_LINEAR_JOIN_YIELDING: Lazy<String> = Lazy::new(|| "work:1000000".into());
+pub static DEFAULT_LINEAR_JOIN_YIELDING: Lazy<String> =
+    Lazy::new(|| "work:1000000,time:100".into());
 static LINEAR_JOIN_YIELDING: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
     name: UncasedStr::new("linear_join_yielding"),
     value: DEFAULT_LINEAR_JOIN_YIELDING.clone(),
@@ -1930,7 +1931,7 @@ feature_flags!(
     {
         name: enable_multi_worker_storage_persist_sink,
         desc: "multi-worker storage persist sink",
-        default: false,
+        default: true,
         internal: true,
         enable_for_item_parsing: true,
     },
@@ -2000,7 +2001,7 @@ feature_flags!(
     {
         name: enable_disk_cluster_replicas,
         desc: "`WITH (DISK)` for cluster replicas",
-        default: false,
+        default: true,
         internal: true,
         enable_for_item_parsing: true,
     },
@@ -2021,7 +2022,7 @@ feature_flags!(
     {
         name: enable_connection_validation_syntax,
         desc: "CREATE CONNECTION .. WITH (VALIDATE) and VALIDATE CONNECTION syntax",
-        default: false,
+        default: true,
         internal: true,
         enable_for_item_parsing: true,
     },
@@ -2091,7 +2092,7 @@ feature_flags!(
     {
         name: enable_unified_clusters,
         desc: "unified compute and storage cluster",
-        default: false,
+        default: true,
         internal: true,
         enable_for_item_parsing: true,
     },
@@ -2105,7 +2106,7 @@ feature_flags!(
     {
         name: enable_comment,
         desc: "the COMMENT ON feature for objects",
-        default: false,
+        default: true,
         internal: false,
         enable_for_item_parsing: true,
     },
@@ -2126,7 +2127,7 @@ feature_flags!(
     {
         name: enable_alter_swap,
         desc: "the ALTER SWAP feature for objects",
-        default: false,
+        default: true,
         internal: false,
         enable_for_item_parsing: true,
     },
@@ -2140,7 +2141,7 @@ feature_flags!(
     {
         name: enable_default_kafka_ssh_tunnel,
         desc: "the top-level SSH TUNNEL feature for kafka connections",
-        default: false,
+        default: true,
         internal: true,
         enable_for_item_parsing: true,
     },


### PR DESCRIPTION
This PR adjusts some feature flags by setting their defaults to the production defaults they have in LD. This makes it more likely that development and testing happens on a configuration similar to production, and that we catch bugs related to features enabled in production.

It's possible that some of these feature flags should be removed too.

### Motivation

   * This PR updates feature defaults.

While doing this for `linear_join_yielding` initially, I decided that it couldn't hurt to also make a pass over the other flags.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A