### PR TITLE
catalog: Always use catalog migrator implementation

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -439,7 +439,8 @@ pub struct Args {
         env = "ADAPTER_STASH_URL",
         value_name = "POSTGRES_URL",
         required_if_eq("catalog-store", "stash"),
-        required_if_eq("catalog-store", "shadow")
+        required_if_eq("catalog-store", "shadow"),
+        required_if_eq("catalog-store", "persist")
     )]
     adapter_stash_url: Option<String>,
     /// The backing durable store of the catalog.
@@ -946,8 +947,13 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         let catalog_config = match args.catalog_store {
             CatalogKind::Stash => CatalogConfig::Stash {
                 url: args.adapter_stash_url.expect("required for stash catalog"),
+                persist_clients,
+                metrics: Arc::new(mz_catalog::durable::Metrics::new(&metrics_registry)),
             },
             CatalogKind::Persist => CatalogConfig::Persist {
+                url: args
+                    .adapter_stash_url
+                    .expect("required for persist catalog"),
                 persist_clients,
                 metrics: Arc::new(mz_catalog::durable::Metrics::new(&metrics_registry)),
             },


### PR DESCRIPTION
This commit updates the chosen catalog implementation to always be `CatalogMigrator`. This means that every time we open the catalog we will always either migrate the catalog contents to persist or rollback the catalog contents to the stash. The default will be rolling the catalog back to the stash, so the actual backing catalog store used will remain as the stash.

As a consequence of this change, every time the stash catalog is opened, we will also open the persist catalog. This will either initialize data in the persist catalog with the set of default objects or migrate the data in the persist catalog. No actual user catalog data will get stored in the persist catalog. This will slightly slow down startup, but opening the durable catalog is not the bottleneck of startup, so hopefully it's not very noticeable. It will also allow us to validate some very basic functionality of the persist catalog, without actually relying on it for important data.

This change will additionally allow us to utilize the `catalog_kind` system variable to migrate an environment to persist or rollback an environment to the stash.

Resolves #22392

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
