### PR TITLE
disabling audience validation in the JWT Validation struct

### DIFF
--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -100,6 +100,7 @@ impl Authentication {
         // We validate with our own now function.
         let mut validation = Validation::new(Algorithm::RS256);
         validation.validate_exp = false;
+        validation.validate_aud = false;
         let validation_config = ValidationConfig {
             decoding_key: config.decoding_key,
             tenant_id: config.tenant_id,

--- a/src/frontegg-client/src/error.rs
+++ b/src/frontegg-client/src/error.rs
@@ -75,6 +75,6 @@ pub enum Error {
     /// An error indicating that the claims are invalid, acoording to the structure
     /// or keys provided. If the error persists,
     /// check if the token claims matches the struct.
-    #[error("Decoding JWT claims.")]
-    DecodingClaims,
+    #[error("Error decoding JWT claims: {0}")]
+    DecodingClaims(#[from] jsonwebtoken::errors::Error),
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Fixing failing nightlies
More context: https://materializeinc.slack.com/archives/CTESPM7FU/p1703815384845419

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->

cc @def- @MaterializeInc/frontend 