### PR TITLE
ci: Support CI_TEST_SELECTION for steps without an id

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -246,12 +246,13 @@ def check_depends_on(pipeline: Any, pipeline_name: str) -> None:
 
 def trim_test_selection(pipeline: Any, steps_to_run: set[str]) -> None:
     def visit(step: dict[str, Any]) -> None:
+        ident = step.get("id") or step.get("command")
         if (
-            step.get("id") not in steps_to_run
+            ident not in steps_to_run
             and "prompt" not in step
             and "wait" not in step
             and "group" not in step
-            and step.get("id")
+            and ident
             not in (
                 "coverage-pr-analyze",
                 "analyze",


### PR DESCRIPTION
for example in the security pipeline

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
