### PR TITLE
parallel-workload: Add toggle-persist-txn scenario

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1072,6 +1072,17 @@ steps:
               composition: parallel-workload
               args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers]
 
+      - id: parallel-workload-persist-txn
+        label: "Parallel Workload (toggle persist-txn)"
+        artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: parallel-workload
+              args: [--runtime=1500, --scenario=toggle-persist-txn]
+
   - id: incident-70
     label: "Test for incident 70"
     timeout_in_minutes: 15

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -44,7 +44,7 @@ from pg8000 import Connection, Cursor
 from materialize import MZ_ROOT, mzbuild, spawn, ui
 from materialize.mzcompose import loader
 from materialize.mzcompose.service import Service
-from materialize.mzcompose.services.minio import MINIO_BLOB_URI
+from materialize.mzcompose.services.minio import minio_blob_uri
 from materialize.ui import UIError
 
 
@@ -1103,7 +1103,7 @@ class Composition:
             "admin",
             "--commit",
             "restore-blob",
-            f"--blob-uri={MINIO_BLOB_URI}",
+            f"--blob-uri={minio_blob_uri()}",
             "--consensus-uri=postgres://root@cockroach:26257?options=--search_path=consensus",
         )
         self.up("materialized")

--- a/misc/python/materialize/mzcompose/services/minio.py
+++ b/misc/python/materialize/mzcompose/services/minio.py
@@ -12,7 +12,9 @@ from materialize.mzcompose.service import (
     Service,
 )
 
-MINIO_BLOB_URI = "s3://minioadmin:minioadmin@persist/persist?endpoint=http://minio:9000/&region=minio"
+
+def minio_blob_uri(address: str = "minio") -> str:
+    return f"s3://minioadmin:minioadmin@persist/persist?endpoint=http://{address}:9000/&region=minio"
 
 
 class Minio(Service):

--- a/misc/python/materialize/mzcompose/services/toxiproxy.py
+++ b/misc/python/materialize/mzcompose/services/toxiproxy.py
@@ -8,6 +8,8 @@
 # by the Apache License, Version 2.0.
 
 
+import random
+
 from materialize.mzcompose.service import (
     Service,
 )
@@ -19,11 +21,13 @@ class Toxiproxy(Service):
         name: str = "toxiproxy",
         image: str = "shopify/toxiproxy:2.1.4",
         port: int = 8474,
