### PR TITLE
persist-txn: Simplify unapplied iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4784,6 +4784,7 @@ dependencies = [
  "crossbeam-channel",
  "differential-dataflow",
  "futures",
+ "itertools",
  "mz-ore",
  "mz-persist-client",
  "mz-persist-types",

--- a/src/persist-txn/Cargo.toml
+++ b/src/persist-txn/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 differential-dataflow = "0.12.0"
 futures = "0.3.25"
+itertools = { version = "0.10.5" }
 mz-ore = { path = "../ore" }
 mz-persist-types = { path = "../persist-types" }
 mz-persist-client = { path = "../persist-client" }


### PR DESCRIPTION
This commit simplifies the unapplied iterator by removing our custom iterator and replacing it with the `merge_by` iterator in itertools. This also removes a `Vec` allocation which should be a small but nice perf improvement.

Touches #22173
Touches #22801

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
