### PR TITLE
sql: Emit notice when Role or System default changes for a variable

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4675,6 +4675,9 @@ impl Coordinator {
         let catalog = self.catalog().for_session(session);
         let role = catalog.get_role(&id);
 
+        // We'll send these notices to the user, if the operation is successful.
+        let mut notices = vec![];
+
         // Get the attributes and variables from the role, as they currently are.
         let mut attributes = role.attributes().clone();
         let mut vars = role.vars().clone();
@@ -4685,6 +4688,10 @@ impl Coordinator {
                 if let Some(inherit) = attrs.inherit {
                     attributes.inherit = inherit;
                 }
+
+                if let Some(notice) = self.should_emit_rbac_notice(session) {
+                    notices.push(notice);
+                }
             }
             PlannedAlterRoleOption::Variable(variable) => {
                 // Get the variable to make sure it's valid and visible.
@@ -4692,7 +4699,7 @@ impl Coordinator {
                     .vars()
                     .get(Some(catalog.system_vars()), variable.name())?;
 
-                match variable {
+                let var_name = match variable {
                     PlannedRoleVariable::Set { name, value } => {
                         // Update our persisted set.
                         match &value {
@@ -4707,12 +4714,20 @@ impl Coordinator {
                                 vars.insert(name.clone(), var);
                             }
                         };
+                        name
                     }
                     PlannedRoleVariable::Reset { name } => {
                         // Remove it from our persisted values.
                         vars.remove(&name);
+                        name
                     }
-                }
+                };
+
+                // Emit a notice that they need to reconnect to see the change take effect.
+                notices.push(AdapterNotice::VarDefaultUpdated {
+                    role: Some(name.clone()),
+                    var_name: Some(var_name),
+                })
             }
         }
 
@@ -4722,9 +4737,15 @@ impl Coordinator {
             attributes,
             vars: RoleVars { map: vars },
         };
-        self.catalog_transact(Some(session), vec![op])
+        let response = self
+            .catalog_transact(Some(session), vec![op])
             .await
-            .map(|_| ExecuteResponse::AlteredRole)
+            .map(|_| ExecuteResponse::AlteredRole)?;
+
+        // Send all of our queued notices.
+        session.add_notices(notices);
+
+        Ok(response)
     }
 
     pub(super) async fn sequence_alter_secret(
@@ -5639,12 +5660,19 @@ impl Coordinator {
         self.is_user_allowed_to_alter_system(session, Some(&name))?;
         let op = match value {
             plan::VariableValue::Values(values) => catalog::Op::UpdateSystemConfiguration {
-                name,
+                name: name.clone(),
                 value: OwnedVarInput::SqlSet(values),
             },
-            plan::VariableValue::Default => catalog::Op::ResetSystemConfiguration { name },
+            plan::VariableValue::Default => {
+                catalog::Op::ResetSystemConfiguration { name: name.clone() }
+            }
         };
         self.catalog_transact(Some(session), vec![op]).await?;
+
+        session.add_notice(AdapterNotice::VarDefaultUpdated {
+            role: None,
+            var_name: Some(name),
+        });
         Ok(ExecuteResponse::AlteredSystemConfiguration)
     }
 
@@ -5654,8 +5682,12 @@ impl Coordinator {
         plan::AlterSystemResetPlan { name }: plan::AlterSystemResetPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.is_user_allowed_to_alter_system(session, Some(&name))?;
-        let op = catalog::Op::ResetSystemConfiguration { name };
+        let op = catalog::Op::ResetSystemConfiguration { name: name.clone() };
         self.catalog_transact(Some(session), vec![op]).await?;
+        session.add_notice(AdapterNotice::VarDefaultUpdated {
+            role: None,
+            var_name: Some(name),
+        });
         Ok(ExecuteResponse::AlteredSystemConfiguration)
     }
 
@@ -5667,6 +5699,10 @@ impl Coordinator {
         self.is_user_allowed_to_alter_system(session, None)?;
         let op = catalog::Op::ResetAllSystemConfiguration;
         self.catalog_transact(Some(session), vec![op]).await?;
+        session.add_notice(AdapterNotice::VarDefaultUpdated {
+            role: None,
+            var_name: None,
+        });
         Ok(ExecuteResponse::AlteredSystemConfiguration)
     }
 

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -442,7 +442,7 @@ impl fmt::Display for AdapterNotice {
                 };
                 write!(
                     f,
-                    "{vars} updated for {target}, please reconnect to take effect"
+                    "{vars} updated for {target}, this will have no effect on the current session"
                 )
             }
             AdapterNotice::Welcome(message) => message.fmt(f),


### PR DESCRIPTION
### Motivation

This PR adds a feature that has not yet been specified.

Currently when running `ALTER ROLE ... SET ...` or `ALTER SYSTEM SET ...` you won't observe the new value for the variable until you start a new session. This is what Postgres does, but it could be a bit confusing to users. This PR adds a new notice that gets emitted whenever a user changes a variable, to let them know it won't take effect until they start a new session. For example:

```
materialize=> ALTER ROLE parker SET cluster TO foo;
NOTICE:  variable "cluster" was updated for "parker", please reconnect to take effect
ALTER ROLE
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds a database notice for whenever users update a variable default
