### PR TITLE
parallel-workload: Expect missing webhook sources

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1558,6 +1558,12 @@ class HttpPostAction(Action):
                 # Expected when Mz is killed
                 if exe.db.scenario not in (Scenario.Kill, Scenario.BackupRestore):
                     raise
+            except QueryError as e:
+                # expected, see #20465
+                if exe.db.scenario != Scenario.Kill or (
+                    "404: no object was found at the path" not in e.msg
+                ):
+                    raise e
         return True
 
 


### PR DESCRIPTION
In kill scenario a DROP SOURCE can succeed, but return an error, so that parallel-workload is not sure whether the source still exists.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
