### PR TITLE
tests: handle accepted regressions in release builds

### DIFF
--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -13,6 +13,8 @@ import subprocess
 from materialize.mz_version import MzVersion
 
 EXISTENCE_OF_IMAGE_NAMES_FROM_EARLIER_CHECK: dict[str, bool] = dict()
+IMAGE_TAG_OF_VERSION_PREFIX = "v"
+IMAGE_TAG_OF_COMMIT_PREFIX = "devel-"
 
 
 def image_of_release_version_exists(version: MzVersion) -> bool:
@@ -58,8 +60,31 @@ def mz_image_tag_exists(image_tag: str) -> bool:
 
 
 def commit_to_image_tag(commit_hash: str) -> str:
-    return f"devel-{commit_hash}"
+    return f"{IMAGE_TAG_OF_COMMIT_PREFIX}{commit_hash}"
 
 
 def version_to_image_tag(version: MzVersion) -> str:
     return str(version)
+
+
+def is_image_tag_of_version(image_tag: str) -> bool:
+    return image_tag.startswith(IMAGE_TAG_OF_VERSION_PREFIX)
+
+
+def is_image_tag_of_commit(image_tag: str) -> bool:
+    return image_tag.startswith(IMAGE_TAG_OF_COMMIT_PREFIX)
+
+
+def get_version_from_image_tag(image_tag: str) -> str:
+    assert image_tag.startswith(IMAGE_TAG_OF_VERSION_PREFIX)
+    # image tag is equal to the version
+    return image_tag
+
+
+def get_mz_version_from_image_tag(image_tag: str) -> MzVersion:
+    return MzVersion.parse_mz(get_version_from_image_tag(image_tag))
+
+
+def get_commit_from_image_tag(image_tag: str) -> str:
+    assert image_tag.startswith(IMAGE_TAG_OF_COMMIT_PREFIX)
+    return image_tag.removeprefix(IMAGE_TAG_OF_COMMIT_PREFIX)

--- a/misc/python/materialize/scalability/comparison_outcome.py
+++ b/misc/python/materialize/scalability/comparison_outcome.py
@@ -14,6 +14,7 @@ from materialize.scalability.df.df_totals import (
     DfTotalsExtended,
     concat_df_totals_extended,
 )
