### PR TITLE
storage: MySQL Source Operator Prototype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,6 +2224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3432,6 +3450,7 @@ dependencies = [
  "base64 0.21.5",
  "bindgen",
  "bitflags 2.4.1",
+ "bitvec",
  "btoi",
  "byteorder",
  "bytes",
@@ -4630,6 +4649,7 @@ dependencies = [
  "thiserror",
  "tonic-build",
  "tracing",
+ "uuid",
  "workspace-hack",
 ]
 
@@ -5721,6 +5741,8 @@ dependencies = [
  "indexmap 2.0.0",
  "itertools",
  "maplit",
+ "mysql_async",
+ "mysql_common",
  "mz-avro",
  "mz-aws-util",
  "mz-build-info",
@@ -5731,6 +5753,7 @@ dependencies = [
  "mz-http-util",
  "mz-interchange",
  "mz-kafka-util",
+ "mz-mysql-util",
  "mz-orchestrator-tracing",
  "mz-ore",
  "mz-persist",
@@ -7298,6 +7321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8524,6 +8553,12 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -9842,6 +9877,8 @@ dependencies = [
  "memchr",
  "mime_guess",
  "mio",
+ "mysql_async",
+ "mysql_common",
  "native-tls",
  "nix",
  "nom",
@@ -9906,6 +9943,15 @@ dependencies = [
  "uuid",
  "zeroize",
  "zstd-sys",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -20,6 +20,11 @@ who = "Matt Arthur <matthewleearthur@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.26.0"
 
+[[audits.bitvec]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+
 [[audits.core_affinity]]
 who = "Jan Teske <jteske@posteo.net>"
 criteria = "safe-to-deploy"
@@ -34,6 +39,11 @@ version = "1.2.6"
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.12.0@git:c5b9baca0283f4d96f7e6f914de8578fb5c521de"
+
+[[audits.funty]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0"
 
 [[audits.futures-timer]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
@@ -104,6 +114,11 @@ version = "4.2.0"
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.11.1"
+
+[[audits.radium]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
 
 [[audits.raw-cpuid]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
@@ -194,6 +209,11 @@ delta = "0.7.1 -> 0.9.0"
 who = "Gus Wynn <gus@materialize.com>"
 criteria = "maintained-and-necessary"
 version = "0.2.4"
+
+[[audits.wyz]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.5.1"
 
 [[audits.zstd]]
 who = "Parker Timmerman <parker.timmerman@materialize.com>"

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -1311,6 +1311,12 @@ criteria = "safe-to-deploy"
 version = "0.1.2"
 notes = "No unsafe usage or ambient capabilities. Old crate from released and unchanged from 2017"
 
+[[audits.embark-studios.audits.tap]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+notes = "No unsafe usage or ambient capabilities"
+
 [[audits.embark-studios.audits.thiserror]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"

--- a/misc/images/mysql-client/Dockerfile
+++ b/misc/images/mysql-client/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+MZFROM ubuntu-base
+
+RUN apt-get update && apt-get install -y mysql-client
+
+ENTRYPOINT ["mysql"]

--- a/misc/images/mysql-client/mzbuild.yml
+++ b/misc/images/mysql-client/mzbuild.yml
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: mysql-client

--- a/src/mysql-util/Cargo.toml
+++ b/src/mysql-util/Cargo.toml
@@ -24,6 +24,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 once_cell = "1.16.0"
 serde = { version = "1.0.152", features = ["derive"] }
 tracing = "0.1.37"
+uuid = { version = "1.2.2", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]

--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -48,3 +48,8 @@ pub enum MySqlError {
     #[error(transparent)]
     MySql(#[from] mysql_async::Error),
 }
+
+// NOTE: this error was renamed between MySQL 5.7 and 8.0
+// https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_source_fatal_error_reading_binlog
+// https://dev.mysql.com/doc/mysql-errors/5.7/en/server-error-reference.html#error_er_master_fatal_error_reading_binlog
+pub const ER_SOURCE_FATAL_ERROR_READING_BINLOG_CODE: u16 = 1236;

--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -21,7 +21,7 @@ pub use desc::{
 mod replication;
 pub use replication::{
     ensure_full_row_binlog_format, ensure_gtid_consistency, ensure_replication_commit_order,
-    query_sys_var,
+    query_sys_var, GtidSet,
 };
 
 pub mod schemas;

--- a/src/mysql-util/src/replication.rs
+++ b/src/mysql-util/src/replication.rs
@@ -7,6 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeMap;
+use std::fmt;
+use std::io;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
 use mysql_async::prelude::Queryable;
 use mysql_async::Conn;
 
@@ -50,10 +58,236 @@ pub async fn ensure_gtid_consistency(conn: &mut Conn) -> Result<(), MySqlError> 
     Ok(())
 }
 
+// TODO: This only applies if connecting to a replica, to ensure that the replica preserves
+// all transactions in the order they were committed on the primary which implies
+// monotonically increasing transaction ids
 pub async fn ensure_replication_commit_order(conn: &mut Conn) -> Result<(), MySqlError> {
     // This system variable was renamed between MySQL 5.7 and 8.0
     match verify_sys_setting(conn, "replica_preserve_commit_order", "1").await {
         Ok(_) => Ok(()),
         Err(_) => verify_sys_setting(conn, "slave_preserve_commit_order", "1").await,
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Hash, PartialEq, Eq)]
+pub struct GtidInterval {
+    pub start: u64,
+    pub end: Option<u64>,
+}
+
+impl GtidInterval {
+    pub fn contains(&self, other: &GtidInterval) -> bool {
+        self.start <= other.start
+            && self.end.unwrap_or(self.start) >= other.end.unwrap_or(other.start)
+    }
+}
+
+impl fmt::Display for GtidInterval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(end) = self.end {
+            write!(f, "{}-{}", self.start, end)
+        } else {
+            write!(f, "{}", self.start)
+        }
+    }
+}
+
+impl FromStr for GtidInterval {
+    type Err = io::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let vals: Vec<u64> = s
+            .split('-')
+            .map(|num| num.parse::<u64>())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid interval in gtid: {}: {}", s, e),
+                )
+            })?;
+        if vals.len() == 1 {
+            Ok(Self {
+                start: vals[0],
+                end: None,
+            })
+        } else if vals.len() == 2 {
+            Ok(Self {
+                start: vals[0],
+                end: Some(vals[1]),
+            })
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid gtid interval: {}", s),
+            ))
+        }
+    }
+}
+
+/// Represents a MySQL GTID with a single Source-ID and a list of intervals
+/// e.g. `3E11FA47-71CA-11E1-9E33-C80AA9429562:1-3:4:5-9`
+/// If this represents a single GTID point e.g. `3E11FA47-71CA-11E1-9E33-C80AA9429562:5`
+/// it will contain just one interval with one start and no end
+/// By convention, intervals will be non-overlapping and sorted in ascending order by start
+/// value and consolidated to combine consecutive intervals
+#[derive(Debug, Clone, Deserialize, Serialize, Hash, PartialEq, Eq)]
+pub struct Gtid {
+    pub uuid: uuid::Uuid,
+    intervals: Vec<GtidInterval>,
+}
+
+impl Gtid {
+    pub fn earliest_transaction_id(&self) -> u64 {
+        self.intervals
+            .first()
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected at least one interval in gtid: {:?}",
+                    self.intervals
+                )
+            })
+            .start
+    }
+
+    pub fn latest_transaction_id(&self) -> u64 {
+        // NOTE: Use the last interval; there might be discrete intervals if they have not been compacted yet
+        // but interval values are guaranteed to be monotonically increasing as long as replica_preserve_commit_order=1
+        // which is why we only care about the highest value
+        let last_interval = self.intervals.last().unwrap_or_else(|| {
+            panic!(
+                "expected at least one interval in gtid: {:?}",
+                self.intervals
+            )
+        });
+        // If this interval is a range use the end value; if not we can use the start value
+        last_interval.end.unwrap_or(last_interval.start)
+    }
+
+    pub fn add_interval(&mut self, new: GtidInterval) {
+        if let Some(last) = self.intervals.last_mut() {
+            // Only allow adding the interval if it is after the last interval
+            assert!(
+                last.end.unwrap_or(last.start) < new.start,
+                "interval must be after the last interval"
+            );
+
+            match last.end {
+                Some(end) if new.start == end + 1 => {
+                    // If the interval starts right after the last interval ends, just extend the last interval
+                    last.end = Some(new.end.unwrap_or(new.start));
+                }
+                None if new.start == last.start + 1 => {
+                    // If the interval starts right after the last 'point' interval starts, just extend the last interval
+                    last.end = Some(new.end.unwrap_or(new.start));
+                }
+                _ => {
+                    self.intervals.push(new);
+                }
+            }
+        } else {
+            // This is the first interval
+            self.intervals.push(new);
+        }
+    }
+}
+
+impl fmt::Display for Gtid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            self.uuid
+                .hyphenated()
+                .encode_upper(&mut Uuid::encode_buffer()),
+        )?;
+        for interval in &self.intervals {
+            write!(f, ":")?;
+            interval.fmt(f)?;
+        }
+        fmt::Result::Ok(())
+    }
+}
+
+impl FromStr for Gtid {
+    type Err = io::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (uuid, intervals) = s.split_once(':').ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, format!("invalid gtid: {}", s))
+        })?;
+        let uuid = Uuid::parse_str(uuid).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid uuid in gtid: {}: {}", s, e),
+            )
+        })?;
+
+        let mut new = Self {
+            uuid,
+            intervals: vec![],
+        };
+        for interval_str in intervals.split(':') {
+            // add_interval() will consolidate consecutive intervals to save representation space
+            // and make comparisons easier, even if the MySQL server has not yet compressed the intervals
+            new.add_interval(GtidInterval::from_str(interval_str)?);
+        }
+        Ok(new)
+    }
+}
+
+/// A representation of a MySQL GTID set (returned from the `gtid_executed` & `gtid_purged` system variables)
+/// e.g. `2174B383-5441-11E8-B90A-C80AA9429562:1-3, 24DA167-0C0C-11E8-8442-00059A3C7B00:1-19`
+#[derive(Debug, Clone, Deserialize, Serialize, Hash, PartialEq, Eq)]
+pub struct GtidSet {
+    gtids: BTreeMap<Uuid, Gtid>,
+}
+
+impl GtidSet {
+    pub fn new() -> Self {
+        Self {
+            gtids: BTreeMap::new(),
+        }
+    }
+
+    pub fn add_gtid(&mut self, new: Gtid) {
+        if let Some(existing) = self.gtids.get_mut(&new.uuid) {
+            for interval in new.intervals {
+                existing.add_interval(interval);
+            }
+        } else {
+            self.gtids.insert(new.uuid, new);
+        }
+    }
+
+    pub fn first(&self) -> Option<&Gtid> {
+        self.gtids.values().next()
+    }
+}
+
+impl fmt::Display for GtidSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (idx, gtid) in self.gtids.values().enumerate() {
+            if idx > 0 {
+                write!(f, ", ")?;
+            }
+            gtid.fmt(f)?;
+        }
+        fmt::Result::Ok(())
+    }
+}
+
+impl FromStr for GtidSet {
+    type Err = io::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut new = Self {
+            gtids: BTreeMap::new(),
+        };
+
+        for gtid_str in s.split(", ") {
+            // add_gtid() will consolidate gtids to save representation space
+            new.add_gtid(Gtid::from_str(gtid_str)?);
+        }
+
+        Ok(new)
     }
 }

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -18,6 +18,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde::{Deserialize, Serialize};
+
 use mz_ore::str::{MaxLenString, StrExt};
 use mz_sql_lexer::keywords::Keyword;
 use std::fmt;
