### PR TITLE
Fix bug in Avro schema resolution with defaulted logical types

### DIFF
--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -144,7 +144,8 @@ mod tests {
     }
 }
 
-fn build_ts_value(value: i64, unit: TsUnit) -> Result<Value, AvroError> {
+/// A convenience function to build timestamp values from underlying longs.
+pub fn build_ts_value(value: i64, unit: TsUnit) -> Result<Value, AvroError> {
     let result = match unit {
         TsUnit::Millis => NaiveDateTime::from_timestamp_millis(value),
         TsUnit::Micros => NaiveDateTime::from_timestamp_micros(value),

--- a/test/testdrive/avro-resolution-logical-type-default.td
+++ b/test/testdrive/avro-resolution-logical-type-default.td
@@ -1,0 +1,39 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Attempt to resovle schemas with a logical type involving a default
+#
+
+$ set writer={"type": "record", "name": "row", "fields": [ ] }
+$ set reader={"type": "record", "name": "row", "fields": [ {"name": "f1", "default": 0, "type": { "logicalType": "timestamp-micros", "type": "long" } } ] }
+
+$ kafka-create-topic topic=resolution
+
+$ kafka-ingest format=avro topic=resolution schema=${writer} timestamp=1
+{}
+
+$ kafka-ingest format=avro topic=resolution schema=${reader} timestamp=2
+{"f1": 123 }
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE SOURCE resolution
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-resolution-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+
+> SELECT f1 FROM resolution
+"1970-01-01 00:00:00"
+"1970-01-01 00:00:00.000123"

--- a/test/testdrive/avro-resolution-union-concrete.td
+++ b/test/testdrive/avro-resolution-union-concrete.td
@@ -1,4 +1,3 @@
-
 # Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License


### PR DESCRIPTION
H/t @benesch for diagnosing the issue.

When reading default values of fields, we were only taking into account physical types, not logical types.

### Motivation

  * This PR fixes a recognized bug.

    Discussed in Slack: https://materializeinc.slack.com/archives/CUFU852KT/p1703154411455399


### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