+from materialize.scalability.endpoint import Endpoint
 from materialize.scalability.scalability_change import (
     Regression,
     ScalabilityChange,
@@ -29,6 +30,7 @@ class ComparisonOutcome:
         self.significant_improvements: list[ScalabilityImprovement] = []
         self.regression_df = DfTotalsExtended()
         self.significant_improvement_df = DfTotalsExtended()
+        self.endpoints_with_regressions: set[Endpoint] = set()
 
     def has_regressions(self) -> bool:
         assert len(self.regressions) == self.regression_df.length()
@@ -81,6 +83,9 @@ class ComparisonOutcome:
         self.significant_improvements.extend(significant_improvements)
         self._append_regression_df(regression_df)
         self._append_significant_improvement_df(significant_improvement_df)
+
+        for regression in regressions:
+            self.endpoints_with_regressions.add(regression.endpoint)
 
     def _append_regression_df(self, regressions_data: DfTotalsExtended) -> None:
         self.regression_df = concat_df_totals_extended(

--- a/misc/python/materialize/scalability/comparison_outcome.py
+++ b/misc/python/materialize/scalability/comparison_outcome.py
@@ -41,6 +41,9 @@ class ComparisonOutcome:
         )
         return len(self.significant_improvements) > 0
 
+    def has_scalability_changes(self) -> bool:
+        return self.has_regressions() or self.has_significant_improvements()
+
     def __str__(self) -> str:
         return f"{len(self.regressions)} regressions, {len(self.significant_improvements)} significant improvements"
 
@@ -60,17 +63,31 @@ class ComparisonOutcome:
         return "\n".join(f"* {x}" for x in entries)
 
     def merge(self, other: ComparisonOutcome) -> None:
-        self.regressions.extend(other.regressions)
-        self.significant_improvements.extend(other.significant_improvements)
-        self.append_regression_df(other.regression_df)
-        self.append_significant_improvement_df(other.significant_improvement_df)
+        self.append_regressions(
+            other.regressions,
+            other.significant_improvements,
+            other.regression_df,
+            other.significant_improvement_df,
+        )
 
-    def append_regression_df(self, regressions_data: DfTotalsExtended) -> None:
+    def append_regressions(
+        self,
+        regressions: list[Regression],
+        significant_improvements: list[ScalabilityImprovement],
+        regression_df: DfTotalsExtended,
+        significant_improvement_df: DfTotalsExtended,
+    ) -> None:
+        self.regressions.extend(regressions)
+        self.significant_improvements.extend(significant_improvements)
+        self._append_regression_df(regression_df)
+        self._append_significant_improvement_df(significant_improvement_df)
+
+    def _append_regression_df(self, regressions_data: DfTotalsExtended) -> None:
         self.regression_df = concat_df_totals_extended(
             [self.regression_df, regressions_data]
         )
 
-    def append_significant_improvement_df(
+    def _append_significant_improvement_df(
         self, significant_improvements_data: DfTotalsExtended
     ) -> None:
         self.significant_improvement_df = concat_df_totals_extended(

--- a/misc/python/materialize/scalability/endpoint.py
+++ b/misc/python/materialize/scalability/endpoint.py
@@ -16,6 +16,9 @@ class Endpoint:
 
     _version: str | None = None
 
+    def __init__(self, specified_target: str):
+        self._specified_target = specified_target
+
     def sql_connection(self) -> psycopg.connection.Connection[tuple[Any, ...]]:
         conn = psycopg.connect(self.url())
         conn.autocommit = True
@@ -25,6 +28,12 @@ class Endpoint:
         return (
             f"postgresql://{self.user()}:{self.password()}@{self.host()}:{self.port()}"
         )
+
+    def specified_target(self) -> str:
+        return self._specified_target
+
+    def resolved_target(self) -> str:
+        return self.specified_target()
 
     def host(self) -> str:
         raise NotImplementedError

--- a/misc/python/materialize/scalability/regression_assessment.py
+++ b/misc/python/materialize/scalability/regression_assessment.py
@@ -1,0 +1,101 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from __future__ import annotations
+
+from materialize.docker import (
+    get_mz_version_from_image_tag,
+    is_image_tag_of_version,
+)
+from materialize.mz_version import MzVersion
+from materialize.scalability.comparison_outcome import ComparisonOutcome
+from materialize.scalability.endpoint import Endpoint
+from materialize.version_list import (
+    ANCESTOR_OVERRIDES_FOR_SCALABILITY_REGRESSIONS,
+    get_commits_of_accepted_regressions_between_versions,
+)
+
+
+class RegressionAssessment:
+    def __init__(
+        self,
+        baseline_endpoint: Endpoint | None,
+        comparison_outcome: ComparisonOutcome,
+    ):
+        self.baseline_endpoint = baseline_endpoint
+        self.comparison_outcome = comparison_outcome
+        self.endpoints_with_regressions_and_justifications: dict[
+            Endpoint, str | None
+        ] = {}
+        self.check_targets()
+        assert len(comparison_outcome.endpoints_with_regressions) == len(
+            self.endpoints_with_regressions_and_justifications
+        )
+
+    def has_comparison_target(self) -> bool:
+        return self.baseline_endpoint is not None
+
+    def has_regressions(self) -> bool:
+        return self.comparison_outcome.has_regressions()
+
+    def has_unjustified_regressions(self):
+        return any(
+            justification is None
+            for justification in self.endpoints_with_regressions_and_justifications.values()
+        )
+
+    def check_targets(self) -> None:
+        if self.baseline_endpoint is None:
+            return
+
+        if not self.comparison_outcome.has_regressions():
+            return
+
+        if not self._endpoint_references_release_version(self.baseline_endpoint):
+            # justified regressions require a version as comparison target
+            self._mark_all_targets_with_regressions_as_unjustified()
+            return
+
+        baseline_version = get_mz_version_from_image_tag(
+            self.baseline_endpoint.resolved_target()
+        )
+
+        for endpoint in self.comparison_outcome.endpoints_with_regressions:
+            if not self._endpoint_references_release_version(endpoint):
+                continue
+
+            endpoint_version = get_mz_version_from_image_tag(endpoint.resolved_target())
+
+            if baseline_version >= endpoint_version:
+                # not supported, should not be a relevant case
+                continue
+
+            commits_with_accepted_regressions = (
+                get_commits_of_accepted_regressions_between_versions(
+                    ANCESTOR_OVERRIDES_FOR_SCALABILITY_REGRESSIONS,
+                    since_version_exclusive=baseline_version,
+                    to_version_inclusive=endpoint_version,
+                )
+            )
+
+            if len(commits_with_accepted_regressions) > 0:
+                self.endpoints_with_regressions_and_justifications[
+                    endpoint
+                ] = ", ".join(commits_with_accepted_regressions)
+            else:
+                self.endpoints_with_regressions_and_justifications[endpoint] = None
+
+    def _mark_all_targets_with_regressions_as_unjustified(self) -> None:
+        for endpoint in self.comparison_outcome.endpoints_with_regressions:
+            self.endpoints_with_regressions_and_justifications[endpoint] = None
+
+    def _endpoint_references_release_version(self, endpoint: Endpoint) -> bool:
+        target = endpoint.resolved_target()
+        return is_image_tag_of_version(target) and MzVersion.is_valid_version_string(
+            target
+        )

--- a/misc/python/materialize/scalability/result_analyzers.py
+++ b/misc/python/materialize/scalability/result_analyzers.py
@@ -60,10 +60,10 @@ class DefaultResultAnalyzer(ResultAnalyzer):
             workload_name,
             other_endpoint,
         )
-        comparison_outcome.regressions.extend(regressions)
-        comparison_outcome.significant_improvements.extend(improvements)
-        comparison_outcome.append_regression_df(entries_worse_than_threshold)
-        comparison_outcome.append_significant_improvement_df(
-            entries_better_than_threshold
+        comparison_outcome.append_regressions(
+            regressions,
+            improvements,
+            entries_worse_than_threshold,
+            entries_better_than_threshold,
         )
         return comparison_outcome

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -391,6 +391,35 @@ def is_valid_release_image(version: MzVersion) -> bool:
     return docker.image_of_release_version_exists(version)
 
 
+def get_commits_of_accepted_regressions_between_versions(
+    ancestor_overrides: dict[str, MzVersion],
+    since_version_exclusive: MzVersion,
+    to_version_inclusive: MzVersion,
+) -> list[str]:
+    """
+    Get commits of accepted regressions between both versions.
+    :param ancestor_overrides: one of #ANCESTOR_OVERRIDES_FOR_PERFORMANCE_REGRESSIONS, #ANCESTOR_OVERRIDES_FOR_SCALABILITY_REGRESSIONS, #ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS
+    :return: commits
+    """
+
+    assert since_version_exclusive <= to_version_inclusive
+
+    commits = []
+
+    for (
+        regression_introducing_commit,
+        first_version_with_regression,
+    ) in ancestor_overrides.items():
+        if (
+            since_version_exclusive
+            < first_version_with_regression
+            <= to_version_inclusive
+        ):
+            commits.append(regression_introducing_commit)
+
+    return commits
+
+
 class VersionsFromDocs:
     """Materialize versions as listed in doc/user/content/versions
 

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -302,7 +302,7 @@ def report_regression_result(
 
     baseline_desc = endpoint_name_to_description(baseline_endpoint.try_load_version())
 
-    if outcome.has_regressions() or outcome.has_significant_improvements():
+    if outcome.has_scalability_changes():
         print(
             f"{'ERROR' if outcome.has_regressions() else 'INFO'}: "
             f"The following scalability changes were detected "


### PR DESCRIPTION
A known performance and scalability regression was introduced in v0.80.0. While regular nightly builds did not fail because because the regressions were marked as accepted, this was not the case for the [release build.](https://buildkite.com/materialize/nightlies/builds/5618)
This PR considers known regressions when running nightly builds for releases, which are based on versions.

### Commits
cfce28b693 docker: add utility methods to classify image tag
6ceb50c411 tests: identify accepted regressions between two versions
89cafdb461 scalability framework: refactorings: extract methods
244a70a59c scalability framework: store resolved target of endpoints
bf2fa67269 scalability framework: collect endpoints with regressions
1d8b4c505d scalability framework: print assessment, do not fail on justified regressions
c2f222ccc9 feature benchmark: refactoring: variable usages
4cbfcd7df2 feature benchmark: print assessment, do not fail on justified regressions

### Status
<s>Draft, need to go over the code myself again.</s> ✅ 
Please pay special attention to c2f222ccc9, which seems risky.

### Nightlies
* Nightly of this branch + [fixed version for ancestor and current:](https://github.com/MaterializeInc/materialize/commit/55da0c0061afa0c7b4094218565c17390ed7df65) [builds](https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Atests%2Fhandle-accepted-regressions-in-release-builds)