### PR TITLE
Run CI mostly against aarch64

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -225,7 +225,7 @@ def set_default_agents_queue(pipeline: Any) -> None:
             and "group" not in step
             and "trigger" not in step
         ):
-            step["agents"] = {"queue": "linux-x86_64"}
+            step["agents"] = {"queue": "linux-aarch64"}
 
     for step in pipeline["steps"]:
         visit(step)

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -13,9 +13,19 @@ steps:
     command: bin/ci-builder run stable bin/pyactivate -m ci.test.build x86_64
     timeout_in_minutes: 60
     # For releases we trigger nightly from the test job directly, no need to build again
+    # TODO(def-) Get rid of this for PRs once we don't have any x86-64 tests remaining
     branches: "!v*.*"
     agents:
       queue: builder-linux-x86_64
+
+  - id: build-aarch64
+    label: Build aarch64
+    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build aarch64
+    timeout_in_minutes: 60
+    # For releases we trigger nightly from the test job directly, no need to build again
+    branches: "!v*.*"
+    agents:
+      queue: builder-linux-aarch64
 
   - wait: ~
 
@@ -23,7 +33,7 @@ steps:
     timeout_in_minutes: 10
     if: build.source == "ui"
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - wait: ~
 
@@ -35,14 +45,14 @@ steps:
       label: Detect references to already closed issues
       command: bin/ci-builder run stable bin/ci-closed-issues-detect
       agents:
-        queue: linux-x86_64-small
+        queue: linux-aarch64-small
 
     - id: unused-deps
       label: Unused dependencies
       command: bin/ci-builder run nightly bin/unused-deps
       timeout_in_minutes: 30
       agents:
-        queue: linux-x86_64
+        queue: linux-aarch64
 
 
   - id: miri-test
@@ -55,7 +65,7 @@ steps:
           composition: cargo-test
           args: [--miri-full]
     agents:
-      queue: builder-linux-x86_64
+      queue: builder-linux-aarch64
 
   - group: Benchmarks
     key: benchmark
@@ -64,7 +74,7 @@ steps:
       label: "Feature benchmark against merge base or 'latest'"
       timeout_in_minutes: 720
       agents:
-        queue: linux-x86_64-large
+        queue: linux-aarch64-large
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -77,7 +87,7 @@ steps:
       label: "Scalability benchmark against merge base or 'latest'"
       timeout_in_minutes: 180
       agents:
-        queue: linux-x86_64
+        queue: linux-aarch64
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -99,6 +109,7 @@ steps:
       label: Kafka smoke test against previous Kafka versions
       timeout_in_minutes: 60
       agents:
+        # no matching manifest for linux/arm64/v8 in the manifest list entries
         queue: linux-x86_64-small
       artifact_paths: junit_*.xml
       plugins:
@@ -109,7 +120,7 @@ steps:
       label: Kafka multi-broker test
       timeout_in_minutes: 10
       agents:
-        queue: linux-x86_64-small
+        queue: linux-aarch64-small
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -122,7 +133,7 @@ steps:
         label: ":panda_face: :racing_car: testdrive"
         timeout_in_minutes: 180
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -147,7 +158,7 @@ steps:
         label: ":racing_car: testdrive with --kafka-default-partitions 5"
         timeout_in_minutes: 180
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -159,7 +170,7 @@ steps:
         label: ":racing_car: testdrive 4 replicas"
         timeout_in_minutes: 180
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -171,7 +182,7 @@ steps:
         label: ":racing_car: testdrive with SIZE 1"
         timeout_in_minutes: 360
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -183,7 +194,7 @@ steps:
         label: ":racing_car: testdrive with SIZE 8"
         timeout_in_minutes: 180
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -195,7 +206,7 @@ steps:
         label: Full Testdrive in Cloudtest (K8s)
         timeout_in_minutes: 300
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -206,7 +217,7 @@ steps:
         label: ":racing_car: testdrive with --persistent-user-tables"
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -221,7 +232,7 @@ steps:
     - id: limits
       label: "Product limits"
       agents:
