### PR TITLE
adapter: Create structure around plan optimization

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -24,7 +24,7 @@ use mz_repr::role_id::RoleId;
 use mz_repr::{GlobalId, Row};
 use mz_sql::ast::{FetchDirection, Raw, Statement};
 use mz_sql::catalog::ObjectType;
-use mz_sql::plan::{ExecuteTimeout, Plan, PlanKind};
+use mz_sql::plan::{generated_from, ExecuteTimeout, PlanKind};
 use mz_sql::session::user::User;
 use mz_sql::session::vars::{OwnedVarInput, Var};
 use mz_sql_parser::ast::{AlterObjectRenameStatement, AlterOwnerStatement, DropObjectsStatement};
@@ -391,7 +391,7 @@ impl TryFrom<&Statement<Raw>> for ExecuteResponse {
 
     /// Returns Ok if this Statement always produces a single, trivial ExecuteResponse.
     fn try_from(stmt: &Statement<Raw>) -> Result<Self, Self::Error> {
-        let resp_kinds = Plan::generated_from(stmt.into())
+        let resp_kinds = generated_from(stmt.into())
             .into_iter()
             .map(ExecuteResponse::generated_from)
             .flatten()

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -114,7 +114,7 @@ use mz_secrets::{SecretsController, SecretsReader};
 use mz_sql::ast::{CreateSubsourceStatement, Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
 use mz_sql::names::{Aug, ResolvedIds};
-use mz_sql::plan::{self, CopyFormat, CreateConnectionPlan, Params, QueryWhen};
+use mz_sql::plan::{self, CopyFormat, CreateConnectionPlan, Optimized, Params, QueryWhen};
 use mz_sql::rbac::UnauthorizedError;
 use mz_sql::session::user::{RoleMetadata, User};
 use mz_sql::session::vars::{self, ConnectionCounter, OwnedVarInput, SystemVars};
@@ -253,6 +253,12 @@ pub enum Message<T = mz_repr::Timestamp> {
         otel_ctx: OpenTelemetryContext,
         stage: SubscribeStage,
     },
+    OptimizationReady {
+        ctx: ExecuteContext,
+        otel_ctx: OpenTelemetryContext,
+        plan: mz_sql::plan::Plan<Optimized>,
+        resolved_ids: ResolvedIds,
+    },
     DrainStatementLog,
     PrivateLinkVpcEndpointEvents(Vec<VpcEndpointEvent>),
 }
@@ -298,6 +304,7 @@ impl Message {
                 "create_materialized_view_stage_ready"
             }
             Message::SubscribeStageReady { .. } => "subscribe_stage_ready",
+            Message::OptimizationReady { .. } => "optimization_ready",
             Message::DrainStatementLog => "drain_statement_log",
             Message::AlterConnectionValidationReady(..) => "alter_connection_validation_ready",
             Message::PrivateLinkVpcEndpointEvents(_) => "private_link_vpc_endpoint_events",

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -19,7 +19,7 @@ use mz_ore::metrics::MetricsFutureExt;
 use mz_ore::task;
 use mz_ore::vec::VecExt;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
-use mz_sql::plan::Plan;
+use mz_sql::plan::{Optimized, Plan};
 use mz_storage_client::client::TimestamplessUpdate;
 use tokio::sync::{oneshot, Notify, OwnedMutexGuard, OwnedSemaphorePermit, Semaphore};
 use tracing::{warn, Instrument, Span};
@@ -45,7 +45,7 @@ pub(crate) enum Deferred {
 pub(crate) struct DeferredPlan {
     #[derivative(Debug = "ignore")]
     pub ctx: ExecuteContext,
-    pub plan: Plan,
+    pub plan: Plan<Optimized>,
     pub validity: PlanValidity,
 }
 

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -22,7 +22,8 @@ use mz_expr::CollectionPlan;
 use mz_repr::GlobalId;
 use mz_sql::catalog::SessionCatalog;
 use mz_sql::plan::{
-    ExplainPlanPlan, ExplainTimestampPlan, Explainee, ExplaineeStatement, Plan, SubscribeFrom,
+    ExplainPlanPlan, ExplainTimestampPlan, Explainee, ExplaineeStatement, Optimized, Plan,
+    SubscribeFrom,
 };
 use smallvec::SmallVec;
 
@@ -38,7 +39,7 @@ use mz_catalog::builtin::MZ_INTROSPECTION_CLUSTER;
 pub fn auto_run_on_introspection<'a, 's, 'p>(
     catalog: &'a ConnCatalog<'a>,
     session: &'s Session,
-    plan: &'p Plan,
+    plan: &'p Plan<Optimized>,
 ) -> TargetCluster {
     let (depends_on, could_run_expensive_function) = match plan {
         Plan::Select(plan) => (
@@ -192,7 +193,7 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
 /// we depend on any objects that we're not allowed to query from the cluster.
 pub fn check_cluster_restrictions(
     catalog: &impl SessionCatalog,
-    plan: &Plan,
+    plan: &Plan<Optimized>,
 ) -> Result<(), AdapterError> {
     // We only impose restrictions if the current cluster is the introspection cluster.
     let cluster = catalog.active_cluster();

--- a/src/adapter/src/coord/optimizer.rs
+++ b/src/adapter/src/coord/optimizer.rs
@@ -1,0 +1,139 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Logic for optimizing [`Plan`]s.
+
+use mz_sql::plan::{CreateViewPlan, Optimized, Plan, Unoptimized, View};
+
+use crate::coord::Coordinator;
+use crate::optimize;
+use crate::optimize::{Optimize, OptimizerError};
+
+impl Coordinator {
+    pub(crate) fn optimize_plan(
+        &mut self,
+        plan: Plan<Unoptimized>,
+    ) -> Result<Plan<Optimized>, OptimizerError> {
+        Ok(match plan {
+            Plan::CreateConnection(plan) => Plan::CreateConnection(plan),
+            Plan::CreateDatabase(plan) => Plan::CreateDatabase(plan),
+            Plan::CreateSchema(plan) => Plan::CreateSchema(plan),
+            Plan::CreateRole(plan) => Plan::CreateRole(plan),
+            Plan::CreateCluster(plan) => Plan::CreateCluster(plan),
+            Plan::CreateClusterReplica(plan) => Plan::CreateClusterReplica(plan),
+            Plan::CreateSource(plan) => Plan::CreateSource(plan),
+            Plan::CreateSources(plan) => Plan::CreateSources(plan),
+            Plan::CreateSecret(plan) => Plan::CreateSecret(plan),
+            Plan::CreateSink(plan) => Plan::CreateSink(plan),
+            Plan::CreateTable(plan) => Plan::CreateTable(plan),
+            Plan::CreateView(plan) => Plan::CreateView(self.optimize_create_view(plan)?),
+            Plan::CreateMaterializedView(plan) => Plan::CreateMaterializedView(plan),
+            Plan::CreateIndex(plan) => Plan::CreateIndex(plan),
+            Plan::CreateType(plan) => Plan::CreateType(plan),
+            Plan::Comment(plan) => Plan::Comment(plan),
+            Plan::DiscardTemp => Plan::DiscardTemp,
+            Plan::DiscardAll => Plan::DiscardAll,
+            Plan::DropObjects(plan) => Plan::DropObjects(plan),
+            Plan::DropOwned(plan) => Plan::DropOwned(plan),
+            Plan::EmptyQuery => Plan::EmptyQuery,
+            Plan::ShowAllVariables => Plan::ShowAllVariables,
+            Plan::ShowCreate(plan) => Plan::ShowCreate(plan),
+            Plan::ShowColumns(plan) => Plan::ShowColumns(plan),
+            Plan::ShowVariable(plan) => Plan::ShowVariable(plan),
+            Plan::InspectShard(plan) => Plan::InspectShard(plan),
+            Plan::SetVariable(plan) => Plan::SetVariable(plan),
+            Plan::ResetVariable(plan) => Plan::ResetVariable(plan),
+            Plan::SetTransaction(plan) => Plan::SetTransaction(plan),
+            Plan::StartTransaction(plan) => Plan::StartTransaction(plan),
+            Plan::CommitTransaction(plan) => Plan::CommitTransaction(plan),
+            Plan::AbortTransaction(plan) => Plan::AbortTransaction(plan),
+            Plan::Select(plan) => Plan::Select(plan),
+            Plan::Subscribe(plan) => Plan::Subscribe(plan),
+            Plan::CopyFrom(plan) => Plan::CopyFrom(plan),
+            Plan::ExplainPlan(plan) => Plan::ExplainPlan(plan),
+            Plan::ExplainTimestamp(plan) => Plan::ExplainTimestamp(plan),
+            Plan::ExplainSinkSchema(plan) => Plan::ExplainSinkSchema(plan),
+            Plan::Insert(plan) => Plan::Insert(plan),
+            Plan::AlterCluster(plan) => Plan::AlterCluster(plan),
+            Plan::AlterClusterSwap(plan) => Plan::AlterClusterSwap(plan),
+            Plan::AlterNoop(plan) => Plan::AlterNoop(plan),
+            Plan::AlterIndexSetOptions(plan) => Plan::AlterIndexSetOptions(plan),
+            Plan::AlterIndexResetOptions(plan) => Plan::AlterIndexResetOptions(plan),
+            Plan::AlterSetCluster(plan) => Plan::AlterSetCluster(plan),
+            Plan::AlterSink(plan) => Plan::AlterSink(plan),
+            Plan::AlterConnection(plan) => Plan::AlterConnection(plan),
+            Plan::AlterSource(plan) => Plan::AlterSource(plan),
+            Plan::PurifiedAlterSource {
+                alter_source,
+                subsources,
+            } => Plan::PurifiedAlterSource {
+                alter_source,
+                subsources,
+            },
+            Plan::AlterClusterRename(plan) => Plan::AlterClusterRename(plan),
+            Plan::AlterClusterReplicaRename(plan) => Plan::AlterClusterReplicaRename(plan),
+            Plan::AlterItemRename(plan) => Plan::AlterItemRename(plan),
+            Plan::AlterItemSwap(plan) => Plan::AlterItemSwap(plan),
+            Plan::AlterSchemaRename(plan) => Plan::AlterSchemaRename(plan),
+            Plan::AlterSchemaSwap(plan) => Plan::AlterSchemaSwap(plan),
+            Plan::AlterSecret(plan) => Plan::AlterSecret(plan),
+            Plan::AlterSystemSet(plan) => Plan::AlterSystemSet(plan),
+            Plan::AlterSystemReset(plan) => Plan::AlterSystemReset(plan),
+            Plan::AlterSystemResetAll(plan) => Plan::AlterSystemResetAll(plan),
+            Plan::AlterRole(plan) => Plan::AlterRole(plan),
+            Plan::AlterOwner(plan) => Plan::AlterOwner(plan),
+            Plan::Declare(plan) => Plan::Declare(plan),
+            Plan::Fetch(plan) => Plan::Fetch(plan),
+            Plan::Close(plan) => Plan::Close(plan),
+            Plan::ReadThenWrite(plan) => Plan::ReadThenWrite(plan),
+            Plan::Prepare(plan) => Plan::Prepare(plan),
+            Plan::Execute(plan) => Plan::Execute(plan),
+            Plan::Deallocate(plan) => Plan::Deallocate(plan),
+            Plan::Raise(plan) => Plan::Raise(plan),
+            Plan::GrantRole(plan) => Plan::GrantRole(plan),
+            Plan::RevokeRole(plan) => Plan::RevokeRole(plan),
+            Plan::GrantPrivileges(plan) => Plan::GrantPrivileges(plan),
+            Plan::RevokePrivileges(plan) => Plan::RevokePrivileges(plan),
+            Plan::AlterDefaultPrivileges(plan) => Plan::AlterDefaultPrivileges(plan),
+            Plan::ReassignOwned(plan) => Plan::ReassignOwned(plan),
+            Plan::SideEffectingFunc(plan) => Plan::SideEffectingFunc(plan),
+            Plan::ValidateConnection(plan) => Plan::ValidateConnection(plan),
+        })
+    }
+
+    fn optimize_create_view(
+        &mut self,
+        plan: CreateViewPlan<Unoptimized>,
+    ) -> Result<CreateViewPlan<Optimized>, OptimizerError> {
+        // Collect optimizer parameters.
+        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
+
+        // Build an optimizer for this VIEW.
+        let mut optimizer = optimize::view::Optimizer::new(optimizer_config);
+
+        // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
+        let raw_expr = plan.view.expr.clone();
+        let optimized_expr = optimizer.optimize(raw_expr)?;
+
+        let view = View {
+            create_sql: plan.view.create_sql,
+            expr: (plan.view.expr, optimized_expr),
+            column_names: plan.view.column_names,
+            temporary: plan.view.temporary,
+        };
+        Ok(CreateViewPlan {
+            name: plan.name,
+            view,
+            replace: plan.replace,
+            drop_ids: plan.drop_ids,
+            if_not_exists: plan.if_not_exists,
+            ambiguous_columns: plan.ambiguous_columns,
+        })
+    }
+}

--- a/src/adapter/src/coord/optimizer.rs
+++ b/src/adapter/src/coord/optimizer.rs
@@ -15,125 +15,159 @@ use crate::coord::Coordinator;
 use crate::optimize;
 use crate::optimize::{Optimize, OptimizerError};
 
+/// Type alias for function that returns an optimized plan.
+type ExpensiveFn = Box<dyn FnOnce() -> Result<Plan<Optimized>, OptimizerError> + Send>;
+
+/// Represents the work that needs to be executed to optimize a plan.
+pub(crate) enum PlanOptimization {
+    /// No optimization is needed and an optimized plan can be returned immediately.
+    NoOp(Plan<Optimized>),
+    /// A potentially expensive amount of work is needed to optimize the plan.
+    Expensive(ExpensiveFn),
+}
+
+impl PlanOptimization {
+    pub(crate) fn execute(self) -> Result<Plan<Optimized>, OptimizerError> {
+        match self {
+            PlanOptimization::NoOp(plan) => Ok(plan),
+            PlanOptimization::Expensive(f) => f(),
+        }
+    }
+}
+
 impl Coordinator {
-    pub(crate) fn optimize_plan(
-        &mut self,
-        plan: Plan<Unoptimized>,
-    ) -> Result<Plan<Optimized>, OptimizerError> {
-        Ok(match plan {
-            Plan::CreateConnection(plan) => Plan::CreateConnection(plan),
-            Plan::CreateDatabase(plan) => Plan::CreateDatabase(plan),
-            Plan::CreateSchema(plan) => Plan::CreateSchema(plan),
-            Plan::CreateRole(plan) => Plan::CreateRole(plan),
-            Plan::CreateCluster(plan) => Plan::CreateCluster(plan),
-            Plan::CreateClusterReplica(plan) => Plan::CreateClusterReplica(plan),
-            Plan::CreateSource(plan) => Plan::CreateSource(plan),
-            Plan::CreateSources(plan) => Plan::CreateSources(plan),
-            Plan::CreateSecret(plan) => Plan::CreateSecret(plan),
-            Plan::CreateSink(plan) => Plan::CreateSink(plan),
-            Plan::CreateTable(plan) => Plan::CreateTable(plan),
-            Plan::CreateView(plan) => Plan::CreateView(self.optimize_create_view(plan)?),
-            Plan::CreateMaterializedView(plan) => Plan::CreateMaterializedView(plan),
-            Plan::CreateIndex(plan) => Plan::CreateIndex(plan),
-            Plan::CreateType(plan) => Plan::CreateType(plan),
-            Plan::Comment(plan) => Plan::Comment(plan),
-            Plan::DiscardTemp => Plan::DiscardTemp,
-            Plan::DiscardAll => Plan::DiscardAll,
-            Plan::DropObjects(plan) => Plan::DropObjects(plan),
-            Plan::DropOwned(plan) => Plan::DropOwned(plan),
-            Plan::EmptyQuery => Plan::EmptyQuery,
-            Plan::ShowAllVariables => Plan::ShowAllVariables,
-            Plan::ShowCreate(plan) => Plan::ShowCreate(plan),
-            Plan::ShowColumns(plan) => Plan::ShowColumns(plan),
-            Plan::ShowVariable(plan) => Plan::ShowVariable(plan),
-            Plan::InspectShard(plan) => Plan::InspectShard(plan),
-            Plan::SetVariable(plan) => Plan::SetVariable(plan),
-            Plan::ResetVariable(plan) => Plan::ResetVariable(plan),
-            Plan::SetTransaction(plan) => Plan::SetTransaction(plan),
-            Plan::StartTransaction(plan) => Plan::StartTransaction(plan),
-            Plan::CommitTransaction(plan) => Plan::CommitTransaction(plan),
-            Plan::AbortTransaction(plan) => Plan::AbortTransaction(plan),
-            Plan::Select(plan) => Plan::Select(plan),
-            Plan::Subscribe(plan) => Plan::Subscribe(plan),
-            Plan::CopyFrom(plan) => Plan::CopyFrom(plan),
-            Plan::ExplainPlan(plan) => Plan::ExplainPlan(plan),
-            Plan::ExplainTimestamp(plan) => Plan::ExplainTimestamp(plan),
-            Plan::ExplainSinkSchema(plan) => Plan::ExplainSinkSchema(plan),
-            Plan::Insert(plan) => Plan::Insert(plan),
-            Plan::AlterCluster(plan) => Plan::AlterCluster(plan),
-            Plan::AlterClusterSwap(plan) => Plan::AlterClusterSwap(plan),
-            Plan::AlterNoop(plan) => Plan::AlterNoop(plan),
-            Plan::AlterIndexSetOptions(plan) => Plan::AlterIndexSetOptions(plan),
-            Plan::AlterIndexResetOptions(plan) => Plan::AlterIndexResetOptions(plan),
-            Plan::AlterSetCluster(plan) => Plan::AlterSetCluster(plan),
-            Plan::AlterSink(plan) => Plan::AlterSink(plan),
-            Plan::AlterConnection(plan) => Plan::AlterConnection(plan),
-            Plan::AlterSource(plan) => Plan::AlterSource(plan),
+    pub(crate) fn optimize_plan(&mut self, plan: Plan<Unoptimized>) -> PlanOptimization {
+        match plan {
+            Plan::CreateView(plan) => PlanOptimization::Expensive(self.optimize_create_view(plan)),
+            Plan::CreateConnection(plan) => PlanOptimization::NoOp(Plan::CreateConnection(plan)),
+            Plan::CreateDatabase(plan) => PlanOptimization::NoOp(Plan::CreateDatabase(plan)),
+            Plan::CreateSchema(plan) => PlanOptimization::NoOp(Plan::CreateSchema(plan)),
+            Plan::CreateRole(plan) => PlanOptimization::NoOp(Plan::CreateRole(plan)),
+            Plan::CreateCluster(plan) => PlanOptimization::NoOp(Plan::CreateCluster(plan)),
+            Plan::CreateClusterReplica(plan) => {
+                PlanOptimization::NoOp(Plan::CreateClusterReplica(plan))
+            }
+            Plan::CreateSource(plan) => PlanOptimization::NoOp(Plan::CreateSource(plan)),
+            Plan::CreateSources(plan) => PlanOptimization::NoOp(Plan::CreateSources(plan)),
+            Plan::CreateSecret(plan) => PlanOptimization::NoOp(Plan::CreateSecret(plan)),
+            Plan::CreateSink(plan) => PlanOptimization::NoOp(Plan::CreateSink(plan)),
+            Plan::CreateTable(plan) => PlanOptimization::NoOp(Plan::CreateTable(plan)),
+            Plan::CreateMaterializedView(plan) => {
+                PlanOptimization::NoOp(Plan::CreateMaterializedView(plan))
+            }
+            Plan::CreateIndex(plan) => PlanOptimization::NoOp(Plan::CreateIndex(plan)),
+            Plan::CreateType(plan) => PlanOptimization::NoOp(Plan::CreateType(plan)),
+            Plan::Comment(plan) => PlanOptimization::NoOp(Plan::Comment(plan)),
+            Plan::DiscardTemp => PlanOptimization::NoOp(Plan::DiscardTemp),
+            Plan::DiscardAll => PlanOptimization::NoOp(Plan::DiscardAll),
+            Plan::DropObjects(plan) => PlanOptimization::NoOp(Plan::DropObjects(plan)),
+            Plan::DropOwned(plan) => PlanOptimization::NoOp(Plan::DropOwned(plan)),
+            Plan::EmptyQuery => PlanOptimization::NoOp(Plan::EmptyQuery),
+            Plan::ShowAllVariables => PlanOptimization::NoOp(Plan::ShowAllVariables),
+            Plan::ShowCreate(plan) => PlanOptimization::NoOp(Plan::ShowCreate(plan)),
+            Plan::ShowColumns(plan) => PlanOptimization::NoOp(Plan::ShowColumns(plan)),
+            Plan::ShowVariable(plan) => PlanOptimization::NoOp(Plan::ShowVariable(plan)),
+            Plan::InspectShard(plan) => PlanOptimization::NoOp(Plan::InspectShard(plan)),
+            Plan::SetVariable(plan) => PlanOptimization::NoOp(Plan::SetVariable(plan)),
+            Plan::ResetVariable(plan) => PlanOptimization::NoOp(Plan::ResetVariable(plan)),
+            Plan::SetTransaction(plan) => PlanOptimization::NoOp(Plan::SetTransaction(plan)),
+            Plan::StartTransaction(plan) => PlanOptimization::NoOp(Plan::StartTransaction(plan)),
+            Plan::CommitTransaction(plan) => PlanOptimization::NoOp(Plan::CommitTransaction(plan)),
+            Plan::AbortTransaction(plan) => PlanOptimization::NoOp(Plan::AbortTransaction(plan)),
+            Plan::Select(plan) => PlanOptimization::NoOp(Plan::Select(plan)),
+            Plan::Subscribe(plan) => PlanOptimization::NoOp(Plan::Subscribe(plan)),
+            Plan::CopyFrom(plan) => PlanOptimization::NoOp(Plan::CopyFrom(plan)),
+            Plan::ExplainPlan(plan) => PlanOptimization::NoOp(Plan::ExplainPlan(plan)),
+            Plan::ExplainTimestamp(plan) => PlanOptimization::NoOp(Plan::ExplainTimestamp(plan)),
+            Plan::ExplainSinkSchema(plan) => PlanOptimization::NoOp(Plan::ExplainSinkSchema(plan)),
+            Plan::Insert(plan) => PlanOptimization::NoOp(Plan::Insert(plan)),
+            Plan::AlterCluster(plan) => PlanOptimization::NoOp(Plan::AlterCluster(plan)),
+            Plan::AlterClusterSwap(plan) => PlanOptimization::NoOp(Plan::AlterClusterSwap(plan)),
+            Plan::AlterNoop(plan) => PlanOptimization::NoOp(Plan::AlterNoop(plan)),
+            Plan::AlterIndexSetOptions(plan) => {
+                PlanOptimization::NoOp(Plan::AlterIndexSetOptions(plan))
+            }
+            Plan::AlterIndexResetOptions(plan) => {
+                PlanOptimization::NoOp(Plan::AlterIndexResetOptions(plan))
+            }
+            Plan::AlterSetCluster(plan) => PlanOptimization::NoOp(Plan::AlterSetCluster(plan)),
+            Plan::AlterSink(plan) => PlanOptimization::NoOp(Plan::AlterSink(plan)),
+            Plan::AlterConnection(plan) => PlanOptimization::NoOp(Plan::AlterConnection(plan)),
+            Plan::AlterSource(plan) => PlanOptimization::NoOp(Plan::AlterSource(plan)),
             Plan::PurifiedAlterSource {
                 alter_source,
                 subsources,
-            } => Plan::PurifiedAlterSource {
+            } => PlanOptimization::NoOp(Plan::PurifiedAlterSource {
                 alter_source,
                 subsources,
-            },
-            Plan::AlterClusterRename(plan) => Plan::AlterClusterRename(plan),
-            Plan::AlterClusterReplicaRename(plan) => Plan::AlterClusterReplicaRename(plan),
-            Plan::AlterItemRename(plan) => Plan::AlterItemRename(plan),
-            Plan::AlterItemSwap(plan) => Plan::AlterItemSwap(plan),
-            Plan::AlterSchemaRename(plan) => Plan::AlterSchemaRename(plan),
-            Plan::AlterSchemaSwap(plan) => Plan::AlterSchemaSwap(plan),
-            Plan::AlterSecret(plan) => Plan::AlterSecret(plan),
-            Plan::AlterSystemSet(plan) => Plan::AlterSystemSet(plan),
-            Plan::AlterSystemReset(plan) => Plan::AlterSystemReset(plan),
-            Plan::AlterSystemResetAll(plan) => Plan::AlterSystemResetAll(plan),
-            Plan::AlterRole(plan) => Plan::AlterRole(plan),
-            Plan::AlterOwner(plan) => Plan::AlterOwner(plan),
-            Plan::Declare(plan) => Plan::Declare(plan),
-            Plan::Fetch(plan) => Plan::Fetch(plan),
-            Plan::Close(plan) => Plan::Close(plan),
-            Plan::ReadThenWrite(plan) => Plan::ReadThenWrite(plan),
-            Plan::Prepare(plan) => Plan::Prepare(plan),
-            Plan::Execute(plan) => Plan::Execute(plan),
-            Plan::Deallocate(plan) => Plan::Deallocate(plan),
-            Plan::Raise(plan) => Plan::Raise(plan),
-            Plan::GrantRole(plan) => Plan::GrantRole(plan),
-            Plan::RevokeRole(plan) => Plan::RevokeRole(plan),
-            Plan::GrantPrivileges(plan) => Plan::GrantPrivileges(plan),
-            Plan::RevokePrivileges(plan) => Plan::RevokePrivileges(plan),
-            Plan::AlterDefaultPrivileges(plan) => Plan::AlterDefaultPrivileges(plan),
-            Plan::ReassignOwned(plan) => Plan::ReassignOwned(plan),
-            Plan::SideEffectingFunc(plan) => Plan::SideEffectingFunc(plan),
-            Plan::ValidateConnection(plan) => Plan::ValidateConnection(plan),
-        })
+            }),
+            Plan::AlterClusterRename(plan) => {
+                PlanOptimization::NoOp(Plan::AlterClusterRename(plan))
+            }
+            Plan::AlterClusterReplicaRename(plan) => {
+                PlanOptimization::NoOp(Plan::AlterClusterReplicaRename(plan))
+            }
+            Plan::AlterItemRename(plan) => PlanOptimization::NoOp(Plan::AlterItemRename(plan)),
+            Plan::AlterItemSwap(plan) => PlanOptimization::NoOp(Plan::AlterItemSwap(plan)),
+            Plan::AlterSchemaRename(plan) => PlanOptimization::NoOp(Plan::AlterSchemaRename(plan)),
+            Plan::AlterSchemaSwap(plan) => PlanOptimization::NoOp(Plan::AlterSchemaSwap(plan)),
+            Plan::AlterSecret(plan) => PlanOptimization::NoOp(Plan::AlterSecret(plan)),
+            Plan::AlterSystemSet(plan) => PlanOptimization::NoOp(Plan::AlterSystemSet(plan)),
+            Plan::AlterSystemReset(plan) => PlanOptimization::NoOp(Plan::AlterSystemReset(plan)),
+            Plan::AlterSystemResetAll(plan) => {
+                PlanOptimization::NoOp(Plan::AlterSystemResetAll(plan))
+            }
+            Plan::AlterRole(plan) => PlanOptimization::NoOp(Plan::AlterRole(plan)),
+            Plan::AlterOwner(plan) => PlanOptimization::NoOp(Plan::AlterOwner(plan)),
+            Plan::Declare(plan) => PlanOptimization::NoOp(Plan::Declare(plan)),
+            Plan::Fetch(plan) => PlanOptimization::NoOp(Plan::Fetch(plan)),
+            Plan::Close(plan) => PlanOptimization::NoOp(Plan::Close(plan)),
+            Plan::ReadThenWrite(plan) => PlanOptimization::NoOp(Plan::ReadThenWrite(plan)),
+            Plan::Prepare(plan) => PlanOptimization::NoOp(Plan::Prepare(plan)),
+            Plan::Execute(plan) => PlanOptimization::NoOp(Plan::Execute(plan)),
+            Plan::Deallocate(plan) => PlanOptimization::NoOp(Plan::Deallocate(plan)),
+            Plan::Raise(plan) => PlanOptimization::NoOp(Plan::Raise(plan)),
+            Plan::GrantRole(plan) => PlanOptimization::NoOp(Plan::GrantRole(plan)),
+            Plan::RevokeRole(plan) => PlanOptimization::NoOp(Plan::RevokeRole(plan)),
+            Plan::GrantPrivileges(plan) => PlanOptimization::NoOp(Plan::GrantPrivileges(plan)),
+            Plan::RevokePrivileges(plan) => PlanOptimization::NoOp(Plan::RevokePrivileges(plan)),
+            Plan::AlterDefaultPrivileges(plan) => {
+                PlanOptimization::NoOp(Plan::AlterDefaultPrivileges(plan))
+            }
+            Plan::ReassignOwned(plan) => PlanOptimization::NoOp(Plan::ReassignOwned(plan)),
+            Plan::SideEffectingFunc(plan) => PlanOptimization::NoOp(Plan::SideEffectingFunc(plan)),
+            Plan::ValidateConnection(plan) => {
+                PlanOptimization::NoOp(Plan::ValidateConnection(plan))
+            }
+        }
     }
 
-    fn optimize_create_view(
-        &mut self,
-        plan: CreateViewPlan<Unoptimized>,
-    ) -> Result<CreateViewPlan<Optimized>, OptimizerError> {
+    fn optimize_create_view(&mut self, plan: CreateViewPlan<Unoptimized>) -> ExpensiveFn {
         // Collect optimizer parameters.
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
 
         // Build an optimizer for this VIEW.
         let mut optimizer = optimize::view::Optimizer::new(optimizer_config);
 
-        // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
-        let raw_expr = plan.view.expr.clone();
-        let optimized_expr = optimizer.optimize(raw_expr)?;
+        Box::new(move || {
+            // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
+            let raw_expr = plan.view.expr.clone();
+            let optimized_expr = optimizer.optimize(raw_expr)?;
 
-        let view = View {
-            create_sql: plan.view.create_sql,
-            expr: (plan.view.expr, optimized_expr),
-            column_names: plan.view.column_names,
-            temporary: plan.view.temporary,
-        };
-        Ok(CreateViewPlan {
-            name: plan.name,
-            view,
-            replace: plan.replace,
-            drop_ids: plan.drop_ids,
-            if_not_exists: plan.if_not_exists,
-            ambiguous_columns: plan.ambiguous_columns,
+            let view = View {
+                create_sql: plan.view.create_sql,
+                expr: (plan.view.expr, optimized_expr),
+                column_names: plan.view.column_names,
+                temporary: plan.view.temporary,
+            };
+            Ok(Plan::CreateView(CreateViewPlan {
+                name: plan.name,
+                view,
+                replace: plan.replace,
+                drop_ids: plan.drop_ids,
+                if_not_exists: plan.if_not_exists,
+                ambiguous_columns: plan.ambiguous_columns,
+            }))
         })
     }
 }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -24,7 +24,7 @@ use mz_sql::catalog::{CatalogCluster, CatalogError};
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan::{
     self, AbortTransactionPlan, CommitTransactionPlan, CreateRolePlan, CreateSourcePlans,
-    FetchPlan, MutationKind, Params, Plan, PlanKind, QueryWhen, RaisePlan,
+    FetchPlan, MutationKind, Optimized, Params, Plan, PlanKind, QueryWhen, RaisePlan,
 };
 use mz_sql::rbac;
 use mz_sql_parser::ast::{Raw, Statement};
@@ -70,7 +70,7 @@ impl Coordinator {
     pub(crate) fn sequence_plan(
         &mut self,
         mut ctx: ExecuteContext,
-        plan: Plan,
+        plan: Plan<Optimized>,
         resolved_ids: ResolvedIds,
     ) -> LocalBoxFuture<'_, ()> {
         async move {

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -9,82 +9,40 @@
 
 use mz_catalog::memory::objects::{CatalogItem, View};
 use mz_expr::CollectionPlan;
-use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::RelationDesc;
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::{ObjectId, ResolvedIds};
-use mz_sql::plan::{self};
+use mz_sql::plan::{self, CreateViewPlan, Optimized};
 
-use crate::command::ExecuteResponse;
 use crate::coord::sequencer::inner::return_if_err;
-use crate::coord::{
-    Coordinator, CreateViewFinish, CreateViewOptimize, CreateViewStage, CreateViewValidate,
-    Message, PlanValidity,
-};
+use crate::coord::Coordinator;
 use crate::error::AdapterError;
-use crate::optimize::{self, Optimize};
-use crate::session::Session;
-use crate::{catalog, AdapterNotice, ExecuteContext};
+use crate::{catalog, AdapterNotice, ExecuteContext, ExecuteResponse};
 
 impl Coordinator {
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn sequence_create_view(
         &mut self,
-        ctx: ExecuteContext,
-        plan: plan::CreateViewPlan,
+        mut ctx: ExecuteContext,
+        plan: CreateViewPlan<Optimized>,
         resolved_ids: ResolvedIds,
     ) {
-        self.sequence_create_view_stage(
-            ctx,
-            CreateViewStage::Validate(CreateViewValidate { plan, resolved_ids }),
-            OpenTelemetryContext::obtain(),
-        )
-        .await;
-    }
-
-    /// Processes as many `create view` stages as possible.
-    #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) async fn sequence_create_view_stage(
-        &mut self,
-        mut ctx: ExecuteContext,
-        mut stage: CreateViewStage,
-        otel_ctx: OpenTelemetryContext,
-    ) {
-        use CreateViewStage::*;
-
-        // Process the current stage and allow for processing the next.
-        loop {
-            // Always verify plan validity. This is cheap, and prevents programming errors
-            // if we move any stages off thread.
-            if let Some(validity) = stage.validity() {
-                return_if_err!(validity.check(self.catalog()), ctx);
-            }
-
-            (ctx, stage) = match stage {
-                Validate(stage) => {
-                    let next = return_if_err!(self.create_view_validate(ctx.session(), stage), ctx);
-                    (ctx, CreateViewStage::Optimize(next))
-                }
-                Optimize(stage) => {
-                    self.create_view_optimize(ctx, stage, otel_ctx).await;
-                    return;
-                }
-                Finish(stage) => {
-                    let result = self.create_view_finish(&mut ctx, stage).await;
-                    ctx.retire(result);
-                    return;
-                }
-            }
-        }
+        return_if_err!(self.create_view_validate(&plan), ctx);
+        let result = self.create_view_finish(&mut ctx, plan, resolved_ids).await;
+        ctx.retire(result);
+        return;
     }
 
     fn create_view_validate(
         &mut self,
-        session: &Session,
-        CreateViewValidate { plan, resolved_ids }: CreateViewValidate,
-    ) -> Result<CreateViewOptimize, AdapterError> {
+        plan: &CreateViewPlan<Optimized>,
+    ) -> Result<(), AdapterError> {
         let plan::CreateViewPlan {
-            view: plan::View { expr, .. },
+            view:
+                plan::View {
+                    expr: (raw_expr, _optimized_expr),
+                    ..
+                },
             ambiguous_columns,
             ..
         } = &plan;
@@ -93,99 +51,33 @@ impl Coordinator {
         // unoptimized plan to better reflect what the user typed. We want to
         // reject queries that depend on a relation in the wrong timeline, for
         // example, even if we can *technically* optimize that reference away.
-        let expr_depends_on = expr.depends_on();
+        let expr_depends_on = raw_expr.depends_on();
         self.validate_timeline_context(expr_depends_on.iter().copied())?;
         self.validate_system_column_references(*ambiguous_columns, &expr_depends_on)?;
 
-        let validity = PlanValidity {
-            transient_revision: self.catalog().transient_revision(),
-            dependency_ids: expr_depends_on.clone(),
-            cluster_id: None,
-            replica_id: None,
-            role_metadata: session.role_metadata().clone(),
-        };
-
-        Ok(CreateViewOptimize {
-            validity,
-            plan,
-            resolved_ids,
-        })
-    }
-
-    async fn create_view_optimize(
-        &mut self,
-        ctx: ExecuteContext,
-        CreateViewOptimize {
-            validity,
-            plan,
-            resolved_ids,
-        }: CreateViewOptimize,
-        otel_ctx: OpenTelemetryContext,
-    ) {
-        // Generate data structures that can be moved to another task where we will perform possibly
-        // expensive optimizations.
-        let internal_cmd_tx = self.internal_cmd_tx.clone();
-
-        let id = return_if_err!(self.catalog_mut().allocate_user_id().await, ctx);
-
-        // Collect optimizer parameters.
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
-
-        // Build an optimizer for this VIEW.
-        let mut optimizer = optimize::view::Optimizer::new(optimizer_config);
-
-        let span = tracing::debug_span!("optimize create view task");
-
-        mz_ore::task::spawn_blocking(
-            || "optimize create view",
-            move || {
-                let _guard = span.enter();
-
-                // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
-                let raw_expr = plan.view.expr.clone();
-                let optimized_expr = return_if_err!(optimizer.optimize(raw_expr), ctx);
-
-                let stage = CreateViewStage::Finish(CreateViewFinish {
-                    validity,
-                    id,
-                    plan,
-                    optimized_expr,
-                    resolved_ids,
-                });
-
-                let _ = internal_cmd_tx.send(Message::CreateViewStageReady {
-                    ctx,
-                    otel_ctx,
-                    stage,
-                });
-            },
-        );
+        Ok(())
     }
 
     async fn create_view_finish(
         &mut self,
         ctx: &mut ExecuteContext,
-        CreateViewFinish {
-            id,
-            plan:
-                plan::CreateViewPlan {
-                    name,
-                    view:
-                        plan::View {
-                            create_sql,
-                            expr: raw_expr,
-                            column_names,
-                            temporary,
-                        },
-                    drop_ids,
-                    if_not_exists,
-                    ..
+        CreateViewPlan {
+            name,
+            view:
+                plan::View {
+                    create_sql,
+                    expr: (raw_expr, optimized_expr),
+                    column_names,
+                    temporary,
                 },
-            optimized_expr,
-            resolved_ids,
+            drop_ids,
+            if_not_exists,
             ..
-        }: CreateViewFinish,
+        }: CreateViewPlan<Optimized>,
+        resolved_ids: ResolvedIds,
     ) -> Result<ExecuteResponse, AdapterError> {
+        let id = self.catalog_mut().allocate_user_id().await?;
+
         let ops = itertools::chain(
             drop_ids
                 .iter()

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -14,7 +14,7 @@ use mz_adapter_types::connection::ConnectionId;
 use mz_ore::now::EpochMillis;
 use mz_repr::{GlobalId, ScalarType};
 use mz_sql::names::{Aug, ResolvedIds};
-use mz_sql::plan::{Params, StatementDesc};
+use mz_sql::plan::{Params, StatementDesc, Unoptimized};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{Raw, Statement, StatementKind};
 
@@ -33,7 +33,7 @@ impl Coordinator {
         stmt: mz_sql::ast::Statement<Aug>,
         params: &mz_sql::plan::Params,
         resolved_ids: &ResolvedIds,
-    ) -> Result<mz_sql::plan::Plan, AdapterError> {
+    ) -> Result<mz_sql::plan::Plan<Unoptimized>, AdapterError> {
         let pcx = session.pcx();
         let catalog = self.catalog().for_session(session);
         let plan = mz_sql::plan::plan(Some(pcx), &catalog, stmt, params, resolved_ids)?;

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -37,7 +37,7 @@ use mz_repr::{Datum, RelationDesc, RowArena};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{Raw, Statement, StatementKind};
 use mz_sql::parse::StatementParseResult;
-use mz_sql::plan::Plan;
+use mz_sql::plan::generated_from;
 use serde::{Deserialize, Serialize};
 use tokio::{select, time};
 use tokio_postgres::error::SqlState;
@@ -933,7 +933,7 @@ async fn execute_request<S: ResultSender>(
         stmt: &Statement<Raw>,
     ) -> Result<(), Error> {
         let kind: StatementKind = stmt.into();
-        let execute_responses = Plan::generated_from(kind)
+        let execute_responses = generated_from(kind)
             .into_iter()
             .map(ExecuteResponse::generated_from)
             .flatten()

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -35,7 +35,9 @@ use crate::names::{
 };
 use crate::normalize;
 use crate::plan::error::PlanError;
-use crate::plan::{query, with_options, Params, Plan, PlanContext, PlanKind};
+use crate::plan::{
+    generated_from, query, with_options, Params, Plan, PlanContext, PlanKind, Unoptimized,
+};
 use crate::session::vars::FeatureFlag;
 
 mod acl;
@@ -262,7 +264,7 @@ pub fn plan(
     stmt: Statement<Aug>,
     params: &Params,
     resolved_ids: &ResolvedIds,
-) -> Result<Plan, PlanError> {
+) -> Result<Plan<Unoptimized>, PlanError> {
     let param_types = params
         .types
         .iter()
@@ -270,7 +272,7 @@ pub fn plan(
         .map(|(i, ty)| (i + 1, ty.clone()))
         .collect();
 
-    let permitted_plans = Plan::generated_from((&stmt).into());
+    let permitted_plans = generated_from((&stmt).into());
 
     let scx = &mut StatementContext {
         pcx,

--- a/src/sql/src/plan/statement/raise.rs
+++ b/src/sql/src/plan/statement/raise.rs
@@ -14,13 +14,16 @@
 
 use crate::ast::RaiseStatement;
 use crate::plan::statement::{StatementContext, StatementDesc};
-use crate::plan::{Plan, PlanError, RaisePlan};
+use crate::plan::{Plan, PlanError, RaisePlan, Unoptimized};
 
 pub fn describe_raise(_: &StatementContext, _: RaiseStatement) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(None))
 }
 
-pub fn plan_raise(scx: &StatementContext, r: RaiseStatement) -> Result<Plan, PlanError> {
+pub fn plan_raise(
+    scx: &StatementContext,
+    r: RaiseStatement,
+) -> Result<Plan<Unoptimized>, PlanError> {
     scx.require_feature_flag(&crate::session::vars::ENABLE_RAISE_STATEMENT)?;
     Ok(Plan::Raise(RaisePlan {
         severity: r.severity,

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -39,7 +39,8 @@ use crate::parse;
 use crate::plan::scope::Scope;
 use crate::plan::statement::{dml, StatementContext, StatementDesc};
 use crate::plan::{
-    query, transform_ast, HirRelationExpr, Params, Plan, PlanError, ShowColumnsPlan, ShowCreatePlan,
+    query, transform_ast, HirRelationExpr, Params, Plan, PlanError, ShowColumnsPlan,
+    ShowCreatePlan, Unoptimized,
 };
 
 pub fn describe_show_create_view(
@@ -844,7 +845,7 @@ impl<'a> ShowSelect<'a> {
     }
 
     /// Converts this `ShowSelect` into a [`Plan`].
-    pub fn plan(self) -> Result<Plan, PlanError> {
+    pub fn plan(self) -> Result<Plan<Unoptimized>, PlanError> {
         dml::plan_select(self.scx, self.stmt, &Params::empty(), None)
     }
 
@@ -865,7 +866,7 @@ impl<'a> ShowColumnsSelect<'a> {
         self.show_select.describe()
     }
 
-    pub fn plan(self) -> Result<Plan, PlanError> {
+    pub fn plan(self) -> Result<Plan<Unoptimized>, PlanError> {
         let select_plan = self.show_select.plan()?;
         match select_plan {
             Plan::Select(select_plan) => Ok(Plan::ShowColumns(ShowColumnsPlan {

--- a/src/sql/src/plan/statement/tcl.rs
+++ b/src/sql/src/plan/statement/tcl.rs
@@ -21,7 +21,7 @@ use crate::ast::{
 use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::{
     AbortTransactionPlan, CommitTransactionPlan, Plan, PlanError, SetTransactionPlan,
-    StartTransactionPlan, TransactionType,
+    StartTransactionPlan, TransactionType, Unoptimized,
 };
 
 pub fn describe_start_transaction(
@@ -34,7 +34,7 @@ pub fn describe_start_transaction(
 pub fn plan_start_transaction(
     _: &StatementContext,
     StartTransactionStatement { modes }: StartTransactionStatement,
-) -> Result<Plan, PlanError> {
+) -> Result<Plan<Unoptimized>, PlanError> {
     let (access, isolation_level) = verify_transaction_modes(modes)?;
     Ok(Plan::StartTransaction(StartTransactionPlan {
         access,
@@ -52,7 +52,7 @@ pub fn describe_set_transaction(
 pub fn plan_set_transaction(
     _: &StatementContext,
     SetTransactionStatement { local, modes }: SetTransactionStatement,
-) -> Result<Plan, PlanError> {
+) -> Result<Plan<Unoptimized>, PlanError> {
     Ok(Plan::SetTransaction(SetTransactionPlan { local, modes }))
 }
 
@@ -88,7 +88,7 @@ pub fn describe_rollback(
 pub fn plan_rollback(
     _: &StatementContext,
     RollbackStatement { chain }: RollbackStatement,
-) -> Result<Plan, PlanError> {
+) -> Result<Plan<Unoptimized>, PlanError> {
     verify_chain(chain)?;
     Ok(Plan::AbortTransaction(AbortTransactionPlan {
         transaction_type: TransactionType::Explicit,
@@ -105,7 +105,7 @@ pub fn describe_commit(
 pub fn plan_commit(
     _: &StatementContext,
     CommitStatement { chain }: CommitStatement,
-) -> Result<Plan, PlanError> {
+) -> Result<Plan<Unoptimized>, PlanError> {
     verify_chain(chain)?;
     Ok(Plan::CommitTransaction(CommitTransactionPlan {
         transaction_type: TransactionType::Explicit,

--- a/src/sql/src/plan/statement/validate.rs
+++ b/src/sql/src/plan/statement/validate.rs
@@ -12,7 +12,7 @@
 use crate::ast::ValidateConnectionStatement;
 use crate::names::Aug;
 use crate::plan::statement::{StatementContext, StatementDesc};
-use crate::plan::{Plan, PlanError, ValidateConnectionPlan};
+use crate::plan::{Plan, PlanError, Unoptimized, ValidateConnectionPlan};
 use crate::session::vars;
 
 pub fn describe_validate_connection(
@@ -25,7 +25,7 @@ pub fn describe_validate_connection(
 pub fn plan_validate_connection(
     scx: &StatementContext,
     stmt: ValidateConnectionStatement<Aug>,
-) -> Result<Plan, PlanError> {
+) -> Result<Plan<Unoptimized>, PlanError> {
     scx.require_feature_flag(&vars::ENABLE_CONNECTION_VALIDATION_SYNTAX)?;
     let item = scx.get_item_by_resolved_name(&stmt.name)?;
 

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -31,8 +31,8 @@ use crate::names::{
 };
 use crate::plan;
 use crate::plan::{
-    DataSourceDesc, Explainee, MutationKind, Plan, SideEffectingFunc, SourceSinkClusterConfig,
-    UpdatePrivilege,
+    DataSourceDesc, Explainee, MutationKind, Optimized, Plan, SideEffectingFunc,
+    SourceSinkClusterConfig, UpdatePrivilege,
 };
 use crate::session::user::{
     RoleMetadata, MZ_SUPPORT_ROLE_ID, MZ_SYSTEM_ROLE_ID, SUPPORT_USER, SYSTEM_USER,
@@ -292,7 +292,7 @@ pub fn check_plan(
     active_conns: &BTreeMap<u32, RoleId>,
     role_metadata: &RoleMetadata,
     session_vars: &SessionVars,
-    plan: &Plan,
+    plan: &Plan<Optimized>,
     target_cluster_id: Option<ClusterId>,
     resolved_ids: &ResolvedIds,
 ) -> Result<(), UnauthorizedError> {
@@ -322,7 +322,7 @@ pub fn is_rbac_enabled_for_session(system_vars: &SystemVars, session_vars: &Sess
 /// Generates all requirements needed to execute a given plan.
 fn generate_rbac_requirements(
     catalog: &impl SessionCatalog,
-    plan: &Plan,
+    plan: &Plan<Optimized>,
     active_conns: &BTreeMap<u32, RoleId>,
     target_cluster_id: Option<ClusterId>,
     role_id: RoleId,


### PR DESCRIPTION
See individual commit messages

### Motivation
This PR refactors existing code.

### Tips for reviewer
 - Hide whitespace
 - Review commit by commit

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
