### PR TITLE
catalog: Update migrate savepoint implementation

### DIFF
--- a/src/catalog/src/durable/impls/migrate.rs
+++ b/src/catalog/src/durable/impls/migrate.rs
@@ -61,10 +61,11 @@ impl OpenableDurableCatalogState for CatalogMigrator {
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
+        let stash_initialized = self.openable_stash.is_initialized().await?;
         let stash = self
             .openable_stash
             .open_savepoint(boot_ts.clone(), bootstrap_args, deploy_generation.clone())
-            .await?;
+            .await;
         let persist_initialized = self.openable_persist.is_initialized().await?;
         let persist = self
             .openable_persist
@@ -78,9 +79,20 @@ impl OpenableDurableCatalogState for CatalogMigrator {
                 && !persist_initialized
                 && self.direction == Direction::RollbackToStash
             {
-                return Ok(stash);
+                return stash;
             }
         }
+        // If our target implementation is the persist, but the stash is uninitialized, then we can
+        // still proceed with only using persist.
+        if let Err(CatalogError::Durable(e)) = &stash {
+            if e.can_recover_with_write_mode()
+                && !stash_initialized
+                && self.direction == Direction::MigrateToPersist
+            {
+                return persist;
+            }
+        }
+        let stash = stash?;
         let persist = persist?;
 
         Self::open_inner(stash, persist, self.direction).await


### PR DESCRIPTION
This commit is a followup to 2c9ef1534c4131c70f6ecb6085fae844d7dedec5, which updates the migrate savepoint implementation to work when the direction is "migrate to persist" and the stash is uninitialized. The approach taken is identical to
2c9ef1534c4131c70f6ecb6085fae844d7dedec5, so see that commit message for more details.

A scenario where we are migrating to persist and the stash is uninitialized is extremely unlikely and probably impossible in production. The `CatalogMigrator` implementation always opens the stash catalog before the persist catalog and all prod environments have an initialized stash catalog. Still, it's better to cover this scenario than to ignore it.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