-        queue: linux-x86_64
+        queue: linux-aarch64
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -233,7 +244,7 @@ steps:
       agents:
         # A larger instance is needed due to the
         # many containers that are being created
-        queue: builder-linux-x86_64
+        queue: linux-aarch64-large
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -246,7 +257,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 3600
       agents:
-        queue: linux-x86_64
+        queue: linux-aarch64
       plugins:
         - ./ci/plugins/mzcompose:
             composition: bounded-memory
@@ -262,7 +273,7 @@ steps:
         - ./ci/plugins/mzcompose:
             composition: upsert
       agents:
-        queue: linux-x86_64-small
+        queue: linux-aarch64-small
 
     - id: upsert-compaction-disabled
       label: Upsert (compaction disabled)
@@ -273,7 +284,7 @@ steps:
             composition: upsert
             args: [--compaction-disabled]
       agents:
-        queue: linux-x86_64-small
+        queue: linux-aarch64-small
 
   - id: ssh-connection-extended
     label: Extended SSH connection tests
@@ -284,7 +295,7 @@ steps:
           composition: ssh-connection
           args: [--extended]
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - group: Zippy
     key: zippy
@@ -293,7 +304,7 @@ steps:
         label: "Zippy Kafka Sources"
         timeout_in_minutes: 120
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -304,7 +315,7 @@ steps:
         label: "Zippy Kafka Parallel Insert"
         timeout_in_minutes: 120
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -315,7 +326,7 @@ steps:
         label: "Zippy User Tables"
         timeout_in_minutes: 180
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -326,7 +337,7 @@ steps:
         label: "Zippy User Tables + toggle persist-txn"
         timeout_in_minutes: 180
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -337,7 +348,7 @@ steps:
         label: "Zippy Postgres CDC"
         timeout_in_minutes: 120
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -348,7 +359,7 @@ steps:
         label: "Zippy Debezium Postgres"
         timeout_in_minutes: 120
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -359,7 +370,7 @@ steps:
         label: "Zippy Cluster Replicas"
         timeout_in_minutes: 120
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -370,7 +381,7 @@ steps:
         label: "Zippy w/ latest CRDB"
         timeout_in_minutes: 120
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -381,7 +392,7 @@ steps:
         label: "Zippy w/ alter connection"
         timeout_in_minutes: 120
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -395,7 +406,7 @@ steps:
         label: AWS (Real)
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -406,7 +417,7 @@ steps:
         label: AWS (Localstack)
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -416,7 +427,7 @@ steps:
         label: "Secrets Local File"
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -431,7 +442,7 @@ steps:
         artifact_paths: junit_*.xml
         agents:
           # A larger instance is needed due to frequent OOMs
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -443,7 +454,7 @@ steps:
         artifact_paths: junit_*.xml
         agents:
           # A larger instance is needed due to frequent OOMs
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -454,7 +465,7 @@ steps:
         timeout_in_minutes: 60
         artifact_paths: junit_*.xml
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -465,7 +476,7 @@ steps:
         timeout_in_minutes: 60
         artifact_paths: junit_*.xml
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -476,7 +487,7 @@ steps:
         timeout_in_minutes: 60
         artifact_paths: junit_*.xml
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -487,7 +498,7 @@ steps:
         timeout_in_minutes: 60
         artifact_paths: junit_*.xml
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -498,7 +509,7 @@ steps:
         skip: "Affected by #23882"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -510,7 +521,7 @@ steps:
         skip: "Affected by #23882"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -522,7 +533,7 @@ steps:
         skip: "Affected by #23882"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -534,7 +545,7 @@ steps:
         skip: "Affected by #23882"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -546,7 +557,7 @@ steps:
         skip: "Affected by #23882"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -558,7 +569,7 @@ steps:
         skip: "Affected by #23882"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -569,7 +580,7 @@ steps:
         label: "Checks upgrade, whole-Mz restart"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -580,7 +591,7 @@ steps:
         label: "Checks upgrade from previous version, whole-Mz restart"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -591,7 +602,7 @@ steps:
         label: "Checks upgrade across two versions"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -602,7 +613,7 @@ steps:
         label: "Checks upgrade from X-2 directly to HEAD"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -613,7 +624,7 @@ steps:
         label: "Checks upgrade across four versions"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -624,7 +635,7 @@ steps:
         label: "Platform checks upgrade, restarting compute clusterd first"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -635,7 +646,7 @@ steps:
         label: "Platform checks upgrade, restarting compute clusterd last"
         timeout_in_minutes: 60
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -647,7 +658,7 @@ steps:
         timeout_in_minutes: 45
         artifact_paths: junit_*.xml
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -658,7 +669,7 @@ steps:
         timeout_in_minutes: 45
         artifact_paths: junit_*.xml
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -669,7 +680,7 @@ steps:
         timeout_in_minutes: 45
         artifact_paths: junit_*.xml
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -680,7 +691,8 @@ steps:
         timeout_in_minutes: 45
         artifact_paths: junit_*.xml
         agents:
