### PR TITLE
persist-txn tests in Platform Checks

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -669,6 +669,28 @@ steps:
               composition: platform-checks
               args: [--scenario=DropCreateDefaultReplica, "--seed=$BUILDKITE_JOB_ID"]
 
+      - id: checks-persist-txn-toggle
+        label: "Checks + Toggle persist_txn"
+        timeout_in_minutes: 45
+        artifact_paths: junit_*.xml
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=PersistTxnToggle, "--seed=$BUILDKITE_JOB_ID"]
+
+      - id: checks-persist-txn-fending
+        label: "Checks + persist_txn fencing"
+        timeout_in_minutes: 45
+        artifact_paths: junit_*.xml
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=PersistTxnFencing, "--seed=$BUILDKITE_JOB_ID"]
+
       - id: checks-upgrade-matrix
         label: "Random upgrades over the entire matrix"
         timeout_in_minutes: 600

--- a/misc/images/materialized/entrypoint.sh
+++ b/misc/images/materialized/entrypoint.sh
@@ -28,19 +28,21 @@ hosted offering we run these services scaled across many machines.
 ********************************* WARNING ********************************
 EOF
 
-COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true cockroach start-single-node \
-    --insecure \
-    --background \
-    --store=/mzdata/cockroach
+if [ -z "${MZ_NO_BUILTIN_COCKROACH:-}" ]; then
+  COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true cockroach start-single-node \
+      --insecure \
+      --background \
+      --store=/mzdata/cockroach
 
-# See: https://github.com/cockroachdb/cockroach/issues/93892
-# See: https://github.com/MaterializeInc/materialize/issues/16726
-cockroach sql --insecure -e "SET CLUSTER SETTING sql.stats.forecasts.enabled = false"
+  # See: https://github.com/cockroachdb/cockroach/issues/93892
+  # See: https://github.com/MaterializeInc/materialize/issues/16726
+  cockroach sql --insecure -e "SET CLUSTER SETTING sql.stats.forecasts.enabled = false"
 
-cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS consensus"
-cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS storage"
-cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS adapter"
-cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS tsoracle"
+  cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS consensus"
+  cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS storage"
+  cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS adapter"
+  cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS tsoracle"
+fi
 
 if [[ ! -f /mzdata/environment-id ]]; then
   echo "docker-container-$(cat /proc/sys/kernel/random/uuid)-0" > /mzdata/environment-id

--- a/misc/python/materialize/checks/all_checks/alter_index.py
+++ b/misc/python/materialize/checks/all_checks/alter_index.py
@@ -67,11 +67,11 @@ class AlterIndex(Check):
                 # When upgrading from old version without roles the indexes are
                 # owned by default_role, thus we have to change the owner
                 # before altering them:
-                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER INDEX alter_index_table_primary_idx OWNER TO materialize;
                 ALTER INDEX alter_index_source_primary_idx OWNER TO materialize;
 
-                $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                $[version>=5500] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER SYSTEM SET enable_index_options = true
                 ALTER SYSTEM SET enable_logical_compaction_window = true
 

