### PR TITLE
ci: add git-based legacy-upgrade test to nightly

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1062,6 +1062,17 @@ steps:
     agents:
       queue: linux-x86_64
 
+  - id: legacy-upgrade
+    label: Legacy upgrade tests (git-based)
+    timeout_in_minutes: 60
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: legacy-upgrade
+          args: ["--versions-source=git"]
+    agents:
+      queue: linux-x86_64
+
   - group: "Language tests"
     key: language-tests
     steps:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1063,7 +1063,7 @@ steps:
       queue: linux-x86_64
 
   - id: legacy-upgrade
-    label: Legacy upgrade tests (git-based)
+    label: Legacy upgrade tests (last version from git)
     timeout_in_minutes: 60
     artifact_paths: junit_*.xml
     plugins:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -265,13 +265,14 @@ steps:
       queue: linux-x86_64
 
   - id: legacy-upgrade
-    label: Legacy upgrade tests
+    label: Legacy upgrade tests (docs-based)
     depends_on: build-x86_64
     timeout_in_minutes: 60
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: legacy-upgrade
+          args: ["--versions-source=docs"]
     agents:
       queue: linux-x86_64
 

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -265,7 +265,7 @@ steps:
       queue: linux-x86_64
 
   - id: legacy-upgrade
-    label: Legacy upgrade tests (docs-based)
+    label: Legacy upgrade tests (last version from docs)
     depends_on: build-x86_64
     timeout_in_minutes: 60
     artifact_paths: junit_*.xml

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -23,7 +23,11 @@ from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.test_certs import TestCerts
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
-from materialize.version_list import VersionsFromDocs
+from materialize.version_list import (
+    VersionsFromDocs,
+    get_all_published_mz_versions,
+    get_published_minor_mz_versions,
+)
 
 mz_options: dict[MzVersion, str] = {}
 
@@ -64,18 +68,36 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument(
         "filter", nargs="?", default="*", help="limit to only the files matching filter"
     )
+    parser.add_argument(
+        "--versions-source",
+        default="docs",
+        choices=["docs", "git"],
+        help="from what source to fetch the versions",
+    )
     args = parser.parse_args()
 
-    version_list = VersionsFromDocs()
-    all_versions = version_list.all_versions()
-
-    tested_versions = version_list.minor_versions()[-2:]
+    all_versions, tested_versions = get_all_and_latest_two_minor_mz_versions(
+        use_versions_from_docs=args.versions_source == "docs"
+    )
 
     for version in tested_versions:
         priors = [v for v in all_versions if v <= version]
         test_upgrade_from_version(c, f"{version}", priors, filter=args.filter)
 
     test_upgrade_from_version(c, "current_source", priors=[], filter=args.filter)
+
+
+def get_all_and_latest_two_minor_mz_versions(
+    use_versions_from_docs: bool,
+) -> tuple[list[MzVersion], list[MzVersion]]:
+    if use_versions_from_docs:
+        version_list = VersionsFromDocs()
+        all_versions = version_list.all_versions()
+        tested_versions = version_list.minor_versions()[-2:]
+    else:
+        tested_versions = get_published_minor_mz_versions(limit=2)
+        all_versions = get_all_published_mz_versions(newest_first=False)
+    return all_versions, tested_versions
 
 
 def test_upgrade_from_version(


### PR DESCRIPTION
Nightly: https://buildkite.com/materialize/nightlies/builds/5664