### PR TITLE
pyfmt: Fix parameter with old bash version

### DIFF
--- a/bin/pyfmt
+++ b/bin/pyfmt
@@ -19,13 +19,13 @@ cd "$(dirname "$0")/.."
 
 try bin/pyactivate -m black . "$@"
 
-args=("--fix")
+arg="--fix"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
     --check)
       # ruff only supports --fix, not --check
-      args=()
+      arg=""
       shift
       ;;
     *)
@@ -35,6 +35,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-try bin/pyactivate -m ruff "${args[@]}" --extend-exclude=misc/dbt-materialize .
-try bin/pyactivate -m ruff --target-version=py38 "${args[@]}" misc/dbt-materialize
+# We want empty arg to not do anything
+# shellcheck disable=SC2086
+try bin/pyactivate -m ruff $arg --extend-exclude=misc/dbt-materialize .
+# shellcheck disable=SC2086
+try bin/pyactivate -m ruff --target-version=py38 $arg misc/dbt-materialize
 try_status_report


### PR DESCRIPTION
Used to fail in bash 3.2 when called with --check

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
