### PR TITLE
docs: Update all references of the "default" cluster to "quickstart"

### DIFF
--- a/doc/user/content/free-trial-faqs.md
+++ b/doc/user/content/free-trial-faqs.md
@@ -17,11 +17,11 @@ During your free trial, the credit consumption rate across all clusters in a reg
 
 For example, let's say you have 3 clusters in a region:
 
-Cluster   | Size      | Replication factor | Credits per hour
-----------|-----------|--------------------|-----------------
-`ingest`  | `2xsmall` | 1                  | 0.5
-`compute` | `2xsmall` | 2                  | 1 (0.5 each)
-`default` | `2xsmall` | 1                  | 0.5
+Cluster     | Size      | Replication factor | Credits per hour
+------------|-----------|--------------------|-----------------
+`ingest`    | `2xsmall` | 1                  | 0.5
+`compute`   | `2xsmall` | 2                  | 1 (0.5 each)
+`quickstart`| `2xsmall` | 1                  | 0.5
 
 In this case, your credit consumption rate would be 2 credits per hour, which is under the rate limit of 4 credits per hour.
 

--- a/doc/user/content/integrations/cli/_index.md
+++ b/doc/user/content/integrations/cli/_index.md
@@ -66,7 +66,7 @@ You can use `mz` to:
    ```
    ```
    Authenticated using profile 'default'.
-   Connected to the default cluster.
+   Connected to the quickstart cluster.
    psql (14.2)
    Type "help" for help.
 

--- a/doc/user/content/integrations/sql-clients.md
+++ b/doc/user/content/integrations/sql-clients.md
@@ -94,7 +94,7 @@ automatically download and install the most recent version.
 
 #### Connect to a specific cluster
 