-          queue: builder-linux-x86_64
+          # Seems to require more memory on aarch64
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -688,10 +700,11 @@ steps:
 
       - id: checks-persist-txn-toggle
         label: "Checks + Toggle persist_txn"
-        timeout_in_minutes: 45
+        timeout_in_minutes: 60
         artifact_paths: junit_*.xml
         agents:
-          queue: builder-linux-x86_64
+          # Seems to require more memory on aarch64
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -702,7 +715,7 @@ steps:
         timeout_in_minutes: 45
         artifact_paths: junit_*.xml
         agents:
-          queue: builder-linux-x86_64
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -734,7 +747,7 @@ steps:
         label: "Random upgrades over the entire matrix"
         timeout_in_minutes: 600
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -745,7 +758,7 @@ steps:
         label: "Platform checks upgrade in Cloudtest/K8s"
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -764,13 +777,13 @@ steps:
               composition: persist
               args: [--consensus=mem, --blob=mem]
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
       - id: persist-maelstrom-single-node
         label: Long single-node Maelstrom coverage of persist
         timeout_in_minutes: 20
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -781,7 +794,7 @@ steps:
         label: Long multi-node Maelstrom coverage of persist with postgres consensus
         timeout_in_minutes: 20
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -792,7 +805,7 @@ steps:
         label: Maelstrom coverage of persist-txn
         timeout_in_minutes: 10
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -804,7 +817,7 @@ steps:
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: persistence
@@ -819,7 +832,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 30
       agents:
-        queue: linux-x86_64-small
+        queue: linux-aarch64-small
       plugins:
         - ./ci/plugins/mzcompose:
             composition: sql-feature-flags
@@ -829,7 +842,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 30
       agents:
-        queue: linux-x86_64-small
+        queue: linux-aarch64-small
       plugins:
         - ./ci/plugins/mzcompose:
             composition: launchdarkly
@@ -841,7 +854,7 @@ steps:
     concurrency: 1
     concurrency_group: 'cloud-canary'
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cloud-canary
@@ -854,7 +867,7 @@ steps:
     concurrency: 1
     concurrency_group: 'mz-e2e'
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: mz-e2e
@@ -880,7 +893,7 @@ steps:
         label: "Output consistency (internal)"
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -891,7 +904,7 @@ steps:
         label: "Output consistency (Postgres)"
         timeout_in_minutes: 58
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -902,6 +915,7 @@ steps:
         label: "Output consistency (version)"
         timeout_in_minutes: 58
         agents:
+          # no matching manifest for linux/arm64/v8 in the manifest list entries
           queue: linux-x86_64-small
         artifact_paths: junit_*.xml
         plugins:
