### PR TITLE
frontegg-{auth,client}: explain disabling audience validation

### DIFF
--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -97,10 +97,26 @@ pub struct ExchangePasswordForTokenResponse {
 impl Authentication {
     /// Creates a new frontegg auth.
     pub fn new(config: AuthenticationConfig, client: Client, registry: &MetricsRegistry) -> Self {
-        // We validate with our own now function.
         let mut validation = Validation::new(Algorithm::RS256);
+
+        // We validate the token expiration with our own now function.
         validation.validate_exp = false;
+
+        // We don't validate the audience because:
+        //
+        //   1. We don't have easy access to the expected audience ID here.
+        //
+        //   2. There is no meaningful security improvement to doing so, because
+        //      Frontegg always sets the audience to the ID of the workspace
+        //      that issued the token. Since we only trust the signing keys from
+        //      a single Frontegg workspace, the audience is redundant.
+        //
+        // See this conversation [0] from the Materialize–Frontegg shared Slack
+        // channel on 1 January 2024.
+        //
+        // [0]: https://materializeinc.slack.com/archives/C02940WNMRQ/p1704131331041669
         validation.validate_aud = false;
+
         let validation_config = ValidationConfig {
             decoding_key: config.decoding_key,
             tenant_id: config.tenant_id,

--- a/src/frontegg-client/src/client.rs
+++ b/src/frontegg-client/src/client.rs
@@ -268,7 +268,22 @@ impl Client {
         let jwks = self.get_jwks().await.map_err(|_| Error::FetchingJwks)?;
         let jwk = jwks.keys.first().ok_or_else(|| Error::EmptyJwks)?;
         let token = self.auth().await?;
+
         let mut validation = Validation::new(Algorithm::RS256);
+
+        // We don't validate the audience because:
+        //
+        //   1. We don't have easy access to the expected audience ID here.
+        //
+        //   2. There is no meaningful security improvement to doing so, because
+        //      Frontegg always sets the audience to the ID of the workspace
+        //      that issued the token. Since we only trust the signing keys from
+        //      a single Frontegg workspace, the audience is redundant.
+        //
+        // For details, see this conversation [0] from the Materialize–Frontegg
+        // shared Slack channel on 1 January 2024.
+        //
+        // [0]: https://materializeinc.slack.com/archives/C02940WNMRQ/p1704131331041669
         validation.validate_aud = false;
 
         let token_data = decode::<Claims>(


### PR DESCRIPTION
This is against the spec's recommendation, so explain why it's not a security problem given how we use Frontegg.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* Add justification for security sensitive code. In general, anything that looks as surprising as this does in security sensitive code absolutely needs a comment!

### Tips for reviewer

Leaving in draft until Frontegg explicitly signs off on disabling audience validation in the linked Slack thread.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
