### PR TITLE
sql+adapter: remove enable_unified_clusters tag

### DIFF
--- a/misc/python/materialize/checks/all_checks/cluster_unification.py
+++ b/misc/python/materialize/checks/all_checks/cluster_unification.py
@@ -20,9 +20,6 @@ class UnifiedCluster(Check):
     def initialize(self) -> Testdrive:
         return Testdrive(
             """
-            $postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-            ALTER SYSTEM SET enable_unified_clusters = true
-
             > CREATE CLUSTER shared_cluster_compute_first SIZE '1', REPLICATION FACTOR 1;
             > CREATE CLUSTER shared_cluster_storage_first SIZE '1', REPLICATION FACTOR 1;
             """

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -66,7 +66,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "storage_source_decode_fuel": "100000",
     # 128 MiB,
     "compute_dataflow_max_inflight_bytes": "134217728",
-    "enable_unified_clusters": "true",
     "enable_jemalloc_profiling": "true",
     "enable_comment": "true",
     "enable_sink_doc_on_option": "true",

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -94,7 +94,6 @@ class MzStart(Action):
         c.sql(
             """
             ALTER CLUSTER default SET (MANAGED = false);
-            ALTER SYSTEM SET enable_unified_clusters = true;
             """,
             user="mz_system",
             port=6877,

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -850,25 +850,6 @@ impl Catalog {
             );
         }
         let cluster = self.resolve_cluster(session.vars().cluster())?;
-
-        if !self
-            .for_session(session)
-            .system_vars()
-            .enable_unified_clusters()
-        {
-            // Disallow queries on storage clusters. There's no technical reason for
-            // this restriction, just a philosophical one: we want all crashes in
-            // a storage cluster to be the result of sources and sinks, not user
-            // queries.
-            if cluster.bound_objects.iter().any(|id| {
-                matches!(
-                    self.get_entry(id).item_type(),
-                    CatalogItemType::Source | CatalogItemType::Sink
-                )
-            }) {
-                coord_bail!("cannot execute queries on cluster containing sources or sinks");
-            }
-        }
         Ok(cluster)
     }
 

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -21,8 +21,8 @@ use mz_controller::clusters::{
 use mz_controller_types::{ClusterId, ReplicaId, DEFAULT_REPLICA_LOGGING_INTERVAL};
 use mz_ore::cast::CastFrom;
 use mz_repr::role_id::RoleId;
-use mz_sql::catalog::{CatalogCluster, CatalogItem, CatalogItemType, ObjectType, SessionCatalog};
-use mz_sql::names::{ObjectId, QualifiedItemName};
+use mz_sql::catalog::{CatalogCluster, ObjectType};
+use mz_sql::names::ObjectId;
 use mz_sql::plan::{
     AlterClusterPlan, AlterClusterRenamePlan, AlterClusterReplicaRenamePlan, AlterClusterSwapPlan,
     AlterOptionParameter, ComputeReplicaIntrospectionConfig, CreateClusterManagedPlan,
@@ -1070,42 +1070,6 @@ impl Coordinator {
         match self.catalog_transact(Some(session), vec![op]).await {
             Ok(()) => Ok(ExecuteResponse::AlteredObject(ObjectType::ClusterReplica)),
             Err(err) => Err(err),
-        }
-    }
-
-    /// Determine whether we can create a compute item in the specified cluster.
-    ///
-    /// Returns `Ok` if the item can be created, and an error otherwise.
-    pub(crate) fn ensure_cluster_can_host_compute_item(
-        &self,
-        name: &QualifiedItemName,
-        cluster_id: ClusterId,
-    ) -> Result<(), AdapterError> {
-        let is_system_schema_specifier = self
-            .catalog()
-            .state()
-            .is_system_schema_specifier(&name.qualifiers.schema_spec);
-
-        let enable_unified_clusters = self
-            .catalog()
-            .for_system_session()
-            .system_vars()
-            .enable_unified_clusters();
-
-        let cluster = self.catalog().get_cluster(cluster_id);
-        let is_compute_cluster = cluster.bound_objects().is_empty()
-            || cluster.bound_objects().iter().any(|id| {
-                matches!(
-                    self.catalog().get_entry(id).item_type(),
-                    CatalogItemType::Index | CatalogItemType::MaterializedView
-                )
-            });
-
-        if !is_system_schema_specifier && !enable_unified_clusters && !is_compute_cluster {
-            let cluster_name = self.catalog().get_cluster(cluster_id).name.clone();
-            Err(AdapterError::BadItemInStorageCluster { cluster_name })
-        } else {
-            Ok(())
         }
     }
 }

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -86,12 +86,9 @@ impl Coordinator {
         CreateIndexValidate { plan, resolved_ids }: CreateIndexValidate,
     ) -> Result<CreateIndexOptimize, AdapterError> {
         let plan::CreateIndexPlan {
-            name,
             index: plan::Index { on, cluster_id, .. },
             ..
         } = &plan;
-
-        self.ensure_cluster_can_host_compute_item(name, *cluster_id)?;
 
         let validity = PlanValidity {
             transient_revision: self.catalog().transient_revision(),

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -95,7 +95,6 @@ impl Coordinator {
         CreateMaterializedViewValidate { plan, resolved_ids }: CreateMaterializedViewValidate,
     ) -> Result<CreateMaterializedViewOptimize, AdapterError> {
         let plan::CreateMaterializedViewPlan {
-            name,
             materialized_view:
                 plan::MaterializedView {
                     expr, cluster_id, ..
@@ -103,8 +102,6 @@ impl Coordinator {
             ambiguous_columns,
             ..
         } = &plan;
-
-        self.ensure_cluster_can_host_compute_item(name, *cluster_id)?;
 
         // Validate any references in the materialized view's expression. We do
         // this on the unoptimized plan to better reflect what the user typed.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1616,7 +1616,11 @@ fn source_sink_cluster_config(
     match (in_cluster, size) {
         (None, None) => Ok(SourceSinkClusterConfig::Undefined),
         (Some(in_cluster), None) => {
-            ensure_cluster_can_host_storage_item(scx, in_cluster.id, ty)?;
+            let cluster = scx.catalog.get_cluster(in_cluster.id);
+            // At most 1 replica
+            if cluster.replica_ids().len() > 1 {
+                sql_bail!("cannot create {ty} in cluster with more than one replica")
+            }
 
             // We also don't allow more objects to be added to a cluster that is already
             // linked to another object.
@@ -3636,31 +3640,6 @@ fn is_storage_cluster(scx: &StatementContext, cluster: &dyn CatalogCluster) -> b
             CatalogItemType::Source | CatalogItemType::Sink
         )
     })
-}
-
-/// Check that the cluster can host storage items.
-fn ensure_cluster_can_host_storage_item(
-    scx: &StatementContext,
-    cluster_id: ClusterId,
-    ty: &'static str,
-) -> Result<(), PlanError> {
-    let cluster = scx.catalog.get_cluster(cluster_id);
-    // At most 1 replica
-    if cluster.replica_ids().len() > 1 {
-        sql_bail!("cannot create {ty} in cluster with more than one replica")
-    }
-    let enable_unified_cluster = scx.catalog.system_vars().enable_unified_clusters();
-    let only_storage_objects = cluster.bound_objects().iter().all(|id| {
-        matches!(
-            scx.catalog.get_item(id).item_type(),
-            CatalogItemType::Source | CatalogItemType::Sink
-        )
-    });
-    // unified clusters or only storage objects on cluster
-    if !enable_unified_cluster && !only_storage_objects {
-        sql_bail!("cannot create {ty} in cluster containing indexes or materialized views");
-    }
-    Ok(())
 }
 
 fn plan_drop_cluster_replica(

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2109,13 +2109,6 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_unified_clusters,
-        desc: "unified compute and storage cluster",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_jemalloc_profiling,
         desc: "jemalloc heap memory profiling",
         default: true,

--- a/test/sqllogictest/unified_cluster.slt
+++ b/test/sqllogictest/unified_cluster.slt
@@ -14,11 +14,6 @@ mode cockroach
 # Start from a pristine state
 reset-server
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_unified_clusters = on;
-----
-COMPLETE 0
-
 statement ok
 CREATE CLUSTER c SIZE '1', REPLICATION FACTOR 2;
 

--- a/test/sqllogictest/webhook.slt
+++ b/test/sqllogictest/webhook.slt
@@ -102,23 +102,6 @@ SHOW COLUMNS FROM webhook_text_include_headers
 body false text
 headers false map
 
-# Make sure that webhook_cluster only contains sources.
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_unified_clusters = false
-----
-COMPLETE 0
-
-statement error cannot create this kind of item in a cluster that contains sources or sinks
-CREATE MATERIALIZED VIEW mat_view_text IN CLUSTER webhook_cluster AS (
-    SELECT body FROM webhook_text_include_headers
-);
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_unified_clusters = true
-----
-COMPLETE 0
-
 statement ok
 CREATE MATERIALIZED VIEW mat_view_text IN CLUSTER webhook_cluster AS (
     SELECT body FROM webhook_text_include_headers
@@ -384,20 +367,6 @@ CREATE CLUSTER compute_cluster REPLICAS (r1 (SIZE '1'));
 
 statement ok
 CREATE MATERIALIZED VIEW mv1 IN CLUSTER compute_cluster AS SELECT name FROM mz_objects;
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_unified_clusters = false
-----
-COMPLETE 0
-
-statement error cannot create source in cluster containing indexes or materialized views
-CREATE SOURCE webhook_on_compute_cluster IN CLUSTER compute_cluster FROM WEBHOOK
-  BODY FORMAT BYTES;
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_unified_clusters = true
-----
-COMPLETE 0
 
 statement ok
 CREATE SOURCE webhook_on_compute_cluster IN CLUSTER compute_cluster FROM WEBHOOK

--- a/test/testdrive/linked-clusters.td
+++ b/test/testdrive/linked-clusters.td
@@ -126,19 +126,6 @@ contains:cannot modify linked cluster "materialize_public_lg1"
 > EXPLAIN SELECT * FROM v
 "Explained Query:\n  ReadStorage materialize.public.v\n"
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unified_clusters = false
-
-! SELECT generate_series(0, 10)
-contains:cannot execute queries on cluster containing sources or sinks
-! SUBSCRIBE v
-contains:cannot execute queries on cluster containing sources or sinks
-! EXPLAIN SELECT * FROM v
-contains:cannot execute queries on cluster containing sources or sinks
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unified_clusters = true
-
 > SET cluster = default
 
 # Test that only the default clusters and replicas remain after dropping

--- a/test/testdrive/storage-clusters.td
+++ b/test/testdrive/storage-clusters.td
@@ -35,21 +35,13 @@ contains:only one of IN CLUSTER or SIZE can be set
 ! ALTER SOURCE loadgen SET (SIZE = '1')
 contains:cannot change the size of a source or sink created with IN CLUSTER
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unified_clusters = false
-
-# Create indexes and materialized views in a storage cluster is banned.
-! CREATE INDEX bad IN CLUSTER storage ON t (a)
-contains:cannot create this kind of item in a cluster that contains sources or sinks
-! CREATE MATERIALIZED VIEW bad IN CLUSTER storage AS SELECT 1
-contains:cannot create this kind of item in a cluster that contains sources or sinks
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unified_clusters = true
+# Create indexes and materialized views in a storage cluster is allowed.
+> CREATE INDEX t_idx IN CLUSTER storage ON t (a)
+> CREATE MATERIALIZED VIEW mv IN CLUSTER storage AS SELECT 1
 
 > CREATE CLUSTER REPLICA storage.r1 SIZE = '1'
 
-# Executing queries on a storage cluster is banned.
+# Executing queries on a storage cluster is allowed.
 > SELECT generate_series(1, 1)
 1
 
@@ -57,39 +49,8 @@ ALTER SYSTEM SET enable_unified_clusters = true
 ! CREATE CLUSTER REPLICA storage.r2 SIZE '1'
 contains:cannot create more than one replica of a cluster containing sources or sinks
 
-# Creating indexes and materialized views in a cluster is permitted once the
-# source has been dropped.
-> DROP SOURCE loadgen;
-> CREATE INDEX idx IN CLUSTER storage ON t (a)
-> CREATE MATERIALIZED VIEW mv IN CLUSTER storage AS SELECT generate_series(1, 1)
-
-# As is running queries.
-> SELECT generate_series(1, 1)
-1
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unified_clusters = false
-
-# Recreating the source is banned.
-! CREATE SOURCE loadgen IN CLUSTER storage FROM LOAD GENERATOR COUNTER
-contains:cannot create source in cluster containing indexes or materialized views
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unified_clusters = true
-
-# Creating a second replica is now allowed.
-> CREATE CLUSTER REPLICA storage.r2 SIZE '1'
-
-# The source cannot be readded even after the index and materialized views
-# are dropped because of the second replica.
-> DROP INDEX idx
-> DROP MATERIALIZED VIEW mv
-! CREATE SOURCE loadgen IN CLUSTER storage FROM LOAD GENERATOR COUNTER
-contains:cannot create source in cluster with more than one replica
-
-# Creating the source is allowed after dropping the second replica
-> DROP CLUSTER REPLICA storage.r2
-> CREATE SOURCE loadgen IN CLUSTER storage FROM LOAD GENERATOR COUNTER
+# Creating sources on clusters containing compute objects is allowed
+> CREATE SOURCE lg2 IN CLUSTER storage FROM LOAD GENERATOR COUNTER
 
 # Test that `DROP CLUSTER` only succeeds with `CASCADE`.
 ! DROP CLUSTER storage


### PR DESCRIPTION
Now that `enable_unified_clusters` is `true` for all environments in prod, the LD flag no longer does anything.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