@@ -917,7 +931,7 @@ steps:
         artifact_paths: junit_*.xml
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlsmith
@@ -928,7 +942,7 @@ steps:
         artifact_paths: junit_*.xml
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlsmith
@@ -942,7 +956,7 @@ steps:
         artifact_paths: junit_*.xml
         timeout_in_minutes: 40
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -953,7 +967,7 @@ steps:
         artifact_paths: junit_*.xml
         timeout_in_minutes: 40
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -964,7 +978,7 @@ steps:
         artifact_paths: junit_*.xml
         timeout_in_minutes: 40
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -975,7 +989,7 @@ steps:
         artifact_paths: junit_*.xml
         timeout_in_minutes: 40
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -989,7 +1003,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 45
       agents:
-        queue: linux-x86_64-small
+        queue: linux-aarch64-small
       plugins:
         - ./ci/plugins/mzcompose:
             composition: rqg
@@ -1001,7 +1015,7 @@ steps:
       timeout_in_minutes: 45
       agents:
         # Runs into timeout on small agents
-        queue: linux-x86_64
+        queue: linux-aarch64
       plugins:
         - ./ci/plugins/mzcompose:
             composition: rqg
@@ -1012,7 +1026,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 45
       agents:
-        queue: linux-x86_64-small
+        queue: linux-aarch64-small
       plugins:
         - ./ci/plugins/mzcompose:
             composition: rqg
@@ -1023,7 +1037,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 45
       agents:
-        queue: linux-x86_64-small
+        queue: linux-aarch64-small
       plugins:
         - ./ci/plugins/mzcompose:
             composition: rqg
@@ -1034,7 +1048,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 45
       agents:
-        queue: linux-x86_64-small
+        queue: linux-aarch64-small
       plugins:
         - ./ci/plugins/mzcompose:
             composition: rqg
@@ -1045,7 +1059,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 45
       agents:
-        queue: linux-x86_64
+        queue: linux-aarch64
       plugins:
         - ./ci/plugins/mzcompose:
             composition: rqg
@@ -1058,7 +1072,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 45
       agents:
-        queue: linux-x86_64-small
+        queue: linux-aarch64-small
       plugins:
         - ./ci/plugins/mzcompose:
             composition: rqg
@@ -1069,7 +1083,7 @@ steps:
     timeout_in_minutes: 15
     artifact_paths: junit_*.xml
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: crdb-restarts
@@ -1079,7 +1093,7 @@ steps:
     timeout_in_minutes: 15
     artifact_paths: junit_*.xml
     agents:
-      queue: linux-x86_64
+      queue: linux-aarch64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: pubsub-disruption
@@ -1090,7 +1104,7 @@ steps:
     timeout_in_minutes: 15
     artifact_paths: junit_*.xml
     agents:
-      queue: linux-x86_64
+      queue: linux-aarch64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: retain-history
@@ -1100,7 +1114,7 @@ steps:
     artifact_paths: junit_*.xml
     timeout_in_minutes: 60
     agents:
-      queue: linux-x86_64
+      queue: linux-aarch64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: data-ingest
@@ -1113,7 +1127,7 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1124,7 +1138,7 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1135,8 +1149,8 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          # OOMs with linux-x86_64-small
-          queue: linux-x86_64
+          # OOMs with linux-aarch64-small
+          queue: linux-aarch64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1147,7 +1161,7 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1158,7 +1172,7 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1170,7 +1184,7 @@ steps:
         timeout_in_minutes: 60
         skip: "TODO(def-): Reenable when #2392 is fixed"
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1181,8 +1195,8 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          # OOMs with linux-x86_64-small
-          queue: linux-x86_64
+          # OOMs with linux-aarch64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1194,7 +1208,7 @@ steps:
         timeout_in_minutes: 60
         skip: "TODO(def-): Properly stop all db actions during backup & restore"
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1205,7 +1219,7 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1216,7 +1230,7 @@ steps:
     timeout_in_minutes: 15
     skip: "Affected by #15209"
     agents:
-      queue: linux-x86_64
+      queue: linux-aarch64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -1227,7 +1241,7 @@ steps:
     label: "Tests for balancerd"
     timeout_in_minutes: 15
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -1241,7 +1255,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: restart
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - id: legacy-upgrade
     label: Legacy upgrade tests (last version from git)
