### PR TITLE
pgwire: fix perf regression with portal paging (#24093)

### DIFF
--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -678,7 +678,6 @@ where
     async fn ensure_transaction(&mut self, num_stmts: usize) -> Result<(), io::Error> {
         if self.txn_needs_commit {
             self.commit_transaction().await?;
-            self.txn_needs_commit = false;
         }
         // start_transaction can't error (but assert that just in case it changes in
         // the future.
@@ -838,6 +837,7 @@ where
     /// End a transaction and report to the user if an error occurred.
     #[instrument(level = "debug", skip_all)]
     async fn end_transaction(&mut self, action: EndTransactionAction) -> Result<(), io::Error> {
+        self.txn_needs_commit = false;
         let resp = self.adapter_client.end_transaction(action).await;
         if let Err(err) = resp {
             self.send(BackendMessage::ErrorResponse(


### PR DESCRIPTION
This commit fixes a performance regression introduced by #24093, which allowed paging through portals in implicit transactions using the extended query protocol.

To demonstrate the flaw in the original code, consider the following sequence of extended query protocol messages, which repeatedly executes a query named `q1`:

  1. Bind q1
  2. Execute q1
  3. Sync
  4. Bind q1
  5. Execute q1
  6. Sync

(1) starts an implicit transaction. (2) sets `txn_needs_commit = true`. (3) commits the implicit transaction but crucially does *not* clear `txn_needs_commit`. Processing of (4) sees that `txn_needs_commit` is true and calls `StateMachine::commit_transaction`. This is a no-op, because the transaction has already been committed and nothing new has occurred, but it causes an additional roundtrip to the coordinator, and thus the performance regression observed in #24149.

This commit adjusts the `StateMachine` to clear `txn_needs_commit` whenever `end_transaction` is called, rather than just when `ensure_transaction` handles `txn_needs_commit` being set. So now the Sync message in (3) properly clears the `txn_needs_commit` flag, the processing of the Bind message in (4) no longer needs an extra roundtrip to the coordinator, and the performance regression disappears.

As an aside, I'm very impressed that the scalability benchmark was sensitive enough to reliably report this regression. It makes sense that only the benchmark of the simplest possible scenario (repeated `SELECT 1` commands) exposed the issue. More complicated queries will spend more time in planning, optimization, and execution, and so the additional coordinator roundtrip is negligible. But for `SELECT 1`, the additional roundtrip is significant.

Fix #24149.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
