### PR TITLE
Fix flake in statement logging test.

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -268,7 +268,7 @@ fn test_statement_logging_immediate() {
     }
 
     // Statement logging happens async, give it a chance to catch up
-    thread::sleep(Duration::from_secs(5));
+    thread::sleep(Duration::from_secs(10));
 
     let mut client = server.connect_internal(postgres::NoTls).unwrap();
     let sl = client


### PR DESCRIPTION
The 5-second wait seems to sometimes not be enough; see e.g. https://github.com/MaterializeInc/materialize/issues/24041

Hopefully this will fix that issue. If not, we will need to do something more principled (e.g. make the logging timer configurable)
