### PR TITLE
storage: remove monotonicity machinery from privatelink status updates

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -109,6 +109,19 @@ the historical status for each AWS PrivateLink connection in the system.
 | `connection_id`   | `text`                     | The unique identifier of the AWS PrivateLink connection. Corresponds to [`mz_catalog.mz_connections.id`](../mz_catalog#mz_connections).   |
 | `status`          | `text`                     | The status of the connection: one of `pending-service-discovery`, `creating-endpoint`, `recreating-endpoint`, `updating-endpoint`, `available`, `deleted`, `deleting`, `expired`, `failed`, `pending`, `pending-acceptance`, `rejected`, or `unknown`.                        |
 
+### `mz_aws_privatelink_connection_statuses`
+
+The `mz_aws_privatelink_connection_statuses` table contains a row describing
+the most recent status for each AWS PrivateLink connection in the system.
+
+<!-- RELATION_SPEC mz_internal.mz_aws_privatelink_connection_statuses -->
+| Field | Type | Meaning |
+|-------|------|---------|
+| `id` | [`text`] | The ID of the connection. Corresponds to [`mz_catalog.mz_connections.id`](../mz_catalog#mz_sinks). |
+| `name` | [`text`] | The name of the connection.  |
+| `last_status_change_at` | [`timestamp with time zone`] | Wall-clock timestamp of the connection status change.|
+| `status` | [`text`] | | The status of the connection: one of `pending-service-discovery`, `creating-endpoint`, `recreating-endpoint`, `updating-endpoint`, `available`, `deleted`, `deleting`, `expired`, `failed`, `pending`, `pending-acceptance`, `rejected`, or `unknown`. |
+
 ### `mz_cluster_replica_frontiers`
 
 The `mz_cluster_replica_frontiers` table describes the per-replica frontiers of

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -257,7 +257,7 @@ pub enum Message<T = mz_repr::Timestamp> {
         stage: SubscribeStage,
     },
     DrainStatementLog,
-    PrivateLinkVpcEndpointEvents(BTreeMap<GlobalId, VpcEndpointEvent>),
+    PrivateLinkVpcEndpointEvents(Vec<VpcEndpointEvent>),
 }
 
 impl Message {

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -188,7 +188,16 @@ impl Coordinator {
                     self.drain_statement_log().await;
                 }
                 Message::PrivateLinkVpcEndpointEvents(events) => {
-                    self.write_privatelink_status_updates(events).await;
+                    self.controller
+                        .storage
+                        .record_introspection_updates(
+                            mz_storage_client::controller::IntrospectionType::PrivatelinkConnectionStatusHistory,
+                            events
+                                .into_iter()
+                                .map(|e| (mz_repr::Row::from(e), 1))
+                                .collect(),
+                        )
+                        .await;
                 }
             }
         }

--- a/src/adapter/src/coord/privatelink_status.rs
+++ b/src/adapter/src/coord/privatelink_status.rs
@@ -8,15 +8,12 @@
 // by the Apache License, Version 2.0.
 
 use std::num::NonZeroU32;
-use std::{collections::BTreeMap, sync::Arc};
+use std::sync::Arc;
 
 use governor::{Quota, RateLimiter};
 
-use mz_cloud_resources::VpcEndpointEvent;
 use mz_ore::future::OreStreamExt;
 use mz_ore::task::spawn;
-use mz_repr::{Datum, GlobalId, Row};
-use mz_storage_client::controller::IntrospectionType;
 
 use crate::coord::Coordinator;
 
@@ -31,15 +28,6 @@ impl Coordinator {
             .privatelink_status_update_quota_per_minute();
 
         if let Some(controller) = &self.cloud_resource_controller {
-            // Retrieve the timestamp of the last event written to the status table for each id
-            // to avoid writing duplicate rows
-            let mut last_written_events = self
-                .controller
-                .storage
-                .get_privatelink_status_table_latest()
-                .clone()
-                .unwrap_or_else(BTreeMap::new);
-
             let controller = Arc::clone(controller);
             spawn(|| "privatelink_vpc_endpoint_watch", async move {
                 let mut stream = controller.watch_vpc_endpoints().await;
@@ -57,52 +45,12 @@ impl Coordinator {
                         // to continue to work, despite not being polled
                         rate_limiter.until_ready().await;
 
-                        // Events to be written, de-duped by connection_id
-                        let mut event_map = BTreeMap::new();
-
-                        for event in new_events {
-                            match last_written_events.get(&event.connection_id) {
-                                // Ignore if an event with this time was already written
-                                Some(time) if time >= &event.time => {}
-                                _ => {
-                                    last_written_events
-                                        .insert(event.connection_id.clone(), event.time.clone());
-                                    event_map.insert(event.connection_id, event);
-                                }
-                            }
-                        }
-
                         // Send the event batch to the coordinator to be written
                         let _ =
-                            internal_cmd_tx.send(Message::PrivateLinkVpcEndpointEvents(event_map));
+                            internal_cmd_tx.send(Message::PrivateLinkVpcEndpointEvents(new_events));
                     }
                 }
             });
         }
