### PR TITLE
test: Adapt persist-txn fencing elapsed time limit

### DIFF
--- a/test/persist-txn-fencing/mzcompose.py
+++ b/test/persist-txn-fencing/mzcompose.py
@@ -33,7 +33,7 @@ class Workload:
     tables: int = 1
     operation = Operation.INSERT
     second_mz_delay = 5
-    operation_count = 2000
+    operation_count = 3000
     max_transaction_size = 100
 
 
@@ -201,6 +201,7 @@ def run_workload(c: Composition, workload: Workload, catalog_store: str) -> None
             commits = executor.map(execute_operation, operations)
 
         elapsed = time.time() - start
+        # The second Mz instance can come up slightly faster
         assert elapsed > (
             workload.second_mz_delay * 2
         ), f"Workload completed too soon - elapsed {elapsed}s is less than 2 x second_mz_delay({workload.second_mz_delay}s)"


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/5841#018cd1e1-9cd8-45c3-8b42-a30c4805940b

Since it's so close to the 10s (9.96 s), I assume this is still working correctly

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
