### PR TITLE
adapter: make ChangedPlan message more specific

### DIFF
--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -178,8 +178,7 @@ impl Coordinator {
             )?;
             if &current_desc != desc {
                 Err(AdapterError::ChangedPlan(format!(
-                    "cached plan must not change result type, plan changed from {:?} to {:?}",
-                    desc, current_desc
+                    "cached plan must not change result type",
                 )))
             } else {
                 Ok(Some(current_revision))

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -177,7 +177,10 @@ impl Coordinator {
                 desc.param_types.iter().map(|ty| Some(ty.clone())).collect(),
             )?;
             if &current_desc != desc {
-                Err(AdapterError::ChangedPlan)
+                Err(AdapterError::ChangedPlan(format!(
+                    "cached plan must not change result type, plan changed from {:?} to {:?}",
+                    desc, current_desc
+                )))
             } else {
                 Ok(Some(current_revision))
             }

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -49,7 +49,7 @@ pub enum AdapterError {
     /// An error occurred in a catalog operation.
     Catalog(mz_catalog::memory::error::Error),
     /// The cached plan or descriptor changed.
-    ChangedPlan,
+    ChangedPlan(String),
     /// The cursor already exists.
     DuplicateCursor(String),
     /// An error while evaluating an expression.
@@ -390,7 +390,7 @@ impl AdapterError {
                 },
                 _ => SqlState::INTERNAL_ERROR,
             },
-            AdapterError::ChangedPlan => SqlState::FEATURE_NOT_SUPPORTED,
+            AdapterError::ChangedPlan(_) => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::DuplicateCursor(_) => SqlState::DUPLICATE_CURSOR,
             AdapterError::Eval(EvalError::CharacterNotValidForEncoding(_)) => {
                 SqlState::PROGRAM_LIMIT_EXCEEDED
@@ -510,7 +510,7 @@ impl fmt::Display for AdapterError {
                     system objects"
                 )
             }
-            AdapterError::ChangedPlan => f.write_str("cached plan must not change result type"),
+            AdapterError::ChangedPlan(e) => write!(f, "{}", e),
             AdapterError::Catalog(e) => e.fmt(f),
             AdapterError::DuplicateCursor(name) => {
                 write!(f, "cursor {} already exists", name.quoted())


### PR DESCRIPTION
Over time, this was used for more error types. This change reflects that and reports a more specific error.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
