### PR TITLE
Use column name instead of index in `ASSERT NOT NULL`

### DIFF
--- a/misc/python/materialize/checks/all_checks/materialized_views.py
+++ b/misc/python/materialize/checks/all_checks/materialized_views.py
@@ -105,31 +105,31 @@ class MaterializedViewsAssertNotNull(Check):
             dedent(
                 """
                 ! SELECT * FROM not_null_view1
-                contains: column 1 must not be null
+                contains: column "x" must not be null
 
                 ! SELECT * FROM not_null_view2
-                contains: column 2 must not be null
+                contains: column "y" must not be null
 
                 ! SELECT * FROM not_null_view3
-                contains: column 3 must not be null
+                contains: column "z" must not be null
 
                 ! SELECT * FROM not_null_view1 WHERE x IS NOT NULL
-                contains: column 1 must not be null
+                contains: column "x" must not be null
 
                 ! SELECT * FROM not_null_view2 WHERE y IS NOT NULL
-                contains: column 2 must not be null
+                contains: column "y" must not be null
 
                 ! SELECT * FROM not_null_view3 WHERE z IS NOT NULL
-                contains: column 3 must not be null
+                contains: column "z" must not be null
 
                 ! SELECT y FROM not_null_view1
-                contains: column 1 must not be null
+                contains: column "x" must not be null
 
                 ! SELECT z FROM not_null_view2
-                contains: column 2 must not be null
+                contains: column "y" must not be null
 
                 ! SELECT x FROM not_null_view3
-                contains: column 3 must not be null
+                contains: column "z" must not be null
 
                 > DELETE FROM not_null_table WHERE x IS NULL;
 
@@ -171,13 +171,13 @@ class MaterializedViewsAssertNotNull(Check):
                 > INSERT INTO not_null_table VALUES (NULL, 22, 23), (24, NULL, 26), (27, 28, NULL);
 
                 ! SELECT * FROM not_null_view1
-                contains: column 1 must not be null
+                contains: column "x" must not be null
 
                 ! SELECT * FROM not_null_view2
-                contains: column 2 must not be null
+                contains: column "y" must not be null
 
                 ! SELECT * FROM not_null_view3
-                contains: column 3 must not be null
+                contains: column "z" must not be null
            """
             )
         )

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -602,19 +602,19 @@ NULL 2 3
 statement ok
 CREATE MATERIALIZED VIEW mv_assertion_at_begin WITH (ASSERT NOT NULL x) AS SELECT * FROM t2;
 
-statement error column 1 must not be null
+statement error column "x" must not be null
 SELECT * FROM mv_assertion_at_begin;
 
 statement ok
 CREATE MATERIALIZED VIEW mv_assertion_at_end WITH (ASSERT NOT NULL z) AS SELECT * FROM t2;
 
-statement error column 3 must not be null
+statement error column "z" must not be null
 SELECT * FROM mv_assertion_at_end;
 
 statement ok
 CREATE MATERIALIZED VIEW mv_two_assertions WITH (ASSERT NOT NULL x, ASSERT NOT NULL z) AS SELECT * FROM t2;
 
-statement error column 1 must not be null
+statement error column "x" must not be null
 SELECT * FROM mv_two_assertions;
 
 statement ok
@@ -632,7 +632,7 @@ CREATE MATERIALIZED VIEW mv_bad_assertion_on_renamed_column (a, b, c) WITH (ASSE
 statement ok
 CREATE MATERIALIZED VIEW mv_good_assertion_on_renamed_column (a, b, c) WITH (ASSERT NOT NULL b) AS SELECT * FROM t2;
 
-statement error column 2 must not be null
+statement error column "b" must not be null
 SELECT * FROM mv_good_assertion_on_renamed_column;
 
 statement ok


### PR DESCRIPTION


### Motivation

Fixes #22840


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improve error message when `ASSERT NOT NULL` condition is violated