### PR TITLE
Move `CREATE VIEW` optimization off the coordinator thread

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -151,6 +151,14 @@ impl Coordinator {
                     otel_ctx.attach_as_parent();
                     self.sequence_peek_stage(ctx, otel_ctx, stage).await;
                 }
+                Message::CreateViewStageReady {
+                    ctx,
+                    otel_ctx,
+                    stage,
+                } => {
+                    otel_ctx.attach_as_parent();
+                    self.sequence_create_view_stage(ctx, stage, otel_ctx).await;
+                }
                 Message::CreateMaterializedViewStageReady {
                     ctx,
                     otel_ctx,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -195,19 +195,7 @@ impl Coordinator {
                     self.sequence_create_sink(ctx, plan, resolved_ids).await;
                 }
                 Plan::CreateView(plan) => {
-                    if self
-                        .catalog()
-                        .system_config()
-                        .enable_off_thread_optimization()
-                    {
-                        self.sequence_create_view_off_thread(ctx, plan, resolved_ids)
-                            .await;
-                    } else {
-                        let result = self
-                            .sequence_create_view(ctx.session_mut(), plan, resolved_ids)
-                            .await;
-                        ctx.retire(result);
-                    }
+                    self.sequence_create_view(ctx, plan, resolved_ids).await;
                 }
                 Plan::CreateMaterializedView(plan) => {
                     self.sequence_create_materialized_view(ctx, plan, resolved_ids)

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -200,10 +200,8 @@ impl Coordinator {
                         .system_config()
                         .enable_off_thread_optimization()
                     {
-                        let result = self
-                            .sequence_create_view_off_thread(ctx.session_mut(), plan, resolved_ids)
+                        self.sequence_create_view_off_thread(ctx, plan, resolved_ids)
                             .await;
-                        ctx.retire(result);
                     } else {
                         let result = self
                             .sequence_create_view(ctx.session_mut(), plan, resolved_ids)

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -51,7 +51,7 @@ use mz_sql::names::{
 // Import `plan` module, but only import select elements to avoid merge conflicts on use statements.
 use mz_adapter_types::connection::ConnectionId;
 use mz_catalog::memory::objects::{
-    CatalogItem, Cluster, Connection, DataSourceDesc, Secret, Sink, Source, Table, Type, View,
+    CatalogItem, Cluster, Connection, DataSourceDesc, Secret, Sink, Source, Table, Type,
 };
 use mz_sql::plan::{
     AlterConnectionAction, AlterConnectionPlan, AlterOptionParameter, ExplainSinkSchemaPlan,
@@ -854,95 +854,6 @@ impl Coordinator {
         } else {
             Ok(())
         }
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub(super) async fn sequence_create_view(
-        &mut self,
-        session: &mut Session,
-        plan: plan::CreateViewPlan,
-        resolved_ids: ResolvedIds,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        let if_not_exists = plan.if_not_exists;
-        let ops = self.generate_view_ops(session, &plan, resolved_ids).await?;
-        match self.catalog_transact(Some(session), ops).await {
-            Ok(()) => Ok(ExecuteResponse::CreatedView),
-            Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
-                kind:
-                    mz_catalog::memory::error::ErrorKind::Sql(CatalogError::ItemAlreadyExists(_, _)),
-            })) if if_not_exists => {
-                session.add_notice(AdapterNotice::ObjectAlreadyExists {
-                    name: plan.name.item,
-                    ty: "view",
-                });
-                Ok(ExecuteResponse::CreatedView)
-            }
-            Err(err) => Err(err),
-        }
-    }
-
-    async fn generate_view_ops(
-        &mut self,
-        session: &Session,
-        plan::CreateViewPlan {
-            name,
-            view,
-            drop_ids,
-            ambiguous_columns,
-            ..
-        }: &plan::CreateViewPlan,
-        resolved_ids: ResolvedIds,
-    ) -> Result<Vec<catalog::Op>, AdapterError> {
-        // Validate any references in the view's expression. We do this on the
-        // unoptimized plan to better reflect what the user typed. We want to
-        // reject queries that depend on a relation in the wrong timeline, for
-        // example, even if we can *technically* optimize that reference away.
-        let depends_on = view.expr.depends_on();
-        self.validate_timeline_context(depends_on.iter().copied())?;
-        self.validate_system_column_references(*ambiguous_columns, &depends_on)?;
-
-        let mut ops = vec![];
-
-        ops.extend(
-            drop_ids
-                .iter()
-                .map(|id| catalog::Op::DropObject(ObjectId::Item(*id))),
-        );
-
-        let view_id = self.catalog_mut().allocate_user_id().await?;
-        let view_oid = self.catalog_mut().allocate_oid()?;
-        let raw_expr = view.expr.clone();
-
-        // Collect optimizer parameters.
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
-
-        // Build an optimizer for this VIEW.
-        let mut optimizer = optimize::view::Optimizer::new(optimizer_config);
-
-        // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
-        let optimized_expr = optimizer.optimize(raw_expr.clone())?;
-
-        let view = View {
-            create_sql: view.create_sql.clone(),
-            raw_expr,
-            desc: RelationDesc::new(optimized_expr.typ(), view.column_names.clone()),
-            optimized_expr,
-            conn_id: if view.temporary {
-                Some(session.conn_id().clone())
-            } else {
-                None
-            },
-            resolved_ids,
-        };
-        ops.push(catalog::Op::CreateItem {
-            id: view_id,
-            oid: view_oid,
-            name: name.clone(),
-            item: CatalogItem::View(view),
-            owner_id: *session.current_role_id(),
-        });
-
-        Ok(ops)
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -114,6 +114,7 @@ use crate::util::{viewable_variables, ClientTransmitter, ComputeSinkId, ResultEx
 use crate::{guard_write_critical_section, PeekResponseUnary, TimestampExplanation};
 
 mod create_materialized_view;
+mod create_view;
 
 /// Attempts to evaluate an expression. If an error is returned then the error is sent
 /// to the client and the function is exited.

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -61,7 +61,7 @@ impl Coordinator {
 
         // Process the current stage and allow for processing the next.
         loop {
-            // Always verify peek validity. This is cheap, and prevents programming errors
+            // Always verify plan validity. This is cheap, and prevents programming errors
             // if we move any stages off thread.
             if let Some(validity) = stage.validity() {
                 return_if_err!(validity.check(self.catalog()), ctx);

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -28,7 +28,7 @@ use crate::{catalog, AdapterNotice, ExecuteContext};
 
 impl Coordinator {
     #[tracing::instrument(level = "debug", skip(self))]
-    pub(crate) async fn sequence_create_view_off_thread(
+    pub(crate) async fn sequence_create_view(
         &mut self,
         ctx: ExecuteContext,
         plan: plan::CreateViewPlan,

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -1,0 +1,117 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use mz_catalog::memory::objects::{CatalogItem, View};
+use mz_expr::CollectionPlan;
+use mz_repr::RelationDesc;
+use mz_sql::catalog::CatalogError;
+use mz_sql::names::{ObjectId, ResolvedIds};
+use mz_sql::plan::{self};
+
+use crate::command::ExecuteResponse;
+use crate::coord::Coordinator;
+use crate::error::AdapterError;
+use crate::optimize::{self, Optimize};
+use crate::session::Session;
+use crate::{catalog, AdapterNotice};
+
+impl Coordinator {
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) async fn sequence_create_view_off_thread(
+        &mut self,
+        session: &mut Session,
+        plan: plan::CreateViewPlan,
+        resolved_ids: ResolvedIds,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        ::tracing::info!("sequence_create_view_off_thread");
+
+        let if_not_exists = plan.if_not_exists;
+        let ops = self
+            .generate_view_ops_off_thread(session, &plan, resolved_ids)
+            .await?;
+        match self.catalog_transact(Some(session), ops).await {
+            Ok(()) => Ok(ExecuteResponse::CreatedView),
+            Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
+                kind:
+                    mz_catalog::memory::error::ErrorKind::Sql(CatalogError::ItemAlreadyExists(_, _)),
+            })) if if_not_exists => {
+                session.add_notice(AdapterNotice::ObjectAlreadyExists {
+                    name: plan.name.item,
+                    ty: "view",
+                });
+                Ok(ExecuteResponse::CreatedView)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn generate_view_ops_off_thread(
+        &mut self,
+        session: &Session,
+        plan::CreateViewPlan {
+            name,
+            view,
+            drop_ids,
+            ambiguous_columns,
+            ..
+        }: &plan::CreateViewPlan,
+        resolved_ids: ResolvedIds,
+    ) -> Result<Vec<catalog::Op>, AdapterError> {
+        // Validate any references in the view's expression. We do this on the
+        // unoptimized plan to better reflect what the user typed. We want to
+        // reject queries that depend on a relation in the wrong timeline, for
+        // example, even if we can *technically* optimize that reference away.
+        let depends_on = view.expr.depends_on();
+        self.validate_timeline_context(depends_on.iter().copied())?;
+        self.validate_system_column_references(*ambiguous_columns, &depends_on)?;
+
+        let mut ops = vec![];
+
+        ops.extend(
+            drop_ids
+                .iter()
+                .map(|id| catalog::Op::DropObject(ObjectId::Item(*id))),
+        );
+
+        let view_id = self.catalog_mut().allocate_user_id().await?;
+        let view_oid = self.catalog_mut().allocate_oid()?;
+        let raw_expr = view.expr.clone();
+
+        // Collect optimizer parameters.
+        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
+
+        // Build an optimizer for this VIEW.
+        let mut optimizer = optimize::view::Optimizer::new(optimizer_config);
+
+        // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
+        let optimized_expr = optimizer.optimize(raw_expr.clone())?;
+
+        let view = View {
+            create_sql: view.create_sql.clone(),
+            raw_expr,
+            desc: RelationDesc::new(optimized_expr.typ(), view.column_names.clone()),
+            optimized_expr,
+            conn_id: if view.temporary {
+                Some(session.conn_id().clone())
+            } else {
+                None
+            },
+            resolved_ids,
+        };
+        ops.push(catalog::Op::CreateItem {
+            id: view_id,
+            oid: view_oid,
+            name: name.clone(),
+            item: CatalogItem::View(view),
+            owner_id: *session.current_role_id(),
+        });
+
+        Ok(ops)
+    }
+}

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -9,79 +9,124 @@
 
 use mz_catalog::memory::objects::{CatalogItem, View};
 use mz_expr::CollectionPlan;
+use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::RelationDesc;
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::{ObjectId, ResolvedIds};
 use mz_sql::plan::{self};
 
 use crate::command::ExecuteResponse;
-use crate::coord::Coordinator;
+use crate::coord::sequencer::inner::return_if_err;
+use crate::coord::{
+    Coordinator, CreateViewFinish, CreateViewOptimize, CreateViewStage, CreateViewValidate,
+    Message, PlanValidity,
+};
 use crate::error::AdapterError;
 use crate::optimize::{self, Optimize};
 use crate::session::Session;
-use crate::{catalog, AdapterNotice};
+use crate::{catalog, AdapterNotice, ExecuteContext};
 
 impl Coordinator {
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn sequence_create_view_off_thread(
         &mut self,
-        session: &mut Session,
+        ctx: ExecuteContext,
         plan: plan::CreateViewPlan,
         resolved_ids: ResolvedIds,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        ::tracing::info!("sequence_create_view_off_thread");
+    ) {
+        self.sequence_create_view_stage(
+            ctx,
+            CreateViewStage::Validate(CreateViewValidate { plan, resolved_ids }),
+            OpenTelemetryContext::obtain(),
+        )
+        .await;
+    }
 
-        let if_not_exists = plan.if_not_exists;
-        let ops = self
-            .generate_view_ops_off_thread(session, &plan, resolved_ids)
-            .await?;
-        match self.catalog_transact(Some(session), ops).await {
-            Ok(()) => Ok(ExecuteResponse::CreatedView),
-            Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
-                kind:
-                    mz_catalog::memory::error::ErrorKind::Sql(CatalogError::ItemAlreadyExists(_, _)),
-            })) if if_not_exists => {
-                session.add_notice(AdapterNotice::ObjectAlreadyExists {
-                    name: plan.name.item,
-                    ty: "view",
-                });
-                Ok(ExecuteResponse::CreatedView)
+    /// Processes as many peek stages as possible.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) async fn sequence_create_view_stage(
+        &mut self,
+        mut ctx: ExecuteContext,
+        mut stage: CreateViewStage,
+        otel_ctx: OpenTelemetryContext,
+    ) {
+        use CreateViewStage::*;
+
+        // Process the current stage and allow for processing the next.
+        loop {
+            // Always verify plan validity. This is cheap, and prevents programming errors
+            // if we move any stages off thread.
+            if let Some(validity) = stage.validity() {
+                return_if_err!(validity.check(self.catalog()), ctx);
             }
-            Err(err) => Err(err),
+
+            (ctx, stage) = match stage {
+                Validate(stage) => {
+                    let next = return_if_err!(self.create_view_validate(ctx.session(), stage), ctx);
+                    (ctx, CreateViewStage::Optimize(next))
+                }
+                Optimize(stage) => {
+                    self.create_view_optimize(ctx, stage, otel_ctx).await;
+                    return;
+                }
+                Finish(stage) => {
+                    let result = self.create_view_finish(&mut ctx, stage).await;
+                    ctx.retire(result);
+                    return;
+                }
+            }
         }
     }
 
-    async fn generate_view_ops_off_thread(
+    fn create_view_validate(
         &mut self,
         session: &Session,
-        plan::CreateViewPlan {
-            name,
-            view,
-            drop_ids,
+        CreateViewValidate { plan, resolved_ids }: CreateViewValidate,
+    ) -> Result<CreateViewOptimize, AdapterError> {
+        let plan::CreateViewPlan {
+            view: plan::View { expr, .. },
             ambiguous_columns,
             ..
-        }: &plan::CreateViewPlan,
-        resolved_ids: ResolvedIds,
-    ) -> Result<Vec<catalog::Op>, AdapterError> {
+        } = &plan;
+
         // Validate any references in the view's expression. We do this on the
         // unoptimized plan to better reflect what the user typed. We want to
         // reject queries that depend on a relation in the wrong timeline, for
         // example, even if we can *technically* optimize that reference away.
-        let depends_on = view.expr.depends_on();
-        self.validate_timeline_context(depends_on.iter().copied())?;
-        self.validate_system_column_references(*ambiguous_columns, &depends_on)?;
+        let expr_depends_on = expr.depends_on();
+        self.validate_timeline_context(expr_depends_on.iter().copied())?;
+        self.validate_system_column_references(*ambiguous_columns, &expr_depends_on)?;
 
-        let mut ops = vec![];
+        let validity = PlanValidity {
+            transient_revision: self.catalog().transient_revision(),
+            dependency_ids: expr_depends_on.clone(),
+            cluster_id: None,
+            replica_id: None,
+            role_metadata: session.role_metadata().clone(),
+        };
 
-        ops.extend(
-            drop_ids
-                .iter()
-                .map(|id| catalog::Op::DropObject(ObjectId::Item(*id))),
-        );
+        Ok(CreateViewOptimize {
+            validity,
+            plan,
+            resolved_ids,
+        })
+    }
 
-        let view_id = self.catalog_mut().allocate_user_id().await?;
-        let view_oid = self.catalog_mut().allocate_oid()?;
-        let raw_expr = view.expr.clone();
+    async fn create_view_optimize(
+        &mut self,
+        ctx: ExecuteContext,
+        CreateViewOptimize {
+            validity,
+            plan,
+            resolved_ids,
+        }: CreateViewOptimize,
+        otel_ctx: OpenTelemetryContext,
+    ) {
+        // Generate data structures that can be moved to another task where we will perform possibly
+        // expensive optimizations.
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
+
+        let id = return_if_err!(self.catalog_mut().allocate_user_id().await, ctx);
 
         // Collect optimizer parameters.
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
@@ -89,29 +134,99 @@ impl Coordinator {
         // Build an optimizer for this VIEW.
         let mut optimizer = optimize::view::Optimizer::new(optimizer_config);
 
-        // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
-        let optimized_expr = optimizer.optimize(raw_expr.clone())?;
+        let span = tracing::debug_span!("optimize create view task");
 
-        let view = View {
-            create_sql: view.create_sql.clone(),
-            raw_expr,
-            desc: RelationDesc::new(optimized_expr.typ(), view.column_names.clone()),
-            optimized_expr,
-            conn_id: if view.temporary {
-                Some(session.conn_id().clone())
-            } else {
-                None
+        mz_ore::task::spawn_blocking(
+            || "optimize create view",
+            move || {
+                let _guard = span.enter();
+
+                // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
+                let raw_expr = plan.view.expr.clone();
+                let optimized_expr = return_if_err!(optimizer.optimize(raw_expr), ctx);
+
+                let stage = CreateViewStage::Finish(CreateViewFinish {
+                    validity,
+                    id,
+                    plan,
+                    optimized_expr,
+                    resolved_ids,
+                });
+
+                let _ = internal_cmd_tx.send(Message::CreateViewStageReady {
+                    ctx,
+                    otel_ctx,
+                    stage,
+                });
             },
+        );
+    }
+
+    async fn create_view_finish(
+        &mut self,
+        ctx: &mut ExecuteContext,
+        CreateViewFinish {
+            id,
+            plan:
+                plan::CreateViewPlan {
+                    name,
+                    view:
+                        plan::View {
+                            create_sql,
+                            expr: raw_expr,
+                            column_names,
+                            temporary,
+                        },
+                    drop_ids,
+                    if_not_exists,
+                    ..
+                },
+            optimized_expr,
             resolved_ids,
-        };
+            ..
+        }: CreateViewFinish,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        let oid = self.catalog_mut().allocate_oid()?;
+
+        let mut ops = vec![];
+        ops.extend(
+            drop_ids
+                .iter()
+                .map(|id| catalog::Op::DropObject(ObjectId::Item(*id))),
+        );
         ops.push(catalog::Op::CreateItem {
-            id: view_id,
-            oid: view_oid,
+            id,
+            oid,
             name: name.clone(),
-            item: CatalogItem::View(view),
-            owner_id: *session.current_role_id(),
+            item: CatalogItem::View(View {
+                create_sql: create_sql.clone(),
+                raw_expr,
+                desc: RelationDesc::new(optimized_expr.typ(), column_names.clone()),
+                optimized_expr,
+                conn_id: if temporary {
+                    Some(ctx.session().conn_id().clone())
+                } else {
+                    None
+                },
+                resolved_ids: resolved_ids.clone(),
+            }),
+            owner_id: *ctx.session().current_role_id(),
         });
 
-        Ok(ops)
+        match self.catalog_transact(Some(ctx.session()), ops).await {
+            Ok(()) => Ok(ExecuteResponse::CreatedView),
+            Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
+                kind:
+                    mz_catalog::memory::error::ErrorKind::Sql(CatalogError::ItemAlreadyExists(_, _)),
+            })) if if_not_exists => {
+                ctx.session()
+                    .add_notice(AdapterNotice::ObjectAlreadyExists {
+                        name: name.item,
+                        ty: "view",
+                    });
+                Ok(ExecuteResponse::CreatedView)
+            }
+            Err(err) => Err(err),
+        }
     }
 }


### PR DESCRIPTION
Part of #16217 (this is part 3/5 for the "off-thread refactoring" for optimized statements).

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

This is similarly structured to #24049.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
