### PR TITLE
catalog: Preserve order on JSON serialization

### DIFF
--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -49,7 +49,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.11.9" }
 postgres-openssl = { version = "0.5.0" }
 serde = "1.0.152"
-serde_json = "1.0.89"
+serde_json = { version = "1.0.89", features = ["preserve_order"] }
 serde_plain = "1.0.1"
 static_assertions = "1.1"
 sha2 = "0.10.6"


### PR DESCRIPTION
This commit adds the preserve_order feature to serde_json, to ensure that the order of fields within a JSON object is deterministic.

Mitigates #23908


### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
