### PR TITLE
storage: revert kafka sink refactor

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -45,6 +45,7 @@ use mz_storage_client::controller::ExportDescription;
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::controller::StorageError;
 use mz_storage_types::read_policy::ReadPolicy;
+use mz_storage_types::sinks::SinkAsOf;
 use mz_storage_types::sources::GenericSourceConnection;
 use serde_json::json;
 use tracing::{event, warn, Level};
@@ -989,7 +990,11 @@ impl Coordinator {
             storage_ids: btreeset! {sink.from},
             compute_ids: btreemap! {},
         };
-        let as_of = self.least_valid_read(&id_bundle);
+        let min_as_of = self.least_valid_read(&id_bundle);
+        let as_of = SinkAsOf {
+            frontier: min_as_of,
+            strict: !sink.with_snapshot,
+        };
 
         let storage_sink_from_entry = self.catalog().get_entry(&sink.from);
         let storage_sink_desc = mz_storage_types::sinks::StorageSinkDesc {
@@ -1007,7 +1012,6 @@ impl Coordinator {
                 .into_inline_connection(self.catalog().state()),
             envelope: sink.envelope,
             as_of,
-            with_snapshot: sink.with_snapshot,
             status_id,
             from_storage_metadata: (),
         };

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -172,7 +172,6 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             config.kafka_transaction_timeout(),
             config.kafka_socket_connection_setup_timeout(),
             config.kafka_fetch_metadata_timeout(),
-            config.kafka_progress_record_fetch_timeout(),
         ),
     }
 }

--- a/src/kafka-util/src/admin.rs
+++ b/src/kafka-util/src/admin.rs
@@ -33,13 +33,11 @@ use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 /// requested in `new_topic`. Empirically, this seems to be the condition that
 /// guarantees that future attempts to consume from or produce to the topic will
 /// succeed.
-///
-/// Returns a boolean indicating whether the topic already existed.
 pub async fn create_new_topic<'a, C>(
     client: &'a AdminClient<C>,
     admin_opts: &AdminOptions,
     new_topic: &'a NewTopic<'a>,
-) -> Result<bool, CreateTopicError>
+) -> Result<(), CreateTopicError>
 where
     C: ClientContext,
 {
@@ -51,7 +49,7 @@ pub async fn ensure_topic<'a, C>(
     client: &'a AdminClient<C>,
     admin_opts: &AdminOptions,
     new_topic: &'a NewTopic<'a>,
-) -> Result<bool, CreateTopicError>
+) -> Result<(), CreateTopicError>
 where
     C: ClientContext,
 {
@@ -63,7 +61,7 @@ async fn create_topic_helper<'a, C>(
     admin_opts: &AdminOptions,
     new_topic: &'a NewTopic<'a>,
     allow_existing: bool,
-) -> Result<bool, CreateTopicError>
+) -> Result<(), CreateTopicError>
 where
     C: ClientContext,
 {
@@ -81,7 +79,7 @@ where
 
     // We don't need to read in metadata / do any validation if the topic already exists.
     if already_exists {
-        return Ok(true);
+        return Ok(());
     }
 
     // Topic creation is asynchronous, and if we don't wait for it to complete,
@@ -117,7 +115,7 @@ where
                     });
                 }
             }
-            Ok(false)
+            Ok(())
         })
         .await
 }

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -634,20 +634,16 @@ pub fn get_partitions<C: ClientContext>(
 pub const DEFAULT_KEEPALIVE: bool = true;
 /// The `rdkafka` default.
 /// - <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
-pub const DEFAULT_SOCKET_TIMEOUT: Duration = Duration::from_secs(60);
+pub const DEFAULT_SOCKET_TIMEOUT: Duration = Duration::from_millis(60000);
 /// The `rdkafka` default.
 /// - <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
-pub const DEFAULT_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(60);
+pub const DEFAULT_TRANSACTION_TIMEOUT: Duration = Duration::from_millis(60000);
 /// The `rdkafka` default.
 /// - <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
-pub const DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT: Duration = Duration::from_secs(30);
+pub const DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT: Duration = Duration::from_millis(30000);
 
 /// A reasonable default timeout when fetching metadata or partitions.
 pub const DEFAULT_FETCH_METADATA_TIMEOUT: Duration = Duration::from_secs(10);
-
-/// The timeout for reading records from the progress topic. Set to something slightly longer than
-/// the idle transaction timeout (60s) to wait out any stuck producers.
-pub const DEFAULT_PROGRESS_RECORD_FETCH_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// Configurable timeouts for Kafka connections.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -663,8 +659,6 @@ pub struct TimeoutConfig {
     pub socket_connection_setup_timeout: Duration,
     /// The timeout for fetching metadata from upstream.
     pub fetch_metadata_timeout: Duration,
-    /// The timeout for reading records from the progress topic.
-    pub progress_record_fetch_timeout: Duration,
 }
 
 impl Default for TimeoutConfig {
@@ -675,7 +669,6 @@ impl Default for TimeoutConfig {
             transaction_timeout: DEFAULT_TRANSACTION_TIMEOUT,
             socket_connection_setup_timeout: DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT,
             fetch_metadata_timeout: DEFAULT_FETCH_METADATA_TIMEOUT,
-            progress_record_fetch_timeout: DEFAULT_PROGRESS_RECORD_FETCH_TIMEOUT,
         }
     }
 }
@@ -689,7 +682,6 @@ impl TimeoutConfig {
         transaction_timeout: Duration,
         socket_connection_setup_timeout: Duration,
         fetch_metadata_timeout: Duration,
-        progress_record_fetch_timeout: Duration,
     ) -> TimeoutConfig {
         // Constrain values based on ranges here:
         // <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
@@ -711,16 +703,6 @@ impl TimeoutConfig {
                 of 1000ms, defaulting to the default of {DEFAULT_TRANSACTION_TIMEOUT:?}"
             );
             DEFAULT_TRANSACTION_TIMEOUT
-        } else {
-            transaction_timeout
-        };
-
-        let progress_record_fetch_timeout = if progress_record_fetch_timeout < transaction_timeout {
-            error!(
-                "progress record fetch ({progress_record_fetch_timeout:?}) less than transaction \
-                timeout ({transaction_timeout:?}), defaulting to the default of {DEFAULT_PROGRESS_RECORD_FETCH_TIMEOUT:?}",
-            );
-            DEFAULT_PROGRESS_RECORD_FETCH_TIMEOUT
         } else {
             transaction_timeout
         };
