### PR TITLE
doc/developer: refine feature lifecycle

### DIFF
--- a/doc/developer/project-lifecycle.md
+++ b/doc/developer/project-lifecycle.md
@@ -78,15 +78,19 @@ Before a project can move to Public Preview, it must:
   one external tester, with additional optional internal testers.
 - Be entirely code complete, if it wasn't already.
 - Have comprehensive tests live and running.
-- Have basic observability live and running.
-- Have basic metrics live and running.
+- Have suitable observability live and running.
+- Have suitable metrics live and running.
 - Have addressed all known stability issues.
 - Have addressed all known limitations, except those that are explicitly out of scope.
 - Support all known customer configurations, except those that are explicitly out of scope.
-- Have polished reference documentation live behind a {{< public-preview >}} flag.
-- Have a merged release note behind a {{< public-preview >}} flag.
-- Have its GitHub epic status set to "Public Preview".
-- Have its feature flag enabled in all environments by default.
+- Have polished reference documentation published with a {{< private-preview >}} notice.
+
+To move a feature to Public Preview:
+
+- Update any documentation about the feature to use the {{< public-preview >}} notice.
+- Add a release note with a {{< public-preview >}} flag.
+- Update the GitHub epic status to "Public Preview".
+- Enable the feature flag in all environments.
 
 ## Public Preview
 
@@ -106,11 +110,15 @@ Before a project can move to General Availability, it must:
 - Be used by at least two customers in production use cases.
 - Have additional documentation (like user guides) live, or
   an explicit justification for why it's not required.
-- Have a blog post describing the project, or an explicit
-  justification for why it's not required.
-- Have a merged release note that the project is in General Availability.
-- Have a merged Changelog announcement.
-- Have its GitHub epic status set to "GA" and closed.
+
+To move a project to General Availability:
+
+- Remove the {{< public-preview >}} notice from the documentation.
+- Write a blog post describing the project, or explicitly
+  justify why a blog post is not required.
+- Write a release note announcing that the project is in General Availability.
+- Write a Changelog announcement.
+- Update the GitHub epic status to "GA", then close the issue.
 
 ## General Availability
 


### PR DESCRIPTION
Split the checklists for progressing to Public Preview and General Availability into two to avoid circularity; the requirements *for* moving are different than what you need to do to facilitate the move.

Also adjust the wording of "basic {observability|metrics}" with "suitable {observability|metrics}", to admit the possibility of a feature being too small to warrant observability/metrics.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR improves processes.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
