### PR TITLE
scalability-framework: Temporarily disable assertion

### DIFF
--- a/misc/python/materialize/scalability/regression_assessment.py
+++ b/misc/python/materialize/scalability/regression_assessment.py
@@ -33,9 +33,10 @@ class RegressionAssessment:
             Endpoint, str | None
         ] = {}
         self.check_targets()
-        assert len(comparison_outcome.endpoints_with_regressions) == len(
-            self.endpoints_with_regressions_and_justifications
-        )
+        # See #24147
+        # assert len(comparison_outcome.endpoints_with_regressions) == len(
+        #     self.endpoints_with_regressions_and_justifications
+        # )
 
     def has_comparison_target(self) -> bool:
         return self.baseline_endpoint is not None


### PR DESCRIPTION
Relates to #24147


### Motivation

Nighlty on the release branch was failing. Disabling the assertion causes the framework to continue and properly report the performance regression.