### PR TITLE
parallel-workload: Fix locking for dropping replica & Ignore 404 in toggle-persist-txn scenario

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1029,9 +1029,12 @@ class DropClusterReplicaAction(Action):
             if len(cluster.replicas) <= 1:
                 return False
             replica = self.rng.choice(cluster.replicas)
-        with replica.lock:
+
+        with cluster.lock, replica.lock:
             # Was dropped while we were acquiring lock
             if replica not in cluster.replicas:
+                return False
+            if cluster not in exe.db.clusters:
                 return False
             # Avoid "has no replicas available to service request" error
             if len(cluster.replicas) <= 1:

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1626,9 +1626,10 @@ class HttpPostAction(Action):
                     raise
             except QueryError as e:
                 # expected, see #20465
-                if exe.db.scenario != Scenario.Kill or (
-                    "404: no object was found at the path" not in e.msg
-                ):
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.TogglePersistTxn,
+                ) or ("404: no object was found at the path" not in e.msg):
                     raise e
         return True
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