-By default, Materialize connects to the [pre-installed `default` cluster](/sql/show-clusters/#pre-installed-clusters).
+By default, Materialize connects to the [pre-installed `quickstart` cluster](/sql/show-clusters/#pre-installed-clusters).
 To connect to a specific [cluster](/get-started/key-concepts/#clusters), you must
 define a bootstrap query in the connection initialization settings.
 

--- a/doc/user/content/manage/access-control/_index.md
+++ b/doc/user/content/manage/access-control/_index.md
@@ -115,7 +115,7 @@ default, members of this role (and therefore **all users**) have the following
 
 Privilege                            | Scope     |
 -------------------------------------|-----------|
-`USAGE`                              | All types, all system catalog schemas, the `materialize.public` schema, the `materialize` database, and the `default` cluster.|
+`USAGE`                              | All types, all system catalog schemas, the `materialize.public` schema, the `materialize` database, and the `quickstart` cluster.|
 `SELECT`                             | All system catalog objects.  |
 
 This means that new, non-administrator users have limited access to resources in

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -61,7 +61,7 @@ common query patterns.
 
 It's important to keep in mind that indexes are **local** to a cluster, and
 maintained in memory. As an example, if you create a materialized view and
-build an index on it in the `default` cluster, querying the view from a
+build an index on it in the `quickstart` cluster, querying the view from a
 different cluster will _not_ use the index; you should create the appropriate
 indexes in each cluster you are referencing the materialized view in.
 

--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -24,17 +24,17 @@ SHOW CLUSTER REPLICAS;
     cluster    | replica |  size  | ready |
 ---------------+---------|--------|-------|
  auction_house | bigger  | xlarge | t     |
- default       | r1      | xsmall | t     |
+ quickstart    | r1      | xsmall | t     |
 ```
 
 ```sql
-SHOW CLUSTER REPLICAS WHERE cluster='default';
+SHOW CLUSTER REPLICAS WHERE cluster='quickstart';
 ```
 
 ```nofmt
     cluster    | replica |  size  | ready|
 ---------------+---------|--------|-------
- default       | r1      | xsmall | t    |
+ quickstart    | r1      | xsmall | t    |
 ```
 
 

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -19,16 +19,18 @@ When you enable a Materialize region, several clusters that are used to improve
 the user experience, as well as support system administration tasks, will be
 pre-installed.
 
-### `default` cluster
+### `quickstart` cluster
 
-A cluster named `default` with a size of `xsmall` and a replication factor of
+A cluster named `quickstart` with a size of `xsmall` and a replication factor of
 `1` will be pre-installed in every environment. You can modify or drop this
 cluster at any time.
 
 {{< note >}}
-The default value for the `cluster` session parameter is `default`.
-If the `default` cluster is dropped, you must run [`SET cluster`](/sql/select/#ad-hoc-queries)
-to choose a valid cluster in order to run `SELECT` queries.
+The default value for the `cluster` session parameter is `quickstart`.
+If the `quickstart` cluster is dropped, you must run [`SET cluster`](/sql/select/#ad-hoc-queries)
+to choose a valid cluster in order to run `SELECT` queries. A superuser (i.e. Frontegg admin)
+can also run [`ALTER SYSTEM SET cluster`](/sql/alter-system-set) to change the
+default value.
 {{< /note >}}
 
 ### `mz_introspection` system cluster

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -28,7 +28,7 @@ cluster at any time.
 {{< note >}}
 The default value for the `cluster` session parameter is `quickstart`.
 If the `quickstart` cluster is dropped, you must run [`SET cluster`](/sql/select/#ad-hoc-queries)
-to choose a valid cluster in order to run `SELECT` queries. A superuser (i.e. Frontegg admin)
+to choose a valid cluster in order to run `SELECT` queries. A _superuser _(i.e. `Organization Admin`)
 can also run [`ALTER SYSTEM SET cluster`](/sql/alter-system-set) to change the
 default value.
 {{< /note >}}

--- a/doc/user/content/sql/show-create-index.md
+++ b/doc/user/content/sql/show-create-index.md
@@ -23,9 +23,9 @@ SHOW INDEXES FROM my_view;
 ```
 
 ```nofmt
-     name    | on  | cluster | key
--------------+-----+---------+--------------------------------------------
- my_view_idx | t   | default | {a, b}
+     name    | on  | cluster    | key
+-------------+-----+------------+--------------------------------------------
+ my_view_idx | t   | quickstart | {a, b}
 ```
 
 ```sql

--- a/doc/user/content/sql/show-create-materialized-view.md
+++ b/doc/user/content/sql/show-create-materialized-view.md
@@ -24,7 +24,7 @@ SHOW CREATE MATERIALIZED VIEW winning_bids;
 ```nofmt
               name               |                                                                                                                       create_sql
 ---------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- materialize.public.winning_bids | CREATE MATERIALIZED VIEW "materialize"."public"."winning_bids" IN CLUSTER "default" AS SELECT * FROM "materialize"."public"."highest_bid_per_auction" WHERE "end_time" < "mz_catalog"."mz_now"()
+ materialize.public.winning_bids | CREATE MATERIALIZED VIEW "materialize"."public"."winning_bids" IN CLUSTER "quickstart" AS SELECT * FROM "materialize"."public"."highest_bid_per_auction" WHERE "end_time" < "mz_catalog"."mz_now"()
 ```
 
 ## Privileges

--- a/doc/user/content/sql/show-materialized-views.md
+++ b/doc/user/content/sql/show-materialized-views.md
@@ -27,7 +27,7 @@ SHOW MATERIALIZED VIEWS;
 ```nofmt
      name     | cluster
 --------------+----------
- winning_bids | default
+ winning_bids | quickstart
 ```
 
 ```sql
@@ -37,7 +37,7 @@ SHOW MATERIALIZED VIEWS LIKE '%bid%';
 ```nofmt
      name     | cluster
 --------------+----------
- winning_bids | default
+ winning_bids | quickstart
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-privileges.md
+++ b/doc/user/content/sql/show-privileges.md
@@ -31,12 +31,12 @@ SHOW PRIVILEGES;
   grantor  |   grantee   |  database   | schema |    name     | object_type | privilege_type
 -----------+-------------+-------------+--------+-------------+-------------+----------------
  mz_system | PUBLIC      | materialize |        | public      | schema      | USAGE
- mz_system | PUBLIC      |             |        | default     | cluster     | USAGE
+ mz_system | PUBLIC      |             |        | quickstart  | cluster     | USAGE
  mz_system | PUBLIC      |             |        | materialize | database    | USAGE
  mz_system | materialize | materialize |        | public      | schema      | CREATE
  mz_system | materialize | materialize |        | public      | schema      | USAGE
- mz_system | materialize |             |        | default     | cluster     | CREATE
- mz_system | materialize |             |        | default     | cluster     | USAGE
+ mz_system | materialize |             |        | quickstart  | cluster     | CREATE
+ mz_system | materialize |             |        | quickstart  | cluster     | USAGE
  mz_system | materialize |             |        | materialize | database    | CREATE
  mz_system | materialize |             |        | materialize | database    | USAGE
  mz_system | materialize |             |        |             | system      | CREATECLUSTER
@@ -65,8 +65,8 @@ SHOW PRIVILEGES FOR materialize;
 -----------+-------------+-------------+--------+-------------+-------------+----------------
  mz_system | materialize | materialize |        | public      | schema      | CREATE
  mz_system | materialize | materialize |        | public      | schema      | USAGE
- mz_system | materialize |             |        | default     | cluster     | CREATE
- mz_system | materialize |             |        | default     | cluster     | USAGE
+ mz_system | materialize |             |        | quickstart  | cluster     | CREATE
+ mz_system | materialize |             |        | quickstart  | cluster     | USAGE
  mz_system | materialize |             |        | materialize | database    | CREATE
  mz_system | materialize |             |        | materialize | database    | USAGE
  mz_system | materialize |             |        |             | system      | CREATECLUSTER

--- a/doc/user/content/sql/show.md
+++ b/doc/user/content/sql/show.md
@@ -37,7 +37,7 @@ SHOW cluster;
 ```
  cluster
 ---------
- default
+ quickstart
 ```
 
 ### Show transaction isolation level

--- a/doc/user/layouts/shortcodes/session-variables.html
+++ b/doc/user/layouts/shortcodes/session-variables.html
@@ -2,7 +2,7 @@
 
 Name                                        | Default value             |  Description  |
 --------------------------------------------|---------------------------|---------------|
-cluster                                     | `default`                 | The current cluster.
+cluster                                     | `quickstart`              | The current cluster.
 cluster_replica                             |                           | The target cluster replica for `SELECT` queries.
 database                                    | `materialize`             | The current database.
 search_path                                 | `public`                  | The schema search order for names that are not schema-qualified.


### PR DESCRIPTION
This PR updates our user documentation to rename the "default" cluster to "quickstart". The pages that were updated are:

* [Free Trials FAQ](https://preview.materialize.com/materialize/24035/free-trial-faqs/)
* [Integrations/CLI](https://preview.materialize.com/materialize/24035/integrations/cli/)
* [Integrations/SQL Clients](https://preview.materialize.com/materialize/24035/integrations/sql-clients/)
* [Access Control](https://preview.materialize.com/materialize/24035/manage/access-control/)
* [`CREATE MATERIALIZED VIEW`](https://preview.materialize.com/materialize/24035/sql/create-materialized-view/)
* [`SHOW CLUSTER REPLICAS`](https://preview.materialize.com/materialize/24035/sql/show-cluster-replicas/)
* [`SHOW CLUSTERS`](https://preview.materialize.com/materialize/24035/sql/show-clusters/)
* [`SHOW CREATE INDEX`](https://preview.materialize.com/materialize/24035/sql/show-create-materialized-view/)
* [`SHOW MATERIALIZED VIEWS`](https://preview.materialize.com/materialize/24035/sql/show-materialized-views/)
* [`SHOW PRIVILEGES`](https://preview.materialize.com/materialize/24035/sql/show-privileges/)
* [`SHOW`](https://preview.materialize.com/materialize/24035/sql/show/)
* [Session Variables](https://preview.materialize.com/materialize/24035/sql/set/#session-variables)

### Motivation

Progress towards: https://github.com/MaterializeInc/materialize/issues/22351

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Update user facing docs to rename "default" cluster to "quickstart"