@@ -1252,7 +1266,7 @@ steps:
           composition: legacy-upgrade
           args: ["--versions-source=git"]
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - id: persist-txn-fencing
     label: Persist-txn fencing
@@ -1263,7 +1277,7 @@ steps:
           composition: persist-txn-fencing
 
     agents:
-      queue: linux-x86_64
+      queue: linux-aarch64
 
   - group: "Language tests"
     key: language-tests
@@ -1276,7 +1290,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: csharp
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
       - id: lang-js
         label: ":js: tests"
@@ -1286,7 +1300,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: js
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
       - id: lang-java
         label: ":java: tests"
@@ -1296,7 +1310,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: java
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
       - id: lang-python
         label: ":python: tests"
@@ -1306,7 +1320,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: python
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
       - id: lang-ruby
         label: ":ruby: tests"
@@ -1316,7 +1330,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: ruby
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
   - wait: ~
     continue_on_failure: true
@@ -1330,4 +1344,4 @@ steps:
           job-uuid-file-pattern: _([^_]*).xml
     priority: 1
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -8,12 +8,12 @@
 # by the Apache License, Version 2.0.
 
 steps:
-  - id: build-x86_64
-    label: Build x86_64
-    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build x86_64
+  - id: build-aarch64
+    label: Build aarch64
+    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build aarch64
     timeout_in_minutes: 60
     agents:
-      queue: builder-linux-x86_64
+      queue: builder-linux-aarch64
     # Don't build for "trigger_job" source, which indicates that this release
     # qualification pipeline was triggered automatically by the tests pipeline
     # because there is a new tag on a v* branch. In this case we want to make
@@ -27,7 +27,7 @@ steps:
     timeout_in_minutes: 10
     if: build.source == "ui"
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - wait: ~
 
@@ -39,7 +39,7 @@ steps:
       # 48h
       timeout_in_minutes: 2880
       agents:
-        queue: linux-x86_64-large
+        queue: linux-aarch64-large
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -51,7 +51,7 @@ steps:
       # 48h
       timeout_in_minutes: 2880
       agents:
-        queue: linux-x86_64-large
+        queue: linux-aarch64-large
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -62,7 +62,7 @@ steps:
       label: "Large Zippy PogresCdc"
       timeout_in_minutes: 2880
       agents:
-        queue: linux-x86_64-large
+        queue: linux-aarch64-large
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -73,7 +73,7 @@ steps:
       label: "Longer Zippy ClusterReplicas"
       timeout_in_minutes: 2880
       agents:
-        queue: linux-x86_64-large
+        queue: linux-aarch64-large
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -85,7 +85,7 @@ steps:
       label: "Large Zippy w/ user tables"
       timeout_in_minutes: 2880
       agents:
-        queue: linux-x86_64-large
+        queue: linux-aarch64-large
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -96,7 +96,7 @@ steps:
       label: "Longer Zippy Debezium Postgres"
       timeout_in_minutes: 2880
       agents:
-        queue: linux-x86_64
+        queue: linux-aarch64
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -107,7 +107,7 @@ steps:
       label: "Large-scale backup+restore"
       timeout_in_minutes: 2880
       agents:
-        queue: linux-x86_64
+        queue: linux-aarch64
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -119,7 +119,7 @@ steps:
       label: "Longer Zippy Kafka Parallel Insert"
       timeout_in_minutes: 2880
       agents:
-        queue: linux-x86_64-large
+        queue: linux-aarch64-large
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -130,7 +130,7 @@ steps:
     label: "Feature benchmark against 'latest' with --scale=+1"
     timeout_in_minutes: 2880
     agents:
-      queue: linux-x86_64-large
+      queue: linux-aarch64-large
     plugins:
       - ./ci/plugins/mzcompose:
           composition: feature-benchmark
@@ -144,7 +144,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 120
       agents:
-        queue: linux-x86_64
+        queue: linux-aarch64
       plugins:
         - ./ci/plugins/mzcompose:
             composition: sqlsmith
@@ -155,7 +155,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 120
       agents:
