### PR TITLE
scalability framework: close plots after saving them

### DIFF
--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -342,6 +342,7 @@ def create_plots(result: BenchmarkResult, baseline_endpoint: Endpoint | None) ->
             include_workload_in_title=True,
         )
         plt.savefig(paths.plot_png("tps", workload_name), bbox_inches="tight", dpi=300)
+        plt.close()
 
     for (
         workload_name,
@@ -361,6 +362,7 @@ def create_plots(result: BenchmarkResult, baseline_endpoint: Endpoint | None) ->
             bbox_inches="tight",
             dpi=300,
         )
+        plt.close()
 
         fig = plt.figure(layout="constrained", figsize=(16, 10))
         (subfigure) = fig.subfigures(1, 1)
@@ -376,6 +378,7 @@ def create_plots(result: BenchmarkResult, baseline_endpoint: Endpoint | None) ->
             bbox_inches="tight",
             dpi=300,
         )
+        plt.close()
 
 
 def upload_regressions_to_buildkite(outcome: ComparisonOutcome) -> None:


### PR DESCRIPTION
This should address

```
/var/lib/buildkite-agent/builds/buildkite-large-1005962-i-0fa0dc810f218773d-1/materialize/nightlies/test/scalability/mzcompose.py:360: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`). Consider using `matplotlib.pyplot.close()`.
```

seen in https://buildkite.com/materialize/nightlies/builds/5618#018c6cb3-07a9-4341-9c63-076c4e012def.