### PR TITLE
docs: fix parsing of segment data

### DIFF
--- a/doc/user/content/ingest-data/segment.md
+++ b/doc/user/content/ingest-data/segment.md
@@ -137,7 +137,7 @@ CREATE VIEW parse_segment AS SELECT
     try_parse_monotonic_iso8601_timestamp(body->>'timestamp') AS timestamp,
     body->>'type' AS type,
     body->>'userId' AS user_id,
-    try_parse_monotonic_iso8601_timestamp(body->>'version') AS version
+    body->>'version' AS version
 FROM my_segment_source;
 ```
 {{< /tab >}}
@@ -195,7 +195,7 @@ CREATE VIEW parse_segment AS SELECT
     body->'traits'->'address'->>'country' AS traits_address_country,
     body->>'type' AS type,
     body->>'userId' AS user_id,
-    (body->>'version') AS version
+    body->>'version' AS version
 FROM my_segment_source;
 ```
 {{< /tab >}}


### PR DESCRIPTION
### Motivation

Version is not a timestamp. It can only be reliably parsed as a string. 


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
