### PR TITLE
ci: avoid using `linux` queue

### DIFF
--- a/ci/license/pipeline.template.yml
+++ b/ci/license/pipeline.template.yml
@@ -12,4 +12,4 @@ steps:
     timeout_in_minutes: 10
     command: ci/license/bump-change-date.sh
     agents:
-      queue: linux
+      queue: linux-x86_64

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -23,7 +23,7 @@ steps:
     timeout_in_minutes: 10
     if: build.source == "ui"
     agents:
-      queue: linux
+      queue: linux-x86_64
 
   - wait: ~
 

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -27,7 +27,7 @@ steps:
     timeout_in_minutes: 10
     if: build.source == "ui"
     agents:
-      queue: linux
+      queue: linux-x86_64
 
   - wait: ~
 

--- a/ci/security/pipeline.template.yml
+++ b/ci/security/pipeline.template.yml
@@ -13,4 +13,4 @@ steps:
   - command: bin/ci-builder run stable cargo deny check advisories
     timeout_in_minutes: 5
     agents:
-      queue: linux
+      queue: linux-x86_64

--- a/ci/test/mkpipeline.sh
+++ b/ci/test/mkpipeline.sh
@@ -46,5 +46,5 @@ steps:
     command: bin/ci-builder run stable bin/pyactivate -m ci.mkpipeline test $@
     priority: 2
     agents:
-      queue: linux
+      queue: linux-x86_64
 EOF


### PR DESCRIPTION
We're trying to move away from this queue name to work around a Buildkite issue. See MaterializeINc/i2#1502.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