-    }
-
-    pub(crate) async fn write_privatelink_status_updates(
-        &mut self,
-        events: BTreeMap<GlobalId, VpcEndpointEvent>,
-    ) {
-        let mut updates = Vec::new();
-        for value in events.into_values() {
-            updates.push((
-                Row::pack_slice(&[
-                    Datum::TimestampTz(value.time.try_into().expect("must fit")),
-                    Datum::String(&value.connection_id.to_string()),
-                    Datum::String(&value.status.to_string()),
-                ]),
-                1,
-            ));
-        }
-
-        self.controller
-            .storage
-            .record_introspection_updates(
-                IntrospectionType::PrivatelinkConnectionStatusHistory,
-                updates,
-            )
-            .await;
     }
 }

--- a/src/cloud-resources/src/lib.rs
+++ b/src/cloud-resources/src/lib.rs
@@ -87,6 +87,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures::stream::BoxStream;
 use mz_repr::GlobalId;
+use mz_repr::Row;
 use serde::{Deserialize, Serialize};
 
 use crate::crd::vpc_endpoint::v1::{VpcEndpointState, VpcEndpointStatus};
@@ -200,4 +201,16 @@ pub struct VpcEndpointEvent {
     pub connection_id: GlobalId,
     pub status: VpcEndpointState,
     pub time: DateTime<Utc>,
+}
+
+impl From<VpcEndpointEvent> for Row {
+    fn from(value: VpcEndpointEvent) -> Self {
+        use mz_repr::Datum;
+
+        Row::pack_slice(&[
+            Datum::TimestampTz(value.time.try_into().expect("must fit")),
+            Datum::String(&value.connection_id.to_string()),
+            Datum::String(&value.status.to_string()),
+        ])
+    }
 }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -22,7 +22,6 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
 use differential_dataflow::lattice::Lattice;
 use mz_cluster_client::client::ClusterReplicaLocation;
 use mz_cluster_client::ReplicaId;
@@ -535,10 +534,6 @@ pub trait StorageController: Debug {
     /// good and there is no possibility of the old code running concurrently
     /// with the new code.
     async fn init_txns(&mut self, init_ts: Self::Timestamp) -> Result<(), StorageError>;
-
-    /// Returns the timestamp of the latest row for each id in the
-    /// privatelink_connection_status_history table seen on startup
-    fn get_privatelink_status_table_latest(&self) -> &Option<BTreeMap<GlobalId, DateTime<Utc>>>;
 }
 
 /// State maintained about individual collections.

--- a/src/storage-client/src/healthcheck.rs
+++ b/src/storage-client/src/healthcheck.rs
@@ -106,12 +106,13 @@ pub static MZ_SINK_STATUS_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
         .with_column("details", ScalarType::Jsonb.nullable(true))
 });
 
-pub static MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
-    RelationDesc::empty()
-        .with_column(
-            "occurred_at",
-            ScalarType::TimestampTz { precision: None }.nullable(false),
-        )
-        .with_column("connection_id", ScalarType::String.nullable(false))
-        .with_column("status", ScalarType::String.nullable(false))
-});
+pub static MZ_AWS_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC: Lazy<RelationDesc> =
+    Lazy::new(|| {
+        RelationDesc::empty()
+            .with_column(
+                "occurred_at",
+                ScalarType::TimestampTz { precision: None }.nullable(false),
+            )
+            .with_column("connection_id", ScalarType::String.nullable(false))
+            .with_column("status", ScalarType::String.nullable(false))
+    });

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -948,7 +948,7 @@ where
                             // Truncate the private link connection status history table and
                             // store the latest timestamp for each id in the table.
                             let occurred_at_col =
-                                healthcheck::MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC
+                                healthcheck::MZ_AWS_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC
                                     .get_by_name(&ColumnName::from("occurred_at"))
                                     .expect("schema has not changed")
                                     .0;
@@ -2732,11 +2732,11 @@ where
                 self.config
                     .parameters
                     .keep_n_privatelink_status_history_entries,
-                healthcheck::MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC
+                healthcheck::MZ_AWS_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC
                     .get_by_name(&ColumnName::from("occurred_at"))
                     .expect("schema has not changed")
                     .0,
-                healthcheck::MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC
+                healthcheck::MZ_AWS_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC
                     .get_by_name(&ColumnName::from("connection_id"))
                     .expect("schema has not changed")
                     .0,

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -81,6 +81,14 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 3  status  text
 
 query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_aws_privatelink_connection_statuses' ORDER BY position
+----
+1  id  text
+2  name  text
+3  last_status_change_at  timestamp␠with␠time␠zone
+4  status  text
+
+query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_frontiers' ORDER BY position
 ----
 1  object_id  text
@@ -698,6 +706,7 @@ mz_arrangement_sizes
 mz_arrangement_sizes_per_worker
 mz_aws_connections
 mz_aws_privatelink_connection_status_history
+mz_aws_privatelink_connection_statuses
 mz_cluster_links
 mz_cluster_replica_frontiers
 mz_cluster_replica_heartbeats

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -325,6 +325,10 @@ mz_aws_privatelink_connection_status_history
 SOURCE
 materialize
 mz_internal
+mz_aws_privatelink_connection_statuses
+VIEW
+materialize
+mz_internal
 mz_cluster_links
 BASE TABLE
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -672,6 +672,7 @@ mz_show_sources
 mz_show_system_privileges
 mz_sink_statuses
 mz_source_statuses
+mz_aws_privatelink_connection_statuses
 mz_statement_execution_history_redacted
 
 > SET database = materialize


### PR DESCRIPTION
Ensuring that we only produce "new" statuses for private link connections introduced a lot of complexity whose benefit could instead be realized by just creating a view over the history table, as we do for sources and sinks.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
