### PR TITLE
fix quotes in sql council workflow file

### DIFF
--- a/.github/workflows/slack_notify_sql_parser.yml
+++ b/.github/workflows/slack_notify_sql_parser.yml
@@ -76,7 +76,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ${{ toJSON(format("• *PR:* <{0}|{1}>", github.event.pull_request.html_url, github.event.pull_request.title)) }}
+                    "text": ${{ toJSON(format('• *PR:* <{0}|{1}>', github.event.pull_request.html_url, github.event.pull_request.title)) }}
                   }
                 },
                 {


### PR DESCRIPTION
Apparently quotes inside a `${{` block need to be single, not double.