### PR TITLE
postgres-util: prevent warning with building without default features

### DIFF
--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -79,15 +79,6 @@
 
 use tracing::warn;
 
-macro_rules! bail_generic {
-    ($fmt:expr, $($arg:tt)*) => {
-        return Err(PostgresError::Generic(anyhow::anyhow!($fmt, $($arg)*)))
-    };
-    ($err:expr $(,)?) => {
-        return Err(PostgresError::Generic(anyhow::anyhow!($err)))
-    };
-}
-
 #[cfg(feature = "replication")]
 pub mod replication;
 #[cfg(feature = "replication")]

--- a/src/postgres-util/src/tunnel.rs
+++ b/src/postgres-util/src/tunnel.rs
@@ -23,6 +23,15 @@ use tracing::{info, warn};
 
 use crate::PostgresError;
 
+macro_rules! bail_generic {
+    ($fmt:expr, $($arg:tt)*) => {
+        return Err(PostgresError::Generic(anyhow::anyhow!($fmt, $($arg)*)))
+    };
+    ($err:expr $(,)?) => {
+        return Err(PostgresError::Generic(anyhow::anyhow!($err)))
+    };
+}
+
 /// Configures an optional tunnel for use when connecting to a PostgreSQL
 /// database.
 #[derive(Debug, PartialEq, Clone)]


### PR DESCRIPTION
this was annoying me in vendored mz repos

### Motivation

   * This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