@@ -773,7 +755,6 @@ impl TimeoutConfig {
             transaction_timeout,
             socket_connection_setup_timeout,
             fetch_metadata_timeout,
-            progress_record_fetch_timeout,
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2646,6 +2646,7 @@ fn kafka_sink_builder(
         connection: connection_id,
         format,
         topic: topic_name,
+        fuel: 10000,
         relation_key_indices,
         key_desc_and_indices,
         value_desc,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1151,15 +1151,6 @@ const KAFKA_FETCH_METADATA_TIMEOUT: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
-/// Controls the timeout when fetching kafka progress records. Defaults to 60s.
-const KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_progress_record_fetch_timeout"),
-    value: mz_kafka_util::client::DEFAULT_PROGRESS_RECORD_FETCH_TIMEOUT,
-    description: "Controls the timeout when fetching kafka progress records. \
-        Defaults to 60s.",
-    internal: true,
-};
-
 /// Controls the connection timeout to Cockroach.
 ///
 /// Used by persist as [`mz_persist_client::cfg::DynamicConfig::consensus_connect_timeout`].
@@ -2956,7 +2947,6 @@ impl SystemVars {
             .with_var(&KAFKA_TRANSACTION_TIMEOUT)
             .with_var(&KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT)
             .with_var(&KAFKA_FETCH_METADATA_TIMEOUT)
-            .with_var(&KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT)
             .with_var(&ENABLE_LAUNCHDARKLY)
             .with_var(&MAX_CONNECTIONS)
             .with_var(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
@@ -3566,11 +3556,6 @@ impl SystemVars {
     /// Returns the `kafka_fetch_metadata_timeout` configuration parameter.
     pub fn kafka_fetch_metadata_timeout(&self) -> Duration {
         *self.expect_value(&KAFKA_FETCH_METADATA_TIMEOUT)
-    }
-
-    /// Returns the `kafka_progress_record_fetch_timeout` configuration parameter.
-    pub fn kafka_progress_record_fetch_timeout(&self) -> Duration {
-        *self.expect_value(&KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT)
     }
 
     /// Returns the `crdb_connect_timeout` configuration parameter.
@@ -5465,7 +5450,6 @@ pub fn is_storage_config_var(name: &str) -> bool {
         || name == KAFKA_TRANSACTION_TIMEOUT.name()
         || name == KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT.name()
         || name == KAFKA_FETCH_METADATA_TIMEOUT.name()
-        || name == KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY.name()

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -303,6 +303,7 @@ macro_rules! for_collections {
             }
             Usage::Storage => {
                 $macro!(storage::METADATA_COLLECTION);
+                $macro!(storage::METADATA_EXPORT);
             }
         }
     };

--- a/src/storage-client/src/sink.rs
+++ b/src/storage-client/src/sink.rs
@@ -322,7 +322,7 @@ pub async fn build_kafka(
     sink_id: mz_repr::GlobalId,
     connection: &KafkaSinkConnection,
     storage_configuration: &StorageConfiguration,
-) -> Result<Option<Timestamp>, ContextCreationError> {
+) -> Result<Option<Option<Timestamp>>, ContextCreationError> {
     // Fetch the progress of the last incarnation of the sink, if any.
     let client_id = connection.client_id(&storage_configuration.connection_context, sink_id);
     let group_id = connection.progress_group_id(&storage_configuration.connection_context, sink_id);
@@ -448,7 +448,7 @@ pub async fn build_kafka(
 /// purely so the sink can maintain its transactional guarantees. Any future user-facing consistency
 /// information should be added elsewhere instead of overloading this record.
 pub struct ProgressRecord {
-    pub timestamp: Timestamp,
+    pub timestamp: Option<Timestamp>,
 }
 
 /// Determines the latest progress record from the specified topic for the given
@@ -467,7 +467,7 @@ async fn determine_latest_progress_record(
     progress_topic: String,
     progress_key: ProgressKey,
     fetch_timeout: Duration,
-) -> Result<Option<Timestamp>, anyhow::Error> {
+) -> Result<Option<Option<Timestamp>>, anyhow::Error> {
     // ****************************** WARNING ******************************
     // Be VERY careful when editing the code in this function. It is very easy
     // to accidentally introduce a correctness or liveness bug when refactoring
@@ -488,7 +488,7 @@ async fn determine_latest_progress_record(
         progress_topic: &str,
         progress_key: &ProgressKey,
         fetch_timeout: Duration,
-    ) -> Result<Option<Timestamp>, anyhow::Error>
+    ) -> Result<Option<Option<Timestamp>>, anyhow::Error>
     where
         C: ConsumerContext,
     {
@@ -655,12 +655,21 @@ async fn determine_latest_progress_record(
             let ProgressRecord { timestamp } =
                 serde_json::from_slice(message.payload().unwrap_or(&[]))?;
             match last_timestamp {
-                Some(last_timestamp) if timestamp < last_timestamp => {
-                    bail!(
-                        "timestamp regressed in topic {progress_topic}:{partition} \
-                        from {last_timestamp} to {timestamp}"
-                    );
-                }
+                Some(prev_ts) => match (prev_ts, timestamp) {
+                    (None, Some(timestamp)) => {
+                        bail!(
+                            "timestamp regressed in topic {progress_topic}:{partition} \
+                            from empty frontier to {timestamp}"
+                        );
+                    }
+                    (Some(prev_ts), Some(timestamp)) if timestamp < prev_ts => {
+                        bail!(
+                            "timestamp regressed in topic {progress_topic}:{partition} \
+                            from {prev_ts} to {timestamp}"
+                        );
+                    }
+                    _ => last_timestamp = Some(timestamp),
+                },
                 _ => last_timestamp = Some(timestamp),
             };
         }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -86,6 +86,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use bytes::BufMut;
 use chrono::{DateTime, Utc};
 use differential_dataflow::lattice::Lattice;
 use futures::stream::BoxStream;
@@ -107,7 +108,7 @@ use mz_persist_txn::txn_read::TxnsRead;
 use mz_persist_txn::txns::TxnsHandle;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::{Codec64, Opaque};
-use mz_proto::RustType;
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::{ColumnName, Datum, Diff, GlobalId, RelationDesc, Row, TimestampManipulation};
 use mz_stash::{self, AppendBatch, StashFactory, TypedCollection};
@@ -131,9 +132,14 @@ use mz_storage_types::controller::{
 use mz_storage_types::instances::StorageInstanceId;
 use mz_storage_types::parameters::StorageParameters;
 use mz_storage_types::read_policy::ReadPolicy;
-use mz_storage_types::sinks::{StorageSinkConnection, StorageSinkDesc};
+use mz_storage_types::sinks::{
+    ProtoDurableExportMetadata, SinkAsOf, StorageSinkConnection, StorageSinkDesc,
+};
 use mz_storage_types::sources::{IngestionDescription, SourceData, SourceExport};
 use mz_storage_types::AlterCompatible;
+use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
+use prost::Message;
+use serde::{Deserialize, Serialize};
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::{Antichain, ChangeBatch, Timestamp};
 use tokio_stream::StreamMap;
@@ -153,14 +159,118 @@ mod statistics;
 pub static METADATA_COLLECTION: TypedCollection<proto::GlobalId, proto::DurableCollectionMetadata> =
     TypedCollection::new("storage-collection-metadata");
 
+pub static METADATA_EXPORT: TypedCollection<proto::GlobalId, proto::DurableExportMetadata> =
+    TypedCollection::new("storage-export-metadata-u64");
+
 pub static PERSIST_TXNS_SHARD: TypedCollection<(), String> =
     TypedCollection::new("persist-txns-shard");
 
 pub static ALL_COLLECTIONS: &[&str] = &[
     METADATA_COLLECTION.name(),
+    METADATA_EXPORT.name(),
     PERSIST_TXNS_SHARD.name(),
     command_wals::SHARD_FINALIZATION.name(),
 ];
+
+// Do this dance so that we keep the storage controller expressed in terms of a generic timestamp `T`.
+struct MetadataExportFetcher;
+trait MetadataExport<T>
+where
+    // Associated type would be better but you can't express this relationship without unstable
+    DurableExportMetadata<T>: RustType<proto::DurableExportMetadata>,
+{
+    fn get_stash_collection(
+    ) -> &'static TypedCollection<proto::GlobalId, proto::DurableExportMetadata>;
+}
+
+impl MetadataExport<mz_repr::Timestamp> for MetadataExportFetcher {
+    fn get_stash_collection(
+    ) -> &'static TypedCollection<proto::GlobalId, proto::DurableExportMetadata> {
+        &METADATA_EXPORT
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DurableExportMetadata<T> {
+    pub initial_as_of: SinkAsOf<T>,
+}
+
+impl PartialOrd for DurableExportMetadata<mz_repr::Timestamp> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for DurableExportMetadata<mz_repr::Timestamp> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let mut s = vec![];
+        let mut o = vec![];
+        self.encode(&mut s);
+        other.encode(&mut o);
+        s.cmp(&o)
+    }
+}
+
+impl RustType<ProtoDurableExportMetadata> for DurableExportMetadata<mz_repr::Timestamp> {
+    fn into_proto(&self) -> ProtoDurableExportMetadata {
+        ProtoDurableExportMetadata {
+            initial_as_of: Some(self.initial_as_of.into_proto()),
+        }
+    }
+
+    fn from_proto(proto: ProtoDurableExportMetadata) -> Result<Self, TryFromProtoError> {
+        Ok(DurableExportMetadata {
+            initial_as_of: proto
+                .initial_as_of
+                .into_rust_if_some("ProtoDurableExportMetadata::initial_as_of")?,
+        })
+    }
+}
+
+impl RustType<mz_storage_types::collections::DurableExportMetadata>
+    for DurableExportMetadata<mz_repr::Timestamp>
+{
+    fn into_proto(&self) -> mz_storage_types::collections::DurableExportMetadata {
+        mz_storage_types::collections::DurableExportMetadata {
+            initial_as_of: Some(self.initial_as_of.into_proto()),
+        }
+    }
+
+    fn from_proto(
+        proto: mz_storage_types::collections::DurableExportMetadata,
+    ) -> Result<Self, TryFromProtoError> {
+        Ok(DurableExportMetadata {
+            initial_as_of: proto
+                .initial_as_of
+                .into_rust_if_some("DurableExportMetadata::initial_as_of")?,
+        })
+    }
+}
+
+impl DurableExportMetadata<mz_repr::Timestamp> {
+    pub fn encode<B: BufMut>(&self, buf: &mut B) {
+        let persisted: ProtoDurableExportMetadata = self.into_proto();
+        persisted
+            .encode(buf)
+            .expect("no required fields means no initialization errors");
+    }
+
+    pub fn decode(buf: &[u8]) -> Result<Self, String> {
+        let proto = ProtoDurableExportMetadata::decode(buf).map_err(|err| err.to_string())?;
+        proto.into_rust().map_err(|err| err.to_string())
+    }
+}
+
+impl Arbitrary for DurableExportMetadata<mz_repr::Timestamp> {
+    type Strategy = BoxedStrategy<Self>;
+    type Parameters = ();
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        (any::<SinkAsOf<mz_repr::Timestamp>>(),)
+            .prop_map(|(initial_as_of,)| Self { initial_as_of })
+            .boxed()
+    }
+}
 
 #[derive(Debug)]
 enum PersistTxns<T> {
@@ -303,6 +413,8 @@ where
         + Into<mz_repr::Timestamp>,
     StorageCommand<T>: RustType<ProtoStorageCommand>,
     StorageResponse<T>: RustType<ProtoStorageResponse>,
+    MetadataExportFetcher: MetadataExport<T>,
+    DurableExportMetadata<T>: RustType<proto::DurableExportMetadata>,
 {
     type Timestamp = T;
 
@@ -1002,6 +1114,34 @@ where
                 acquired_since = ?dependency_since,
                 "prepare_export: sink acquired read holds"
             );
+
+            // It's worth adding a quick note on write frontiers here.
+            //
+            // The write frontier that sinks communicate back to the controller
+            // indicates that all further writes will happen at a time `t` such
+            // that `!timely::ParitalOrder::less_than(&t, &write_frontier)` is
+            // true.  On restart, the sink will receive an SinkAsOf from this
+            // controller indicating that it should ignore everything at or
+            // before the `since` of the from collection. This will not miss any
+            // records because, if there were records not yet written out that
+            // have an uncompacted time of `since`, the write frontier
+            // previously reported from the sink must be less than `since` so we
+            // would not have compacted up to `since`! This is tested by the
+            // kafka persistence tests.
+            //
+            // TODO: Remove upper frontier manipulation from sinks, the read
+            // policy ensures that we can always resume and discern the updates
+            // that happened at upper. The comment above is slightly wrong:
+            // sinks report `F-1` as the upper when they are at upper `F`
+            // (speaking in terms of a timely frontier). We should change sinks
+            // to divorce what they write out to the progress topic and what
+            // they report back as the write upper. To make sure that the
+            // reported write upper conforms with what other parts of the system
+            // think how uppers work.
+            //
+            // Note: This is where the sink code (kafka) calculates the write
+            // frontier that it reports back:
+            // https://github.com/MaterializeInc/materialize/blob/ec8560a532eb5e7282041757d6c1d650f0ffaa77/src/storage/src/sink/kafka.rs#L857
             let read_policy = ReadPolicy::step_back();
 
             let from_collection = self.collection(from_id)?;
@@ -1009,10 +1149,27 @@ where
 
             let storage_dependencies = vec![from_id];
 
+            let value = MetadataExportFetcher::get_stash_collection()
+                .insert_key_without_overwrite(
+                    &mut self.stash,
+                    id.into_proto(),
+                    DurableExportMetadata {
+                        initial_as_of: description.sink.as_of.clone(),
+                    }
+                    .into_proto(),
+                )
+                .await?;
+            let mut durable_export_data = DurableExportMetadata::from_proto(value)
+                .map_err(|e| StorageError::IOError(e.into()))?;
+
+            durable_export_data
+                .initial_as_of
+                .downgrade(&dependency_since);
+
             info!(
                 sink_id = id.to_string(),
                 from_id = from_id.to_string(),
-                as_of = ?description.sink.as_of,
+                initial_as_of = ?durable_export_data.initial_as_of,
                 "create_exports: creating sink"
             );
 
@@ -1043,10 +1200,9 @@ where
                     from_desc: description.sink.from_desc,
                     connection: description.sink.connection,
                     envelope: description.sink.envelope,
-                    as_of: description.sink.as_of,
+                    as_of: durable_export_data.initial_as_of,
                     status_id,
                     from_storage_metadata,
-                    with_snapshot: description.sink.with_snapshot,
                 },
             };
 
@@ -1085,8 +1241,26 @@ where
             // Ensure compatibility
             current_sink.alter_compatible(id, &export.description.sink)?;
 
+            // Get export data
+            let value = MetadataExportFetcher::get_stash_collection()
+                .peek_key_one(&mut self.stash, id.into_proto())
+                .await?
+                .expect("known to exist");
+
+            let mut durable_export_data = DurableExportMetadata::from_proto(value)
+                .map_err(|e| StorageError::IOError(e.into()))?;
+
             let from_collection = self.collection(export.description.sink.from)?;
             let from_storage_metadata = from_collection.collection_metadata.clone();
+
+            let read_capability = export.read_capability.to_owned();
+
+            // Downgrade this since--this mostly informs us whether or not we
+            // want to read the snapshot. For more details, see the
+            // implementation of `downgrade`.
+            durable_export_data
+                .initial_as_of
+                .downgrade(&read_capability);
 
             let status_id = if let Some(status_collection_id) = export.description.sink.status_id {
                 Some(
@@ -1105,18 +1279,7 @@ where
                     from_desc: export.description.sink.from_desc.clone(),
                     connection: export.description.sink.connection.clone(),
                     envelope: export.description.sink.envelope,
-                    with_snapshot: export.description.sink.with_snapshot,
-                    // Here we are about to send a RunSinkCommand with the current read capaibility
-                    // held by this sink. However, clusters are already running a version of the
-                    // sink and nothing guarantees that by the time this command arrives at the
-                    // clusters they won't have made additional progress such that this read
-                    // capability is invalidated.
-                    // The solution to this problem is for the controller to track specific
-                    // executions of dataflows such that it can track the shutdown of the current
-                    // instance and the initialization of the new instance separately and ensure
-                    // read holds are held for the correct amount of time.
-                    // TODO(petrosagg): change the controller to explicitly track dataflow executions
-                    as_of: export.read_capability.clone(),
+                    as_of: durable_export_data.initial_as_of,
                     status_id,
                     from_storage_metadata,
                 },
@@ -2148,15 +2311,18 @@ where
                     // names, but runs quick.
                     let (
                         metadata_collection,
+                        metadata_export,
                         persist_txns_shard,
                         shard_finalization,
                     ) = futures::join!(
                         maybe_get_init_batch(&tx, &METADATA_COLLECTION),
+                        maybe_get_init_batch(&tx, &METADATA_EXPORT),
                         maybe_get_init_batch(&tx, &PERSIST_TXNS_SHARD),
                         maybe_get_init_batch(&tx, &command_wals::SHARD_FINALIZATION),
                     );
                     let batches: Vec<AppendBatch> = [
                         metadata_collection,
+                        metadata_export,
                         persist_txns_shard,
                         shard_finalization,
                     ]

--- a/src/storage-controller/src/rehydration.rs
+++ b/src/storage-controller/src/rehydration.rs
@@ -493,7 +493,7 @@ where
                 for (id, frontier) in frontiers {
                     match self.sinks.get_mut(id) {
                         Some(export) => {
-                            export.description.as_of.clone_from(frontier);
+                            export.description.as_of.downgrade(frontier);
                         }
                         None if self.sources.contains_key(id) => continue,
                         None => panic!("AllowCompaction command for non-existent {id}"),

--- a/src/storage-types/src/collections.proto
+++ b/src/storage-types/src/collections.proto
@@ -31,6 +31,15 @@ message TimestampAntichain {
     repeated Timestamp elements = 1;
 }
 
+message SinkAsOf {
+    TimestampAntichain frontier = 1;
+    bool strict = 2;
+}
+
+message DurableExportMetadata {
+    SinkAsOf initial_as_of = 1;
+}
+
 message DurableCollectionMetadata {
     reserved 1;
     reserved "remap_shard";

--- a/src/storage-types/src/collections.rs
+++ b/src/storage-types/src/collections.rs
@@ -11,11 +11,12 @@
 
 include!(concat!(env!("OUT_DIR"), "/mz_storage_types.collections.rs"));
 
-use mz_proto::{ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId as RustGlobalId, Timestamp as RustTimestamp};
 use timely::progress::Antichain;
 
 use crate::controller::DurableCollectionMetadata as RustDurableCollectionMetadata;
+use crate::sinks::SinkAsOf as RustSinkAsOf;
 
 impl RustType<GlobalId> for RustGlobalId {
     fn into_proto(&self) -> GlobalId {
@@ -75,6 +76,23 @@ where
             .collect::<Result<_, _>>()?;
 
         Ok(Antichain::from_iter(elements))
+    }
+}
+
+impl RustType<SinkAsOf> for RustSinkAsOf<mz_repr::Timestamp> {
+    fn into_proto(&self) -> SinkAsOf {
+        SinkAsOf {
+            frontier: Some(self.frontier.into_proto()),
+            strict: self.strict,
+        }
+    }
+
+    fn from_proto(proto: SinkAsOf) -> Result<Self, TryFromProtoError> {
+        let frontier = proto.frontier.into_rust_if_some("SinkAsOf::frontier")?;
+        Ok(RustSinkAsOf {
+            frontier,
+            strict: proto.strict,
+        })
     }
 }
 

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -49,6 +49,7 @@ message ProtoPgSourceTcpTimeouts {
 }
 
 message ProtoKafkaTimeouts {
+    reserved 6;
     bool keepalive = 1;
     mz_proto.ProtoDuration socket_timeout = 2;
     mz_proto.ProtoDuration transaction_timeout = 5;

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -54,7 +54,6 @@ message ProtoKafkaTimeouts {
     mz_proto.ProtoDuration transaction_timeout = 5;
     mz_proto.ProtoDuration socket_connection_setup_timeout = 3;
     mz_proto.ProtoDuration fetch_metadata_timeout = 4;
-    mz_proto.ProtoDuration progress_record_fetch_timeout = 6;
 }
 message ProtoSshTimeoutConfig {
     mz_proto.ProtoDuration check_interval = 1;

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -322,7 +322,6 @@ impl RustType<ProtoKafkaTimeouts> for mz_kafka_util::client::TimeoutConfig {
                 self.socket_connection_setup_timeout.into_proto(),
             ),
             fetch_metadata_timeout: Some(self.fetch_metadata_timeout.into_proto()),
-            progress_record_fetch_timeout: Some(self.progress_record_fetch_timeout.into_proto()),
         }
     }
 
@@ -343,9 +342,6 @@ impl RustType<ProtoKafkaTimeouts> for mz_kafka_util::client::TimeoutConfig {
             fetch_metadata_timeout: proto
                 .fetch_metadata_timeout
                 .into_rust_if_some("ProtoKafkaSourceTcpTimeouts::fetch_metadata_timeout")?,
-            progress_record_fetch_timeout: proto
-                .progress_record_fetch_timeout
-                .into_rust_if_some("ProtoKafkaSourceTcpTimeouts::progress_record_fetch_timeout")?,
         })
     }
 }

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -20,11 +20,12 @@ import "storage-types/src/connections.proto";
 package mz_storage_types.sinks;
 
 message ProtoStorageSinkDesc {
+    reserved 5, 8, 9;
     mz_repr.global_id.ProtoGlobalId from = 1;
     mz_repr.relation_and_scalar.ProtoRelationDesc from_desc = 2;
     ProtoStorageSinkConnection connection = 3;
     optional ProtoSinkEnvelope envelope = 4;
-    ProtoSinkAsOf as_of = 5;
+    ProtoSinkAsOf as_of = 10;
     optional mz_storage_types.controller.ProtoCollectionMetadata from_storage_metadata = 6;
     optional string status_id = 7;
 }
@@ -75,7 +76,7 @@ message ProtoKafkaSinkConnectionV2 {
         repeated uint64 relation_key_indices = 1;
     }
 
-    reserved 8 to 10, 12, 13;
+    reserved 7 to 10, 12, 13;
 
     mz_repr.global_id.ProtoGlobalId connection_id = 1;
     mz_storage_types.connections.ProtoKafkaConnection connection = 2;
@@ -83,7 +84,7 @@ message ProtoKafkaSinkConnectionV2 {
     optional ProtoKeyDescAndIndices key_desc_and_indices = 4;
     optional ProtoRelationKeyIndicesVec relation_key_indices = 5;
     mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 6;
-    uint64 fuel = 7;
+    uint64 fuel = 21;
     ProtoKafkaSinkFormat format = 11;
     oneof compression_type {
         google.protobuf.Empty none = 14;

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -20,15 +20,13 @@ import "storage-types/src/connections.proto";
 package mz_storage_types.sinks;
 
 message ProtoStorageSinkDesc {
-    reserved 5;
     mz_repr.global_id.ProtoGlobalId from = 1;
     mz_repr.relation_and_scalar.ProtoRelationDesc from_desc = 2;
     ProtoStorageSinkConnection connection = 3;
     optional ProtoSinkEnvelope envelope = 4;
+    ProtoSinkAsOf as_of = 5;
     optional mz_storage_types.controller.ProtoCollectionMetadata from_storage_metadata = 6;
     optional string status_id = 7;
-    mz_repr.antichain.ProtoU64Antichain as_of = 8;
-    bool with_snapshot = 9;
 }
 
 message ProtoSinkEnvelope {
@@ -45,6 +43,11 @@ message ProtoStorageSinkConnection {
     oneof kind {
         ProtoKafkaSinkConnectionV2 kafka_v2 = 2;
     }
+}
+
+message ProtoSinkAsOf {
+    mz_repr.antichain.ProtoU64Antichain frontier = 1;
+    bool strict = 2;
 }
 
 message ProtoKafkaSinkFormat {
@@ -72,7 +75,7 @@ message ProtoKafkaSinkConnectionV2 {
         repeated uint64 relation_key_indices = 1;
     }
 
-    reserved 7 to 10, 12, 13;
+    reserved 8 to 10, 12, 13;
 
     mz_repr.global_id.ProtoGlobalId connection_id = 1;
     mz_storage_types.connections.ProtoKafkaConnection connection = 2;
@@ -80,6 +83,7 @@ message ProtoKafkaSinkConnectionV2 {
     optional ProtoKeyDescAndIndices key_desc_and_indices = 4;
     optional ProtoRelationKeyIndicesVec relation_key_indices = 5;
     mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 6;
+    uint64 fuel = 7;
     ProtoKafkaSinkFormat format = 11;
     oneof compression_type {
         google.protobuf.Empty none = 14;
@@ -105,4 +109,9 @@ message ProtoKafkaIdStyle {
 message ProtoPersistSinkConnection {
     mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 1;
     mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 2;
+}
+
+message ProtoDurableExportMetadata {
+    // This message is persisted to disk. Changes must be backwards compatible.
+    mz_storage_types.sinks.ProtoSinkAsOf initial_as_of = 1;
 }

--- a/src/storage/src/metrics/mod.rs
+++ b/src/storage/src/metrics/mod.rs
@@ -40,6 +40,7 @@ use mz_storage_operators::metrics::BackpressureMetrics;
 pub mod decode;
 pub mod kafka;
 pub mod postgres;
+pub mod sink;
 pub mod source;
 pub mod upsert;
 
@@ -55,6 +56,7 @@ pub mod upsert;
 pub struct StorageMetrics {
     pub(crate) decode_defs: decode::DecodeMetricDefs,
     pub(crate) source_defs: source::SourceMetricDefs,
+    pub(crate) sink_defs: sink::SinkMetricDefs,
 
     // Defined in the `statistics` module, as they are kept in sync with
     // user-facing data.
@@ -68,6 +70,7 @@ impl StorageMetrics {
         Self {
             decode_defs: decode::DecodeMetricDefs::register_with(registry),
             source_defs: source::SourceMetricDefs::register_with(registry),
+            sink_defs: sink::SinkMetricDefs::register_with(registry),
             source_statistics: SourceStatisticsMetricDefs::register_with(registry),
             sink_statistics: SinkStatisticsMetricDefs::register_with(registry),
         }
@@ -133,6 +136,16 @@ impl StorageMetrics {
             data_shard,
             output_index,
         )
+    }
+
+    /// Get a `SinkMetrics` for the given connection, id, and worker id.
+    pub(crate) fn get_sink_metrics(
+        &self,
+        topic_name: &str,
+        id: GlobalId,
+        worker_id: usize,
+    ) -> sink::SinkMetrics {
+        sink::SinkMetrics::new(&self.sink_defs, topic_name, id, worker_id)
     }
 
     /// Get a `SourceMetrics` for the given id and worker id.

--- a/src/storage/src/metrics/sink.rs
+++ b/src/storage/src/metrics/sink.rs
@@ -1,0 +1,91 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Metrics that sinks report.
+
+use mz_ore::metric;
+use mz_ore::metrics::{
+    CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt, IntCounterVec,
+    MetricsRegistry, UIntGaugeVec,
+};
+use mz_repr::GlobalId;
+use prometheus::core::AtomicU64;
+
+/// Definitions for metrics reported by each kafka sink.
+#[derive(Clone, Debug)]
+pub struct SinkMetricDefs {
+    pub(crate) messages_sent_counter: IntCounterVec,
+    pub(crate) message_send_errors_counter: IntCounterVec,
+    pub(crate) message_delivery_errors_counter: IntCounterVec,
+    pub(crate) rows_queued: UIntGaugeVec,
+}
+
+impl SinkMetricDefs {
+    pub(crate) fn register_with(registry: &MetricsRegistry) -> Self {
+        Self {
+            messages_sent_counter: registry.register(metric!(
+                name: "mz_kafka_messages_sent_total",
+                help: "The number of messages the Kafka producer successfully sent for this sink",
+                var_labels: ["topic", "sink_id", "worker_id"],
+            )),
+            message_send_errors_counter: registry.register(metric!(
+                name: "mz_kafka_message_send_errors_total",
+                help: "The number of times the Kafka producer encountered an error on send",
+                var_labels: ["topic", "sink_id", "worker_id"],
+            )),
+            message_delivery_errors_counter: registry.register(metric!(
+                name: "mz_kafka_message_delivery_errors_total",
+                help: "The number of messages that the Kafka producer could not deliver to the topic",
+                var_labels: ["topic", "sink_id", "worker_id"],
+            )),
+            rows_queued: registry.register(metric!(
+                name: "mz_kafka_sink_rows_queued",
+                help: "The current number of rows queued by the Kafka sink operator (note that one row can generate multiple Kafka messages)",
+                var_labels: ["topic", "sink_id", "worker_id"],
+            )),
+        }
+    }
+}
+
+/// Per-Kafka sink metrics.
+pub(crate) struct SinkMetrics {
+    pub(crate) messages_sent_counter: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) message_send_errors_counter: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) message_delivery_errors_counter:
+        DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) rows_queued: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+}
+
+impl SinkMetrics {
+    /// Create a `SinkMetrics` from the `SinkMetricDefs`.
+    pub(crate) fn new(
+        base: &SinkMetricDefs,
+        topic_name: &str,
+        sink_id: GlobalId,
+        worker_id: usize,
+    ) -> SinkMetrics {
+        let labels = vec![
+            topic_name.to_string(),
+            sink_id.to_string(),
+            worker_id.to_string(),
+        ];
+        SinkMetrics {
+            messages_sent_counter: base
+                .messages_sent_counter
+                .get_delete_on_drop_counter(labels.clone()),
+            message_send_errors_counter: base
+                .message_send_errors_counter
+                .get_delete_on_drop_counter(labels.clone()),
+            message_delivery_errors_counter: base
+                .message_delivery_errors_counter
+                .get_delete_on_drop_counter(labels.clone()),
+            rows_queued: base.rows_queued.get_delete_on_drop_gauge(labels),
+        }
+    }
+}

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -45,19 +45,13 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
     let sink_render = get_sink_render_for(&sink.connection);
 
     let mut tokens = vec![];
-
-    let snapshot_mode = if sink.with_snapshot {
-        SnapshotMode::Include
-    } else {
-        SnapshotMode::Exclude
-    };
     let (ok_collection, err_collection, persist_tokens) = persist_source::persist_source(
         scope,
         sink.from,
         Arc::clone(&storage_state.persist_clients),
         sink.from_storage_metadata.clone(),
-        Some(sink.as_of.clone()),
-        snapshot_mode,
+        Some(sink.as_of.frontier.clone()),
+        SnapshotMode::Include,
         timely::progress::Antichain::new(),
         None,
         None,

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -457,7 +457,7 @@ impl KafkaSinkState {
         storage_configuration: &StorageConfiguration,
         gate_ts: Rc<Cell<Option<Timestamp>>>,
         healthchecker: HealthOutputHandle,
-    ) -> (Self, Option<Timestamp>) {
+    ) -> (Self, Option<Option<Timestamp>>) {
         let metrics = Arc::new(metrics.get_sink_metrics(&connection.topic, sink_id, worker_id));
 
         let retry_manager = Arc::new(Mutex::new(KafkaSinkSendRetryManager::new()));
@@ -599,7 +599,7 @@ impl KafkaSinkState {
             .expect("Infinite retry cannot fail");
     }
 
-    async fn send_progress_record(&self, transaction_id: Timestamp) {
+    async fn send_progress_record(&self, transaction_id: Option<Timestamp>) {
         let encoded = serde_json::to_vec(&ProgressRecord {
             timestamp: transaction_id,
         })
@@ -687,7 +687,7 @@ impl KafkaSinkState {
                     "{}: sending progress for gate ts: {:?}",
                     &self.name, min_frontier
                 );
-                self.send_progress_record(min_frontier).await;
+                self.send_progress_record(Some(min_frontier)).await;
 
                 self.halt_on_err(
                     self.producer
@@ -711,6 +711,24 @@ impl KafkaSinkState {
             write_frontier.clear();
             write_frontier.insert(min_frontier);
         } else {
+            // record the write frontier in the progress topic.
+            self.halt_on_err(
+                self.producer
+                    .retry_on_txn_error(|p| p.begin_transaction())
+                    .await,
+            )
+            .await;
+
+            debug!("{}: sending progress for empty frontier", &self.name);
+            self.send_progress_record(None).await;
+
+            self.halt_on_err(
+                self.producer
+                    .retry_on_txn_error(|p| p.commit_transaction())
+                    .await,
+            )
+            .await;
+
             // If there's no longer an input frontier, we will no longer receive any data forever and, therefore, will
             // never output more data
             info!("{}: advancing write frontier to empty", &self.name);
@@ -952,6 +970,18 @@ where
             "{}: initial as_of: {:?}, latest progress record: {:?}",
             s.name, as_of.frontier, latest_ts
         );
+
+        s.update_status(HealthStatusUpdate::running(), StatusNamespace::Kafka)
+            .await;
+
+        let latest_ts = match latest_ts {
+            Some(Some(latest_ts)) => Some(latest_ts),
+            Some(None) => {
+                info!("{}: sink shutting down", s.name);
+                return;
+            }
+            None => None,
+        };
         shared_gate_ts.set(latest_ts);
 
         if let Some(gate) = latest_ts {
@@ -966,9 +996,6 @@ where
             );
             s.maybe_update_progress(&gate);
         }
-
-        s.update_status(HealthStatusUpdate::running(), StatusNamespace::Kafka)
-            .await;
 
         while let Some(event) = input.next_mut().await {
             match event {
@@ -1076,7 +1103,7 @@ where
 
                         // We don't count this record as part of the message count in user-facing
                         // statistics.
-                        s.send_progress_record(*ts).await;
+                        s.send_progress_record(Some(*ts)).await;
 
                         info!("{}: committing transaction for {:?}", id, ts);
                         s.halt_on_err(

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -7,117 +7,68 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Code to render the sink dataflow of a [`KafkaSinkConnection`]. The dataflow consists
-//! of two operators in order to take advantage of all the available workers.
-//!
-//! ```text
-//!        ┏━━━━━━━━━━━━━━┓
-//!        ┃   persist    ┃
-//!        ┃    source    ┃
-//!        ┗━━━━━━┯━━━━━━━┛
-//!               │ row data, the input to this module
-//!               │
-//!        ┏━━━━━━v━━━━━━┓
-//!        ┃    row      ┃
-//!        ┃   encoder   ┃
-//!        ┗━━━━━━┯━━━━━━┛
-//!               │ encoded data
-//!               │
-//!        ┏━━━━━━v━━━━━━┓
-//!        ┃    kafka    ┃ (single worker)
-//!        ┃    sink     ┃
-//!        ┗━━┯━━━━━━━━┯━┛
-//!   records │        │ uppers
-//!      ╭────v──╮ ╭───v──────╮
-//!      │ data  │ │ progress │  <- records and uppers are produced
-//!      │ topic │ │  topic   │     transactionally to both topics
-//!      ╰───────╯ ╰──────────╯
-//! ```
-//!
-//! # Encoding
-//!
-//! One part of the dataflow deals with encoding the rows that we read from persist. There isn't
-//! anything surprizing here, it is *almost* just a `Collection::map` with the exception of an
-//! initialization step that makes sure the schemas are published to the Schema Registry. After
-//! that step the operator just encodes each batch it receives record by record.
-//!
-//! # Sinking
-//!
-//! The other part of the dataflow, and what this module mostly deals with, is interacting with the
-//! Kafka cluster in order to transactionally commit batches (sets of records associated with a
-//! frontier). All the processing happens in a single worker and so all previously encoded records
-//! go through an exchange in order to arrive at the chosen worker. We may be able to improve this
-//! in the future by committing disjoint partitions of the key space for independent workers but
-//! for now we do the simple thing.
-//!
-//! ## Retries
-//!
-//! All of the retry logic heavy lifting is offloaded to `librdkafka` since it already implements
-//! the required behavior[1]. In particular we only ever enqueue records to its send queue and
-//! eventually call `commit_transaction` which will ensure that all queued messages are
-//! successfully delivered before the transaction is reported as committed.
-//!
-//! The only error that is possible during sending is that the queue is full. We are purposefully
-//! NOT handling this error and simply configure `librdkafka` with a very large queue. The reason
-//! for this choice is that the only choice for hanlding such an error ourselves would be to queue
-//! it, and there isn't a good argument about two small queues being better than one big one. If we
-//! reach the queue limit we simply error out the entire sink dataflow and start over.
-//!
-//! # Error handling
-//!
-//! Both the encoding operator and the sinking operator can produce a transient error that is wired
-//! up with our health monitoring and will trigger a restart of the sink dataflow.
-//!
-//! [1]: https://github.com/confluentinc/librdkafka/blob/master/INTRODUCTION.md#message-reliability
-
-use std::cell::RefCell;
-use std::cmp::Ordering;
-use std::collections::BTreeMap;
+use std::cell::{Cell, RefCell};
+use std::collections::{BTreeMap, VecDeque};
+use std::fmt::Debug;
+use std::future;
+use std::future::Future;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context};
-use differential_dataflow::{AsCollection, Collection, Hashable};
+use differential_dataflow::{Collection, Hashable};
+use futures::{StreamExt, TryFutureExt};
+use maplit::btreemap;
 use mz_interchange::avro::{AvroEncoder, AvroSchemaGenerator, AvroSchemaOptions};
 use mz_interchange::encode::Encode;
 use mz_interchange::json::JsonEncoder;
 use mz_kafka_util::client::{MzClientContext, TunnelingClientContext};
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
+use mz_ore::retry::{Retry, RetryResult};
 use mz_ore::task;
-use mz_ore::vec::VecExt;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
+use mz_ssh_util::tunnel::SshTunnelStatus;
 use mz_storage_client::sink::progress_key::ProgressKey;
-use mz_storage_client::sink::{ProgressRecord, TopicCleanupPolicy, TopicConfig};
+use mz_storage_client::sink::ProgressRecord;
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::errors::{ContextCreationError, ContextCreationErrorExt, DataflowError};
 use mz_storage_types::sinks::{
-    KafkaSinkConnection, KafkaSinkFormat, MetadataFilled, SinkEnvelope, StorageSinkDesc,
+    KafkaSinkConnection, KafkaSinkFormat, MetadataFilled, SinkAsOf, SinkEnvelope, StorageSinkDesc,
 };
-use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{
     Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
-use rdkafka::error::KafkaError;
-use rdkafka::message::{Header, OwnedHeaders};
-use rdkafka::metadata::Metadata;
-use rdkafka::producer::{BaseProducer, BaseRecord, Producer};
-use rdkafka::types::RDKafkaErrorCode;
-use timely::dataflow::channels::pact::{Exchange, Pipeline};
-use timely::dataflow::operators::{CapabilitySet, Concatenate, Map, ToStream};
+use rdkafka::client::ClientContext;
+use rdkafka::error::{KafkaError, KafkaResult, RDKafkaError, RDKafkaErrorCode};
+use rdkafka::message::{Header, Message, OwnedHeaders, OwnedMessage, ToBytes};
+use rdkafka::producer::{BaseRecord, DeliveryResult, Producer, ProducerContext, ThreadedProducer};
+use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::channels::pushers::TeeCore;
+use timely::dataflow::operators::Concat;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp as _};
 use timely::PartialOrder;
-use tracing::{error, info};
+use tokio::sync::Mutex;
+use tracing::{debug, error, info, warn};
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
+use crate::metrics::sink::SinkMetrics;
+use crate::metrics::StorageMetrics;
 use crate::render::sinks::SinkRender;
 use crate::statistics::SinkStatistics;
 use crate::storage_state::StorageState;
 
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+// 30s is a good maximum backoff for network operations. Long enough to reduce
+// load on an upstream system, but short enough that we can respond quickly when
+// the upstream system comes back online.
+const BACKOFF_CLAMP: Duration = Duration::from_secs(30);
 
-impl<G: Scope<Timestamp = Timestamp>> SinkRender<G> for KafkaSinkConnection {
+impl<G> SinkRender<G> for KafkaSinkConnection
+where
+    G: Scope<Timestamp = Timestamp>,
+{
     fn uses_keys(&self) -> bool {
         true
     }
@@ -137,531 +88,1152 @@ impl<G: Scope<Timestamp = Timestamp>> SinkRender<G> for KafkaSinkConnection {
         storage_state: &mut StorageState,
         sink: &StorageSinkDesc<MetadataFilled, Timestamp>,
         sink_id: GlobalId,
-        input: Collection<G, (Option<Row>, Option<Row>), Diff>,
+        sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         // TODO(benesch): errors should stream out through the sink,
         // if we figure out a protocol for that.
         _err_collection: Collection<G, DataflowError, Diff>,
-    ) -> (Stream<G, HealthStatusMessage>, Vec<PressOnDropButton>) {
-        let mut scope = input.scope();
+    ) -> (Stream<G, HealthStatusMessage>, Vec<PressOnDropButton>)
+    where
+        G: Scope<Timestamp = Timestamp>,
+    {
+        // TODO: this is a brittle way to indicate the worker that will write to the sink
+        // because it relies on us continuing to hash on the sink_id, with the same hash
+        // function, and for the Exchange pact to continue to distribute by modulo number
+        // of workers.
+        let peers = sinked_collection.inner.scope().peers();
+        let worker_index = sinked_collection.inner.scope().index();
+        let active_write_worker = (usize::cast_from(sink_id.hashed()) % peers) == worker_index;
 
-        let write_frontier = Rc::new(RefCell::new(Antichain::from_elem(Timestamp::minimum())));
-        storage_state
-            .sink_write_frontiers
-            .insert(sink_id, Rc::clone(&write_frontier));
+        // Only the active_write_worker will ever produce data so all other workers have
+        // an empty frontier.  It's necessary to insert all of these into `storage_state.
+        // sink_write_frontier` below so we properly clear out default frontiers of
+        // non-active workers.
+        let shared_frontier = Rc::new(RefCell::new(if active_write_worker {
+            Antichain::from_elem(Timestamp::minimum())
+        } else {
+            Antichain::new()
+        }));
 
-        let (encoded, encode_status, encode_token) = encode_collection(
-            format!("kafka-{sink_id}-{}-encode", self.format.get_format_name()),
-            &input,
-            sink.envelope,
-            self.clone(),
-            storage_state.storage_configuration.clone(),
-        );
-
-        let (sink_status, sink_token) = sink_collection(
-            format!("kafka-{sink_id}-sink"),
-            &encoded,
+        let (health, tokens) = kafka(
+            sinked_collection,
             sink_id,
             self.clone(),
-            storage_state.storage_configuration.clone(),
+            sink.envelope,
             sink.as_of.clone(),
+            Rc::clone(&shared_frontier),
+            &storage_state.metrics,
             storage_state
                 .sink_statistics
                 .get(&sink_id)
                 .expect("statistics initialized")
                 .clone(),
-            write_frontier,
+            &storage_state.storage_configuration,
         );
 
-        let running_status = Some(HealthStatusMessage {
-            index: 0,
-            update: HealthStatusUpdate::Running,
-            namespace: StatusNamespace::Kafka,
-        })
-        .to_stream(&mut scope);
+        storage_state
+            .sink_write_frontiers
+            .insert(sink_id, shared_frontier);
 
-        let status = scope.concatenate([running_status, encode_status, sink_status]);
-
-        (status, vec![encode_token, sink_token])
+        (health, tokens)
     }
 }
 
-struct TransactionalProducer {
-    /// The task name used for any blocking calls spawned onto the tokio threadpool.
-    task_name: String,
-    /// The topic where all the updates go.
-    data_topic: String,
-    /// The topic where all the upper frontiers go.
-    progress_topic: String,
-    /// The key each progress record is associated with.
-    progress_key: ProgressKey,
-    /// The underlying Kafka producer.
-    producer: BaseProducer<TunnelingClientContext<MzClientContext>>,
-    /// A handle to the metrics associated with this sink.
-    statistics: SinkStatistics,
-    /// The number of messages staged for the currently open transactions. It is reset to zero
-    /// every time a transaction commits.
-    staged_messages: u64,
-    /// The total number bytes staged for the currently open transactions. It is reset to zero
-    /// every time a transaction commits.
-    staged_bytes: u64,
+#[derive(Clone)]
+pub struct KafkaSinkSendRetryManager {
+    // Because we flush this fully before moving onto the next timestamp, this queue cannot contain
+    // more messages than are contained in a single timely timestamp.  It's also unlikely to get
+    // beyond the size of the rdkafka internal message queue because that seems to stop accepting
+    // new messages when errors are being returned by the delivery callback -- though we should not
+    // rely on that fact if/when we eventually (tm) get around to making our queues bounded.
+    //
+    // If perf becomes an issue, we can do something slightly more complex with a crossbeam channel
+    q: VecDeque<OwnedMessage>,
+    outstanding_send_count: u64,
 }
 
-impl TransactionalProducer {
-    /// Initializes a transcational producer for the sink identified by `sink_id`. After this call
-    /// returns it is guranteed that all previous `TransactionalProducer` instances for the same
-    /// sink have been fenced out (i.e `init_transations()` has been called successfully).
-    async fn new(
-        sink_id: GlobalId,
-        connection: &KafkaSinkConnection,
-        storage_configuration: &StorageConfiguration,
-        statistics: SinkStatistics,
-    ) -> Result<Self, ContextCreationError> {
+impl KafkaSinkSendRetryManager {
+    fn new() -> Self {
+        Self {
+            q: VecDeque::new(),
+            outstanding_send_count: 0,
+        }
+    }
+    fn record_send(&mut self) {
+        self.outstanding_send_count += 1;
+    }
+    fn record_error(&mut self, msg: OwnedMessage) {
+        self.q.push_back(msg);
+        self.outstanding_send_count -= 1;
+    }
+    fn record_success(&mut self) {
+        self.outstanding_send_count -= 1;
+    }
+    fn sends_flushed(&mut self) -> bool {
+        self.outstanding_send_count == 0 && self.q.is_empty()
+    }
+    fn pop_retry(&mut self) -> Option<OwnedMessage> {
+        self.q.pop_front()
+    }
+}
+
+#[derive(Clone)]
+pub struct SinkProducerContext {
+    metrics: Arc<SinkMetrics>,
+    retry_manager: Arc<Mutex<KafkaSinkSendRetryManager>>,
+    inner: MzClientContext,
+}
+
+impl ClientContext for SinkProducerContext {
+    // The shape of the rdkafka *Context traits require us to forward to the `MzClientContext`
+    // implementation.
+    fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
+        self.inner.log(level, fac, log_message)
+    }
+    fn error(&self, error: KafkaError, reason: &str) {
+        self.inner.error(error, reason)
+    }
+}
+impl ProducerContext for SinkProducerContext {
+    type DeliveryOpaque = ();
+
+    fn delivery(&self, result: &DeliveryResult, _: Self::DeliveryOpaque) {
+        match result {
+            Ok(_) => self.retry_manager.blocking_lock().record_success(),
+            Err((e, msg)) => {
+                self.metrics.message_delivery_errors_counter.inc();
+                // TODO: figure out a good way to back these retries off.  Should be okay without
+                // because we seem to very rarely end up in a constant state where rdkafka::send
+                // works but everything is immediately rejected and hits this branch.
+                warn!("Kafka producer delivery error {:?} for {:?}", e, msg);
+                self.retry_manager
+                    .blocking_lock()
+                    .record_error(msg.detach());
+            }
+        }
+    }
+}
+
+struct KafkaTxProducerConfig<'a> {
+    name: String,
+    connection: &'a KafkaSinkConnection,
+    storage_configuration: &'a StorageConfiguration,
+    producer_context: SinkProducerContext,
+    sink_id: GlobalId,
+}
+
+#[derive(Clone)]
+struct KafkaTxProducer {
+    name: String,
+    inner: Arc<ThreadedProducer<TunnelingClientContext<SinkProducerContext>>>,
+    timeout: Duration,
+}
+
+impl KafkaTxProducer {
+    async fn new<'a>(
+        KafkaTxProducerConfig {
+            name,
+            connection,
+            storage_configuration,
+            producer_context,
+            sink_id,
+        }: KafkaTxProducerConfig<'a>,
+    ) -> Result<KafkaTxProducer, ContextCreationError> {
         let client_id = connection.client_id(&storage_configuration.connection_context, sink_id);
         let transactional_id =
             connection.transactional_id(&storage_configuration.connection_context, sink_id);
 
-        let mut options = BTreeMap::new();
-        // Ensure that messages are sinked in order and without duplicates. Note that this only
-        // applies to a single instance of a producer - in the case of restarts, all bets are off
-        // and full exactly once support is required.
-        options.insert("enable.idempotence", "true".into());
-        // Use the compression type requested by the user.
-        options.insert(
-            "compression.type",
-            connection.compression_type.to_librdkafka_option().into(),
-        );
-        // Increase limits for the Kafka producer's internal buffering of messages. Currently we
-        // don't have a great backpressure mechanism to tell indexes or views to slow down, so the
-        // only thing we can do with a message that we can't immediately send is to put it in a
-        // buffer and there's no point having buffers within the dataflow layer and Kafka. If the
-        // sink starts falling behind and the buffers start consuming too much memory the best
-        // thing to do is to drop the sink. Sets the buffer size to be 16 GB (note that this
-        // setting is in KB)
-        options.insert("queue.buffering.max.kbytes", format!("{}", 16 << 20));
-        // Set the max messages buffered by the producer at any time to 10MM which is the maximum
-        // allowed value.
-        options.insert("queue.buffering.max.messages", format!("{}", 10_000_000));
-        // Make the Kafka producer wait at least 10 ms before sending out MessageSets
-        options.insert("queue.buffering.max.ms", format!("{}", 10));
-        // Time out transactions after 60 seconds
-        options.insert("transaction.timeout.ms", format!("{}", 60_000));
-        // Use the transactional ID requested by the user.
-        options.insert("transactional.id", transactional_id);
-        // Allow Kafka monitoring tools to identify this producer.
-        options.insert("client.id", client_id);
-
-        let producer: BaseProducer<_> = connection
+        let producer = connection
             .connection
-            .create_with_context(storage_configuration, MzClientContext::default(), &options)
+            .create_with_context(
+                storage_configuration,
+                producer_context,
+                &btreemap! {
+                    // Allow Kafka monitoring tools to identify this producer.
+                    "client.id" => client_id,
+                    // Ensure that messages are sinked in order and without
+                    // duplicates. Note that this only applies to a single
+                    // instance of a producer - in the case of restarts, all
+                    // bets are off and full exactly once support is required.
+                    "enable.idempotence" => "true".into(),
+                    // Use the compression type requested by the user.
+                    "compression.type" => connection.compression_type.to_librdkafka_option().into(),
+                    // Increase limits for the Kafka producer's internal
+                    // buffering of messages Currently we don't have a great
+                    // backpressure mechanism to tell indexes or views to slow
+                    // down, so the only thing we can do with a message that we
+                    // can't immediately send is to put it in a buffer and
+                    // there's no point having buffers within the dataflow layer
+                    // and Kafka If the sink starts falling behind and the
+                    // buffers start consuming too much memory the best thing to
+                    // do is to drop the sink Sets the buffer size to be 16 GB
+                    // (note that this setting is in KB)
+                    "queue.buffering.max.kbytes" => format!("{}", 16 << 20),
+                    // Set the max messages buffered by the producer at any time
+                    // to 10MM which is the maximum allowed value.
+                    "queue.buffering.max.messages" => format!("{}", 10_000_000),
+                    // Make the Kafka producer wait at least 10 ms before
+                    // sending out MessageSets TODO(rkhaitan): experiment with
+                    // different settings for this value to see if it makes a
+                    // big difference.
+                    "queue.buffering.max.ms" => format!("{}", 10),
+                    // Use the transactional ID requested by the user.
+                    "transactional.id" => transactional_id,
+                    // Use the default transaction timeout. (At time of writing: 60s.)
+                    // The Kafka sink may have long-running transactions, since it expects
+                    // to be able to write all data at the same timestamp in a single
+                    // transaction... including the initial snapshot.
+                },
+            )
             .await?;
 
-        let task_name = format!("kafka_sink_producer:{sink_id}");
-        let progress_key = ProgressKey::new(sink_id);
-
-        let producer = Self {
-            task_name,
-            data_topic: connection.topic.clone(),
-            progress_topic: connection
-                .progress_topic(&storage_configuration.connection_context)
-                .into_owned(),
-            progress_key,
-            producer,
-            statistics,
-            staged_messages: 0,
-            staged_bytes: 0,
+        let producer = KafkaTxProducer {
+            name,
+            inner: Arc::new(producer),
+            timeout: Duration::from_secs(5),
         };
 
         producer
-            .spawn_blocking(|p| p.init_transactions(DEFAULT_TIMEOUT))
-            .await?;
+            .retry_on_txn_error(|p| p.init_transactions())
+            .await
+            .check_ssh_status(producer.inner.client().context())?;
 
         Ok(producer)
     }
 
-    /// Runs the blocking operation `f` on the producer in the tokio threadpool and checks for SSH
-    /// status in case of failure.
-    async fn spawn_blocking<F, R>(&self, f: F) -> Result<R, ContextCreationError>
+    fn init_transactions(&self) -> impl Future<Output = KafkaResult<()>> {
+        let self_producer = Arc::clone(&self.inner);
+        let self_timeout = self.timeout;
+        task::spawn_blocking(
+            || format!("init_transactions:{}", self.name),
+            move || self_producer.init_transactions(self_timeout),
+        )
+        .unwrap_or_else(|_| Err(KafkaError::Canceled))
+    }
+
+    fn begin_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
+        let self_producer = Arc::clone(&self.inner);
+        task::spawn_blocking(
+            || format!("begin_transaction:{}", self.name),
+            move || self_producer.begin_transaction(),
+        )
+        .unwrap_or_else(|_| Err(KafkaError::Canceled))
+    }
+
+    fn commit_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
+        let self_producer = Arc::clone(&self.inner);
+        let self_timeout = self.timeout;
+        task::spawn_blocking(
+            || format!("commit_transaction:{}", self.name),
+            move || self_producer.commit_transaction(self_timeout),
+        )
+        .unwrap_or_else(|_| Err(KafkaError::Canceled))
+    }
+
+    fn abort_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
+        let self_producer = Arc::clone(&self.inner);
+        let self_timeout = self.timeout;
+        task::spawn_blocking(
+            || format!("abort_transaction:{}", self.name),
+            move || self_producer.abort_transaction(self_timeout),
+        )
+        .unwrap_or_else(|_| Err(KafkaError::Canceled))
+    }
+
+    fn flush(&self) -> impl Future<Output = KafkaResult<()>> {
+        let self_producer = Arc::clone(&self.inner);
+        let self_timeout = self.timeout;
+        task::spawn_blocking(
+            || format!("flush:{}", self.name),
+            move || self_producer.flush(self_timeout),
+        )
+        .unwrap_or_else(|_| Err(KafkaError::Canceled))
+    }
+
+    fn send<'a, K, P>(
+        &self,
+        record: BaseRecord<'a, K, P>,
+    ) -> Result<(), (KafkaError, Box<BaseRecord<'a, K, P>>)>
     where
-        F: FnOnce(BaseProducer<TunnelingClientContext<MzClientContext>>) -> Result<R, KafkaError>
-            + Send
-            + 'static,
-        R: Send + 'static,
+        K: ToBytes + ?Sized,
+        P: ToBytes + ?Sized,
     {
-        let producer = self.producer.clone();
-        task::spawn_blocking(|| &self.task_name, move || f(producer))
-            .await
-            .unwrap()
-            .check_ssh_status(self.producer.context())
+        self.inner
+            .send(record)
+            // box the entire record the rdkakfa crate gives us back
+            .map_err(|(e, record)| (e, Box::new(record)))
     }
 
-    async fn fetch_metadata(&self) -> Result<Metadata, ContextCreationError> {
-        self.spawn_blocking(|p| p.client().fetch_metadata(None, Duration::from_secs(10)))
-            .await
-    }
-
-    async fn begin_transaction<'a>(&'a mut self) -> Result<(), ContextCreationError> {
-        self.spawn_blocking(|p| p.begin_transaction()).await
-    }
-
-    /// Synchronously puts the provided message to librdkafka's send queue. This method only
-    /// returns an error if the queue is full. Handling this error by buffering the message and
-    /// retrying is equivalent to adjusting the maximum number of queued items in rdkafka so it is
-    /// adviced that callers only handle this error in order to apply backpressure to the rest of
-    /// the system.
-    fn send(
-        &mut self,
-        key: Option<&[u8]>,
-        value: Option<&[u8]>,
-        time: Timestamp,
-        diff: Diff,
-    ) -> Result<(), KafkaError> {
-        assert_eq!(diff, 1, "invalid sink update");
-
-        let headers = OwnedHeaders::new().insert(Header {
-            key: "materialize-timestamp",
-            value: Some(time.to_string().as_bytes()),
-        });
-        let record = BaseRecord {
-            topic: &self.data_topic,
-            key,
-            payload: value,
-            headers: Some(headers),
-            partition: None,
-            timestamp: None,
-            delivery_opaque: (),
-        };
-        let key_size = key.map(|k| k.len()).unwrap_or(0);
-        let value_size = value.map(|k| k.len()).unwrap_or(0);
-        let record_size = u64::cast_from(key_size + value_size);
-        self.statistics.inc_messages_staged_by(1);
-        self.staged_messages += 1;
-        self.statistics.inc_bytes_staged_by(record_size);
-        self.staged_bytes += record_size;
-        self.producer.send(record).map_err(|(e, _)| e)
-    }
-
-    /// Commits all the staged updates of the currently open transaction plus a progress record
-    /// describing `upper` to the progress topic.
-    async fn commit_transaction(
-        &mut self,
-        upper: Antichain<Timestamp>,
-    ) -> Result<(), ContextCreationError> {
-        let progress = ProgressRecord {
-            frontier: upper.into(),
-        };
-        let payload = serde_json::to_vec(&progress).expect("infallible");
-        let record = BaseRecord::to(&self.progress_topic)
-            .payload(&payload)
-            .key(&self.progress_key);
-        self.producer.send(record).map_err(|(e, _)| e)?;
-
-        match self
-            .spawn_blocking(|p| p.commit_transaction(DEFAULT_TIMEOUT))
-            .await
-        {
-            Ok(()) => {
-                // librdkafka guarantees that all outstanding messages are successfully delivered
-                // before the transaction commits. We assert this fact here.
-                assert_eq!(self.producer.in_flight_count(), 0);
-                self.statistics
-                    .inc_messages_committed_by(self.staged_messages);
-                self.statistics.inc_bytes_committed_by(self.staged_bytes);
-                self.staged_messages = 0;
-                self.staged_bytes = 0;
-                Ok(())
-            }
-            Err(ContextCreationError::KafkaError(KafkaError::Transaction(err))) => {
-                // Make one attempt at aborting the transaction before letting the error percolate
-                // up and the process exit. Aborting allows the consumers of the topic to skip over
-                // any messages we've written in the transaction, so it's polite to do... but if it
-                // fails, the transaction will be aborted either when fenced out by a future
-                // version of this producer or by the broker-side timeout.
-                if err.txn_requires_abort() {
-                    self.spawn_blocking(|p| p.abort_transaction(DEFAULT_TIMEOUT))
-                        .await?;
+    async fn retry_on_txn_error<'a, F, Fut, T>(&self, f: F) -> Result<T, anyhow::Error>
+    where
+        F: Fn(KafkaTxProducer) -> Fut,
+        Fut: Future<Output = KafkaResult<T>>,
+    {
+        Retry::default()
+            .clamp_backoff(BACKOFF_CLAMP)
+            .max_tries(3)
+            .retry_async(|_| async {
+                match f(self.clone()).await {
+                    Ok(value) => RetryResult::Ok(value),
+                    Err(KafkaError::Transaction(e)) if e.txn_requires_abort() => {
+                        // Make one attempt at aborting the transaction before letting the error
+                        // percolate up and the process exit. Aborting allows the consumers of the
+                        // topic to skip over any messages we've written in the transaction, so it's
+                        // polite to do... but if it fails, the transaction will be aborted either
+                        // when fenced out by a future version of this producer or by the
+                        // broker-side timeout.
+                        if let Err(e) = self.abort_transaction().await {
+                            warn!(
+                                error =? e,
+                                "failed to abort transaction after an error that required it"
+                            );
+                        }
+                        RetryResult::FatalErr(
+                            anyhow!(e).context("transaction error requiring abort"),
+                        )
+                    }
+                    Err(KafkaError::Transaction(e)) if e.is_retriable() => {
+                        RetryResult::RetryableErr(anyhow!(e).context("retriable transaction error"))
+                    }
+                    Err(e) => {
+                        RetryResult::FatalErr(anyhow!(e).context("non-retriable transaction error"))
+                    }
                 }
-                Err(ContextCreationError::KafkaError(KafkaError::Transaction(
-                    err,
-                )))
+            })
+            .await
+    }
+}
+
+struct HealthOutputHandle {
+    health_cap: timely::dataflow::operators::Capability<Timestamp>,
+    // TODO(guswynn): We probably don't need this Mutex, but removing it
+    // is a large refactor of this entire module.
+    handle: Mutex<
+        mz_timely_util::builder_async::AsyncOutputHandle<
+            mz_repr::Timestamp,
+            Vec<HealthStatusMessage>,
+            TeeCore<mz_repr::Timestamp, Vec<HealthStatusMessage>>,
+        >,
+    >,
+}
+
+struct KafkaSinkState {
+    name: String,
+    topic: String,
+    metrics: Arc<SinkMetrics>,
+    producer: KafkaTxProducer,
+    pending_rows: BTreeMap<Timestamp, Vec<EncodedRow>>,
+    ready_rows: VecDeque<(Timestamp, Vec<EncodedRow>)>,
+    retry_manager: Arc<Mutex<KafkaSinkSendRetryManager>>,
+
+    progress_topic: String,
+    progress_key: ProgressKey,
+
+    healthchecker: HealthOutputHandle,
+    gate_ts: Rc<Cell<Option<Timestamp>>>,
+
+    /// Timestamp of the latest progress record that was written out to Kafka.
+    latest_progress_ts: Timestamp,
+
+    /// Write frontier of this sink.
+    ///
+    /// The write frontier potentially blocks compaction of timestamp bindings
+    /// in upstream sources. The latest written progress record is used when
+    /// restarting the sink to gate updates with a lower timestamp. We advance
+    /// the write frontier in lockstep with writing out progress records. This
+    /// ensures that we don't write updates more than once, ensuring
+    /// exactly-once guarantees.
+    write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
+}
+
+impl KafkaSinkState {
+    // Until `try` blocks, we need this for using `fail_point!` correctly.
+    async fn new(
+        sink_id: GlobalId,
+        connection: KafkaSinkConnection,
+        sink_name: String,
+        worker_id: usize,
+        write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
+        metrics: &StorageMetrics,
+        storage_configuration: &StorageConfiguration,
+        gate_ts: Rc<Cell<Option<Timestamp>>>,
+        healthchecker: HealthOutputHandle,
+    ) -> (Self, Option<Timestamp>) {
+        let metrics = Arc::new(metrics.get_sink_metrics(&connection.topic, sink_id, worker_id));
+
+        let retry_manager = Arc::new(Mutex::new(KafkaSinkSendRetryManager::new()));
+
+        let producer_context = SinkProducerContext {
+            metrics: Arc::clone(&metrics),
+            retry_manager: Arc::clone(&retry_manager),
+            inner: MzClientContext::default(),
+        };
+
+        let producer = halt_on_err(
+            &healthchecker,
+            #[allow(clippy::redundant_closure_call)]
+            (|| async {
+                fail::fail_point!("kafka_sink_creation_error", |_| Err(
+                    ContextCreationError::Other(anyhow::anyhow!("synthetic error"))
+                ));
+
+                KafkaTxProducer::new(KafkaTxProducerConfig {
+                    name: sink_name.clone(),
+                    connection: &connection,
+                    storage_configuration,
+                    producer_context,
+                    sink_id,
+                })
+                .await
+            })()
+            .await,
+            None,
+        )
+        .await;
+
+        // Note that where this lies in the rendering cycle means that we might
+        // create the collateral topics each time the sink is rendered, e.g. if
+        // the broker's admin deleted the progress and data topics. For more
+        // details, see `mz_storage_client::sink::build_kafka`.
+        let latest_ts = halt_on_err(
+            &healthchecker,
+            mz_storage_client::sink::build_kafka(sink_id, &connection, storage_configuration).await,
+            None,
+        )
+        .await;
+
+        let progress_topic = connection
+            .progress_topic(&storage_configuration.connection_context)
+            .into_owned();
+        (
+            KafkaSinkState {
+                name: sink_name,
+                topic: connection.topic,
+                metrics,
+                producer,
+                pending_rows: BTreeMap::new(),
+                ready_rows: VecDeque::new(),
+                retry_manager,
+                progress_topic,
+                progress_key: ProgressKey::new(sink_id),
+                healthchecker,
+                gate_ts,
+                latest_progress_ts: Timestamp::minimum(),
+                write_frontier,
+            },
+            latest_ts,
+        )
+    }
+
+    async fn send<'a, K, P>(&self, mut record: BaseRecord<'a, K, P>)
+    where
+        K: ToBytes + ?Sized,
+        P: ToBytes + ?Sized,
+    {
+        let tries = Retry::default()
+            .max_tries(usize::MAX)
+            .clamp_backoff(Duration::from_secs(60 * 10))
+            .into_retry_stream();
+        tokio::pin!(tries);
+        loop {
+            tries.next().await.expect("infinite stream");
+            match self.producer.send(record) {
+                Ok(()) => {
+                    self.metrics.messages_sent_counter.inc();
+                    self.retry_manager.lock().await.record_send();
+                    return;
+                }
+                Err((e, rec)) => {
+                    record = *rec;
+                    self.metrics.message_send_errors_counter.inc();
+
+                    if let KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull) = e {
+                        debug!(
+                            "unable to produce message in {}: rdkafka queue full; will retry",
+                            self.name
+                        );
+                        continue;
+                    } else {
+                        // We've received an error that is not transient
+                        self.halt_on_err(Err(anyhow!(format!(
+                            "fatal error while producing message in {}: {e}",
+                            self.name
+                        ))))
+                        .await
+                    }
+                }
             }
-            Err(err) => Err(err),
+        }
+    }
+
+    async fn flush(&self) {
+        self.flush_inner().await;
+        while !{
+            let mut guard = self.retry_manager.lock().await;
+            guard.sends_flushed()
+        } {
+            while let Some(msg) = {
+                let mut guard = self.retry_manager.lock().await;
+                guard.pop_retry()
+            } {
+                let mut transformed_msg = BaseRecord::to(msg.topic());
+                transformed_msg = match msg.key() {
+                    Some(k) => transformed_msg.key(k),
+                    None => transformed_msg,
+                };
+                transformed_msg = match msg.payload() {
+                    Some(p) => transformed_msg.payload(p),
+                    None => transformed_msg,
+                };
+                self.send(transformed_msg).await;
+            }
+            self.flush_inner().await;
+        }
+    }
+
+    async fn flush_inner(&self) {
+        Retry::default()
+            .max_tries(usize::MAX)
+            .clamp_backoff(BACKOFF_CLAMP)
+            .retry_async(|_| self.producer.flush())
+            .await
+            .expect("Infinite retry cannot fail");
+    }
+
+    async fn send_progress_record(&self, transaction_id: Timestamp) {
+        let encoded = serde_json::to_vec(&ProgressRecord {
+            timestamp: transaction_id,
+        })
+        .expect("serialization to vec cannot fail");
+        let record = BaseRecord::to(&self.progress_topic)
+            .payload(&encoded)
+            .key(&self.progress_key);
+        self.send(record).await
+    }
+
+    /// Asserts that the write frontier has not yet advanced beyond `t`.
+    fn assert_progress(&self, ts: &Timestamp) {
+        assert!(self.write_frontier.borrow().less_equal(ts));
+    }
+
+    /// Updates the latest progress update timestamp to `latest_update_ts` if it
+    /// is greater than the currently maintained timestamp.
+    ///
+    /// This does not emit a progress update and should be used when the sink
+    /// emits a progress update that is not based on updates of the input
+    /// frontier.
+    ///
+    /// See [`maybe_emit_progress`](Self::maybe_emit_progress).
+    fn maybe_update_progress(&mut self, latest_update_ts: &Timestamp) {
+        if *latest_update_ts > self.latest_progress_ts {
+            self.latest_progress_ts = *latest_update_ts;
+        }
+    }
+
+    /// Updates the latest progress update timestamp based on the given
+    /// input frontier and pending rows.
+    ///
+    /// This will emit a progress record to the progress topic if the frontier
+    /// advanced and advance the maintained write frontier, which will in turn
+    /// unblock compaction of timestamp bindings in sources.
+    ///
+    /// *NOTE*: Progress records will only be emitted when
+    /// `KafkaSinkConnection.consistency` points to a progress topic. The
+    /// write frontier will be advanced regardless.
+    async fn maybe_emit_progress(
+        &mut self,
+        mut input_frontier: Antichain<Timestamp>,
+        as_of: &SinkAsOf<Timestamp>,
+    ) -> bool {
+        input_frontier.extend(self.pending_rows.keys().min().cloned());
+        let min_frontier = input_frontier;
+
+        // If we emit a progress record before the as_of, we open ourselves to the possibility that
+        // we restart the sink with a gate timestamp behind the ASOF.  If that happens, we're unable
+        // to tell the difference between some records we've already written out and those that we
+        // still need to write out. (This is because asking for records with a given ASOF will fast
+        // forward all records at or before to the requested ASOF.)
+        //
+        // N.B. This condition is _not_ symmetric with the assert on the gate_ts on sink startup
+        // because we subtract 1 below to determine what progress value to actually write out.
+        if !PartialOrder::less_than(&as_of.frontier, &min_frontier) {
+            return false;
+        }
+
+        let mut progress_emitted = false;
+
+        if let Some(min_frontier) = min_frontier.into_option() {
+            // A frontier of `t` means we still might receive updates with `t`. The progress
+            // frontier we emit `f` indicates that all future values will be greater than `f`.
+            //
+            // The progress notion of frontier does not mesh with the notion of frontier in timely.
+            // This is confusing -- but still preferrable.  Were we to define the "progress
+            // frontier" to be the earliest time we could still write more data, we would need to
+            // write out a progress record of `t + 1` when we write out data.  Furthermore, were we
+            // to ever move to a notion of multi-dimensional time, it is more natural (and easier
+            // to keep the system correct) to record the time of the data we write to the progress
+            // topic.
+            let min_frontier = min_frontier.saturating_sub(1);
+
+            if min_frontier > self.latest_progress_ts {
+                // record the write frontier in the progress topic.
+                self.halt_on_err(
+                    self.producer
+                        .retry_on_txn_error(|p| p.begin_transaction())
+                        .await,
+                )
+                .await;
+
+                debug!(
+                    "{}: sending progress for gate ts: {:?}",
+                    &self.name, min_frontier
+                );
+                self.send_progress_record(min_frontier).await;
+
+                self.halt_on_err(
+                    self.producer
+                        .retry_on_txn_error(|p| p.commit_transaction())
+                        .await,
+                )
+                .await;
+
+                progress_emitted = true;
+                self.latest_progress_ts = min_frontier;
+            }
+
+            let mut write_frontier = self.write_frontier.borrow_mut();
+
+            // make sure we don't regress
+            debug!(
+                "{}: downgrading write frontier to: {:?}",
+                &self.name, min_frontier
+            );
+            assert!(write_frontier.less_equal(&min_frontier));
+            write_frontier.clear();
+            write_frontier.insert(min_frontier);
+        } else {
+            // If there's no longer an input frontier, we will no longer receive any data forever and, therefore, will
+            // never output more data
+            info!("{}: advancing write frontier to empty", &self.name);
+            self.write_frontier.borrow_mut().clear();
+        }
+
+        progress_emitted
+    }
+
+    async fn update_status(&self, status: HealthStatusUpdate, namespace: StatusNamespace) {
+        update_status(&self.healthchecker, status, namespace).await;
+    }
+
+    /// Report a stalled HealthStatusUpdate and then halt with the same message.
+    pub async fn halt_on_err<T>(&self, result: Result<T, anyhow::Error>) -> T {
+        // We may not get an up-to-date ssh status here, but on restart we will.
+        let ssh_status = self.producer.inner.client().context().tunnel_status();
+
+        halt_on_err(
+            &self.healthchecker,
+            result.map_err(ContextCreationError::Other),
+            Some(ssh_status),
+        )
+        .await
+    }
+}
+
+async fn update_status(
+    healthchecker: &HealthOutputHandle,
+    status: HealthStatusUpdate,
+    namespace: StatusNamespace,
+) {
+    healthchecker
+        .handle
+        .lock()
+        .await
+        .give(
+            &healthchecker.health_cap,
+            HealthStatusMessage {
+                // sinks only have 1 logical object.
+                index: 0,
+                namespace,
+                update: status,
+            },
+        )
+        .await;
+}
+
+async fn halt_on_err<T>(
+    healthchecker: &HealthOutputHandle,
+    // We use a `ContextCreationError` for convenience here because it can be an ssh error during
+    // `create_with_context` calls, or an `anyhow::Error` for transient failures during operation.
+    // In the future we could probably also use the `KafkaError` variant as well.
+    result: Result<T, ContextCreationError>,
+    // The status of the ssh tunnel, if it already exists.
+    ssh_status: Option<SshTunnelStatus>,
+) -> T {
+    match result {
+        Ok(t) => t,
+        Err(error) => {
+            let kafka_error = match error {
+                ContextCreationError::KafkaError(KafkaError::Transaction(ref e)) => Some(e),
+                ContextCreationError::Other(ref err) => err.downcast_ref::<RDKafkaError>(),
+                ContextCreationError::KafkaError(_) | ContextCreationError::Ssh(_) => None,
+            };
+            let hint = match kafka_error {
+                Some(e) => {
+                    if e.is_retriable() && e.code() == RDKafkaErrorCode::OperationTimedOut {
+                        let hint =
+                            "If you're running a single Kafka broker, ensure that the configs \
+                        transaction.state.log.replication.factor, transaction.state.log.min.isr, \
+                        and offsets.topic.replication.factor are set to 1 on the broker";
+                        Some(hint.to_owned())
+                    } else {
+                        None
+                    }
+                }
+                None => None,
+            };
+
+            // Update the ssh status. This could be overridden below, but this ensures the
+            // user gets a useful error if the kafka error is a result of this status.
+            if let Some(SshTunnelStatus::Errored(e)) = ssh_status {
+                update_status(
+                    healthchecker,
+                    HealthStatusUpdate::stalled(e, None),
+                    StatusNamespace::Ssh,
+                )
+                .await;
+            }
+
+            update_status(
+                healthchecker,
+                HealthStatusUpdate::halting(format!("{}", error.display_with_causes()), hint),
+                if matches!(error, ContextCreationError::Ssh(_)) {
+                    StatusNamespace::Ssh
+                } else {
+                    StatusNamespace::Kafka
+                },
+            )
+            .await;
+
+            // Make sure to never return, preventing the sink from writing
+            // out anything it might regret in the future.
+            future::pending().await
         }
     }
 }
 
-/// Sinks a collection of encoded rows to Kafka.
+#[derive(Debug)]
+struct EncodedRow {
+    key: Option<Vec<u8>>,
+    value: Option<Vec<u8>>,
+    count: usize,
+}
+
+fn kafka<G>(
+    collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
+    id: GlobalId,
+    connection: KafkaSinkConnection,
+    envelope: SinkEnvelope,
+    as_of: SinkAsOf,
+    write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
+    metrics: &StorageMetrics,
+    sink_statistics: SinkStatistics,
+    storage_configuration: &StorageConfiguration,
+) -> (Stream<G, HealthStatusMessage>, Vec<PressOnDropButton>)
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    let name = format!("kafka-{}", id);
+
+    let stream = &collection.inner;
+
+    let shared_gate_ts = Rc::new(Cell::new(None));
+
+    let (encoded_stream, encode_health_stream, encode_token) = encode_stream(
+        stream,
+        id,
+        as_of.clone(),
+        Rc::clone(&shared_gate_ts),
+        &name,
+        connection.clone(),
+        storage_configuration.clone(),
+        envelope,
+    );
+
+    let (produce_health_stream, produce_token) = produce_to_kafka(
+        encoded_stream,
+        id,
+        name,
+        connection,
+        as_of,
+        shared_gate_ts,
+        write_frontier,
+        metrics,
+        sink_statistics,
+        storage_configuration.clone(),
+    );
+
+    (
+        encode_health_stream.concat(&produce_health_stream),
+        vec![encode_token, produce_token],
+    )
+}
+
+/// Produces/sends a stream of encoded rows (as `Vec<u8>`) to Kafka.
 ///
 /// This operator exchanges all updates to a single worker by hashing on the given sink `id`.
 ///
-/// Updates are sent in ascending timestamp order.
-fn sink_collection<G: Scope<Timestamp = Timestamp>>(
+/// Updates are only sent to Kafka once the input frontier has passed their `time`. Updates are
+/// sent in ascending timestamp order. The order of updates at the same timestamp will not be changed.
+/// However, it is important to keep in mind that this operator exchanges updates so if the input
+/// stream is sharded updates will likely arrive at this operator in some non-deterministic order.
+///
+/// Updates that are not beyond the given [`SinkAsOf`] and/or the `gate_ts` in
+/// [`KafkaSinkConnection`] will be discarded without producing them.
+fn produce_to_kafka<G>(
+    stream: Stream<G, ((Option<Vec<u8>>, Option<Vec<u8>>), Timestamp, Diff)>,
+    id: GlobalId,
     name: String,
-    input: &Collection<G, (Option<Vec<u8>>, Option<Vec<u8>>), Diff>,
-    sink_id: GlobalId,
     connection: KafkaSinkConnection,
-    storage_configuration: StorageConfiguration,
-    as_of: Antichain<Timestamp>,
-    statistics: SinkStatistics,
+    as_of: SinkAsOf,
+    shared_gate_ts: Rc<Cell<Option<Timestamp>>>,
     write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
-) -> (Stream<G, HealthStatusMessage>, PressOnDropButton) {
-    let scope = input.scope();
-    let mut builder = AsyncOperatorBuilder::new(name.clone(), input.inner.scope());
+    metrics: &StorageMetrics,
+    sink_statistics: SinkStatistics,
+    storage_configuration: StorageConfiguration,
+) -> (Stream<G, HealthStatusMessage>, PressOnDropButton)
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    let metrics = metrics.clone();
+    let worker_id = stream.scope().index();
+    let worker_count = stream.scope().peers();
+    let mut builder = AsyncOperatorBuilder::new(name.clone(), stream.scope());
+
+    // keep the latest progress updates, if any, in order to update
+    // our internal state after the send loop
+    let mut progress_update = None;
 
     // We want exactly one worker to send all the data to the sink topic.
-    let hashed_id = sink_id.hashed();
-    let is_active_worker = usize::cast_from(hashed_id) % scope.peers() == scope.index();
+    let hashed_id = id.hashed();
+    let is_active_worker = usize::cast_from(hashed_id) % worker_count == worker_id;
 
-    let mut input = builder.new_input(&input.inner, Exchange::new(move |_| hashed_id));
+    let mut input = builder.new_input(&stream, Exchange::new(move |_| hashed_id));
 
-    let (button, errors) = builder.build_fallible(move |_caps| {
-        Box::pin(async move {
-            if !is_active_worker {
-                write_frontier.borrow_mut().clear();
-                return Ok(());
-            }
+    // The frontier of this output is never inspected, so we can just use a
+    // normal output, even if its frontier is connected to the input.
+    //
+    // n.b. each operator needs to have its own `HealthOutputHandle` and they
+    // cannot be shared between operators.
+    let (health_output, health_stream) = builder.new_output();
 
-            fail::fail_point!("kafka_sink_creation_error", |_| Err(
-                ContextCreationError::Other(anyhow::anyhow!("synthetic error"))
-            ));
+    let button = builder.build(move |caps| async move {
+        let [health_cap]: [_; 1] = caps.try_into().unwrap();
 
-            let mut producer = TransactionalProducer::new(
-                sink_id,
-                &connection,
-                &storage_configuration,
-                statistics,
-            )
-            .await?;
-            // Instantiating the transactional producer fences out all previous ones, making it
-            // safe to determine the resume upper.
-            let resume_upper = mz_storage_client::sink::determine_sink_resume_upper(
-                sink_id,
-                &connection,
-                &storage_configuration,
-            )
-            .await?;
+        if !is_active_worker {
+            return;
+        }
 
-            let resume_upper = match resume_upper {
-                Some(upper) => {
-                    // If there are committed progress messages then we only check if the data
-                    // topic exists, because if it does not then it must have been deleted after
-                    // the fact, which is a bit of a problem.
-                    let meta = producer.fetch_metadata().await?;
-                    if !meta.topics().iter().any(|t| t.name() == &connection.topic) {
-                        return Err(anyhow!(
-                            "sink progress data exists, but sink data topic is missing"
-                        )
-                        .into());
-                    }
-                    upper
-                }
-                None => {
-                    mz_storage_client::sink::ensure_kafka_topic(
-                        &connection,
-                        &storage_configuration,
-                        &connection.topic,
-                        // TODO: allow users to configure these parameters.
-                        TopicConfig {
-                            partition_count: -1,
-                            replication_factor: -1,
-                            cleanup_policy: TopicCleanupPolicy::Retention {
-                                ms: Some(-1),
-                                bytes: Some(-1),
-                            },
-                        },
-                    )
-                    .await?;
-                    Antichain::from_elem(Timestamp::minimum())
-                }
-            };
+        let (mut s, latest_ts) = KafkaSinkState::new(
+            id,
+            connection,
+            name,
+            worker_id,
+            write_frontier,
+            &metrics,
+            &storage_configuration,
+            Rc::clone(&shared_gate_ts),
+            HealthOutputHandle {
+                health_cap,
+                handle: Mutex::new(health_output),
+            },
+        )
+        .await;
 
-            // The input has overcompacted if
-            let overcompacted =
-                // ..we have made some progress in the past
-                *resume_upper != [Timestamp::minimum()] &&
-                // ..but the since frontier is now beyond that
-                !PartialOrder::less_equal(&as_of, &resume_upper);
-            if overcompacted {
-                let err = format!(
-                    "{name}: input compacted past resume upper: as_of {}, resume_upper: {}",
-                    as_of.pretty(),
-                    resume_upper.pretty()
-                );
-                // This would normally be an assertion but because it can happen after a
-                // Materialize backup/restore we log an error so that it appears on Sentry but
-                // leaves the rest of the objects in the cluster unaffected.
-                error!("{err}");
-                return Err(anyhow!("{err}").into());
-            }
+        info!(
+            "{}: initial as_of: {:?}, latest progress record: {:?}",
+            s.name, as_of.frontier, latest_ts
+        );
+        shared_gate_ts.set(latest_ts);
 
-            info!(
-                "{name}: as_of: {}, resume upper: {}",
-                as_of.pretty(),
-                resume_upper.pretty()
+        if let Some(gate) = latest_ts {
+            assert!(
+                PartialOrder::less_equal(&as_of.frontier, &Antichain::from_elem(gate)),
+                "{}: some element of the Sink as_of frontier is too \
+                    far advanced for our output-gating timestamp: \
+                    as_of {:?}, gate_ts: {:?}",
+                s.name,
+                as_of.frontier,
+                gate
             );
+            s.maybe_update_progress(&gate);
+        }
 
-            // The section below relies on TotalOrder for correctness so we'll work with timestamps
-            // directly to make sure this doesn't compile if someone attempts to make this operator
-            // generic over partial orders in the future.
-            let Some(mut upper) = resume_upper.clone().into_option() else {
-                return Ok(());
-            };
-            let mut deferred_updates = vec![];
-            let mut extra_updates = vec![];
-            // We must wait until we have data to commit before starting a transaction because
-            // Kafka doesn't have a heartbeating mechanism to keep a transaction open indefinitely.
-            // This flag tracks whether we have started the transaction.
-            let mut transaction_begun = false;
-            while let Some(event) = input.next_mut().await {
-                match event {
-                    Event::Data(_cap, batch) => {
-                        for ((key, value), time, diff) in batch.drain(..) {
-                            // We want to publish updates in time order and we know that we have
-                            // already committed all times not beyond `upper`. Therefore, if this
-                            // update happens *exactly* at upper then it is the minimum pending
-                            // time and so emitting it now will not violate the timestamp publish
-                            // order. This optimization is load bearing because it is the mechanism
-                            // by which we incrementally stream the initial snapshot out to Kafka
-                            // instead of buffering it all in memory first. This argument doesn't
-                            // hold for partially ordered time because many different timestamps
-                            // can be *exactly* at upper but we can't know ahead of time which one
-                            // will be advanced in the next progress message.
-                            match upper.cmp(&time) {
-                                Ordering::Less => deferred_updates.push(((key, value), time, diff)),
-                                Ordering::Equal => {
-                                    if !transaction_begun {
-                                        producer.begin_transaction().await?;
-                                        transaction_begun = true;
-                                    }
-                                    producer.send(key.as_deref(), value.as_deref(), time, diff)?;
-                                }
-                                Ordering::Greater => continue,
+        s.update_status(HealthStatusUpdate::running(), StatusNamespace::Kafka)
+            .await;
+
+        while let Some(event) = input.next_mut().await {
+            match event {
+                Event::Data(_, rows) => {
+                    // Queue all pending rows waiting to be sent to kafka
+                    assert!(is_active_worker);
+                    for ((key, value), time, diff) in rows.drain(..) {
+                        let should_emit = if as_of.strict {
+                            as_of.frontier.less_than(&time)
+                        } else {
+                            as_of.frontier.less_equal(&time)
+                        };
+
+                        let previously_published = Some(time) <= s.gate_ts.get();
+
+                        if !should_emit || previously_published {
+                            // Skip stale data for already published timestamps
+                            continue;
+                        }
+
+                        if diff == 0 {
+                            // Explicitly refuse to send no-op records
+                            continue;
+                        };
+                        let count =
+                            usize::try_from(diff).expect("can't sink negative multiplicities");
+
+                        let rows = s.pending_rows.entry(time).or_default();
+                        rows.push(EncodedRow { key, value, count });
+                        s.metrics.rows_queued.inc();
+                    }
+                }
+                Event::Progress(frontier) => {
+                    // Move any newly closed timestamps from pending to ready
+                    let mut closed_ts: Vec<Timestamp> = s
+                        .pending_rows
+                        .iter()
+                        .filter(|(ts, _)| !frontier.less_equal(*ts))
+                        .map(|(&ts, _)| ts)
+                        .collect();
+                    closed_ts.sort_unstable();
+                    closed_ts.into_iter().for_each(|ts| {
+                        let rows = s.pending_rows.remove(&ts).unwrap();
+                        s.ready_rows.push_back((ts, rows));
+                    });
+
+                    while let Some((ts, rows)) = s.ready_rows.front() {
+                        assert!(is_active_worker);
+
+                        info!(
+                            "{}: beginning transaction for {:?} with {:?} rows",
+                            id,
+                            ts,
+                            rows.len()
+                        );
+                        s.halt_on_err(
+                            s.producer
+                                .retry_on_txn_error(|p| p.begin_transaction())
+                                .await,
+                        )
+                        .await;
+
+                        let mut repeat_counter = 0;
+
+                        let count_for_stats = u64::cast_from(rows.len());
+                        let mut total_size_for_stats = 0;
+                        for encoded_row in rows {
+                            let record = BaseRecord::to(&s.topic);
+                            let record = match encoded_row.value.as_ref() {
+                                Some(r) => record.payload(r),
+                                None => record,
+                            };
+                            let record = match encoded_row.key.as_ref() {
+                                Some(r) => record.key(r),
+                                None => record,
+                            };
+
+                            let ts_bytes = ts.to_string().into_bytes();
+                            let record = record.headers(OwnedHeaders::new().insert(Header {
+                                key: "materialize-timestamp",
+                                value: Some(&ts_bytes),
+                            }));
+
+                            let size_for_stats =
+                                u64::cast_from(record.payload.as_ref().map_or(0, |p| p.len()))
+                                    + u64::cast_from(record.key.as_ref().map_or(0, |k| k.len()));
+                            total_size_for_stats += size_for_stats;
+
+                            s.send(record).await;
+                            sink_statistics.inc_messages_staged_by(1);
+                            sink_statistics.inc_bytes_staged_by(size_for_stats);
+
+                            // advance to the next repetition of this row, or the next row if all
+                            // repetitions are exhausted
+                            repeat_counter += 1;
+                            if repeat_counter == encoded_row.count {
+                                repeat_counter = 0;
+                                s.metrics.rows_queued.dec();
                             }
                         }
-                    }
-                    Event::Progress(progress) => {
-                        // Ignore progress updates before our resumption frontier
-                        if !PartialOrder::less_equal(&resume_upper, &progress) {
-                            continue;
-                        }
-                        // Also ignore progress updates until we are past the as_of frontier. This
-                        // is to avoid the following pathological scenario:
-                        // 1. Sink gets instantiated with an as_of = {10}, resume_upper = {0}.
-                        //    `progress` initially jumps at {10}, then the snapshot appears at time
-                        //    10.
-                        // 2. `progress` would normally advance to say {11} and we would commit the
-                        //    snapshot but clusterd crashes instead.
-                        // 3. A new cluster restarts the sink with an earlier as_of, say {5}. This
-                        //    is valid, the earlier as_of has strictly more information. The
-                        //    snapshot now appears at time 5.
-                        //
-                        // If we were to commit an empty transaction in step 1 and advanced the
-                        // resume_upper to {10} then in step 3 we would ignore the snapshot that
-                        // now appears at 5 completely. So it is important to only start committing
-                        // transactions after we're strictly beyond the as_of.
-                        // TODO(petrosagg): is this logic an indication of us holding something
-                        // wrong elsewhere? Investigate.
-                        // Note: !PartialOrder::less_than(as_of, progress) would not be equivalent
-                        // nor correct for partially ordered times.
-                        if !as_of.iter().all(|t| !progress.less_equal(t)) {
-                            continue;
-                        }
-                        if !transaction_begun {
-                            producer.begin_transaction().await?;
-                        }
-                        extra_updates.extend(
-                            deferred_updates
-                                .drain_filter_swapping(|(_, time, _)| !progress.less_equal(time)),
-                        );
-                        extra_updates.sort_unstable_by(|a, b| a.1.cmp(&b.1));
-                        for ((key, value), time, diff) in extra_updates.drain(..) {
-                            producer.send(key.as_deref(), value.as_deref(), time, diff)?;
-                        }
 
-                        info!("{name}: committing transaction for {}", progress.pretty());
-                        producer.commit_transaction(progress.clone()).await?;
-                        transaction_begun = false;
-                        *write_frontier.borrow_mut() = progress.clone();
-                        match progress.into_option() {
-                            Some(new_upper) => upper = new_upper,
-                            None => break,
+                        // Flush to make sure that errored messages have been properly retried before
+                        // sending progress records and commit transactions.
+                        s.flush().await;
+
+                        // We don't count this record as part of the message count in user-facing
+                        // statistics.
+                        s.send_progress_record(*ts).await;
+
+                        info!("{}: committing transaction for {:?}", id, ts);
+                        s.halt_on_err(
+                            s.producer
+                                .retry_on_txn_error(|p| p.commit_transaction())
+                                .await,
+                        )
+                        .await;
+                        sink_statistics.inc_messages_committed_by(count_for_stats);
+                        sink_statistics.inc_bytes_committed_by(total_size_for_stats);
+
+                        s.flush().await;
+
+                        // sanity check for the continuous updating
+                        // of the write frontier below
+                        s.assert_progress(ts);
+                        progress_update.replace(ts.clone());
+
+                        s.ready_rows.pop_front();
+                    }
+
+                    // Update our state based on any progress we may have sent.  This
+                    // call is required for us to periodically write progress updates
+                    // even without new data coming in.
+                    if let Some(ts) = progress_update.take() {
+                        s.maybe_update_progress(&ts);
+                    }
+
+                    // If we don't have ready rows, our write frontier equals the minimum
+                    // of the input frontier and any stashed timestamps.
+                    // While we still have ready rows that we're emitting, hold the write
+                    // frontier at the previous time.
+                    //
+                    // Only one worker receives all the updates and we don't want the
+                    // other workers to also emit progress.
+                    if is_active_worker {
+                        let progress_emitted =
+                            s.maybe_emit_progress(frontier.clone(), &as_of).await;
+                        if progress_emitted {
+                            // Don't flush if we know there were no records emitted.
+                            // It has a noticeable negative performance impact.
+                            s.flush().await;
+                        }
+                    }
+
+                    // We want debug_assert but also to print out if we would have failed the assertion in release mode
+                    let in_flight_count = s.producer.inner.in_flight_count();
+                    let sends_flushed = s.retry_manager.lock().await.sends_flushed();
+                    if cfg!(debug_assertions) {
+                        assert_eq!(in_flight_count, 0);
+                        assert!(sends_flushed);
+                    } else {
+                        if in_flight_count != 0 {
+                            error!("Producer has {:?} messages in flight", in_flight_count);
+                        }
+                        if !sends_flushed {
+                            error!("Retry manager has not flushed sends");
                         }
                     }
                 }
             }
-            Ok(())
-        })
-    });
-
-    let statuses = errors.map(|error: Rc<ContextCreationError>| {
-        let hint = match *error {
-            ContextCreationError::KafkaError(KafkaError::Transaction(ref e)) => {
-                if e.is_retriable() && e.code() == RDKafkaErrorCode::OperationTimedOut {
-                    let hint = "If you're running a single Kafka broker, ensure that the configs \
-                        transaction.state.log.replication.factor, transaction.state.log.min.isr, \
-                        and offsets.topic.replication.factor are set to 1 on the broker";
-                    Some(hint.to_owned())
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        };
-
-        HealthStatusMessage {
-            index: 0,
-            update: HealthStatusUpdate::halting(format!("{}", error.display_with_causes()), hint),
-            namespace: if matches!(*error, ContextCreationError::Ssh(_)) {
-                StatusNamespace::Ssh
-            } else {
-                StatusNamespace::Kafka
-            },
         }
     });
 
-    (statuses, button.press_on_drop())
+    (health_stream, button.press_on_drop())
 }
 
 /// Encodes a stream of `(Option<Row>, Option<Row>)` updates using the specified encoder.
 ///
+/// This operator will only encode `fuel` number of updates per invocation. If necessary, it will
+/// stash updates and use an [`timely::scheduling::Activator`] to re-schedule future invocations.
+///
 /// Input [`Row`] updates must me compatible with the given implementor of [`Encode`].
-fn encode_collection<G: Scope>(
-    name: String,
-    input: &Collection<G, (Option<Row>, Option<Row>), Diff>,
-    envelope: SinkEnvelope,
+///
+/// Updates that are not beyond the given [`SinkAsOf`] and/or the `gate_ts` will be discarded
+/// without encoding them.
+///
+/// Input updates do not have to be partitioned and/or sorted. This operator will not exchange
+/// data. Updates with lower timestamps will be processed before updates with higher timestamps
+/// if they arrive in order. However, this is not a guarantee, as this operator does not wait
+/// for the frontier to signal completeness. It is an optimization for downstream operators
+/// that behave suboptimal when receiving updates that are too far in the future with respect
+/// to the current frontier. The order of updates that arrive at the same timestamp will not be
+/// changed.
+fn encode_stream<G>(
+    input_stream: &Stream<G, ((Option<Row>, Option<Row>), Timestamp, Diff)>,
+    sink_id: GlobalId,
+    as_of: SinkAsOf,
+    shared_gate_ts: Rc<Cell<Option<Timestamp>>>,
+    name_prefix: &str,
     connection: KafkaSinkConnection,
     storage_configuration: StorageConfiguration,
+    envelope: SinkEnvelope,
 ) -> (
-    Collection<G, (Option<Vec<u8>>, Option<Vec<u8>>), Diff>,
+    Stream<G, ((Option<Vec<u8>>, Option<Vec<u8>>), Timestamp, Diff)>,
     Stream<G, HealthStatusMessage>,
     PressOnDropButton,
-) {
-    let mut builder = AsyncOperatorBuilder::new(name, input.inner.scope());
+)
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    let name = format!(
+        "{}-{}_encode",
+        name_prefix,
+        connection.format.get_format_name()
+    );
+    let worker_id = input_stream.scope().index();
+    let worker_count = input_stream.scope().peers();
+    let hashed_id = sink_id.hashed();
+    let is_active_worker = usize::cast_from(hashed_id) % worker_count == worker_id;
 
-    let mut input = builder.new_input(&input.inner, Pipeline);
+    let mut builder = AsyncOperatorBuilder::new(name.clone(), input_stream.scope());
+
+    let mut input = builder.new_input(input_stream, Exchange::new(move |_| hashed_id));
     let (mut output, stream) = builder.new_output();
 
-    let (button, errors) = builder.build_fallible(move |caps| {
-        Box::pin(async move {
-            let [capset]: &mut [_; 1] = caps.try_into().unwrap();
-            let key_desc = connection
-                .key_desc_and_indices
-                .as_ref()
-                .map(|(desc, _indices)| desc.clone());
-            let value_desc = connection.value_desc;
+    // The frontier of this output is never inspected, so we can just use a normal output,
+    // even if its frontier is connected to the input.
+    let (health_output, health_stream) = builder.new_output();
 
-            let encoder: Box<dyn Encode> = match connection.format {
-                KafkaSinkFormat::Avro {
-                    key_schema,
-                    value_schema,
-                    csr_connection,
-                } => {
-                    // Ensure that schemas are registered with the schema registry.
-                    //
-                    // Note that where this lies in the rendering cycle means that we will publish the
-                    // schemas each time the sink is rendered.
-                    let ccsr = csr_connection.connect(&storage_configuration).await?;
-                    let (key_schema_id, value_schema_id) =
-                        mz_storage_client::sink::publish_kafka_schemas(
+    let button = builder.build(move |caps| async move {
+        let [output_cap, health_cap]: [_; 2] = caps.try_into().unwrap();
+        drop(output_cap);
+
+        if !is_active_worker {
+            return;
+        }
+
+        let healthchecker = HealthOutputHandle {
+            health_cap,
+            handle: Mutex::new(health_output),
+        };
+
+        let key_desc = connection
+            .key_desc_and_indices
+            .as_ref()
+            .map(|(desc, _indices)| desc.clone());
+        let value_desc = connection.value_desc.clone();
+
+        let encoder: Box<dyn Encode> = match connection.format {
+            KafkaSinkFormat::Avro {
+                key_schema,
+                value_schema,
+                csr_connection,
+            } => {
+                // Ensure that schemas are registered with the schema registry.
+                // While this looks somewhat innocuous, this step is why this
+                // must be an async operator.
+                //
+                // Also note that where this lies in the rendering cycle means
+                // that we will publish the schemas each time the sink is
+                // rendered.
+                let (key_schema_id, value_schema_id) = halt_on_err(
+                    &healthchecker,
+                    async {
+                        let ccsr = csr_connection.connect(&storage_configuration).await?;
+                        let ids = mz_storage_client::sink::publish_kafka_schemas(
                             &ccsr,
                             &connection.topic,
                             key_schema.as_deref(),
@@ -671,52 +1243,56 @@ fn encode_collection<G: Scope>(
                         )
                         .await
                         .context("error publishing kafka schemas for sink")?;
-
-                    let options = AvroSchemaOptions {
-                        is_debezium: matches!(envelope, SinkEnvelope::Debezium),
-                        ..Default::default()
-                    };
-
-                    let schema_generator = AvroSchemaGenerator::new(key_desc, value_desc, options)
-                        .expect("avro schema validated");
-                    Box::new(AvroEncoder::new(
-                        schema_generator,
-                        key_schema_id,
-                        value_schema_id,
-                    ))
-                }
-                KafkaSinkFormat::Json => Box::new(JsonEncoder::new(
-                    key_desc,
-                    value_desc,
-                    matches!(envelope, SinkEnvelope::Debezium),
-                )),
-            };
-
-            // !IMPORTANT!
-            // Correctness of this operator relies on no fallible operations happening after this
-            // point. This is a temporary workaround of build_fallible's bad interaction of owned
-            // capabilities and errors.
-            // TODO(petrosagg): Make the fallible async operator safe
-            *capset = CapabilitySet::new();
-
-            while let Some(event) = input.next_mut().await {
-                if let Event::Data(cap, rows) = event {
-                    for ((key, value), time, diff) in rows.drain(..) {
-                        let key = key.map(|key| encoder.encode_key_unchecked(key));
-                        let value = value.map(|value| encoder.encode_value_unchecked(value));
-                        output.give(&cap, ((key, value), time, diff)).await;
+                        Ok(ids)
                     }
+                    .await,
+                    None,
+                )
+                .await;
+
+                let options = AvroSchemaOptions {
+                    is_debezium: matches!(envelope, SinkEnvelope::Debezium),
+                    ..Default::default()
+                };
+
+                let schema_generator = AvroSchemaGenerator::new(key_desc, value_desc, options)
+                    .expect("avro schema validated");
+                Box::new(AvroEncoder::new(
+                    schema_generator,
+                    key_schema_id,
+                    value_schema_id,
+                ))
+            }
+            KafkaSinkFormat::Json => Box::new(JsonEncoder::new(
+                key_desc,
+                value_desc,
+                matches!(envelope, SinkEnvelope::Debezium),
+            )),
+        };
+
+        while let Some(event) = input.next_mut().await {
+            if let Event::Data(cap, rows) = event {
+                for ((key, value), time, diff) in rows.drain(..) {
+                    let should_emit = if as_of.strict {
+                        as_of.frontier.less_than(&time)
+                    } else {
+                        as_of.frontier.less_equal(&time)
+                    };
+                    let ts_gated = Some(time) <= shared_gate_ts.get();
+
+                    if !should_emit || ts_gated {
+                        // Skip stale data for already published timestamps
+                        continue;
+                    }
+
+                    let key = key.map(|key| encoder.encode_key_unchecked(key));
+                    let value = value.map(|value| encoder.encode_value_unchecked(value));
+
+                    output.give(&cap, ((key, value), time, diff)).await;
                 }
             }
-            Ok::<(), anyhow::Error>(())
-        })
+        }
     });
 
-    let statuses = errors.map(|error| HealthStatusMessage {
-        index: 0,
-        update: HealthStatusUpdate::halting(format!("{}", error.display_with_causes()), None),
-        namespace: StatusNamespace::Kafka,
-    });
-
-    (stream.as_collection(), statuses, button.press_on_drop())
+    (stream, health_stream, button.press_on_drop())
 }

--- a/src/storage/src/statistics.rs
+++ b/src/storage/src/statistics.rs
@@ -503,28 +503,28 @@ impl SinkStatistics {
         }
     }
 
-    /// Increment the `messages_staged` stat.
+    /// Increment the `messages_received` stat.
     pub fn inc_messages_staged_by(&self, value: u64) {
         let mut cur = self.stats.borrow_mut();
         cur.1.messages_staged = cur.1.messages_staged + value;
         cur.2.messages_staged.inc_by(value);
     }
 
-    /// Increment the `bytes_received` stat.
+    /// Increment the `messages_received` stat.
     pub fn inc_bytes_staged_by(&self, value: u64) {
         let mut cur = self.stats.borrow_mut();
         cur.1.bytes_staged = cur.1.bytes_staged + value;
         cur.2.bytes_staged.inc_by(value);
     }
 
-    /// Increment the `messages_committed` stat.
+    /// Increment the `messages_received` stat.
     pub fn inc_messages_committed_by(&self, value: u64) {
         let mut cur = self.stats.borrow_mut();
         cur.1.messages_committed = cur.1.messages_committed + value;
         cur.2.messages_committed.inc_by(value);
     }
 
-    /// Increment the `bytes_committed` stat.
+    /// Increment the `messages_received` stat.
     pub fn inc_bytes_committed_by(&self, value: u64) {
         let mut cur = self.stats.borrow_mut();
         cur.1.bytes_committed = cur.1.bytes_committed + value;

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1263,7 +1263,7 @@ impl StorageState {
                                 export.id,
                                 &export.description.from_storage_metadata,
                                 export.description.from_storage_metadata.data_shard,
-                                export.description.as_of.clone(),
+                                export.description.as_of.frontier.clone(),
                                 Arc::clone(&self.persist_clients),
                             ),
                         );
@@ -1287,7 +1287,7 @@ impl StorageState {
                         Some(export_description) => {
                             // Update our knowledge of the `as_of`, in case we need to internally
                             // restart a sink in the future.
-                            export_description.as_of.clone_from(&frontier);
+                            export_description.as_of.downgrade(&frontier);
 
                             // Sinks maintain a read handle over their input data to ensure that we
                             // can restart at the `as_of` that we store and update in the export

--- a/test/kafka-auth/test-kafka-acl-lockdown.td
+++ b/test/kafka-auth/test-kafka-acl-lockdown.td
@@ -112,7 +112,7 @@ true
     FROM mz_sinks
     JOIN mz_internal.mz_sink_status_history ON mz_sinks.id = mz_sink_status_history.sink_id
     WHERE name = 'broken2'
-    AND error ILIKE '%kafka: error registering kafka progress topic for sink%Topic authorization failed%'
+    AND error ILIKE '%Unable to fetch metadata about progress topic%Topic authorization failed%'
   )
 true
 > DROP SINK broken2

--- a/test/testdrive/github-24173.td
+++ b/test/testdrive/github-24173.td
@@ -1,0 +1,32 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE SOURCE tpch FROM LOAD GENERATOR TPCH (SCALE FACTOR 0.1) FOR ALL TABLES WITH (SIZE = '1');
+
+> CREATE CONNECTION kafka_fixed TO KAFKA (
+    BROKER '${testdrive.kafka-addr}',
+    PROGRESS TOPIC 'testdrive-progress-fixed-${testdrive.seed}',
+    SECURITY PROTOCOL PLAINTEXT
+  );
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> CREATE SINK sink FROM supplier
+  INTO KAFKA CONNECTION kafka_fixed (TOPIC 'testdrive-supplier-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+> CREATE SOURCE progress_check
+  FROM KAFKA CONNECTION kafka_fixed (TOPIC 'testdrive-progress-fixed-${testdrive.seed}')
+  FORMAT JSON ENVELOPE NONE
+
+> SELECT COUNT(*) FROM progress_check WHERE data->'timestamp' = 'null'::jsonb;
+1

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -301,16 +301,8 @@ $ kafka-verify-data headers=materialize-timestamp format=avro sink=materialize.p
 1	{"before": null, "after": {"row": {"a": 1, "b": 1}}}
 1	{"before": null, "after": {"row": {"a": 2, "b": 2}}}
 
-> CREATE SOURCE compaction_test_sink_check
-  FROM KAFKA CONNECTION kafka_fixed (TOPIC 'testdrive-progress-fixed-${testdrive.seed}')
-  FORMAT JSON ENVELOPE NONE
-
-# Retrieve all the progress messages that are beyond [2]. There should be
-# exactly one of them because the upper of the CDCv2 stream stops at [2].
-> SELECT data->'frontier'
-  FROM compaction_test_sink_check
-  WHERE data->'frontier'->0 IS NULL OR (data->'frontier'->0)::int >= 2
-[2]
+$ kafka-verify-data format=json key=false topic=testdrive-progress-fixed-${testdrive.seed}
+{"timestamp": 1}
 
 # verify output with real-time timestamps
 

--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -75,8 +75,6 @@ $ set-from-sql var=sink_id
 SELECT id FROM mz_sinks WHERE name = 'kafka_sink'
 
 # Verify we get a starting -- it's possible we move to running by the time this query runs.
-# Additionally it can happen that both 'starting' and 'running' are reported on the same millisecond
-# so we filter out any other statuses.
 > SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id}' AND status = 'starting' ORDER BY occurred_at ASC LIMIT 1;
 "<TIMESTAMP> UTC" ${sink_id} starting <null> <null>
 

--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -75,7 +75,7 @@ $ set-from-sql var=sink_id
 SELECT id FROM mz_sinks WHERE name = 'kafka_sink'
 
 # Verify we get a starting -- it's possible we move to running by the time this query runs.
-> SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id}' AND status = 'starting' ORDER BY occurred_at ASC LIMIT 1;
+> SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id}' ORDER BY occurred_at ASC LIMIT 1;
 "<TIMESTAMP> UTC" ${sink_id} starting <null> <null>
 
 $ kafka-ingest format=bytes topic=status-history


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

There is a check in the kafka sink code that is meant to detect bugs that manifest as the input since frontiers overcompacting. Unfortunately the way the previous version of the sink was written makes it impossible to tell this bad state from a good state in situations where the frontier has advanced to the empty frontier. The old implementation used to write additional metadata to the stash (in the collection called `DURABLE_EXPORT_METADATA`) as a workaround but the new implementation does not do that and doesn't want to do that.

The easiest option to deal with this situation is to revert the refactor PR to get back to the version that uses the additional stash metadata and slightly modify the old version to record the required information to the kafka topic. Namely, record that the frontier reached the empty Antichain. Once this modified old version has been running for a while in prod we will have migrated all sinks into a state where the required information is in the progress topics and the refactor will be safely deployable.

### Tips for reviewer

This PR implements the plan described above. The first two commits are clean reverts of the refactor and don't need to get reviewed. The third commit adds the ability to record the empty frontier in the progress topic and a test that exercises this codepath.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->



<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
