### PR TITLE
test: Update persist-txn-fencing to use stash

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -94,6 +94,7 @@ IGNORE_RE = re.compile(
     | (platform-checks|legacy-upgrade|upgrade-matrix|feature-benchmark)-materialized-.* \| .*cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
     # Fencing warnings are OK in fencing test
     | persist-txn-fencing-mz_first-.* \| .*unexpected\ fence\ epoch
+    | persist-txn-fencing-mz_first-.* \| .*fenced\ by\ new\ catalog\ upper
     # For platform-checks upgrade tests
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage(\ to\ set\ (default|configured)\ parameter)?
     | internal\ error:\ no\ AWS\ external\ ID\ prefix\ configured

--- a/test/persist-txn-fencing/mzcompose.py
+++ b/test/persist-txn-fencing/mzcompose.py
@@ -141,98 +141,100 @@ def run_workload(c: Composition, workload: Workload) -> None:
         "mz_second": workload.persist_txn_second,
     }
 
-    with c.override(
-        *[
-            Materialized(
-                name=mz_name,
-                external_cockroach=True,
-                external_minio=True,
-                sanity_restart=False,
-                additional_system_parameter_defaults={
-                    "persist_txn_tables": mzs[mz_name]
-                },
-                # Shadow catalog can't gracefully handle fences.
-                catalog_store="stash",
-            )
-            for mz_name in mzs
-        ]
-    ):
-        c.up("mz_first")
+    # Run the test twice with each catalog implementation.
+    for catalog_store in ["stash", "persist"]:
+        print(f"+++ Running workload with {catalog_store} catalog implementation ...")
+        with c.override(
+            *[
+                Materialized(
+                    name=mz_name,
+                    external_cockroach=True,
+                    external_minio=True,
+                    sanity_restart=False,
+                    additional_system_parameter_defaults={
+                        "persist_txn_tables": mzs[mz_name]
+                    },
+                    catalog_store=catalog_store,
+                )
+                for mz_name in mzs
+            ]
+        ):
+            c.up("mz_first")
 
-        c.sql(
-            """
-                ALTER SYSTEM SET max_tables = 1000;
-                ALTER SYSTEM SET max_materialized_views = 1000;
-            """,
-            port=6877,
-            user="mz_system",
-            service="mz_first",
-        )
-
-        print("+++ Creating database objects ...")
-        for table_id in range(workload.tables):
             c.sql(
-                f"""
-                    CREATE TABLE IF NOT EXISTS table{table_id}(id INTEGER, subid INTEGER, mz_service STRING);
-                    CREATE MATERIALIZED VIEW view{table_id} AS SELECT DISTINCT id, subid, mz_service FROM table{table_id};
+                """
+                    ALTER SYSTEM SET max_tables = 1000;
+                    ALTER SYSTEM SET max_materialized_views = 1000;
                 """,
+                port=6877,
+                user="mz_system",
                 service="mz_first",
             )
 
-        print("+++ Running workload ...")
-        start = time.time()
-
-        # Schedule the start of the second Mz instance
-        operations = [(c, workload, Operation.START_SECOND_MZ, 0)]
-
-        # As well as all the other operations in the workload
-        operations = operations + [
-            (c, workload, workload.operation, id)
-            for id in range(workload.operation_count)
-        ]
-
-        with futures.ThreadPoolExecutor(
-            workload.concurrency,
-        ) as executor:
-            commits = executor.map(execute_operation, operations)
-
-        elapsed = time.time() - start
-        assert elapsed > (
-            workload.second_mz_delay * 2
-        ), f"Workload completed too soon - elapsed {elapsed}s is less than 2 x second_mz_delay({workload.second_mz_delay}s)"
-
-        print(
-            f"Workload completed in {elapsed} seconds, with second_mz_delay being {workload.second_mz_delay} seconds."
-        )
-
-        # Confirm that the first Mz has properly given up the ghost
-        mz_first_log = c.invoke("logs", "mz_first", capture=True)
-        assert (
-            "unable to confirm leadership" in mz_first_log.stdout
-            or "unexpected fence epoch" in mz_first_log.stdout
-        )
-
-        print("+++ Verifying committed transactions ...")
-        cursor = c.sql_cursor(service="mz_second")
-        for commit in commits:
-            if commit is None:
-                continue
-            for target in ["table", "view"]:
-                cursor.execute(
+            print("+++ Creating database objects ...")
+            for table_id in range(workload.tables):
+                c.sql(
                     f"""
-                    SELECT id, COUNT(*) AS transaction_size
-                    FROM {target}{commit.table_id}
-                    WHERE id = {commit.row_id}
-                    GROUP BY id
-                    """
+                        CREATE TABLE IF NOT EXISTS table{table_id}(id INTEGER, subid INTEGER, mz_service STRING);
+                        CREATE MATERIALIZED VIEW view{table_id} AS SELECT DISTINCT id, subid, mz_service FROM table{table_id};
+                    """,
+                    service="mz_first",
                 )
