### PR TITLE
more principled frontier checking to avoid flakes

### DIFF
--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -301,8 +301,16 @@ $ kafka-verify-data headers=materialize-timestamp format=avro sink=materialize.p
 1	{"before": null, "after": {"row": {"a": 1, "b": 1}}}
 1	{"before": null, "after": {"row": {"a": 2, "b": 2}}}
 
-$ kafka-verify-data format=json key=false topic=testdrive-progress-fixed-${testdrive.seed}
-{"frontier": [2]}
+> CREATE SOURCE compaction_test_sink_check
+  FROM KAFKA CONNECTION kafka_fixed (TOPIC 'testdrive-progress-fixed-${testdrive.seed}')
+  FORMAT JSON ENVELOPE NONE
+
+# Retrieve all the progress messages that are beyond [2]. There should be
+# exactly one of them because the upper of the CDCv2 stream stops at [2].
+> SELECT data->'frontier'
+  FROM compaction_test_sink_check
+  WHERE data->'frontier'->0 IS NULL OR (data->'frontier'->0)::int >= 2
+[2]
 
 # verify output with real-time timestamps
 


### PR DESCRIPTION
This test assumed that the frontier jumps directly from {0} to {2} but it is totally valid for the data to be committed in two steps, first until frontier {1} and then until frontier {2}. The latter only happens rarely due to the amount of data being very small and usually the dataflows directly go to {2} but when it happened the tests would produce false negative.

This PR fixes the problem by reading back the progress messages and enforcing a more principled invariant checking by requiring that all recorded frontiers beyond the expected upper are exactly one. This is robust to additional steps being taken before the progress reaches the expected frontier and additionally asserts that the frontier didn't move *more* than it should have, something that the previous tests wouldn't have caught.

Fixes #24063

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
