### PR TITLE
Equivalence propagation

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -65,6 +65,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_comment": "true",
     "enable_disk_cluster_replicas": "true",
     "enable_eager_delta_joins": "true",
+    "enable_equivalence_propagation": "true",
     "enable_expressions_in_limit_syntax": "true",
     "enable_logical_compaction_window": "true",
     "enable_multi_worker_storage_persist_sink": "true",

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -155,35 +155,28 @@ where
 ///
 /// To add a new feature flag, do the following steps:
 ///
-/// 1. To make the flag available to all stages in our [`Optimize`] pipelines:
-///    1. Add the flag as an [`OptimizerConfig`] field.
+/// 1. To make the flag available to all stages in our [`Optimize`] pipelines
+///    and allow engineers to set a system-wide override:
+///    1. Add the flag to the `optimizer_feature_flags!(...)` macro call.
+///    2. Add the flag to the `feature_flags!(...)` macro call and extend the
+///       `From<&SystemVars>` implementation for [`OptimizerFeatures`].
 ///
-/// 2. To allow engineers to set a system-wide override for this feature flag:
-///    1. Add the flag to the `feature_flags!(...)` macro call.
-///    2. Extend the `From<&SystemVars>` implementation for [`OptimizerConfig`].
-///
-/// 3. To enable `EXPLAIN ... WITH(...)` overrides which will allow engineers to
+/// 2. To enable `EXPLAIN ... WITH(...)` overrides which will allow engineers to
 ///    inspect plan differences before deploying the optimizer changes:
-///    1. Add the flag as a [`mz_repr::explain::ExplainConfig`] field.
-///    2. Add the flag to the `ExplainPlanOptionName` definition.
-///    3. Add the flag to the `generate_extracted_config!(ExplainPlanOption,
+///    1. Add the flag to the `ExplainPlanOptionName` definition.
+///    2. Add the flag to the `generate_extracted_config!(ExplainPlanOption,
 ///       ...)` macro call.
-///    4. Extend the `TryFrom<ExplainPlanOptionExtracted>` implementation for
+///    3. Extend the `TryFrom<ExplainPlanOptionExtracted>` implementation for
 ///       [`mz_repr::explain::ExplainConfig`].
-///    5. Extend the `OverrideFrom<ExplainContext>` implementation for
-///       [`OptimizerConfig`].
 ///
-/// 4. To enable `CLUSTER ... FEATURES(...)` overrides which will allow
+/// 3. To enable `CLUSTER ... FEATURES(...)` overrides which will allow
 ///    engineers to experiment with runtime differences before deploying the
 ///    optimizer changes:
-///    1. Add the flag to the `optimizer_feature_flags!(...)` macro call.
-///    2. Add the flag to the `ClusterFeatureName` definition.
-///    3. Add the flag to the `generate_extracted_config!(ClusterFeature, ...)`
+///    1. Add the flag to the `ClusterFeatureName` definition.
+///    2. Add the flag to the `generate_extracted_config!(ClusterFeature, ...)`
 ///       macro call.
-///    4. Extend the `let optimizer_feature_overrides = ...` call in
+///    3. Extend the `let optimizer_feature_overrides = ...` call in
 ///       `plan_create_cluster`.
