### PR TITLE
coverage: Fix empty services.log

### DIFF
--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -17,51 +17,10 @@ run() {
     bin/ci-builder run stable bin/mzcompose --mz-quiet --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
 }
 
-# Run before potential "run down" in coverage
-docker ps --all --quiet | xargs --no-run-if-empty docker inspect > docker-inspect.log
-
-export_cov() {
-    bin/ci-builder run stable rust-cov export \
-      --ignore-filename-regex=.cargo/ \
-      --ignore-filename-regex=target/release/ \
-      --ignore-filename-regex=/cargo/ \
-      --ignore-filename-regex=/mnt/build/ \
-      --ignore-filename-regex=/rustc/ \
-      --format=lcov "$1" --instr-profile=coverage/"$BUILDKITE_JOB_ID".profdata src/ \
-      > coverage/"$BUILDKITE_JOB_ID"-"$(basename "$1")".lcov
-}
-
-if [ -n "${CI_COVERAGE_ENABLED:-}" ] && [ -z "${BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_COVERAGE:-}" ];  then
-    ci_unimportant_heading "Generate coverage information"
-    run --mz-quiet down --volumes
-
-    if [ -n "$(find . -name '*.profraw')" ]; then
-        # Workaround for "invalid instrumentation profile data (file header is corrupt)"
-        find . -name '*.profraw' | while read -r i; do
-            bin/ci-builder run stable rust-profdata show "$i" > /dev/null || rm "$i"
-        done
-        find . -name '*.profraw' -exec bin/ci-builder run stable rust-profdata merge -sparse -o coverage/"$BUILDKITE_JOB_ID".profdata {} +
-        find . -name '*.profraw' -delete
-
-        ARGS=()
-        for program in clusterd environmentd balancerd sqllogictest testdrive; do
-            if [ -f coverage/"$program" ]; then
-                export_cov coverage/"$program"
-                ARGS+=("-a" coverage/"$BUILDKITE_JOB_ID"-"$program".lcov)
-            fi
-        done
-        rm coverage/"$BUILDKITE_JOB_ID".profdata
-        if [ "${#ARGS[@]}" != 0 ]; then
-            bin/ci-builder run stable lcov "${ARGS[@]}" -o coverage/"$BUILDKITE_JOB_ID".lcov
-            rm coverage/"$BUILDKITE_JOB_ID"-*.lcov
-            bin/ci-builder run stable zstd coverage/"$BUILDKITE_JOB_ID".lcov
-            buildkite-agent artifact upload coverage/"$BUILDKITE_JOB_ID".lcov.zst
-        fi
-    fi
-fi
-
 ci_unimportant_heading "Upload log artifacts"
 
+# Run before potential "run down" in coverage
+docker ps --all --quiet | xargs --no-run-if-empty docker inspect > docker-inspect.log
 # services.log might already exist and contain logs from before composition was downed
 run logs --no-color >> services.log
 # shellcheck disable=SC2024
@@ -111,4 +70,44 @@ bin/ci-builder run stable bin/ci-logged-errors-detect "${artifacts[@]}"
 if [ ! -s services.log ] && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of persist" ] && [ "$BUILDKITE_LABEL" != "Long single-node Maelstrom coverage of persist" ] && [ "$BUILDKITE_LABEL" != "Mz E2E Test" ] && [ "$BUILDKITE_LABEL" != "Output consistency (version)" ]; then
     echo "+++ services.log is empty, failing"
     exit 1
+fi
+
+export_cov() {
+    bin/ci-builder run stable rust-cov export \
+      --ignore-filename-regex=.cargo/ \
+      --ignore-filename-regex=target/release/ \
+      --ignore-filename-regex=/cargo/ \
+      --ignore-filename-regex=/mnt/build/ \
+      --ignore-filename-regex=/rustc/ \
+      --format=lcov "$1" --instr-profile=coverage/"$BUILDKITE_JOB_ID".profdata src/ \
+      > coverage/"$BUILDKITE_JOB_ID"-"$(basename "$1")".lcov
+}
+
+if [ -n "${CI_COVERAGE_ENABLED:-}" ] && [ -z "${BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_COVERAGE:-}" ];  then
+    ci_unimportant_heading "Generate coverage information"
+    run --mz-quiet down --volumes
+
+    if [ -n "$(find . -name '*.profraw')" ]; then
+        # Workaround for "invalid instrumentation profile data (file header is corrupt)"
+        find . -name '*.profraw' | while read -r i; do
+            bin/ci-builder run stable rust-profdata show "$i" > /dev/null || rm "$i"
+        done
+        find . -name '*.profraw' -exec bin/ci-builder run stable rust-profdata merge -sparse -o coverage/"$BUILDKITE_JOB_ID".profdata {} +
+        find . -name '*.profraw' -delete
+
+        ARGS=()
+        for program in clusterd environmentd balancerd sqllogictest testdrive; do
+            if [ -f coverage/"$program" ]; then
+                export_cov coverage/"$program"
+                ARGS+=("-a" coverage/"$BUILDKITE_JOB_ID"-"$program".lcov)
+            fi
+        done
+        rm coverage/"$BUILDKITE_JOB_ID".profdata
+        if [ "${#ARGS[@]}" != 0 ]; then
+            bin/ci-builder run stable lcov "${ARGS[@]}" -o coverage/"$BUILDKITE_JOB_ID".lcov
+            rm coverage/"$BUILDKITE_JOB_ID"-*.lcov
+            bin/ci-builder run stable zstd coverage/"$BUILDKITE_JOB_ID".lcov
+            buildkite-agent artifact upload coverage/"$BUILDKITE_JOB_ID".lcov.zst
+        fi
+    fi
 fi


### PR DESCRIPTION
See for example https://buildkite.com/materialize/coverage/builds/332

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