-        queue: linux-x86_64
+        queue: linux-aarch64
       plugins:
         - ./ci/plugins/mzcompose:
             composition: sqlsmith
@@ -174,4 +174,4 @@ steps:
           job-uuid-file-pattern: _([^_]*).xml
     priority: 1
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small

--- a/ci/security/pipeline.template.yml
+++ b/ci/security/pipeline.template.yml
@@ -13,4 +13,4 @@ steps:
   - command: bin/ci-builder run stable cargo deny check advisories
     timeout_in_minutes: 5
     agents:
-      queue: linux-x86_64
+      queue: linux-aarch64

--- a/ci/slt/pipeline.template.yml
+++ b/ci/slt/pipeline.template.yml
@@ -8,12 +8,12 @@
 # by the Apache License, Version 2.0.
 
 steps:
-  - id: build-x86_64
-    label: Build x86_64
-    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build x86_64
+  - id: build-aarch64
+    label: Build aarch64
+    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build aarch64
     timeout_in_minutes: 60
     agents:
-      queue: builder-linux-x86_64
+      queue: builder-linux-aarch64
 
   - wait: ~
 
@@ -23,7 +23,7 @@ steps:
     parallelism: 10
     artifact_paths: junit_*.xml
     agents:
-      queue: linux-x86_64
+      queue: linux-aarch64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
@@ -35,7 +35,7 @@ steps:
     parallelism: 10
     artifact_paths: junit_*.xml
     agents:
-      queue: linux-x86_64
+      queue: linux-aarch64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
@@ -55,4 +55,4 @@ steps:
           job-uuid-file-pattern: _([^_]*).xml
     priority: 1
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small

--- a/ci/test/mkpipeline.sh
+++ b/ci/test/mkpipeline.sh
@@ -46,5 +46,5 @@ steps:
     command: bin/ci-builder run stable bin/pyactivate -m ci.mkpipeline test $@
     priority: 2
     agents:
-      queue: linux-x86_64
+      queue: linux-aarch64-small
 EOF

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -25,6 +25,7 @@ steps:
   - group: Builds
     key: builds
     steps:
+      # TODO(def-) Get rid of this for PRs once we don't have any x86-64 tests remaining
       - id: build-x86_64
         label: Build x86_64
         command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
@@ -44,10 +45,8 @@ steps:
         depends_on: []
         priority: 1
         timeout_in_minutes: 60
-        branches: "main v*.*"
         agents:
           queue: builder-linux-aarch64
-        coverage: skip
 
       - id: build-wasm
         label: Build WASM
@@ -57,6 +56,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 10
         agents:
+          # Error: no prebuilt wasm-opt binaries are available for this platform: Unrecognized target!
           queue: linux-x86_64-small
         coverage: skip
 
@@ -70,7 +70,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         if: "build.pull_request.id != null"
         coverage: skip
 
@@ -84,7 +84,7 @@ steps:
           - build-aarch64
         timeout_in_minutes: 10
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         coverage: skip
         # Fortify against intermittent DockerHub issues
         retry:
@@ -103,7 +103,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 10
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         coverage: skip
 
       - id: lint-slow
@@ -116,6 +116,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 30
         agents:
+          # note: the `x86_64-unknown-linux-gnu` target may not be installed
           queue: builder-linux-x86_64
         coverage: skip
 
@@ -145,7 +146,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         coverage: skip
 
       - id: vet-check
@@ -157,7 +158,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 5
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
         coverage: skip
 
       - id: lint-docs
@@ -170,6 +171,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 30
         agents:
+          # hugo: command not found
           queue: linux-x86_64-small
         coverage: skip
 
@@ -180,6 +182,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 30
         agents:
+          # hugo: command not found
           queue: linux-x86_64-small
         coverage: skip
 
@@ -206,7 +209,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: cargo-test
         agents:
-          queue: builder-linux-x86_64
+          queue: builder-linux-aarch64
 
       - id: miri-test
         label: Miri test (fast)
@@ -220,12 +223,12 @@ steps:
               composition: cargo-test
               args: [--miri-fast]
         agents:
