### PR TITLE
persist-txn: Make apply idempotent on closed shard

### DIFF
--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -480,7 +480,7 @@ pub(crate) async fn empty_caa<S, F, K, V, T, D>(
     let name = name();
     let empty: &[((&K, &V), &T, D)] = &[];
     let Some(mut upper) = txns_or_data_write.shared_upper().into_option() else {
-        // Shard is closed.
+        // Shard is closed, which means the upper must be past init_ts.
         return;
     };
     loop {
@@ -526,7 +526,7 @@ async fn apply_caa<K, V, T, D>(
     let batch = ProtoBatch::decode(batch_raw).expect("valid batch");
     let mut batch = data_write.batch_from_transmittable_batch(batch);
     let Some(mut upper) = data_write.shared_upper().into_option() else {
-        // Shard is closed.
+        // Shard is closed, which means the upper must be past init_ts.
         // Mark the batch as consumed, so we don't get warnings in the logs.
         batch.into_hollow_batch();
         return;


### PR DESCRIPTION
Applying a transaction is meant to be idempotent, i.e. applying a
transaction multiple times should succeed and not affect the
correctness of the system. Previously, if someone tried to apply a
transaction on a data shard after closing that data shard, then the
system would panic. This commit fixes the described issue by returning
successfully from application on a closed shard.

We know that if a data shard is closed, then all transactions must have
already been applied, so it's safe to return immediately.

Fixes #23964

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
