### PR TITLE
adapter,pgwire: allow paging through portals

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -472,14 +472,6 @@ impl Coordinator {
                         "DECLARE CURSOR".into(),
                     )));
                 }
-
-                // TODO(mjibson): The current code causes DDL statements (well, any statement
-                // that doesn't call `add_transaction_ops`) to execute outside of the extended
-                // protocol transaction. For example, executing in extended a SELECT, then
-                // CREATE, then SELECT, followed by a Sync would register the transaction
-                // as read only in the first SELECT, then the CREATE ignores the transaction
-                // ops, and the last SELECT will use the timestamp from the first. This isn't
-                // correct, but this is an edge case that we can fix later.
             }
 
             // Implicit or explicit transactions.

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -309,6 +309,7 @@ where
     let machine = StateMachine {
         conn,
         adapter_client,
+        txn_needs_commit: false,
     };
 
     select! {
@@ -428,6 +429,7 @@ enum State {
 struct StateMachine<'a, A> {
     conn: &'a mut FramedConn<A>,
     adapter_client: mz_adapter::SessionClient,
+    txn_needs_commit: bool,
 }
 
 enum SendRowsEndedReason {
@@ -551,17 +553,22 @@ where
                     )
                     .instrument(execute_root_span)
                     .await?;
-                // Close the current transaction if we are in an implicit transaction.
                 // In PostgreSQL, when using the extended query protocol, some statements may
                 // trigger an eager commit of the current implicit transaction,
                 // see: <https://git.postgresql.org/gitweb/?p=postgresql.git&a=commitdiff&h=f92944137>.
-                // In Materialize however, we eagerly commit all statements outside of an explicit
-                // transaction when using the extended query protocol. This allows us to remove
-                // the ambiguity between multiple and single statement implicit transactions when
-                // using the extended query protocol and apply some optimizations to single
-                // statement transactions.
+                //
+                // In Materialize, however, we eagerly commit every statement outside of an explicit
+                // transaction when using the extended query protocol. This allows us to eliminate
+                // the possibility of a multiple statement implicit transaction, which in turn
+                // allows us to apply single-statement optimizations to queries issued in implicit
+                // transactions in the extended query protocol.
+                //
+                // We don't immediately commit here to allow users to page through the portal if
+                // necessary. Committing the transaction would destroy the portal before the next
+                // Execute command has a chance to resume it. So we instead mark the transaction
+                // for commit the next time that `ensure_transaction` is called.
                 if self.adapter_client.session().transaction().is_implicit() {
-                    self.commit_transaction().await?;
+                    self.txn_needs_commit = true;
                 }
                 state
             }
@@ -668,11 +675,16 @@ where
         result
     }
 
-    fn start_transaction(&mut self, stmts: Option<usize>) {
+    async fn ensure_transaction(&mut self, num_stmts: usize) -> Result<(), io::Error> {
+        if self.txn_needs_commit {
+            self.commit_transaction().await?;
+            self.txn_needs_commit = false;
+        }
         // start_transaction can't error (but assert that just in case it changes in
         // the future.
-        let res = self.adapter_client.start_transaction(stmts);
+        let res = self.adapter_client.start_transaction(Some(num_stmts));
         assert!(res.is_ok());
+        Ok(())
     }
 
     fn parse_sql<'b>(&self, sql: &'b str) -> Result<Vec<StatementParseResult<'b>>, ErrorResponse> {
@@ -718,7 +730,7 @@ where
             // This needs to be done in the loop instead of once at the top because
             // a COMMIT/ROLLBACK statement needs to start a new transaction on next
             // statement.
