### PR TITLE
environmentd: improve http/ws errors

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -234,7 +234,14 @@ impl AdapterError {
             message: self.to_string(),
             detail: self.detail(),
             hint: self.hint(),
-            position: None,
+            position: self.position(),
+        }
+    }
+
+    pub fn position(&self) -> Option<usize> {
+        match self {
+            AdapterError::ParseError(err) => Some(err.error.pos),
+            _ => None,
         }
     }
 

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2411,7 +2411,7 @@ fn test_cancel_ws() {
     loop {
         let msg = ws.read().unwrap();
         if let Ok(msg) = msg.into_text() {
-            if msg.contains("query canceled") {
+            if msg.contains("canceling statement") {
                 break;
             }
         }
@@ -2703,7 +2703,7 @@ fn test_github_20262() {
     let mut expect = VecDeque::from([
         r#"{"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":true}}"#,
         r#"{"type":"Rows","payload":{"columns":[{"name":"mz_timestamp","type_oid":1700,"type_len":-1,"type_mod":2555908},{"name":"mz_diff","type_oid":20,"type_len":8,"type_mod":-1},{"name":"i","type_oid":23,"type_len":4,"type_mod":-1}]}}"#,
-        r#"{"type":"Error","payload":{"message":"query canceled","code":"XX000"}}"#,
+        r#"{"type":"Error","payload":{"message":"canceling statement due to user request","code":"57014"}}"#,
         r#"{"type":"ReadyForQuery","payload":"I"}"#,
         r#"{"type":"CommandStarting","payload":{"has_rows":false,"is_streaming":false}}"#,
         r#"{"type":"CommandComplete","payload":"COMMIT"}"#,

--- a/src/environmentd/tests/testdata/http/ws
+++ b/src/environmentd/tests/testdata/http/ws
@@ -10,13 +10,19 @@
 ws-text
 {"query": "bad sql"}
 ----
-{"type":"Error","payload":{"message":"Expected a keyword at the beginning of a statement, found identifier \"bad\"","code":"XX000"}}
+{"type":"Error","payload":{"message":"Expected a keyword at the beginning of a statement, found identifier \"bad\"","code":"42601","position":0}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text
 {"queries": [{"query": "bad sql"}]}
 ----
-{"type":"Error","payload":{"message":"Expected a keyword at the beginning of a statement, found identifier \"bad\"","code":"XX000"}}
+{"type":"Error","payload":{"message":"Expected a keyword at the beginning of a statement, found identifier \"bad\"","code":"42601","position":0}}
+{"type":"ReadyForQuery","payload":"I"}
+
+ws-text
+{"queries": [{"query": "SELECT 1 1"}]}
+----
+{"type":"Error","payload":{"message":"Expected end of statement, found number \"1\"","code":"42601","position":9}}
 {"type":"ReadyForQuery","payload":"I"}
 
 ws-text
@@ -217,7 +223,7 @@ ws-text
 {"query": "CREATE VIEW v AS SELECT 1"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":false,"is_streaming":false}}
-{"type":"Error","payload":{"message":"current transaction is aborted, commands ignored until end of transaction block","code":"XX000"}}
+{"type":"Error","payload":{"message":"current transaction is aborted, commands ignored until end of transaction block","code":"25P02"}}
 {"type":"ReadyForQuery","payload":"E"}
 
 
@@ -225,7 +231,7 @@ ws-text
 {"query": "SELECT 2"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":false,"is_streaming":false}}
-{"type":"Error","payload":{"message":"current transaction is aborted, commands ignored until end of transaction block","code":"XX000"}}
+{"type":"Error","payload":{"message":"current transaction is aborted, commands ignored until end of transaction block","code":"25P02"}}
 {"type":"ReadyForQuery","payload":"E"}
 
 ws-text


### PR DESCRIPTION
Plumb details, hints, codes, and positions through to the http and websocket errors when present.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improve error details in HTTP and WebSockets.