### PR TITLE
platform-checks: Fix the UnifiedCluster scenario

### DIFF
--- a/misc/python/materialize/checks/all_checks/cluster_unification.py
+++ b/misc/python/materialize/checks/all_checks/cluster_unification.py
@@ -20,6 +20,9 @@ class UnifiedCluster(Check):
     def initialize(self) -> Testdrive:
         return Testdrive(
             """
+            $[version<8100] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+            ALTER SYSTEM SET enable_unified_clusters = true
+
             > CREATE CLUSTER shared_cluster_compute_first SIZE '1', REPLICATION FACTOR 1;
             > CREATE CLUSTER shared_cluster_storage_first SIZE '1', REPLICATION FACTOR 1;
             """


### PR DESCRIPTION
Even though the flag is removed in HEAD, it needs to be explicitly enabled in older versions.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
 Nighlty CI was failing.