-          queue: builder-linux-x86_64
+          queue: builder-linux-aarch64
         coverage: skip
 
   - id: testdrive
     label: Testdrive %N
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 30
     inputs: [test/testdrive]
     parallelism: 6
@@ -237,11 +240,11 @@ steps:
           composition: testdrive
           args: [--aws-region=us-east-1]
     agents:
-      queue: linux-x86_64
+      queue: linux-aarch64
 
   - id: cluster-tests
     label: Cluster tests %N
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     inputs: [test/cluster]
@@ -250,11 +253,11 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: cluster
     agents:
-      queue: linux-x86_64
+      queue: linux-aarch64
 
   - id: sqllogictest-fast
     label: Fast SQL logic tests %N
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 30
     parallelism: 6
     inputs: [test/sqllogictest]
@@ -263,22 +266,22 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - id: restarts
     label: Restart test
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: restart
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - id: legacy-upgrade
     label: Legacy upgrade tests (last version from docs)
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 60
     artifact_paths: junit_*.xml
     plugins:
@@ -286,14 +289,14 @@ steps:
           composition: legacy-upgrade
           args: ["--versions-source=docs"]
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - group: "Debezium tests"
     key: debezium-tests
     steps:
       - id: debezium-postgres
         label: Debezium Postgres tests
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/debezium]
         artifact_paths: junit_*.xml
@@ -302,11 +305,11 @@ steps:
               composition: debezium
               run: postgres
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
       - id: debezium-sql-server
         label: Debezium SQL Server tests
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/debezium]
         artifact_paths: junit_*.xml
@@ -315,11 +318,13 @@ steps:
               composition: debezium
               run: sql-server
         agents:
+          # sql-server The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
+          # See https://github.com/microsoft/mssql-docker/issues/802
           queue: linux-x86_64-small
 
       - id: debezium-mysql
         label: Debezium MySQL tests
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/debezium]
         artifact_paths: junit_*.xml
@@ -328,14 +333,14 @@ steps:
               composition: debezium
               run: mysql
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
   - group: "MySQL tests"
     key: mysql-tests
     steps:
       - id: mysql-cdc
         label: MySQL CDC tests
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/mysql-cdc]
         artifact_paths: junit_*.xml
@@ -343,14 +348,14 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
   - group: "Postgres tests"
     key: postgres-tests
     steps:
       - id: pg-cdc
         label: Postgres CDC tests
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/pg-cdc]
         artifact_paths: junit_*.xml
@@ -358,12 +363,12 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc
         agents:
-          queue: linux-x86_64 # TODO(def-) Switch to small when #24324 is fixed
+          queue: linux-aarch64 # TODO(def-) Switch to small when #24324 is fixed
 
       - id: pg-cdc-resumption
         label: Postgres CDC resumption tests
         parallelism: 2
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/pg-cdc-resumption]
         artifact_paths: junit_*.xml
@@ -371,11 +376,11 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc-resumption
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
   - id: ssh-connection
     label: SSH connection tests
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 20
     inputs: [test/ssh-connection]
     artifact_paths: junit_*.xml
@@ -383,25 +388,25 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: ssh-connection
     agents:
-      queue: linux-x86_64
+      queue: linux-aarch64
 
   - group: "Kafka tests"
     key: kafka-tests
     steps:
       - id: kafka-resumption
         label: Kafka resumption tests
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         timeout_in_minutes: 30
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
               composition: kafka-resumption
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
       - id: kafka-auth
         label: Kafka auth test
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/kafka-auth/smoketest.td]
         artifact_paths: junit_*.xml
@@ -409,27 +414,27 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-auth
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
       - id: kafka-exactly-once
         label: Kafka exactly-once tests
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         timeout_in_minutes: 30
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
               composition: kafka-exactly-once
         agents:
