### PR TITLE
sql-parser: correct parsing of nested subqueries

### DIFF
--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -459,6 +459,55 @@ SELECT * FROM t WHERE x NOT IN (VALUES (1))
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("x")]), subquery: Query { ctes: Simple([]), body: Values(Values([[Value(Number("1"))]])), order_by: [], limit: None, offset: None }, negated: true }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
+SELECT * FROM t WHERE x IN (TABLE t)
+----
+SELECT * FROM t WHERE x IN (TABLE t)
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("x")]), subquery: Query { ctes: Simple([]), body: Table(Name(UnresolvedItemName([Ident("t")]))), order_by: [], limit: None, offset: None }, negated: false }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM t WHERE x IN (SHOW SOURCES)
+----
+SELECT * FROM t WHERE x IN (SHOW SOURCES)
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("x")]), subquery: Query { ctes: Simple([]), body: Show(ShowObjects(ShowObjectsStatement { object_type: Source { in_cluster: None }, from: None, filter: None })), order_by: [], limit: None, offset: None }, negated: false }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM t WHERE x IN (((SELECT 1)))
+----
+SELECT * FROM t WHERE x IN (SELECT 1)
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("x")]), subquery: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, negated: false }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM t WHERE x IN ((SELECT 1) UNION (SELECT 1))
+----
+SELECT * FROM t WHERE x IN ((SELECT 1) UNION (SELECT 1))
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("x")]), subquery: Query { ctes: Simple([]), body: SetOperation { op: Union, all: false, left: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), right: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) }, order_by: [], limit: None, offset: None }, negated: false }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT ((SELECT 1) + 1, 2 + ((SELECT 1) UNION (SELECT 2 WHERE false)));
+----
+SELECT ROW((SELECT 1) + 1, 2 + ((SELECT 1) UNION (SELECT 2 WHERE false)))
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Row { exprs: [Op { op: Op { namespace: None, op: "+" }, expr1: Subquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), expr2: Some(Value(Number("1"))) }, Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("2")), expr2: Some(Subquery(Query { ctes: Simple([]), body: SetOperation { op: Union, all: false, left: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), right: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: None }], from: [], selection: Some(Value(Boolean(false))), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) }, order_by: [], limit: None, offset: None })) }] }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM t WHERE x IN ((SELECT 1) + 1, 2 + ((SELECT 1) UNION (SELECT 2 WHERE false)));
+----
+SELECT * FROM t WHERE x IN ((SELECT 1) + 1, 2 + ((SELECT 1) UNION (SELECT 2 WHERE false)))
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: Some(InList { expr: Identifier([Ident("x")]), list: [Op { op: Op { namespace: None, op: "+" }, expr1: Subquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), expr2: Some(Value(Number("1"))) }, Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("2")), expr2: Some(Subquery(Query { ctes: Simple([]), body: SetOperation { op: Union, all: false, left: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), right: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: None }], from: [], selection: Some(Value(Boolean(false))), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) }, order_by: [], limit: None, offset: None })) }], negated: false }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM t WHERE x IN (((SELECT 1)) AND false
+----
+error: Expected right parenthesis, found EOF
+SELECT * FROM t WHERE x IN (((SELECT 1)) AND false
+                                                  ^
+
+parse-statement
 SELECT * FROM customers WHERE age BETWEEN 25 AND 32
 ----
 SELECT * FROM customers WHERE age BETWEEN 25 AND 32
@@ -1551,9 +1600,23 @@ SELECT 1 < ANY (SELECT 1)
 SELECT 1 < ANY (SELECT 1)
 
 parse-statement roundtrip
+SELECT 1 < ANY (1, 1)
+----
+error: ANY requires a single expression or subquery, not an expression list
+SELECT 1 < ANY (1, 1)
+                    ^
+
+parse-statement roundtrip
 SELECT 1 < ALL (SELECT 1)
 ----
 SELECT 1 < ALL (SELECT 1)
+
+parse-statement roundtrip
+SELECT 1 < ALL (1, 1)
+----
+error: ALL requires a single expression or subquery, not an expression list
+SELECT 1 < ALL (1, 1)
+                    ^
 
 parse-statement roundtrip
 SELECT * FROM data ORDER BY a, b AS OF AT LEAST 1

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -414,7 +414,17 @@ SELECT col FROM (SELECT 1 AS col) t WHERE col = ANY(VALUES (1))
 1
 
 query I
+SELECT col FROM (SELECT 1 AS col) t WHERE col = ANY((VALUES (1)))
+----
+1
+
+query I
 SELECT col FROM (SELECT 1 AS col) t WHERE col IN(VALUES(1))
+----
+1
+
+query I
+SELECT col FROM (SELECT 1 AS col) t WHERE col IN(((VALUES(1))))
 ----
 1
 


### PR DESCRIPTION
This commit fixes the issue described in #24156, where an IN, ANY, ALL, or SOME expression where the subquery on the right hand side was nested within more than one pair of parentheses, e.g.:

    x IN ((SELECT 1))

was parsed incorrectly. Specifically, it was previously parsed incorrectly as an Expr::InList(list: [Expr::Nested(Expr::Subquery)]), whereas it was supposed to be parsed as an Expr::InSubquery.

Along the way, this commit fixes a number of places where the parser was inconsistent about what tokens it allowed to start a query--most often not recognizing `TABLE` or `SHOW` as valid starts to a query.

It also fixes a bug where expressions like:

    ((1) + 1, 1)

were incorrectly rejected by the parser--the notable feature being that the first element of an implicit row constructor was an expression that 1) started with a nested expression and 2) followed the nested expression with at least one other expression.

Fix #24156.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
