### PR TITLE
cargo-hakari: Increase format version

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -1,5 +1,5 @@
 hakari-package = "workspace-hack"
-dep-format-version = "3"
+dep-format-version = "4"
 resolver = "2"
 platforms = [
     "x86_64-unknown-linux-gnu",


### PR DESCRIPTION
```
info: new hakari format version available: 4 (current: 3) (add or update `dep-format-version = "4"` in hakari.toml, then run `cargo hakari generate && cargo hakari manage-deps`)
```
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