-///    4. Extend the `OverrideFrom<OptimizerFeatureOverrides>` implementation
-///       for [`OptimizerConfig`].
 #[derive(Clone, Debug)]
 pub struct OptimizerConfig {
     /// The mode in which the optimizer runs.

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -97,6 +97,8 @@ optimizer_feature_flags!({
     enable_consolidate_after_union_negate: bool,
     // Bound from `SystemVars::enable_eager_delta_joins`.
     enable_eager_delta_joins: bool,
+    // Enable the `EquivalencePropagation` transform in the optimizer.
+    enable_equivalence_propagation: bool,
     // Bound from `SystemVars::enable_new_outer_join_lowering`.
     enable_new_outer_join_lowering: bool,
     // Bound from `SystemVars::enable_reduce_mfp_fusion`.

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -138,6 +138,7 @@ End
 Endpoint
 Enforced
 Envelope
+Equivalence
 Error
 Escape
 Every
@@ -310,6 +311,7 @@ Primary
 Privatelink
 Privileges
 Progress
+Propagation
 Protobuf
 Protocol
 Publication

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3093,6 +3093,7 @@ pub enum ExplainPlanOptionName {
     ReoptimizeImportedViews,
     EnableNewOuterJoinLowering,
     EnableEagerDeltaJoins,
+    EnableEquivalencePropagation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1732,6 +1732,7 @@ pub enum ClusterFeatureName {
     ReoptimizeImportedViews,
     EnableNewOuterJoinLowering,
     EnableEagerDeltaJoins,
+    EnableEquivalencePropagation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3336,7 +3336,8 @@ generate_extracted_config!(
     ClusterFeature,
     (ReoptimizeImportedViews, Option<bool>, Default(None)),
     (EnableEagerDeltaJoins, Option<bool>, Default(None)),
-    (EnableNewOuterJoinLowering, Option<bool>, Default(None))
+    (EnableNewOuterJoinLowering, Option<bool>, Default(None)),
+    (EnableEquivalencePropagation, Option<bool>, Default(None))
 );
 
 pub fn plan_create_cluster(
@@ -3413,12 +3414,14 @@ pub fn plan_create_cluster(
             reoptimize_imported_views,
             enable_eager_delta_joins,
             enable_new_outer_join_lowering,
+            enable_equivalence_propagation,
             seen: _,
         } = ClusterFeatureExtracted::try_from(features)?;
         let optimizer_feature_overrides = OptimizerFeatureOverrides {
             reoptimize_imported_views,
             enable_eager_delta_joins,
             enable_new_outer_join_lowering,
+            enable_equivalence_propagation,
             ..Default::default()
         };
 

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -353,7 +353,8 @@ generate_extracted_config!(
     (Types, bool, Default(false)),
     (ReoptimizeImportedViews, Option<bool>, Default(None)),
     (EnableNewOuterJoinLowering, Option<bool>, Default(None)),
-    (EnableEagerDeltaJoins, Option<bool>, Default(None))
+    (EnableEagerDeltaJoins, Option<bool>, Default(None)),
+    (EnableEquivalencePropagation, Option<bool>, Default(None))
 );
 
 impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
@@ -395,6 +396,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
             types: v.types,
             features: OptimizerFeatureOverrides {
                 enable_eager_delta_joins: v.enable_eager_delta_joins,
+                enable_equivalence_propagation: v.enable_equivalence_propagation,
                 enable_new_outer_join_lowering: v.enable_new_outer_join_lowering,
                 reoptimize_imported_views: v.reoptimize_imported_views,
                 ..Default::default()

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2108,7 +2108,7 @@ feature_flags!(
     {
         name: enable_equivalence_propagation,
         desc: "Enable the EquivalencePropagation transform in the optimizer",
-        default: false,
+        default: true, // TODO(aalexandrov): revert this to false
         internal: true,
         enable_for_item_parsing: false,
     },

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2105,6 +2105,13 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_equivalence_propagation,
+        desc: "Enable the EquivalencePropagation transform in the optimizer",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {
@@ -2112,6 +2119,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
         Self {
             enable_consolidate_after_union_negate: vars.enable_consolidate_after_union_negate(),
             enable_eager_delta_joins: vars.enable_eager_delta_joins(),
+            enable_equivalence_propagation: vars.enable_equivalence_propagation(),
             enable_new_outer_join_lowering: vars.enable_new_outer_join_lowering(),
             enable_reduce_mfp_fusion: vars.enable_reduce_mfp_fusion(),
             persist_fast_path_limit: vars.persist_fast_path_limit(),

--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -9,6 +9,8 @@
 
 //! Traits and types for reusable expression analysis
 
+pub mod equivalences;
+
 use mz_expr::MirRelationExpr;
 
 pub use common::{Derived, DerivedBuilder, DerivedView};

--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -123,6 +123,7 @@ pub mod common {
     ///
     /// This is best thought of as a node in a tree rather
     #[allow(missing_debug_implementations)]
+    #[derive(Copy, Clone)]
     pub struct DerivedView<'a> {
         derived: &'a Derived,
         lower: usize,

--- a/src/transform/src/analysis/equivalences.rs
+++ b/src/transform/src/analysis/equivalences.rs
@@ -1,0 +1,560 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! An analysis that reports all known-equivalent expressions for each relation.
+//!
+//! Expressions are equivalent at a relation if they are certain to evaluate to
+//! the same `Datum` for all records in the relation.
+//!
+//! Equivalances are recorded in an `EquivalenceClasses`, which lists all known
+//! equivalences classes, each a list of equivalent expressions.
+
+use std::collections::BTreeMap;
+
+use mz_expr::{Id, MirRelationExpr, MirScalarExpr};
+use mz_repr::{ColumnType, Datum};
+
+use crate::analysis::Analysis;
+use crate::analysis::{Arity, RelationType};
+use crate::analysis::{Derived, DerivedBuilder};
+
+/// Pulls up and pushes down predicate information represented as equivalences
+#[derive(Debug, Default)]
+pub struct Equivalences;
+
+impl Analysis for Equivalences {
+    type Value = EquivalenceClasses;
+
+    fn announce_dependencies(builder: &mut DerivedBuilder) {
+        builder.require::<Arity>();
+        builder.require::<RelationType>(); // needed for expression reduction.
+    }
+
+    fn derive(expr: &MirRelationExpr, results: &[Self::Value], depends: &Derived) -> Self::Value {
+        let mut equivalences = match expr {
+            MirRelationExpr::Constant { rows, typ } => {
+                // Trawl `rows` for any constant information worth recording.
+                // Literal columns may be valuable; non-nullability could be too.
+                let mut equivalences = EquivalenceClasses::default();
+                if let Ok([(row, _cnt), rows @ ..]) = rows.as_deref() {
+                    // Vector of `Option<Datum>` which becomes `None` once a column has a second datum.
+                    let len = row.iter().count();
+                    let mut common = Vec::with_capacity(len);
+                    common.extend(row.iter().map(Some));
+
+                    for (row, _cnt) in rows.iter() {
+                        for (datum, common) in row.iter().zip(common.iter_mut()) {
+                            if Some(datum) != *common {
+                                *common = None;
+                            }
+                        }
+                    }
+                    for (index, common) in common.into_iter().enumerate() {
+                        if let Some(datum) = common {
+                            equivalences.classes.push(vec![
+                                MirScalarExpr::Column(index),
+                                MirScalarExpr::literal_ok(
+                                    datum,
+                                    typ.column_types[index].scalar_type.clone(),
+                                ),
+                            ]);
+                        }
+                    }
+                }
+                equivalences
+            }
+            MirRelationExpr::Get { id, .. } => {
+                let mut equivalences = EquivalenceClasses::default();
+                // Find local identifiers, but nothing for external identifiers.
+                if let Id::Local(id) = id {
+                    if let Some(offset) = depends.bindings().get(id) {
+                        // It is possible we have derived nothing for a recursive term
+                        if let Some(result) = results.get(*offset) {
+                            equivalences.clone_from(result);
+                        }
+                    }
+                }
+                equivalences
+            }
+            MirRelationExpr::Let { .. } => results.last().unwrap().clone(),
+            MirRelationExpr::LetRec { .. } => results.last().unwrap().clone(),
+            MirRelationExpr::Project { outputs, .. } => {
+                // restrict equivalences, and introduce equivalences for repeated outputs.
+                let mut equivalences = results.last().unwrap().clone();
+                equivalences.project(outputs.iter().cloned());
+                equivalences
+            }
+            MirRelationExpr::Map { scalars, .. } => {
+                // introduce equivalences for new columns and expressions that define them.
+                let mut equivalences = results.last().unwrap().clone();
+                let input_arity = depends.results::<Arity>().unwrap()[results.len() - 1];
+                for (pos, expr) in scalars.iter().enumerate() {
+                    equivalences
+                        .classes
+                        .push(vec![MirScalarExpr::Column(input_arity + pos), expr.clone()]);
+                }
+                equivalences
+            }
+            MirRelationExpr::FlatMap { .. } => results.last().unwrap().clone(),
+            MirRelationExpr::Filter { predicates, .. } => {
+                let mut equivalences = results.last().unwrap().clone();
+                let mut class = predicates.clone();
+                class.push(MirScalarExpr::literal_ok(
+                    Datum::True,
+                    mz_repr::ScalarType::Bool,
+                ));
+                equivalences.classes.push(class);
+                equivalences
+            }
+            MirRelationExpr::Join { equivalences, .. } => {
+                // Collect equivalences from all inputs;
+                let expr_index = results.len();
+                let mut children = depends
+                    .children_of_rev(expr_index, expr.children().count())
+                    .collect::<Vec<_>>();
+                children.reverse();
+
+                let arity = depends.results::<Arity>().unwrap();
+                let mut columns = 0;
+                let mut result = EquivalenceClasses::default();
+                for child in children.into_iter() {
+                    let input_arity = arity[child];
+                    let mut equivalences = results[child].clone();
+                    let permutation = (columns..(columns + input_arity)).collect::<Vec<_>>();
+                    equivalences.permute(&permutation);
+                    result.classes.extend(equivalences.classes);
+                    columns += input_arity;
+                }
+
+                // Fold join equivalences into our results.
+                result.classes.extend(equivalences.iter().cloned());
+                result
+            }
+            MirRelationExpr::Reduce {
+                group_key,
+                aggregates: _,
+                ..
+            } => {
+                let input_arity = depends.results::<Arity>().unwrap()[results.len() - 1];
+                let mut equivalences = results.last().unwrap().clone();
+                // Introduce keys column equivalences as a map, then project to them as a projection.
+                for (pos, expr) in group_key.iter().enumerate() {
+                    equivalences
+                        .classes
+                        .push(vec![MirScalarExpr::Column(input_arity + pos), expr.clone()]);
+                }
+                // TODO: MIN, MAX, ANY, ALL aggregates pass through all certain properties of their columns.
+                // They also pass through equivalences of them and other constant columns (e.g. key columns).
+                // However, it is not correct to simply project onto these columns, as relationships amongst
+                // aggregate columns may no longer be preserved. MAX(col) != MIN(col) even though col = col.
+                // TODO: COUNT ensures a non-null value.
+                equivalences.project(input_arity..(input_arity + group_key.len()));
+                equivalences
+            }
+            MirRelationExpr::TopK { .. } => results.last().unwrap().clone(),
+            MirRelationExpr::Negate { .. } => results.last().unwrap().clone(),
+            MirRelationExpr::Threshold { .. } => results.last().unwrap().clone(),
+            MirRelationExpr::Union { .. } => {
+                // TODO: `EquivalenceClasses::union` takes references, and we could probably skip much of this cloning.
+                let expr_index = results.len();
+                depends
+                    .children_of_rev(expr_index, expr.children().count())
+                    .map(|c| results[c].clone())
+                    .reduce(|e1, e2| e1.union(&e2))
+                    .unwrap()
+            }
+            MirRelationExpr::ArrangeBy { .. } => results.last().unwrap().clone(),
+        };
+
+        let expr_type = &depends.results::<RelationType>().unwrap()[results.len()];
+        equivalences.minimize(expr_type);
+        equivalences
+    }
+}
+
+/// A compact representation of classes of expressions that must be equivalent.
+///
+/// Each "class" contains a list of expressions, each of which must be `Eq::eq` equal.
+/// Ideally, the first element is the "simplest", e.g. a literal or column reference,
+/// and any other element of that list can be replaced by it.
+///
+/// The classes are meant to be minimized, with each expression as reduced as it can be,
+/// and all classes sharing an element merged.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug)]
+pub struct EquivalenceClasses {
+    /// Multiple lists of equivalent expressions, each representing an equivalence class.
+    ///
+    /// The first element should be the "canonical" simplest element, that any other element
+    /// can be replaced by.
+    /// These classes are unified whenever possible, to minimize the number of classes.
+    pub classes: Vec<Vec<MirScalarExpr>>,
+}
+
+impl EquivalenceClasses {
+    /// Update `self` to maintain the same equivalences which potentially reducing along `Ord::le`.
+    ///
+    /// Informally this means simplifying constraints, removing redundant constraints, and unifying equivalence classes.
+    pub fn minimize(&mut self, columns: &Option<Vec<ColumnType>>) {
+        // Repeatedly, we reduce each of the classes themselves, then unify the classes.
+        // This should strictly reduce complexity, and reach a fixed point.
+        // Ideally it is *confluent*, arriving at the same fixed point no matter the order of operations.
+
+        for class in self.classes.iter_mut() {
+            class.sort_by(|e1, e2| match (e1, e2) {
+                (MirScalarExpr::Literal(_, _), MirScalarExpr::Literal(_, _)) => e1.cmp(e2),
+                (MirScalarExpr::Literal(_, _), _) => std::cmp::Ordering::Less,
+                (_, MirScalarExpr::Literal(_, _)) => std::cmp::Ordering::Greater,
+                (x, y) => x.cmp(y),
+            });
+            class.dedup();
+        }
+        self.classes.retain(|c| c.len() > 1);
+        self.classes.sort();
+
+        // We continue as long as any simplification has occurred.
+        // An expression can be simplified, a duplication found, or two classes unified.
+        let mut complete = false;
+        while !complete {
+            // We are complete unless we experience an expression simplification, or an equivalence class unification.
+            complete = true;
+
+            // 0. Reduce each expression
+            if let Some(columns) = columns {
+                for class in self.classes.iter_mut() {
+                    for expr in class.iter_mut() {
+                        let prev_expr = expr.clone();
+                        expr.reduce(columns);
+                        if &prev_expr != expr {
+                            complete = false;
+                        }
+                    }
+                }
+            }
+
+            // 1. Reduce each class.
+            //    Each class can be reduced in the context of *other* classes, which are available for substitution.
+            for class_index in 0..self.classes.len() {
+                for index in 0..self.classes[class_index].len() {
+                    let mut cloned = self.classes[class_index][index].clone();
+                    // Use `reduce_child` rather than `reduce_expr` to avoid entire expression replacement.
+                    let reduced = self.reduce_child(&mut cloned);
+                    if reduced {
+                        self.classes[class_index][index] = cloned;
+                        complete = false;
+                    }
+                }
+            }
+
+            // 2. Unify classes.
+            //    If the same expression is in two classes, we can unify the classes.
+            //    This element may not be the representative.
+            //    TODO: If all lists are sorted, this could be a linear merge among all.
+            //          They stop being sorted as soon as we make any modification, though.
+            //          But, it would be a fast rejection when faced with lots of data.
+            for index1 in 0..self.classes.len() {
+                for index2 in 0..index1 {
+                    if self.classes[index1]
+                        .iter()
+                        .any(|x| self.classes[index2].iter().any(|y| x == y))
+                    {
+                        let prior = std::mem::take(&mut self.classes[index2]);
+                        self.classes[index1].extend(prior);
+                        complete = false;
+                    }
+                }
+            }
+
+            // 3. Identify idioms
+            //    E.g. If Eq(x, y) must be true, we can introduce classes `[x, y]` and `[true, Not(IsNull(x), Not(IsNull(y))]`.
+            let mut to_add = Vec::new();
+            for class in self.classes.iter_mut() {
+                if class.iter().any(|c| c.is_literal_true()) {
+                    for expr in class.iter() {
+                        if let MirScalarExpr::CallBinary {
+                            func: mz_expr::BinaryFunc::Eq,
+                            expr1,
+                            expr2,
+                        } = expr
+                        {
+                            to_add.push(vec![*expr1.clone(), *expr2.clone()]);
+                            to_add.push(vec![
+                                MirScalarExpr::literal_true(),
+                                expr1.clone().call_is_null().not(),
+                                expr2.clone().call_is_null().not(),
+                            ]);
+                        }
+                    }
+                    class.retain(|expr| {
+                        if let MirScalarExpr::CallBinary {
+                            func: mz_expr::BinaryFunc::Eq,
+                            expr1: _,
+                            expr2: _,
+                        } = expr
+                        {
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                }
+            }
+            self.classes.extend(to_add);
+
+            // Tidy up classes, restore representative.
+            for class in self.classes.iter_mut() {
+                // TODO: Ideally we put literals as representatives, to reduce dependencies on rows.
+                // It is important that this order be "by complexity", so that
+                class.sort_by(|e1, e2| match (e1, e2) {
+                    (MirScalarExpr::Literal(_, _), MirScalarExpr::Literal(_, _)) => e1.cmp(e2),
+                    (MirScalarExpr::Literal(_, _), _) => std::cmp::Ordering::Less,
+                    (_, MirScalarExpr::Literal(_, _)) => std::cmp::Ordering::Greater,
+                    (MirScalarExpr::Column(_), MirScalarExpr::Column(_)) => e1.cmp(e2),
+                    (MirScalarExpr::Column(_), _) => std::cmp::Ordering::Less,
+                    (_, MirScalarExpr::Column(_)) => std::cmp::Ordering::Greater,
+                    (x, y) => {
+                        // General expressions should be ordered by their size,
+                        // to ensure we only simplify expressions by substititution.
+                        let x_size = x.size();
+                        let y_size = y.size();
+                        if x_size == y_size {
+                            x.cmp(y)
+                        } else {
+                            x_size.cmp(&y_size)
+                        }
+                    }
+                });
+                class.dedup();
+            }
+
+            // Discard trivial equivalence classes.
+            self.classes.retain(|class| class.len() > 1);
+            self.classes.sort();
+        }
+    }
+
+    /// Produce the equivalences present in both inputs.
+    pub fn union(&self, other: &Self) -> Self {
+        // TODO: seems like this could be extended, with similar concepts to localization:
+        //       We may removed non-shared constraints, but ones that remain could take over
+        //       and substitute in to retain more equivalences.
+
+        // For each pair of equivalence clasess, their intersection.
+        let mut equivalences = EquivalenceClasses {
+            classes: Vec::new(),
+        };
+        for class1 in self.classes.iter() {
+            for class2 in other.classes.iter() {
+                let class = class1
+                    .iter()
+                    .filter(|e1| class2.iter().any(|e2| e1 == &e2))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if class.len() > 1 {
+                    equivalences.classes.push(class);
+                }
+            }
+        }
+        equivalences.minimize(&None);
+        equivalences
+    }
+
+    /// Permutes each expression, looking up each column reference in `permutation` and replacing with what it finds.
+    pub fn permute(&mut self, permutation: &[usize]) {
+        for class in self.classes.iter_mut() {
+            for expr in class.iter_mut() {
+                expr.permute(permutation);
+            }
+        }
+    }
+
+    /// Subject the constraints to the column projection, reworking and removing equivalences.
+    ///
+    /// This method should also introduce equivalences representing any repeated columns.
+    pub fn project<I>(&mut self, output_columns: I)
+    where
+        I: IntoIterator<Item = usize> + Clone,
+    {
+        // Retain the first instance of each column, and record subsequent instances as duplicates.
+        let mut dupes = Vec::new();
+        let mut remap = BTreeMap::default();
+        for (idx, col) in output_columns.into_iter().enumerate() {
+            if let Some(pos) = remap.get(&col) {
+                dupes.push((*pos, idx));
+            } else {
+                remap.insert(col, idx);
+            }
+        }
+
+        // Some expressions may be "localized" in that they only reference columns in `output_columns`.
+        // Many expressions may not be localized, but may reference canonical non-localized expressions
+        // for classes that contain a localized expression; in that case we can "backport" the localized
+        // expression to give expressions referencing the canonical expression a shot at localization.
+        //
+        // Expressions should only contain instances of canonical expressions, and so we shouldn't need
+        // to look any further than backporting those. Backporting should have the property that the simplest
+        // localized expression in each class does not contain any non-localized canonical expressions
+        // (as that would make it non-localized); our backporting of non-localized canonicals with localized
+        // expressions should never fire a second
+
+        // Let's say an expression is "localized" once we are able to rewrite its support in terms of `output_columns`.
+        // Not all expressions can be localized, although some of them may be equivalent to localized expressions.
+        // As we find localized expressions, we can replace uses of their equivalent representative with them,
+        // which may allow further expression localization.
+        // We continue the process until no further classes can be localized.
+
+        // A map from representatives to our first localization of their equivalence class.
+        let mut localized = false;
+        while !localized {
+            localized = true;
+            for class in self.classes.iter_mut() {
+                if !class[0].support().iter().all(|c| remap.contains_key(c)) {
+                    if let Some(pos) = class
+                        .iter()
+                        .position(|e| e.support().iter().all(|c| remap.contains_key(c)))
+                    {
+                        class.swap(0, pos);
+                        localized = false;
+                    }
+                }
+            }
+            // attempt to replace representatives with equivalent localizeable expressions.
+            for class_index in 0..self.classes.len() {
+                for index in 0..self.classes[class_index].len() {
+                    let mut cloned = self.classes[class_index][index].clone();
+                    // Use `reduce_child` rather than `reduce_expr` to avoid entire expression replacement.
+                    let reduced = self.reduce_child(&mut cloned);
+                    if reduced {
+                        self.classes[class_index][index] = cloned;
+                    }
+                }
+            }
+            // NB: Do *not* `self.minimize()`, as we are developing localizable rather than canonical representatives.
+        }
+
+        // Localize all localizable expressions and discard others.
+        for class in self.classes.iter_mut() {
+            class.retain(|e| e.support().iter().all(|c| remap.contains_key(c)));
+            for expr in class.iter_mut() {
+                expr.permute_map(&remap);
+            }
+        }
+        self.classes.retain(|c| c.len() > 1);
+        // If column repetitions, introduce them as equivalences.
+        // We introduce only the equivalence to the first occurrence, and rely on minimization to collect them.
+        for (col1, col2) in dupes {
+            self.classes.push(vec![
+                MirScalarExpr::Column(col1),
+                MirScalarExpr::Column(col2),
+            ]);
+        }
+        self.minimize(&None);
+    }
+
+    /// Perform any exact replacement for `expr`, report if it had an effect.
+    fn replace(&self, expr: &mut MirScalarExpr) -> bool {
+        for class in self.classes.iter() {
+            // TODO: If `class` is sorted We only need to iterate through "simpler" expressions;
+            // we can stop once x > expr.
+            // We need to be careful with that reasoning, as it interferes with self-improvement;
+            // if we are modifying `self` we must restore the invariant before relying on it again.
+            if class[1..].iter().any(|x| x == expr) {
+                expr.clone_from(&class[0]);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Perform any simplification, report if effective.
+    pub fn reduce_expr(&self, expr: &mut MirScalarExpr) -> bool {
+        let mut simplified = false;
+        simplified = simplified || self.reduce_child(expr);
+        simplified = simplified || self.replace(expr);
+        simplified
+    }
+
+    /// Perform any simplification on children, report if effective.
+    pub fn reduce_child(&self, expr: &mut MirScalarExpr) -> bool {
+        let mut simplified = false;
+        match expr {
+            MirScalarExpr::CallBinary { expr1, expr2, .. } => {
+                simplified = self.reduce_expr(expr1) || simplified;
+                simplified = self.reduce_expr(expr2) || simplified;
+            }
+            MirScalarExpr::CallUnary { expr, .. } => {
+                simplified = self.reduce_expr(expr) || simplified;
+            }
+            MirScalarExpr::CallVariadic { exprs, .. } => {
+                for expr in exprs.iter_mut() {
+                    simplified = self.reduce_expr(expr) || simplified;
+                }
+            }
+            MirScalarExpr::If { cond, then, els } => {
+                simplified = self.reduce_expr(cond) || simplified;
+                simplified = self.reduce_expr(then) || simplified;
+                simplified = self.reduce_expr(els) || simplified;
+            }
+            _ => {}
+        }
+        simplified
+    }
+
+    /// True if any equivalence class contains two distinct non-error literals.
+    pub fn unsatisfiable(&self) -> bool {
+        for class in self.classes.iter() {
+            let mut literal_ok = None;
+            for expr in class.iter() {
+                if let MirScalarExpr::Literal(Ok(row), _) = expr {
+                    if literal_ok.is_some() && literal_ok != Some(row) {
+                        return true;
+                    } else {
+                        literal_ok = Some(row);
+                    }
+                }
+            }
+        }
+        false
+    }
+}
+
+// fn preserves_equivalences(func: &AggregateFunc) -> bool {
+//     match func {
+//           AggregateFunc::MaxInt16
+//         | AggregateFunc::MaxInt32
+//         | AggregateFunc::MaxInt64
+//         | AggregateFunc::MaxUInt16
+//         | AggregateFunc::MaxUInt32
+//         | AggregateFunc::MaxUInt64
+//         | AggregateFunc::MaxMzTimestamp
+//         | AggregateFunc::MaxFloat32
+//         | AggregateFunc::MaxFloat64
+//         | AggregateFunc::MaxBool
+//         | AggregateFunc::MaxString
+//         | AggregateFunc::MaxDate
+//         | AggregateFunc::MaxTimestamp
+//         | AggregateFunc::MaxTimestampTz
+//         | AggregateFunc::MinInt16
+//         | AggregateFunc::MinInt32
+//         | AggregateFunc::MinInt64
+//         | AggregateFunc::MinUInt16
+//         | AggregateFunc::MinUInt32
+//         | AggregateFunc::MinUInt64
+//         | AggregateFunc::MinMzTimestamp
+//         | AggregateFunc::MinFloat32
+//         | AggregateFunc::MinFloat64
+//         | AggregateFunc::MinBool
+//         | AggregateFunc::MinString
+//         | AggregateFunc::MinDate
+//         | AggregateFunc::MinTimestamp
+//         | AggregateFunc::MinTimestampTz
+//         | AggregateFunc::Any
+//         | AggregateFunc::All => true,
+//         _ => false,
+//     }
+// }

--- a/src/transform/src/analysis/equivalences.rs
+++ b/src/transform/src/analysis/equivalences.rs
@@ -198,8 +198,10 @@ pub struct EquivalenceClasses {
 
 impl EquivalenceClasses {
     /// Sorts and deduplicates each class, and the classes themselves.
-    fn sort_dedup(&mut self) {
+    fn tidy(&mut self) {
         for class in self.classes.iter_mut() {
+            // Remove all literal errors, as they cannot be equated to other things.
+            class.retain(|e| !e.is_literal_err());
             class.sort_by(|e1, e2| match (e1, e2) {
                 (MirScalarExpr::Literal(_, _), MirScalarExpr::Literal(_, _)) => e1.cmp(e2),
                 (MirScalarExpr::Literal(_, _), _) => std::cmp::Ordering::Less,
@@ -233,7 +235,7 @@ impl EquivalenceClasses {
         // Repeatedly, we reduce each of the classes themselves, then unify the classes.
         // This should strictly reduce complexity, and reach a fixed point.
         // Ideally it is *confluent*, arriving at the same fixed point no matter the order of operations.
-        self.sort_dedup();
+        self.tidy();
 
         // We continue as long as any simplification has occurred.
         // An expression can be simplified, a duplication found, or two classes unified.
@@ -392,7 +394,7 @@ impl EquivalenceClasses {
         self.classes.extend(to_add);
 
         // Tidy up classes, restore representative.
-        self.sort_dedup();
+        self.tidy();
 
         stable
     }

--- a/src/transform/src/attribute/mod.rs
+++ b/src/transform/src/attribute/mod.rs
@@ -53,9 +53,7 @@ pub trait Attribute {
     fn handle_env_tasks(&mut self) {}
 
     /// The attribute ids of all other attributes that this attribute depends on.
-    fn add_dependencies(builder: &mut DerivedAttributesBuilder)
-    where
-        Self: Sized;
+    fn add_dependencies(builder: &mut DerivedAttributesBuilder);
 
     /// Attributes for each subexpression, visited in post-order.
     fn get_results(&self) -> &Vec<Self::Value>;

--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -1,0 +1,546 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Propagates expression equivalence from leaves to root, and back down again.
+//! 
+//! Expression equivalences are `MirScalarExpr` replacements by simpler expressions.
+//! These equivalences derive from
+//!   Filters:  predicates must evaluate to `Datum::True`.
+//!   Maps:     new columns equal the expressions that define them.
+//!   Joins:    equated columns must be equal.
+//!   Others:   lots of other predicates we might learn (range constraints on aggregates; non-negativity)
+//!
+//! From leaf to root the equivalences are *enforced*, and communicate that the expression will not produce rows that do not satisfy the equivalence.
+//! From root to leaf the equivalences are *advised*, and communicate that the expression may discard any outputs that do not satisfy the equivalence.
+//!
+//! Importantly, in descent the operator *may not* assume any equivalence filtering will be applied to its results.
+//! It cannot therefore produce rows it would otherwise not, even rows that do not satisfy the equivalence.
+//! Operators *may* introduce filtering in descent, and they must do so to take further advantage of the equivalences. 
+//!
+//! The subtlety is due to the expressions themselves causing the equivalences, and allowing more rows may invalidate equivalences.
+//! For example, we might learn that `Column(7)` equals `Literal(3)`, but must refrain from introducing that substitution in descent,
+//! because it is possible that the equivalence derives from restrictions in the expression we are visiting. Were we certain that the
+//! equivalence was independent of the expression (e.g. through a more nuanced expression traversal) we could imaging relaxing this.
+
+use std::collections::BTreeMap;
+
+use mz_expr::{Id, MirRelationExpr, MirScalarExpr};
+use mz_repr::Datum;
+
+use crate::{TransformCtx, TransformError};
+
+/// Pulls up and pushes down predicate information represented as equivalences
+#[derive(Debug, Default)]
+pub struct EquivalencePropagation;
+
+impl crate::Transform for EquivalencePropagation {
+    #[tracing::instrument(
+        target = "optimizer"
+        level = "trace",
+        skip_all,
+        fields(path.segment = "equivalence_propagation")
+    )]
+    fn transform(
+        &self,
+        relation: &mut MirRelationExpr,
+        _: &mut TransformCtx,
+    ) -> Result<(), TransformError> {
+        let mut empty = BTreeMap::new();
+        // let pre = relation.clone();
+        self.pull(relation, &mut empty);
+        mz_repr::explain::trace_plan(&*relation);
+        // if pre != *relation {
+        //     println!("PREV: {:?}", pre);
+        //     println!("NEXT: {:?}", relation);
+        // }
+        relation.typ();
+        Ok(())
+    }
+}
+
+impl EquivalencePropagation {
+
+    /// Returns equivalence classes that are ensured by `relation`.
+    pub fn pull(
+        &self,
+        relation: &mut MirRelationExpr,
+        get_equivalences: &mut BTreeMap<Id, EquivalenceClasses>,
+    ) -> EquivalenceClasses {
+        match relation {
+            MirRelationExpr::Constant { rows, typ } => {
+                // Trawl `rows` for any constant information worth recording.
+                // Literal columns may be valuable; non-nullability could be too.
+                let mut equivalences = EquivalenceClasses::default();
+                if let Ok([(row, _cnt), rows @ ..]) = rows.as_deref() {
+                    // Vector of `Option<Datum>` which becomes `None` once a column has a second datum.
+                    let len = row.iter().count();
+                    let mut common = Vec::with_capacity(len);
+                    common.extend(row.iter().map(|d| Some(d)));
+
+                    for (row, _cnt) in rows.iter() {
+                        for (datum, common) in row.iter().zip(common.iter_mut()) {
+                            if Some(datum) != *common {
+                                *common = None;
+                            }
+                        }
+                    }
+                    for (index, common) in common.into_iter().enumerate() {
+                        if let Some(datum) = common {
+                            equivalences.classes.push(vec![
+                                MirScalarExpr::Column(index), 
+                                MirScalarExpr::literal_ok(datum, typ.column_types[index].scalar_type.clone())
+                            ]);
+                        }
+                    }
+                }
+                equivalences.minimize();
+                equivalences
+            }
+            MirRelationExpr::Get { id, .. } => {
+                // Find local identifiers, but nothing for external identifiers.
+                if let Some(equivalences) = get_equivalences.get(id) {
+                    equivalences.clone()
+                } else {
+                    EquivalenceClasses::default()
+                }
+            }
+            MirRelationExpr::Let { id, body, value } => {
+                // Determine any equivalences for `value`, then use in `body`.
+                let value_equivalences = self.pull(value, get_equivalences);
+                get_equivalences.insert(Id::Local(*id), value_equivalences);
+                self.pull(body, get_equivalences)
+            }
+            MirRelationExpr::LetRec {
+                ids,
+                values,
+                limits: _,
+                body,
+            } => {
+                // Start with trivial (empty) equivalence classes for each identifier.
+                get_equivalences.extend(ids.iter().map(|id| (Id::Local(*id), EquivalenceClasses::default())));
+
+                // It is inappropriate to iterate through a method that may mutate operators,
+                // as the mutation may invalidate its enforcement. If we install equivalence
+                // enforces atop each `Let` binding, and ensure they advance monotonically, 
+                // this might be fine. 
+
+                // let mut improvement = true;
+                // while improvement {
+                //     improvement = false;
+                    for (id, value) in ids.iter().zip(values) {
+                        let value_equivalences = self.pull(value, get_equivalences);
+                        if get_equivalences[&Id::Local(*id)] != value_equivalences {
+                            get_equivalences.insert(Id::Local(*id), value_equivalences);
+                            // improvement = true;
+                        }
+                    }
+                // }
+
+                self.pull(body, get_equivalences)
+            }
+            MirRelationExpr::Project { input, outputs } => { 
+                // restrict equivalences, and introduce equivalences for repeated outputs.
+                let mut equivalences = self.pull(input, get_equivalences);
+                equivalences.project(outputs);
+                equivalences
+            }
+            MirRelationExpr::Map { input, scalars } => { 
+                // introduce equivalences for new columns and expressions that define them.
+                let mut equivalences = self.pull(input, get_equivalences);
+                // Reduce `scalars` based on the promises of `input` equivalences.
+                for expr in scalars.iter_mut() {
+                    equivalences.reduce_expr(expr);
+                }
+
+                let input_arity = input.arity();
+                for (pos, expr) in scalars.iter().enumerate() {
+                    equivalences.classes.push(vec![MirScalarExpr::Column(input_arity + pos), expr.clone()]);
+                }
+                equivalences.minimize();
+                equivalences
+            }
+            MirRelationExpr::FlatMap { input, exprs, .. } => { 
+                // not sure we can do anything here.
+                let equivalences = self.pull(input, get_equivalences);
+                for expr in exprs.iter_mut() {
+                    equivalences.reduce_expr(expr);
+                }
+                equivalences
+            }
+            MirRelationExpr::Filter { input, predicates } => { 
+                let mut equivalences = self.pull(input, get_equivalences);
+                // Reduce `predicates` based on the promises of `input` equivalences.
+                for expr in predicates.iter_mut() {
+                    equivalences.reduce_expr(expr);
+                }
+                predicates.sort();
+                predicates.dedup();
+                // TODO: further simplify `predicates`
+                // introduce equivalences to `Datum::True`.
+                let mut class = predicates.clone();
+                class.push(MirScalarExpr::literal_ok(Datum::True, mz_repr::ScalarType::Bool));
+                equivalences.classes.push(class);
+                equivalences.minimize();
+                equivalences
+            }
+
+            MirRelationExpr::Join {
+                inputs,
+                equivalences,
+                ..
+            } => {
+                // Collect equivalences from all inputs;
+                let mut columns = 0;
+                let mut result = EquivalenceClasses::default();
+                for input in inputs.iter_mut() {
+                    let input_arity = input.arity();
+                    let mut equivalences = self.pull(input, get_equivalences);
+                    let permutation = (columns .. (columns + input_arity)).collect::<Vec<_>>();
+                    equivalences.permute(&permutation);
+                    result.classes.extend(equivalences.classes);
+                    columns += input_arity;
+                }
+
+                // We can apply the equivalences to the join equivalences.
+                // This is acceptable to do, but it is perhaps harmful, in that we may remove
+                // valuable signals for what we must join on. E.g. if we simplify `Col(3)` to `Col(1)`,
+                // without introducing their equivalence as a constraint, we may miss an index on `Col(3)`
+                // and instead build one on `Col(1)`.
+                for class in equivalences.iter_mut() {
+                    for expr in class.iter_mut() {
+                        result.reduce_expr(expr);
+                    }
+                }
+                // We could plausibly *introduce* the equivalences to the join equivalences,
+                // but this has the potential to introduce work we are not compelled to perform,
+                // for uncertain benefit. We should always be able to re-derive the equivalences,
+                // and optimize them away, in the future if we do insert them here.
+
+                // Fold join equivalences into our results.
+                result.classes.extend(equivalences.iter().cloned());
+                result.minimize();
+
+                // TODO: This is an opportunity to press what we know now back to children.
+                //       Ideally we would do it in combination with information from parents.
+
+                result
+            }
+            MirRelationExpr::Reduce { input, group_key, aggregates, .. } => {
+                let mut equivalences = self.pull(input, get_equivalences);
+                // Reduce group key and aggregate expressions based on promises of `input` equivalences.
+                for expr in group_key.iter_mut() {
+                    equivalences.reduce_expr(expr);
+                }
+                for aggr in aggregates.iter_mut() {
+                    equivalences.reduce_expr(&mut aggr.expr);
+                }
+                // Introduce keys column equivalences as a map, then project to them as a projection.
+                let input_arity = input.arity();
+                for (pos, expr) in group_key.iter().enumerate() {
+                    equivalences.classes.push(vec![MirScalarExpr::Column(input_arity + pos), expr.clone()]);
+                }
+                equivalences.minimize();
+                let outputs = (input_arity .. (input_arity + group_key.len())).collect::<Vec<_>>();
+                equivalences.project(&outputs[..]);
+
+                // TODO: There are cases where equivalences can make their way through,
+                //       such as `MIN`, `MAX`, `ANY`, `ALL` aggregates that surface columns.
+
+                equivalences
+            }
+            MirRelationExpr::TopK { input, .. } => {
+                // Nothing to do.
+                self.pull(input, get_equivalences)
+            }
+            MirRelationExpr::Negate { input } => {
+                // Nothing to do.
+                self.pull(input, get_equivalences)
+            }
+            MirRelationExpr::Threshold { input } => {
+                // Nothing to do.
+                self.pull(input, get_equivalences)
+            }
+            MirRelationExpr::Union { base, inputs } => {
+                // Restrict equivalences to those common in all inputs.
+                let mut equivalences = self.pull(base, get_equivalences);
+                for input in inputs.iter_mut() {
+                    equivalences = equivalences.union(&self.pull(input, get_equivalences))
+                }
+                equivalences
+            }
+            MirRelationExpr::ArrangeBy { input, .. } => {
+                // Nothing to do.
+                self.pull(input, get_equivalences)
+            }
+        } 
+    }
+
+    // /// Impresses upon `relation` equivalences that can further restrict the records `relation` produces.
+    // ///
+    // /// These equivalences are not *enforced* atop `relation`, and it is incorrect for `relation` to emit 
+    // /// additional records under the premise that they will be filtered out (they may not be). However, if
+    // /// `relation` fails to produce any records that do not satisfy these equivalences, the ultimate results
+    // /// will remain correct.
+    // ///
+    // /// Essentially, `relation` may optionally install a `Filter` containing any subset of these equivalences.
+    // /// If this improves a `Join` by providing more equivalences, great! If this allows additional predicate 
+    // /// pushdown through a `Let` binding, great!
+    // pub fn push(
+    //     &self,
+    //     relation: &mut MirRelationExpr,
+    //     outer_equivalences: EquivalenceClasses,
+    //     get_equivalences: &mut BTreeMap<Id, EquivalenceClasses>,
+    // ) {
+    // }
+}
+
+/// A compact representation of classes of expressions that must be equivalent.
+///
+/// Each "class" contains a list of expressions, each of which must be `Eq::eq` equal.
+/// Ideally, the first element is the "simplest", e.g. a literal or column reference, 
+/// and any other element of that list can be replaced by it.
+///
+/// The classes are meant to be minimized, with each expression as reduced as it can be,
+/// and all classes sharing an element merged.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug)]
+pub struct EquivalenceClasses {
+    /// Multiple lists of equivalent expressions, each representing an equivalence class.
+    ///
+    /// The first element should be the "canonical" simplest element, that any other element
+    /// can be replaced by. 
+    /// These classes are unified whenever possible, to minimize the number of classes.
+    classes: Vec<Vec<MirScalarExpr>>,
+}
+
+impl EquivalenceClasses {
+    /// Update `self` to maintain the same equivalences which potentially reducing along `Ord::le`.
+    /// 
+    /// Informally this means simplifying constraints, removing redundant constraints, and unifying equivalence classes.
+    fn minimize(&mut self) {
+        // Repeatedly, we reduce each of the classes themselves, then unify the classes.
+        // This should strictly reduce complexity, and reach a fixed point.
+        // Ideally it is *confluent*, arriving at the same fixed point no matter the order of operations.
+
+        for class in self.classes.iter_mut() {
+            class.sort_by(|e1,e2| {
+                match (e1, e2) {
+                    (MirScalarExpr::Literal(_,_), MirScalarExpr::Literal(_,_)) => e1.cmp(e2),
+                    (MirScalarExpr::Literal(_,_), _) => std::cmp::Ordering::Less,
+                    (_, MirScalarExpr::Literal(_,_)) => std::cmp::Ordering::Greater,
+                    (x, y) => x.cmp(y),
+                }
+            });
+            class.dedup();
+        }
+        self.classes.retain(|c| c.len() > 1);
+        self.classes.sort();
+
+        // We continue as long as any simplification has occurred.
+        // An expression can be simplified, a duplication found, or two classes unified.
+        let mut complete = false;
+        while !complete {
+            // We are complete unless we experience an expression simplification, or an equivalence class unification.
+            complete = true;
+
+            // 1. Reduce each class.
+            //    Each class can be reduced in the context of *other* classes, which are available for substitution.
+            for class_index in 0 .. self.classes.len() {
+                for index in 0 .. self.classes[class_index].len() {
+                    let mut cloned = self.classes[class_index][index].clone();
+                    // Use `reduce_child` rather than `reduce_expr` to avoid entire expression replacement.
+                    let reduced = self.reduce_child(&mut cloned);
+                    if reduced {
+                        self.classes[class_index][index] = cloned;
+                        complete = false;
+                    }
+                }
+            }
+
+            // 2. Unify classes.
+            //    If the same expression is in two classes, we can unify the classes.
+            //    This element may not be the representative.
+            //    TODO: If all lists are sorted, this could be a linear merge among all.
+            //          They stop being sorted as soon as we make any modification, though.
+            //          But, it would be a fast rejection when faced with lots of data.
+            for index1 in 0 .. self.classes.len() {
+                for index2 in 0 .. index1 {
+                    if self.classes[index1].iter().any(|x| self.classes[index2].iter().any(|y| x == y)) {
+                        let prior = std::mem::take(&mut self.classes[index2]);
+                        self.classes[index1].extend(prior);
+                        complete = false;
+                    }
+                }
+            }
+
+            // Tidy up classes, restore representative.
+            for class in self.classes.iter_mut() {
+                // TODO: Ideally we put literals as representatives, to reduce dependencies on rows.
+                class.sort_by(|e1,e2| {
+                    match (e1, e2) {
+                        (MirScalarExpr::Literal(_,_), MirScalarExpr::Literal(_,_)) => e1.cmp(e2),
+                        (MirScalarExpr::Literal(_,_), _) => std::cmp::Ordering::Less,
+                        (_, MirScalarExpr::Literal(_,_)) => std::cmp::Ordering::Greater,
+                        (x, y) => x.cmp(y),
+                    }
+                });
+                class.dedup();
+            }
+
+            // Discard trivial equivalence classes.
+            self.classes.retain(|class| class.len() > 1);
+            self.classes.sort();
+        }
+    }
+
+    /// Produce the equivalences present in both inputs.
+    fn union(&self, other: &Self) -> Self {
+
+        // TODO: seems like this could be extended, with similar concepts to localization:
+        //       We may removed non-shared constraints, but ones that remain could take over
+        //       and substitute in to retain more equivalences.
+
+        // For each pair of equivalence clasess, their intersection.
+        let mut equivalences = EquivalenceClasses { classes: Vec::new() };
+        for class1 in self.classes.iter() {
+            for class2 in other.classes.iter() {
+                let class = class1.iter().filter(|e1| class2.iter().any(|e2| e1 == &e2)).cloned().collect::<Vec<_>>();
+                if class.len() > 1 {
+                    equivalences.classes.push(class);
+                }
+            }
+        }
+        equivalences.minimize();
+        equivalences
+    }
+
+    fn permute(&mut self, permutation: &[usize]) {
+        for class in self.classes.iter_mut() {
+            for expr in class.iter_mut() {
+                expr.permute(permutation);
+            }
+        }
+    }
+
+    /// Subject the constraints to the column projection, reworking and removing equivalences.
+    ///
+    /// This method should also introduce equivalences representing any repeated columns.
+    fn project(&mut self, output_columns: &[usize]) {
+        let remap = output_columns.iter().enumerate().map(|(idx, col)| (*col, idx)).collect::<BTreeMap<_,_>>();
+
+        // Some expressions may be "localized" in that they only reference columns in `output_columns`.
+        // Many expressions may not be localized, but may reference canonical non-localized expressions 
+        // for classes that contain a localized expression; in that case we can "backport" the localized 
+        // expression to give expressions referencing the canonical expression a shot at localization.
+        //
+        // Expressions should only contain instances of canonical expressions, and so we shouldn't need
+        // to look any further than backporting those. Backporting should have the property that the simplest 
+        // localized expression in each class does not contain any non-localized canonical expressions 
+        // (as that would make it non-localized); our backporting of non-localized canonicals with localized
+        // expressions should never fire a second 
+        
+        // Let's say an expression is "localized" once we are able to rewrite its support in terms of `output_columns`.
+        // Not all expressions can be localized, although some of them may be equivalent to localized expressions.
+        // As we find localized expressions, we can replace uses of their equivalent representative with them, 
+        // which may allow further expression localization. 
+        // We continue the process until no further classes can be localized.
+
+        // A map from representatives to our first localization of their equivalence class.
+        let mut localized = false;
+        while !localized {
+            localized = true;
+            for class in self.classes.iter_mut() {
+                if !class[0].support().iter().all(|c| output_columns.contains(c)) {
+                    if let Some(pos) = class.iter().position(|e| e.support().iter().all(|c| output_columns.contains(c))) {
+                        class.swap(0, pos);
+                        localized = false;
+                    }
+                }
+            }
+            // attempt to replace representatives with equivalent localizeable expressions.
+            for class_index in 0 .. self.classes.len() {
+                for index in 0 .. self.classes[class_index].len() {
+                    let mut cloned = self.classes[class_index][index].clone();
+                    // Use `reduce_child` rather than `reduce_expr` to avoid entire expression replacement.
+                    let reduced = self.reduce_child(&mut cloned);
+                    if reduced {
+                        self.classes[class_index][index] = cloned;
+                    }
+                }
+            }
+            // NB: Do *not* `self.minimize()`, as we are developing localizable rather than canonical representatives.
+        }
+
+        // Localize all localizable expressions and discard others.
+        for class in self.classes.iter_mut() {
+            class.retain(|e| e.support().iter().all(|c| output_columns.contains(c)));
+            for expr in class.iter_mut() {
+                expr.permute_map(&remap);
+            }
+        }
+        self.classes.retain(|c| c.len() > 1);
+        // If column repetitions, introduce them as equivalences.
+        // We introduce only the equivalence to the first occurrence, and rely on minimization to collect them.
+        for c in 0 .. output_columns.len() {
+            if let Some(pos) = output_columns[..c].iter().position(|x| x == &output_columns[c]) {
+                self.classes.push(vec![MirScalarExpr::Column(pos), MirScalarExpr::Column(c)]);
+            }
+        }
+
+        self.minimize();
+    }
+
+    /// Perform any exact replacement for `expr`, report if it had an effect.
+    fn replace(&self, expr: &mut MirScalarExpr) -> bool {
+        for class in self.classes.iter() {
+            // TODO: If `class` is sorted We only need to iterate through "simpler" expressions;
+            // we can stop once x > expr.
+            // We need to be careful with that reasoning, as it interferes with self-improvement;
+            // if we are modifying `self` we must restore the invariant before relying on it again.
+            if class[1..].iter().any(|x| x == expr) {
+                expr.clone_from(&class[0]);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Perform any simplification, report if effective.
+    fn reduce_expr(&self, expr: &mut MirScalarExpr) -> bool {
+        let mut simplified = false;
+        simplified = simplified || self.reduce_child(expr);
+        simplified = simplified || self.replace(expr);
+        simplified
+    }
+    
+    /// Perform any simplification on children, report if effective.
+    fn reduce_child(&self, expr: &mut MirScalarExpr) -> bool {
+        let mut simplified = false;
+        match expr {
+            MirScalarExpr::CallBinary { expr1, expr2, .. } => {
+                simplified = self.reduce_expr(expr1) || simplified;
+                simplified = self.reduce_expr(expr2) || simplified;
+            }
+            MirScalarExpr::CallUnary { expr, .. } => {
+                simplified = self.reduce_expr(expr) || simplified;
+            }
+            MirScalarExpr::CallVariadic { exprs, .. } => {
+                for expr in exprs.iter_mut() {
+                    simplified = self.reduce_expr(expr) || simplified;
+                }
+            }
+            MirScalarExpr::If { cond, then, els} => {
+                simplified = self.reduce_expr(cond) || simplified;
+                simplified = self.reduce_expr(then) || simplified;
+                simplified = self.reduce_expr(els) || simplified;
+            }
+            _ => { }
+        }
+        simplified
+    }
+}

--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 //! Propagates expression equivalence from leaves to root, and back down again.
-//! 
+//!
 //! Expression equivalences are `MirScalarExpr` replacements by simpler expressions.
 //! These equivalences derive from
 //!   Filters:  predicates must evaluate to `Datum::True`.
@@ -21,7 +21,7 @@
 //!
 //! Importantly, in descent the operator *may not* assume any equivalence filtering will be applied to its results.
 //! It cannot therefore produce rows it would otherwise not, even rows that do not satisfy the equivalence.
-//! Operators *may* introduce filtering in descent, and they must do so to take further advantage of the equivalences. 
+//! Operators *may* introduce filtering in descent, and they must do so to take further advantage of the equivalences.
 //!
 //! The subtlety is due to the expressions themselves causing the equivalences, and allowing more rows may invalidate equivalences.
 //! For example, we might learn that `Column(7)` equals `Literal(3)`, but must refrain from introducing that substitution in descent,
@@ -32,6 +32,9 @@ use std::collections::BTreeMap;
 
 use mz_expr::{Id, MirRelationExpr, MirScalarExpr};
 use mz_repr::Datum;
+
+use crate::analysis::equivalences::{EquivalenceClasses, Equivalences};
+use crate::analysis::{Arity, Derived, RelationType, SubtreeSize};
 
 use crate::{TransformCtx, TransformError};
 
@@ -51,143 +54,208 @@ impl crate::Transform for EquivalencePropagation {
         relation: &mut MirRelationExpr,
         _: &mut TransformCtx,
     ) -> Result<(), TransformError> {
-        let mut empty = BTreeMap::new();
-        // let pre = relation.clone();
-        self.pull(relation, &mut empty);
+        // Perform bottom-up equivalence class analysis.
+        use crate::analysis::DerivedBuilder;
+        let mut builder = DerivedBuilder::default();
+        builder.require::<Equivalences>();
+        let derived = builder.visit(relation);
+
+        let relation_index = derived.results::<Equivalences>().unwrap().len() - 1;
+        let mut get_equivalences = BTreeMap::default();
+        self.apply(
+            relation,
+            relation_index,
+            &derived,
+            EquivalenceClasses::default(),
+            &mut get_equivalences,
+        );
+
         mz_repr::explain::trace_plan(&*relation);
-        // if pre != *relation {
-        //     println!("PREV: {:?}", pre);
-        //     println!("NEXT: {:?}", relation);
-        // }
-        relation.typ();
         Ok(())
     }
 }
 
 impl EquivalencePropagation {
-
-    /// Returns equivalence classes that are ensured by `relation`.
-    pub fn pull(
+    /// Provides the opportunity to mutate `relation` in response to equivalences enforced by others.
+    ///
+    /// Provides the opportunity to mutate `relation` in response to equivalences enforced by their children,
+    /// as presented in `derived`, and equivalences enforced of their output (by their ancestors), as presented
+    /// in `outer_equivalences` and `get_equivalences`.
+    ///
+    /// The mutations should never invalidate an equivalence the operator has been reported as providing, as that
+    /// information may have already been acted upon by others.
+    ///
+    /// The `expr_index` argument must equal `expr`s position in post-order, so that it can be used as a reference
+    /// into `derived`. The argument can be used with the `SubtreeSize` analysis to determine the range of values
+    /// associated with `expr`.
+    ///
+    /// After the call, `get_equivalences` will be populated with certainly equivalences that will be certainly
+    /// enforced for all uses of each identifier. The information can be harvested and propagated to the definitions
+    /// of those identifiers.
+    pub fn apply(
         &self,
-        relation: &mut MirRelationExpr,
+        expr: &mut MirRelationExpr,
+        expr_index: usize,
+        derived: &Derived,
+        mut outer_equivalences: EquivalenceClasses,
         get_equivalences: &mut BTreeMap<Id, EquivalenceClasses>,
-    ) -> EquivalenceClasses {
-        match relation {
-            MirRelationExpr::Constant { rows, typ } => {
-                // Trawl `rows` for any constant information worth recording.
-                // Literal columns may be valuable; non-nullability could be too.
-                let mut equivalences = EquivalenceClasses::default();
-                if let Ok([(row, _cnt), rows @ ..]) = rows.as_deref() {
-                    // Vector of `Option<Datum>` which becomes `None` once a column has a second datum.
-                    let len = row.iter().count();
-                    let mut common = Vec::with_capacity(len);
-                    common.extend(row.iter().map(|d| Some(d)));
+    ) {
+        // TODO: The top-down traversal can be coded as a worklist, with arguments tupled and enqueued.
+        // This has the potential to do a lot more cloning (of `outer_equivalences`), and some care is needed
+        // for `get_equivalences` which would be scoped to the whole method rather than tupled and enqueued.
 
-                    for (row, _cnt) in rows.iter() {
-                        for (datum, common) in row.iter().zip(common.iter_mut()) {
-                            if Some(datum) != *common {
-                                *common = None;
+        let subtrees = derived.results::<SubtreeSize>().unwrap();
+        let derived_types = derived.results::<RelationType>().unwrap();
+        let derived_equivalences = derived.results::<Equivalences>().unwrap();
+
+        // Optimize `outer_equivalences` in the context of `derived_equivalences[expr_index]`.
+        // If it ends up unsatisfiable, we can replace `expr` with an empty constant of the same relation type.
+        let expr_equivalences = &derived_equivalences[expr_index];
+        for class in outer_equivalences.classes.iter_mut() {
+            for expr in class.iter_mut() {
+                expr_equivalences.reduce_expr(expr);
+            }
+        }
+
+        outer_equivalences.minimize(&derived_types[expr_index]);
+        if outer_equivalences.unsatisfiable() {
+            expr.take_safely();
+            return;
+        }
+
+        match expr {
+            MirRelationExpr::Constant { rows, typ: _ } => {
+                if let Ok(rows) = rows {
+                    let mut datum_vec = mz_repr::DatumVec::new();
+                    // Delete any rows that violate the equivalences.
+                    // Do not delete rows that produce errors, as they are semantically important.
+                    rows.retain(|(row, _count)| {
+                        let temp_storage = mz_repr::RowArena::new();
+                        let datums = datum_vec.borrow_with(row);
+                        outer_equivalences.classes.iter().all(|class| {
+                            // Any subset of `Ok` results must equate, or we can drop the row.
+                            let mut oks = class
+                                .iter()
+                                .filter_map(|e| e.eval(&datums[..], &temp_storage).ok());
+                            if let Some(e1) = oks.next() {
+                                oks.all(|e2| e1 == e2)
+                            } else {
+                                true
                             }
-                        }
-                    }
-                    for (index, common) in common.into_iter().enumerate() {
-                        if let Some(datum) = common {
-                            equivalences.classes.push(vec![
-                                MirScalarExpr::Column(index), 
-                                MirScalarExpr::literal_ok(datum, typ.column_types[index].scalar_type.clone())
-                            ]);
-                        }
-                    }
+                        })
+                    });
                 }
-                equivalences.minimize();
-                equivalences
             }
             MirRelationExpr::Get { id, .. } => {
-                // Find local identifiers, but nothing for external identifiers.
-                if let Some(equivalences) = get_equivalences.get(id) {
-                    equivalences.clone()
+                // Install and intersect with other equivalences from other `Get` sites.
+                if let Some(equivs) = get_equivalences.get_mut(id) {
+                    *equivs = equivs.union(&outer_equivalences);
                 } else {
-                    EquivalenceClasses::default()
+                    get_equivalences.insert(*id, outer_equivalences);
                 }
             }
-            MirRelationExpr::Let { id, body, value } => {
-                // Determine any equivalences for `value`, then use in `body`.
-                let value_equivalences = self.pull(value, get_equivalences);
-                get_equivalences.insert(Id::Local(*id), value_equivalences);
-                self.pull(body, get_equivalences)
+            MirRelationExpr::Let { id, value, body } => {
+                // Traverse `body` first to assemble equivalences to push to `value`.
+                // Descend without a key for `id`, treating the absence as the identity for union.
+                // `Get` nodes with identifier `id` will populate the equivalence classes with the intersection of their guarantees.
+                self.apply(
+                    body,
+                    expr_index - 1,
+                    derived,
+                    outer_equivalences.clone(),
+                    get_equivalences,
+                );
+                // We expect to find `id` in `get_equivalences`, as otherwise the binding is
+                // not referenced and can be removed.
+                if let Some(equivalences) = get_equivalences.get(&Id::Local(*id)) {
+                    let value_index = expr_index - 1 - subtrees[expr_index - 1];
+                    self.apply(
+                        value,
+                        value_index,
+                        derived,
+                        equivalences.clone(),
+                        get_equivalences,
+                    );
+                }
             }
-            MirRelationExpr::LetRec {
-                ids,
-                values,
-                limits: _,
-                body,
-            } => {
-                // Start with trivial (empty) equivalence classes for each identifier.
-                get_equivalences.extend(ids.iter().map(|id| (Id::Local(*id), EquivalenceClasses::default())));
-
-                // It is inappropriate to iterate through a method that may mutate operators,
-                // as the mutation may invalidate its enforcement. If we install equivalence
-                // enforces atop each `Let` binding, and ensure they advance monotonically, 
-                // this might be fine. 
-
-                // let mut improvement = true;
-                // while improvement {
-                //     improvement = false;
-                    for (id, value) in ids.iter().zip(values) {
-                        let value_equivalences = self.pull(value, get_equivalences);
-                        if get_equivalences[&Id::Local(*id)] != value_equivalences {
-                            get_equivalences.insert(Id::Local(*id), value_equivalences);
-                            // improvement = true;
-                        }
-                    }
-                // }
-
-                self.pull(body, get_equivalences)
+            MirRelationExpr::LetRec { body, .. } => {
+                // Only descend into `body` without more careful analysis.
+                // We could determine non-recursive bindings, for example, and process them.
+                self.apply(
+                    body,
+                    expr_index - 1,
+                    derived,
+                    outer_equivalences,
+                    get_equivalences,
+                );
             }
-            MirRelationExpr::Project { input, outputs } => { 
-                // restrict equivalences, and introduce equivalences for repeated outputs.
-                let mut equivalences = self.pull(input, get_equivalences);
-                equivalences.project(outputs);
-                equivalences
+            MirRelationExpr::Project { input, outputs } => {
+                // Transform `outer_equivalences` to one relevant for `input`.
+                outer_equivalences.permute(outputs);
+                self.apply(
+                    input,
+                    expr_index - 1,
+                    derived,
+                    outer_equivalences,
+                    get_equivalences,
+                );
             }
-            MirRelationExpr::Map { input, scalars } => { 
-                // introduce equivalences for new columns and expressions that define them.
-                let mut equivalences = self.pull(input, get_equivalences);
-                // Reduce `scalars` based on the promises of `input` equivalences.
+            MirRelationExpr::Map { input, scalars } => {
+                // Optimize `scalars` with respect to input equivalences.
+                let input_equivalences = &derived_equivalences[expr_index - 1];
                 for expr in scalars.iter_mut() {
-                    equivalences.reduce_expr(expr);
+                    input_equivalences.reduce_expr(expr);
                 }
-
-                let input_arity = input.arity();
-                for (pos, expr) in scalars.iter().enumerate() {
-                    equivalences.classes.push(vec![MirScalarExpr::Column(input_arity + pos), expr.clone()]);
-                }
-                equivalences.minimize();
-                equivalences
+                let input_arity = derived.results::<Arity>().unwrap()[expr_index - 1];
+                outer_equivalences.project(0..input_arity);
+                self.apply(
+                    input,
+                    expr_index - 1,
+                    derived,
+                    outer_equivalences,
+                    get_equivalences,
+                );
             }
-            MirRelationExpr::FlatMap { input, exprs, .. } => { 
-                // not sure we can do anything here.
-                let equivalences = self.pull(input, get_equivalences);
+            MirRelationExpr::FlatMap { input, exprs, .. } => {
+                // Transform `exprs` by guarantees from `input` *and* from `outer`???
+                let input_equivalences = &derived_equivalences[expr_index - 1];
                 for expr in exprs.iter_mut() {
-                    equivalences.reduce_expr(expr);
+                    input_equivalences.reduce_expr(expr);
                 }
-                equivalences
+                let input_arity = derived.results::<Arity>().unwrap()[expr_index - 1];
+                outer_equivalences.project(0..input_arity);
+                self.apply(
+                    input,
+                    expr_index - 1,
+                    derived,
+                    outer_equivalences,
+                    get_equivalences,
+                );
             }
-            MirRelationExpr::Filter { input, predicates } => { 
-                let mut equivalences = self.pull(input, get_equivalences);
-                // Reduce `predicates` based on the promises of `input` equivalences.
+            MirRelationExpr::Filter { input, predicates } => {
+                // Transform `predicates` by guarantees from `input` *and* from `outer`???
+                // If we reduce based on `input` guarantees, we won't be able to push those
+                // constraints down into input, which may be fine but is worth considering.
+                let input_equivalences = &derived_equivalences[expr_index - 1];
+                let input_types = &derived_types[expr_index];
                 for expr in predicates.iter_mut() {
-                    equivalences.reduce_expr(expr);
+                    input_equivalences.reduce_expr(expr);
                 }
-                predicates.sort();
-                predicates.dedup();
-                // TODO: further simplify `predicates`
-                // introduce equivalences to `Datum::True`.
+                // Incorporate `predicates` into `outer_equivalences`.
                 let mut class = predicates.clone();
-                class.push(MirScalarExpr::literal_ok(Datum::True, mz_repr::ScalarType::Bool));
-                equivalences.classes.push(class);
-                equivalences.minimize();
-                equivalences
+                class.push(MirScalarExpr::literal_ok(
+                    Datum::True,
+                    mz_repr::ScalarType::Bool,
+                ));
+                outer_equivalences.classes.push(class);
+                outer_equivalences.minimize(input_types);
+                self.apply(
+                    input,
+                    expr_index - 1,
+                    derived,
+                    outer_equivalences,
+                    get_equivalences,
+                );
             }
 
             MirRelationExpr::Join {
@@ -195,352 +263,174 @@ impl EquivalencePropagation {
                 equivalences,
                 ..
             } => {
-                // Collect equivalences from all inputs;
+                // Certain equivalences are ensured by each of the inputs.
+                // Other equivalences are imposed by parents of the expression.
+                // We must not weaken the properties provided by the expression to its parents,
+                // meaning we can optimize `equivalences` with respect to input guararentees,
+                // but not with respect to `outer_equivalences`.
+
+                let mut join_equivalences = EquivalenceClasses::default();
+                join_equivalences
+                    .classes
+                    .extend(equivalences.iter().cloned());
+
+                // // Optionally, introduce `outer_equivalences` into `equivalences`.
+                // // This is not required, but it could be very helpful. To be seen.
+                // join_equivalences
+                //     .classes
+                //     .extend(outer_equivalences.classes.clone());
+
+                let input_types = &derived_types[expr_index];
+                join_equivalences.minimize(input_types);
+
+                // Each child can be presented with the integration of `join_equivalences`, `outer_equivalences`,
+                // and each input equivalence *other than* their own, projected onto the input's columns.
+                let arity = derived.results::<Arity>().unwrap();
+
+                // Enumerate locations to find each child's analysis outputs.
+                let mut children: Vec<usize> = derived
+                    .children_of_rev(expr_index, inputs.len())
+                    .collect::<Vec<_>>();
+                children.reverse();
+
+                // For each child, assemble its equivalences using join-relative column numbers.
+                // Don't do anything with the children yet, as we'll want to revisit each with
+                // this information at hand.
                 let mut columns = 0;
-                let mut result = EquivalenceClasses::default();
-                for input in inputs.iter_mut() {
-                    let input_arity = input.arity();
-                    let mut equivalences = self.pull(input, get_equivalences);
-                    let permutation = (columns .. (columns + input_arity)).collect::<Vec<_>>();
+                let mut input_equivalences = Vec::with_capacity(children.len());
+                for child in children.iter().cloned() {
+                    let input_arity = arity[child];
+                    let mut equivalences = derived_equivalences[child].clone();
+                    let permutation = (columns..(columns + input_arity)).collect::<Vec<_>>();
                     equivalences.permute(&permutation);
-                    result.classes.extend(equivalences.classes);
+                    input_equivalences.push(equivalences);
                     columns += input_arity;
                 }
 
-                // We can apply the equivalences to the join equivalences.
-                // This is acceptable to do, but it is perhaps harmful, in that we may remove
-                // valuable signals for what we must join on. E.g. if we simplify `Col(3)` to `Col(1)`,
-                // without introducing their equivalence as a constraint, we may miss an index on `Col(3)`
-                // and instead build one on `Col(1)`.
-                for class in equivalences.iter_mut() {
-                    for expr in class.iter_mut() {
-                        result.reduce_expr(expr);
+                // Revisit each child, determining the information to present to it, and recurring.
+                let mut columns = 0;
+                for ((index, child), expr) in
+                    children.into_iter().enumerate().zip(inputs.iter_mut())
+                {
+                    let input_arity = arity[child];
+
+                    let mut push_equivalences = join_equivalences.clone();
+                    push_equivalences
+                        .classes
+                        .extend(outer_equivalences.classes.clone());
+                    for (other, input_equivs) in input_equivalences.iter().enumerate() {
+                        if index != other {
+                            push_equivalences
+                                .classes
+                                .extend(input_equivs.classes.clone());
+                        }
                     }
+                    push_equivalences.project(columns..(columns + input_arity));
+                    self.apply(expr, child, derived, push_equivalences, get_equivalences);
+
+                    columns += input_arity;
                 }
-                // We could plausibly *introduce* the equivalences to the join equivalences,
-                // but this has the potential to introduce work we are not compelled to perform,
-                // for uncertain benefit. We should always be able to re-derive the equivalences,
-                // and optimize them away, in the future if we do insert them here.
 
-                // Fold join equivalences into our results.
-                result.classes.extend(equivalences.iter().cloned());
-                result.minimize();
-
-                // TODO: This is an opportunity to press what we know now back to children.
-                //       Ideally we would do it in combination with information from parents.
-
-                result
+                equivalences.clone_from(&join_equivalences.classes);
             }
-            MirRelationExpr::Reduce { input, group_key, aggregates, .. } => {
-                let mut equivalences = self.pull(input, get_equivalences);
-                // Reduce group key and aggregate expressions based on promises of `input` equivalences.
-                for expr in group_key.iter_mut() {
-                    equivalences.reduce_expr(expr);
-                }
-                for aggr in aggregates.iter_mut() {
-                    equivalences.reduce_expr(&mut aggr.expr);
-                }
-                // Introduce keys column equivalences as a map, then project to them as a projection.
-                let input_arity = input.arity();
-                for (pos, expr) in group_key.iter().enumerate() {
-                    equivalences.classes.push(vec![MirScalarExpr::Column(input_arity + pos), expr.clone()]);
-                }
-                equivalences.minimize();
-                let outputs = (input_arity .. (input_arity + group_key.len())).collect::<Vec<_>>();
-                equivalences.project(&outputs[..]);
+            MirRelationExpr::Reduce {
+                input,
+                group_key,
+                aggregates: _,
+                ..
+            } => {
+                // TODO: MIN, MAX, ANY, ALL aggregates pass through all certain properties of their columns.
+                // This may involve projection and permutation, to reposition the information appropriately.
+                // TODO: Non-null constraints likely push down into the support of the aggregate expressions.
 
-                // TODO: There are cases where equivalences can make their way through,
-                //       such as `MIN`, `MAX`, `ANY`, `ALL` aggregates that surface columns.
+                // To transform `outer_equivalences` to one about `input`, we will "pretend" to pre-pend all of
+                // the input columns, introduce equivalences about the evaluation of `group_key` on them
+                // and the key columns themselves, and then project onto these "input" columns.
+                let input_arity = derived.results::<Arity>().unwrap()[expr_index - 1];
+                let output_arity = derived.results::<Arity>().unwrap()[expr_index];
 
-                equivalences
+                // Permute `outer_equivalences` to reference columns `input_arity` later.
+                let permutation = (input_arity..(input_arity + output_arity)).collect::<Vec<_>>();
+                outer_equivalences.permute(&permutation[..]);
+                for (index, group) in group_key.iter().enumerate() {
+                    outer_equivalences.classes.push(vec![
+                        MirScalarExpr::Column(input_arity + index),
+                        group.clone(),
+                    ]);
+                }
+                outer_equivalences.project(0..input_arity);
+                self.apply(
+                    input,
+                    expr_index - 1,
+                    derived,
+                    outer_equivalences,
+                    get_equivalences,
+                );
             }
-            MirRelationExpr::TopK { input, .. } => {
-                // Nothing to do.
-                self.pull(input, get_equivalences)
+            MirRelationExpr::TopK {
+                input,
+                group_key,
+                limit,
+                ..
+            } => {
+                if let Some(expr) = limit {
+                    let input_equivalences = &derived_equivalences[expr_index - 1];
+                    input_equivalences.reduce_expr(expr);
+                }
+                outer_equivalences.project(0..group_key.len());
+                self.apply(
+                    input,
+                    expr_index - 1,
+                    derived,
+                    outer_equivalences,
+                    get_equivalences,
+                );
             }
             MirRelationExpr::Negate { input } => {
-                // Nothing to do.
-                self.pull(input, get_equivalences)
+                self.apply(
+                    input,
+                    expr_index - 1,
+                    derived,
+                    outer_equivalences,
+                    get_equivalences,
+                );
             }
             MirRelationExpr::Threshold { input } => {
-                // Nothing to do.
-                self.pull(input, get_equivalences)
+                self.apply(
+                    input,
+                    expr_index - 1,
+                    derived,
+                    outer_equivalences,
+                    get_equivalences,
+                );
             }
-            MirRelationExpr::Union { base, inputs } => {
-                // Restrict equivalences to those common in all inputs.
-                let mut equivalences = self.pull(base, get_equivalences);
-                for input in inputs.iter_mut() {
-                    equivalences = equivalences.union(&self.pull(input, get_equivalences))
+            MirRelationExpr::Union { inputs, .. } => {
+                // Push outer equivalences at each child.
+                let children = inputs.len() + 1;
+                for (child, index) in expr
+                    .children_mut()
+                    .rev()
+                    .zip(derived.children_of_rev(expr_index, children))
+                {
+                    self.apply(
+                        child,
+                        index,
+                        derived,
+                        outer_equivalences.clone(),
+                        get_equivalences,
+                    );
                 }
-                equivalences
             }
             MirRelationExpr::ArrangeBy { input, .. } => {
-                // Nothing to do.
-                self.pull(input, get_equivalences)
-            }
-        } 
-    }
-
-    // /// Impresses upon `relation` equivalences that can further restrict the records `relation` produces.
-    // ///
-    // /// These equivalences are not *enforced* atop `relation`, and it is incorrect for `relation` to emit 
-    // /// additional records under the premise that they will be filtered out (they may not be). However, if
-    // /// `relation` fails to produce any records that do not satisfy these equivalences, the ultimate results
-    // /// will remain correct.
-    // ///
-    // /// Essentially, `relation` may optionally install a `Filter` containing any subset of these equivalences.
-    // /// If this improves a `Join` by providing more equivalences, great! If this allows additional predicate 
-    // /// pushdown through a `Let` binding, great!
-    // pub fn push(
-    //     &self,
-    //     relation: &mut MirRelationExpr,
-    //     outer_equivalences: EquivalenceClasses,
-    //     get_equivalences: &mut BTreeMap<Id, EquivalenceClasses>,
-    // ) {
-    // }
-}
-
-/// A compact representation of classes of expressions that must be equivalent.
-///
-/// Each "class" contains a list of expressions, each of which must be `Eq::eq` equal.
-/// Ideally, the first element is the "simplest", e.g. a literal or column reference, 
-/// and any other element of that list can be replaced by it.
-///
-/// The classes are meant to be minimized, with each expression as reduced as it can be,
-/// and all classes sharing an element merged.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug)]
-pub struct EquivalenceClasses {
-    /// Multiple lists of equivalent expressions, each representing an equivalence class.
-    ///
-    /// The first element should be the "canonical" simplest element, that any other element
-    /// can be replaced by. 
-    /// These classes are unified whenever possible, to minimize the number of classes.
-    classes: Vec<Vec<MirScalarExpr>>,
-}
-
-impl EquivalenceClasses {
-    /// Update `self` to maintain the same equivalences which potentially reducing along `Ord::le`.
-    /// 
-    /// Informally this means simplifying constraints, removing redundant constraints, and unifying equivalence classes.
-    fn minimize(&mut self) {
-        // Repeatedly, we reduce each of the classes themselves, then unify the classes.
-        // This should strictly reduce complexity, and reach a fixed point.
-        // Ideally it is *confluent*, arriving at the same fixed point no matter the order of operations.
-
-        for class in self.classes.iter_mut() {
-            class.sort_by(|e1,e2| {
-                match (e1, e2) {
-                    (MirScalarExpr::Literal(_,_), MirScalarExpr::Literal(_,_)) => e1.cmp(e2),
-                    (MirScalarExpr::Literal(_,_), _) => std::cmp::Ordering::Less,
-                    (_, MirScalarExpr::Literal(_,_)) => std::cmp::Ordering::Greater,
-                    (x, y) => x.cmp(y),
-                }
-            });
-            class.dedup();
-        }
-        self.classes.retain(|c| c.len() > 1);
-        self.classes.sort();
-
-        // We continue as long as any simplification has occurred.
-        // An expression can be simplified, a duplication found, or two classes unified.
-        let mut complete = false;
-        while !complete {
-            // We are complete unless we experience an expression simplification, or an equivalence class unification.
-            complete = true;
-
-            // 1. Reduce each class.
-            //    Each class can be reduced in the context of *other* classes, which are available for substitution.
-            for class_index in 0 .. self.classes.len() {
-                for index in 0 .. self.classes[class_index].len() {
-                    let mut cloned = self.classes[class_index][index].clone();
-                    // Use `reduce_child` rather than `reduce_expr` to avoid entire expression replacement.
-                    let reduced = self.reduce_child(&mut cloned);
-                    if reduced {
-                        self.classes[class_index][index] = cloned;
-                        complete = false;
-                    }
-                }
-            }
-
-            // 2. Unify classes.
-            //    If the same expression is in two classes, we can unify the classes.
-            //    This element may not be the representative.
-            //    TODO: If all lists are sorted, this could be a linear merge among all.
-            //          They stop being sorted as soon as we make any modification, though.
-            //          But, it would be a fast rejection when faced with lots of data.
-            for index1 in 0 .. self.classes.len() {
-                for index2 in 0 .. index1 {
-                    if self.classes[index1].iter().any(|x| self.classes[index2].iter().any(|y| x == y)) {
-                        let prior = std::mem::take(&mut self.classes[index2]);
-                        self.classes[index1].extend(prior);
-                        complete = false;
-                    }
-                }
-            }
-
-            // Tidy up classes, restore representative.
-            for class in self.classes.iter_mut() {
-                // TODO: Ideally we put literals as representatives, to reduce dependencies on rows.
-                class.sort_by(|e1,e2| {
-                    match (e1, e2) {
-                        (MirScalarExpr::Literal(_,_), MirScalarExpr::Literal(_,_)) => e1.cmp(e2),
-                        (MirScalarExpr::Literal(_,_), _) => std::cmp::Ordering::Less,
-                        (_, MirScalarExpr::Literal(_,_)) => std::cmp::Ordering::Greater,
-                        (x, y) => x.cmp(y),
-                    }
-                });
-                class.dedup();
-            }
-
-            // Discard trivial equivalence classes.
-            self.classes.retain(|class| class.len() > 1);
-            self.classes.sort();
-        }
-    }
-
-    /// Produce the equivalences present in both inputs.
-    fn union(&self, other: &Self) -> Self {
-
-        // TODO: seems like this could be extended, with similar concepts to localization:
-        //       We may removed non-shared constraints, but ones that remain could take over
-        //       and substitute in to retain more equivalences.
-
-        // For each pair of equivalence clasess, their intersection.
-        let mut equivalences = EquivalenceClasses { classes: Vec::new() };
-        for class1 in self.classes.iter() {
-            for class2 in other.classes.iter() {
-                let class = class1.iter().filter(|e1| class2.iter().any(|e2| e1 == &e2)).cloned().collect::<Vec<_>>();
-                if class.len() > 1 {
-                    equivalences.classes.push(class);
-                }
+                // TODO: Option to alter arrangement keys, though .. terrifying.
+                self.apply(
+                    input,
+                    expr_index - 1,
+                    derived,
+                    outer_equivalences,
+                    get_equivalences,
+                );
             }
         }
-        equivalences.minimize();
-        equivalences
-    }
-
-    fn permute(&mut self, permutation: &[usize]) {
-        for class in self.classes.iter_mut() {
-            for expr in class.iter_mut() {
-                expr.permute(permutation);
-            }
-        }
-    }
-
-    /// Subject the constraints to the column projection, reworking and removing equivalences.
-    ///
-    /// This method should also introduce equivalences representing any repeated columns.
-    fn project(&mut self, output_columns: &[usize]) {
-        let remap = output_columns.iter().enumerate().map(|(idx, col)| (*col, idx)).collect::<BTreeMap<_,_>>();
-
-        // Some expressions may be "localized" in that they only reference columns in `output_columns`.
-        // Many expressions may not be localized, but may reference canonical non-localized expressions 
-        // for classes that contain a localized expression; in that case we can "backport" the localized 
-        // expression to give expressions referencing the canonical expression a shot at localization.
-        //
-        // Expressions should only contain instances of canonical expressions, and so we shouldn't need
-        // to look any further than backporting those. Backporting should have the property that the simplest 
-        // localized expression in each class does not contain any non-localized canonical expressions 
-        // (as that would make it non-localized); our backporting of non-localized canonicals with localized
-        // expressions should never fire a second 
-        
-        // Let's say an expression is "localized" once we are able to rewrite its support in terms of `output_columns`.
-        // Not all expressions can be localized, although some of them may be equivalent to localized expressions.
-        // As we find localized expressions, we can replace uses of their equivalent representative with them, 
-        // which may allow further expression localization. 
-        // We continue the process until no further classes can be localized.
-
-        // A map from representatives to our first localization of their equivalence class.
-        let mut localized = false;
-        while !localized {
-            localized = true;
-            for class in self.classes.iter_mut() {
-                if !class[0].support().iter().all(|c| output_columns.contains(c)) {
-                    if let Some(pos) = class.iter().position(|e| e.support().iter().all(|c| output_columns.contains(c))) {
-                        class.swap(0, pos);
-                        localized = false;
-                    }
-                }
-            }
-            // attempt to replace representatives with equivalent localizeable expressions.
-            for class_index in 0 .. self.classes.len() {
-                for index in 0 .. self.classes[class_index].len() {
-                    let mut cloned = self.classes[class_index][index].clone();
-                    // Use `reduce_child` rather than `reduce_expr` to avoid entire expression replacement.
-                    let reduced = self.reduce_child(&mut cloned);
-                    if reduced {
-                        self.classes[class_index][index] = cloned;
-                    }
-                }
-            }
-            // NB: Do *not* `self.minimize()`, as we are developing localizable rather than canonical representatives.
-        }
-
-        // Localize all localizable expressions and discard others.
-        for class in self.classes.iter_mut() {
-            class.retain(|e| e.support().iter().all(|c| output_columns.contains(c)));
-            for expr in class.iter_mut() {
-                expr.permute_map(&remap);
-            }
-        }
-        self.classes.retain(|c| c.len() > 1);
-        // If column repetitions, introduce them as equivalences.
-        // We introduce only the equivalence to the first occurrence, and rely on minimization to collect them.
-        for c in 0 .. output_columns.len() {
-            if let Some(pos) = output_columns[..c].iter().position(|x| x == &output_columns[c]) {
-                self.classes.push(vec![MirScalarExpr::Column(pos), MirScalarExpr::Column(c)]);
-            }
-        }
-
-        self.minimize();
-    }
-
-    /// Perform any exact replacement for `expr`, report if it had an effect.
-    fn replace(&self, expr: &mut MirScalarExpr) -> bool {
-        for class in self.classes.iter() {
-            // TODO: If `class` is sorted We only need to iterate through "simpler" expressions;
-            // we can stop once x > expr.
-            // We need to be careful with that reasoning, as it interferes with self-improvement;
-            // if we are modifying `self` we must restore the invariant before relying on it again.
-            if class[1..].iter().any(|x| x == expr) {
-                expr.clone_from(&class[0]);
-                return true;
-            }
-        }
-        false
-    }
-
-    /// Perform any simplification, report if effective.
-    fn reduce_expr(&self, expr: &mut MirScalarExpr) -> bool {
-        let mut simplified = false;
-        simplified = simplified || self.reduce_child(expr);
-        simplified = simplified || self.replace(expr);
-        simplified
-    }
-    
-    /// Perform any simplification on children, report if effective.
-    fn reduce_child(&self, expr: &mut MirScalarExpr) -> bool {
-        let mut simplified = false;
-        match expr {
-            MirScalarExpr::CallBinary { expr1, expr2, .. } => {
-                simplified = self.reduce_expr(expr1) || simplified;
-                simplified = self.reduce_expr(expr2) || simplified;
-            }
-            MirScalarExpr::CallUnary { expr, .. } => {
-                simplified = self.reduce_expr(expr) || simplified;
-            }
-            MirScalarExpr::CallVariadic { exprs, .. } => {
-                for expr in exprs.iter_mut() {
-                    simplified = self.reduce_expr(expr) || simplified;
-                }
-            }
-            MirScalarExpr::If { cond, then, els} => {
-                simplified = self.reduce_expr(cond) || simplified;
-                simplified = self.reduce_expr(then) || simplified;
-                simplified = self.reduce_expr(els) || simplified;
-            }
-            _ => { }
-        }
-        simplified
     }
 }

--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -376,18 +376,13 @@ impl EquivalencePropagation {
                 );
             }
             MirRelationExpr::TopK {
-                input,
-                group_key,
-                limit,
-                ..
+                input, group_key, ..
             } => {
-                if let Some(expr) = limit {
-                    let input_equivalences = derived
-                        .last_child()
-                        .value::<Equivalences>()
-                        .expect("Equivalences required");
-                    input_equivalences.reduce_expr(expr);
-                }
+                // TODO: Update `limit` expressions, but only if we update `group_key` at the same time.
+                //       It is important to both or neither, to ensure that `limit` only references columns in `group_key`.
+
+                // Discard equivalences among non-key columns, as it is not correct that `input` may drop rows
+                // that violate constraints among non-key columns without affecting the result.
                 outer_equivalences.project(0..group_key.len());
                 self.apply(
                     input,

--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -43,10 +43,9 @@ use crate::{TransformCtx, TransformError};
 pub struct EquivalencePropagation;
 
 impl crate::Transform for EquivalencePropagation {
-    #[tracing::instrument(
+    #[mz_ore::instrument(
         target = "optimizer"
         level = "trace",
-        skip_all,
         fields(path.segment = "equivalence_propagation")
     )]
     fn transform(
@@ -61,7 +60,6 @@ impl crate::Transform for EquivalencePropagation {
         let derived = builder.visit(relation);
         let derived = derived.as_view();
 
-        // let relation_index = derived.results::<Equivalences>().unwrap().len() - 1;
         let mut get_equivalences = BTreeMap::default();
         self.apply(
             relation,

--- a/src/transform/src/fusion/filter.rs
+++ b/src/transform/src/fusion/filter.rs
@@ -13,10 +13,11 @@
 //!
 //! ```rust
 //! use mz_expr::{MirRelationExpr, MirScalarExpr};
-//! use mz_repr::{typecheck, ColumnType, Datum, RelationType, ScalarType};
-//! use mz_repr::optimizer::OptimizerFeatures;
-//! use mz_transform::{Transform, TransformCtx};
+//! use mz_repr::{ColumnType, Datum, RelationType, ScalarType};
+//! use mz_repr::optimize::OptimizerFeatures;
+//! use mz_transform::{typecheck, Transform, TransformCtx};
 //! use mz_transform::dataflow::DataflowMetainfo;
+//!
 //! use mz_transform::fusion::filter::Filter;
 //!
 //! let input = MirRelationExpr::constant(vec![], RelationType::new(vec![

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -41,6 +41,7 @@ pub mod compound;
 pub mod cse;
 pub mod dataflow;
 pub mod demand;
+pub mod equivalence_propagation;
 pub mod fold_constants;
 pub mod fusion;
 pub mod join_implementation;
@@ -479,6 +480,7 @@ impl Optimizer {
                 transforms: vec![
                     // Predicate pushdown sets the equivalence classes of joins.
                     Box::new(crate::predicate_pushdown::PredicatePushdown::default()),
+                    Box::new(crate::equivalence_propagation::EquivalencePropagation::default()),
                     // Lifts the information `!isnull(col)`
                     Box::new(crate::nonnullable::NonNullable),
                     // Lifts the information `col = literal`

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -30,6 +30,9 @@
 //! use mz_expr::{BinaryFunc, MirRelationExpr, MirScalarExpr};
 //! use mz_ore::id_gen::IdGen;
 //! use mz_repr::{ColumnType, Datum, RelationType, ScalarType};
+//! use mz_repr::optimize::OptimizerFeatures;
+//! use mz_transform::{typecheck, Transform, TransformCtx};
+//! use mz_transform::dataflow::DataflowMetainfo;
 //!
 //! use mz_transform::predicate_pushdown::PredicatePushdown;
 //!
@@ -60,22 +63,12 @@
 //!        predicate012.clone(),
 //!    ]);
 //!
-//! use mz_transform::{Transform, TransformCtx};
-//! use mz_transform::dataflow::DataflowMetainfo;
-//! PredicatePushdown::default().transform(&mut expr, &mut TransformCtx {
-//!   indexes: &mz_transform::EmptyIndexOracle,
-//!   stats: &mz_transform::EmptyStatisticsOracle,
-//!   global_id: None,
-//!   features: &mz_repr::optimizer::OptimizerFeatures {
-//!       enable_consolidate_after_union_negate: false,
-//!       enable_eager_delta_joins: false,
-//!       enable_new_outer_join_lowering: false,
-//!       enable_reduce_mfp_fusion: false,
-//!       persist_fast_path_limit: 0,
-//!       reoptimize_imported_views: false,
-//!   },
-//!   df_meta: &mut DataflowMetainfo::default(),
-//! });
+//! let features = OptimizerFeatures::default();
+//! let typecheck_ctx = typecheck::empty_context();
+//! let mut df_meta = DataflowMetainfo::default();
+//! let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta);
+//!
+//! PredicatePushdown::default().transform(&mut expr, &mut transform_ctx);
 //!
 //! let predicate00 = MirScalarExpr::column(0).call_binary(MirScalarExpr::column(0), BinaryFunc::AddInt64);
 //! let expected_expr = MirRelationExpr::join(

--- a/test/rqg/mzcompose.py
+++ b/test/rqg/mzcompose.py
@@ -196,7 +196,7 @@ def run_workload(c: Composition, args: argparse.Namespace, workload: Workload) -
     participants: list[Service] = [
         Materialized(
             name="mz_this",
-            ports=["16875:6875", "16877:6877"],
+            ports=["16875:6875", "16876:6876", "16877:6877", "16878:6878"],
             image=f"materialize/materialized:{args.this_tag}"
             if args.this_tag
             else None,
@@ -227,7 +227,7 @@ def run_workload(c: Composition, args: argparse.Namespace, workload: Workload) -
                     image=f"materialize/materialized:{args.other_tag}"
                     if args.other_tag
                     else None,
-                    ports=["26875:6875", "26877:6877"],
+                    ports=["26875:6875", "26876:6876", "26877:6877", "26878:6878"],
                     use_default_volumes=False,
                 )
             )

--- a/test/sqllogictest/explain/view.slt
+++ b/test/sqllogictest/explain/view.slt
@@ -124,7 +124,7 @@ Return
             Negate
               Join on=(#2 = integer_to_bigint(#0))
                 Get l1
-                Distinct project=[integer_to_bigint(#0)]
+                Distinct project=[#2]
                   Get l0
           Get l1
       Filter (#1 = 100)
@@ -173,7 +173,7 @@ Return
             Negate
               Join on=(#2 = integer_to_bigint(#0))
                 Get l1
-                Distinct project=[integer_to_bigint(#0)]
+                Distinct project=[#2]
                   Get l0
           Get l1
       Filter (#1 = 100)

--- a/test/sqllogictest/github-9782.slt
+++ b/test/sqllogictest/github-9782.slt
@@ -87,7 +87,7 @@ Explained Query:
                         Project (#1, #2) // { arity: 2 }
                           Get l0 // { arity: 3 }
             Get l1 // { arity: 3 }
-            Filter (#0 = #1) AND (#0 = #2) // { arity: 3 }
+            Filter (#0 = #1) // { arity: 3 }
               Get l0 // { arity: 3 }
   With
     cte l1 =

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -614,7 +614,7 @@ SELECT f1, f2, f1 + f2 FROM c0;
 ----
 Explained Query:
   Return // { arity: 3, types: "(integer, integer, integer)" }
-    Map ((#0 + #1)) // { arity: 3, types: "(integer, integer, integer)" }
+    Map (8) // { arity: 3, types: "(integer, integer, integer)" }
       Get l0 // { arity: 2, types: "(integer, integer)" }
   With Mutually Recursive [recursion_limit=1]
     cte l0 =

--- a/test/sqllogictest/transform/fold_vs_dataflow/3_number_aggfns_dataflow.slt
+++ b/test/sqllogictest/transform/fold_vs_dataflow/3_number_aggfns_dataflow.slt
@@ -54,12 +54,11 @@ FROM t_using_dataflow_rendering;
 ----
 Explained Query:
   Return
-    Project (#0..=#17, #30..=#35)
-      Map ((#18 / bigint_to_real(case when (#19 = 0) then null else #19 end)), (#20 / bigint_to_double(case when (#21 = 0) then null else #21 end)), (#22 / bigint_to_numeric(case when (#23 = 0) then null else #23 end)), (#24 / bigint_to_real(case when (#25 = 0) then null else #25 end)), (#26 / bigint_to_double(case when (#27 = 0) then null else #27 end)), (#28 / bigint_to_numeric(case when (#29 = 0) then null else #29 end)))
+    Project (#0..=#17, #24..=#29)
+      Map ((#0 / bigint_to_real(case when (#18 = 0) then null else #18 end)), (#1 / bigint_to_double(case when (#19 = 0) then null else #19 end)), (#2 / bigint_to_numeric(case when (#20 = 0) then null else #20 end)), (#3 / bigint_to_real(case when (#21 = 0) then null else #21 end)), (#4 / bigint_to_double(case when (#22 = 0) then null else #22 end)), (#5 / bigint_to_numeric(case when (#23 = 0) then null else #23 end)))
         Union
-          Project (#0..=#17, #0, #18, #1, #19, #2, #20, #3, #21, #4, #22, #5, #23)
-            Get l0
-          Map (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, 0, null, 0, null, 0, null, 0, null, 0, null, 0)
+          Get l0
+          Map (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, 0, 0, 0, 0, 0, 0)
             Union
               Negate
                 Project ()

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -638,38 +638,33 @@ explain with(arity, join implementations) select min(a) from t_pk where a betwee
 Explained Query:
   Return // { arity: 1 }
     Union // { arity: 1 }
-      Get l1 // { arity: 1 }
+      Get l0 // { arity: 1 }
       Map (null) // { arity: 1 }
         Union // { arity: 0 }
           Negate // { arity: 0 }
             Project () // { arity: 0 }
-              Get l1 // { arity: 1 }
+              Get l0 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
   With
-    cte l1 =
+    cte l0 =
       Reduce aggregates=[min(#0)] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Join on=(#0 = #1) type=differential // { arity: 2 }
             implementation
-              %0:t_pk[#0]UKiif » %1[#0]Kiif
+              %0:t_pk[#0]UKiif » %1[#0]UKiif
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (#0 <= 195) AND (#0 >= 38) // { arity: 2 }
                   ReadStorage materialize.public.t_pk // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
-              Union // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Get l0 // { arity: 2 }
-                Map (error("more than one record produced in subquery")) // { arity: 1 }
-                  Project () // { arity: 0 }
-                    Filter (#0 > 1) // { arity: 1 }
-                      Reduce aggregates=[count(*)] // { arity: 1 }
-                        Project () // { arity: 0 }
-                          Get l0 // { arity: 2 }
-    cte l0 =
-      Filter (#0 = 1308) // { arity: 2 }
-        ReadStorage materialize.public.t // { arity: 2 }
+              Map (error("more than one record produced in subquery")) // { arity: 1 }
+                Project () // { arity: 0 }
+                  Filter (#0 > 1) // { arity: 1 }
+                    Reduce aggregates=[count(*)] // { arity: 1 }
+                      Project () // { arity: 0 }
+                        Filter (#0 = 1308) // { arity: 2 }
+                          ReadStorage materialize.public.t // { arity: 2 }
 
 Source materialize.public.t
   filter=((#0 = 1308))
@@ -684,38 +679,33 @@ explain with(arity, join implementations) select min(a) from t where a between 3
 Explained Query:
   Return // { arity: 1 }
     Union // { arity: 1 }
-      Get l1 // { arity: 1 }
+      Get l0 // { arity: 1 }
       Map (null) // { arity: 1 }
         Union // { arity: 0 }
           Negate // { arity: 0 }
             Project () // { arity: 0 }
-              Get l1 // { arity: 1 }
+              Get l0 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
   With
-    cte l1 =
+    cte l0 =
       Reduce aggregates=[min(#0)] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Join on=(#0 = #1) type=differential // { arity: 2 }
             implementation
-              %0:t[#0]Kiif » %1[#0]Kiif
+              %1[#0]UK » %0:t[#0]Kiif
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (#0 <= 195) AND (#0 >= 38) // { arity: 2 }
                   ReadStorage materialize.public.t // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
-              Union // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Get l0 // { arity: 2 }
-                Map (error("more than one record produced in subquery")) // { arity: 1 }
-                  Project () // { arity: 0 }
-                    Filter (#0 > 1) // { arity: 1 }
-                      Reduce aggregates=[count(*)] // { arity: 1 }
-                        Project () // { arity: 0 }
-                          Get l0 // { arity: 2 }
-    cte l0 =
-      Filter (#0 = 1308) // { arity: 2 }
-        ReadStorage materialize.public.t // { arity: 2 }
+              Map (error("more than one record produced in subquery")) // { arity: 1 }
+                Project () // { arity: 0 }
+                  Filter (#0 > 1) // { arity: 1 }
+                    Reduce aggregates=[count(*)] // { arity: 1 }
+                      Project () // { arity: 0 }
+                        Filter (#0 = 1308) // { arity: 2 }
+                          ReadStorage materialize.public.t // { arity: 2 }
 
 EOF
 

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -85,15 +85,15 @@ EXPLAIN WITH(arity, join implementations)
   SELECT * FROM
     (SELECT a, b, b+1 as c FROM
       (SELECT a, a+1 as b FROM y))
-WHERE b = 3 AND c = 3
+WHERE b = 3 AND c = 4
 ----
 Explained Query:
-  Filter (#1 = 3) AND (#2 = 3) // { arity: 3 }
-    Map ((#0 + 1), (#1 + 1)) // { arity: 3 }
+  Filter (#1 = 3) AND (4 = (#1 + 1)) // { arity: 3 }
+    Map ((#0 + 1), 4) // { arity: 3 }
       ReadStorage materialize.public.y // { arity: 1 }
 
 Source materialize.public.y
-  filter=((3 = #1) AND (3 = (#1 + 1)))
+  filter=((3 = #1) AND (4 = (#1 + 1)))
   map=((#0 + 1))
 
 EOF

--- a/test/sqllogictest/uniqueness_propagation_filter.slt
+++ b/test/sqllogictest/uniqueness_propagation_filter.slt
@@ -212,8 +212,8 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT DISTINCT f1 + 1 , f2 FROM v1 WHERE f1 + 1 = f3;
 ----
 Explained Query:
-  Distinct project=[(#0 + 1), #1] // { arity: 2 }
-    Project (#0, #1) // { arity: 2 }
+  Distinct project=[#1, #0] // { arity: 2 }
+    Project (#1, #2) // { arity: 2 }
       Filter (#2 = (#0 + 1)) // { arity: 3 }
         ReadIndex on=v1 v1_primary_idx=[*** full scan ***] // { arity: 3 }
 

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -709,7 +709,7 @@ ReduceMinsMaxes
 "Arrange ReduceMinsMaxes"                     1
 "ArrangeAccumulable [val: empty]"             3
 "ArrangeBy[[Column(0), Column(2)]]"           1
-"ArrangeBy[[Column(0)]] [val: empty]"         2
+"ArrangeBy[[Column(0)]] [val: empty]"         1
 "ArrangeBy[[Column(0)]]-errors"              21
 "ArrangeBy[[Column(0)]]"                     41
 "ArrangeBy[[Column(1), Column(3)]]"           2


### PR DESCRIPTION
Transformation that propagates "equivalence" information, of the form `expr1 = expr2` under Rust's `=`. This allows us to communicate arbitrary predicates (`expr = true`) but also compactly represent normalizing equivalences that equate classes of expressions (and allow substitution by the simplest representatives).

At the moment, it optimizes away queries like
```sql
-- Demonstrates absence of cross-join input sharing.
SELECT COUNT(*) FROM 
    (SELECT * FROM foo WHERE foo.a = 7) foo,
    (SELECT * FROM bar WHERE bar.a < 5) bar
WHERE foo.a = bar.a;
```
but should be more fully explored to see what it does to expressions, and whether it mis-optimizes any. This PR is meant to read out any test failures in that regard.

The longer term goal is to consolidate places where we try and reason about "equivalence" in ad-hoc manners. There are several transforms that overlap with this reasoning, and several of them could be simplified, improved, or potentially just removed. They include:
1. Predicate pushdown (encourage `Get` nodes to house predicates, and provide guarantees for users)
2. Literal lifting (identify columns as literals, and remove dependence on the columns themselves)
3. Column knowledge (identify columns as literals or non-null. more generally, other predicates of columns)
4. Non-null requirements (push down the information that rows with null columns can be dropped)
5. Nonnullability (harvest more accurate information about non-nullability than `typ()` provides)
6. Predicate canonicalization (`Filter`-local predicate simplification that now extends further)
7. Demand analysis (identify equivalent columns to reduce demand on one of them)

The main gotcha at the moment is that several of the above perform light physical plan modification as they go. For example `LiteralLifting` projects away any lifted columns, in addition to highlighting the information that the column is a literal. To do this it goes through a bunch of permutation pain, but it ends up with an expression that for example removes unit join terms, where without the projection they are a column containing unread data that we don't know how to prune (the code was never written).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
