### PR TITLE
catalog: Remove usages of AdapterError

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1081,7 +1081,7 @@ impl Catalog {
         location: mz_catalog::durable::ReplicaLocation,
         allowed_sizes: &Vec<String>,
         allowed_availability_zones: Option<&[String]>,
-    ) -> Result<ReplicaLocation, AdapterError> {
+    ) -> Result<ReplicaLocation, Error> {
         self.state
             .concretize_replica_location(location, allowed_sizes, allowed_availability_zones)
     }
@@ -1090,7 +1090,7 @@ impl Catalog {
         &self,
         allowed_sizes: &[String],
         size: &String,
-    ) -> Result<(), AdapterError> {
+    ) -> Result<(), Error> {
         self.state.ensure_valid_replica_size(allowed_sizes, size)
     }
 

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1119,19 +1119,23 @@ impl Catalog {
         for (name, value) in &system_parameter_defaults {
             match state.set_system_configuration_default(name, VarInput::Flat(value)) {
                 Ok(_) => (),
-                Err(AdapterError::VarError(VarError::UnknownParameter(name))) => {
+                Err(Error {
+                    kind: ErrorKind::VarError(VarError::UnknownParameter(name)),
+                }) => {
                     warn!(%name, "cannot load unknown system parameter from catalog storage to set default parameter");
                 }
-                Err(e) => return Err(e),
+                Err(e) => return Err(e.into()),
             };
         }
         for mz_catalog::durable::SystemConfiguration { name, value } in system_config {
             match state.insert_system_configuration(&name, VarInput::Flat(&value)) {
                 Ok(_) => (),
-                Err(AdapterError::VarError(VarError::UnknownParameter(name))) => {
+                Err(Error {
+                    kind: ErrorKind::VarError(VarError::UnknownParameter(name)),
+                }) => {
                     warn!(%name, "cannot load unknown system parameter from catalog storage to set configured parameter");
                 }
-                Err(e) => return Err(e),
+                Err(e) => return Err(e.into()),
             };
         }
         if let Some(remote_system_parameters) = remote_system_parameters {


### PR DESCRIPTION
This commit removes some usages of AdapterError from the mz_adapter::catalog module.

Works towards resolving #22593

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
