### PR TITLE
Minimize postorder traversal

### DIFF
--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1119,14 +1119,14 @@ impl MapFilterProject {
         let mut reference_count = vec![0; input_arity + self.expressions.len()];
         // Increment reference counts for each use
         for expr in self.expressions.iter() {
-            expr.visit_pre(&mut |e| {
+            expr.visit_pre(|e| {
                 if let MirScalarExpr::Column(i) = e {
                     reference_count[*i] += 1;
                 }
             });
         }
         for (_, pred) in self.predicates.iter() {
-            pred.visit_pre(&mut |e| {
+            pred.visit_pre(|e| {
                 if let MirScalarExpr::Column(i) = e {
                     reference_count[*i] += 1;
                 }

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -176,7 +176,7 @@ fn rank_complexity(expr: &MirScalarExpr) -> usize {
         return 0;
     }
     let mut non_literal_count = 1;
-    expr.visit_pre(&mut |e| {
+    expr.visit_pre(|e| {
         if !e.is_literal() {
             non_literal_count += 1
         }

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -176,8 +176,7 @@ fn rank_complexity(expr: &MirScalarExpr) -> usize {
         return 0;
     }
     let mut non_literal_count = 1;
-    #[allow(deprecated)]
-    expr.visit_post_nolimit(&mut |e| {
+    expr.visit_pre(&mut |e| {
         if !e.is_literal() {
             non_literal_count += 1
         }

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -180,8 +180,7 @@ impl JoinInputMapper {
     /// where column references have been remapped to the local context.
     /// Assumes that all columns in `expr` are from the same input.
     pub fn map_expr_to_local(&self, mut expr: MirScalarExpr) -> MirScalarExpr {
-        #[allow(deprecated)]
-        expr.visit_mut_post_nolimit(&mut |e| {
+        expr.visit_pre_mut(|e| {
             if let MirScalarExpr::Column(c) = e {
                 *c -= self.prior_arities[self.input_relation[*c]];
             }
@@ -193,8 +192,7 @@ impl JoinInputMapper {
     /// creates a new version where column references have been remapped to the
     /// global context.
     pub fn map_expr_to_global(&self, mut expr: MirScalarExpr, index: usize) -> MirScalarExpr {
-        #[allow(deprecated)]
-        expr.visit_mut_post_nolimit(&mut |e| {
+        expr.visit_pre_mut(|e| {
             if let MirScalarExpr::Column(c) = e {
                 *c += self.prior_arities[index];
             }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -585,7 +585,7 @@ impl MirScalarExpr {
     }
 
     pub fn support_into(&self, support: &mut BTreeSet<usize>) {
-        self.visit_pre(&mut |e| {
+        self.visit_pre(|e| {
             if let MirScalarExpr::Column(i) = e {
                 support.insert(*i);
             }
@@ -1855,7 +1855,7 @@ impl MirScalarExpr {
     /// `UnmaterializableFunc::MzNow`.
     pub fn contains_temporal(&self) -> bool {
         let mut contains = false;
-        self.visit_pre(&mut |e| {
+        self.visit_pre(|e| {
             if let MirScalarExpr::CallUnmaterializable(UnmaterializableFunc::MzNow) = e {
                 contains = true;
             }
@@ -1866,7 +1866,7 @@ impl MirScalarExpr {
     /// True iff the expression contains an `UnmaterializableFunc`.
     pub fn contains_unmaterializable(&self) -> bool {
         let mut contains = false;
-        self.visit_pre(&mut |e| {
+        self.visit_pre(|e| {
             if let MirScalarExpr::CallUnmaterializable(_) = e {
                 contains = true;
             }
@@ -1878,7 +1878,7 @@ impl MirScalarExpr {
     /// list.
     pub fn contains_unmaterializable_except(&self, exceptions: &[UnmaterializableFunc]) -> bool {
         let mut contains = false;
-        self.visit_pre(&mut |e| match e {
+        self.visit_pre(|e| match e {
             MirScalarExpr::CallUnmaterializable(f) if !exceptions.contains(f) => contains = true,
             _ => (),
         });
@@ -1888,7 +1888,7 @@ impl MirScalarExpr {
     /// True iff the expression contains a `Column`.
     pub fn contains_column(&self) -> bool {
         let mut contains = false;
-        self.visit_pre(&mut |e| {
+        self.visit_pre(|e| {
             if let MirScalarExpr::Column(_) = e {
                 contains = true;
             }
@@ -2111,7 +2111,7 @@ impl MirScalarExpr {
     }
 
     /// Visits all subexpressions in DFS preorder.
-    pub fn visit_pre<F>(&self, f: &mut F)
+    pub fn visit_pre<F>(&self, mut f: F)
     where
         F: FnMut(&Self),
     {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -587,8 +587,7 @@ impl MirScalarExpr {
     }
 
     pub fn support_into(&self, support: &mut BTreeSet<usize>) {
-        #[allow(deprecated)]
-        self.visit_post_nolimit(&mut |e| {
+        self.visit_pre(&mut |e| {
             if let MirScalarExpr::Column(i) = e {
                 support.insert(*i);
             }
@@ -1858,8 +1857,7 @@ impl MirScalarExpr {
     /// `UnmaterializableFunc::MzNow`.
     pub fn contains_temporal(&self) -> bool {
         let mut contains = false;
-        #[allow(deprecated)]
-        self.visit_post_nolimit(&mut |e| {
+        self.visit_pre(&mut |e| {
             if let MirScalarExpr::CallUnmaterializable(UnmaterializableFunc::MzNow) = e {
                 contains = true;
             }
@@ -1870,8 +1868,7 @@ impl MirScalarExpr {
     /// True iff the expression contains an `UnmaterializableFunc`.
     pub fn contains_unmaterializable(&self) -> bool {
         let mut contains = false;
-        #[allow(deprecated)]
-        self.visit_post_nolimit(&mut |e| {
+        self.visit_pre(&mut |e| {
             if let MirScalarExpr::CallUnmaterializable(_) = e {
                 contains = true;
             }
@@ -1883,8 +1880,7 @@ impl MirScalarExpr {
     /// list.
     pub fn contains_unmaterializable_except(&self, exceptions: &[UnmaterializableFunc]) -> bool {
         let mut contains = false;
-        #[allow(deprecated)]
-        self.visit_post_nolimit(&mut |e| match e {
+        self.visit_pre(&mut |e| match e {
             MirScalarExpr::CallUnmaterializable(f) if !exceptions.contains(f) => contains = true,
             _ => (),
         });
@@ -1894,8 +1890,7 @@ impl MirScalarExpr {
     /// True iff the expression contains a `Column`.
     pub fn contains_column(&self) -> bool {
         let mut contains = false;
-        #[allow(deprecated)]
-        self.visit_post_nolimit(&mut |e| {
+        self.visit_pre(&mut |e| {
             if let MirScalarExpr::Column(_) = e {
                 contains = true;
             }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1903,12 +1903,13 @@ impl MirScalarExpr {
         contains
     }
 
-    pub fn size(&self) -> Result<usize, RecursionLimitError> {
+    /// The size of the expression as a tree.
+    pub fn size(&self) -> usize {
         let mut size = 0;
-        self.visit_post(&mut |_: &MirScalarExpr| {
+        self.visit_pre(&mut |_: &MirScalarExpr| {
             size += 1;
-        })?;
-        Ok(size)
+        });
+        size
     }
 }
 

--- a/src/sql/src/plan/explain/mod.rs
+++ b/src/sql/src/plan/explain/mod.rs
@@ -144,7 +144,7 @@ pub fn normalize_subqueries<'a>(expr: &'a mut HirRelationExpr) -> Result<(), Rec
 fn id_gen(expr: &HirRelationExpr) -> Result<impl Iterator<Item = LocalId>, RecursionLimitError> {
     let mut max_id = 0_u64;
 
-    expr.visit_post(&mut |expr| {
+    expr.visit_pre(&mut |expr| {
         match expr {
             HirRelationExpr::Let { id, .. } => max_id = std::cmp::max(max_id, id.into()),
             _ => (),

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -138,7 +138,7 @@ impl Demand {
                     limits: _,
                     body,
                 } => {
-                    let ids_used_across_iterations = MirRelationExpr::recursive_ids(ids, values)?
+                    let ids_used_across_iterations = MirRelationExpr::recursive_ids(ids, values)
                         .iter()
                         .map(|id| Id::Local(*id))
                         .collect::<BTreeSet<_>>();

--- a/src/transform/src/fusion/filter.rs
+++ b/src/transform/src/fusion/filter.rs
@@ -48,7 +48,6 @@
 //! assert_eq!(expr, correct);
 //! ```
 
-use mz_expr::visit::Visit;
 use mz_expr::MirRelationExpr;
 
 use crate::TransformCtx;
@@ -69,7 +68,7 @@ impl crate::Transform for Filter {
         relation: &mut MirRelationExpr,
         _: &mut TransformCtx,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut Self::action)?;
+        relation.visit_pre_mut(Self::action);
         mz_repr::explain::trace_plan(&*relation);
         Ok(())
     }

--- a/src/transform/src/fusion/map.rs
+++ b/src/transform/src/fusion/map.rs
@@ -19,7 +19,6 @@
 
 use std::mem;
 
-use mz_expr::visit::Visit;
 use mz_expr::MirRelationExpr;
 
 use crate::TransformCtx;
@@ -40,7 +39,7 @@ impl crate::Transform for Map {
         relation: &mut MirRelationExpr,
         _: &mut TransformCtx,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut Self::action)?;
+        relation.visit_pre_mut(Self::action);
         mz_repr::explain::trace_plan(&*relation);
         Ok(())
     }

--- a/src/transform/src/fusion/negate.rs
+++ b/src/transform/src/fusion/negate.rs
@@ -9,7 +9,6 @@
 
 //! Fuses a sequence of `Negate` operators in to one or zero `Negate` operators.
 
-use mz_expr::visit::Visit;
 use mz_expr::MirRelationExpr;
 
 use crate::TransformCtx;
@@ -30,7 +29,7 @@ impl crate::Transform for Negate {
         relation: &mut MirRelationExpr,
         _: &mut TransformCtx,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut Self::action)?;
+        relation.visit_pre_mut(Self::action);
         mz_repr::explain::trace_plan(&*relation);
         Ok(())
     }

--- a/src/transform/src/fusion/project.rs
+++ b/src/transform/src/fusion/project.rs
@@ -11,7 +11,6 @@
 
 // TODO(frank): evaluate for redundancy with projection hoisting.
 
-use mz_expr::visit::Visit;
 use mz_expr::MirRelationExpr;
 
 use crate::TransformCtx;
@@ -32,7 +31,7 @@ impl crate::Transform for Project {
         relation: &mut MirRelationExpr,
         _: &mut TransformCtx,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut Self::action)?;
+        relation.visit_pre_mut(Self::action);
         mz_repr::explain::trace_plan(&*relation);
         Ok(())
     }

--- a/src/transform/src/fusion/reduce.rs
+++ b/src/transform/src/fusion/reduce.rs
@@ -57,11 +57,11 @@ impl Reduce {
                 // Collect all columns referenced by outer
                 let mut outer_cols = vec![];
                 for expr in group_key.iter() {
-                    expr.visit_post(&mut |e| {
+                    expr.visit_pre(&mut |e| {
                         if let MirScalarExpr::Column(i) = e {
                             outer_cols.push(*i);
                         }
-                    })?;
+                    });
                 }
 
                 // We can fuse reduce operators as long as the outer one doesn't

--- a/src/transform/src/fusion/reduce.rs
+++ b/src/transform/src/fusion/reduce.rs
@@ -57,7 +57,7 @@ impl Reduce {
                 // Collect all columns referenced by outer
                 let mut outer_cols = vec![];
                 for expr in group_key.iter() {
-                    expr.visit_pre(&mut |e| {
+                    expr.visit_pre(|e| {
                         if let MirScalarExpr::Column(i) = e {
                             outer_cols.push(*i);
                         }

--- a/src/transform/src/fusion/top_k.rs
+++ b/src/transform/src/fusion/top_k.rs
@@ -9,7 +9,6 @@
 
 //! Fuses a sequence of `TopK` operators in to one `TopK` operator
 
-use mz_expr::visit::Visit;
 use mz_expr::MirRelationExpr;
 
 use crate::TransformCtx;
@@ -31,7 +30,7 @@ impl crate::Transform for TopK {
         relation: &mut MirRelationExpr,
         _: &mut TransformCtx,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut_pre(&mut Self::action)?;
+        relation.visit_pre_mut(&mut Self::action);
         mz_repr::explain::trace_plan(&*relation);
         Ok(())
     }

--- a/src/transform/src/literal_lifting.rs
+++ b/src/transform/src/literal_lifting.rs
@@ -268,7 +268,7 @@ impl LiteralLifting {
                     limits: _,
                     body,
                 } => {
-                    let recursive_ids = MirRelationExpr::recursive_ids(ids, values)?;
+                    let recursive_ids = MirRelationExpr::recursive_ids(ids, values);
 
                     // Extend the context with empty `literals` vectors for all
                     // recursive IDs.

--- a/src/transform/src/movement/projection_lifting.rs
+++ b/src/transform/src/movement/projection_lifting.rs
@@ -104,7 +104,7 @@ impl ProjectionLifting {
                     limits: _,
                     body,
                 } => {
-                    let recursive_ids = MirRelationExpr::recursive_ids(ids, values)?;
+                    let recursive_ids = MirRelationExpr::recursive_ids(ids, values);
 
                     for (local_id, value) in zip_eq(ids.iter(), values.iter_mut()) {
                         self.action(value, gets)?;

--- a/src/transform/src/non_null_requirements.rs
+++ b/src/transform/src/non_null_requirements.rs
@@ -119,7 +119,7 @@ impl NonNullRequirements {
                     limits: _,
                 } => {
                     // Determine the recursive IDs in this LetRec binding.
-                    let rec_ids = MirRelationExpr::recursive_ids(ids, values)?;
+                    let rec_ids = MirRelationExpr::recursive_ids(ids, values);
 
                     // Seed the gets map with an empty vector for each ID.
                     for id in ids.iter() {

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -14,7 +14,6 @@
 
 // TODO(frank): evaluate for redundancy with `column_knowledge`, or vice-versa.
 
-use mz_expr::visit::Visit;
 use mz_expr::{func, AggregateExpr, AggregateFunc, MirRelationExpr, MirScalarExpr, UnaryFunc};
 use mz_repr::{Datum, RelationType, ScalarType};
 
@@ -36,15 +35,15 @@ impl crate::Transform for NonNullable {
         relation: &mut MirRelationExpr,
         _: &mut TransformCtx,
     ) -> Result<(), TransformError> {
-        let result = relation.try_visit_mut_pre(&mut |e| self.action(e));
+        let result = relation.visit_pre_mut(|e| self.action(e));
         mz_repr::explain::trace_plan(&*relation);
-        result
+        Ok(result)
     }
 }
 
 impl NonNullable {
     /// Harvests information about non-nullability of columns from sources.
-    pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), TransformError> {
+    pub fn action(&self, relation: &mut MirRelationExpr) {
         match relation {
             MirRelationExpr::Map { input, scalars } => {
                 let contains_isnull = scalars
@@ -97,7 +96,6 @@ impl NonNullable {
             }
             _ => {}
         }
-        Ok(())
     }
 }
 

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -104,7 +104,7 @@ impl NonNullable {
 /// True if the expression contains a "is null" test.
 fn scalar_contains_isnull(expr: &MirScalarExpr) -> bool {
     let mut result = false;
-    expr.visit_pre(&mut |e| {
+    expr.visit_pre(|e| {
         if let MirScalarExpr::CallUnary {
             func: UnaryFunc::IsNull(func::IsNull),
             ..

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -546,7 +546,7 @@ mod let_motion {
             // Bindings to lower.
             let mut lowered = BTreeMap::<LocalId, MirRelationExpr>::new();
 
-            let rec_ids = MirRelationExpr::recursive_ids(ids, values)?;
+            let rec_ids = MirRelationExpr::recursive_ids(ids, values);
 
             while ids.last().map(|id| !rec_ids.contains(id)).unwrap_or(false) {
                 let id = ids.pop().expect("non-empty ids");

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -304,7 +304,7 @@ impl PredicatePushdown {
                                 if !predicate.is_literal_err() || all_errors {
                                     let mut supported = true;
                                     let mut new_predicate = predicate.clone();
-                                    new_predicate.visit_pre(&mut |e| {
+                                    new_predicate.visit_pre(|e| {
                                         if let MirScalarExpr::Column(c) = e {
                                             if *c >= group_key.len() {
                                                 supported = false;
@@ -965,7 +965,7 @@ impl PredicatePushdown {
             let mut support = BTreeSet::new();
 
             // Seed with `map_exprs` support in `expr`.
-            expr.visit_pre(&mut |e| {
+            expr.visit_pre(|e| {
                 if let MirScalarExpr::Column(c) = e {
                     if *c >= input_arity {
                         support.insert(*c);
@@ -981,7 +981,7 @@ impl PredicatePushdown {
                 std::mem::swap(&mut workset, &mut buffer);
                 // Drain the `buffer` and update `support` and `workset`.
                 for c in buffer.drain(..) {
-                    map_exprs[c - input_arity].visit_pre(&mut |e| {
+                    map_exprs[c - input_arity].visit_pre(|e| {
                         if let MirScalarExpr::Column(c) = e {
                             if *c >= input_arity {
                                 if support.insert(*c) {

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -1040,7 +1040,7 @@ impl PredicatePushdown {
                 }
             })?;
 
-            soft_assert_eq_no_log!(new_size, new_expr.size()?);
+            soft_assert_eq_no_log!(new_size, new_expr.size());
             if new_size <= size_limit {
                 Ok(Some(new_expr)) // We managed to stay within the limit.
             } else {

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -215,7 +215,7 @@ impl RedundantJoin {
                         // Update the column offsets in the binding expressions to catch
                         // up with the removal of `remove_input_idx`.
                         for expr in bindings.iter_mut() {
-                            expr.visit_mut_post(&mut |e| {
+                            expr.visit_pre_mut(|e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     let (_local_col, input_relation) =
                                         old_input_mapper.map_column_to_local(*c);
@@ -223,7 +223,7 @@ impl RedundantJoin {
                                         *c -= old_input_mapper.input_arity(remove_input_idx);
                                     }
                                 }
-                            })?;
+                            });
                         }
 
                         // Replace column references from `remove_input_idx` with the corresponding


### PR DESCRIPTION
An attempt to minimize postorder traversal requiring recursion, to reduce the amount of potentially erroring traversals.

The methodology here is to identify recursive traversals that could be converted to iterative traversals, by shifting from post-order traversal to pre-order traversal. Many traversals are fine as pre-order, for example traversal that count the number of certain AST nodes, or ones that want to rewrite column identifiers, etc. Others are not obviously fine, for example when replacing some AST nodes by others (where pre- vs post-order determines whether the traversal should enter the substituted AST node). I made an effort to avoid swapping out post-order traversal in cases where I could not tell whether it would be a correct change, but I may have made errors and we should carefully look at each case.

Going forward, I can imagine introducing an unopinionated visitor that defaults to pre-order, at which point post-order is an exception rather than the rule, and we can ideally leave ourselves comments about why we prefer post-order (or pre-order, in cases where it is important). But generally, there was quite a bit of post-order calls that were actually unopinionated, and having the code reflect that would reduce its complexity.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
