### PR TITLE
storage: move PrivateLink status updates into storage controller

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -257,7 +257,7 @@ pub enum Message<T = mz_repr::Timestamp> {
         stage: SubscribeStage,
     },
     DrainStatementLog,
-    PrivateLinkVpcEndpointEvents(BTreeMap<GlobalId, VpcEndpointEvent>),
+    PrivateLinkVpcEndpointEvents(Vec<VpcEndpointEvent>),
 }
 
 impl Message {

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -188,7 +188,10 @@ impl Coordinator {
                     self.drain_statement_log().await;
                 }
                 Message::PrivateLinkVpcEndpointEvents(events) => {
-                    self.write_privatelink_status_updates(events).await;
+                    self.controller
+                        .storage
+                        .append_status_updates(mz_storage_client::controller::IntrospectionType::PrivatelinkConnectionStatusHistory, events.into_iter().map(mz_repr::Row::from).collect(),)
+                        .await;
                 }
             }
         }

--- a/src/cloud-resources/src/lib.rs
+++ b/src/cloud-resources/src/lib.rs
@@ -86,7 +86,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures::stream::BoxStream;
-use mz_repr::GlobalId;
+use mz_repr::{Datum, GlobalId, Row};
 use serde::{Deserialize, Serialize};
 
 use crate::crd::vpc_endpoint::v1::{VpcEndpointState, VpcEndpointStatus};
@@ -195,9 +195,19 @@ pub fn vpc_endpoint_host(id: GlobalId, availability_zone: Option<&str>) -> Strin
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VpcEndpointEvent {
     pub connection_id: GlobalId,
     pub status: VpcEndpointState,
     pub time: DateTime<Utc>,
+}
+
+impl From<VpcEndpointEvent> for Row {
+    fn from(value: VpcEndpointEvent) -> Self {
+        Row::pack_slice(&[
+            Datum::TimestampTz(value.time.try_into().expect("must fit")),
+            Datum::String(&value.connection_id.to_string()),
+            Datum::String(&value.status.to_string()),
+        ])
+    }
 }

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -369,6 +369,82 @@ pub struct StatusUpdate {
     pub namespaced_errors: BTreeMap<String, String>,
 }
 
+impl StatusUpdate {
+    /// Synthesize a "dropped" status update.
+    pub fn dropped(id: GlobalId, timestamp: chrono::DateTime<chrono::Utc>) -> StatusUpdate {
+        StatusUpdate {
+            id,
+            timestamp,
+            status: "dropped".to_string(),
+            error: None,
+            hints: Default::default(),
+            namespaced_errors: Default::default(),
+        }
+    }
+
+    /// Meant to check the `status` field of two `StatusUpdates` to determine if
+    /// the new status succeeds the previous status, i.e. will drive the finite
+    /// state machine of status updates.
+    ///
+    /// This function takes strings as opposed to `&self` because where it is
+    /// meant to be used does not necessarily have the `StatusUpdate` intact,
+    /// i.e. it might have been taken into a row.
+    pub fn new_status_succeeds_prev(prev: &str, new: &str) -> bool {
+        match (prev, new) {
+            // TODO(guswynn): Ideally only `failed` sources should not be marked as paused.
+            // Additionally, dropping a replica and then restarting environmentd will
+            // fail this check. This will all be resolved in:
+            // https://github.com/MaterializeInc/materialize/pull/23013
+            (prev, new) if prev == "stalled" && new == "paused" => false,
+            // Don't re-mark that object as paused.
+            (prev, new) if prev == "paused" && new == "paused" => false,
+            // De-duplication of other statuses is currently managed by the
+            // `health_operator`.
+            _ => true,
+        }
+    }
+}
+
+impl From<StatusUpdate> for Row {
+    fn from(update: StatusUpdate) -> Self {
+        use mz_repr::Datum;
+
+        let timestamp = Datum::TimestampTz(update.timestamp.try_into().expect("must fit"));
+        let id = update.id.to_string();
+        let id = Datum::String(&id);
+        let status = Datum::String(&update.status);
+        let error = update.error.as_deref().into();
+
+        let mut row = Row::default();
+        let mut packer = row.packer();
+        packer.extend([timestamp, id, status, error]);
+
+        if !update.hints.is_empty() || !update.namespaced_errors.is_empty() {
+            packer.push_dict_with(|dict_packer| {
+                // `hint` and `namespaced` are ordered,
+                // as well as the BTree's they each contain.
+                if !update.hints.is_empty() {
+                    dict_packer.push(Datum::String("hints"));
+                    dict_packer.push_list(update.hints.iter().map(|s| Datum::String(s)));
+                }
+                if !update.namespaced_errors.is_empty() {
+                    dict_packer.push(Datum::String("namespaced"));
+                    dict_packer.push_dict(
+                        update
+                            .namespaced_errors
+                            .iter()
+                            .map(|(k, v)| (k.as_str(), Datum::String(v))),
+                    );
+                }
+            });
+        } else {
+            packer.push(Datum::Null);
+        }
+
+        row
+    }
+}
+
 impl RustType<proto_storage_response::ProtoStatusUpdate> for StatusUpdate {
     fn into_proto(&self) -> proto_storage_response::ProtoStatusUpdate {
         proto_storage_response::ProtoStatusUpdate {

--- a/src/storage-controller/src/healthcheck.rs
+++ b/src/storage-controller/src/healthcheck.rs
@@ -151,6 +151,9 @@ impl TryFrom<IntrospectionType> for &IntrospectionStatusUpdate {
         match value {
             IntrospectionType::SourceStatusHistory => Ok(&SOURCE_STATUS_UPDATES),
             IntrospectionType::SinkStatusHistory => Ok(&SINK_STATUS_UPDATES),
+            IntrospectionType::PrivatelinkConnectionStatusHistory => {
+                Ok(&PRIVATELINK_STATUS_UPDATES)
+            }
             _ => Err(()),
         }
     }
@@ -199,6 +202,26 @@ static SINK_STATUS_UPDATES: Lazy<IntrospectionStatusUpdate> = Lazy::new(|| {
         },
     }
 });
+
+static PRIVATELINK_STATUS_UPDATES: Lazy<IntrospectionStatusUpdate> =
+    Lazy::new(|| IntrospectionStatusUpdate {
+        global_id_idx: healthcheck::MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC
+            .get_by_name(&ColumnName::from("connection_id"))
+            .expect("schema has not changed")
+            .0,
+
+        value_idx: healthcheck::MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC
+            .get_by_name(&ColumnName::from("occurred_at"))
+            .expect("schema has not changed")
+            .0,
+
+        produce_new_value: |prev: Datum, new: Datum| -> bool {
+            let new = new.unwrap_timestamptz();
+            let prev = prev.unwrap_timestamptz();
+
+            prev < new
+        },
+    });
 
 impl<T> IntrospectionStatusManager<T>
 where

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -285,10 +285,6 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     /// Write frontiers that have been recorded in the `ReplicaFrontiers` collection, kept to be
     /// able to retract old rows.
     recorded_replica_frontiers: BTreeMap<(GlobalId, ReplicaId), Antichain<T>>,
-
-    /// The latest timestamp for each id in the mz_privatelink_connection_status_history
-    /// table, read on startup by the adapter to initialize the privatelink vpce watch task
-    privatelink_status_table_latest: Option<BTreeMap<GlobalId, DateTime<Utc>>>,
 }
 
 #[async_trait(?Send)]