-            self.start_transaction(Some(num_stmts));
+            self.ensure_transaction(num_stmts).await?;
 
             match self.one_query(stmt, sql.to_string()).await? {
                 State::Ready => (),
@@ -749,7 +761,7 @@ where
         param_oids: Vec<u32>,
     ) -> Result<State, io::Error> {
         // Start a transaction if we aren't in one.
-        self.start_transaction(Some(1));
+        self.ensure_transaction(1).await?;
 
         let mut param_types = vec![];
         for oid in param_oids {
@@ -846,7 +858,7 @@ where
         result_formats: Vec<Format>,
     ) -> Result<State, io::Error> {
         // Start a transaction if we aren't in one.
-        self.start_transaction(Some(1));
+        self.ensure_transaction(1).await?;
 
         let aborted_txn = self.is_aborted_txn();
         let stmt = match self
@@ -1020,7 +1032,7 @@ where
             match &mut portal.state {
                 PortalState::NotStarted => {
                     // Start a transaction if we aren't in one.
-                    self.start_transaction(Some(1));
+                    self.ensure_transaction(1).await?;
                     match self
                         .adapter_client
                         .execute(
@@ -1149,7 +1161,7 @@ where
     #[instrument(level = "debug", skip_all)]
     async fn describe_statement(&mut self, name: &str) -> Result<State, io::Error> {
         // Start a transaction if we aren't in one.
-        self.start_transaction(Some(1));
+        self.ensure_transaction(1).await?;
 
         let stmt = match self.adapter_client.get_prepared_statement(name).await {
             Ok(stmt) => stmt,
@@ -1175,7 +1187,7 @@ where
     #[instrument(level = "debug", skip_all)]
     async fn describe_portal(&mut self, name: &str) -> Result<State, io::Error> {
         // Start a transaction if we aren't in one.
-        self.start_transaction(Some(1));
+        self.ensure_transaction(1).await?;
 
         let session = self.adapter_client.session();
         let row_desc = session

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1019,10 +1019,7 @@ where
             let row_desc = portal.desc.relation_desc.clone();
             match &mut portal.state {
                 PortalState::NotStarted => {
-                    // Start a transaction if we aren't in one. Postgres does this both here and
-                    // in bind. We don't do it in bind because I'm not sure what purpose it would
-                    // serve us (i.e., I'm not aware of a pgtest that would differ between us and
-                    // Postgres).
+                    // Start a transaction if we aren't in one.
                     self.start_transaction(Some(1));
                     match self
                         .adapter_client

--- a/test/lang/js/mzcompose.py
+++ b/test/lang/js/mzcompose.py
@@ -15,7 +15,7 @@ SERVICES = [
     Service(
         name="js",
         config={
-            "image": "node:14.15.0",
+            "image": "node:20.10.0",
             "volumes": [
                 "../../../:/workdir",
             ],

--- a/test/lang/js/package.json
+++ b/test/lang/js/package.json
@@ -14,7 +14,8 @@
     "@types/pg": "^7.14.3",
     "babel-jest": "^27.0.0",
     "jest": "^27.0.0",
-    "pg": "^8.4.1",
+    "pg": "^8.11.3",
+    "pg-query-stream": "^4.5.3",
     "prettier": "^2.0.4"
   },
   "prettier": {

--- a/test/lang/js/yarn.lock
+++ b/test/lang/js/yarn.lock
@@ -2803,6 +2803,11 @@ pg-connection-string@^2.6.2:
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.6.2.tgz#713d82053de4e2bd166fab70cd4f26ad36aab475"
   integrity sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==
 
+pg-cursor@^2.10.3:
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/pg-cursor/-/pg-cursor-2.10.3.tgz#4b44fbaede168a4785def56b8ac195e7df354472"
+  integrity sha512-rDyBVoqPVnx/PTmnwQAYgusSeAKlTL++gmpf5klVK+mYMFEqsOc6VHHZnPKc/4lOvr4r6fiMuoxSFuBF1dx4FQ==
+
 pg-int8@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
@@ -2818,6 +2823,13 @@ pg-protocol@^1.2.0, pg-protocol@^1.6.0:
   resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.6.0.tgz#4c91613c0315349363af2084608db843502f8833"
   integrity sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==
 
+pg-query-stream@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/pg-query-stream/-/pg-query-stream-4.5.3.tgz#841ce414064d7b14bd2540d2267bdf40779d26f2"
+  integrity sha512-ufa94r/lHJdjAm3+zPZEO0gXAmCb4tZPaOt7O76mjcxdL/HxwTuryy76km+u0odBBgtfdKFYq/9XGfiYeQF0yA==
+  dependencies:
+    pg-cursor "^2.10.3"
+
 pg-types@^2.1.0, pg-types@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
@@ -2829,7 +2841,7 @@ pg-types@^2.1.0, pg-types@^2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8.4.1:
+pg@^8.11.3:
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/pg/-/pg-8.11.3.tgz#d7db6e3fe268fcedd65b8e4599cda0b8b4bf76cb"
   integrity sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==

--- a/test/pgtest-mz/portals.pt
+++ b/test/pgtest-mz/portals.pt
@@ -1,9 +1,13 @@
-# In Materialize we eagerly commint implicit transactions after Execute
-# messages, causing portals to be destroyed.
+# Verify that portals are destroyed after a non-Execute command in an implicit
+# transaction. This is a Materialize-specific deviation from PostgreSQL to allow
+# optimizations for single-statement implicit transactions in the extended
+# query protocol.
+# See #15255 and #24093.
 send
 Parse {"query": "VALUES (1), (2)"}
 Bind {"portal": "c"}
 Execute {"portal": "c", "max_rows": 1}
+Parse {"query": "VALUES (1), (2)"}
 Execute {"portal": "c", "max_rows": 1}
 Sync
 ----
@@ -15,26 +19,6 @@ ParseComplete
 BindComplete
 DataRow {"fields":["1"]}
 PortalSuspended
+ParseComplete
 ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"c\" does not exist"}]}
-ReadyForQuery {"status":"I"}
-
-# Verify that portals (cursors) are destroyed on Execute.
-send
-Parse {"query": "VALUES (1), (2)"}
-Bind {"portal": "c"}
-Execute {"portal": "c", "max_rows": 1}
-Sync
-Query {"query": "FETCH c"}
-----
-
-until
-ReadyForQuery
-ReadyForQuery
-----
-ParseComplete
-BindComplete
-DataRow {"fields":["1"]}
-PortalSuspended
-ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"34000"},{"typ":"M","value":"cursor \"c\" does not exist"}]}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest/portals.pt
+++ b/test/pgtest/portals.pt
@@ -137,3 +137,46 @@ ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"42P03"}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
+
+# Test that multiple execute commands are permitted in the same implicit
+# transaction.
+send
+Parse {"query": "VALUES (1), (2)"}
+Bind {"portal": "c"}
+Execute {"portal": "c", "max_rows": 1}
+Execute {"portal": "c", "max_rows": 1}
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+PortalSuspended
+DataRow {"fields":["2"]}
+PortalSuspended
+ReadyForQuery {"status":"I"}
+
+# Verify that portals (cursors) are destroyed after a Sync command commits
+# the implicit transaction.
+send
+Parse {"query": "VALUES (1), (2)"}
+Bind {"portal": "c"}
+Execute {"portal": "c", "max_rows": 1}
+Sync
+Query {"query": "FETCH c"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+PortalSuspended
+ReadyForQuery {"status":"I"}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"34000"},{"typ":"M","value":"cursor \"c\" does not exist"}]}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
The single-statement optimization introduced in #15255 caused Materialize to deviate in behavior from PostgreSQL when statements are submitted in implicit transactions using the extended query protocol. The deviation in behavior was intentional, as doing so greatly simplifies our code and it's fairly hard to hit this case in the protocol.

However, a user recently discovered that the Node.js pg-query-stream library does not work correctly with Materialize due to this deviation in behavior. pg-query-stream attempts to page through a portal that is established in an implicit transaction via the extended query protocol, but the portal is immediately expired after the first batch of results.

This commit adjusts the adapter/pgwire protocol to special-case paging through a portal established in an implicit transaction via the extended protocol, without losing the single-statement optimizations from #15255. It adds an end-to-end test to verify that the Node.js pg-query-stream library is now working as expected.

Fix #24059.

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

~Just a test that exposes the problem for now. The implementation is still TODO, but I optimistically wrote up the commit message as if I'd fixed the bug.~ Implementation complete.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
