### PR TITLE
storage: report hydration time for all source types

### DIFF
--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -12,7 +12,6 @@ use std::cmp::Reverse;
 use std::convert::AsRef;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
-use std::time::Instant;
 
 use differential_dataflow::consolidation;
 use differential_dataflow::hashable::Hashable;
@@ -396,8 +395,6 @@ where
         Exchange::new(move |((key, _, _), _, _)| UpsertKey::hashed(key)),
     );
 
-    let rehydration_started = Instant::now();
-
     // We only care about UpsertValueError since this is the only error that we can retract
     let previous = previous.flat_map(move |result| {
         let value = match result {
@@ -418,7 +415,6 @@ where
     let (mut health_output, health_stream) = builder.new_output();
 
     let upsert_shared_metrics = Arc::clone(&upsert_metrics.shared);
-    let source_metrics = source_config.source_statistics.clone();
     let shutdown_button = builder.build(move |caps| async move {
         let [mut output_cap, health_cap]: [_; 2] = caps.try_into().unwrap();
 
@@ -566,14 +562,6 @@ where
             output_handle.give(&output_cap, (retraction, time.clone(), -diff)).await;
             output_handle.give(&output_cap, (insertion, time, diff)).await;
         }
-
-        tracing::info!(
-            "timely-{} upsert source {} finished rehydration",
-            source_config.worker_id,
-            source_config.id
-        );
-        source_metrics
-                .set_rehydration_latency_ms(rehydration_started.elapsed().as_millis().try_into().expect("Rehydration took more than ~584 million years!"));
 
         // A re-usable buffer of changes, per key. This is an `IndexMap` because it has to be `drain`-able
         // and have a consistent iteration order.

--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -76,10 +76,9 @@ mammalmore    moose   2
 
 # NOTE: These queries are slow to succeed because the default metrics scraping
 # interval is 30 seconds.
-# rehydration_latency should be null for non-UPSERT sources
 > SELECT s.name,
   bool_and(u.snapshot_committed),
-  SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NULL)
+  SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('metrics_test_source')
@@ -94,7 +93,7 @@ metrics_test_source true 2 2 2 true true
 # jitter on when metrics are produced for each sub-source.
 > SELECT s.name,
   bool_and(u.snapshot_committed),
-  SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NULL)
+  SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('accounts', 'auction_house', 'auctions', 'bids', 'organizations', 'users')


### PR DESCRIPTION
This PR makes all sources report a "rehydration latency", instead of just having upsert sources do so. The approach taken is agnostic to source implementation details and instead just looks at frontier advancements: Once a source advances its output frontier beyond the resumption upper, it is considered hydrated. This is the same definition we use for compute dataflow hydration, which makes things nicely consistent.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
