### PR TITLE
persist-txn: tweak debug logging in the operators

### DIFF
--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -107,12 +107,14 @@ where
     F: Future<Output = PersistClient> + Send + 'static,
     G: Scope<Timestamp = T>,
 {
+    let unique_id = (name, passthrough.scope().addr()).hashed();
     let (txns, source_button) = txns_progress_source::<K, V, T, D, P, C, G>(
         passthrough.scope(),
         name,
         client_fn(),
         txns_id,
         data_id,
+        unique_id,
     );
     // Each of the `txns_frontiers` workers wants the full copy of the txns
     // shard (modulo filtered for data_id).
@@ -127,6 +129,7 @@ where
         as_of,
         data_key_schema,
         data_val_schema,
+        unique_id,
     );
     (passthrough, vec![source_button, frontiers_button])
 }
@@ -137,6 +140,7 @@ fn txns_progress_source<K, V, T, D, P, C, G>(
     client: impl Future<Output = PersistClient> + 'static,
     txns_id: ShardId,
     data_id: ShardId,
+    unique_id: u64,
 ) -> (Stream<G, (TxnsEntry, T, i64)>, PressOnDropButton)
 where
     K: Debug + Codec,
@@ -151,6 +155,7 @@ where
     let chosen_worker = usize::cast_from(name.hashed()) % scope.peers();
     let name = format!("txns_progress_source({})", name);
     let mut builder = AsyncOperatorBuilder::new(name.clone(), scope);
+    let name = format!("{} [{}]", name, unique_id);
     let (mut txns_output, txns_stream) = builder.new_output();
 
     let shutdown_button = builder.build(move |capabilities| async move {
@@ -207,6 +212,7 @@ fn txns_progress_frontiers<K, V, T, D, P, C, G>(
     as_of: T,
     data_key_schema: Arc<K::Schema>,
     data_val_schema: Arc<V::Schema>,
+    unique_id: u64,
 ) -> (Stream<G, P>, PressOnDropButton)
 where
     K: Debug + Codec,
@@ -219,6 +225,13 @@ where
 {
     let name = format!("txns_progress_frontiers({})", name);
     let mut builder = AsyncOperatorBuilder::new(name.clone(), passthrough.scope());
+    let name = format!(
+        "{} [{}] {}/{}",
+        name,
+        unique_id,
+        passthrough.scope().index(),
+        passthrough.scope().peers(),
+    );
     let (mut passthrough_output, passthrough_stream) = builder.new_output();
     let txns_input = builder.new_input_connection(&txns, Pipeline, vec![Antichain::new()]);
     let mut passthrough_input =


### PR DESCRIPTION
It has been useful when looking into a hang in CI to be able to distinguish the debug logging from individual operator instances.

Touches https://github.com/MaterializeInc/materialize/issues/22173
Touches https://github.com/MaterializeInc/materialize/issues/22801

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
