### PR TITLE
release: Add script to cut release

### DIFF
--- a/bin/cut-release
+++ b/bin/cut-release
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# cut-release -- cuts a new Materialize version and pushes it to the Materialize repo.
+
+exec "$(dirname "$0")"/pyactivate -m materialize.cut-release "$@"

--- a/misc/python/materialize/cut-release.py
+++ b/misc/python/materialize/cut-release.py
@@ -27,6 +27,7 @@ def main():
         "--sha",
         help="Chosen SHA of the release",
         type=str,
+        required=True,
     )
     parser.add_argument(
         "--version",

--- a/misc/python/materialize/cut-release.py
+++ b/misc/python/materialize/cut-release.py
@@ -33,6 +33,7 @@ def main():
         "--version",
         help="Version of release",
         type=Version.parse,
+        required=True,
     )
     parser.add_argument(
         "--remote",

--- a/misc/python/materialize/cut-release.py
+++ b/misc/python/materialize/cut-release.py
@@ -15,7 +15,7 @@ import sys
 from semver.version import Version
 
 from materialize import spawn
-from materialize.git import checkout, tag_annotated, get_branch_name, push
+from materialize.git import checkout, tag_annotated, get_branch_name
 
 
 def main():
@@ -39,14 +39,11 @@ def main():
         "--remote",
         help="Git remote name of Materialize repo",
         type=str,
+        required=True,
     )
 
     args = parser.parse_args()
-
-    # Validate and format version.
-    version = args.version
-    version = f"v{Version.parse(version)}"
-
+    version = f"v{args.version}"
     current_branch = get_branch_name()
 
     try:
@@ -57,7 +54,7 @@ def main():
         print("Tagging version")
         tag_annotated(version)
         print("Pushing tag to Materialize repo")
-        push(remote=args.remote, tag=version)
+        spawn.runv(["git", "push", args.remote, version])
     finally:
         # The caller may have started in a detached HEAD state.
         if current_branch:

--- a/misc/python/materialize/cut-release.py
+++ b/misc/python/materialize/cut-release.py
@@ -31,7 +31,7 @@ def main():
     parser.add_argument(
         "--version",
         help="Version of release",
-        type=str,
+        type=Version.parse,
     )
     parser.add_argument(
         "--remote",

--- a/misc/python/materialize/cut-release.py
+++ b/misc/python/materialize/cut-release.py
@@ -15,7 +15,7 @@ import sys
 from semver.version import Version
 
 from materialize import spawn
-from materialize.git import checkout, tag_annotated, get_branch_name
+from materialize.git import checkout, get_branch_name, tag_annotated
 
 
 def main():

--- a/misc/python/materialize/cut-release.py
+++ b/misc/python/materialize/cut-release.py
@@ -1,0 +1,66 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Cut a new release and push it to the Materialize repo"""
+
+import argparse
+import sys
+
+from semver.version import Version
+
+from materialize import spawn
+from materialize.git import checkout, tag_annotated, get_branch_name, push
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="cut_release",
+        description="Creates a new release for Materialize.",
+    )
+    parser.add_argument(
+        "--sha",
+        help="Chosen SHA of the release",
+        type=str,
+    )
+    parser.add_argument(
+        "--version",
+        help="Version of release",
+        type=str,
+    )
+    parser.add_argument(
+        "--remote",
+        help="Git remote name of Materialize repo",
+        type=str,
+    )
+
+    args = parser.parse_args()
+
+    # Validate and format version.
+    version = args.version
+    version = f"v{Version.parse(version)}"
+
+    current_branch = get_branch_name()
+
+    try:
+        print(f"Checking out SHA {args.sha}")
+        checkout(args.sha)
+        print(f"Bumping version to {version}")
+        spawn.runv(["./bin/bump-version", version])
+        print("Tagging version")
+        tag_annotated(version)
+        print("Pushing tag to Materialize repo")
+        push(remote=args.remote, tag=version)
+    finally:
+        # The caller may have started in a detached HEAD state.
+        if current_branch:
+            checkout(current_branch)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/misc/python/materialize/cut-release.py
+++ b/misc/python/materialize/cut-release.py
@@ -14,7 +14,7 @@ import sys
 
 from semver.version import Version
 
-from materialize import spawn
+from materialize import MZ_ROOT, spawn
 from materialize.git import checkout, get_branch_name, tag_annotated
 
 
@@ -50,7 +50,7 @@ def main():
         print(f"Checking out SHA {args.sha}")
         checkout(args.sha)
         print(f"Bumping version to {version}")
-        spawn.runv(["./bin/bump-version", version])
+        spawn.runv([MZ_ROOT / "bin" / "bump-version", version])
         print("Tagging version")
         tag_annotated(version)
         print("Pushing tag to Materialize repo")

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -350,12 +350,3 @@ def commit_all_changed(message: str) -> None:
 def tag_annotated(tag: str) -> None:
     """Create an annotated tag on HEAD"""
     spawn.runv(["git", "tag", "-a", "-m", tag, tag])
-
-
-def push(remote: str, remote_ref: str | None = None, tag: str | None = None) -> None:
-    if remote_ref:
-        spawn.runv(["git", "push", remote, f"HEAD:{remote_ref}"])
-    elif tag:
-        spawn.runv(["git", "push", remote, tag])
-    else:
-        spawn.runv(["git", "push", remote])

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -352,8 +352,10 @@ def tag_annotated(tag: str) -> None:
     spawn.runv(["git", "tag", "-a", "-m", tag, tag])
 
 
-def push(remote: str, remote_ref: str | None = None) -> None:
+def push(remote: str, remote_ref: str | None = None, tag: str | None = None) -> None:
     if remote_ref:
         spawn.runv(["git", "push", remote, f"HEAD:{remote_ref}"])
+    elif tag:
+        spawn.runv(["git", "push", remote, tag])
     else:
         spawn.runv(["git", "push", remote])


### PR DESCRIPTION
This commit adds a script to perform the steps of cutting a new Materialize release that was previously done by hand.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