-                result = cursor.fetchall()
-                assert len(result) == 1
-                assert (
-                    result[0][0] == commit.row_id
-                ), f"Unexpected result {result}; commit: {commit}; target {target}"
-                assert (
-                    result[0][1] == commit.transaction_size
-                ), f"Unexpected result {result}; commit: {commit}; target {target}"
 
-        print("Verification complete.")
+            print("+++ Running workload ...")
+            start = time.time()
+
+            # Schedule the start of the second Mz instance
+            operations = [(c, workload, Operation.START_SECOND_MZ, 0)]
+
+            # As well as all the other operations in the workload
+            operations = operations + [
+                (c, workload, workload.operation, id)
+                for id in range(workload.operation_count)
+            ]
+
+            with futures.ThreadPoolExecutor(
+                workload.concurrency,
+            ) as executor:
+                commits = executor.map(execute_operation, operations)
+
+            elapsed = time.time() - start
+            assert elapsed > (
+                workload.second_mz_delay * 2
+            ), f"Workload completed too soon - elapsed {elapsed}s is less than 2 x second_mz_delay({workload.second_mz_delay}s)"
+
+            print(
+                f"Workload completed in {elapsed} seconds, with second_mz_delay being {workload.second_mz_delay} seconds."
+            )
+
+            # Confirm that the first Mz has properly given up the ghost
+            mz_first_log = c.invoke("logs", "mz_first", capture=True)
+            assert (
+                "unable to confirm leadership" in mz_first_log.stdout
+                or "unexpected fence epoch" in mz_first_log.stdout
+            )
+
+            print("+++ Verifying committed transactions ...")
+            cursor = c.sql_cursor(service="mz_second")
+            for commit in commits:
+                if commit is None:
+                    continue
+                for target in ["table", "view"]:
+                    cursor.execute(
+                        f"""
+                        SELECT id, COUNT(*) AS transaction_size
+                        FROM {target}{commit.table_id}
+                        WHERE id = {commit.row_id}
+                        GROUP BY id
+                        """
+                    )
+                    result = cursor.fetchall()
+                    assert len(result) == 1
+                    assert (
+                        result[0][0] == commit.row_id
+                    ), f"Unexpected result {result}; commit: {commit}; target {target}"
+                    assert (
+                        result[0][1] == commit.transaction_size
+                    ), f"Unexpected result {result}; commit: {commit}; target {target}"
+
+            print("Verification complete.")

--- a/test/persist-txn-fencing/mzcompose.py
+++ b/test/persist-txn-fencing/mzcompose.py
@@ -151,6 +151,8 @@ def run_workload(c: Composition, workload: Workload) -> None:
                 additional_system_parameter_defaults={
                     "persist_txn_tables": mzs[mz_name]
                 },
+                # Shadow catalog can't gracefully handle fences.
+                catalog_store="stash",
             )
             for mz_name in mzs
         ]

--- a/test/persist-txn-fencing/mzcompose.py
+++ b/test/persist-txn-fencing/mzcompose.py
@@ -133,7 +133,9 @@ def execute_operation(
 
 
 def run_workload(c: Composition, workload: Workload, catalog_store: str) -> None:
-    print(f"+++ Running workload {workload.name} with {catalog_store} catalog implementation ...")
+    print(
+        f"+++ Running workload {workload.name} with {catalog_store} catalog implementation ..."
+    )
     c.silent = True
 
     c.down(destroy_volumes=True)
@@ -212,6 +214,7 @@ def run_workload(c: Composition, workload: Workload, catalog_store: str) -> None
         assert (
             "unable to confirm leadership" in mz_first_log.stdout
             or "unexpected fence epoch" in mz_first_log.stdout
+            or "fenced by new catalog upper" in mz_first_log.stdout
         )
 
         print("+++ Verifying committed transactions ...")


### PR DESCRIPTION
This commit updates the persist-txn-fencing test to use the stash catalog instead of the shadow catalog. The shadow catalog can't gracefully handle fencing.

Fixes #24159

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
