### PR TITLE
[DNM] adapter: move `CREATE MATERIALIZED VIEW` optimization off the main thread

### DIFF
--- a/misc/python/materialize/issue_accounts_29.py
+++ b/misc/python/materialize/issue_accounts_29.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# pyactivate — runs a script in the Materialize Python virtualenv.
+
+import sys
+from textwrap import dedent
+
+SCHEMA = "accounts_29"
+
+
+def init_schema(num_cols: int) -> str:
+    return dedent(
+        f"""
+        DROP SCHEMA IF EXISTS {SCHEMA} CASCADE;
+        CREATE SCHEMA {SCHEMA};
+        SET SCHEMA = {SCHEMA};
+
+        CREATE TABLE t1({", ".join((f"f{i:03} int" for i in range(num_cols)))}, read_time int not null);
+        """
+    ).lstrip("\n")
+
+
+def init_view_def(num_exprs: int) -> str:
+    expressions = ",\n            ".join(
+        (
+            f"COALESCE(f{i:03}, lag(f{i:03}, 1) IGNORE NULLS OVER (ORDER BY read_time)) AS f{i:03}_filled"
+            for i in range(num_exprs)
+        )
+    )
+
+    return dedent(
+        f"""
+        CREATE OR REPLACE MATERIALIZED VIEW materialize.{SCHEMA}.test_view AS
+        SELECT
+            {expressions}
+        FROM 
+            materialize.{SCHEMA}.t1;
+        """
+    ).lstrip("\n")
+
+
+def main(args: list[str]) -> int:
+    if len(args) != 2:
+        print("USAGE: <prog> [schema|query] n", file=sys.stderr)
+        return 1
+
+    if str(args[0]) == "schema":
+        print(init_schema(int(args[1])))
+        return 0
+    elif str(args[0]) == "query":
+        print(init_view_def(int(args[1])))
+        return 0
+    else:
+        print("USAGE: <prog> [schema|query] n", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
This should protect the `environmentd` process of getting wedged due to pathological behavior like the one observed in #23970.

### Motivation

  * This PR adds a known-desirable feature.

Shrinks the blast radius of #23970 to the enclosing session. Part of #16217.

### Tips for reviewer

Opening this for discussion only for now, as the current attempt doesn't seem to work as expected. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
