### PR TITLE
doc/user: restore blue coloring of public preview notice

### DIFF
--- a/doc/user/assets/sass/_base.scss
+++ b/doc/user/assets/sass/_base.scss
@@ -101,7 +101,15 @@ body.dark {
     --shadow-default: 0 0.625rem 1.5rem 0 rgba(0, 0, 0, 0.4);
     --note: #fffad411;
     --note-border: #b9a61545;
+    --note-after: #fbe2d9;
     --note-gutter: #ffe600;
+    // NOTE(benesch): please ensure these colors stay blueish. Public preview
+    // requires a mild amount of caution. Importantly, green is not the right
+    // color, as that implies encouragement rather than caution.
+    --public-preview: #e9f7fb;
+    --public-preview-border: #c0d3d8;
+    --public-preview-after: #c0d3d8;
+    --public-preview-gutter: #186477;
 }
 
 body.light {
@@ -129,9 +137,17 @@ body.light {
     --body: var(--black-light);
     --highlight: var(--purple-dark);
 
-    --note: #fffad451;
+    --note: #fffad411;
     --note-border: #b9a61545;
+    --note-after: #fbe2d9;
     --note-gutter: #7b7b29;
+    // NOTE(benesch): please ensure these colors stay blueish. Public preview
+    // requires a mild amount of caution. Importantly, green is not the right
+    // color, as that implies encouragement rather than caution.
+    --public-preview: #e9f7fb;
+    --public-preview-border: #c0d3d8;
+    --public-preview-after: #c0d3d8;
+    --public-preview-gutter: #186477;
 }
 
 *,

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -458,6 +458,9 @@ p+p {
 
     .warning,
     .private-preview {
+        // NOTE(benesch): please ensure these colors stay yellowish/orange.
+        // Private preview and warnings should indicate a moderate amount of
+        // caution--not serious danger, but nothing to overlook either.
         background: rgba(238, 134, 96, 0.05);
         border: 1px solid rgba(238, 134, 96, 0.2);
 
@@ -490,8 +493,8 @@ p+p {
         }
 
         &::after {
-            border-color: var(--bg) var(--bg) #fbe2d9 #fbe2d9;
-            background: #fbe2d9;
+            border-color: var(--bg) var(--bg) var(--note-after) var(--note-after);
+            background: var(--note-after);
         }
 
         .gutter {
@@ -500,17 +503,17 @@ p+p {
     }
 
     .public-preview {
-        background: #d8fad9;
-        border: 1px solid #c0d8c5;
+        background: var(--public-preview);
+        border: 1px solid var(--public-preview-border);
         color: var(--black);
 
         &::after {
-            border-color: var(--bg) var(--bg) #c0d8c5 #c0d8c5;
-            background: #c0d8c5;
+            border-color: var(--bg) var(--bg) var(--public-preview-after) var(--public-preview-after);
+            background: var(--public-preview-after);
         }
 
         .gutter {
-            color: #186477;
+            color: var(--public-preview-gutter);
         }
     }
 


### PR DESCRIPTION
The public preview notice was changed to green in #15970. But green is not the right color for this notice. Green implies something favorable, when in fact using a public preview requires caution.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
