### PR TITLE
buf: Fix running against older main state

### DIFF
--- a/ci/test/lint-main/checks/check-protobuf.sh
+++ b/ci/test/lint-main/checks/check-protobuf.sh
@@ -56,7 +56,8 @@ if [[ $IN_BUILDKITE_PR || $IN_LOCAL_NON_MAIN_BRANCH ]]; then
 
   ci_collapsed_heading "Lint protobuf"
   COMMON_ANCESTOR="$(get_common_ancestor_commit_of_pr_and_target)"
-  try buf breaking src --against ".git#ref=$COMMON_ANCESTOR,subdir=src" --verbose
+  # Default is depth 50, which can be insufficient to grab the relevant ancestor commit
+  try buf breaking src --against ".git#ref=$COMMON_ANCESTOR,subdir=src,depth=10000" --verbose
 fi
 
 try_status_report


### PR DESCRIPTION
As reported by @mgree in https://materializeinc.slack.com/archives/C01LKF361MZ/p1702922521934739

See https://buf.build/docs/reference/inputs#other-options

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