+        seed: int = random.randrange(2**63),
     ) -> None:
         super().__init__(
             name=name,
             config={
                 "image": image,
+                "command": ["-host=0.0.0.0", f"-seed={seed}"],
                 "ports": [port],
                 "healthcheck": {
                     "test": ["CMD", "nc", "-z", "localhost", "8474"],

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -23,7 +23,7 @@ from materialize.data_ingest.data_type import NUMBER_TYPES, Text, TextTextMap
 from materialize.data_ingest.query_error import QueryError
 from materialize.data_ingest.row import Operation
 from materialize.mzcompose.composition import Composition
-from materialize.mzcompose.services.minio import MINIO_BLOB_URI
+from materialize.mzcompose.services.minio import minio_blob_uri
 from materialize.parallel_workload.database import (
     DB,
     MAX_CLUSTER_REPLICAS,
@@ -1229,7 +1229,7 @@ class BackupRestoreAction(Action):
                 "admin",
                 "--commit",
                 "restore-blob",
-                f"--blob-uri={MINIO_BLOB_URI}",
+                f"--blob-uri={minio_blob_uri()}",
                 "--consensus-uri=postgres://root@cockroach:26257?options=--search_path=consensus",
             )
             self.composition.up("materialized")

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -12,6 +12,7 @@ import json
 import random
 import time
 import urllib.parse
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import pg8000
@@ -23,6 +24,7 @@ from materialize.data_ingest.data_type import NUMBER_TYPES, Text, TextTextMap
 from materialize.data_ingest.query_error import QueryError
 from materialize.data_ingest.row import Operation
 from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import minio_blob_uri
 from materialize.parallel_workload.database import (
     DB,
@@ -97,7 +99,11 @@ class Action:
                     "canceling statement due to user request",
                 ]
             )
-        if exe.db.scenario in (Scenario.Kill, Scenario.BackupRestore):
+        if exe.db.scenario in (
+            Scenario.Kill,
+            Scenario.TogglePersistTxn,
+            Scenario.BackupRestore,
+        ):
             result.extend(
                 [
                     "network error",
@@ -265,7 +271,11 @@ class SQLsmithAction(Action):
                 # it. Ignore for now
                 return
         except:
-            if exe.db.scenario not in (Scenario.Kill, Scenario.BackupRestore):
+            if exe.db.scenario not in (
+                Scenario.Kill,
+                Scenario.TogglePersistTxn,
+                Scenario.BackupRestore,
+            ):
                 raise
         finally:
             self.composition.silent = False
@@ -454,7 +464,10 @@ class DropIndexAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if exe.db.scenario != Scenario.Kill or (
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.TogglePersistTxn,
+                ) or (
                     "unknown catalog item" not in e.msg
                     and "unknown schema" not in e.msg
                 ):
@@ -500,7 +513,10 @@ class DropTableAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if exe.db.scenario != Scenario.Kill or (
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.TogglePersistTxn,
+                ) or (
                     "unknown catalog item" not in e.msg
                     and "unknown schema" not in e.msg
                 ):
@@ -647,7 +663,10 @@ class DropSchemaAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if exe.db.scenario != Scenario.Kill or "unknown schema" not in e.msg:
+                if (
+                    exe.db.scenario not in (Scenario.Kill, Scenario.TogglePersistTxn)
+                    or "unknown schema" not in e.msg
+                ):
                     raise e
             exe.db.schemas.remove(schema)
         return True
@@ -798,7 +817,10 @@ class DropViewAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if exe.db.scenario != Scenario.Kill or (
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.TogglePersistTxn,
+                ) or (
                     "unknown catalog item" not in e.msg
                     and "unknown schema" not in e.msg
                 ):
@@ -842,7 +864,10 @@ class DropRoleAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if exe.db.scenario != Scenario.Kill or "unknown role" not in e.msg:
+                if (
+                    exe.db.scenario not in (Scenario.Kill, Scenario.TogglePersistTxn)
+                    or "unknown role" not in e.msg
+                ):
                     raise e
             exe.db.roles.remove(role)
         return True
@@ -891,7 +916,10 @@ class DropClusterAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if exe.db.scenario != Scenario.Kill or "unknown cluster" not in e.msg:
+                if (
+                    exe.db.scenario not in (Scenario.Kill, Scenario.TogglePersistTxn)
+                    or "unknown cluster" not in e.msg
+                ):
                     raise e
             exe.db.clusters.remove(cluster)
         return True
@@ -1015,7 +1043,7 @@ class DropClusterReplicaAction(Action):
             except QueryError as e:
                 # expected, see #20465
                 if (
-                    exe.db.scenario != Scenario.Kill
+                    exe.db.scenario not in (Scenario.Kill, Scenario.TogglePersistTxn)
                     or "has no CLUSTER REPLICA named" not in e.msg
                 ):
                     raise e
@@ -1163,15 +1191,34 @@ class KillAction(Action):
         self,
         rng: random.Random,
         composition: Composition | None,
+        catalog_store: str,
+        sanity_restart: bool,
+        system_param_fn: Callable[[dict[str, str]], dict[str, str]] = lambda x: x,
     ):
         super().__init__(rng, composition)
+        self.system_param_fn = system_param_fn
+        self.system_parameters = {}
+        self.catalog_store = catalog_store
+        self.sanity_restart = sanity_restart
 
     def run(self, exe: Executor) -> bool:
         assert self.composition
         self.composition.kill("materialized")
         # Otherwise getting failure on "up" locally
         time.sleep(1)
-        self.composition.up("materialized", detach=True)
+        self.system_parameters = self.system_param_fn(self.system_parameters)
+        with self.composition.override(
+            Materialized(
+                restart="on-failure",
+                external_minio="toxiproxy",
+                external_cockroach="toxiproxy",
+                ports=["6975:6875", "6976:6876", "6977:6877"],
+                catalog_store=self.catalog_store,
+                sanity_restart=self.sanity_restart,
+                additional_system_parameter_defaults=self.system_parameters,
+            )
+        ):
+            self.composition.up("materialized", detach=True)
         time.sleep(self.rng.uniform(120, 240))
         return True
 
@@ -1239,7 +1286,7 @@ class BackupRestoreAction(Action):
 class CreateWebhookSourceAction(Action):
     def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
-        if exe.db.scenario == Scenario.Kill:
+        if exe.db.scenario in (Scenario.Kill, Scenario.TogglePersistTxn):
             result.extend(
                 ["cannot create source in cluster with more than one replica"]
             )
@@ -1287,7 +1334,10 @@ class DropWebhookSourceAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if exe.db.scenario != Scenario.Kill or (
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.TogglePersistTxn,
+                ) or (
                     "unknown catalog item" not in e.msg
                     and "unknown schema" not in e.msg
                 ):
@@ -1299,7 +1349,7 @@ class DropWebhookSourceAction(Action):
 class CreateKafkaSourceAction(Action):
     def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
-        if exe.db.scenario == Scenario.Kill:
+        if exe.db.scenario in (Scenario.Kill, Scenario.TogglePersistTxn):
             result.extend(
                 ["cannot create source in cluster with more than one replica"]
             )
@@ -1331,7 +1381,7 @@ class CreateKafkaSourceAction(Action):
                 source.create(exe)
                 exe.db.kafka_sources.append(source)
             except:
-                if exe.db.scenario != Scenario.Kill:
+                if exe.db.scenario not in (Scenario.Kill, Scenario.TogglePersistTxn):
                     raise
         return True
 
@@ -1357,7 +1407,10 @@ class DropKafkaSourceAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if exe.db.scenario != Scenario.Kill or (
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.TogglePersistTxn,
+                ) or (
                     "unknown catalog item" not in e.msg
                     and "unknown schema" not in e.msg
                 ):
@@ -1369,7 +1422,7 @@ class DropKafkaSourceAction(Action):
 class CreatePostgresSourceAction(Action):
     def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
-        if exe.db.scenario == Scenario.Kill:
+        if exe.db.scenario in (Scenario.Kill, Scenario.TogglePersistTxn):
             result.extend(
                 ["cannot create source in cluster with more than one replica"]
             )
@@ -1405,7 +1458,7 @@ class CreatePostgresSourceAction(Action):
                 source.create(exe)
                 exe.db.postgres_sources.append(source)
             except:
-                if exe.db.scenario != Scenario.Kill:
+                if exe.db.scenario not in (Scenario.Kill, Scenario.TogglePersistTxn):
                     raise
         return True
 
@@ -1431,7 +1484,10 @@ class DropPostgresSourceAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if exe.db.scenario != Scenario.Kill or (
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.TogglePersistTxn,
+                ) or (
                     "unknown catalog item" not in e.msg
                     and "unknown schema" not in e.msg
                 ):
@@ -1495,7 +1551,10 @@ class DropKafkaSinkAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if exe.db.scenario != Scenario.Kill or (
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.TogglePersistTxn,
+                ) or (
                     "unknown catalog item" not in e.msg
                     and "unknown schema" not in e.msg
                 ):
@@ -1556,7 +1615,11 @@ class HttpPostAction(Action):
                     raise QueryError(f"{result.status_code}: {result.text}", log)
             except (requests.exceptions.ConnectionError):
                 # Expected when Mz is killed
-                if exe.db.scenario not in (Scenario.Kill, Scenario.BackupRestore):
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.TogglePersistTxn,
+                    Scenario.BackupRestore,
+                ):
                     raise
             except QueryError as e:
                 # expected, see #20465

--- a/misc/python/materialize/parallel_workload/settings.py
+++ b/misc/python/materialize/parallel_workload/settings.py
@@ -28,6 +28,7 @@ class Scenario(Enum):
     Kill = "kill"
     Rename = "rename"
     BackupRestore = "backup-restore"
+    TogglePersistTxn = "toggle-persist-txn"
 
     @classmethod
     def _missing_(cls, value):

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -69,8 +69,8 @@ class MzStart(Action):
 
         with c.override(
             Materialized(
-                external_minio=True,
-                external_cockroach=True,
+                external_minio="toxiproxy",
+                external_cockroach="toxiproxy",
                 sanity_restart=False,
                 additional_system_parameter_defaults=self.additional_system_parameter_defaults,
             )

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -70,7 +70,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     scenario = Scenario(args.scenario)
     complexity = Complexity(args.complexity)
 
-    if scenario in (Scenario.Kill, Scenario.BackupRestore):
+    if scenario in (Scenario.Kill, Scenario.BackupRestore, Scenario.TogglePersistTxn):
         catalog_store = "stash"
         sanity_restart = False
     else:
@@ -118,6 +118,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             args.naughty_identifiers,
             args.fast_startup,
             c,
+            catalog_store,
+            sanity_restart,
         )
         # TODO: Only ignore errors that will be handled by parallel-workload, not others
         # except Exception:

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -10,6 +10,8 @@
 
 import random
 
+import requests
+
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.cockroach import Cockroach
@@ -18,6 +20,7 @@ from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc, Minio
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
+from materialize.mzcompose.services.toxiproxy import Toxiproxy
 from materialize.mzcompose.services.zookeeper import Zookeeper
 from materialize.parallel_workload.parallel_workload import parse_common_args, run
 from materialize.parallel_workload.settings import Complexity, Scenario
@@ -44,6 +47,7 @@ SERVICES = [
         name="persistcli",
         config={"mzbuild": "jobs"},
     ),
+    Toxiproxy(),
 ]
 
 
@@ -75,14 +79,15 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     with c.override(
         Materialized(
-            external_cockroach=True,
             restart="on-failure",
-            external_minio=True,
+            external_minio="toxiproxy",
+            external_cockroach="toxiproxy",
             ports=["6975:6875", "6976:6876", "6977:6877"],
             catalog_store=catalog_store,
             sanity_restart=sanity_restart,
         )
     ):
+        toxiproxy_start(c)
         c.up(*service_names)
         c.up("mc", persistent=True)
         c.exec(
@@ -120,3 +125,47 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         #     # Don't fail the entire run. We ran into a crash,
         #     # ci-logged-errors-detect will handle this if it's an unknown failure.
         #     return
+
+
+def toxiproxy_start(c: Composition) -> None:
+    c.up("toxiproxy")
+
+    port = c.default_port("toxiproxy")
+    r = requests.post(
+        f"http://localhost:{port}/proxies",
+        json={
+            "name": "cockroach",
+            "listen": "0.0.0.0:26257",
+            "upstream": "cockroach:26257",
+            "enabled": True,
+        },
+    )
+    assert r.status_code == 201, r
+    r = requests.post(
+        f"http://localhost:{port}/proxies",
+        json={
+            "name": "minio",
+            "listen": "0.0.0.0:9000",
+            "upstream": "minio:9000",
+            "enabled": True,
+        },
+    )
+    assert r.status_code == 201, r
+    r = requests.post(
+        f"http://localhost:{port}/proxies/cockroach/toxics",
+        json={
+            "name": "cockroach",
+            "type": "latency",
+            "attributes": {"latency": 0, "jitter": 100},
+        },
+    )
+    assert r.status_code == 200, r
+    r = requests.post(
+        f"http://localhost:{port}/proxies/minio/toxics",
+        json={
+            "name": "minio",
+            "type": "latency",
+            "attributes": {"latency": 0, "jitter": 100},
+        },
+    )
+    assert r.status_code == 200, r

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -85,7 +85,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             ports=["6975:6875", "6976:6876", "6977:6877"],
             catalog_store=catalog_store,
             sanity_restart=sanity_restart,
-        )
+        ),
+        Toxiproxy(seed=random.randrange(2**63)),
     ):
         toxiproxy_start(c)
         c.up(*service_names)

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -163,6 +163,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             external_cockroach="toxiproxy",
             sanity_restart=False,
         ),
+        # Override so seed gets respected
+        Toxiproxy(seed=random.randrange(2**63)),
     ):
         toxiproxy_start(c)
 


### PR DESCRIPTION
Part of #24027

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
