### PR TITLE
Move `SUBSCRIBE` optimization off the coordinator thread

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -176,6 +176,14 @@ impl Coordinator {
                     self.sequence_create_materialized_view_stage(ctx, stage, otel_ctx)
                         .await;
                 }
+                Message::SubscribeStageReady {
+                    ctx,
+                    otel_ctx,
+                    stage,
+                } => {
+                    otel_ctx.attach_as_parent();
+                    self.sequence_subscribe_stage(ctx, stage, otel_ctx).await;
+                }
                 Message::DrainStatementLog => {
                     self.drain_statement_log().await;
                 }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -292,19 +292,7 @@ impl Coordinator {
                     self.sequence_peek(ctx, plan, target_cluster).await;
                 }
                 Plan::Subscribe(plan) => {
-                    if self
-                        .catalog()
-                        .system_config()
-                        .enable_off_thread_optimization()
-                    {
-                        self.sequence_subscribe_off_thread(ctx, plan, target_cluster)
-                            .await;
-                    } else {
-                        let result = self
-                            .sequence_subscribe(&mut ctx, plan, target_cluster)
-                            .await;
-                        ctx.retire(result);
-                    }
+                    self.sequence_subscribe(ctx, plan, target_cluster).await;
                 }
                 Plan::SideEffectingFunc(plan) => {
                     ctx.retire(self.sequence_side_effecting_func(plan));

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -297,10 +297,8 @@ impl Coordinator {
                         .system_config()
                         .enable_off_thread_optimization()
                     {
-                        let result = self
-                            .sequence_subscribe_off_thread(&mut ctx, plan, target_cluster)
+                        self.sequence_subscribe_off_thread(ctx, plan, target_cluster)
                             .await;
-                        ctx.retire(result);
                     } else {
                         let result = self
                             .sequence_subscribe(&mut ctx, plan, target_cluster)

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -79,7 +79,7 @@ use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::notice::{OptimizerNoticeApi, OptimizerNoticeKind, RawOptimizerNotice};
 use mz_transform::{EmptyStatisticsOracle, StatisticsOracle};
 use timely::progress::Antichain;
-use tokio::sync::{mpsc, oneshot, OwnedMutexGuard};
+use tokio::sync::{oneshot, OwnedMutexGuard};
 use tracing::instrument::WithSubscriber;
 use tracing::Instrument;
 use tracing::{event, warn, Level, Span};
@@ -107,8 +107,7 @@ use crate::notice::{AdapterNotice, DroppedInUseIndex};
 use crate::optimize::dataflows::{prep_scalar_expr, EvalTime, ExprPrepStyle};
 use crate::optimize::{self, Optimize, OptimizerConfig};
 use crate::session::{EndTransactionAction, Session, TransactionOps, TransactionStatus, WriteOp};
-use crate::subscribe::ActiveSubscribe;
-use crate::util::{viewable_variables, ClientTransmitter, ComputeSinkId, ResultExt};
+use crate::util::{viewable_variables, ClientTransmitter, ResultExt};
 use crate::{guard_write_critical_section, PeekResponseUnary, TimestampExplanation};
 
 mod create_index;
@@ -2531,182 +2530,6 @@ impl Coordinator {
             Some(self.controller.recent_timestamp(source_ids))
         } else {
             None
-        }
-    }
-
-    pub(super) async fn sequence_subscribe(
-        &mut self,
-        ctx: &mut ExecuteContext,
-        plan: plan::SubscribePlan,
-        target_cluster: TargetCluster,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        let plan::SubscribePlan {
-            from,
-            with_snapshot,
-            when,
-            copy_to,
-            emit_progress,
-            up_to,
-            output,
-        } = plan;
-
-        let cluster = self
-            .catalog()
-            .resolve_target_cluster(target_cluster, ctx.session())?;
-        let cluster_id = cluster.id;
-
-        let target_replica_name = ctx.session().vars().cluster_replica();
-        let mut target_replica = target_replica_name
-            .map(|name| {
-                cluster
-                    .replica_id(name)
-                    .ok_or(AdapterError::UnknownClusterReplica {
-                        cluster_name: cluster.name.clone(),
-                        replica_name: name.to_string(),
-                    })
-            })
-            .transpose()?;
-
-        // SUBSCRIBE AS OF, similar to peeks, doesn't need to worry about transaction
-        // timestamp semantics.
-        if when == QueryWhen::Immediately {
-            // If this isn't a SUBSCRIBE AS OF, the SUBSCRIBE can be in a transaction if it's the
-            // only operation.
-            ctx.session_mut()
-                .add_transaction_ops(TransactionOps::Subscribe)?;
-        }
-
-        let depends_on = from.depends_on();
-
-        // Run `check_log_reads` and emit notices.
-        let notices = check_log_reads(
-            self.catalog(),
-            cluster,
-            &depends_on,
-            &mut target_replica,
-            ctx.session().vars(),
-        )?;
-        ctx.session_mut().add_notices(notices);
-
-        // Determine timeline.
-        let mut timeline = self.validate_timeline_context(depends_on.clone())?;
-        if matches!(timeline, TimelineContext::TimestampIndependent) && from.contains_temporal() {
-            // If the from IDs are timestamp independent but the query contains temporal functions
-            // then the timeline context needs to be upgraded to timestamp dependent.
-            timeline = TimelineContext::TimestampDependent;
-        }
-
-        // Collect optimizer parameters.
-        let compute_instance = self
-            .instance_snapshot(cluster_id)
-            .expect("compute instance does not exist");
-        let id = self.allocate_transient_id()?;
-        let conn_id = ctx.session().conn_id().clone();
-        let up_to = up_to
-            .map(|expr| Coordinator::evaluate_when(self.catalog().state(), expr, ctx.session_mut()))
-            .transpose()?;
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
-
-        // Build an optimizer for this SUBSCRIBE.
-        let mut optimizer = optimize::subscribe::Optimizer::new(
-            self.owned_catalog(),
-            compute_instance,
-            id,
-            conn_id,
-            with_snapshot,
-            up_to,
-            optimizer_config,
-        );
-
-        // MIR ⇒ MIR optimization (global)
-        let global_mir_plan = optimizer.optimize(from)?;
-        // Timestamp selection
-        let oracle_read_ts = self.oracle_read_ts(&ctx.session, &timeline, &when).await;
-        let as_of = self
-            .determine_timestamp(
-                ctx.session(),
-                &global_mir_plan.id_bundle(optimizer.cluster_id()),
-                &when,
-                cluster_id,
-                &timeline,
-                oracle_read_ts,
-                None,
-            )
-            .await?
-            .timestamp_context
-            .timestamp_or_default();
-        if let Some(id) = ctx.extra().contents() {
-            self.set_statement_execution_timestamp(id, as_of);
-        }
-        if let Some(up_to) = up_to {
-            if as_of == up_to {
-                ctx.session_mut()
-                    .add_notice(AdapterNotice::EqualSubscribeBounds { bound: up_to });
-            } else if as_of > up_to {
-                return Err(AdapterError::AbsurdSubscribeBounds { as_of, up_to });
-            }
-        }
-        let global_mir_plan = global_mir_plan.resolve(Antichain::from_elem(as_of));
-        // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-        let global_lir_plan = optimizer.optimize(global_mir_plan.clone())?;
-
-        let sink_id = global_lir_plan.sink_id();
-
-        let (tx, rx) = mpsc::unbounded_channel();
-        let active_subscribe = ActiveSubscribe {
-            user: ctx.session().user().clone(),
-            conn_id: ctx.session().conn_id().clone(),
-            channel: tx,
-            emit_progress,
-            as_of,
-            arity: global_lir_plan.sink_desc().from_desc.arity(),
-            cluster_id,
-            depends_on: depends_on.into_iter().collect(),
-            start_time: self.now(),
-            dropping: false,
-            output,
-        };
-        active_subscribe.initialize();
-
-        let (df_desc, df_meta) = global_lir_plan.unapply();
-        // Emit notices.
-        self.emit_optimizer_notices(ctx.session(), &df_meta.optimizer_notices);
-
-        // Add metadata for the new SUBSCRIBE.
-        let write_notify_fut = self.add_active_subscribe(sink_id, active_subscribe).await;
-        // Ship dataflow.
-        let ship_dataflow_fut = self.ship_dataflow(df_desc, cluster_id);
-
-        // Both adding metadata for the new SUBSCRIBE and shipping the underlying dataflow, send
-        // requests to external services, which can take time, so we run them concurrently.
-        let ((), ()) = futures::future::join(write_notify_fut, ship_dataflow_fut).await;
-
-        if let Some(target) = target_replica {
-            self.controller
-                .compute
-                .set_subscribe_target_replica(cluster_id, sink_id, target)
-                .unwrap_or_terminate("cannot fail to set subscribe target replica");
-        }
-
-        self.active_conns
-            .get_mut(ctx.session().conn_id())
-            .expect("must exist for active sessions")
-            .drop_sinks
-            .push(ComputeSinkId {
-                cluster_id,
-                global_id: sink_id,
-            });
-
-        let resp = ExecuteResponse::Subscribing {
-            rx,
-            ctx_extra: std::mem::take(ctx.extra_mut()),
-        };
-        match copy_to {
-            None => Ok(resp),
-            Some(format) => Ok(ExecuteResponse::CopyTo {
-                format,
-                resp: Box::new(resp),
-            }),
         }
     }
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -114,6 +114,7 @@ use crate::{guard_write_critical_section, PeekResponseUnary, TimestampExplanatio
 mod create_index;
 mod create_materialized_view;
 mod create_view;
+mod subscribe;
 
 /// Attempts to evaluate an expression. If an error is returned then the error is sent
 /// to the client and the function is exited.

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -27,7 +27,7 @@ use crate::{optimize, AdapterNotice, ExecuteContext, TimelineContext};
 
 impl Coordinator {
     #[tracing::instrument(level = "debug", skip(self))]
-    pub(crate) async fn sequence_subscribe_off_thread(
+    pub(crate) async fn sequence_subscribe(
         &mut self,
         ctx: ExecuteContext,
         plan: plan::SubscribePlan,

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -1,0 +1,203 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use mz_sql::plan::{self, QueryWhen};
+use timely::progress::Antichain;
+use tokio::sync::mpsc;
+
+use crate::command::ExecuteResponse;
+use crate::coord::sequencer::inner::check_log_reads;
+use crate::coord::{Coordinator, TargetCluster};
+use crate::error::AdapterError;
+use crate::optimize::Optimize;
+use crate::session::TransactionOps;
+use crate::subscribe::ActiveSubscribe;
+use crate::util::{ComputeSinkId, ResultExt};
+use crate::{optimize, AdapterNotice, ExecuteContext, TimelineContext};
+
+impl Coordinator {
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) async fn sequence_subscribe_off_thread(
+        &mut self,
+        ctx: &mut ExecuteContext,
+        plan: plan::SubscribePlan,
+        target_cluster: TargetCluster,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        ::tracing::info!("sequence_subscribe_off_thread");
+
+        let plan::SubscribePlan {
+            from,
+            with_snapshot,
+            when,
+            copy_to,
+            emit_progress,
+            up_to,
+            output,
+        } = plan;
+
+        let cluster = self
+            .catalog()
+            .resolve_target_cluster(target_cluster, ctx.session())?;
+        let cluster_id = cluster.id;
+
+        let target_replica_name = ctx.session().vars().cluster_replica();
+        let mut target_replica = target_replica_name
+            .map(|name| {
+                cluster
+                    .replica_id(name)
+                    .ok_or(AdapterError::UnknownClusterReplica {
+                        cluster_name: cluster.name.clone(),
+                        replica_name: name.to_string(),
+                    })
+            })
+            .transpose()?;
+
+        // SUBSCRIBE AS OF, similar to peeks, doesn't need to worry about transaction
+        // timestamp semantics.
+        if when == QueryWhen::Immediately {
+            // If this isn't a SUBSCRIBE AS OF, the SUBSCRIBE can be in a transaction if it's the
+            // only operation.
+            ctx.session_mut()
+                .add_transaction_ops(TransactionOps::Subscribe)?;
+        }
+
+        let depends_on = from.depends_on();
+
+        // Run `check_log_reads` and emit notices.
+        let notices = check_log_reads(
+            self.catalog(),
+            cluster,
+            &depends_on,
+            &mut target_replica,
+            ctx.session().vars(),
+        )?;
+        ctx.session_mut().add_notices(notices);
+
+        // Determine timeline.
+        let mut timeline = self.validate_timeline_context(depends_on.clone())?;
+        if matches!(timeline, TimelineContext::TimestampIndependent) && from.contains_temporal() {
+            // If the from IDs are timestamp independent but the query contains temporal functions
+            // then the timeline context needs to be upgraded to timestamp dependent.
+            timeline = TimelineContext::TimestampDependent;
+        }
+
+        // Collect optimizer parameters.
+        let compute_instance = self
+            .instance_snapshot(cluster_id)
+            .expect("compute instance does not exist");
+        let id = self.allocate_transient_id()?;
+        let conn_id = ctx.session().conn_id().clone();
+        let up_to = up_to
+            .map(|expr| Coordinator::evaluate_when(self.catalog().state(), expr, ctx.session_mut()))
+            .transpose()?;
+        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
+
+        // Build an optimizer for this SUBSCRIBE.
+        let mut optimizer = optimize::subscribe::Optimizer::new(
+            self.owned_catalog(),
+            compute_instance,
+            id,
+            conn_id,
+            with_snapshot,
+            up_to,
+            optimizer_config,
+        );
+
+        // MIR ⇒ MIR optimization (global)
+        let global_mir_plan = optimizer.optimize(from)?;
+        // Timestamp selection
+        let oracle_read_ts = self.oracle_read_ts(&ctx.session, &timeline, &when).await;
+        let as_of = self
+            .determine_timestamp(
+                ctx.session(),
+                &global_mir_plan.id_bundle(optimizer.cluster_id()),
+                &when,
+                cluster_id,
+                &timeline,
+                oracle_read_ts,
+                None,
+            )
+            .await?
+            .timestamp_context
+            .timestamp_or_default();
+        if let Some(id) = ctx.extra().contents() {
+            self.set_statement_execution_timestamp(id, as_of);
+        }
+        if let Some(up_to) = up_to {
+            if as_of == up_to {
+                ctx.session_mut()
+                    .add_notice(AdapterNotice::EqualSubscribeBounds { bound: up_to });
+            } else if as_of > up_to {
+                return Err(AdapterError::AbsurdSubscribeBounds { as_of, up_to });
+            }
+        }
+        let global_mir_plan = global_mir_plan.resolve(Antichain::from_elem(as_of));
+        // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
+        let global_lir_plan = optimizer.optimize(global_mir_plan.clone())?;
+
+        let sink_id = global_lir_plan.sink_id();
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        let active_subscribe = ActiveSubscribe {
+            user: ctx.session().user().clone(),
+            conn_id: ctx.session().conn_id().clone(),
+            channel: tx,
+            emit_progress,
+            as_of,
+            arity: global_lir_plan.sink_desc().from_desc.arity(),
+            cluster_id,
+            depends_on: depends_on.into_iter().collect(),
+            start_time: self.now(),
+            dropping: false,
+            output,
+        };
+        active_subscribe.initialize();
+
+        let (df_desc, df_meta) = global_lir_plan.unapply();
+        // Emit notices.
+        self.emit_optimizer_notices(ctx.session(), &df_meta.optimizer_notices);
+
+        // Add metadata for the new SUBSCRIBE.
+        let write_notify_fut = self.add_active_subscribe(sink_id, active_subscribe).await;
+        // Ship dataflow.
+        let ship_dataflow_fut = self.ship_dataflow(df_desc, cluster_id);
+
+        // Both adding metadata for the new SUBSCRIBE and shipping the underlying dataflow, send
+        // requests to external services, which can take time, so we run them concurrently.
+        let ((), ()) = futures::future::join(write_notify_fut, ship_dataflow_fut).await;
+
+        if let Some(target) = target_replica {
+            self.controller
+                .compute
+                .set_subscribe_target_replica(cluster_id, sink_id, target)
+                .unwrap_or_terminate("cannot fail to set subscribe target replica");
+        }
+
+        self.active_conns
+            .get_mut(ctx.session().conn_id())
+            .expect("must exist for active sessions")
+            .drop_sinks
+            .push(ComputeSinkId {
+                cluster_id,
+                global_id: sink_id,
+            });
+
+        let resp = ExecuteResponse::Subscribing {
+            rx,
+            ctx_extra: std::mem::take(ctx.extra_mut()),
+        };
+        match copy_to {
+            None => Ok(resp),
+            Some(format) => Ok(ExecuteResponse::CopyTo {
+                format,
+                resp: Box::new(resp),
+            }),
+        }
+    }
+}

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -145,10 +145,6 @@ impl Coordinator {
             timeline = TimelineContext::TimestampDependent;
         }
 
-        // TODO: this check is present in `sequence_create_index` / `sequence_create_materialized_view`
-        // Should we have it here as well?
-        // self.ensure_cluster_can_host_compute_item(name, *cluster_id)?;
-
         let validity = PlanValidity {
             transient_revision: self.catalog().transient_revision(),
             dependency_ids: depends_on,
@@ -357,7 +353,9 @@ impl Coordinator {
             conn_id: ctx.session().conn_id().clone(),
             channel: tx,
             emit_progress,
-            as_of: global_lir_plan.as_of(),
+            as_of: global_lir_plan
+                .as_of()
+                .expect("set to Some in an earlier stage"),
             arity: global_lir_plan.sink_desc().from_desc.arity(),
             cluster_id,
             depends_on: validity.dependency_ids,

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -135,8 +135,8 @@ impl GlobalLirPlan {
         *sink_id
     }
 
-    pub fn as_of(&self) -> Timestamp {
-        self.df_desc.as_of.clone().expect("as_of").into_element()
+    pub fn as_of(&self) -> Option<Timestamp> {
+        self.df_desc.as_of.clone().map(|as_of| as_of.into_element())
     }
 
     pub fn sink_desc(&self) -> &ComputeSinkDesc {

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -17,6 +17,7 @@ use mz_adapter_types::connection::ConnectionId;
 use mz_compute_types::plan::Plan;
 use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, SubscribeSinkConnection};
 use mz_compute_types::ComputeInstanceId;
+use mz_ore::collections::CollectionExt;
 use mz_ore::soft_assert_or_log;
 use mz_repr::explain::trace_plan;
 use mz_repr::{GlobalId, RelationDesc, Timestamp};
@@ -56,6 +57,19 @@ pub struct Optimizer {
     config: OptimizerConfig,
 }
 
+// A bogey `Debug` implementation that hides fields. This is needed to make the
+// `event!` call in `sequence_peek_stage` not emit a lot of data.
+//
+// For now, we skip almost all fields, but we might revisit that bit if it turns
+// out that we really need those for debugging purposes.
+impl std::fmt::Debug for Optimizer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Optimizer")
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
 impl Optimizer {
     pub fn new(
         catalog: Arc<Catalog>,
@@ -81,6 +95,10 @@ impl Optimizer {
     pub fn cluster_id(&self) -> ComputeInstanceId {
         self.compute_instance.instance_id()
     }
+
+    pub fn up_to(&self) -> Option<Timestamp> {
+        self.up_to.clone()
+    }
 }
 
 /// The (sealed intermediate) result after:
@@ -88,7 +106,7 @@ impl Optimizer {
 /// 1. embedding a [`SubscribeFrom`] plan into a [`MirDataflowDescription`],
 /// 2. transitively inlining referenced views, and
 /// 3. jointly optimizing the `MIR` plans in the [`MirDataflowDescription`].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GlobalMirPlan<T: Clone> {
     df_desc: MirDataflowDescription,
     df_meta: DataflowMetainfo,
@@ -104,7 +122,7 @@ impl<T: Clone> GlobalMirPlan<T> {
 
 /// The (final) result after MIR ⇒ LIR lowering and optimizing the resulting
 /// `DataflowDescription` with `LIR` plans.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GlobalLirPlan {
     df_desc: LirDataflowDescription,
     df_meta: DataflowMetainfo,
@@ -117,6 +135,10 @@ impl GlobalLirPlan {
         *sink_id
     }
 
+    pub fn as_of(&self) -> Timestamp {
+        self.df_desc.as_of.clone().expect("as_of").into_element()
+    }
+
     pub fn sink_desc(&self) -> &ComputeSinkDesc {
         let sink_exports = &self.df_desc.sink_exports;
         let sink_desc = sink_exports.values().next().expect("valid sink");
@@ -126,7 +148,7 @@ impl GlobalLirPlan {
 
 /// Marker type for [`GlobalMirPlan`] structs representing an optimization
 /// result without a resolved timestamp.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Unresolved;
 
 /// Marker type for [`GlobalMirPlan`] structs representing an optimization
@@ -134,7 +156,7 @@ pub struct Unresolved;
 ///
 /// The actual timestamp value is set in the [`MirDataflowDescription`] of the
 /// surrounding [`GlobalMirPlan`] when we call `resolve()`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Resolved;
 
 impl Optimize<SubscribeFrom> for Optimizer {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -777,7 +777,7 @@ pub struct SubscribePlan {
     pub output: SubscribeOutput,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum SubscribeFrom {
     Id(GlobalId),
     Query {


### PR DESCRIPTION
Part of #16217 (this is part 5/5 for the "off-thread refactoring" for optimized statements).

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

This is similarly structured to #24049, #24068, #24072, and #24072.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
