### PR TITLE
*: fix name of `mz_compute_hydration_statuses`

### DIFF
--- a/doc/user/content/releases/v0.79.md
+++ b/doc/user/content/releases/v0.79.md
@@ -24,7 +24,7 @@ patch: 1
 
 #### SQL
 
-* Add [`mz_compute_hydration_status`](/sql/system-catalog/mz_internal/#mz_compute_hydration_status)
+* Add [`mz_compute_hydration_status`](/sql/system-catalog/mz_internal/#mz_compute_hydration_statuses)
   to the system catalog. This table describes the per-replica hydration status of
   indexes, materialized views, or subscriptions, which is useful to track when
   objects are "caught up" in the context of [blue/green deployments](/manage/blue-green).

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -248,13 +248,13 @@ SQL objects that don't exist in the compute layer (such as views) are omitted.
 | `object_id`     | [`text`] | The ID of a compute object. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), or [`mz_internal.mz_subscriptions`](#mz_subscriptions).                                                           |
 | `dependency_id` | [`text`] | The ID of a compute dependency. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables). |
 
-### `mz_compute_hydration_status`
+### `mz_compute_hydration_statuses`
 
-The `mz_compute_hydration_status` table describes the per-replica hydration status of each compute object (index, materialized view, or subscription).
+The `mz_compute_hydration_statuses` table describes the per-replica hydration status of each compute object (index, materialized view, or subscription).
 
 A compute object is hydrated on a given replica when it has fully processed the initial snapshot of data available in its inputs.
 
-<!-- RELATION_SPEC mz_internal.mz_compute_hydration_status -->
+<!-- RELATION_SPEC mz_internal.mz_compute_hydration_statuses -->
 | Field        | Type        | Meaning                                                                                                                                                                                                                                  |
 | -----------  | ----------- | --------                                                                                                                                                                                                                                 |
 | `object_id`  | [`text`]    | The ID of a compute object. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), or [`mz_internal.mz_subscriptions`](#mz_subscriptions). |

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -1924,8 +1924,8 @@ pub static MZ_COMPUTE_DEPENDENCIES: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSo
     is_retained_metrics_object: false,
     sensitivity: DataSensitivity::Public,
 });
-pub static MZ_COMPUTE_HYDRATION_STATUS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
-    name: "mz_compute_hydration_status",
+pub static MZ_COMPUTE_HYDRATION_STATUSES: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
+    name: "mz_compute_hydration_statuses",
     schema: MZ_INTERNAL_SCHEMA,
     data_source: Some(IntrospectionType::ComputeHydrationStatus),
     desc: RelationDesc::empty()
@@ -6359,7 +6359,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Source(&MZ_FRONTIERS),
         Builtin::View(&MZ_GLOBAL_FRONTIERS),
         Builtin::Source(&MZ_COMPUTE_DEPENDENCIES),
-        Builtin::Source(&MZ_COMPUTE_HYDRATION_STATUS),
+        Builtin::Source(&MZ_COMPUTE_HYDRATION_STATUSES),
         Builtin::View(&MZ_MATERIALIZATION_LAG),
         Builtin::View(&MZ_COMPUTE_ERROR_COUNTS_PER_WORKER),
         Builtin::View(&MZ_COMPUTE_ERROR_COUNTS),

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -144,7 +144,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 2  dependency_id  text
 
 query ITT
-SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_compute_hydration_status' ORDER BY position
+SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_compute_hydration_statuses' ORDER BY position
 ----
 1  object_id  text
 2  replica_id  text
@@ -694,7 +694,7 @@ mz_compute_exports
 mz_compute_exports_per_worker
 mz_compute_frontiers
 mz_compute_frontiers_per_worker
-mz_compute_hydration_status
+mz_compute_hydration_statuses
 mz_compute_import_frontiers
 mz_compute_import_frontiers_per_worker
 mz_compute_operator_durations_histogram

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -405,7 +405,7 @@ mz_compute_frontiers_per_worker
 SOURCE
 materialize
 mz_internal
-mz_compute_hydration_status
+mz_compute_hydration_statuses
 SOURCE
 materialize
 mz_internal

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -544,7 +544,7 @@ mz_compute_dependencies                      source <null>  <null>
 mz_compute_error_counts_raw                  log   <null>   <null>
 mz_compute_exports_per_worker                log   <null>   <null>
 mz_compute_frontiers_per_worker              log   <null>   <null>
-mz_compute_hydration_status                  source <null>  <null>
+mz_compute_hydration_statuses                source <null>  <null>
 mz_compute_import_frontiers_per_worker       log   <null>   <null>
 mz_compute_operator_durations_histogram_raw  log   <null>   <null>
 mz_dataflow_addresses_per_worker             log   <null>   <null>

