### PR TITLE
Revert "Revert "catalog: Always use catalog migrator implementation (…

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -439,7 +439,8 @@ pub struct Args {
         env = "ADAPTER_STASH_URL",
         value_name = "POSTGRES_URL",
         required_if_eq("catalog-store", "stash"),
-        required_if_eq("catalog-store", "shadow")
+        required_if_eq("catalog-store", "shadow"),
+        required_if_eq("catalog-store", "persist")
     )]
     adapter_stash_url: Option<String>,
     /// The backing durable store of the catalog.
@@ -946,8 +947,13 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         let catalog_config = match args.catalog_store {
             CatalogKind::Stash => CatalogConfig::Stash {
                 url: args.adapter_stash_url.expect("required for stash catalog"),
+                persist_clients,
+                metrics: Arc::new(mz_catalog::durable::Metrics::new(&metrics_registry)),
             },
             CatalogKind::Persist => CatalogConfig::Persist {
+                url: args
+                    .adapter_stash_url
+                    .expect("required for persist catalog"),
                 persist_clients,
                 metrics: Arc::new(mz_catalog::durable::Metrics::new(&metrics_registry)),
             },


### PR DESCRIPTION
…#24087)" (#24145)"

This reverts commit 144d6ab720c68ac82484e7c5b4ac5c9a40692f5c.

144d6ab720c68ac82484e7c5b4ac5c9a40692f5c was used to revert
37415b312a1c2550281548734d58c212b619bf3b which had a bug with the
savepoint implementation. A fix for the bug was merged in 
2c9ef1534c4131c70f6ecb6085fae844d7dedec5.

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
