### PR TITLE
adapter: Add validation for subscribe cluster

### DIFF
--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -1073,18 +1073,23 @@ impl Coordinator {
         }
     }
 
-    /// Determine whether we can create a compute item in the specified cluster.
+    /// Determine whether we can create a compute object in the specified cluster.
     ///
     /// Returns `Ok` if the item can be created, and an error otherwise.
-    pub(crate) fn ensure_cluster_can_host_compute_item(
+    pub(crate) fn ensure_cluster_can_host_compute_object(
         &self,
-        name: &QualifiedItemName,
+        name: Option<&QualifiedItemName>,
         cluster_id: ClusterId,
     ) -> Result<(), AdapterError> {
-        let is_system_schema_specifier = self
-            .catalog()
-            .state()
-            .is_system_schema_specifier(&name.qualifiers.schema_spec);
+        let is_system_schema_specifier = if let Some(name) = name {
+            self.catalog()
+                .state()
+                .is_system_schema_specifier(&name.qualifiers.schema_spec)
+        } else {
+            // If there's no name then it must be some temporary/transient object and not a system
+            // item.
+            false
+        };
 
         let enable_unified_clusters = self
             .catalog()

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -91,7 +91,7 @@ impl Coordinator {
             ..
         } = &plan;
 
-        self.ensure_cluster_can_host_compute_item(name, *cluster_id)?;
+        self.ensure_cluster_can_host_compute_object(Some(name), *cluster_id)?;
 
         let validity = PlanValidity {
             transient_revision: self.catalog().transient_revision(),

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -104,7 +104,7 @@ impl Coordinator {
             ..
         } = &plan;
 
-        self.ensure_cluster_can_host_compute_item(name, *cluster_id)?;
+        self.ensure_cluster_can_host_compute_object(Some(name), *cluster_id)?;
 
         // Validate any references in the materialized view's expression. We do
         // this on the unoptimized plan to better reflect what the user typed.

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -145,6 +145,8 @@ impl Coordinator {
             timeline = TimelineContext::TimestampDependent;
         }
 
+        self.ensure_cluster_can_host_compute_object(None, cluster_id)?;
+
         let validity = PlanValidity {
             transient_revision: self.catalog().transient_revision(),
             dependency_ids: depends_on,


### PR DESCRIPTION
This commit adds a validation for the cluster used to run a subscribe.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