--- a/test/testdrive/compute-hydration-status.td
+++ b/test/testdrive/compute-hydration-status.td
@@ -8,16 +8,16 @@
 # by the Apache License, Version 2.0.
 
 # Test reporting of compute dataflow hydration status through
-# `mz_internal.mz_compute_hydration_status`.
+# `mz_internal.mz_compute_hydration_statuses`.
 #
 # Note that all of the below tests only assert that the `hydrated` flag
 # eventually becomes `true`, not that it starts off as `false`. That's because
 # we have no control about the hydration timing of dataflows or the update
-# cadence of `mz_compute_hydration_status`, so we have no reliable way of
+# cadence of `mz_compute_hydration_statuses`, so we have no reliable way of
 # ensuring that a query arrives before a dataflow has hydrated.
 #
 # These tests rely on testdrive's retry feature, as the
-# `mz_compute_hydration_status` table is asynchronously updates, so DDL
+# `mz_compute_hydration_statuses` table is asynchronously updates, so DDL
 # commands are not immediately reflected there.
 
 > CREATE CLUSTER test REPLICAS (hydrated_test_1 (SIZE '1'))
@@ -25,7 +25,7 @@
 
 # Test that on an empty cluster only the introspection dataflows show up.
 > SELECT DISTINCT left(h.object_id, 1), h.hydrated
-  FROM mz_internal.mz_compute_hydration_status h
+  FROM mz_internal.mz_compute_hydration_statuses h
   JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   WHERE r.name LIKE 'hydrated_test%';
 s true
@@ -37,7 +37,7 @@ s true
 > CREATE MATERIALIZED VIEW mv AS SELECT * FROM t
 
 > SELECT o.name, r.name, h.hydrated
-  FROM mz_internal.mz_compute_hydration_status h
+  FROM mz_internal.mz_compute_hydration_statuses h
   JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
@@ -51,7 +51,7 @@ mv  hydrated_test_1 true
 > CREATE CLUSTER REPLICA test.hydrated_test_2 SIZE '1'
 
 > SELECT o.name, r.name, h.hydrated
-  FROM mz_internal.mz_compute_hydration_status h
+  FROM mz_internal.mz_compute_hydration_statuses h
   JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
@@ -67,7 +67,7 @@ mv  hydrated_test_2 true
 > DROP CLUSTER REPLICA test.hydrated_test_1
 
 > SELECT o.name, r.name, h.hydrated
-  FROM mz_internal.mz_compute_hydration_status h
+  FROM mz_internal.mz_compute_hydration_statuses h
   JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
@@ -79,7 +79,7 @@ mv  hydrated_test_2 true
 > DROP CLUSTER REPLICA test.hydrated_test_2
 
 > SELECT o.name, r.name, h.hydrated
-  FROM mz_internal.mz_compute_hydration_status h
+  FROM mz_internal.mz_compute_hydration_statuses h
   JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
@@ -91,7 +91,7 @@ mv  hydrated_test_2 true
 > CREATE CLUSTER REPLICA test.hydrated_test_3 SIZE '1'
 
 > SELECT o.name, r.name, h.hydrated
-  FROM mz_internal.mz_compute_hydration_status h
+  FROM mz_internal.mz_compute_hydration_statuses h
   JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
@@ -103,7 +103,7 @@ mv  hydrated_test_3 true
 > DROP MATERIALIZED VIEW mv;
 
 > SELECT o.name, r.name, h.hydrated
-  FROM mz_internal.mz_compute_hydration_status h
+  FROM mz_internal.mz_compute_hydration_statuses h
   JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
@@ -114,7 +114,7 @@ idx hydrated_test_3 true
 > DROP INDEX idx;
 
 > SELECT o.name, r.name, h.hydrated
-  FROM mz_internal.mz_compute_hydration_status h
+  FROM mz_internal.mz_compute_hydration_statuses h
   JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   JOIN mz_objects o ON (o.id = h.object_id)
   WHERE


### PR DESCRIPTION
In line with other `_statuses` relations we already have in the system catalog, this one should be called `mz_compute_hydration_statuses`, not `mz_compute_hydration_status`.

### Motivation

  * This PR fixes a previously unreported bug.

The name `mz_compute_hydration_status` is inconsistent with other status relations, like `mz_cluster_replica_statuses`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Rename the system table `mz_internal.mz_cluster_replica_status` to `mz_internal.mz_cluster_replica_statuses`.