### PR TITLE
compute: bring back flow control plumbing

### DIFF
--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -207,6 +207,14 @@ struct Args {
     /// Optional memory limit (bytes) of the cluster replica
     #[clap(long)]
     announce_memory_limit: Option<usize>,
+
+    /// The `max_inflight_bytes` value to use for compute flow control.
+    ///
+    /// This is only meant as a temporary config for verification of an end-to-end compute
+    /// backpressure poc.
+    /// TODO(#23897): replace this with an LD option
+    #[clap(long, env = "COMPUTE_FLOW_CONTROL_BYTES")]
+    compute_flow_control_bytes: Option<usize>,
 }
 
 #[tokio::main]
@@ -367,6 +375,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         },
         ComputeInstanceContext {
             scratch_directory: args.scratch_directory,
+            flow_control_bytes: args.compute_flow_control_bytes.unwrap_or(usize::MAX),
         },
     )?;
     info!(

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -131,7 +131,7 @@ impl ComputeState {
             persist_clients,
             command_history,
             max_result_size: u32::MAX,
-            dataflow_max_inflight_bytes: usize::MAX,
+            dataflow_max_inflight_bytes: context.flow_control_bytes,
             persist_source_max_inflight_bytes: None,
             linear_join_spec: Default::default(),
             metrics,

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -25,6 +25,8 @@ use mz_repr::{ColumnType, DatumVec, DatumVecBorrow, Diff, GlobalId, Row, RowAren
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
+use mz_timely_util::probe;
+use mz_timely_util::probe::ProbeNotify;
 use timely::container::columnation::Columnation;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::OutputHandle;
@@ -335,6 +337,19 @@ impl<S: Scope> SpecializedArrangement<S>
 where
     S: ScopeParent<Timestamp = mz_repr::Timestamp>,
 {
+    /// Attaches probes to the stream of the underlying arrangement
+    /// to notify on index frontier advancement.
+    pub fn probe_notify_with(&self, probes: Vec<probe::Handle<mz_repr::Timestamp>>) {
+        match self {
+            SpecializedArrangement::RowUnit(inner) => {
+                inner.stream.probe_notify_with(probes);
+            }
+            SpecializedArrangement::RowRow(inner) => {
+                inner.stream.probe_notify_with(probes);
+            }
+        }
+    }
+
     /// Obtains a `SpecializedTraceHandle` for the underlying arrangement.
     pub fn trace_handle(&self) -> SpecializedTraceHandle {
         match self {

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -117,6 +117,7 @@ use mz_expr::{EvalError, Id};
 use mz_persist_client::operators::shard_source::SnapshotMode;
 use mz_repr::{Diff, GlobalId};
 use mz_storage_operators::persist_source;
+use mz_storage_operators::persist_source::FlowControl;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
@@ -189,6 +190,10 @@ pub fn build_compute_dataflow<A: Allocate>(
 
     let worker_logging = timely_worker.log_register().get("timely");
 
+    // Probe providing feedback to `persist_source` flow control.
+    // Only set if the dataflow instantiates any `persist_source`s.
+    let mut flow_control_probe: Option<probe::Handle<_>> = None;
+
     let name = format!("Dataflow: {}", &dataflow.debug_name);
     let input_name = format!("InputRegion: {}", &dataflow.debug_name);
     let build_name = format!("BuildRegion: {}", &dataflow.debug_name);
@@ -209,6 +214,20 @@ pub fn build_compute_dataflow<A: Allocate>(
                             .expect("Linear operators should always be valid")
                     });
 
+                    let probe = flow_control_probe.get_or_insert_with(Default::default);
+                    let flow_control_input = probe::source(
+                        inner.clone(),
+                        format!("flow_control_input({source_id})"),
+                        probe.clone(),
+                    );
+                    let flow_control = FlowControl {
+                        progress_stream: flow_control_input,
+                        max_inflight_bytes: compute_state.dataflow_max_inflight_bytes,
+                        summary: mz_repr::Timestamp::minimum().step_forward(),
+                        // TODO(guswynn): add metrics for compute flow control
+                        metrics: None,
+                    };
+
                     // Note: For correctness, we require that sources only emit times advanced by
                     // `dataflow.as_of`. `persist_source` is documented to provide this guarantee.
                     let (mut ok_stream, err_stream, token) = persist_source::persist_source(
@@ -220,7 +239,8 @@ pub fn build_compute_dataflow<A: Allocate>(
                         SnapshotMode::Include,
                         dataflow.until.clone(),
                         mfp.as_mut(),
-                        compute_state.dataflow_max_inflight_bytes,
+                        compute_state.persist_source_max_inflight_bytes,
+                        Some(flow_control),
                     );
 
                     // If `mfp` is non-identity, we need to apply what remains.
@@ -265,6 +285,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                 &collection.index_flow_control_probes
             })
             .cloned()
+            .chain(flow_control_probe)
             .collect();
 
         // If there exists a recursive expression, we'll need to use a non-region scope,

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -23,6 +23,7 @@ use mz_repr::{Diff, GlobalId, Row};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
+use mz_timely_util::probe;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 use timely::progress::Antichain;
@@ -45,6 +46,7 @@ where
         dependency_ids: BTreeSet<GlobalId>,
         sink_id: GlobalId,
         sink: &ComputeSinkDesc<CollectionMetadata>,
+        probes: Vec<probe::Handle<mz_repr::Timestamp>>,
     ) {
         soft_assert_or_log!(
             sink.non_null_assertions.is_strictly_sorted(),
@@ -132,6 +134,7 @@ where
                     self.as_of_frontier.clone(),
                     ok_collection.enter_region(inner),
                     err_collection.enter_region(inner),
+                    probes,
                 );
 
                 if let Some(sink_token) = sink_token {
@@ -157,6 +160,7 @@ where
         as_of: Antichain<mz_repr::Timestamp>,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
+        probes: Vec<probe::Handle<mz_repr::Timestamp>>,
     ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = mz_repr::Timestamp>;

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -38,7 +38,7 @@ use timely::scheduling::{Scheduler, SyncActivator};
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::SendError;
-use tracing::trace;
+use tracing::{info, trace};
 
 use crate::compute_state::{ActiveComputeState, ComputeState, ReportedFrontier};
 use crate::logging::compute::ComputeEvent;
@@ -49,6 +49,8 @@ use crate::metrics::ComputeMetrics;
 pub struct ComputeInstanceContext {
     /// A directory that can be used for scratch work.
     pub scratch_directory: Option<PathBuf>,
+    /// The `max_inflight_bytes` value to use for compute flow control.
+    pub flow_control_bytes: usize,
 }
 
 /// Configures the server with compute-specific metrics.
@@ -73,6 +75,8 @@ pub fn serve(
     ),
     Error,
 > {
+    info!(?context, "starting the compute server");
+
     let metrics = ComputeMetrics::register_with(&config.metrics_registry);
     let compute_config = Config { metrics, context };
 

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -104,6 +104,7 @@ where
         SnapshotMode::Include,
         Antichain::new(), // we want all updates
         None,             // no MFP
+        None,             // no internal backpressure
         None,             // no flow control
     );
     use differential_dataflow::AsCollection;

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -9,6 +9,7 @@
 
 use std::any::Any;
 use std::cell::RefCell;
+use std::convert::Infallible;
 use std::ops::DerefMut;
 use std::rc::Rc;
 
@@ -19,9 +20,10 @@ use mz_compute_types::sinks::{ComputeSinkDesc, SubscribeSinkConnection};
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
+use mz_timely_util::probe::{self, ProbeNotify};
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use timely::dataflow::Scope;
+use timely::dataflow::operators::Operator;
+use timely::dataflow::{Scope, Stream};
 use timely::progress::timestamp::Timestamp as TimelyTimestamp;
 use timely::progress::Antichain;
 use timely::PartialOrder;
@@ -40,6 +42,7 @@ where
         as_of: Antichain<Timestamp>,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
+        probes: Vec<probe::Handle<Timestamp>>,
     ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = Timestamp>,
@@ -64,6 +67,7 @@ where
             as_of,
             sink.up_to.clone(),
             subscribe_protocol_handle,
+            probes,
         );
 
         // Inform the coordinator that we have been dropped,
@@ -85,84 +89,92 @@ fn subscribe<G>(
     as_of: Antichain<G::Timestamp>,
     up_to: Antichain<G::Timestamp>,
     subscribe_protocol_handle: Rc<RefCell<Option<SubscribeProtocol>>>,
+    probes: Vec<probe::Handle<Timestamp>>,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
-    let name = format!("subscribe-{}", sink_id);
-    let mut op = OperatorBuilder::new(name, sinked_collection.scope());
-    let mut ok_input = op.new_input(&sinked_collection.inner, Pipeline);
-    let mut err_input = op.new_input(&err_collection.inner, Pipeline);
+    // Let the subscribe sink emit a progress stream, so we can attach the flow control probes.
+    // The `Infallible` type signals that this steam never transports data updates.
+    // TODO: Replace `Infallible` with `!` once the latter is stabilized.
+    let progress_stream: Stream<G, Infallible>;
 
-    op.build(|_cap| {
-        let mut rows_to_emit = Vec::new();
-        let mut errors_to_emit = Vec::new();
-        let mut finished = false;
-        let mut ok_buf = Default::default();
-        let mut err_buf = Default::default();
+    let mut rows_to_emit = Vec::new();
+    let mut errors_to_emit = Vec::new();
+    let mut finished = false;
+    let mut ok_buf = Default::default();
+    let mut err_buf = Default::default();
+    progress_stream = sinked_collection.inner.binary_frontier(
+        &err_collection.inner,
+        Pipeline,
+        Pipeline,
+        &format!("subscribe-{}", sink_id),
+        move |_cap, _info| {
+            move |ok_input, err_input, _output| {
+                if finished {
+                    // Drain the inputs, to avoid the operator being constantly rescheduled
+                    ok_input.for_each(|_, _| {});
+                    err_input.for_each(|_, _| {});
+                    return;
+                }
 
-        move |frontiers| {
-            if finished {
-                // Drain the inputs, to avoid the operator being constantly rescheduled
-                ok_input.for_each(|_, _| {});
-                err_input.for_each(|_, _| {});
-                return;
-            }
+                let mut frontier = ok_input.frontier().frontier().to_owned();
+                frontier.extend(err_input.frontier().frontier().iter().copied());
 
-            let mut frontier = Antichain::new();
-            for input_frontier in frontiers {
-                frontier.extend(input_frontier.frontier().iter().copied());
-            }
-
-            let should_emit = |time: &Timestamp| {
-                let beyond_as_of = if with_snapshot {
-                    as_of.less_equal(time)
-                } else {
-                    as_of.less_than(time)
+                let should_emit = |time: &Timestamp| {
+                    let beyond_as_of = if with_snapshot {
+                        as_of.less_equal(time)
+                    } else {
+                        as_of.less_than(time)
+                    };
+                    let before_up_to = !up_to.less_equal(time);
+                    beyond_as_of && before_up_to
                 };
-                let before_up_to = !up_to.less_equal(time);
-                beyond_as_of && before_up_to
-            };
 
-            ok_input.for_each(|_, data| {
-                data.swap(&mut ok_buf);
-                for (row, time, diff) in ok_buf.drain(..) {
-                    if should_emit(&time) {
-                        rows_to_emit.push((time, row, diff));
+                ok_input.for_each(|_, data| {
+                    data.swap(&mut ok_buf);
+                    for (row, time, diff) in ok_buf.drain(..) {
+                        if should_emit(&time) {
+                            rows_to_emit.push((time, row, diff));
+                        }
                     }
-                }
-            });
-            err_input.for_each(|_, data| {
-                data.swap(&mut err_buf);
-                for (error, time, diff) in err_buf.drain(..) {
-                    if should_emit(&time) {
-                        errors_to_emit.push((time, error, diff));
+                });
+                err_input.for_each(|_, data| {
+                    data.swap(&mut err_buf);
+                    for (error, time, diff) in err_buf.drain(..) {
+                        if should_emit(&time) {
+                            errors_to_emit.push((time, error, diff));
+                        }
                     }
-                }
-            });
+                });
 
-            if let Some(subscribe_protocol) = subscribe_protocol_handle.borrow_mut().deref_mut() {
-                subscribe_protocol.send_batch(
-                    frontier.clone(),
-                    &mut rows_to_emit,
-                    &mut errors_to_emit,
-                );
-            }
-
-            if PartialOrder::less_equal(&up_to, &frontier) {
-                finished = true;
-                // We are done; indicate this by sending a batch at the
-                // empty frontier.
                 if let Some(subscribe_protocol) = subscribe_protocol_handle.borrow_mut().deref_mut()
                 {
                     subscribe_protocol.send_batch(
-                        Antichain::default(),
-                        &mut Vec::new(),
-                        &mut Vec::new(),
+                        frontier.clone(),
+                        &mut rows_to_emit,
+                        &mut errors_to_emit,
                     );
                 }
+
+                if PartialOrder::less_equal(&up_to, &frontier) {
+                    finished = true;
+                    // We are done; indicate this by sending a batch at the
+                    // empty frontier.
+                    if let Some(subscribe_protocol) =
+                        subscribe_protocol_handle.borrow_mut().deref_mut()
+                    {
+                        subscribe_protocol.send_batch(
+                            Antichain::default(),
+                            &mut Vec::new(),
+                            &mut Vec::new(),
+                        );
+                    }
+                }
             }
-        }
-    });
+        },
+    );
+
+    progress_stream.probe_notify_with(probes);
 }
 
 /// A type that guides the transmission of rows back to the coordinator.

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -137,6 +137,8 @@ pub fn persist_source<G>(
     until: Antichain<Timestamp>,
     map_filter_project: Option<&mut MfpPlan>,
     max_inflight_bytes: Option<usize>,
+    // TODO(#23897): wire up end-to-end flow control
+    _flow_control: Option<FlowControl<G>>,
 ) -> (
     Stream<G, (Row, Timestamp, Diff)>,
     Stream<G, (DataflowError, Timestamp, Diff)>,

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -61,6 +61,7 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
         timely::progress::Antichain::new(),
         None,
         None,
+        None,
     );
     tokens.extend(persist_tokens);
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -342,6 +342,7 @@ where
                                     Antichain::new(),
                                     None,
                                     None,
+                                    None,
                                 );
                             let (tx_source_ok, tx_source_err) = (
                                 tx_source_ok_stream.as_collection(),


### PR DESCRIPTION
This PR brings back the end-to-end flow control plumbing for compute dataflows. There is no support yet in `persist_source`, so passing a flow control configuration to it doesn't to anything at the moment. The intention here is to be ready once the persist team finds some time to add in that external flow control support.

The PR also introduces a `clusterd` command line flag, `--compute-flow-control-bytes`, that control the value passed to `persist_sources`. This is easier than wiring up a new LD flag and compute parameter and sufficient for running validation tests in production. We will replace the command line flag with an LD flag at a later point.

See https://github.com/MaterializeInc/database-issues/issues/7176 for details on the current plan for end-to-end compute backpressure. This PR addresses steps (1) and (2).

### Motivation

  * This PR adds a known-desirable feature.

Part of MaterializeInc/database-issues#7176.

### Tips for reviewer

Most of this PR is reverting previous changes to bring back the compute flow control plumbing that already existed.

* Commit 1 mostly reverts MaterializeInc/materialize#22643.
* Commit 2 reverts the compute parts of MaterializeInc/materialize#22549.
* Commit 3 adds the command line flag. 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
