### PR TITLE
catalog: Add comment explaining JSON serialization

### DIFF
--- a/src/catalog/build.rs
+++ b/src/catalog/build.rs
@@ -195,6 +195,18 @@ fn main() -> anyhow::Result<()> {
     // 'as' is okay here because we're using it to define the type of the empty slice, which is
     // necessary since the method takes the slice as a generic arg.
     #[allow(clippy::as_conversions)]
+    // DO NOT change how JSON serialization works for these objects. The catalog relies on the JSON
+    // serialization of these objects remaining stable for a specific objects_vX version. If you
+    // want to change the JSON serialization format then follow these steps:
+    //
+    //   1. Create a new version of the `objects.proto` file.
+    //   2. Update the path of .proto files given to this compile block so that it is only the
+    //      previous .proto files.
+    //   3. Add a new `prost_build::Config::new()...compile_protos(...)` block that only compiles
+    //      the new and all future .proto files with the changed JSON serialization.
+    //
+    // Once we delete all the `.proto` that use the old JSON serialization, then we can delete
+    // the compile block for them as well.
     prost_build::Config::new()
         .btree_map(["."])
         .bytes(["."])


### PR DESCRIPTION
### Motivation
Add comment

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
