### PR TITLE
dbt-materialize: release v1.7.2

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt-materialize Changelog
 
-## Unreleased
+## 1.7.2 - 2023-12-18
 
 * Backport [dbt-core #8887](https://github.com/dbt-labs/dbt-core/pull/8887) to
   unblock users using any custom type with data contracts.
@@ -12,7 +12,7 @@
 
 * Work around [dbt-core #8353](https://github.com/dbt-labs/dbt-core/issues/8353)
   while a permanent fix doesn't land in dbt Core to unblock users using UUID
-  types.
+  types with data contracts.
 
 ## 1.7.0 - 2023-11-20
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.7.1"
+version = "1.7.2"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,7 +26,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.7.1",
+    version="1.7.2",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Release dbt-materialize v1.7.2.

See `CHANGELOG.md` for an overview of the release.