### PR TITLE
stash: Elevate stuck consolidator priority

### DIFF
--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -1060,6 +1060,7 @@ impl Stash {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Priority {
     Low,
+    #[allow(dead_code)]
     Normal,
     High,
 }


### PR DESCRIPTION
Previously, CRDB stash transactions were always high priority and CRDB stash consolidator transactions were always low priority. We found that for some environments, the stash transaction was ALWAYS aborting the stash consolidator transaction. This prevented any stash data from being consolidated and caused the stash to grow without bounds.

This commit will elevate the CRDB transaction priority of the stash consolidator from low to high if it has failed to consolidate multiple times. The normal stash transaction is downgraded to normal priority. This will allow stash consolidation to complete if it has failed enough times.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
