### PR TITLE
Revert "sql: teach subsources about RETAIN HISTORY"

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -3674,11 +3674,6 @@ async fn test_retain_history() {
                         &[],
                     )
                     .await?;
-                // Assert that subsources have retain history propagated.
-                for row in client.query(&format!("SELECT create_sql FROM mz_sources WHERE id LIKE 'u%' AND name LIKE '{name}%'"), &[]).await.unwrap(){
-                    let sql :String = row.get(0);
-                    assert_contains!(sql, "RETAIN HISTORY = FOR");
-                }
                 Ok(())
             })
             .await

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1035,16 +1035,18 @@ impl_display_t!(ReferencedSubsources);
 pub enum CreateSubsourceOptionName {
     Progress,
     References,
-    RetainHistory,
 }
 
 impl AstDisplay for CreateSubsourceOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_str(match self {
-            CreateSubsourceOptionName::Progress => "PROGRESS",
-            CreateSubsourceOptionName::References => "REFERENCES",
-            CreateSubsourceOptionName::RetainHistory => "RETAIN HISTORY",
-        });
+        match self {
+            CreateSubsourceOptionName::Progress => {
+                f.write_str("PROGRESS");
+            }
+            CreateSubsourceOptionName::References => {
+                f.write_str("REFERENCES");
+            }
+        }
     }
 }
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2571,33 +2571,22 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    /// Parse the name of a CREATE SUBSOURCE optional parameter
+    /// Parse the name of a CREATE SINK optional parameter
     fn parse_create_subsource_option_name(
         &mut self,
     ) -> Result<CreateSubsourceOptionName, ParserError> {
-        let name = match self.expect_one_of_keywords(&[PROGRESS, REFERENCES, RETAIN])? {
+        let name = match self.expect_one_of_keywords(&[PROGRESS, REFERENCES])? {
             PROGRESS => CreateSubsourceOptionName::Progress,
             REFERENCES => CreateSubsourceOptionName::References,
-            RETAIN => {
-                self.expect_keyword(HISTORY)?;
-                CreateSubsourceOptionName::RetainHistory
-            }
             _ => unreachable!(),
         };
         Ok(name)
     }
 
-    /// Parse a NAME = VALUE parameter for CREATE SUBSOURCE
+    /// Parse a NAME = VALUE parameter for CREATE SINK
     fn parse_create_subsource_option(&mut self) -> Result<CreateSubsourceOption<Raw>, ParserError> {
-        let name = self.parse_create_subsource_option_name()?;
-        if name == CreateSubsourceOptionName::RetainHistory {
-            return Ok(CreateSubsourceOption {
-                name,
-                value: self.parse_option_retain_history()?,
-            });
-        }
         Ok(CreateSubsourceOption {
-            name,
+            name: self.parse_create_subsource_option_name()?,
             value: self.parse_optional_option_value()?,
         })
     }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2844,10 +2844,3 @@ CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (SIZE '1', RETAIN HISTORY FOR '
 CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (SIZE = '1', RETAIN HISTORY = FOR '1s')
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("s")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("1"))) }, CreateSourceOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1s"))) }], referenced_subsources: None, progress_subsource: None })
-
-parse-statement
-CREATE SUBSOURCE accounts (id pg_catalog.int8 NOT NULL, UNIQUE (id)) WITH (REFERENCES = true, RETAIN HISTORY = FOR '1h')
-----
-CREATE SUBSOURCE accounts (id pg_catalog.int8 NOT NULL, UNIQUE (id)) WITH (REFERENCES = true, RETAIN HISTORY = FOR '1h')
-=>
-CreateSubsource(CreateSubsourceStatement { name: UnresolvedItemName([Ident("accounts")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("pg_catalog"), Ident("int8")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false, nulls_not_distinct: false }], if_not_exists: false, with_options: [CreateSubsourceOption { name: References, value: Some(Value(Boolean(true))) }, CreateSubsourceOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1h"))) }] })

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1295,8 +1295,7 @@ pub fn plan_create_source(
 generate_extracted_config!(
     CreateSubsourceOption,
     (Progress, bool, Default(false)),
-    (References, bool, Default(false)),
-    (RetainHistory, Duration)
+    (References, bool, Default(false))
 );
 
 pub fn plan_create_subsource(
@@ -1314,8 +1313,7 @@ pub fn plan_create_subsource(
     let CreateSubsourceOptionExtracted {
         progress,
         references,
-        retain_history,
-        seen: _,
+        ..
     } = with_options.clone().try_into()?;
 
     // This invariant is enforced during purification; we are responsible for
@@ -1432,13 +1430,6 @@ pub fn plan_create_subsource(
     let typ = RelationType::new(column_types).with_keys(keys);
     let desc = RelationDesc::new(typ, names);
 
-    let compaction_window = retain_history
-        .map(|cw| {
-            scx.require_feature_flag(&vars::ENABLE_LOGICAL_COMPACTION_WINDOW)?;
-            Ok::<_, PlanError>(cw.try_into()?)
-        })
-        .transpose()?;
-
     let source = Source {
         create_sql,
         data_source: if progress {
@@ -1449,7 +1440,7 @@ pub fn plan_create_subsource(
             unreachable!("state prohibited above")
         },
         desc,
-        compaction_window,
+        compaction_window: None,
     };
 
     Ok(Plan::CreateSource(CreateSourcePlan {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -29,12 +29,11 @@ use mz_repr::{strconv, GlobalId};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
     AlterSourceAction, AlterSourceAddSubsourceOptionName, AlterSourceStatement, AvroDocOn,
-    CreateSinkConnection, CreateSinkStatement, CreateSourceOptionName, CreateSubsourceOption,
-    CreateSubsourceOptionName, CsrConfigOption, CsrConfigOptionName, CsrConnection, CsrSeedAvro,
-    CsrSeedProtobuf, CsrSeedProtobufSchema, DbzMode, DeferredItemName, DocOnIdentifier,
-    DocOnSchema, Envelope, Ident, KafkaSourceConfigOption, KafkaSourceConfigOptionName,
-    PgConfigOption, PgConfigOptionName, RawItemName, ReaderSchemaSelectionStrategy, Statement,
-    UnresolvedItemName,
+    CreateSinkConnection, CreateSinkStatement, CreateSubsourceOption, CreateSubsourceOptionName,
+    CsrConfigOption, CsrConfigOptionName, CsrConnection, CsrSeedAvro, CsrSeedProtobuf,
+    CsrSeedProtobufSchema, DbzMode, DeferredItemName, DocOnIdentifier, DocOnSchema, Envelope,
+    Ident, KafkaSourceConfigOption, KafkaSourceConfigOptionName, PgConfigOption,
+    PgConfigOptionName, RawItemName, ReaderSchemaSelectionStrategy, Statement, UnresolvedItemName,
 };
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::connections::inline::IntoInlineConnection;
@@ -409,19 +408,8 @@ async fn purify_create_source(
         include_metadata: _,
         referenced_subsources,
         progress_subsource,
-        with_options,
         ..
     } = &mut stmt;
-
-    let subsource_retain_history = with_options.iter().find_map(|o| {
-        if o.name != CreateSourceOptionName::RetainHistory {
-            return None;
-        }
-        Some(CreateSubsourceOption {
-            name: CreateSubsourceOptionName::RetainHistory,
-            value: o.value.clone(),
-        })
-    });
 
     // Disallow manually targetting subsources, this syntax is reserved for purification only
     named_subsource_err(progress_subsource)?;
@@ -925,13 +913,6 @@ async fn purify_create_source(
         }],
     };
     subsources.push((transient_id, subsource));
-
-    // Apply the outer source's RETAIN HISTORY option to all subsources.
-    for (_, subsource) in subsources.iter_mut() {
-        subsource
-            .with_options
-            .extend(subsource_retain_history.clone());
-    }
 
     purify_source_format(
         &catalog,


### PR DESCRIPTION
This reverts commit 4d6fd02eb483c79eb09c28cb2489af1a72e9f53c.

Reverting in favor of #24010.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a