### PR TITLE
sql: teach subsources about RETAIN HISTORY

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -3674,6 +3674,11 @@ async fn test_retain_history() {
                         &[],
                     )
                     .await?;
+                // Assert that subsources have retain history propagated.
+                for row in client.query(&format!("SELECT create_sql FROM mz_sources WHERE id LIKE 'u%' AND name LIKE '{name}%'"), &[]).await.unwrap(){
+                    let sql :String = row.get(0);
+                    assert_contains!(sql, "RETAIN HISTORY = FOR");
+                }
                 Ok(())
             })
             .await

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1035,18 +1035,16 @@ impl_display_t!(ReferencedSubsources);
 pub enum CreateSubsourceOptionName {
     Progress,
     References,
+    RetainHistory,
 }
 
 impl AstDisplay for CreateSubsourceOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        match self {
-            CreateSubsourceOptionName::Progress => {
-                f.write_str("PROGRESS");
-            }
-            CreateSubsourceOptionName::References => {
-                f.write_str("REFERENCES");
-            }
-        }
+        f.write_str(match self {
+            CreateSubsourceOptionName::Progress => "PROGRESS",
+            CreateSubsourceOptionName::References => "REFERENCES",
+            CreateSubsourceOptionName::RetainHistory => "RETAIN HISTORY",
+        });
     }
 }
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2844,3 +2844,10 @@ CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (SIZE '1', RETAIN HISTORY FOR '
 CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (SIZE = '1', RETAIN HISTORY = FOR '1s')
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("s")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("1"))) }, CreateSourceOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1s"))) }], referenced_subsources: None, progress_subsource: None })
+
+parse-statement
+CREATE SUBSOURCE accounts (id pg_catalog.int8 NOT NULL, UNIQUE (id)) WITH (REFERENCES = true, RETAIN HISTORY = FOR '1h')
+----
+CREATE SUBSOURCE accounts (id pg_catalog.int8 NOT NULL, UNIQUE (id)) WITH (REFERENCES = true, RETAIN HISTORY = FOR '1h')
+=>
+CreateSubsource(CreateSubsourceStatement { name: UnresolvedItemName([Ident("accounts")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("pg_catalog"), Ident("int8")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false, nulls_not_distinct: false }], if_not_exists: false, with_options: [CreateSubsourceOption { name: References, value: Some(Value(Boolean(true))) }, CreateSubsourceOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1h"))) }] })

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1295,7 +1295,8 @@ pub fn plan_create_source(
 generate_extracted_config!(
     CreateSubsourceOption,
     (Progress, bool, Default(false)),
-    (References, bool, Default(false))
+    (References, bool, Default(false)),
+    (RetainHistory, Duration)
 );
 
 pub fn plan_create_subsource(
@@ -1313,7 +1314,8 @@ pub fn plan_create_subsource(
     let CreateSubsourceOptionExtracted {
         progress,
         references,
-        ..
+        retain_history,
+        seen: _,
     } = with_options.clone().try_into()?;
 
     // This invariant is enforced during purification; we are responsible for
@@ -1430,6 +1432,13 @@ pub fn plan_create_subsource(
     let typ = RelationType::new(column_types).with_keys(keys);
     let desc = RelationDesc::new(typ, names);
 
+    let compaction_window = retain_history
+        .map(|cw| {
+            scx.require_feature_flag(&vars::ENABLE_LOGICAL_COMPACTION_WINDOW)?;
+            Ok::<_, PlanError>(cw.try_into()?)
+        })
+        .transpose()?;
+
     let source = Source {
         create_sql,
         data_source: if progress {
@@ -1440,7 +1449,7 @@ pub fn plan_create_subsource(
             unreachable!("state prohibited above")
         },
         desc,
-        compaction_window: None,
+        compaction_window,
     };
 
     Ok(Plan::CreateSource(CreateSourcePlan {


### PR DESCRIPTION
Propagate the parent source option to all subsources.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a