### PR TITLE
cloudtest: Fix flaky test_cluster_replica_sizes

### DIFF
--- a/test/cloudtest/test_compute.py
+++ b/test/cloudtest/test_compute.py
@@ -10,6 +10,7 @@
 import copy
 import json
 import logging
+import time
 
 import pytest
 from pg8000.exceptions import InterfaceError
@@ -147,37 +148,47 @@ def test_disk_label(mz: MaterializeApplication) -> None:
 
 def test_cluster_replica_sizes(mz: MaterializeApplication) -> None:
     """Test that --cluster-replica-sizes mapping is respected"""
+    # Some time for existing cluster drops to complete so we don't try to spin them up again
+    time.sleep(5)
     cluster_replica_size_map = {
         "small": {
             "scale": 1,
             "workers": 1,
-            "cpu_limit": 2,
-            "credits_per_hour": "0",
+            "cpu_limit": None,
+            "memory_limit": None,
+            "disk_limit": None,
+            "credits_per_hour": "1",
+            "disabled": False,
             "selectors": {"key1": "value1"},
         },
         "medium": {
             "scale": 1,
-            "workers": 4,
-            "cpu_limit": 8,
-            "credits_per_hour": "0",
+            "workers": 1,
+            "cpu_limit": None,
+            "memory_limit": None,
+            "disk_limit": None,
+            "credits_per_hour": "1",
+            "disabled": False,
             "selectors": {"key2": "value2", "key3": "value3"},
         },
         # for existing clusters
         "1": {
             "scale": 1,
             "workers": 1,
-            "cpu_limit": 2,
-            "memory_limit": "8GiB",
-            "disk_limit": "10GiB",
-            "credits_per_hour": "0",
+            "cpu_limit": None,
+            "memory_limit": None,
+            "disk_limit": None,
+            "disabled": False,
+            "credits_per_hour": "1",
         },
         "2-1": {
             "scale": 2,
-            "workers": 1,
-            "cpu_limit": 2,
-            "memory_limit": "8GiB",
-            "disk_limit": "10GiB",
-            "credits_per_hour": "0",
+            "workers": 2,
+            "cpu_limit": None,
+            "memory_limit": None,
+            "disk_limit": None,
+            "disabled": False,
+            "credits_per_hour": "2",
         },
     }
 


### PR DESCRIPTION
Failure seen in https://buildkite.com/materialize/tests/builds/72363#018cd854-7315-4afc-a149-856524374ea8

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
