### PR TITLE
git utils: do not assume that origin points to the mz repo when running locally

### DIFF
--- a/misc/buildkite/git.bash
+++ b/misc/buildkite/git.bash
@@ -16,6 +16,11 @@ set -euo pipefail
 export BUILDKITE_REPO_REF="${BUILDKITE_REPO_REF:-origin}"
 export BUILDKITE_PULL_REQUEST_BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
 
+if [[ "${BUILDKITE:-}" != "true" ]]; then
+  # when running locally, we origin may point to a fork of the repo but we want the mz repo
+  BUILDKITE_REPO_REF=$(git remote -v | grep "MaterializeInc/materialize" | grep "fetch" | head -n1 | cut -f1)
+fi
+
 configure_git_user_if_in_buildkite() {
   if [[ "${BUILDKITE:-}" == "true" ]]; then
     ci_collapsed_heading "Configure git"

--- a/misc/buildkite/git.bash
+++ b/misc/buildkite/git.bash
@@ -13,12 +13,12 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-export BUILDKITE_REPO_REF="${BUILDKITE_REPO_REF:-origin}"
-export BUILDKITE_PULL_REQUEST_BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
+MZ_REPO_REF="${BUILDKITE_REPO_REF:-origin}"
+MZ_REPO_PULL_REQUEST_BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
 
 if [[ "${BUILDKITE:-}" != "true" ]]; then
   # when running locally, we origin may point to a fork of the repo but we want the mz repo
-  BUILDKITE_REPO_REF=$(git remote -v | grep "MaterializeInc/materialize" | grep "fetch" | head -n1 | cut -f1)
+  MZ_REPO_REF=$(git remote -v | grep "MaterializeInc/materialize" | grep "fetch" | head -n1 | cut -f1)
 fi
 
 configure_git_user_if_in_buildkite() {
@@ -31,16 +31,16 @@ configure_git_user_if_in_buildkite() {
 
 fetch_pr_target_branch() {
   ci_collapsed_heading "Fetch target branch"
-  run git fetch "$BUILDKITE_REPO_REF" "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"
+  run git fetch "$MZ_REPO_REF" "$MZ_REPO_PULL_REQUEST_BASE_BRANCH"
 }
 
 merge_pr_target_branch() {
   configure_git_user_if_in_buildkite
 
   ci_collapsed_heading "Merge target branch"
-  run git merge "$BUILDKITE_REPO_REF"/"$BUILDKITE_PULL_REQUEST_BASE_BRANCH" --message "Merge"
+  run git merge "$MZ_REPO_REF"/"$MZ_REPO_PULL_REQUEST_BASE_BRANCH" --message "Merge"
 }
 
 get_common_ancestor_commit_of_pr_and_target() {
-  run git merge-base HEAD "$BUILDKITE_REPO_REF"/"$BUILDKITE_PULL_REQUEST_BASE_BRANCH"
+  run git merge-base HEAD "$MZ_REPO_REF"/"$MZ_REPO_PULL_REQUEST_BASE_BRANCH"
 }


### PR DESCRIPTION
This fixes local buf checks when origin points to an outdated fork of the mz repo.

See also: https://materializeinc.slack.com/archives/C01LKF361MZ/p1702922521934739