### PR TITLE
sql: make interval planning consistent across WITH options and expressions

### DIFF
--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -67,6 +67,7 @@ use crate::names::{
 pub(crate) mod error;
 pub(crate) mod explain;
 pub(crate) mod expr;
+pub(crate) mod literal;
 pub(crate) mod lowering;
 pub(crate) mod notice;
 pub(crate) mod plan_utils;

--- a/src/sql/src/plan/literal.rs
+++ b/src/sql/src/plan/literal.rs
@@ -1,0 +1,52 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use mz_repr::adt::interval::Interval;
+use mz_repr::strconv;
+use mz_sql_parser::ast::IntervalValue;
+
+use crate::plan::PlanError;
+
+pub fn plan_interval(iv: &IntervalValue) -> Result<Interval, PlanError> {
+    let leading_precision = parser_datetimefield_to_adt(iv.precision_high);
+    let mut i = strconv::parse_interval_w_disambiguator(
+        &iv.value,
+        match leading_precision {
+            mz_repr::adt::datetime::DateTimeField::Hour
+            | mz_repr::adt::datetime::DateTimeField::Minute => Some(leading_precision),
+            _ => None,
+        },
+        parser_datetimefield_to_adt(iv.precision_low),
+    )?;
+    i.truncate_high_fields(parser_datetimefield_to_adt(iv.precision_high));
+    i.truncate_low_fields(
+        parser_datetimefield_to_adt(iv.precision_low),
+        iv.fsec_max_precision,
+    )?;
+    Ok(i)
+}
+
+fn parser_datetimefield_to_adt(
+    dtf: mz_sql_parser::ast::DateTimeField,
+) -> mz_repr::adt::datetime::DateTimeField {
+    use mz_sql_parser::ast::DateTimeField::*;
+    match dtf {
+        Millennium => mz_repr::adt::datetime::DateTimeField::Millennium,
+        Century => mz_repr::adt::datetime::DateTimeField::Century,
+        Decade => mz_repr::adt::datetime::DateTimeField::Decade,
+        Year => mz_repr::adt::datetime::DateTimeField::Year,
+        Month => mz_repr::adt::datetime::DateTimeField::Month,
+        Day => mz_repr::adt::datetime::DateTimeField::Day,
+        Hour => mz_repr::adt::datetime::DateTimeField::Hour,
+        Minute => mz_repr::adt::datetime::DateTimeField::Minute,
+        Second => mz_repr::adt::datetime::DateTimeField::Second,
+        Milliseconds => mz_repr::adt::datetime::DateTimeField::Milliseconds,
+        Microseconds => mz_repr::adt::datetime::DateTimeField::Microseconds,
+    }
+}

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -9,15 +9,16 @@
 
 //! Provides tooling to handle `WITH` options.
 
+use mz_repr::adt::interval::Interval;
 use mz_repr::{strconv, GlobalId};
 use mz_sql_parser::ast::{Ident, KafkaBroker, ReplicaDefinition};
 use mz_storage_types::connections::StringOrSecret;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-use crate::ast::{AstInfo, IntervalValue, UnresolvedItemName, Value, WithOptionValue};
+use crate::ast::{AstInfo, UnresolvedItemName, Value, WithOptionValue};
 use crate::names::{ResolvedDataType, ResolvedItemName};
-use crate::plan::{Aug, PlanError};
+use crate::plan::{literal, Aug, PlanError};
 
 pub trait TryFromValue<T>: Sized {
     fn try_from_value(v: T) -> Result<Self, PlanError>;
@@ -162,21 +163,9 @@ impl ImpliedValue for StringOrSecret {
     }
 }
 
-// This conversion targets the standard library's `Duration` type rather than
-// the Materialize SQL-specific `Interval` type because, at the time of writing,
-// `Duration` was the desired Rust type for every interval-valued option.
-//
-// In the future, it would be reasonable to add an implementation that targets
-// `Interval` for options that want it as such, e.g., because they need to
-// support negative intervals.
 impl TryFromValue<Value> for Duration {
     fn try_from_value(v: Value) -> Result<Self, PlanError> {
-        let interval = match v {
-            Value::Interval(IntervalValue { value, .. })
-            | Value::Number(value)
-            | Value::String(value) => strconv::parse_interval(&value)?,
-            _ => sql_bail!("cannot use value as interval"),
-        };
+        let interval = Interval::try_from_value(v)?;
         Ok(interval.duration()?)
     }
     fn name() -> String {
@@ -185,6 +174,25 @@ impl TryFromValue<Value> for Duration {
 }
 
 impl ImpliedValue for Duration {
+    fn implied_value() -> Result<Self, PlanError> {
+        sql_bail!("must provide an interval value")
+    }
+}
+
+impl TryFromValue<Value> for Interval {
+    fn try_from_value(v: Value) -> Result<Self, PlanError> {
+        match v {
+            Value::Interval(value) => literal::plan_interval(&value),
+            Value::Number(value) | Value::String(value) => Ok(strconv::parse_interval(&value)?),
+            _ => sql_bail!("cannot use value as interval"),
+        }
+    }
+    fn name() -> String {
+        "interval".to_string()
+    }
+}
+
+impl ImpliedValue for Interval {
     fn implied_value() -> Result<Self, PlanError> {
         sql_bail!("must provide an interval value")
     }


### PR DESCRIPTION
WITH option planning previously ignored interval modifiers; at variance from how intervals were planned when used in expressions. This commit refactors the interval planning code into a helper method that is shared by both expression planning and WITH option planning.

This commit also introduces a new `TryFromValue` implementation targeting `Interval`, to tee up the planning of the forthcoming `REFRESH` option (#23870), which wants the interval as an `Interval` rather than as a `Duration`.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
