### PR TITLE
persist-txn fix combo of persist fast path plus lazy persist-txn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3940,6 +3940,7 @@ dependencies = [
  "mz-expr",
  "mz-ore",
  "mz-persist-client",
+ "mz-persist-txn",
  "mz-persist-types",
  "mz-pid-file",
  "mz-prof",

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -26,6 +26,7 @@ mz-compute-types = { path = "../compute-types" }
 mz-expr = { path = "../expr" }
 mz-ore = { path = "../ore", features = ["async", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
+mz-persist-txn = { path = "../persist-txn" }
 mz-persist-types = { path = "../persist-types" }
 mz-pid-file = { path = "../pid-file" }
 mz-prof = { path = "../prof" }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1483,7 +1483,7 @@ where
                     .await;
                 let mut handle = self.read_handle_for_snapshot(id).await?;
                 let cursor = data_snapshot
-                    .snapshot_cursor(&mut handle)
+                    .snapshot_cursor(&mut handle, |_| true)
                     .await
                     .map_err(|_| StorageError::ReadBeforeSince(id))?;
                 SnapshotCursor {


### PR DESCRIPTION
`PersistPeek` and `StatsCursor` were not yet aware of persist-txn, so do the necessary plumbing.

No regression test because this is immediately caught by CI when using persist-txn=lazy.

Touches https://github.com/MaterializeInc/materialize/issues/22173
Touches https://github.com/MaterializeInc/materialize/issues/22801

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
