### PR TITLE
Revert "ci: Reenable checks-backup-rollback"

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -488,6 +488,7 @@ steps:
 
       - id: checks-backup-rollback
         label: "Checks + backup + rollback to previous"
+        skip: "Requires #18628 to be fixed"
         timeout_in_minutes: 60
         artifact_paths: junit_*.xml
         agents:


### PR DESCRIPTION
Reverts MaterializeInc/materialize#24062

For release 0.81.3 we reverted the sink refactor, so disabling corresponding tests.