### PR TITLE
cluster test: Decrease tick interval for blue/green deployment test

### DIFF
--- a/test/cluster/blue-green-deployment/deploy.td
+++ b/test/cluster/blue-green-deployment/deploy.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 > CREATE SCHEMA prod_deploy
-> CREATE SOURCE prod_deploy.counter IN CLUSTER prod_deploy FROM LOAD GENERATOR counter (TICK INTERVAL '1s')
+> CREATE SOURCE prod_deploy.counter IN CLUSTER prod_deploy FROM LOAD GENERATOR counter (TICK INTERVAL '0.01s')
 > CREATE MATERIALIZED VIEW prod_deploy.counter_mv IN CLUSTER prod_deploy AS SELECT count(*), 'some new value' FROM prod_deploy.counter
 > CREATE DEFAULT INDEX IN CLUSTER prod_deploy ON prod_deploy.counter
 > CREATE DEFAULT INDEX IN CLUSTER prod_deploy ON prod_deploy.counter_mv

--- a/test/cluster/blue-green-deployment/setup.td
+++ b/test/cluster/blue-green-deployment/setup.td
@@ -28,7 +28,7 @@ ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
 > DROP SCHEMA IF EXISTS prod_deploy CASCADE
 
 > CREATE SCHEMA prod
-> CREATE SOURCE prod.counter IN CLUSTER prod FROM LOAD GENERATOR counter (TICK INTERVAL '1s')
+> CREATE SOURCE prod.counter IN CLUSTER prod FROM LOAD GENERATOR counter (TICK INTERVAL '0.01s')
 > CREATE MATERIALIZED VIEW prod.counter_mv IN CLUSTER prod AS SELECT count(*) FROM prod.counter
 > CREATE DEFAULT INDEX IN CLUSTER prod ON prod.counter
 > CREATE SOURCE prod.tpch


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
