### PR TITLE
catalog: Clean up CatalogKind enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3677,6 +3677,7 @@ dependencies = [
  "bytes",
  "bytesize",
  "chrono",
+ "clap",
  "derivative",
  "differential-dataflow",
  "fail",

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -87,7 +87,6 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
-use clap::clap_derive::ArgEnum;
 use clap::Parser;
 use mz_adapter::catalog::Catalog;
 use mz_build_info::{build_info, BuildInfo};
@@ -101,7 +100,7 @@ use mz_catalog::durable::debug::{
     SystemPrivilegeCollection, TimestampCollection, Trace,
 };
 use mz_catalog::durable::{
-    persist_backed_catalog_state, stash_backed_catalog_state, BootstrapArgs,
+    persist_backed_catalog_state, stash_backed_catalog_state, BootstrapArgs, CatalogKind,
     OpenableDurableCatalogState, StashConfig,
 };
 use mz_ore::cli::{self, CliConfig};
@@ -153,12 +152,6 @@ pub struct Args {
 
     #[clap(subcommand)]
     action: Action,
-}
-
-#[derive(ArgEnum, Debug, Clone)]
-enum CatalogKind {
-    Stash,
-    Persist,
 }
 
 #[derive(Debug, clap::Subcommand)]
@@ -248,6 +241,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             let metrics = Arc::new(mz_catalog::durable::Metrics::new(&metrics_registry));
             Box::new(persist_backed_catalog_state(persist_client, organization_id, metrics).await)
         }
+        CatalogKind::Shadow => panic!("cannot use shadow catalog with catalog-debug tool"),
     };
 
     match args.action {

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = "0.1.68"
 bytes = { version = "1.3.0", features = ["serde"] }
 bytesize = "1.1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
+clap = { version = "3.2.24", features = ["derive"] }
 derivative = "2.2.0"
 differential-dataflow = "0.12.0"
 fail = { version = "0.5.1", features = ["failpoints"] }

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -10,6 +10,7 @@
 //! This crate is responsible for durably storing and modifying the catalog contents.
 
 use async_trait::async_trait;
+use clap::clap_derive::ArgEnum;
 use mz_storage_types::controller::PersistTxnTablesImpl;
 use std::fmt::Debug;
 use std::num::NonZeroI64;
@@ -285,6 +286,13 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         let id = id.into_element();
         Ok(ReplicaId::User(id))
     }
+}
+
+#[derive(ArgEnum, Debug, Clone)]
+pub enum CatalogKind {
+    Stash,
+    Persist,
+    Shadow,
 }
 
 /// Creates a openable durable catalog state implemented using the stash.

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -96,6 +96,7 @@ use itertools::Itertools;
 use mz_aws_secrets_controller::AwsSecretsController;
 use mz_build_info::BuildInfo;
 use mz_catalog::config::ClusterReplicaSizeMap;
+use mz_catalog::durable::CatalogKind;
 use mz_cloud_resources::{AwsExternalIdPrefix, CloudResourceController};
 use mz_controller::ControllerConfig;
 use mz_environmentd::{CatalogConfig, Listeners, ListenersConfig, BUILD_INFO};
@@ -605,13 +606,6 @@ pub struct Args {
 enum OrchestratorKind {
     Kubernetes,
     Process,
-}
-
-#[derive(ArgEnum, Debug, Clone)]
-enum CatalogKind {
-    Stash,
-    Persist,
-    Shadow,
 }
 
 // TODO [Alex Hunt] move this to a shared function that can be imported by the

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -84,10 +84,10 @@ use std::{io, process};
 
 use aws_credential_types::Credentials;
 use aws_types::region::Region;
-use clap::clap_derive::ArgEnum;
 use globset::GlobBuilder;
 use itertools::Itertools;
 use mz_build_info::{build_info, BuildInfo};
+use mz_catalog::durable::CatalogKind;
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::path::PathExt;
 use mz_testdrive::{CatalogConfig, Config};
@@ -315,13 +315,6 @@ struct Args {
         env = "AWS_SECRET_ACCESS_KEY"
     )]
     aws_secret_access_key: String,
-}
-
-#[derive(ArgEnum, Debug, Clone)]
-enum CatalogKind {
-    Stash,
-    Persist,
-    Shadow,
 }
 
 #[tokio::main]


### PR DESCRIPTION
A mostly identical CatalogKind enum was defined in three separate places. This commit creates a single definition and uses it everywhere.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
