### PR TITLE
mzcompose,cloudtest: Make sure the same AWS-related env varibles are …

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -40,11 +40,7 @@ class StartMz(MzcomposeAction):
         mz_service: str | None = None,
     ) -> None:
         self.tag = tag
-        self.environment_extra = [
-            "MZ_AWS_CONNECTION_ROLE_ARN=arn:aws:iam::123456789000:role/MaterializeConnection",
-            "MZ_AWS_EXTERNAL_ID_PREFIX=eb5cb59b-e2fe-41f3-87ca-d2176a495345",
-            *environment_extra,
-        ]
+        self.environment_extra = environment_extra
         self.system_parameter_defaults = system_parameter_defaults
         self.additional_system_parameter_defaults = additional_system_parameter_defaults
         self.catalog_store = (

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -272,6 +272,10 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
                 name="MZ_AWS_PRIVATELINK_AVAILABILITY_ZONES", value="use1-az1,use1-az2"
             ),
             V1EnvVar(
+                name="MZ_AWS_CONNECTION_ROLE_ARN",
+                value="arn:aws:iam::123456789000:role/MaterializeConnection",
+            ),
+            V1EnvVar(
                 name="MZ_SYSTEM_PARAMETER_DEFAULT",
                 value=";".join(
                     [

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -73,6 +73,8 @@ class Materialized(Service):
             "MZ_ORCHESTRATOR_PROCESS_PROMETHEUS_SERVICE_DISCOVERY_DIRECTORY=/mzdata/prometheus",
             "MZ_BOOTSTRAP_ROLE=materialize",
             "MZ_INTERNAL_PERSIST_PUBSUB_LISTEN_ADDR=0.0.0.0:6879",
+            "MZ_AWS_CONNECTION_ROLE_ARN=arn:aws:iam::123456789000:role/MaterializeConnection",
+            "MZ_AWS_EXTERNAL_ID_PREFIX=eb5cb59b-e2fe-41f3-87ca-d2176a495345",
             f"MZ_CATALOG_STORE={catalog_store}",
             # Please think twice before forwarding additional environment
             # variables from the host, as it's easy to write tests that are


### PR DESCRIPTION
…in effect

Make sure all tests in all frameworks run with the same AWS-related env variables.

Fixes: #24113

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Nighlty was failing:
- in platform checks, because Mz was initially started with a certain set of AWS-related env options but then on restart it was started with the default set
- in cloudtest, because the AWS-related env variables were not present at all.

In a follow-up PR, I hope to further unify the handling between the two frameworks, so the code duplication is removed altogether.