### PR TITLE
ci: Trim unnecessary builds

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -780,6 +780,11 @@ class DependencySet:
             if returncode:
                 raise subprocess.CalledProcessError(returncode, push.args)
 
+    def check(self) -> bool:
+        """Check all publishable images in this dependency set exist on Docker
+        Hub. Don't try to download or build them."""
+        return all(dep.is_published_if_necessary() for dep in self)
+
     def __iter__(self) -> Iterator[ResolvedImage]:
         return iter(self._dependencies.values())
 


### PR DESCRIPTION
This should be much cheaper than waiting for a builder agent to spin up just to check that all docker images already exist and it has to do nothing

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
