### PR TITLE
stash: Explicitly set the transaction priority

### DIFF
--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -1184,8 +1184,7 @@ impl Consolidator {
         // priority to high. Otherwise we can get into a state where the consolidator is never able
         // to finish consolidating and the stash grows without bound.
         if attempt >= HIGH_PRIORITY_ATTEMPT_THRESHOLD {
-            tx.batch_execute(&format!("SET TRANSACTION PRIORITY HIGH;"))
-                .await?;
+            tx.batch_execute("SET TRANSACTION PRIORITY HIGH;").await?;
         }
         let deleted = match since.borrow().as_option() {
             Some(since) => {


### PR DESCRIPTION
This commit modifies the stash consolidator by explicitly setting the transaction priority via `SET TRANSACTION PRIORITY` when a transaction has failed a certain number of times, instead of changing the default transaction priority via `SET default_transaction_priority = _`. There isn't a very good reason to do this other than we might not have a correct understanding of what `default_transaction_priority` and `SET TRANSACTION PRIORITY` is more explicit. `SET
default_transaction_priority = _` has not prevented the stash consolidator from aborting in production like we thought it would.

The docs for this feature can be found here:
https://www.cockroachlabs.com/docs/v23.1/transactions#transaction-priorities

### Motivation
This PR might fix a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
