### PR TITLE
catalog: Add escape hatch catalog kind flag

### DIFF
--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -242,6 +242,9 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             Box::new(persist_backed_catalog_state(persist_client, organization_id, metrics).await)
         }
         CatalogKind::Shadow => panic!("cannot use shadow catalog with catalog-debug tool"),
+        CatalogKind::LegacyStash => {
+            panic!("cannot use legacy stash variant with catalog-debug tool, use stash instead")
+        }
     };
 
     match args.action {

--- a/src/catalog/src/durable/impls/migrate.rs
+++ b/src/catalog/src/durable/impls/migrate.rs
@@ -41,7 +41,7 @@ impl TryFrom<CatalogKind> for Direction {
         match catalog_kind {
             CatalogKind::Stash => Ok(Direction::RollbackToStash),
             CatalogKind::Persist => Ok(Direction::MigrateToPersist),
-            CatalogKind::Shadow => Err(catalog_kind),
+            CatalogKind::Shadow | CatalogKind::LegacyStash => Err(catalog_kind),
         }
     }
 }

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -440,7 +440,8 @@ pub struct Args {
         value_name = "POSTGRES_URL",
         required_if_eq("catalog-store", "stash"),
         required_if_eq("catalog-store", "shadow"),
-        required_if_eq("catalog-store", "persist")
+        required_if_eq("catalog-store", "persist"),
+        required_if_eq("catalog-store", "legacy-stash")
     )]
     adapter_stash_url: Option<String>,
     /// The backing durable store of the catalog.
@@ -960,6 +961,11 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             CatalogKind::Shadow => CatalogConfig::Shadow {
                 url: args.adapter_stash_url.expect("required for shadow catalog"),
                 persist_clients,
+            },
+            CatalogKind::LegacyStash => CatalogConfig::LegacyStash {
+                url: args
+                    .adapter_stash_url
+                    .expect("required for legacy-stash catalog"),
             },
         };
         listeners

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -260,6 +260,11 @@ pub enum CatalogConfig {
         /// Persist catalog metrics.
         metrics: Arc<mz_catalog::durable::Metrics>,
     },
+    /// The catalog contents are stored the stash and we don't attempt to rollback from persist.
+    LegacyStash {
+        /// The PostgreSQL URL for the adapter stash.
+        url: String,
+    },
     /// The catalog contents are stored in persist.
     Persist {
         /// The PostgreSQL URL for the adapter stash.
@@ -285,6 +290,7 @@ impl CatalogConfig {
             CatalogConfig::Stash { .. } => CatalogKind::Stash,
             CatalogConfig::Persist { .. } => CatalogKind::Persist,
             CatalogConfig::Shadow { .. } => CatalogKind::Shadow,
+            CatalogConfig::LegacyStash { .. } => CatalogKind::LegacyStash,
         }
     }
 }
@@ -801,6 +807,20 @@ async fn catalog_opener(
                 )
                 .await,
             )
+        }
+        CatalogConfig::LegacyStash { url } => {
+            info!("Using legacy stash backed catalog");
+            let stash_factory =
+                mz_stash::StashFactory::from_metrics(Arc::clone(&controller_config.stash_metrics));
+            let tls = mz_tls_util::make_tls(&tokio_postgres::config::Config::from_str(url)?)?;
+            Box::new(mz_catalog::durable::stash_backed_catalog_state(
+                StashConfig {
+                    stash_factory,
+                    stash_url: url.clone(),
+                    schema: None,
+                    tls,
+                },
+            ))
         }
         CatalogConfig::Persist {
             url,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -5738,6 +5738,8 @@ pub enum CatalogKind {
     Stash = 0,
     Persist = 1,
     Shadow = 2,
+    /// Escape hatch to use the stash directly without trying to rollover from persist.
+    LegacyStash = 3,
 }
 
 impl CatalogKind {
@@ -5746,6 +5748,7 @@ impl CatalogKind {
             CatalogKind::Stash => "stash",
             CatalogKind::Persist => "persist",
             CatalogKind::Shadow => "shadow",
+            CatalogKind::LegacyStash => "legacy-stash",
         }
     }
 
@@ -5754,6 +5757,7 @@ impl CatalogKind {
             CatalogKind::Stash.as_str(),
             CatalogKind::Persist.as_str(),
             CatalogKind::Shadow.as_str(),
+            CatalogKind::LegacyStash.as_str(),
         ]
     }
 }

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -429,6 +429,7 @@ async fn main() {
                     .clone()
                     .expect("required for shadow catalog"),
             },
+            CatalogKind::LegacyStash => panic!("legacy stash cannot be used with testdrive"),
         }),
         None => None,
     };


### PR DESCRIPTION
This commit adds a new value to the catalog kind flag called "legacy stash". This variant uses the stash implementation directly without first attempting to rollback from the persist implementation. This can be used as an escape hatch in case the persist catalog is very broken and unable to rollback successfully. Using this variant is potentially very scary because it implies that we may be losing whatever data is stored in persist. At that point we'd have to manually try and recover the persist data and write it into the stash. Even though it's potentially scary, if we ever do need this variant then we'll be glad that we have it and are able to boot at all.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
