### PR TITLE
storage: correctly transition the envelope_state_bytes value when moving moving from memory to rocksdb

### DIFF
--- a/test/upsert/autospill/01-setup.td
+++ b/test/upsert/autospill/01-setup.td
@@ -1,0 +1,20 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> DROP CLUSTER IF EXISTS storage_cluster CASCADE;
+
+> CREATE CLUSTER storage_cluster REPLICAS (
+    r1 (
+      STORAGECTL ADDRESSES ['clusterd1:2100'],
+      STORAGE ADDRESSES ['clusterd1:2103'],
+      COMPUTECTL ADDRESSES ['clusterd1:2101'],
+      COMPUTE ADDRESSES ['clusterd1:2102'],
+      WORKERS 1
+    )
+  )

--- a/test/upsert/autospill/02-memory.td
+++ b/test/upsert/autospill/02-memory.td
@@ -1,0 +1,36 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-create-topic topic=autospill
+
+> CREATE CONNECTION conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT
+
+> CREATE SOURCE autospill
+  IN CLUSTER storage_cluster
+  FROM KAFKA CONNECTION conn (TOPIC
+  'testdrive-autospill-${testdrive.seed}'
+  )
+  KEY FORMAT TEXT VALUE FORMAT TEXT
+  ENVELOPE UPSERT
+
+
+$ kafka-ingest format=bytes topic=autospill key-format=bytes key-terminator=:
+bird:goose
+animal:whale
+
+> SELECT count(*) from autospill;
+2
+
+> SELECT
+  SUM(u.envelope_state_bytes) > 0
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name = 'autospill'
+true

--- a/test/upsert/autospill/03-rocksdb.td
+++ b/test/upsert/autospill/03-rocksdb.td
@@ -7,33 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ kafka-create-topic topic=autospill
-
-> CREATE CONNECTION conn
-  FOR KAFKA BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT
-
-> CREATE SOURCE autospill
-  FROM KAFKA CONNECTION conn (TOPIC
-  'testdrive-autospill-${testdrive.seed}'
-  )
-  KEY FORMAT TEXT VALUE FORMAT TEXT
-  ENVELOPE UPSERT WITH (SIZE '1')
-
-
-$ kafka-ingest format=bytes topic=autospill key-format=bytes key-terminator=:
-bird:goose
-animal:whale
-
-> SELECT count(*) from autospill;
-2
-
-> SELECT
-  SUM(u.envelope_state_bytes) > 0
-  FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
-  WHERE s.name = 'autospill'
-true
-
 $ set-from-sql var=previous-bytes
 SELECT
   (SUM(u.envelope_state_bytes))::text

--- a/test/upsert/autospill/bytes.td
+++ b/test/upsert/autospill/bytes.td
@@ -17,7 +17,7 @@ $ kafka-create-topic topic=autospill
   'testdrive-autospill-${testdrive.seed}'
   )
   KEY FORMAT TEXT VALUE FORMAT TEXT
-  ENVELOPE UPSERT
+  ENVELOPE UPSERT WITH (SIZE '1')
 
 
 $ kafka-ingest format=bytes topic=autospill key-format=bytes key-terminator=:
@@ -26,6 +26,20 @@ animal:whale
 
 > SELECT count(*) from autospill;
 2
+
+> SELECT
+  SUM(u.envelope_state_bytes) > 0
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name = 'autospill'
+true
+
+$ set-from-sql var=previous-bytes
+SELECT
+  (SUM(u.envelope_state_bytes))::text
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name = 'autospill'
 
 # Inserting large value should trigger auto spill
 $ kafka-ingest format=bytes topic=autospill key-format=bytes key-terminator=:
@@ -36,13 +50,18 @@ fish:AREALLYBIGFISHAREALLYBIGFISHAREALLYBIGFISHAREALLYBIGFISH
 
 > SELECT
     SUM(u.envelope_state_bytes) > 0,
+    -- This + the assertion below that ensures the byte count goes to 0 tests
+    -- that we correctly transition the `envelope_state_bytes` count to the
+    -- in-rocksdb. In the past, we would accidentally SUM the previous and
+    -- new size here.
+    SUM(u.envelope_state_bytes) < (${previous-bytes} * 2),
     SUM(u.envelope_state_records)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
-  WHERE s.name IN ('autospill')
+  WHERE s.name = 'autospill'
   GROUP BY s.name
   ORDER BY s.name
-true 3
+true true 3
 
 # Removing all the inserted keys
 $ kafka-ingest format=bytes topic=autospill key-format=bytes key-terminator=:

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -431,7 +431,7 @@ def workflow_autospill(c: Composition) -> None:
                 "--orchestrator-process-scratch-directory=/mzdata/source_data",
             ],
             additional_system_parameter_defaults={
-                "disk_cluster_replicas_default": "false",
+                "disk_cluster_replicas_default": "true",
                 "upsert_rocksdb_auto_spill_to_disk": "true",
                 "upsert_rocksdb_auto_spill_threshold_bytes": "200",
                 "storage_dataflow_delay_sources_past_rehydration": "true",


### PR DESCRIPTION
We noticed during an investigation that `mz_envelope_state_bytes` seemed to _double-count_ the actual size of the 

This is because we have this bug, which erroneously always subtracts 0 when transitioning this size from the memory-size to the rocksdb size. This was not noticed in the past because:

- `workflow_autospill` was not actually testing the right codepath
  - even if it was, I think using more than 1 worker can mask the issue
- before correctness property 2 was fixed, the size problem was only for a single buffer's work of kafka messages. Now, during hydration, the entire snapshot is double-counted.
- Its fixed after the first rehydration.

This pr fixes all these issues AND adds an additional commit to ensure the test actually is testing what its supposed to be testing. 

### Motivation
  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
