### PR TITLE
platform-checks: Explicitly capture logs on upgrade

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -211,14 +211,20 @@ class ConfigureMz(MzcomposeAction):
 
 
 class KillMz(MzcomposeAction):
-    def __init__(self, mz_service: str = "materialized") -> None:
+    def __init__(
+        self, mz_service: str = "materialized", capture_logs: bool = False
+    ) -> None:
         self.mz_service = mz_service
+        self.capture_logs = capture_logs
 
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
 
         with c.override(Materialized(name=self.mz_service)):
             c.kill(self.mz_service, wait=True)
+
+            if self.capture_logs:
+                c.capture_logs(self.mz_service)
 
 
 class Down(MzcomposeAction):
@@ -268,10 +274,16 @@ class UseClusterdCompute(MzcomposeAction):
 
 
 class KillClusterdCompute(MzcomposeAction):
+    def __init__(self, capture_logs: bool = False) -> None:
+        self.capture_logs = capture_logs
+
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
         with c.override(Clusterd(name="clusterd_compute_1")):
             c.kill("clusterd_compute_1")
+
+            if self.capture_logs:
+                c.capture_logs("clusterd_compute_1")
 
 
 class StartClusterdCompute(MzcomposeAction):

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -61,7 +61,9 @@ class UpgradeEntireMz(Scenario):
             StartMz(self, tag=self.base_version()),
             Initialize(self),
             Manipulate(self, phase=1),
-            KillMz(),
+            KillMz(
+                capture_logs=True
+            ),  #  We always use True here otherwise docker-compose will lose the pre-upgrade logs
             StartMz(self, tag=None),
             Manipulate(self, phase=2),
             Validate(self),
@@ -95,11 +97,11 @@ class UpgradeEntireMzTwoVersions(Scenario):
             StartMz(self, tag=self.base_version()),
             Initialize(self),
             # Upgrade to last_version
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, tag=get_last_version()),
             Manipulate(self, phase=1),
             # Upgrade to current source
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, tag=None),
             Manipulate(self, phase=2),
             Validate(self),
@@ -124,7 +126,7 @@ class UpgradeEntireMzSkipVersion(Scenario):
             Initialize(self),
             Manipulate(self, phase=1),
             # Upgrade directly to current source
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, tag=None),
             Manipulate(self, phase=2),
             Validate(self),
@@ -154,15 +156,15 @@ class UpgradeEntireMzFourVersions(Scenario):
         return [
             StartMz(self, tag=self.minor_versions[3]),
             Initialize(self),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, tag=self.minor_versions[2]),
             Manipulate(self, phase=1),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, tag=get_previous_version()),
             Manipulate(self, phase=2),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, tag=get_last_version()),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, tag=None),
             Validate(self),
             KillMz(),
@@ -193,7 +195,7 @@ class UpgradeClusterdComputeLast(Scenario):
             UseClusterdCompute(self),
             Initialize(self),
             Manipulate(self, phase=1),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, tag=None),
             # No useful work can be done while clusterd is old-version
             # and environmentd is new-version. So we proceed
@@ -201,7 +203,7 @@ class UpgradeClusterdComputeLast(Scenario):
             # We sleep here to allow some period of coexistence, even
             # though we are not issuing queries during that time.
             Sleep(10),
-            KillClusterdCompute(),
+            KillClusterdCompute(capture_logs=True),
             StartClusterdCompute(tag=None),
             Manipulate(self, phase=2),
             Validate(self),
@@ -225,7 +227,7 @@ class UpgradeClusterdComputeFirst(Scenario):
             UseClusterdCompute(self),
             Initialize(self),
             Manipulate(self, phase=1),
-            KillClusterdCompute(),
+            KillClusterdCompute(capture_logs=True),
             StartClusterdCompute(tag=None),
             # No useful work can be done while clusterd is new-version
             # and environmentd is old-version. So we

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -96,6 +96,7 @@ IGNORE_RE = re.compile(
     | persist-txn-fencing-mz_first-.* \| .*unexpected\ fence\ epoch
     | persist-txn-fencing-mz_first-.* \| .*fenced\ by\ new\ catalog\ upper
     # For platform-checks upgrade tests
+    | platform-checks-clusterd.* \| .* received\ persist\ state\ from\ the\ future
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage(\ to\ set\ (default|configured)\ parameter)?
     | internal\ error:\ no\ AWS\ external\ ID\ prefix\ configured
     )

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -794,11 +794,11 @@ class Composition:
                 "Sanity Restart skipped because Mz not in services or `sanity_restart` label not set"
             )
 
-    def capture_logs(self) -> None:
+    def capture_logs(self, *services: str) -> None:
         # Capture logs into services.log since they will be lost otherwise
         # after dowing a composition.
         with open(MZ_ROOT / "services.log", "a") as f:
-            self.invoke("logs", "--no-color", capture=f)
+            self.invoke("logs", "--no-color", *services, capture=f)
 
     def down(
         self,


### PR DESCRIPTION
When upgrading, docker-compose will lose the logs accumulated prior to the upgrade. Therefore, they need to be explicitly preserved.

### Motivation

Pre-upgrade logs were missing in services.log