### PR TITLE
Fix SQL council github action

### DIFF
--- a/.github/workflows/slack_notify_sql_parser.yml
+++ b/.github/workflows/slack_notify_sql_parser.yml
@@ -76,7 +76,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "• *PR:* <${{ github.event.pull_request.html_url }}|${{ toJSON(github.event.pull_request.title) }}>"
+                    "text": ${{ toJSON(format("• *PR:* <{0}|{1}>", github.event.pull_request.html_url, github.event.pull_request.title)) }}
                   }
                 },
                 {


### PR DESCRIPTION

### Motivation

  * This PR fixes a previously unreported bug.

    The current GH action always fails as it inserts extraneous extra quotes. For example, if `bar` is the string `Hello, World`, `"foo ${{ toJSON(bar) }}"` expands to `"foo "Hello, World""`. We need to call `toJSON` on the entire string so that there will only be one pair of (unescaped) quotes.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
Totally untested, but since the one we have now is always failing, there should be no risk.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
