### PR TITLE
persist: remove maybe_heartbeat_reader call from Subscribe::next

### DIFF
--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -137,9 +137,6 @@ where
         // If Some, an override for the default listen sleep retry parameters.
         listen_retry: Option<RetryParameters>,
     ) -> Vec<ListenEvent<T, LeasedBatchPart<T>>> {
-        // This is odd, but we move our handle into a `Listen`.
-        self.listen.handle.maybe_heartbeat_reader().await;
-
         match self.snapshot.take() {
             Some(parts) => vec![ListenEvent::Updates(parts)],
             None => {
@@ -871,6 +868,7 @@ where
     /// call it as frequently as they like. Call this [Self::downgrade_since],
     /// or [Self::maybe_downgrade_since] on some interval that is "frequent"
     /// compared to PersistConfig::FAKE_READ_LEASE_DURATION.
+    #[allow(dead_code)]
     pub(crate) async fn maybe_heartbeat_reader(&mut self) {
         let min_elapsed = self.cfg.dynamic.reader_lease_duration() / 2;
         let heartbeat_ts = (self.cfg.now)();


### PR DESCRIPTION
This is vestigial from before we had the background heartbeat tasks.

The motivation is a very odd bug we're seeing in the persist catalog impl. Writes to it are rare-ish, and so this Subscribe only gets new batches rarely. This means the maybe_heartbeat call fires every time it is run. Notably, this updates the last_heartbeat_ts on the read handle. Then, the maybe_downgrade_since call inside the Listen (which would actually update the since and seqno holds) gets skipped every time, causing the shard since to get stuck indefinitely.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