@@ -26,7 +28,7 @@ use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{AstInfo, QualifiedReplica};
 
 /// An identifier.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Ident(pub(crate) String);
 
 impl Ident {
@@ -336,7 +338,7 @@ pub enum IdentError {
 }
 
 /// A name of a table, view, custom type, etc. that lives in a schema, possibly multi-part, i.e. db.schema.obj
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct UnresolvedItemName(pub Vec<Ident>);
 
 pub enum CatalogName {

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -34,6 +34,8 @@ http = "0.2.8"
 indexmap = { version = "2.0.0", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
 maplit = "1.0.2"
+mysql_async = { version = "0.33.0", default-features = false, features = ["minimal", "binlog"] }
+mysql_common = { version = "0.31.0", default-features = false }
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util", features = ["s3"] }
 mz-build-info = { path = "../build-info" }
@@ -43,6 +45,7 @@ mz-expr = { path = "../expr" }
 mz-cluster = { path = "../cluster" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
+mz-mysql-util = { path = "../mysql-util" }
 mz-ore = { path = "../ore", features = ["async", "tracing_", "chrono"] }
 mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -9,19 +9,36 @@
 
 //! Code to render the ingestion dataflow of a [`MySqlSourceConnection`].
 
+use std::collections::BTreeMap;
 use std::convert::Infallible;
+use std::io;
+use std::rc::Rc;
 
-use differential_dataflow::{AsCollection, Collection};
-use mz_repr::{Diff, Row};
-use mz_storage_types::sources::MySqlSourceConnection;
-use mz_timely_util::builder_async::PressOnDropButton;
+use differential_dataflow::Collection;
+use mysql_async::Row as MySqlRow;
+use mysql_common::value::convert::FromValue;
+use mz_mysql_util::MySqlTableDesc;
+use serde::{Deserialize, Serialize};
+use timely::dataflow::operators::Concat;
+use timely::dataflow::operators::Map;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 
-use crate::healthcheck::{HealthStatusMessage, StatusNamespace};
+use mz_mysql_util::{GtidSet, MySqlError};
+use mz_ore::error::ErrorExt;
+use mz_repr::{Diff, Row, ScalarType, Datum};
+use mz_sql_parser::ast::{Ident, UnresolvedItemName};
+use mz_storage_types::errors::SourceErrorDetails;
+use mz_storage_types::sources::MySqlSourceConnection;
+use mz_storage_types::sources::SourceTimestamp;
+use mz_timely_util::builder_async::PressOnDropButton;
+
+use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
 use crate::source::types::SourceRender;
 use crate::source::{RawSourceCreationConfig, SourceMessage, SourceReaderError};
 
+mod replication;
+mod snapshot;
 mod timestamp;
 
 use timestamp::TransactionId;
@@ -39,8 +56,8 @@ impl SourceRender for MySqlSourceConnection {
     fn render<G: Scope<Timestamp = TransactionId>>(
         self,
         scope: &mut G,
-        _config: RawSourceCreationConfig,
-        _resume_uppers: impl futures::Stream<Item = Antichain<TransactionId>> + 'static,
+        config: RawSourceCreationConfig,
+        resume_uppers: impl futures::Stream<Item = Antichain<TransactionId>> + 'static,
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
         Collection<G, (usize, Result<SourceMessage<(), Row>, SourceReaderError>), Diff>,
@@ -48,9 +65,223 @@ impl SourceRender for MySqlSourceConnection {
         Stream<G, HealthStatusMessage>,
         Vec<PressOnDropButton>,
     ) {
-        let data = timely::dataflow::operators::generic::operator::empty(scope);
-        let health = timely::dataflow::operators::generic::operator::empty(scope);
+        // Determined which collections need to be snapshot and which already have been.
+        let subsource_resume_uppers: BTreeMap<_, _> = config
+            .source_resume_uppers
+            .iter()
+            .map(|(id, upper)| {
+                assert!(
+                    config.source_exports.contains_key(id),
+                    "all source resume uppers must be present in source exports"
+                );
 
-        (data.as_collection(), None, health, vec![])
+                (
+                    *id,
+                    Antichain::from_iter(upper.iter().map(TransactionId::decode_row)),
+                )
+            })
+            .collect();
+
+        // Collect the tables that we will be ingesting.
+        let mut table_info = BTreeMap::new();
+        for (i, desc) in self.details.tables.iter().enumerate() {
+            table_info.insert(
+                table_name(&desc.schema_name, &desc.name).expect("valid idents"),
+                (
+                    // Index zero maps to the main source
+                    i + 1,
+                    desc.clone(),
+                ),
+            );
+        }
+
+        let (snapshot_updates, rewinds, snapshot_err, snapshot_token) = snapshot::render(
+            scope.clone(),
+            config.clone(),
+            self.clone(),
+            subsource_resume_uppers.clone(),
+            table_info.clone(),
+        );
+
+        let (repl_updates, uppers, repl_err, repl_token) = replication::render(
+            scope.clone(),
+            config,
+            self,
+            subsource_resume_uppers,
+            table_info,
+            &rewinds,
+            resume_uppers,
+        );
+
+        let updates = snapshot_updates.concat(&repl_updates).map(|(output, res)| {
+            let res = res.map(|row| SourceMessage {
+                key: (),
+                value: row,
+                metadata: Row::default(),
+            });
+            (output, res)
+        });
+
+        let health = snapshot_err.concat(&repl_err).map(move |err| {
+            // This update will cause the dataflow to restart
+            let err_string = err.display_with_causes().to_string();
+            let update = HealthStatusUpdate::halting(err_string.clone(), None);
+            // TODO: change namespace for SSH errors
+            let namespace = Self::STATUS_NAMESPACE.clone();
+
+            HealthStatusMessage {
+                index: 0,
+                namespace: namespace.clone(),
+                update,
+            }
+        });
+
+        (
+            updates,
+            Some(uppers),
+            health,
+            vec![snapshot_token, repl_token],
+        )
     }
+}
+
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum ReplicationError {
+    #[error(transparent)]
+    Transient(#[from] Rc<TransientError>),
+    #[error(transparent)]
+    Definite(#[from] Rc<DefiniteError>),
+}
+
+/// A transient error that never ends up in the collection of a specific table.
+#[derive(Debug, thiserror::Error)]
+pub enum TransientError {
+    #[error("couldn't decode binlog row")]
+    BinlogRowDecodeError(#[from] mysql_async::binlog::row::BinlogRowToRowError),
+    #[error("stream ended prematurely")]
+    ReplicationEOF,
+    #[error("unsupported type: {0}")]
+    UnsupportedDataType(String),
+    #[error(transparent)]
+    IoError(#[from] io::Error),
+    #[error("sql client error")]
+    SQLClient(#[from] mysql_async::Error),
+    #[error("ident decode error")]
+    IdentError(#[from] mz_sql_parser::ast::IdentError),
+    #[error(transparent)]
+    MySqlError(#[from] MySqlError),
+    #[error(transparent)]
+    Generic(#[from] anyhow::Error),
+}
+
+/// A definite error that always ends up in the collection of a specific table.
+#[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error)]
+pub enum DefiniteError {
+    #[error("mysql server does not have the binlog available at the requested gtid set")]
+    BinlogNotAvailable,
+    #[error("server gtid error: {0}")]
+    ServerGTIDError(String),
+}
+
+impl From<DefiniteError> for SourceReaderError {
+    fn from(err: DefiniteError) -> Self {
+        SourceReaderError {
+            inner: SourceErrorDetails::Other(err.to_string()),
+        }
+    }
+}
+
+/// TODO: This should use a partitioned timestamp implementation instead of the snapshot gtid set.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct RewindRequest {
+    /// The table that should be rewound.
+    pub(crate) table: UnresolvedItemName,
+    /// The GTID set at the start of the snapshot, returned by the server's `gtid_executed` system variable.
+    pub(crate) snapshot_gtid_set: GtidSet,
+}
+
+pub(crate) fn table_name(
+    schema_name: &str,
+    table_name: &str,
+) -> Result<UnresolvedItemName, TransientError> {
+    Ok(UnresolvedItemName::qualified(&[
+        Ident::new(schema_name)?,
+        Ident::new(table_name)?,
+    ]))
+}
+
+fn datum_from_scalar<'a, T>(row: &'a mut MySqlRow, col_index: usize, nullable: bool) -> Datum
+where
+    T: FromValue,
+    Datum<'a>: std::convert::From<T> + std::convert::From<Option<T>>
+{
+    if nullable {
+        Datum::from(row.take::<Option<T>, _>(col_index).unwrap())
+    } else {
+        Datum::from(row.take::<T, _>(col_index).unwrap())
+    }
+}
+
+fn datum_from_string<'a>(temp: &'a mut Vec<String>, row: &mut MySqlRow, col_index: usize, nullable: bool) -> Datum<'a>
+{
+    if nullable {
+        if let Some(data) = row.take::<Option<String>, _>(col_index).unwrap() {
+            temp.push(data);
+            Datum::from(temp.last().unwrap().as_str())
+        } else {
+            Datum::Null
+        }
+    } else {
+        let data = row.take::<String, _>(col_index).unwrap();
+        temp.push(data);
+        Datum::from(temp.last().unwrap().as_str())
+    }
+}
+
+fn datum_from_bytes<'a>(temp: &'a mut Vec<Vec<u8>>, row: &mut MySqlRow, col_index: usize, nullable: bool) -> Datum<'a>
+{
+    if nullable {
+        if let Some(data) = row.take::<Option<Vec<u8>>, _>(col_index).unwrap() {
+            temp.push(data);
+            Datum::from(temp.last().unwrap().as_slice())
+        } else {
+            Datum::Null
+        }
+    } else {
+        let data = row.take::<Vec<u8>, _>(col_index).unwrap();
+        temp.push(data);
+        Datum::from(temp.last().unwrap().as_slice())
+    }
+}
+
+
+pub(crate) fn pack_mysql_row(row_container: &mut Row, row: &mut MySqlRow, table_desc: &MySqlTableDesc) -> Result<Row, TransientError> {
+    let mut packer = row_container.packer();
+    let mut temp_bytes = vec![];
+    let mut temp_strs = vec![];
+    for (col_index, col_desc) in table_desc.columns.iter().enumerate() {
+        let nullable = col_desc.column_type.nullable;
+        let datum = match col_desc.column_type.scalar_type {
+            ScalarType::Bool => datum_from_scalar::<bool>(row, col_index, nullable),
+            ScalarType::UInt16 => datum_from_scalar::<u16>(row, col_index, nullable),
+            ScalarType::Int16 => datum_from_scalar::<i16>(row, col_index, nullable),
+            ScalarType::UInt32 => datum_from_scalar::<u32>(row, col_index, nullable),
+            ScalarType::Int32 =>  datum_from_scalar::<i32>(row, col_index, nullable),
+            ScalarType::UInt64 => datum_from_scalar::<u64>(row, col_index, nullable),
+            ScalarType::Int64 => datum_from_scalar::<i64>(row, col_index, nullable),
+            ScalarType::Float32 => datum_from_scalar::<f32>(row, col_index, nullable),
+            ScalarType::Float64 => datum_from_scalar::<f64>(row, col_index, nullable),
+            ScalarType::Char { length: _ } => datum_from_string(&mut temp_strs, row, col_index, nullable),
+            ScalarType::VarChar { max_length: _ } => datum_from_string(&mut temp_strs, row, col_index, nullable),
+            ScalarType::String => datum_from_string(&mut temp_strs, row, col_index, nullable),
+            ScalarType::Bytes => datum_from_bytes(&mut temp_bytes, row, col_index, nullable),
+            // TODO(roshan): IMPLEMENT OTHER TYPES
+            ref data_type => {
+                Err(TransientError::UnsupportedDataType(format!("{:?}", data_type)))?
+            }
+        };
+        packer.push(datum);
+    }
+
+    Ok(row_container.clone())
 }

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -46,7 +46,8 @@ use crate::source::types::SourceReaderError;
 use crate::source::RawSourceCreationConfig;
 
 use super::{
-    table_name, pack_mysql_row, DefiniteError, ReplicationError, RewindRequest, TransactionId, TransientError,
+    pack_mysql_row, table_name, DefiniteError, ReplicationError, RewindRequest, TransactionId,
+    TransientError,
 };
 
 // Used as a partition id to determine if the worker is responsible for reading from the

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -1,0 +1,384 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::Infallible;
+use std::pin::pin;
+use std::rc::Rc;
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use bytes::Bytes;
+use differential_dataflow::{AsCollection, Collection};
+use futures::StreamExt;
+use mysql_async::prelude::Queryable;
+use mysql_async::{BinlogStream, BinlogStreamRequest, Conn, GnoInterval, Sid};
+use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::operators::{Concat, Map};
+use timely::dataflow::{Scope, Stream};
+use timely::progress::Antichain;
+use timely::progress::Timestamp;
+use tracing::trace;
+use uuid::Uuid;
+
+use mz_mysql_util::GtidSet;
+use mz_mysql_util::{
+    ensure_full_row_binlog_format, ensure_gtid_consistency, ensure_replication_commit_order,
+    MySqlTableDesc,
+};
+use mz_ore::cast::CastFrom;
+use mz_ore::result::ResultExt;
+use mz_repr::{Diff, GlobalId, Row};
+use mz_sql_parser::ast::UnresolvedItemName;
+use mz_storage_types::sources::MySqlSourceConnection;
+use mz_timely_util::builder_async::{
+    Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+};
+
+use crate::source::types::SourceReaderError;
+use crate::source::RawSourceCreationConfig;
+
+use super::{
+    table_name, pack_mysql_row, DefiniteError, ReplicationError, RewindRequest, TransactionId, TransientError,
+};
+
+// Used as a partition id to determine if the worker is responsible for reading from the
+// MySQL replication stream
+static REPL_READER: &str = "reader";
+
+/// Renders the replication dataflow. See the module documentation for more information.
+pub(crate) fn render<G: Scope<Timestamp = TransactionId>>(
+    scope: G,
+    config: RawSourceCreationConfig,
+    connection: MySqlSourceConnection,
+    subsource_resume_uppers: BTreeMap<GlobalId, Antichain<TransactionId>>,
+    table_info: BTreeMap<UnresolvedItemName, (usize, MySqlTableDesc)>,
+    rewind_stream: &Stream<G, RewindRequest>,
+    _committed_uppers: impl futures::Stream<Item = Antichain<TransactionId>> + 'static,
+) -> (
+    Collection<G, (usize, Result<Row, SourceReaderError>), Diff>,
+    Stream<G, Infallible>,
+    Stream<G, ReplicationError>,
+    PressOnDropButton,
+) {
+    let op_name = format!("MySqlReplicationReader({})", config.id);
+    let mut builder = AsyncOperatorBuilder::new(op_name, scope);
+
+    let repl_reader_id = u64::cast_from(config.responsible_worker(REPL_READER));
+    // TODO(roshan): Why do we need to use an Exchange pact in this case?
+    let (mut data_output, data_stream) = builder.new_output();
+    let (upper_output, upper_stream) = builder.new_output();
+    let (mut definite_error_handle, definite_errors) = builder.new_output();
+    let mut rewind_input = builder.new_input_for_many(
+        rewind_stream,
+        Exchange::new(move |_| repl_reader_id),
+        [&data_output, &upper_output],
+    );
+
+    // TODO: Add metrics
+
+    let (button, transient_errors) = builder.build_fallible(move |caps| {
+        Box::pin(async move {
+            let (id, worker_id) = (config.id, config.worker_id);
+            let [data_cap_set, upper_cap_set, definite_error_cap_set]: &mut [_; 3] = caps.try_into().unwrap();
+
+            // Only run the replication reader on the worker responsible for it.
+            if !config.responsible_for(REPL_READER) {
+                return Ok(());
+            }
+
+            let connection_config = connection
+                .connection
+                .config(&*config.config.connection_context.secrets_reader, &config.config)
+                .await?;
+
+            let mut conn = connection_config.connect(
+                &format!("timely-{worker_id} MySQL replication reader"),
+                &config.config.connection_context.ssh_tunnel_manager,
+            ).await?;
+
+            // Get the set of GTIDs currently available in the binlogs (GTIDs that we can safely start replication from)
+            let binlog_gtid_set: String = conn.query_first("SELECT GTID_SUBTRACT(@@global.gtid_executed, @@global.gtid_purged)").await?.unwrap();
+            // NOTE: The assumption here for the MVP is that there is only one source-id in the GTID set, so we can just
+            // take the transaction_id from the first one. Fix this once we move to a partitioned timestamp.
+            let binlog_start_gtid = GtidSet::from_str(&binlog_gtid_set)?.first().expect("At least one gtid").to_owned();
+            let binlog_start_transaction_id = TransactionId::new(binlog_start_gtid.earliest_transaction_id());
+
+            let resume_upper = Antichain::from_iter(
+                subsource_resume_uppers
+                    .values()
+                    .flat_map(|f| f.elements())
+                    // Advance any upper as far as the start of the binlog.
+                    .map(|t| std::cmp::max(*t, binlog_start_transaction_id))
+            );
+
+            let Some(resume_transaction_id) = resume_upper.into_option() else {
+                return Ok(());
+            };
+            data_cap_set.downgrade([&resume_transaction_id]);
+            upper_cap_set.downgrade([&resume_transaction_id]);
+            trace!(%id, "timely-{worker_id} replication reader started transaction_id={}", resume_transaction_id);
+
+            let mut rewinds = BTreeMap::new();
+            while let Some(event) = rewind_input.next().await {
+                if let AsyncEvent::Data(caps, data) = event {
+                    for req in data {
+                        let snapshot_transaction_id = TransactionId::new(req.snapshot_gtid_set.first().expect("at least one gtid").latest_transaction_id());
+                        // TODO: Should this be an assert? Or should we raise a DefiniteError?
+                        assert!(
+                            resume_transaction_id <= snapshot_transaction_id + TransactionId::new(1),
+                            "binlogs compacted past snapshot point. snapshot consistent point={} resume_transaction_id={resume_transaction_id}", snapshot_transaction_id + TransactionId::new(1)
+                        );
+                        rewinds.insert(req.table.clone(), (caps.clone(), req));
+                    }
+                }
+            }
+            trace!(%id, "timely-{worker_id} pending rewinds {rewinds:?}");
+
+            let stream_result = raw_stream(
+                &config,
+                conn,
+                binlog_start_gtid.uuid,
+                *data_cap_set[0].time(),
+            )
+            .await?;
+
+            let binlog_stream = match stream_result {
+                Ok(stream) => stream,
+                Err(err) => {
+                    // If the replication stream cannot be obtained in a definite way there is
+                    // nothing else to do. These errors are not retractable.
+                    for (output_index, _) in table_info.values() {
+                        // We pick `u64::MAX` as the TransactionId which will (in practice) never conflict
+                        // any previously revealed portions of the TVC.
+                        let update = ((*output_index, Err(err.clone())), TransactionId::new(u64::MAX), 1);
+                        data_output.give(&data_cap_set[0], update).await;
+                    }
+                    definite_error_handle.give(&definite_error_cap_set[0], ReplicationError::Definite(Rc::new(err))).await;
+                    return Ok(());
+                }
+            };
+            let mut stream = pin!(binlog_stream.peekable());
+
+            let mut container = Vec::new();
+            let max_capacity = timely::container::buffer::default_capacity::<((u32, Result<Vec<Option<Bytes>>, DefiniteError>), TransactionId, Diff)>();
+
+            // Binlog Table Id -> Table Name (its key in the `table_info` map)
+            let mut table_id_map = BTreeMap::<u64, UnresolvedItemName>::new();
+            let mut skipped_table_ids = BTreeSet::<u64>::new();
+
+            let mut final_row = Row::default();
+
+            let mut new_upper = *data_cap_set[0].time();
+            let mut advance_on_heartbeat = false;
+
+            trace!(%id, "timely-{worker_id} starting replication at {new_upper:?}");
+            while let Some(event) = stream.as_mut().next().await {
+                use mysql_async::binlog::events::*;
+                let event = event?;
+                let event_data = event.read_data()?;
+
+                if let Some(EventData::HeartbeatEvent) = event_data {
+                    // The upstream MySQL source only emits a heartbeat when there are no other events
+                    // sent within the heartbeat interval. This means that we can safely advance the
+                    // frontier once since we know there were no more events for the last sent GTID.
+                    if advance_on_heartbeat {
+                        data_output.give_container(&data_cap_set[0], &mut container).await;
+
+                        new_upper = new_upper + TransactionId::new(1);
+                        trace!(%id, "heartbeat: timely-{worker_id} advancing frontier to {new_upper:?}");
+                        upper_cap_set.downgrade([&new_upper]);
+                        data_cap_set.downgrade([&new_upper]);
+                        rewinds.retain(|_, (_, req)| data_cap_set[0].time() <= &TransactionId::new(req.snapshot_gtid_set.first().expect("at least one gtid").latest_transaction_id()));
+                        advance_on_heartbeat = false;
+                    }
+                    continue;
+                }
+
+                match event_data {
+                    // We receive a GtidEvent that tells us the transaction-id of proceeding
+                    // RowsEvents (and other events)
+                    Some(EventData::GtidEvent(event)) => {
+                        // TODO: Use this when we use a partitioned timestamp
+                        let _source_id = Uuid::from_bytes(event.sid());
+                        let received_upper = TransactionId::new(event.gno());
+                        assert!(new_upper <= received_upper, "GTID went backwards {} -> {}", new_upper, received_upper);
+                        new_upper = received_upper;
+
+                        // Indicate that we should advance the frontier if we receive a heartbeat since that would indicate
+                        // that there are no more records for this GTID.
+                        advance_on_heartbeat = true;
+                    }
+                    // A row event is a write/update/delete event
+                    Some(EventData::RowsEvent(data)) => {
+                        // Find the relevant table
+                        let binlog_table_id = data.table_id();
+                        let table_map_event = stream.get_ref().get_tme(binlog_table_id).ok_or_else(|| {
+                            TransientError::Generic(anyhow::anyhow!("Table map event not found"))
+                        })?;
+                        let table = match (
+                            table_id_map.get(&binlog_table_id),
+                            skipped_table_ids.get(&binlog_table_id),
+                        ) {
+                            (Some(table), None) => table,
+                            (None, Some(_)) => {
+                                // We've seen this table ID before and it was skipped
+                                continue;
+                            }
+                            (None, None) => {
+                                let table = table_name(&*table_map_event.database_name(), &*table_map_event.table_name())?;
+                                if table_info.contains_key(&table) {
+                                    table_id_map.insert(binlog_table_id, table);
+                                    &table_id_map[&binlog_table_id]
+                                } else {
+                                    skipped_table_ids.insert(binlog_table_id);
+                                    // We don't know about this table, so skip this event
+                                    continue;
+                                }
+                            }
+                            _ => unreachable!(),
+                        };
+
+                        let (output_index, table_desc) = &table_info[table];
+
+                        // Iterate over the rows in this RowsEvent. Each row is a pair of 'before_row', 'after_row',
+                        // to accomodate for updates and deletes (which include a before_row),
+                        // and updates and inserts (which inclued an after row).
+                        let mut rows_iter = data.rows(table_map_event);
+                        while let Some(Ok((before_row, after_row))) = rows_iter.next() {
+                            for (binlog_row, diff) in vec![(before_row, -1), (after_row, 1)].drain(..) {
+                                // TODO: Map columns from table schema to indexes in each row
+                                if let Some(inner_row) = binlog_row {
+                                    let mut row = mysql_async::Row::try_from(inner_row)?;
+                                    let packed_row = pack_mysql_row(&mut final_row, &mut row, table_desc)?;
+                                    let data = (*output_index, Ok(packed_row));
+
+                                    // Rewind this update if it was already present in the snapshot
+                                    if let Some((rewind_caps, req)) = rewinds.get(table) {
+                                        let latest_transaction_id = req.snapshot_gtid_set.first().expect("at least one gtid").latest_transaction_id();
+                                        let [data_cap, _upper_cap] = rewind_caps;
+                                        if new_upper <= TransactionId::new(latest_transaction_id) {
+                                            data_output.give(data_cap, (data.clone(), TransactionId::minimum(), -diff)).await;
+                                        }
+                                    }
+                                    trace!(%id, "timely-{worker_id} sending update {data:?} at {new_upper:?}");
+                                    container.push((data, new_upper, diff));
+                                }
+                            }
+                        }
+
+                        // flush any pending records and advance our frontier
+                        if container.len() > max_capacity {
+                            data_output.give_container(&data_cap_set[0], &mut container).await;
+                            trace!(%id, "timely-{worker_id} advancing frontier to {new_upper:?}");
+                            upper_cap_set.downgrade([&new_upper]);
+                            data_cap_set.downgrade([&new_upper]);
+                            rewinds.retain(|_, (_, req)| data_cap_set[0].time() <= &TransactionId::new(req.snapshot_gtid_set.first().expect("at least one gtid").latest_transaction_id()));
+                        }
+                    }
+                    _ => {
+                        // TODO: Handle other event types
+                        // We definitely need to handle 'query' events and parse them for DDL changes
+                        // that might affect the schema of the tables we care about.
+                    }
+                }
+
+                // TODO: Do we need to downgrade the frontier if the stream yields? Or is that handled by the heartbeat?
+            }
+            // We never expect the replication stream to gracefully end
+            Err(TransientError::ReplicationEOF)
+        })
+    });
+
+    // TODO: Split row decoding into a separate operator that can be distributed across all workers
+    let replication_updates = data_stream
+        .as_collection()
+        .map(|(output_index, row)| (output_index, row.err_into()));
+
+    let errors = definite_errors.concat(&transient_errors.map(ReplicationError::from));
+
+    (
+        replication_updates,
+        upper_stream,
+        errors,
+        button.press_on_drop(),
+    )
+}
+
+/// Produces the logical replication stream while taking care of regularly sending standby
+/// keepalive messages with the provided `uppers` stream.
+///
+/// The returned stream will contain all transactions that whose commit LSN is beyond `resume_lsn`.
+async fn raw_stream<'a>(
+    config: &'a RawSourceCreationConfig,
+    mut conn: Conn,
+    // TODO: this is only needed while we use a single source-id for the timestamp; remove once we move to a partitioned timestamp
+    gtid_source_id: Uuid,
+    resume_transaction_id: TransactionId,
+) -> Result<Result<BinlogStream, DefiniteError>, TransientError> {
+    // Verify the MySQL system settings are correct for consistent row-based replication using GTIDs
+    // TODO: Should these return DefiniteError instead of TransientError?
+    ensure_gtid_consistency(&mut conn).await?;
+    ensure_full_row_binlog_format(&mut conn).await?;
+    ensure_replication_commit_order(&mut conn).await?;
+
+    // To start the stream we need to provide a GTID set of the transactions that we've 'seen'
+    // and the server will send us all transactions that have been committed after that point.
+    // NOTE: The 'Gno' intervals in this transaction-set use an open set [start, end)
+    // interval, which is different than the closed-set [start, end] form returned by the
+    // @gtid_executed system variable. So the intervals we construct in this GTID set
+    // end with the value of the transaction-id that we want to start replication at,
+    // which happens to be our `resume_transaction_id`
+    let seen_gtids = match resume_transaction_id.into() {
+        0 | 1 => {
+            // If we're starting from the beginning of the binlog or the first transaction id
+            // we haven't seen 'anything'
+            Vec::new()
+        }
+        ref a => {
+            // NOTE: Since we enforce replica_preserve_commit_order=ON we can start the interval at 1
+            // since we know that all transactions with a lower transaction id were monotonic
+            vec![Sid::new(*gtid_source_id.as_bytes()).with_interval(GnoInterval::new(1, *a))]
+        }
+    };
+
+    // Request that the stream provide us with a heartbeat message when no other messages have been sent
+    let heartbeat = Duration::from_secs(3);
+    conn.query_drop(format!(
+        "SET @master_heartbeat_period = {};",
+        heartbeat.as_nanos()
+    ))
+    .await?;
+
+    let repl_stream = match conn
+        .get_binlog_stream(
+            // TODO: The server-id should probably be something more static than the worker-id?
+            BinlogStreamRequest::new(
+                config
+                    .worker_id
+                    .try_into()
+                    .map_err(|_| TransientError::Generic(anyhow!("invalid worker-id")))?,
+            )
+            .with_gtid()
+            .with_gtid_set(seen_gtids),
+        )
+        .await
+    {
+        Ok(stream) => stream,
+        Err(mysql_async::Error::Server(ref server_err)) if server_err.code == 1236 => {
+            // The GTID set we requested is no longer available
+            return Ok(Err(DefiniteError::BinlogNotAvailable));
+        }
+        // TODO: handle other error types. Some may require a re-snapshot and some may be transient
+        Err(err) => return Err(err.into()),
+    };
+
+    Ok(Ok(repl_stream))
+}

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -1,0 +1,281 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
+use std::str::FromStr;
+
+use differential_dataflow::{AsCollection, Collection};
+use futures::TryStreamExt;
+use mysql_async::prelude::Queryable;
+use mysql_async::{IsolationLevel, Row as MySqlRow, TxOpts};
+use mz_sql_parser::ast::display::AstDisplay;
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::{Broadcast, CapabilitySet, Concat, ConnectLoop, Feedback, Map};
+use timely::dataflow::{Scope, Stream};
+use timely::progress::{Antichain, Timestamp};
+use tracing::trace;
+
+use mz_mysql_util::{
+    ensure_full_row_binlog_format, ensure_gtid_consistency, ensure_replication_commit_order,
+    query_sys_var, GtidSet, SchemaRequest,
+};
+use mz_mysql_util::{schema_info, MySqlTableDesc};
+use mz_repr::{Diff, GlobalId, Row};
+use mz_sql_parser::ast::UnresolvedItemName;
+use mz_storage_types::sources::MySqlSourceConnection;
+use mz_timely_util::builder_async::{
+    Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+};
+
+use crate::source::{RawSourceCreationConfig, SourceReaderError};
+
+use super::{ReplicationError, RewindRequest, TransactionId, TransientError, pack_mysql_row};
+
+/// Renders the snapshot dataflow. See the module documentation for more information.
+pub(crate) fn render<G: Scope<Timestamp = TransactionId>>(
+    mut scope: G,
+    config: RawSourceCreationConfig,
+    connection: MySqlSourceConnection,
+    subsource_resume_uppers: BTreeMap<GlobalId, Antichain<TransactionId>>,
+    table_info: BTreeMap<UnresolvedItemName, (usize, MySqlTableDesc)>,
+) -> (
+    Collection<G, (usize, Result<Row, SourceReaderError>), Diff>,
+    Stream<G, RewindRequest>,
+    Stream<G, ReplicationError>,
+    PressOnDropButton,
+) {
+    let mut builder =
+        AsyncOperatorBuilder::new(format!("MySqlSnapshot({})", config.id), scope.clone());
+
+    let (mut raw_handle, raw_data) = builder.new_output();
+    let (mut rewinds_handle, rewinds) = builder.new_output();
+    let (mut _definite_error_handle, definite_errors) = builder.new_output();
+
+    // Broadcast a signal from the snapshot leader worker to the other workers when the table
+    // lock is in place. Upon receiving the first message the workers should start a transaction
+    // that guarantees they all see a consistent view from the same GTID.
+    let (mut lock_start_handle, lock_start) = builder.new_output();
+    let (ls_feedback_handle, ls_feedback_data) = scope.feedback(Default::default());
+    let mut lock_start_input = builder.new_disconnected_input(&ls_feedback_data, Pipeline);
+    lock_start.broadcast().connect_loop(ls_feedback_handle);
+
+    // Broadcast a signal from the all workers that they have begun a transaction and that the
+    // table lock held by the snapshot leader can be released
+    let (mut transaction_start_handle, transaction_start) = builder.new_output();
+    let (ts_feedback_handle, ts_feedback_data) = scope.feedback(Default::default());
+    let mut transaction_start_input = builder.new_disconnected_input(&ts_feedback_data, Pipeline);
+    transaction_start
+        .broadcast()
+        .connect_loop(ts_feedback_handle);
+
+    let is_snapshot_leader = config.responsible_for("snapshot_leader");
+
+    // A global view of all exports that need to be snapshot by all workers. Note that this affects
+    // `reader_snapshot_table_info` but must be kept separate from it because each worker needs to
+    // understand if any worker is snapshotting any subsource.
+    let export_indexes_to_snapshot: BTreeSet<_> = subsource_resume_uppers
+        .into_iter()
+        .filter_map(|(id, upper)| {
+            // Determined which collections need to be snapshot and which already have been.
+            if id != config.id && *upper == [TransactionId::minimum()] {
+                // Convert from `GlobalId` to output index.
+                Some(config.source_exports[&id].output_index)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let mut all_table_names = vec![];
+    // A map containing only the table infos that this worker should snapshot.
+    let mut reader_snapshot_table_info = BTreeMap::new();
+
+    for (table, val) in table_info {
+        mz_ore::soft_assert_or_log!(
+            val.0 != 0,
+            "primary collection should not be represented in table info"
+        );
+        if !export_indexes_to_snapshot.contains(&val.0) {
+            continue;
+        }
+        all_table_names.push(table.clone());
+        if config.responsible_for(&table) {
+            reader_snapshot_table_info.insert(table, val);
+        }
+    }
+
+    let (button, transient_errors): (_, Stream<G, Rc<TransientError>>) = builder.build_fallible(move |caps| {
+        Box::pin(async move {
+            let id = config.id;
+            let worker_id = config.worker_id;
+
+            let [data_cap_set, rewind_cap_set, _definite_error_cap_set, lock_start_cap_set, transaction_start_cap_set]: &mut [_; 5] =
+                caps.try_into().unwrap();
+            trace!(
+                %id,
+                "timely-{worker_id} initializing table reader with {} tables to snapshot",
+                reader_snapshot_table_info.len()
+            );
+
+            // Nothing needs to be snapshot.
+            if all_table_names.is_empty() {
+                trace!(%id, "no exports to snapshot");
+                return Ok(());
+            }
+
+            let connection_config = connection
+                .connection
+                .config(
+                    &*config.config.connection_context.secrets_reader,
+                    &config.config,
+                )
+                .await?;
+            let task_name = format!("timely-{worker_id} MySQL snapshotter");
+
+            // The snapshot leader is responsible for ensuring a consistent snapshot of
+            // all tables that need to be snapshot. The leader will create a new 'lock connection'
+            // that takes a table lock on all tables to be snapshot and then read the active GTID
+            // at that time.
+            //
+            // Once this lock is acquired, the leader is responsible for sending a signal to all
+            // workers that they should start their own transactions. The workers will then start a
+            // transaction with REPEATABLE READ and 'CONSISTENT SNAPSHOT' semantics.
+            // Once each worker has started their transaction, they will send a signal to the
+            // leader that the table lock can be released. This will allow further writes to the
+            // tables by other clients to occur, while ensuring that the snapshot workers all see
+            // a consistent view of the tables starting from the same GTID.
+            let mut lock_conn = None;
+            if is_snapshot_leader {
+                let lock_clauses = all_table_names
+                    .iter()
+                    .map(|t| format!("{} READ", t.to_ast_string()))
+                    .collect::<Vec<String>>()
+                    .join(", ");
+                let leader_task_name = format!("{} leader", task_name);
+                lock_conn = Some(Box::new(connection_config.connect(&leader_task_name, &config.config.connection_context.ssh_tunnel_manager).await?));
+
+                trace!(%id, "timely-{worker_id} acquiring table locks: {lock_clauses}");
+                lock_conn.as_mut().expect("lock_conn just created")
+                    .query_drop(format!("LOCK TABLES {lock_clauses}"))
+                    .await?;
+
+                // Record the GTID set at the start of the snapshot
+                let snapshot_gtid_set = query_sys_var(lock_conn.as_mut().expect("lock_conn just created"), "global.gtid_executed").await?;
+                let snapshot_gtid_set = GtidSet::from_str(snapshot_gtid_set.as_str())?;
+                trace!(%id, "timely-{worker_id} acquired table locks at start gtid set: {snapshot_gtid_set:?}");
+                // TODO(roshan): Insert metric for how long it took to acquire the locks
+
+                // Send a signal to all workers that they should start their transactions
+                lock_start_handle.give(&lock_start_cap_set[0], snapshot_gtid_set).await;
+            }
+            *lock_start_cap_set = CapabilitySet::new();
+
+            // This worker has no tables to snapshot.
+            if reader_snapshot_table_info.is_empty() {
+                // Send a signal to the leader that this worker is okay with releasing the table locks
+                transaction_start_handle.give(&transaction_start_cap_set[0], ()).await;
+                *transaction_start_cap_set = CapabilitySet::new();
+                return Ok(());
+            }
+
+            let mut conn = connection_config.connect(&task_name, &config.config.connection_context.ssh_tunnel_manager).await?;
+
+            // Verify the MySQL system settings are correct for consistent row-based replication using GTIDs
+            // TODO: Should these return DefiniteError instead of TransientError?
+            ensure_gtid_consistency(&mut conn).await?;
+            ensure_full_row_binlog_format(&mut conn).await?;
+            ensure_replication_commit_order(&mut conn).await?;
+
+            // Wait for the start_gtids from the leader, which indicate that the table locks have
+            // been acquired and we should start a transaction.
+            let snapshot_gtid_set = loop {
+                match lock_start_input.next().await {
+                    Some(AsyncEvent::Data(_, mut data)) => break data.pop().expect("Sent above"),
+                    Some(AsyncEvent::Progress(_)) => (),
+                    None => panic!("lock_start_input closed unexpectedly"),
+                }
+            };
+
+            trace!(%id, "timely-{worker_id} starting transaction with consistent snapshot at gtid set: {snapshot_gtid_set:?}");
+
+            // Start a transaction with REPEATABLE READ and 'CONSISTENT SNAPSHOT' semantics
+            // so we can read a consistent snapshot of the table at the specific GTID we read.
+            let mut tx_opts = TxOpts::default();
+            tx_opts
+                .with_isolation_level(IsolationLevel::RepeatableRead)
+                .with_consistent_snapshot(true)
+                .with_readonly(true);
+            conn.start_transaction(tx_opts).await?;
+            conn.query_drop("set @@session.time_zone = '+00:00'")
+                .await?;
+
+            // Read the schemas of the tables we are snapshotting
+            // TODO: verify the schema matches the expected schema
+            let _ = schema_info(&mut conn, &SchemaRequest::Tables(reader_snapshot_table_info.keys().map(|f| (f.0[0].as_str(), f.0[1].as_str())).collect())).await?;
+
+            // Send a signal to the leader that we have started our transaction
+            transaction_start_handle.give(&transaction_start_cap_set[0], ()).await;
+            *transaction_start_cap_set = CapabilitySet::new();
+
+            trace!(%id, "timely-{worker_id} started transaction");
+
+            if is_snapshot_leader {
+                // Wait for all workers to start their transactions so we can release the table locks
+                let mut received = 0;
+                while received < config.worker_count {
+                    match transaction_start_input.next().await {
+                        Some(AsyncEvent::Data(_, _)) => received += 1,
+                        Some(AsyncEvent::Progress(_)) => (),
+                        None => panic!("transaction_start_input closed unexpectedly"),
+                    }
+                }
+
+                trace!(%id, "timely-{worker_id} releasing table locks");
+                if let Some(mut lock_conn) = lock_conn.take() {
+                    lock_conn.query_drop("UNLOCK TABLES").await?;
+                    lock_conn.disconnect().await?;
+                } else {
+                    panic!("lock_conn should have been created for the snapshot leader");
+                }
+                drop(lock_conn);
+            }
+
+            // We have established a snapshot GTID set so we can broadcast the rewind requests
+            for table in reader_snapshot_table_info.keys() {
+                trace!(%id, "timely-{worker_id} producing rewind request for {table}");
+                let req = RewindRequest { table: table.clone(), snapshot_gtid_set: snapshot_gtid_set.clone() };
+                rewinds_handle.give(&rewind_cap_set[0], req).await;
+            }
+            *rewind_cap_set = CapabilitySet::new();
+
+            // Read the snapshot data from the tables
+            let mut final_row = Row::default();
+            for (table, (output_index, table_desc)) in reader_snapshot_table_info {
+                let query = format!("SELECT * FROM {}", table.to_ast_string());
+                trace!(%id, "timely-{worker_id} reading snapshot from table: {table}\n{table_desc:?}");
+                let mut results = conn.exec_stream(query, ()).await?;
+                while let Some(row) = results.try_next().await? {
+                    let mut row: MySqlRow = row;
+                    let packed_row = pack_mysql_row(&mut final_row, &mut row, &table_desc)?;
+                    raw_handle.give(&data_cap_set[0], ((output_index, Ok(packed_row)), TransactionId::minimum(), 1)).await;
+                }
+            }
+
+            Ok(())
+        })
+    });
+
+    // TODO: Split row decoding into a separate operator that can be distributed across all workers
+    let snapshot_updates = raw_data.as_collection();
+
+    let errors = definite_errors.concat(&transient_errors.map(ReplicationError::from));
+
+    (snapshot_updates, rewinds, errors, button.press_on_drop())
+}

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -36,7 +36,7 @@ use mz_timely_util::builder_async::{
 
 use crate::source::{RawSourceCreationConfig, SourceReaderError};
 
-use super::{ReplicationError, RewindRequest, TransactionId, TransientError, pack_mysql_row};
+use super::{pack_mysql_row, ReplicationError, RewindRequest, TransactionId, TransientError};
 
 /// Renders the snapshot dataflow. See the module documentation for more information.
 pub(crate) fn render<G: Scope<Timestamp = TransactionId>>(

--- a/src/storage/src/source/mysql/timestamp.rs
+++ b/src/storage/src/source/mysql/timestamp.rs
@@ -40,6 +40,8 @@ impl TransactionId {
     pub fn new(id: u64) -> Self {
         Self(id)
     }
+
+    pub const MAX: TransactionId = TransactionId(u64::MAX);
 }
 
 impl Add for TransactionId {

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -278,6 +278,8 @@ pub enum TransientError {
 /// A definite error that always ends up in the collection of a specific table.
 #[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error)]
 pub enum DefiniteError {
+    #[error("slot compacted past snapshot point. snapshot consistent point={0} resume_lsn={1}")]
+    SlotCompactedPastResumePoint(MzOffset, MzOffset),
     #[error("table was truncated")]
     TableTruncated,
     #[error("table was dropped")]

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -110,7 +110,7 @@ pub struct RawSourceCreationConfig {
     /// The upper frontier this source should resume ingestion at
     pub as_of: Antichain<mz_repr::Timestamp>,
     /// For each source export, the upper frontier this source should resume ingestion at in the
-    /// source time domain.
+    /// system time domain.
     pub resume_uppers: BTreeMap<GlobalId, Antichain<mz_repr::Timestamp>>,
     /// For each source export, the upper frontier this source should resume ingestion at in the
     /// source time domain.

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -66,6 +66,8 @@ log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.8", features = ["net", "os-ext"] }
+mysql_async = { version = "0.33.0", default-features = false, features = ["binlog", "minimal", "tracing"] }
+mysql_common = { version = "0.31.0", default-features = false, features = ["binlog"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
@@ -179,6 +181,8 @@ log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.8", features = ["net", "os-ext"] }
+mysql_async = { version = "0.33.0", default-features = false, features = ["binlog", "minimal", "tracing"] }
+mysql_common = { version = "0.31.0", default-features = false, features = ["binlog"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }

--- a/test/mysql-cdc/10-create-connection.td
+++ b/test/mysql-cdc/10-create-connection.td
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-sql-timeout duration=1s
-$ set-max-tries max-tries=3
-
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 
 #

--- a/test/mysql-cdc/15-create-source.td
+++ b/test/mysql-cdc/15-create-source.td
@@ -28,8 +28,6 @@ DROP DATABASE IF EXISTS dummyschema;
 CREATE DATABASE dummyschema;
 USE dummyschema;
 CREATE TABLE dummy (f1 INTEGER PRIMARY KEY, id VARCHAR(128));
-INSERT INTO dummy VALUES (123, "dummy data");
-INSERT INTO dummy VALUES (234, "moar dummy");
 COMMIT;
 
 #
@@ -65,14 +63,17 @@ COMMIT;
   FOR TABLES (public.t1);
 
 > SELECT * FROM a.t1;
+1
 
 > CREATE SCHEMA another;
 > CREATE SOURCE another.mz_source FROM MYSQL CONNECTION mysqc
   FOR TABLES (public.t1, public.t2);
 
 > SELECT * FROM another.t1;
+1
 
 > SELECT * FROM another.t2;
+5
 
 > CREATE SCHEMA foo;
 > CREATE SCHEMA bar;
@@ -84,17 +85,21 @@ contains: unknown
 
 # table1 gets created in source schema foo because it doesn't have any prefix
 > SELECT * FROM foo.table1;
+1
 
 ! SELECT * FROM foo.table2;
 contains: unknown
 
 # table2 gets created in mentioned bar because it does have a prefix
 > SELECT * FROM bar.table2;
+5
 
 > CREATE SCHEMA baz;
 > CREATE SOURCE baz.mz_source FROM MYSQL CONNECTION mysqc
   FOR SCHEMAS (public);
 
 > SELECT * FROM baz.t1;
+1
 
 > SELECT * FROM baz.t2;
+5

--- a/test/mysql-cdc/20-source-replication.td
+++ b/test/mysql-cdc/20-source-replication.td
@@ -1,0 +1,45 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_mysql_source = true
+
+> CREATE CONNECTION mysq TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS dummyschema;
+CREATE DATABASE dummyschema;
+USE dummyschema;
+CREATE TABLE dummy (f1 INTEGER PRIMARY KEY, id VARCHAR(128));
+INSERT INTO dummy VALUES (123, "dummy data");
+INSERT INTO dummy VALUES (234, "moar dummy");
+COMMIT;
+
+> CREATE SOURCE foo FROM MYSQL CONNECTION mysq FOR ALL TABLES;
+> SELECT * FROM dummy;
+123 "dummy data"
+234 "moar dummy"
+
+$ mysql-execute name=mysql
+USE dummyschema;
+INSERT INTO dummy VALUES (145, "next row");
+COMMIT;
+
+> SELECT * FROM dummy;
+123 "dummy data"
+234 "moar dummy"
+145 "next row"

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -13,7 +13,11 @@ from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.services.testdrive import Testdrive
 
 SERVICES = [
-    Materialized(),
+    Materialized(
+        additional_system_parameter_defaults={
+            "log_filter": "mz_storage::source::mysql=trace,info"
+        }
+    ),
     MySql(
         additional_args=[
             "--log-bin=mysql-bin",
@@ -38,6 +42,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = parser.parse_args()
 
     c.up("materialized", "mysql")
+
     c.run(
         "testdrive",
         f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

This is a prototype of the MySQL Source Operator, supporting replication from a MySQL database that has row-based GTID replication enabled.

The operator is split into 2 main operators, following the model of the Postgres source. The snapshot operator is able to snapshot concurrently across multiple timely workers at a consistent 'GTID set' by obtaining a table-lock on all desired tables, opening transactions with repeatable-read semantics in each of the timely workers, and then releasing the lock.
This snapshot operator issues 'rewind' requests to the replication operator, similar to the postgres source implementation. The replication operator starts a GTID replication stream to receive ongoing updates from MySQL.

For this prototype we're using a `TransactionId` timestamp-type to simplify this initial work, however this is an incorrect implementation since it assumes the GTID set only contains a single 'source-id'. We will soon replace this with a Partitioned-timestamp type for tracking the `TransactionId`s across all seen source-ids.

More details are available in our project notion notes: https://www.notion.so/materialize/MySQL-Source-Prototype-8838b49eb2124e3580a4e9922761d423



### Motivation

* This PR adds a known-desirable feature: part of https://github.com/MaterializeInc/materialize/issues/15901

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

It helps to have an understanding of the Postgres Source operator first, since this is modeled after that implementation.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
