### PR TITLE
catalog: Add log message for catalog kind

### DIFF
--- a/src/catalog/src/durable/impls/migrate.rs
+++ b/src/catalog/src/durable/impls/migrate.rs
@@ -10,7 +10,7 @@
 use async_trait::async_trait;
 use mz_ore::now::EpochMillis;
 use mz_sql::session::vars::CatalogKind;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::durable::debug::{DebugCatalogState, Trace};
 use crate::durable::impls::persist::UnopenedPersistCatalogState;
@@ -153,6 +153,7 @@ impl OpenableDurableCatalogState for CatalogMigrator {
     }
 
     fn set_catalog_kind(&mut self, catalog_kind: CatalogKind) {
+        info!("Switching to {} backed catalog", catalog_kind.as_str());
         let direction = match catalog_kind.try_into() {
             Ok(direction) => direction,
             Err(catalog_kind) => {

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -780,13 +780,16 @@ async fn catalog_opener(
     controller_config: &ControllerConfig,
     environment_id: &EnvironmentId,
 ) -> Result<Box<dyn OpenableDurableCatalogState>, anyhow::Error> {
+    info!(
+        "Using {} backed catalog",
+        catalog_config.catalog_kind().as_str()
+    );
     Ok(match catalog_config {
         CatalogConfig::Stash {
             url,
             persist_clients,
             metrics,
         } => {
-            info!("Using stash backed catalog");
             let stash_factory =
                 mz_stash::StashFactory::from_metrics(Arc::clone(&controller_config.stash_metrics));
             let tls = mz_tls_util::make_tls(&tokio_postgres::config::Config::from_str(url)?)?;
@@ -809,7 +812,6 @@ async fn catalog_opener(
             )
         }
         CatalogConfig::EmergencyStash { url } => {
-            info!("Using emergency stash backed catalog");
             let stash_factory =
                 mz_stash::StashFactory::from_metrics(Arc::clone(&controller_config.stash_metrics));
             let tls = mz_tls_util::make_tls(&tokio_postgres::config::Config::from_str(url)?)?;
@@ -827,7 +829,6 @@ async fn catalog_opener(
             persist_clients,
             metrics,
         } => {
-            info!("Using persist backed catalog");
             let stash_factory =
                 mz_stash::StashFactory::from_metrics(Arc::clone(&controller_config.stash_metrics));
             let tls = mz_tls_util::make_tls(&tokio_postgres::config::Config::from_str(url)?)?;
@@ -853,7 +854,6 @@ async fn catalog_opener(
             url,
             persist_clients,
         } => {
-            info!("Using shadow catalog");
             let stash_factory =
                 mz_stash::StashFactory::from_metrics(Arc::clone(&controller_config.stash_metrics));
             let tls = mz_tls_util::make_tls(&tokio_postgres::config::Config::from_str(url)?)?;


### PR DESCRIPTION
This commit adds a log message to indicate if the catalog implementation was switched to something other than the passed in `environmentd` command line arg.

### Motivation
Adds a log.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
