### PR TITLE
explain: change `ExplainConfig` defaults in production

### DIFF
--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -246,11 +246,14 @@ impl TryFrom<BTreeSet<String>> for ExplainConfig {
         }
         let result = ExplainConfig {
             redacted: flags.remove("redacted"),
-            arity: flags.remove("arity"),
+            arity: flags.remove("arity") || !SOFT_ASSERTIONS.load(Ordering::Relaxed),
             cardinality: flags.remove("cardinality"),
             column_names: flags.remove("column_names"),
-            filter_pushdown: flags.remove("filter_pushdown") || flags.remove("mfp_pushdown"),
-            humanized_exprs: flags.remove("humanized_exprs") && !flags.contains("raw_plans"),
+            filter_pushdown: flags.remove("filter_pushdown")
+                || flags.remove("mfp_pushdown")
+                || !SOFT_ASSERTIONS.load(Ordering::Relaxed),
+            humanized_exprs: !flags.contains("raw_plans")
+                && (flags.remove("humanized_exprs") || !SOFT_ASSERTIONS.load(Ordering::Relaxed)),
             join_impls: flags.remove("join_impls"),
             keys: flags.remove("keys"),
             linear_chains: flags.remove("linear_chains") && !flags.contains("raw_plans"),


### PR DESCRIPTION
Change the following `ExplainConfig` defaults in environments that run with `SOFT_ASSERTIONS` disabled (which is true for our `staging` and `production` environments, but not for CI):

- `arity`
- `filter_pushdown` (a.k.a. `mfp_pushdown`)
- `humanized_exprs` (unless `raw_plans` is selected)

### Motivation

  * This PR adds a feature that has not yet been specified.

Implementing changes proposed both by me and @sjwiesman.

### Tips for reviewer

Tests won't change here unless they specifically run some of the CI tests with `MZ_SOFT_ASSERTIONS`. I ran a manual check on my `staging` environment with the `dev-` build from this PR to verify that the defaults are picked up as expected.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - `EXPLAIN` output will now show humanized expressions, filter pushdown, and arity information by default.
