### PR TITLE
storage: report hydration time for all source types

### DIFF
--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -996,9 +996,10 @@ where
         >::new();
 
         if !active_worker {
-            // The non-active workers report that they are done snapshotting.
-            source_statistics
-                .initialize_snapshot_committed(&Antichain::<mz_repr::Timestamp>::new());
+            // The non-active workers report that they are done snapshotting and hydrating.
+            let empty_frontier = Antichain::new();
+            source_statistics.initialize_snapshot_committed(&empty_frontier);
+            source_statistics.update_rehydration_latency_ms(&empty_frontier);
             return Ok(());
         }
 
@@ -1219,6 +1220,7 @@ where
                 source_statistics
                     .inc_updates_committed_by(batch_metrics.inserts + batch_metrics.retractions);
                 source_statistics.update_snapshot_committed(&batch_upper);
+                source_statistics.update_rehydration_latency_ms(&batch_upper);
 
                 metrics.processed_batches.inc();
                 metrics.row_inserts.inc_by(batch_metrics.inserts);

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -12,7 +12,6 @@ use std::cmp::Reverse;
 use std::convert::AsRef;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
-use std::time::Instant;
 
 use differential_dataflow::consolidation;
 use differential_dataflow::hashable::Hashable;
@@ -396,8 +395,6 @@ where
         Exchange::new(move |((key, _, _), _, _)| UpsertKey::hashed(key)),
     );
 
