### PR TITLE
reclock: fix read hold leak leading to large in-memory traces

### DIFF
--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -583,12 +583,6 @@ where
     // TODO(guswynn): expose function
     let bytes_read_counter = metrics.source_defs.bytes_read.clone();
 
-    // TODO(petrosagg): figure out what this operator's read requirements are. The code currently
-    // relies on the other handle that is present in the source operator to not over compact, which
-    // is currently true since it's driven by the resumption frontier. Nevertheless, we should fix
-    // this and reason locally instead of globally.
-    timestamper.compact(Antichain::new());
-
     let operator_name = format!("reclock({})", id);
     let mut reclock_op = AsyncOperatorBuilder::new(operator_name, scope.clone());
     let (mut reclocked_output, reclocked_stream) = reclock_op.new_output();


### PR DESCRIPTION
When a reclock handle was cloned its current read hold was (correctly) re-added to the mutable antichain tracking the minimum compaction frontier. When a reclock handle was dropped it first compacted itself to the empty frontier in order to release its requirements on the frontier. This would be correct if only for the fact that
`ReclockFollower::compact` only actually compacts if the handle is initialized. This means that if a handle was shared and dropped before the handle had a chance to initialize then we would start accumulate reclock bindings in-memory, which make every future reclocking operation continously slower. This PR fixes this issue and adds a unit test.

This issue looks related to #22128 but I'm not convinced yet that they are the same because the only way I've found to trigger this bug is to use a source that causes a drop of a `ReclockFollower`. The sources that have this behavior are the ones that ignore the feedback mechanism to commit offsets back to the upstream system but both Kafka and Postgres sources actively use that.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