--- a/misc/python/materialize/checks/all_checks/cluster.py
+++ b/misc/python/materialize/checks/all_checks/cluster.py
@@ -19,19 +19,19 @@ class CreateCluster(Check):
             Testdrive(dedent(s))
             for s in [
                 """
-                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT CREATECLUSTER ON SYSTEM TO materialize
 
-                $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 ALTER ROLE materialize CREATECLUSTER
 
                 > CREATE CLUSTER create_cluster1 REPLICAS (replica1 (SIZE '2-2'));
                 """,
                 """
-                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT CREATECLUSTER ON SYSTEM TO materialize
 
-                $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 ALTER ROLE materialize CREATECLUSTER
 
                 > CREATE CLUSTER create_cluster2 REPLICAS (replica1 (SIZE '2-2'));

--- a/misc/python/materialize/checks/all_checks/databases.py
+++ b/misc/python/materialize/checks/all_checks/databases.py
@@ -18,10 +18,10 @@ class CheckDatabaseCreate(Check):
             Testdrive(dedent(s))
             for s in [
                 """
-                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT CREATEDB ON SYSTEM TO materialize
 
-                $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 ALTER ROLE materialize CREATEDB
 
                 > CREATE DATABASE to_be_created1;
@@ -30,10 +30,10 @@ class CheckDatabaseCreate(Check):
                 > INSERT INTO t1 VALUES (1);
                 """,
                 """
-                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT CREATEDB ON SYSTEM TO materialize
 
-                $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 ALTER ROLE materialize CREATEDB
 
                 > CREATE DATABASE to_be_created2;
@@ -90,7 +90,7 @@ class CheckDatabaseDrop(Check):
                 # When upgrading from old version without roles the database is
                 # owned by default_role, thus we have to change the owner
                 # before dropping it:
-                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER DATABASE to_be_dropped OWNER TO materialize;
 
                 > DROP DATABASE to_be_dropped CASCADE;

--- a/misc/python/materialize/checks/all_checks/default_privileges.py
+++ b/misc/python/materialize/checks/all_checks/default_privileges.py
@@ -29,7 +29,7 @@ class DefaultPrivileges(Check):
             > CREATE ROLE defpriv_role1
             >[version<5900] ALTER ROLE defpriv_role1 CREATEDB CREATECLUSTER
 
-            $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+            $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
             GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role1
 
             > CREATE TABLE defpriv_table1 (c int)
@@ -48,7 +48,7 @@ class DefaultPrivileges(Check):
                 > CREATE ROLE defpriv_role2
                 >[version<5900] ALTER ROLE defpriv_role2 CREATEDB CREATECLUSTER
 
-                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role2
 
                 > CREATE TABLE defpriv_table2 (c int)
@@ -60,7 +60,7 @@ class DefaultPrivileges(Check):
                 > CREATE ROLE defpriv_role3
                 >[version<5900] ALTER ROLE defpriv_role3 CREATEDB CREATECLUSTER
 
-                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO defpriv_role3
 
                 > CREATE TABLE defpriv_table3 (c int)

--- a/misc/python/materialize/checks/all_checks/drop_index.py
+++ b/misc/python/materialize/checks/all_checks/drop_index.py
@@ -43,7 +43,7 @@ class DropIndex(Check):
                 # When upgrading from old version without roles the indexes are
                 # owned by default_role, thus we have to change the owner
                 # before dropping them:
-                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER INDEX drop_index_table_primary_idx OWNER TO materialize;
                 ALTER INDEX drop_index_index2 OWNER TO materialize;
 

--- a/misc/python/materialize/checks/all_checks/drop_table.py
+++ b/misc/python/materialize/checks/all_checks/drop_table.py
@@ -37,7 +37,7 @@ class DropTable(Check):
                 # When upgrading from old version without roles the table is
                 # owned by default_role, thus we have to change the owner
                 # before dropping it:
-                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER TABLE drop_table2 OWNER TO materialize;
 
                 > DROP TABLE drop_table2;

--- a/misc/python/materialize/checks/all_checks/owners.py
+++ b/misc/python/materialize/checks/all_checks/owners.py
@@ -18,15 +18,15 @@ class Owners(Check):
     def _create_objects(self, role: str, i: int, expensive: bool = False) -> str:
         s = dedent(
             f"""
-            $[version>=5200] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+            $[version>=5200] postgres-execute connection=postgres://mz_system@${{testdrive.materialize-internal-sql-addr}}
             GRANT CREATE ON DATABASE materialize TO {role}
             GRANT CREATE ON SCHEMA materialize.public TO {role}
             GRANT CREATE ON CLUSTER default TO {role}
-            $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+            $[version>=5900] postgres-execute connection=postgres://mz_system@${{testdrive.materialize-internal-sql-addr}}
             GRANT CREATEDB ON SYSTEM TO {role}
-            $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+            $[version<5900] postgres-execute connection=postgres://mz_system@${{testdrive.materialize-internal-sql-addr}}
             ALTER ROLE {role} CREATEDB
-            $ postgres-execute connection=postgres://{role}@materialized:6875/materialize
+            $ postgres-execute connection=postgres://{role}@${{testdrive.materialize-sql-addr}}
             CREATE DATABASE owner_db{i}
             CREATE SCHEMA owner_schema{i}
             CREATE CONNECTION owner_kafka_conn{i} FOR KAFKA {self._kafka_broker()}
@@ -53,7 +53,7 @@ class Owners(Check):
     def _alter_object_owners(self, i: int, expensive: bool = False) -> str:
         s = dedent(
             f"""
-            $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+            $ postgres-execute connection=postgres://mz_system@${{testdrive.materialize-internal-sql-addr}}
             ALTER DATABASE owner_db{i} OWNER TO other_owner
             ALTER SCHEMA owner_schema{i} OWNER TO other_owner
             ALTER CONNECTION owner_kafka_conn{i} OWNER TO other_owner
@@ -102,7 +102,7 @@ class Owners(Check):
         ]
         if success:
             return (
-                f"$ postgres-execute connection=postgres://{role}@materialized:6875/materialize\n"
+                f"$ postgres-execute connection=postgres://{role}@${{testdrive.materialize-sql-addr}}\n"
                 + "\n".join(cmds)
                 + "\n"
             )
@@ -122,16 +122,16 @@ class Owners(Check):
         return Testdrive(
             dedent(
                 """
-                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT CREATEROLE ON SYSTEM TO materialize
 
-                $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 ALTER ROLE materialize CREATEROLE
 
                 > CREATE ROLE owner_role_01
                 >[version<5900] ALTER ROLE owner_role_01 CREATEDB CREATECLUSTER
 
-                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO owner_role_01
 
                 > CREATE ROLE other_owner
@@ -151,16 +151,16 @@ class Owners(Check):
                 + self._alter_object_owners(4)
                 + dedent(
                     """
-                    $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     GRANT CREATEROLE ON SYSTEM TO materialize
 
-                    $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     ALTER ROLE materialize CREATEROLE
 
                     > CREATE ROLE owner_role_02
                     >[version<5900] ALTER ROLE owner_role_02 CREATEDB CREATECLUSTER
 
-                    $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO owner_role_02
                     """
                 ),
@@ -172,16 +172,16 @@ class Owners(Check):
                 + self._alter_object_owners(8)
                 + dedent(
                     """
-                    $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     GRANT CREATEROLE ON SYSTEM TO materialize
 
-                    $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     ALTER ROLE materialize CREATEROLE
 
                     > CREATE ROLE owner_role_03
                     >[version<5900] ALTER ROLE owner_role_03 CREATEDB CREATECLUSTER
 
-                    $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     GRANT CREATEDB, CREATECLUSTER ON SYSTEM TO owner_role_03
                     """
                 ),

--- a/misc/python/materialize/checks/all_checks/pg_cdc.py
+++ b/misc/python/materialize/checks/all_checks/pg_cdc.py
@@ -97,7 +97,7 @@ class PgCdcBase:
                     else ""
                 ),
                 f"""
-                $[version>=5200] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5200] postgres-execute connection=postgres://mz_system@${{testdrive.materialize-internal-sql-addr}}
                 GRANT USAGE ON CONNECTION pg2{self.suffix} TO materialize
 
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
@@ -157,7 +157,7 @@ class PgCdcBase:
         return Testdrive(
             dedent(
                 f"""
-                $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $ postgres-execute connection=postgres://mz_system@${{testdrive.materialize-internal-sql-addr}}
                 GRANT SELECT ON postgres_source_tableA{self.suffix} TO materialize
                 GRANT SELECT ON postgres_source_tableB{self.suffix} TO materialize
                 GRANT SELECT ON postgres_source_tableC{self.suffix} TO materialize

--- a/misc/python/materialize/checks/all_checks/privileges.py
+++ b/misc/python/materialize/checks/all_checks/privileges.py
@@ -18,7 +18,7 @@ class Privileges(Check):
     def _create_objects(self, i: int, expensive: bool = False) -> str:
         s = dedent(
             f"""
-            $ postgres-execute connection=postgres://materialize@materialized:6875/materialize
+            $ postgres-execute connection=postgres://materialize@${{testdrive.materialize-sql-addr}}
             CREATE DATABASE privilege_db{i}
             CREATE SCHEMA privilege_schema{i}
             CREATE CONNECTION privilege_kafka_conn{i} FOR KAFKA {self._kafka_broker()}
@@ -45,7 +45,7 @@ class Privileges(Check):
     def _grant_privileges(self, role: str, i: int, expensive: bool = False) -> str:
         s = dedent(
             f"""
-            $ postgres-execute connection=postgres://materialize@materialized:6875/materialize
+            $ postgres-execute connection=postgres://materialize@${{testdrive.materialize-sql-addr}}
             GRANT ALL PRIVILEGES ON DATABASE privilege_db{i} TO {role}
             GRANT ALL PRIVILEGES ON SCHEMA privilege_schema{i} TO {role}
             GRANT ALL PRIVILEGES ON CONNECTION privilege_kafka_conn{i} TO {role}
@@ -70,7 +70,7 @@ class Privileges(Check):
     def _revoke_privileges(self, role: str, i: int, expensive: bool = False) -> str:
         s = dedent(
             f"""
-                $ postgres-execute connection=postgres://materialize@materialized:6875/materialize
+                $ postgres-execute connection=postgres://materialize@${{testdrive.materialize-sql-addr}}
                 REVOKE ALL PRIVILEGES ON DATABASE privilege_db{i} FROM {role}
                 REVOKE ALL PRIVILEGES ON SCHEMA privilege_schema{i} FROM {role}
                 REVOKE ALL PRIVILEGES ON CONNECTION privilege_kafka_conn{i} FROM {role}
@@ -116,7 +116,7 @@ class Privileges(Check):
             f"DROP DATABASE privilege_db{i}",
         ]
         return (
-            "$ postgres-execute connection=postgres://materialize@materialized:6875/materialize\n"
+            "$ postgres-execute connection=postgres://materialize@${testdrive.materialize-sql-addr}/materialize\n"
             + "\n".join(cmds)
             + "\n"
         )
@@ -129,10 +129,10 @@ class Privileges(Check):
         return Testdrive(
             dedent(
                 """
-                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT CREATEROLE ON SYSTEM TO materialize
 
-                $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 ALTER ROLE materialize CREATEROLE
 
                 > CREATE ROLE role_1
@@ -150,10 +150,10 @@ class Privileges(Check):
             for s in [
                 dedent(
                     """
-                    $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     GRANT CREATEROLE ON SYSTEM TO materialize
 
-                    $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     ALTER ROLE materialize CREATEROLE
                     """
                 )
@@ -163,10 +163,10 @@ class Privileges(Check):
                 + self._grant_privileges("role_2", 2),
                 dedent(
                     """
-                    $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     GRANT CREATEROLE ON SYSTEM TO materialize
 
-                    $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     ALTER ROLE materialize CREATEROLE
                     """
                 )

--- a/misc/python/materialize/checks/all_checks/rename_index.py
+++ b/misc/python/materialize/checks/all_checks/rename_index.py
@@ -40,7 +40,7 @@ class RenameIndex(Check):
                 # When upgrading from old version without roles the indexes are
                 # owned by default_role, thus we have to change the owner
                 # before altering them:
-                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER INDEX rename_index_index1 OWNER TO materialize;
                 ALTER INDEX rename_index_index2 OWNER TO materialize;
 

--- a/misc/python/materialize/checks/all_checks/rename_source.py
+++ b/misc/python/materialize/checks/all_checks/rename_source.py
@@ -68,7 +68,7 @@ class RenameSource(Check):
                 # When upgrading from old version without roles the source is
                 # owned by default_role, thus we have to change the owner
                 # before dropping it:
-                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER SOURCE rename_source2 OWNER TO materialize;
 
                 $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema}

--- a/misc/python/materialize/checks/all_checks/rename_table.py
+++ b/misc/python/materialize/checks/all_checks/rename_table.py
@@ -37,7 +37,7 @@ class RenameTable(Check):
                 # When upgrading from old version without roles the table is
                 # owned by default_role, thus we have to change the owner
                 # before dropping it:
-                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER TABLE rename_table2 OWNER TO materialize;
 
                 > INSERT INTO rename_table2 VALUES (4);

--- a/misc/python/materialize/checks/all_checks/rename_view.py
+++ b/misc/python/materialize/checks/all_checks/rename_view.py
@@ -39,7 +39,7 @@ class RenameView(Check):
                 # When upgrading from old version without roles the views are
                 # owned by default_role, thus we have to change the owner
                 # before dropping them:
-                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER VIEW rename_view_viewB2 OWNER TO materialize;
                 ALTER VIEW rename_view_viewA2 OWNER TO materialize;
 

--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -85,7 +85,7 @@ class SinkUpsert(Check):
             Testdrive(schemas() + dedent(s))
             for s in [
                 """
-                $[version>=5200] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5200] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT SELECT ON sink_source_view TO materialize
                 GRANT USAGE ON CONNECTION kafka_conn TO materialize
                 GRANT USAGE ON CONNECTION csr_conn TO materialize
@@ -101,7 +101,7 @@ class SinkUpsert(Check):
                   ENVELOPE DEBEZIUM
                 """,
                 """
-                $[version>=5200] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5200] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT SELECT ON sink_source_view TO materialize
                 GRANT USAGE ON CONNECTION kafka_conn TO materialize
                 GRANT USAGE ON CONNECTION csr_conn TO materialize
@@ -123,15 +123,15 @@ class SinkUpsert(Check):
         return Testdrive(
             dedent(
                 """
-                $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT SELECT ON sink_source_view TO materialize
                 GRANT USAGE ON CONNECTION kafka_conn TO materialize
                 GRANT USAGE ON CONNECTION csr_conn TO materialize
 
-                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT CREATECLUSTER ON SYSTEM TO materialize
 
-                $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 ALTER ROLE materialize CREATECLUSTER
 
                 > SELECT * FROM sink_source_view;
@@ -350,7 +350,7 @@ class SinkNullDefaults(Check):
             Testdrive(schemas_null() + dedent(s))
             for s in [
                 """
-                $[version>=5200] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5200] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT SELECT ON sink_source_null_view TO materialize
                 GRANT USAGE ON CONNECTION kafka_conn TO materialize
                 GRANT USAGE ON CONNECTION csr_conn TO materialize
@@ -367,7 +367,7 @@ class SinkNullDefaults(Check):
                   ENVELOPE DEBEZIUM
                 """,
                 """
-                $[version>=5200] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5200] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT SELECT ON sink_source_null_view TO materialize
                 GRANT USAGE ON CONNECTION kafka_conn TO materialize
                 GRANT USAGE ON CONNECTION csr_conn TO materialize
@@ -399,15 +399,15 @@ class SinkNullDefaults(Check):
                 $ schema-registry-verify schema-type=avro subject=sink-sink-null3-value
                 {"type":"record","name":"envelope","fields":[{"name":"before","type":["null",{"type":"record","name":"row","fields":[{"name":"l_k","type":"string"},{"name":"l_v1","type":["null","string"],"default":null},{"name":"l_v2","type":["null","long"],"default":null},{"name":"c","type":"long"}]}],"default":null},{"name":"after","type":["null","row"],"default":null}]}
 
-                $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT SELECT ON sink_source_null_view TO materialize
                 GRANT USAGE ON CONNECTION kafka_conn TO materialize
                 GRANT USAGE ON CONNECTION csr_conn TO materialize
 
-                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT CREATECLUSTER ON SYSTEM TO materialize
 
-                $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 ALTER ROLE materialize CREATECLUSTER
 
                 > SELECT * FROM sink_source_null_view;
@@ -606,7 +606,7 @@ class SinkComments(Check):
             Testdrive(schemas_null() + dedent(s))
             for s in [
                 """
-                $[version>=5200] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5200] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT SELECT ON sink_source_comments_view TO materialize
                 GRANT USAGE ON CONNECTION kafka_conn TO materialize
                 GRANT USAGE ON CONNECTION csr_conn TO materialize
@@ -628,7 +628,7 @@ class SinkComments(Check):
                   ENVELOPE DEBEZIUM
                 """,
                 """
-                $[version>=5200] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5200] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT SELECT ON sink_source_comments_view TO materialize
                 GRANT USAGE ON CONNECTION kafka_conn TO materialize
                 GRANT USAGE ON CONNECTION csr_conn TO materialize
@@ -674,15 +674,15 @@ class SinkComments(Check):
                 $ schema-registry-verify schema-type=avro subject=sink-sink-comments3-value
                 {"type":"record","name":"envelope","fields":[{"name":"before","type":["null",{"type":"record","name":"row","doc":"comment on view sink_source_comments_view","fields":[{"name":"l_k","type":"string"},{"name":"l_v1","type":["null","string"],"default":null,"doc":"doc on l_v1"},{"name":"l_v2","type":["null","long"],"default":null,"doc":"value doc on l_v2"},{"name":"c","type":"long"}]}],"default":null},{"name":"after","type":["null","row"],"default":null}]}
 
-                $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT SELECT ON sink_source_comments_view TO materialize
                 GRANT USAGE ON CONNECTION kafka_conn TO materialize
                 GRANT USAGE ON CONNECTION csr_conn TO materialize
 
-                $[version>=5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version>=5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 GRANT CREATECLUSTER ON SYSTEM TO materialize
 
-                $[version<5900] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version<5900] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 ALTER ROLE materialize CREATECLUSTER
 
                 > SELECT * FROM sink_source_comments_view;

--- a/misc/python/materialize/checks/all_checks/statement_logging.py
+++ b/misc/python/materialize/checks/all_checks/statement_logging.py
@@ -22,7 +22,7 @@ class StatementLogging(Check):
         return Testdrive(
             dedent(
                 """
-                $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 ALTER SYSTEM SET statement_logging_max_sample_rate TO 1.0
                 """
             )
@@ -58,12 +58,12 @@ class StatementLogging(Check):
             return Testdrive(
                 dedent(
                     """
-                    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     ALTER SYSTEM SET enable_rbac_checks TO false
                     > SELECT sql, finished_status FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh WHERE mseh.prepared_statement_id = mpsh.id AND sql LIKE '%/* Btv was here */' ORDER BY mseh.began_at;
                     "SELECT 'hello' /* Btv was here */" success
                     "SELECT 'goodbye' /* Btv was here */" success
-                    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     ALTER SYSTEM SET enable_rbac_checks TO true
                     """
                 )
@@ -73,11 +73,11 @@ class StatementLogging(Check):
             return Testdrive(
                 dedent(
                     """
-                    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     ALTER SYSTEM SET enable_rbac_checks TO false
                     > SELECT count(*) <= 2 FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh WHERE mseh.prepared_statement_id = mpsh.id AND sql LIKE '%/* Btv was here */'
                     true
-                    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     ALTER SYSTEM SET enable_rbac_checks TO true
                     """
                 )

--- a/misc/python/materialize/checks/all_checks/with_mutually_recursive.py
+++ b/misc/python/materialize/checks/all_checks/with_mutually_recursive.py
@@ -17,7 +17,7 @@ class WithMutuallyRecursive(Check):
         return Testdrive(
             dedent(
                 """
-                $[version<7100] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                $[version<7100] postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                 ALTER SYSTEM SET enable_with_mutually_recursive = true
 
                 > CREATE MATERIALIZED VIEW wmr1 AS WITH MUTUALLY RECURSIVE (RETURN AT RECURSION LIMIT 100)

--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -8,10 +8,14 @@
 # by the Apache License, Version 2.0.
 
 from random import Random
+from typing import TYPE_CHECKING
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.executors import Executor
 from materialize.mz_version import MzVersion
+
+if TYPE_CHECKING:
+    from materialize.checks.actions import Action
 
 TESTDRIVE_NOP = "$ nop"
 
@@ -53,34 +57,37 @@ class Check:
     def validate(self) -> Testdrive:
         assert False
 
-    def start_initialize(self, e: Executor) -> None:
+    def start_initialize(self, e: Executor, a: "Action") -> None:
         if self._can_run(e) and self.enabled:
             self.current_version = e.current_mz_version
             self._initialize = self.initialize()
-            self._initialize.execute(e)
+            self._initialize.execute(e, a.mz_service)
 
     def join_initialize(self, e: Executor) -> None:
         if self._can_run(e) and self.enabled:
             self._initialize.join(e)
 
-    def start_manipulate(self, e: Executor, phase: int) -> None:
+    def start_manipulate(self, e: Executor, a: "Action") -> None:
         if self._can_run(e) and self.enabled:
             self.current_version = e.current_mz_version
             self._manipulate = self.manipulate()
             assert (
                 len(self._manipulate) == 2
             ), f"manipulate() should return a list with exactly 2 elements, but actually returns {len(self._manipulate)} elements"
-            self._manipulate[phase].execute(e)
 
-    def join_manipulate(self, e: Executor, phase: int) -> None:
+            assert a.phase is not None
+            self._manipulate[a.phase].execute(e, a.mz_service)
+
+    def join_manipulate(self, e: Executor, a: "Action") -> None:
         if self._can_run(e) and self.enabled:
-            self._manipulate[phase].join(e)
+            assert a.phase is not None
+            self._manipulate[a.phase].join(e)
 
-    def start_validate(self, e: Executor) -> None:
+    def start_validate(self, e: Executor, a: "Action") -> None:
         if self._can_run(e) and self.enabled:
             self.current_version = e.current_mz_version
             self._validate = self.validate()
-            self._validate.execute(e)
+            self._validate.execute(e, a.mz_service)
 
     def join_validate(self, e: Executor) -> None:
         if self._can_run(e) and self.enabled:

--- a/misc/python/materialize/checks/executors.py
+++ b/misc/python/materialize/checks/executors.py
@@ -29,7 +29,9 @@ class Executor:
     # persisted.
     system_settings: set[str] = set()
 
-    def testdrive(self, input: str, caller: Traceback | None = None) -> Any:
+    def testdrive(
+        self, input: str, caller: Traceback | None = None, mz_service: str | None = None
+    ) -> Any:
         assert False
 
     def mzcompose_composition(self) -> Composition:
@@ -49,8 +51,10 @@ class MzcomposeExecutor(Executor):
     def mzcompose_composition(self) -> Composition:
         return self.composition
 
-    def testdrive(self, input: str, caller: Traceback | None = None) -> None:
-        self.composition.testdrive(input, caller=caller)
+    def testdrive(
+        self, input: str, caller: Traceback | None = None, mz_service: str | None = None
+    ) -> None:
+        self.composition.testdrive(input, caller=caller, mz_service=mz_service)
 
 
 class MzcomposeExecutorParallel(MzcomposeExecutor):
@@ -58,14 +62,18 @@ class MzcomposeExecutorParallel(MzcomposeExecutor):
         self.composition = composition
         self.exception: BaseException | None = None
 
-    def testdrive(self, input: str, caller: Traceback | None = None) -> Any:
+    def testdrive(
+        self, input: str, caller: Traceback | None = None, mz_service: str | None = None
+    ) -> Any:
         thread = threading.Thread(target=self._testdrive, args=[input, caller])
         thread.start()
         return thread
 
-    def _testdrive(self, input: str, caller: Traceback | None = None) -> None:
+    def _testdrive(
+        self, input: str, caller: Traceback | None = None, mz_service: str | None = None
+    ) -> None:
         try:
-            self.composition.testdrive(input, caller=caller)
+            self.composition.testdrive(input, caller=caller, mz_service=mz_service)
         except BaseException as e:
             self.exception = e
 
@@ -85,7 +93,12 @@ class CloudtestExecutor(Executor):
     def cloudtest_application(self) -> MaterializeApplication:
         return self.application
 
-    def testdrive(self, input: str, caller: Traceback | None = None) -> None:
+    def testdrive(
+        self, input: str, caller: Traceback | None = None, mz_service: str | None = None
+    ) -> None:
+        assert (
+            mz_service is None
+        ), "CloudtestExecutor not yet compatible with custom mz_service names"
         self.application.testdrive.run(
             input=input, no_reset=True, seed=self.seed, caller=caller
         )

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -86,9 +86,11 @@ class Scenario:
 
         for index, action in enumerate(actions):
             # Implicitly call configure to raise version-dependent limits
-            if isinstance(action, StartMz) or isinstance(
-                action, ReplaceEnvironmentdStatefulSet
-            ):
+            if isinstance(action, StartMz):
+                actions.insert(
+                    index + 1, ConfigureMz(self, mz_service=action.mz_service)
+                )
+            elif isinstance(action, ReplaceEnvironmentdStatefulSet):
                 actions.insert(index + 1, ConfigureMz(self))
 
         for action in actions:

--- a/misc/python/materialize/checks/scenarios_persist_txn.py
+++ b/misc/python/materialize/checks/scenarios_persist_txn.py
@@ -1,0 +1,77 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.checks.actions import Action, Initialize, Manipulate, Validate
+from materialize.checks.mzcompose_actions import Down, KillMz, StartMz
+from materialize.checks.scenarios import Scenario
+
+
+class PersistTxnToggle(Scenario):
+    """Toggle persist_txn_tables between `off` and `eager`"""
+
+    def actions(self) -> list[Action]:
+        return [
+            StartMz(
+                self, additional_system_parameter_defaults={"persist_txn_tables": "off"}
+            ),
+            Initialize(self),
+            KillMz(),
+            StartMz(
+                self,
+                additional_system_parameter_defaults={"persist_txn_tables": "eager"},
+            ),
+            Manipulate(self, phase=1),
+            KillMz(),
+            StartMz(
+                self, additional_system_parameter_defaults={"persist_txn_tables": "off"}
+            ),
+            Manipulate(self, phase=2),
+            KillMz(),
+            StartMz(
+                self,
+                additional_system_parameter_defaults={"persist_txn_tables": "eager"},
+            ),
+            Validate(self),
+            KillMz(),
+            StartMz(
+                self, additional_system_parameter_defaults={"persist_txn_tables": "off"}
+            ),
+            Validate(self),
+        ]
+
+
+class PersistTxnFencing(Scenario):
+    """Switch between two instances with different persist_txn_tables settings.
+    Fencing should kick in to prevent data corruption."""
+
+    def actions(self) -> list[Action]:
+        return [
+            StartMz(self, mz_service="mz_txn_tables_default"),
+            Initialize(self, mz_service="mz_txn_tables_default"),
+            StartMz(
+                self,
+                additional_system_parameter_defaults={"persist_txn_tables": "off"},
+                mz_service="mz_txn_tables_off",
+            ),
+            Manipulate(self, phase=1, mz_service="mz_txn_tables_off"),
+            StartMz(
+                self,
+                additional_system_parameter_defaults={"persist_txn_tables": "eager"},
+                mz_service="mz_txn_tables_eager",
+            ),
+            Manipulate(self, phase=2, mz_service="mz_txn_tables_eager"),
+            Validate(self, mz_service="mz_txn_tables_eager"),
+            StartMz(self, mz_service="mz_txn_tables_default"),
+            Validate(self, mz_service="mz_txn_tables_default"),
+            # Since we are creating Mz instances with a non-default name,
+            # we need to perform explicit cleanup here
+            KillMz(mz_service="mz_txn_tables_default"),
+            Down(),
+        ]

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -31,7 +31,7 @@ class Materialized(Service):
 
     def __init__(
         self,
-        name: str = "materialized",
+        name: str | None = None,
         image: str | None = None,
         environment_extra: list[str] = [],
         volumes_extra: list[str] = [],
@@ -54,6 +54,9 @@ class Materialized(Service):
         sanity_restart: bool = True,
         catalog_store: str | None = "shadow",
     ) -> None:
+        if name is None:
+            name = "materialized"
+
         depends_graph: dict[str, ServiceDependency] = {
             s: {"condition": "service_started"} for s in depends_on
         }
@@ -149,7 +152,8 @@ class Materialized(Service):
                 "--persist-consensus-url=postgres://root@cockroach:26257?options=--search_path=consensus",
             ]
             environment += [
-                "MZ_TIMESTAMP_ORACLE_URL=postgres://root@cockroach:26257?options=--search_path=tsoracle"
+                "MZ_TIMESTAMP_ORACLE_URL=postgres://root@cockroach:26257?options=--search_path=tsoracle",
+                "MZ_NO_BUILTIN_COCKROACH=1",
             ]
 
         command += [

--- a/misc/python/materialize/mzcompose/services/ssh_bastion_host.py
+++ b/misc/python/materialize/mzcompose/services/ssh_bastion_host.py
@@ -57,15 +57,17 @@ class SshBastionHost(Service):
         )
 
 
-def setup_default_ssh_test_connection(c: Composition, ssh_tunnel_name: str) -> None:
-
+def setup_default_ssh_test_connection(
+    c: Composition, ssh_tunnel_name: str, mz_service: str | None = None
+) -> None:
     c.sql(
         f"""
             CREATE CONNECTION IF NOT EXISTS {ssh_tunnel_name} TO SSH TUNNEL (
             HOST 'ssh-bastion-host',
             USER 'mz',
             PORT 22)
-        """
+        """,
+        service=mz_service,
     )
 
     public_key = c.sql_query(
@@ -73,7 +75,8 @@ def setup_default_ssh_test_connection(c: Composition, ssh_tunnel_name: str) -> N
             select public_key_1 from mz_ssh_tunnel_connections ssh \
             join mz_connections c on c.id = ssh.id
             where c.name = '{ssh_tunnel_name}';
-        """
+        """,
+        service=mz_service,
     )[0][0]
 
     c.exec(

--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -47,6 +47,7 @@ class Testdrive(Service):
         no_consistency_checks: bool = False,
         external_cockroach: bool = False,
         external_minio: bool = False,
+        mz_service: str = "materialized",
     ) -> None:
         depends_graph: dict[str, ServiceDependency] = {}
 
@@ -141,7 +142,7 @@ class Testdrive(Service):
             )
         else:
             entrypoint.append(
-                "--persist-consensus-url=postgres://root@materialized:26257?options=--search_path=consensus"
+                f"--persist-consensus-url=postgres://root@{mz_service}:26257?options=--search_path=consensus"
             )
 
         entrypoint.extend(entrypoint_extra)

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -15,6 +15,7 @@ from materialize.checks.executors import MzcomposeExecutor, MzcomposeExecutorPar
 from materialize.checks.scenarios import *  # noqa: F401 F403
 from materialize.checks.scenarios import Scenario
 from materialize.checks.scenarios_backup_restore import *  # noqa: F401 F403
+from materialize.checks.scenarios_persist_txn import *  # noqa: F401 F403
 from materialize.checks.scenarios_upgrade import *  # noqa: F401 F403
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.clusterd import Clusterd


### PR DESCRIPTION
### Motivation

This PR adds two new Platform Checks:
- one toggles between different values of persist-txn while restarting Mz
- the other one switches between different values using separate Mz instances; The fencing mechanism is expected to prevent any data corruption.

As currently the persist-txn mechanism kicks in for user tables only, additional, INSERT-heavy, non-Platform-checks fencing tests are needed.

Relates to #24027

### Tips for reviewer

This can be reviewed commit by commit. One section would benefit from whitespace off.