-    let rehydration_started = Instant::now();
-
     // We only care about UpsertValueError since this is the only error that we can retract
     let previous = previous.flat_map(move |result| {
         let value = match result {
@@ -418,7 +415,6 @@ where
     let (mut health_output, health_stream) = builder.new_output();
 
     let upsert_shared_metrics = Arc::clone(&upsert_metrics.shared);
-    let source_metrics = source_config.source_statistics.clone();
     let shutdown_button = builder.build(move |caps| async move {
         let [mut output_cap, health_cap]: [_; 2] = caps.try_into().unwrap();
 
@@ -572,8 +568,6 @@ where
             source_config.worker_id,
             source_config.id
         );
-        source_metrics
-                .set_rehydration_latency_ms(rehydration_started.elapsed().as_millis().try_into().expect("Rehydration took more than ~584 million years!"));
 
         // A re-usable buffer of changes, per key. This is an `IndexMap` because it has to be `drain`-able
         // and have a consistent iteration order.

--- a/src/storage/src/render/upsert/types.rs
+++ b/src/storage/src/render/upsert/types.rs
@@ -85,7 +85,7 @@ use prometheus::core::AtomicU64;
 use crate::metrics::upsert::{UpsertMetrics, UpsertSharedMetrics};
 use crate::render::upsert::rocksdb::RocksDB;
 use crate::render::upsert::{UpsertKey, UpsertValue};
-use crate::source::SourceStatistics;
+use crate::statistics::SourceStatistics;
 
 /// The default set of `bincode` options used for consolidating
 /// upsert snapshots (and writing values to RocksDB).

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -30,7 +30,6 @@ use mz_ore::retry::{Retry, RetryResult};
 use mz_ore::task;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_ssh_util::tunnel::SshTunnelStatus;
-use mz_storage_client::client::SinkStatisticsUpdate;
 use mz_storage_client::sink::progress_key::ProgressKey;
 use mz_storage_client::sink::ProgressRecord;
 use mz_storage_types::configuration::StorageConfiguration;
@@ -58,7 +57,7 @@ use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespac
 use crate::metrics::sink::SinkMetrics;
 use crate::metrics::StorageMetrics;
 use crate::render::sinks::SinkRender;
-use crate::statistics::{SinkStatisticsMetrics, StorageStatistics};
+use crate::statistics::SinkStatistics;
 use crate::storage_state::StorageState;
 
 // 30s is a good maximum backoff for network operations. Long enough to reduce
@@ -836,7 +835,7 @@ fn kafka<G>(
     as_of: SinkAsOf,
     write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
     metrics: &StorageMetrics,
-    sink_statistics: StorageStatistics<SinkStatisticsUpdate, SinkStatisticsMetrics>,
+    sink_statistics: SinkStatistics,
     storage_configuration: &StorageConfiguration,
 ) -> (Stream<G, HealthStatusMessage>, Vec<PressOnDropButton>)
 where
@@ -898,7 +897,7 @@ fn produce_to_kafka<G>(
     shared_gate_ts: Rc<Cell<Option<Timestamp>>>,
     write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
     metrics: &StorageMetrics,
-    sink_statistics: StorageStatistics<SinkStatisticsUpdate, SinkStatisticsMetrics>,
+    sink_statistics: SinkStatistics,
     storage_configuration: StorageConfiguration,
 ) -> (Stream<G, HealthStatusMessage>, PressOnDropButton)
 where

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -38,4 +38,4 @@ pub mod testscript;
 pub mod types;
 
 pub use kafka::KafkaSourceReader;
-pub use source_reader_pipeline::{create_raw_source, RawSourceCreationConfig, SourceStatistics};
+pub use source_reader_pipeline::{create_raw_source, RawSourceCreationConfig};

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -49,7 +49,6 @@ use mz_ore::now::NowFn;
 use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
 use mz_repr::{Diff, GlobalId, RelationDesc, Row};
-use mz_storage_client::client::SourceStatisticsUpdate;
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::SourceError;
@@ -81,9 +80,7 @@ use crate::source::reclock::{ReclockBatch, ReclockError, ReclockFollower, Recloc
 use crate::source::types::{
     MaybeLength, SourceMessage, SourceOutput, SourceReaderError, SourceRender,
 };
-use crate::statistics::{SourceStatisticsMetrics, StorageStatistics};
-
-pub type SourceStatistics = StorageStatistics<SourceStatisticsUpdate, SourceStatisticsMetrics>;
+use crate::statistics::SourceStatistics;
 
 /// Shared configuration information for all source types. This is used in the
 /// `create_raw_source` functions, which produce raw sources.

--- a/src/storage/src/statistics.rs
+++ b/src/storage/src/statistics.rs
@@ -269,7 +269,13 @@ impl<Stats: Clone, Metrics> StorageStatistics<Stats, Metrics> {
     }
 }
 
-impl StorageStatistics<SourceStatisticsUpdate, SourceStatisticsMetrics> {
+/// Statistics maintained for sources.
+pub type SourceStatistics = StorageStatistics<SourceStatisticsUpdate, SourceStatisticsMetrics>;
+
+/// Statistics maintained for sinks.
+pub type SinkStatistics = StorageStatistics<SinkStatisticsUpdate, SinkStatisticsMetrics>;
+
+impl SourceStatistics {
     pub(crate) fn new(
         id: GlobalId,
         worker_id: usize,
@@ -422,7 +428,7 @@ impl StorageStatistics<SourceStatisticsUpdate, SourceStatisticsMetrics> {
     }
 }
 
-impl StorageStatistics<SinkStatisticsUpdate, SinkStatisticsMetrics> {
+impl SinkStatistics {
     pub(crate) fn new(id: GlobalId, worker_id: usize, metrics: &SinkStatisticsMetricDefs) -> Self {
         Self {
             stats: Rc::new(RefCell::new((

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -753,6 +753,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         &self.storage_state.metrics.source_statistics,
                         ingestion_id,
                         &export.storage_metadata.data_shard,
+                        ingestion_description.desc.envelope.clone(),
                         resume_uppers[export_id].clone(),
                     );
                     self.storage_state

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -753,6 +753,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         &self.storage_state.metrics.source_statistics,
                         ingestion_id,
                         &export.storage_metadata.data_shard,
+                        resume_uppers[export_id].clone(),
                     );
                     self.storage_state
                         .source_statistics

--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -76,10 +76,9 @@ mammalmore    moose   2
 
 # NOTE: These queries are slow to succeed because the default metrics scraping
 # interval is 30 seconds.
-# rehydration_latency should be null for non-UPSERT sources
 > SELECT s.name,
   bool_and(u.snapshot_committed),
-  SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NULL)
+  SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('metrics_test_source')
@@ -94,7 +93,7 @@ metrics_test_source true 2 2 2 true true
 # jitter on when metrics are produced for each sub-source.
 > SELECT s.name,
   bool_and(u.snapshot_committed),
-  SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NULL)
+  SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('accounts', 'auction_house', 'auctions', 'bids', 'organizations', 'users')


### PR DESCRIPTION
This PR makes all sources report a "rehydration latency", instead of just having upsert sources do so. The approach taken is agnostic to source implementation details and instead just looks at frontier advancements: Once a source advances its output frontier beyond the resumption upper, it is considered hydrated. This is the same definition we use for compute dataflow hydration, which makes things nicely consistent.

Additional, this PR adds an "envelope" label to the `mz_source_rehydration_latency_ms` metric, to retain the possibility to differentiate between the different envelope types in Prometheus.

### Motivation

  * This PR adds a known-desirable feature.

Part of #22166.

[Discussion in Slack.](https://materializeinc.slack.com/archives/C01CFKM1QRF/p1702901541030109)

### Tips for reviewer

Look at the commits separately!

If it seems useful, we can easily add the "envelope" label to other source metrics too.

If you have previously looked at https://github.com/MaterializeInc/materialize/pull/23978, this PR improves on that one by:

* ... not requiring a new dataflow operator.
* ... applying the `rehydration_latency` statistics updates the same way as the `snapshot_committed` ones are applied.
* ... also working for subsources.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
