### PR TITLE
zippy/parallel-workload: Add CRDB/S3 jitter

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -44,7 +44,7 @@ from pg8000 import Connection, Cursor
 from materialize import MZ_ROOT, mzbuild, spawn, ui
 from materialize.mzcompose import loader
 from materialize.mzcompose.service import Service
-from materialize.mzcompose.services.minio import MINIO_BLOB_URI
+from materialize.mzcompose.services.minio import minio_blob_uri
 from materialize.ui import UIError
 
 
@@ -1103,7 +1103,7 @@ class Composition:
             "admin",
             "--commit",
             "restore-blob",
-            f"--blob-uri={MINIO_BLOB_URI}",
+            f"--blob-uri={minio_blob_uri()}",
             "--consensus-uri=postgres://root@cockroach:26257?options=--search_path=consensus",
         )
         self.up("materialized")

--- a/misc/python/materialize/mzcompose/services/minio.py
+++ b/misc/python/materialize/mzcompose/services/minio.py
@@ -12,7 +12,9 @@ from materialize.mzcompose.service import (
     Service,
 )
 
-MINIO_BLOB_URI = "s3://minioadmin:minioadmin@persist/persist?endpoint=http://minio:9000/&region=minio"
+
+def minio_blob_uri(address: str = "minio") -> str:
+    return f"s3://minioadmin:minioadmin@persist/persist?endpoint=http://{address}:9000/&region=minio"
 
 
 class Minio(Service):

--- a/misc/python/materialize/mzcompose/services/toxiproxy.py
+++ b/misc/python/materialize/mzcompose/services/toxiproxy.py
@@ -8,6 +8,8 @@
 # by the Apache License, Version 2.0.
 
 
+import random
+
 from materialize.mzcompose.service import (
     Service,
 )
@@ -19,11 +21,13 @@ class Toxiproxy(Service):
         name: str = "toxiproxy",
         image: str = "shopify/toxiproxy:2.1.4",
         port: int = 8474,
+        seed: int = random.randrange(2**63),
     ) -> None:
         super().__init__(
             name=name,
             config={
                 "image": image,
+                "command": ["-host=0.0.0.0", f"-seed={seed}"],
                 "ports": [port],
                 "healthcheck": {
                     "test": ["CMD", "nc", "-z", "localhost", "8474"],

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -23,7 +23,7 @@ from materialize.data_ingest.data_type import NUMBER_TYPES, Text, TextTextMap
 from materialize.data_ingest.query_error import QueryError
 from materialize.data_ingest.row import Operation
 from materialize.mzcompose.composition import Composition
-from materialize.mzcompose.services.minio import MINIO_BLOB_URI
+from materialize.mzcompose.services.minio import minio_blob_uri
 from materialize.parallel_workload.database import (
     DB,
     MAX_CLUSTER_REPLICAS,
@@ -1229,7 +1229,7 @@ class BackupRestoreAction(Action):
                 "admin",
                 "--commit",
                 "restore-blob",
-                f"--blob-uri={MINIO_BLOB_URI}",
+                f"--blob-uri={minio_blob_uri()}",
                 "--consensus-uri=postgres://root@cockroach:26257?options=--search_path=consensus",
             )
             self.composition.up("materialized")

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -69,8 +69,8 @@ class MzStart(Action):
 
         with c.override(
             Materialized(
-                external_minio=True,
-                external_cockroach=True,
+                external_minio="toxiproxy",
+                external_cockroach="toxiproxy",
                 sanity_restart=False,
                 additional_system_parameter_defaults=self.additional_system_parameter_defaults,
             )

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -10,6 +10,8 @@
 
 import random
 
+import requests
+
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.cockroach import Cockroach
@@ -18,6 +20,7 @@ from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc, Minio
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
+from materialize.mzcompose.services.toxiproxy import Toxiproxy
 from materialize.mzcompose.services.zookeeper import Zookeeper
 from materialize.parallel_workload.parallel_workload import parse_common_args, run
 from materialize.parallel_workload.settings import Complexity, Scenario
@@ -44,6 +47,7 @@ SERVICES = [
         name="persistcli",
         config={"mzbuild": "jobs"},
     ),
+    Toxiproxy(),
 ]
 
 
@@ -75,14 +79,15 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     with c.override(
         Materialized(
-            external_cockroach=True,
             restart="on-failure",
-            external_minio=True,
+            external_minio="toxiproxy",
+            external_cockroach="toxiproxy",
             ports=["6975:6875", "6976:6876", "6977:6877"],
             catalog_store=catalog_store,
             sanity_restart=sanity_restart,
         )
     ):
+        toxiproxy_start(c)
         c.up(*service_names)
         c.up("mc", persistent=True)
         c.exec(
@@ -120,3 +125,47 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         #     # Don't fail the entire run. We ran into a crash,
         #     # ci-logged-errors-detect will handle this if it's an unknown failure.
         #     return
+
+
+def toxiproxy_start(c: Composition) -> None:
+    c.up("toxiproxy")
+
+    port = c.default_port("toxiproxy")
+    r = requests.post(
+        f"http://localhost:{port}/proxies",
+        json={
+            "name": "cockroach",
+            "listen": "0.0.0.0:26257",
+            "upstream": "cockroach:26257",
+            "enabled": True,
+        },
+    )
+    assert r.status_code == 201, r
+    r = requests.post(
+        f"http://localhost:{port}/proxies",
+        json={
+            "name": "minio",
+            "listen": "0.0.0.0:9000",
+            "upstream": "minio:9000",
+            "enabled": True,
+        },
+    )
+    assert r.status_code == 201, r
+    r = requests.post(
+        f"http://localhost:{port}/proxies/cockroach/toxics",
+        json={
+            "name": "cockroach",
+            "type": "latency",
+            "attributes": {"latency": 0, "jitter": 100},
+        },
+    )
+    assert r.status_code == 200, r
+    r = requests.post(
+        f"http://localhost:{port}/proxies/minio/toxics",
+        json={
+            "name": "minio",
+            "type": "latency",
+            "attributes": {"latency": 0, "jitter": 100},
+        },
+    )
+    assert r.status_code == 200, r

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -85,7 +85,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             ports=["6975:6875", "6976:6876", "6977:6877"],
             catalog_store=catalog_store,
             sanity_restart=sanity_restart,
-        )
+        ),
+        Toxiproxy(seed=random.randrange(2**63)),
     ):
         toxiproxy_start(c)
         c.up(*service_names)

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -163,6 +163,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             external_cockroach="toxiproxy",
             sanity_restart=False,
         ),
+        # Override so seed gets respected
+        Toxiproxy(seed=random.randrange(2**63)),
     ):
         toxiproxy_start(c)
 


### PR DESCRIPTION
using toxiproxy

Part of #24027, for persist-txn testing

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
