### PR TITLE
lint: Don't fix Python formattings using ruff

### DIFF
--- a/bin/pyfmt
+++ b/bin/pyfmt
@@ -18,6 +18,23 @@ cd "$(dirname "$0")/.."
 . misc/shlib/shlib.bash
 
 try bin/pyactivate -m black . "$@"
-try bin/pyactivate -m ruff --fix --extend-exclude=misc/dbt-materialize .
-try bin/pyactivate -m ruff --target-version=py38 --fix misc/dbt-materialize
+
+args=("--fix")
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --check)
+      # ruff only supports --fix, not --check
+      args=()
+      shift
+      ;;
+    *)
+      # Ignore all unknown arguments
+      shift
+      ;;
+  esac
+done
+
+try bin/pyactivate -m ruff "${args[@]}" --extend-exclude=misc/dbt-materialize .
+try bin/pyactivate -m ruff --target-version=py38 "${args[@]}" misc/dbt-materialize
 try_status_report


### PR DESCRIPTION
As reported by Joe: https://materializeinc.slack.com/archives/C01LKF361MZ/p1703167926627519

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
