### PR TITLE
ci: Support CI_TEST_SELECTION env variable

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -171,6 +171,7 @@ case "$cmd" in
             --env AWS_SESSION_TOKEN
             --env CI
             --env CI_COVERAGE_ENABLED
+            --env CI_TEST_SELECTION
             --env CONFLUENT_CLOUD_DEVEX_KAFKA_PASSWORD
             --env CONFLUENT_CLOUD_DEVEX_KAFKA_USERNAME
             --env GITHUB_TOKEN
@@ -179,6 +180,7 @@ case "$cmd" in
             --env LAUNCHDARKLY_SDK_KEY
             --env NIGHTLY_CANARY_APP_PASSWORD
             --env MZ_CLI_APP_PASSWORD
+            --env MZ_SOFT_ASSERTIONS
             --env NO_COLOR
             --env NPM_TOKEN
             --env POLAR_SIGNALS_API_TOKEN
@@ -190,7 +192,6 @@ case "$cmd" in
             --env SCHEMA_REGISTRY_URL
             --env POSTGRES_URL
             --env COCKROACH_URL
-            --env MZ_SOFT_ASSERTIONS
         )
 
         if [[ $detach_container == "true" ]]; then

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -134,7 +134,10 @@ so it is executed.""",
 
     permit_rerunning_successful_steps(pipeline)
 
-    add_test_selection_block(pipeline, args.pipeline)
+    if test_selection := os.getenv("CI_TEST_SELECTION"):
+        trim_test_selection(pipeline, set(test_selection.split(",")))
+    else:
+        add_test_selection_block(pipeline, args.pipeline)
 
     check_depends_on(pipeline, args.pipeline)
 
@@ -232,6 +235,32 @@ def check_depends_on(pipeline: Any, pipeline_name: str) -> None:
             raise UIError(
                 f"Every step should have an explicit depends_on value, missing in: {step}"
             )
+
+    for step in pipeline["steps"]:
+        visit(step)
+        if "group" in step:
+            for inner_step in step.get("steps", []):
+                visit(inner_step)
+
+
+def trim_test_selection(pipeline: Any, steps_to_run: set[str]) -> None:
+    def visit(step: dict[str, Any]) -> None:
+        if (
+            step.get("id") not in steps_to_run
+            and "prompt" not in step
+            and "wait" not in step
+            and "group" not in step
+            and step.get("id")
+            not in (
+                "coverage-pr-analyze",
+                "analyze",
+                "build-x86_64",
+                "build-aarch64",
+                "build-wasm",
+            )
+            and not step.get("async")
+        ):
+            step["skip"] = True
 
     for step in pipeline["steps"]:
         visit(step)


### PR DESCRIPTION
to directly run a selection of tests without manual selection in buildkite. to be used from https://github.com/MaterializeInc/trigger-ci

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
