### PR TITLE
sql: Enable Role Variables by Default

### DIFF
--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2104,7 +2104,7 @@ feature_flags!(
     {
         name: enable_role_vars,
         desc: "setting default session variables for a role",
-        default: false,
+        default: true,
         internal: true,
         enable_for_item_parsing: true,
     },

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -453,15 +453,6 @@ RESET max_query_result_size
 statement ok
 CREATE ROLE parker;
 
-statement error setting default session variables for a role is not supported
-ALTER ROLE parker SET cluster TO foo;
-
-# Enable Role variable defaults.
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_role_vars TO true;
-----
-COMPLETE 0
-
 statement ok
 ALTER ROLE parker SET cluster TO foo;
 


### PR DESCRIPTION
With the merging of https://github.com/MaterializeInc/materialize/issues/22351 we've fixed the last blocker for enabling Role variables, and https://github.com/MaterializeInc/materialize/issues/22107 adds documentation for the feature. This PR sets the default value for the `enable_role_vars` feature gate to `true`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Enables Role variable defaults for all users