-          queue: linux-x86_64-small
+          queue: linux-aarch64-small
 
   - id: zippy-kafka-sources-short
     label: "Short Zippy"
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     inputs: [misc/python/materialize/zippy]
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
@@ -440,13 +445,13 @@ steps:
     steps:
       - id: checks-restart-environmentd-clusterd-storage
         label: "Checks + restart of environmentd & storage clusterd (%N)"
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
         parallelism: 5
         artifact_paths: junit_*.xml
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -454,13 +459,13 @@ steps:
 
       - id: checks-no-restart-no-upgrade
         label: "Checks without restart or upgrade"
-        depends_on: build-x86_64
+        depends_on: build-aarch64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
         parallelism: 2
         artifact_paths: junit_*.xml
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -468,7 +473,7 @@ steps:
 
   - id: cloudtest
     label: Cloudtest %N
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     parallelism: 6
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
@@ -486,10 +491,10 @@ steps:
   - id: source-sink-errors
     label: "Source/Sink Error Reporting"
     artifact_paths: junit_*.xml
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 30
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: source-sink-errors
@@ -497,17 +502,17 @@ steps:
   - id: backup-restore
     label: "CRDB / Persist backup and restore"
     artifact_paths: junit_*.xml
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 10
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: backup-restore
 
   - id: feature-benchmark-kafka-only
     label: "Feature benchmark (Kafka only)"
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 45
     artifact_paths: junit_*.xml
     plugins:
@@ -522,7 +527,7 @@ steps:
   # for an agent
   - id: replica-isolation
     label: Replica isolation
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 20
     inputs: [test/replica-isolation]
     artifact_paths: junit_*.xml
@@ -530,34 +535,34 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: replica-isolation
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - id: persistence
     label: Persistence tests
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: persistence
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - id: cluster-isolation
     label: Cluster isolation test
-    depends_on: build-x86_64
-    timeout_in_minutes: 10
+    depends_on: build-aarch64
+    timeout_in_minutes: 20
     inputs: [test/cluster-isolation]
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cluster-isolation
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - id: chbench-demo
     label: chbench smoke test
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -565,23 +570,25 @@ steps:
           args: [--run-seconds=10, --wait]
     timeout_in_minutes: 30
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - id: metabase-demo
     label: Metabase smoke test
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 10
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: metabase
     agents:
+      # metabase The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
+      # See https://github.com/metabase/metabase/issues/13119
       queue: linux-x86_64-small
 
   - id: dbt-materialize
     label: dbt-materialize tests
-    depends_on: build-x86_64
-    timeout_in_minutes: 15
+    depends_on: build-aarch64
+    timeout_in_minutes: 20
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -592,17 +599,17 @@ steps:
   - id: storage-usage
     label: "Storage Usage Table Test"
     artifact_paths: junit_*.xml
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 30
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: storage-usage
 
   - id: tracing
     label: "Tracing Fast Path"
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 10
     inputs: [test/tracing]
     artifact_paths: junit_*.xml
@@ -610,7 +617,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: tracing
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - id: persist-catalog-migration
     label: "Persist Catalog Migration"
@@ -718,7 +725,7 @@ steps:
     inputs: ["*"]
     priority: 1
     agents:
-      queue: builder-linux-x86_64
+      queue: linux-aarch64-large
     coverage: only
 
   - wait: ~
@@ -734,7 +741,7 @@ steps:
           job-uuid-file-pattern: _([^_]*).xml
     priority: 1
     agents:
-      queue: linux-x86_64-small
+      queue: linux-aarch64-small
 
   - wait: ~
 


### PR DESCRIPTION
There might be plans to switch Mz to run on aarch64 for staging and prod, see https://materializeinc.slack.com/archives/CNVRXGFDJ/p1703944130413899

Before that we should switch CI to aarch64 too.

Based on my experiment most of our tests seem to work fine out of the box with aarch64, but I'm seeing more OoMs than with x86-64. Do we expect higher memory usage?
Another problem is that some tests are failing because of docker images being x86-64 only, so we'd have to build our own versions or potentially require both x86-64 and aarch64 builds on PRs, which is not great.
Some tests are slower now, this seems expected.

I'm not sure what the timeline should be, so will leave this as a draft for now.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
