### PR TITLE
sql: propagate primary source logical compaction to subsources

### DIFF
--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -451,6 +451,9 @@ pub struct Source {
     pub desc: RelationDesc,
     pub timeline: Timeline,
     pub resolved_ids: ResolvedIds,
+    /// This value is ignored for subsources, i.e. for
+    /// [`DataSourceDesc::Source`]. Instead, it uses the primary sources logical
+    /// compaction window.
     pub custom_logical_compaction_window: Option<CompactionWindow>,
     /// Whether the source's logical compaction window is controlled by
     /// METRICS_RETENTION

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -83,8 +83,8 @@ pub struct IngestionDescription<S = (), C: ConnectionAccess = InlinedConnection>
     pub ingestion_metadata: S,
     /// Collections to be exported by this ingestion.
     ///
-    /// This field includes the primary source's ID, which must be filtered out
-    /// to understand which exports are data-bearing subsources.
+    /// This field includes the primary source's ID, which might need to be
+    /// filtered out to understand which exports are data-bearing subsources.
     ///
     /// Note that this does _not_ include the remap collection, which is tracked
     /// in its own field.


### PR DESCRIPTION
For PG sources, we allow setting a custom compaction window on the primary source, but it should really take effect on the subsources.

To do this, we need to set the compaction policy whenever we create the PG source or add subsources.

cc @mjibson 

### Motivation

This PR adds a known-desirable feature.

### Tips for reviewer

@mjibson I think this is a little easier to accomplish than the idea of propagating the option to the subsource statement itself. Namely, if we ever allow users to change this setting on the source, it's preferable if we just get the latest version of this value, rather than trying to maintain consistency across all of the objects.

The downside here is that for subsources, the compaction window is never read, which is goofy.

wdyt?

(Sorry not including more detail am running to catch a plane).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