@@ -851,34 +847,19 @@ where
                             )
                         }
                         IntrospectionType::PrivatelinkConnectionStatusHistory => {
-                            // Truncate the private link connection status history table and
-                            // store the latest timestamp for each id in the table.
-                            let occurred_at_col =
-                                healthcheck::MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC
-                                    .get_by_name(&ColumnName::from("occurred_at"))
-                                    .expect("schema has not changed")
-                                    .0;
-                            self.privatelink_status_table_latest = self
+                            let last_status_per_id = self
                                 .partially_truncate_status_history(
                                     IntrospectionType::PrivatelinkConnectionStatusHistory,
                                 )
-                                .await
-                                .and_then(|map| {
-                                    Some(
-                                        map.into_iter()
-                                            .map(|(id, row)| {
-                                                (
-                                                    id,
-                                                    row.iter()
-                                                        .nth(occurred_at_col)
-                                                        .expect("schema has not changed")
-                                                        .unwrap_timestamptz()
-                                                        .into(),
-                                                )
-                                            })
-                                            .collect(),
-                                    )
-                                });
+                                .await;
+
+                            self.introspection_status_manager.extend_previous_statuses(
+                                last_status_per_id
+                                    .into_iter()
+                                    .map(|s| s.into_values())
+                                    .flatten(),
+                                IntrospectionType::PrivatelinkConnectionStatusHistory,
+                            )
                         }
 
                         // Truncate compute-maintained collections.
@@ -1934,6 +1915,12 @@ where
         self.append_to_managed_collection(id, updates).await;
     }
 
+    async fn append_status_updates(&mut self, type_: IntrospectionType, updates: Vec<Row>) {
+        self.introspection_status_manager
+            .append_rows(type_, updates)
+            .await
+    }
+
     /// With the CRDB based timestamp oracle, there is no longer write timestamp
     /// fencing. As in, when a new Coordinator, `B`, starts up, there is nothing
     /// that prevents an old Coordinator, `A`, from getting a new write
@@ -2053,10 +2040,6 @@ where
 
         self.txns_init_run = true;
         Ok(())
-    }
-
-    fn get_privatelink_status_table_latest(&self) -> &Option<BTreeMap<GlobalId, DateTime<Utc>>> {
-        &self.privatelink_status_table_latest
     }
 }
 
@@ -2295,7 +2278,6 @@ where
             metrics: StorageControllerMetrics::new(metrics_registry),
             recorded_frontiers: BTreeMap::new(),
             recorded_replica_frontiers: BTreeMap::new(),
-            privatelink_status_table_latest: None,
         }
     }
 


### PR DESCRIPTION
See #24000 for initial details.

I think there's additional status-related work that can be moved in here now (e.g. de-duplication), but think this is sufficient to stand alone.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
