### PR TITLE
Revert "catalog: Always use catalog migrator implementation (#24087)"

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -439,8 +439,7 @@ pub struct Args {
         env = "ADAPTER_STASH_URL",
         value_name = "POSTGRES_URL",
         required_if_eq("catalog-store", "stash"),
-        required_if_eq("catalog-store", "shadow"),
-        required_if_eq("catalog-store", "persist")
+        required_if_eq("catalog-store", "shadow")
     )]
     adapter_stash_url: Option<String>,
     /// The backing durable store of the catalog.
@@ -947,13 +946,8 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         let catalog_config = match args.catalog_store {
             CatalogKind::Stash => CatalogConfig::Stash {
                 url: args.adapter_stash_url.expect("required for stash catalog"),
-                persist_clients,
-                metrics: Arc::new(mz_catalog::durable::Metrics::new(&metrics_registry)),
             },
             CatalogKind::Persist => CatalogConfig::Persist {
-                url: args
-                    .adapter_stash_url
-                    .expect("required for persist catalog"),
                 persist_clients,
                 metrics: Arc::new(mz_catalog::durable::Metrics::new(&metrics_registry)),
             },

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -255,15 +255,9 @@ pub enum CatalogConfig {
     Stash {
         /// The PostgreSQL URL for the adapter stash.
         url: String,
-        /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
-        persist_clients: Arc<PersistClientCache>,
-        /// Persist catalog metrics.
-        metrics: Arc<mz_catalog::durable::Metrics>,
     },
     /// The catalog contents are stored in persist.
     Persist {
-        /// The PostgreSQL URL for the adapter stash.
-        url: String,
         /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
         persist_clients: Arc<PersistClientCache>,
         /// Persist catalog metrics.
@@ -775,53 +769,31 @@ async fn catalog_opener(
     environment_id: &EnvironmentId,
 ) -> Result<Box<dyn OpenableDurableCatalogState>, anyhow::Error> {
     Ok(match catalog_config {
-        CatalogConfig::Stash {
-            url,
-            persist_clients,
-            metrics,
-        } => {
+        CatalogConfig::Stash { url } => {
             info!("Using stash backed catalog");
             let stash_factory =
                 mz_stash::StashFactory::from_metrics(Arc::clone(&controller_config.stash_metrics));
             let tls = mz_tls_util::make_tls(&tokio_postgres::config::Config::from_str(url)?)?;
-            let persist_client = persist_clients
-                .open(controller_config.persist_location.clone())
-                .await?;
-            Box::new(
-                mz_catalog::durable::rollback_from_persist_to_stash_state(
-                    StashConfig {
-                        stash_factory,
-                        stash_url: url.clone(),
-                        schema: None,
-                        tls,
-                    },
-                    persist_client,
-                    environment_id.organization_id(),
-                    Arc::clone(metrics),
-                )
-                .await,
-            )
+            Box::new(mz_catalog::durable::stash_backed_catalog_state(
+                StashConfig {
+                    stash_factory,
+                    stash_url: url.clone(),
+                    schema: None,
+                    tls,
+                },
+            ))
         }
         CatalogConfig::Persist {
-            url,
             persist_clients,
             metrics,
         } => {
             info!("Using persist backed catalog");
-            let stash_factory =
-                mz_stash::StashFactory::from_metrics(Arc::clone(&controller_config.stash_metrics));
-            let tls = mz_tls_util::make_tls(&tokio_postgres::config::Config::from_str(url)?)?;
             let persist_client = persist_clients
                 .open(controller_config.persist_location.clone())
                 .await?;
+
             Box::new(
-                mz_catalog::durable::migrate_from_stash_to_persist_state(
-                    StashConfig {
-                        stash_factory,
-                        stash_url: url.clone(),
-                        schema: None,
-                        tls,
-                    },
+                mz_catalog::durable::persist_backed_catalog_state(
                     persist_client,
                     environment_id.organization_id(),
                     Arc::clone(metrics),


### PR DESCRIPTION
This reverts commit 37415b312a1c2550281548734d58c212b619bf3b.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
