### PR TITLE
gate new cc cluster sizings behind feature flag

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5511,7 +5511,7 @@ fn ensure_cluster_size_allowed(scx: &StatementContext, size: &str) -> Result<(),
     // cluster size names. This feature flag can be removed upon
     // completion of https://github.com/MaterializeInc/cloud/issues/5343
     // and https://github.com/MaterializeInc/cloud/issues/7013
-    if size.ends_with("cc") || size.ends_with("C") {
+    if size.ends_with("cc") || size.ends_with('C') {
         scx.require_feature_flag(&vars::ENABLE_CC_CLUSTER_SIZES)
     } else {
         Ok(())

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2172,6 +2172,13 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_cc_cluster_sizes,
+        desc: "use of 'cc' cluster sizes",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
 );
 
 /// Represents the input to a variable.

--- a/test/testdrive/cc_cluster_sizes.td
+++ b/test/testdrive/cc_cluster_sizes.td
@@ -1,0 +1,52 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_cc_cluster_sizes = false
+
+# Clean up cluster manually, since testdrive does not automatically clean up
+# clusters.
+> DROP CLUSTER IF EXISTS c;
+
+# Cannot create clusters with cc cluster size naming schemes
+! CREATE CLUSTER c SIZE '1cc';
+contains:use of 'cc' cluster sizes is not supported
+
+! CREATE CLUSTER c SIZE '512C';
+contains:use of 'cc' cluster sizes is not supported
+
+# Nor can we create an unmanaged replica directly
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+
+! CREATE CLUSTER c REPLICAS (r1 (SIZE '1cc'))
+contains:use of 'cc' cluster sizes is not supported
+
+# The existing cluster names are fine
+> CREATE CLUSTER c SIZE '1';
+
+# But ensure we cannot ALTER our way to a cc name either
+! ALTER CLUSTER c SET (SIZE '1cc');
+contains:use of 'cc' cluster sizes is not supported
+
+> DROP CLUSTER IF EXISTS c;
+
+# Now flip the flag and test that we can create clusters
+# with this naming scheme. Note that here the commands
+# still fail (haven't hooked up any of these size names
+# for testing), but crucially the error isn't due to the
+# feature flag gating
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_cc_cluster_sizes = true
+
+! CREATE CLUSTER c SIZE '1cc';
+contains:unknown cluster replica size 1cc
+
+! CREATE CLUSTER c SIZE '1C';
+contains:unknown cluster replica size 1C


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

As we work towards the revamped cluster sizes, we'll want to gate access to the new sizings behind a feature flag. Most importantly, we need to make sure that the rollout to existing customers tracks with the Finance team's work.

This PR adds a very quick feature flag `enable_cc_cluster_sizes` that, if enabled, gives access to the cluster sizes outlined in https://github.com/MaterializeInc/cloud/pull/7728

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
