### PR TITLE
persist-txn: add distributed timestamp oracle to maelstrom tests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -787,7 +787,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: persist
-              args: [--consensus=mem, --blob=mem, --persist-txn]
+              args: [--node-count=4, --consensus=cockroach, --blob=maelstrom, --time-limit=300, --rate=500, --persist-txn]
 
   - id: persistence-failpoints
     label: Persistence failpoints

--- a/src/persist-cli/src/maelstrom/services.rs
+++ b/src/persist-cli/src/maelstrom/services.rs
@@ -332,7 +332,7 @@ pub struct MaelstromOracleKey {
 impl MaelstromOracle {
     pub async fn new(handle: Handle) -> Result<Self, ExternalError> {
         let read_ts = MaelstromOracleKey::new(handle.clone(), "tso_read", 0).await?;
-        let write_ts = MaelstromOracleKey::new(handle.clone(), "tso_write", 1).await?;
+        let write_ts = MaelstromOracleKey::new(handle.clone(), "tso_write", 0).await?;
         Ok(MaelstromOracle { read_ts, write_ts })
     }
 

--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -256,7 +256,6 @@ impl Transactor {
                         data_id, init_ts, new_init_ts
                     );
                     init_ts = self.oracle.write_ts().await?;
-                    assert!(new_init_ts <= init_ts);
                     continue;
                 }
             }


### PR DESCRIPTION
This will let us verify that persist-txn is linearizable when timestamps are selected correctly.

Touches https://github.com/MaterializeInc/materialize/issues/22173
Touches https://github.com/MaterializeInc/materialize/issues/22801

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Initially marking as draft because, uhhhh, this is very much not linearizable.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
