### PR TITLE
persist: correctly set grpc connect timeout

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -147,6 +147,8 @@ pub struct PersistConfig {
     pub critical_downgrade_interval: Duration,
     /// Timeout per connection attempt to Persist PubSub service.
     pub pubsub_connect_attempt_timeout: Duration,
+    /// Timeout per request attempt to Persist PubSub service.
+    pub pubsub_request_timeout: Duration,
     /// Maximum backoff when retrying connection establishment to Persist PubSub service.
     pub pubsub_connect_max_backoff: Duration,
     /// Size of channel used to buffer send messages to PubSub service.
@@ -230,6 +232,7 @@ impl PersistConfig {
             writer_lease_duration: 60 * Duration::from_secs(60),
             critical_downgrade_interval: Duration::from_secs(30),
             pubsub_connect_attempt_timeout: Duration::from_secs(5),
+            pubsub_request_timeout: Duration::from_secs(5),
             pubsub_connect_max_backoff: Duration::from_secs(60),
             pubsub_client_sender_channel_size: 25,
             pubsub_client_receiver_channel_size: 25,

--- a/src/persist-client/src/rpc.rs
+++ b/src/persist-client/src/rpc.rs
@@ -223,7 +223,9 @@ impl GrpcPubSubClient {
                         Err(err) => return RetryResult::FatalErr(err),
                     };
                     ProtoPersistPubSubClient::connect(
-                        endpoint.timeout(config.persist_cfg.pubsub_connect_attempt_timeout),
+                        endpoint
+                            .connect_timeout(config.persist_cfg.pubsub_connect_attempt_timeout)
+                            .timeout(config.persist_cfg.pubsub_request_timeout),
                     )
                     .await
                     .into()


### PR DESCRIPTION
After discussing with @pH14 , we realized this was a bug. This pr ensures that `attempt_timeout` parameter actually applies to connection attempts. It also preserves the previous behavior, where requests were also timed-out after 5 seconds (its unclear how much this matter for bidi streams tho).

For keepalives and making these dynamically configurable, see https://github.com/MaterializeInc/materialize/issues/23869 (its non-trivial as we setup pubsub connections _before_ we receive LD parameters from envd)

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
