### PR TITLE
timely-util: separate range bounds from `Partitioned`

### DIFF
--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -634,6 +634,7 @@ mod tests {
     use mz_repr::{GlobalId, RelationDesc, ScalarType, Timestamp};
     use mz_storage_client::util::remap_handle::RemapHandle;
     use mz_storage_types::controller::CollectionMetadata;
+    use mz_storage_types::sources::kafka::RangeBound;
     use mz_storage_types::sources::{MzOffset, SourceData};
     use mz_timely_util::order::Partitioned;
     use once_cell::sync::Lazy;
@@ -673,12 +674,12 @@ mod tests {
         as_of: Antichain<Timestamp>,
     ) -> (
         ReclockOperator<
-            Partitioned<i32, MzOffset>,
+            Partitioned<RangeBound<i32>, MzOffset>,
             Timestamp,
-            impl RemapHandle<FromTime = Partitioned<i32, MzOffset>, IntoTime = Timestamp>,
+            impl RemapHandle<FromTime = Partitioned<RangeBound<i32>, MzOffset>, IntoTime = Timestamp>,
             impl Stream<Item = (Timestamp, Antichain<Timestamp>)>,
         >,
-        ReclockFollower<Partitioned<i32, MzOffset>, Timestamp>,
+        ReclockFollower<Partitioned<RangeBound<i32>, MzOffset>, Timestamp>,
     ) {
         let metadata = CollectionMetadata {
             persist_location: PersistLocation {
@@ -735,22 +736,29 @@ mod tests {
         (operator, follower)
     }
 
-    /// Generates a `Partitioned<i32, MzOffset>` antichain where all the provided
+    /// Generates a `Partitioned<RangeBound<i32>, MzOffset>` antichain where all the provided
     /// partitions are at the specified offset and the gaps in between are filled with range
     /// timestamps at offset zero.
-    fn partitioned_frontier<I>(items: I) -> Antichain<Partitioned<i32, MzOffset>>
+    fn partitioned_frontier<I>(items: I) -> Antichain<Partitioned<RangeBound<i32>, MzOffset>>
     where
         I: IntoIterator<Item = (i32, MzOffset)>,
     {
         let mut frontier = Antichain::new();
-        let mut prev = None;
+        let mut prev = RangeBound::NegInfinity;
         for (pid, offset) in items {
-            assert!(prev.as_ref() < Some(&pid));
-            let gap = Partitioned::with_range(prev.clone(), Some(pid.clone()), MzOffset::from(0));
-            frontier.extend([gap, Partitioned::with_partition(pid.clone(), offset)]);
-            prev = Some(pid);
+            assert!(prev < RangeBound::before(pid));
+            let gap = Partitioned::new_range(prev, RangeBound::before(pid), MzOffset::from(0));
+            frontier.extend([
+                gap,
+                Partitioned::new_singleton(RangeBound::exact(pid), offset),
+            ]);
+            prev = RangeBound::after(pid);
         }
-        frontier.insert(Partitioned::with_range(prev, None, MzOffset::from(0)));
+        frontier.insert(Partitioned::new_range(
+            prev,
+            RangeBound::PosInfinity,
+            MzOffset::from(0),
+        ));
         frontier
     }
 
@@ -762,9 +770,18 @@ mod tests {
 
         // Reclock offsets 1 and 3 to timestamp 1000
         let batch = vec![
-            (1, Partitioned::with_partition(0, MzOffset::from(1))),
-            (1, Partitioned::with_partition(0, MzOffset::from(1))),
-            (3, Partitioned::with_partition(0, MzOffset::from(3))),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
         ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(4))]);
         follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
@@ -788,8 +805,14 @@ mod tests {
 
         // Reclock more messages for offsets 3 to the same timestamp
         let batch = vec![
-            (3, Partitioned::with_partition(0, MzOffset::from(3))),
-            (3, Partitioned::with_partition(0, MzOffset::from(3))),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
         ];
         let reclocked_msgs = follower
             .reclock(batch)
@@ -865,49 +888,77 @@ mod tests {
             BTreeSet::from_iter([
                 // Initial state
                 (
-                    Partitioned::with_range(None, None, MzOffset::from(0)),
+                    Partitioned::new_range(
+                        RangeBound::NegInfinity,
+                        RangeBound::PosInfinity,
+                        MzOffset::from(0)
+                    ),
                     0.into(),
                     1
                 ),
                 // updates from first mint
                 (
-                    Partitioned::with_range(None, Some(1), MzOffset::from(0)),
+                    Partitioned::new_range(
+                        RangeBound::NegInfinity,
+                        RangeBound::before(1),
+                        MzOffset::from(0)
+                    ),
                     1000.into(),
                     1
                 ),
                 (
-                    Partitioned::with_range(None, None, MzOffset::from(0)),
+                    Partitioned::new_range(
+                        RangeBound::NegInfinity,
+                        RangeBound::PosInfinity,
+                        MzOffset::from(0)
+                    ),
                     1000.into(),
                     -1
                 ),
                 (
-                    Partitioned::with_range(Some(1), None, MzOffset::from(0)),
+                    Partitioned::new_range(
+                        RangeBound::after(1),
+                        RangeBound::PosInfinity,
+                        MzOffset::from(0)
+                    ),
                     1000.into(),
                     1
                 ),
                 (
-                    Partitioned::with_partition(1, MzOffset::from(10)),
+                    Partitioned::new_singleton(RangeBound::exact(1), MzOffset::from(10)),
                     1000.into(),
                     1
                 ),
                 // updates from second mint
                 (
-                    Partitioned::with_range(Some(1), Some(2), MzOffset::from(0)),
+                    Partitioned::new_range(
+                        RangeBound::after(1),
+                        RangeBound::before(2),
+                        MzOffset::from(0)
+                    ),
                     2000.into(),
                     1
                 ),
                 (
-                    Partitioned::with_range(Some(1), None, MzOffset::from(0)),
+                    Partitioned::new_range(
+                        RangeBound::after(1),
+                        RangeBound::PosInfinity,
+                        MzOffset::from(0)
+                    ),
                     2000.into(),
                     -1
                 ),
                 (
-                    Partitioned::with_range(Some(2), None, MzOffset::from(0)),
+                    Partitioned::new_range(
+                        RangeBound::after(2),
+                        RangeBound::PosInfinity,
+                        MzOffset::from(0)
+                    ),
                     2000.into(),
                     1
                 ),
                 (
-                    Partitioned::with_partition(2, MzOffset::from(10)),
+                    Partitioned::new_singleton(RangeBound::exact(2), MzOffset::from(10)),
                     2000.into(),
                     1
                 ),
@@ -985,8 +1036,14 @@ mod tests {
 
         // Reclock offsets 1 and 2 to timestamp 1000
         let batch = vec![
-            (1, Partitioned::with_partition(0, MzOffset::from(1))),
-            (2, Partitioned::with_partition(0, MzOffset::from(2))),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
         ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(3))]);
 
@@ -999,8 +1056,14 @@ mod tests {
 
         // Reclock offsets 3 and 4 to timestamp 2000
         let batch = vec![
-            (3, Partitioned::with_partition(0, MzOffset::from(3))),
-            (4, Partitioned::with_partition(0, MzOffset::from(4))),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
         ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(5))]);
 
@@ -1013,8 +1076,14 @@ mod tests {
 
         // Reclock the same offsets again
         let batch = vec![
-            (1, Partitioned::with_partition(0, MzOffset::from(1))),
-            (2, Partitioned::with_partition(0, MzOffset::from(2))),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
         ];
 
         let reclocked_msgs = follower
@@ -1025,10 +1094,22 @@ mod tests {
 
         // Reclock a batch with offsets that spans multiple bindings
         let batch = vec![
-            (1, Partitioned::with_partition(0, MzOffset::from(1))),
-            (2, Partitioned::with_partition(0, MzOffset::from(2))),
-            (3, Partitioned::with_partition(0, MzOffset::from(3))),
-            (4, Partitioned::with_partition(0, MzOffset::from(4))),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
         ];
         let reclocked_msgs = follower
             .reclock(batch)
@@ -1046,10 +1127,22 @@ mod tests {
 
         // Reclock a batch that contains multiple messages having the same offset
         let batch = vec![
-            (1, Partitioned::with_partition(0, MzOffset::from(1))),
-            (1, Partitioned::with_partition(0, MzOffset::from(1))),
-            (3, Partitioned::with_partition(0, MzOffset::from(3))),
-            (3, Partitioned::with_partition(0, MzOffset::from(3))),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
         ];
         let reclocked_msgs = follower
             .reclock(batch)
@@ -1087,7 +1180,10 @@ mod tests {
 
         // Reclockng (0, 50) must ignore the updates on the FromTime frontier that happened at
         // timestamp 2000 since those are completely unrelated
-        let batch = vec![(50, Partitioned::with_partition(0, MzOffset::from(50)))];
+        let batch = vec![(
+            50,
+            Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(50)),
+        )];
         let reclocked_msgs = follower
             .reclock(batch)
             .map(|(m, ts)| (m, ts.unwrap()))
@@ -1125,8 +1221,14 @@ mod tests {
 
         // Reclock offsets 1 and 2 to timestamp 1000
         let batch = vec![
-            (1, Partitioned::with_partition(0, MzOffset::from(1))),
-            (2, Partitioned::with_partition(0, MzOffset::from(2))),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
         ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(3))]);
 
@@ -1139,8 +1241,14 @@ mod tests {
 
         // Reclock offsets 3 and 4 to timestamp 2000
         let batch = vec![
-            (3, Partitioned::with_partition(0, MzOffset::from(3))),
-            (4, Partitioned::with_partition(0, MzOffset::from(4))),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
         ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(5))]);
 
@@ -1159,8 +1267,14 @@ mod tests {
 
         // Reclock offsets 3 and 4 again to see we get the uncompacted result
         let batch = vec![
-            (3, Partitioned::with_partition(0, MzOffset::from(3))),
-            (4, Partitioned::with_partition(0, MzOffset::from(4))),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
         ];
 
         let reclocked_msgs = follower
@@ -1170,7 +1284,7 @@ mod tests {
         assert_eq!(reclocked_msgs, &[(3, 2000.into()), (4, 2000.into())]);
 
         // Attempting to reclock offset 2 should return compacted bindings
-        let src_ts = Partitioned::with_partition(0, MzOffset::from(2));
+        let src_ts = Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2));
         let batch = vec![(2, src_ts.clone())];
 
         let reclocked_msgs = follower
@@ -1185,8 +1299,14 @@ mod tests {
 
         // Reclocking offsets 3 and 4 should succeed
         let batch = vec![
-            (3, Partitioned::with_partition(0, MzOffset::from(3))),
-            (4, Partitioned::with_partition(0, MzOffset::from(4))),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
         ];
 
         let reclocked_msgs = follower
@@ -1196,7 +1316,10 @@ mod tests {
         assert_eq!(reclocked_msgs, &[(3, 2000.into()), (4, 2000.into())]);
 
         // But attempting to reclock offset 2 should return an error
-        let batch = vec![(2, Partitioned::with_partition(0, MzOffset::from(2)))];
+        let batch = vec![(
+            2,
+            Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+        )];
 
         let reclocked_msgs = follower
             .reclock(batch)
@@ -1260,7 +1383,10 @@ mod tests {
         drop(shared_follower);
 
         // Verify that we reclock partition 0 offset 0 correctly
-        let batch = vec![(0, Partitioned::with_partition(0, MzOffset::from(0)))];
+        let batch = vec![(
+            0,
+            Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(0)),
+        )];
         let reclocked_msgs = follower
             .reclock(batch)
             .map(|(m, ts)| (m, ts.unwrap()))
@@ -1281,8 +1407,14 @@ mod tests {
         // Reclock a batch from one of the operators
         // Reclock offsets 1 and 2 to timestamp 1000 from operator A
         let batch = vec![
-            (1, Partitioned::with_partition(0, MzOffset::from(1))),
-            (2, Partitioned::with_partition(0, MzOffset::from(2))),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
         ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(3))]);
 
@@ -1300,10 +1432,22 @@ mod tests {
 
         // Reclock a batch that includes messages from the bindings already minted
         let batch = vec![
-            (1, Partitioned::with_partition(0, MzOffset::from(1))),
-            (2, Partitioned::with_partition(0, MzOffset::from(2))),
-            (3, Partitioned::with_partition(0, MzOffset::from(3))),
-            (4, Partitioned::with_partition(0, MzOffset::from(4))),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
         ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(5))]);
         // This operator should attempt to mint in one go, fail, re-sync, and retry only for the
@@ -1355,8 +1499,14 @@ mod tests {
         // SETUP
         // Reclock offsets 1 and 2 to timestamp 1000
         let batch = vec![
-            (1, Partitioned::with_partition(0, MzOffset::from(1))),
-            (2, Partitioned::with_partition(0, MzOffset::from(2))),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
         ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(3))]);
 
@@ -1368,8 +1518,14 @@ mod tests {
         assert_eq!(reclocked_msgs, &[(1, 1000.into()), (2, 1000.into())]);
         // Reclock offsets 3 and 4 to timestamp 2000
         let batch = vec![
-            (3, Partitioned::with_partition(0, MzOffset::from(3))),
-            (4, Partitioned::with_partition(0, MzOffset::from(4))),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
         ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(5))]);
 
@@ -1381,8 +1537,14 @@ mod tests {
         assert_eq!(reclocked_msgs, &[(3, 2000.into()), (4, 2000.into())]);
         // Reclock offsets 5 and 6 to timestamp 3000
         let batch = vec![
-            (5, Partitioned::with_partition(0, MzOffset::from(5))),
-            (6, Partitioned::with_partition(0, MzOffset::from(6))),
+            (
+                5,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(5)),
+            ),
+            (
+                6,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(6)),
+            ),
         ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(7))]);
 

--- a/src/timely-util/src/order.rs
+++ b/src/timely-util/src/order.rs
@@ -16,140 +16,87 @@
 //! Traits and types for partially ordered sets.
 
 use std::cmp::Ordering;
-use std::fmt;
+use std::fmt::{self, Debug};
+use std::hash::Hash;
 
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use timely::communication::Data;
 use timely::order::Product;
 use timely::progress::timestamp::{PathSummary, Refines, Timestamp};
 use timely::progress::Antichain;
 use timely::PartialOrder;
 
 /// A partially ordered timestamp that is partitioned by an arbitrary number of partitions
-/// identified by `P`. The construction allows for efficient representation frontiers with
+/// identified by `P`. The construction allows for efficient representation of frontiers with
 /// Antichains.
 ///
-/// ## The problem of partitioned timestamps
+/// A `Partitioned<P, T>` timestamp is internally the product order of an `Interval<P>` and a bare
+/// timestamp `T`. An `Interval<P>` represents an inclusive range of values from the type `P` and
+/// its partial order corresponds to the subset order.
 ///
-/// To understand this timestamp it helps to first think about how one would represent a
-/// partitioned, partially ordered timestamp type where each partition follows its own independent
-/// timeline in a natural way. Timely requires that all timestamps have a minimum element that is
-/// less than all other elements so you could express a partitioned timestamp like so:
-///
-/// ```rust
-/// enum Partitioned<P, T> {
-///     Bottom,
-///     Partition(P, T),
-/// }
-/// ```
-/// Laying out the order in a graph we'd see something like this:
-///
-/// ```text
-///           -----(P1, T0)---(P1, T1)--- ... ---(P1, Tn)
-///          / ----(P2, T0)---(P2, T1)--- ... ---(P2, Tn)
-///         / / ,--(P3, T0)---(P3, T1)--- ... ---(P3, Tn)
-/// Bottom-+-+-+     .
-///         \        .
-///          \       .
-///           '----(Pn, T0)---(Pn, T1)--- ... ---(Pn, Tn)
-/// ```
-///
-/// This timestamp has the problem that if you want to downgrade your operator's capability to
-/// indicate progress in one of the partitions, which implies dropping your `Bottom` capability,
-/// you are forced to also mint one capability per partition that you intend to produce data for in
-/// the future. If those partitions are unknown or, even worse, infinite, this type brings you to a
-/// dead end.
-///
-/// ## How this type works
-///
-/// The idea of this `Partitioned` timestamp is to extend the idea of the `Bottom` element above
-/// into a `Range` element that is parameterized by a lower and upper bound and represents a
-/// *range* of partitions at some timestamp `T`. The represented range has exclusive bounds.
-///
-/// The minimum timestamp of this type is `Product(Range(Bottom, Top), T::minimum())` which is less
-/// than any other `Range` element and all `Point` elements. Now, suppose an operator needs to
-/// start working on some partition `P1` and present progress. All it has to do is downgrade its
-/// `Antichain { Product(Range(Bottom, Top), 0) }` frontier in this frontier: `Antichain {
-/// Product(Range(Bottom, Elem(P1)), 0), Product(Point(P1), T::minimum()), Product(Range(Elem(P1),
-/// Top), 0) }`.
-///
-/// Essentially a `Range` element can be split at some partition P iff that partition is within
-/// its range and produce two more `Range` elements representing the range to the left and to the
-/// right of the partition respectively, plus a timestamp for the desired partition that can now be
-/// downgraded individually to present progress.
+/// Effectively, the minimum `Partitioned` timestamp will start out with the maximum possible
+/// `Interval<P>` on one side and the minimum timestamp `T` on the other side. Users of this
+/// timestamp can selectively downgrade the timestamp by advancing `T`, shrinking the interval, or
+/// both.
 ///
 /// Antichains of this type are efficient in storage. In the worst case, where all chosen
 /// partitions have gaps between them, the produced antichain has twice as many elements as
-/// partitions.
+/// partitions. This is because the "dead space" between the selected partitions must have a
+/// representative timestamp in order for that space to be useable in the future.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Partitioned<P, T>(Product<Interval<P>, T>);
 
-impl<P: fmt::Display, T: fmt::Display> fmt::Display for Partitioned<P, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.write_str("(")?;
-        match self.interval() {
-            Interval::Range(lower, upper) => {
-                match lower {
-                    RangeBound::Elem(p) => p.fmt(f)?,
-                    RangeBound::Bottom => f.write_str("-inf")?,
-                    RangeBound::Top => unreachable!(),
-                }
-                f.write_str("..")?;
-                match upper {
-                    RangeBound::Elem(p) => p.fmt(f)?,
-                    RangeBound::Top => f.write_str("+inf")?,
-                    RangeBound::Bottom => unreachable!(),
-                }
-            }
-            Interval::Point(p) => p.fmt(f)?,
-        }
-        f.write_str(", ")?;
-        self.timestamp().fmt(f)?;
-        f.write_str(")")?;
-        Ok(())
-    }
-}
-
-impl<P, T> Partitioned<P, T> {
-    /// Construct a new timestamp for a specific partition
-    pub fn with_partition(partition: P, timestamp: T) -> Self {
-        Self(Product::new(Interval::Point(partition), timestamp))
+impl<P: Clone + PartialOrd, T> Partitioned<P, T> {
+    /// Constructs a new timestamp for a specific partition.
+    pub fn new_singleton(partition: P, timestamp: T) -> Self {
+        let interval = Interval {
+            lower: partition.clone(),
+            upper: partition,
+        };
+        Self(Product::new(interval, timestamp))
     }
 
-    /// Construct a new timestamp for an exclusive partition range
-    pub fn with_range(lower: Option<P>, upper: Option<P>, timestamp: T) -> Self {
-        let lower = lower.map(RangeBound::Elem).unwrap_or(RangeBound::Bottom);
-        let upper = upper.map(RangeBound::Elem).unwrap_or(RangeBound::Top);
-        Self(Product::new(Interval::Range(lower, upper), timestamp))
+    /// Constructs a new timestamp for a partition range.
+    pub fn new_range(lower: P, upper: P, timestamp: T) -> Self {
+        assert!(lower <= upper, "invalid range bounds");
+        Self(Product::new(Interval { lower, upper }, timestamp))
     }
 
-    /// Access the interval of this partitioned timestamp
+    /// Returns the interval component of this partitioned timestamp.
     pub fn interval(&self) -> &Interval<P> {
         &self.0.outer
     }
 
-    /// Returns the partition of this timestamp if it's not a range timestamp
-    pub fn partition(&self) -> Option<&P> {
-        match self.0.outer {
-            Interval::Point(ref partition) => Some(partition),
-            Interval::Range(_, _) => None,
-        }
-    }
-
-    /// Returns the timestamp of this partition interval
+    /// Returns the timestamp component of this partitioned timestamp.
     pub fn timestamp(&self) -> &T {
         &self.0.inner
     }
 }
 
-impl<P: Partition, T: Timestamp> Timestamp for Partitioned<P, T> {
-    type Summary = PartitionedSummary<P, T>;
+impl<P: fmt::Display, T: fmt::Display> fmt::Display for Partitioned<P, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str("(")?;
+        self.0.outer.fmt(f)?;
+        f.write_str(", ")?;
+        self.0.inner.fmt(f)?;
+        f.write_str(")")?;
+        Ok(())
+    }
+}
+
+impl<P, T: Timestamp> Timestamp for Partitioned<P, T>
+where
+    P: Extrema + Clone + Debug + Data + Hash + Ord,
+{
+    type Summary = ();
     fn minimum() -> Self {
         Self(Timestamp::minimum())
     }
 }
-
-impl<P: Partition, T: Timestamp> Refines<()> for Partitioned<P, T> {
+impl<P, T: Timestamp> Refines<()> for Partitioned<P, T>
+where
+    P: Extrema + Clone + Debug + Data + Hash + Ord,
+{
     fn to_inner(_other: ()) -> Self {
         Self::minimum()
     }
@@ -159,207 +106,111 @@ impl<P: Partition, T: Timestamp> Refines<()> for Partitioned<P, T> {
     fn summarize(_path: Self::Summary) {}
 }
 
-impl<P: Eq, T: PartialOrder> PartialOrder for Partitioned<P, T>
-where
-    Interval<P>: PartialOrder,
-{
+impl<P: Ord + Eq, T: PartialOrder> PartialOrder for Partitioned<P, T> {
     #[inline]
     fn less_equal(&self, other: &Self) -> bool {
         self.0.less_equal(&other.0)
     }
 }
-
-/// Helper type alias to access to access the Summary type of a Timestamp implementing type
-type Summary<T> = <T as Timestamp>::Summary;
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct PartitionedSummary<P: Partition, T: Timestamp>(
-    Product<Summary<Interval<P>>, Summary<T>>,
-);
-
-impl<P: Partition, T: Timestamp> Default for PartitionedSummary<P, T> {
-    fn default() -> Self {
-        PartitionedSummary(Default::default())
-    }
-}
-
-impl<P: Partition, T: Timestamp> PartialOrder for PartitionedSummary<P, T> {
-    #[inline]
-    fn less_equal(&self, other: &Self) -> bool {
-        self.0.less_equal(&other.0)
-    }
-}
-
-impl<P: Partition, T: Timestamp> PathSummary<Partitioned<P, T>> for PartitionedSummary<P, T> {
+impl<P: Clone, T: Timestamp> PathSummary<Partitioned<P, T>> for () {
     #[inline]
     fn results_in(&self, src: &Partitioned<P, T>) -> Option<Partitioned<P, T>> {
-        self.0.results_in(&src.0).map(Partitioned)
+        Some(src.clone())
     }
 
     #[inline]
-    fn followed_by(&self, other: &Self) -> Option<Self> {
-        PathSummary::<Product<Interval<P>, T>>::followed_by(&self.0, &other.0)
-            .map(PartitionedSummary)
+    fn followed_by(&self, _other: &Self) -> Option<Self> {
+        Some(())
     }
 }
 
-impl<P: Partition, T: Timestamp> PartitionedSummary<P, T> {
-    /// Construct a new summary for a specific partition
-    pub fn with_partition(partition: P, timestamp: Summary<T>) -> Self {
-        Self(Product::new(Interval::Point(partition), timestamp))
-    }
+/// A trait defining the minimum and maximum values of a type.
+pub trait Extrema {
+    /// The minimum value of this type.
+    fn minimum() -> Self;
+    /// The maximum value of this type.
+    fn maximum() -> Self;
+}
 
-    /// Construct a new summary for an exclusive partition range
-    pub fn with_range(lower: Option<P>, upper: Option<P>, timestamp: Summary<T>) -> Self {
-        let lower = lower.map(RangeBound::Elem).unwrap_or(RangeBound::Bottom);
-        let upper = upper.map(RangeBound::Elem).unwrap_or(RangeBound::Top);
-        Self(Product::new(Interval::Range(lower, upper), timestamp))
+impl Extrema for u64 {
+    fn minimum() -> Self {
+        Self::MIN
+    }
+    fn maximum() -> Self {
+        Self::MAX
+    }
+}
+
+impl Extrema for i32 {
+    fn minimum() -> Self {
+        Self::MIN
+    }
+    fn maximum() -> Self {
+        Self::MAX
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-/// A type that represents either an exclusive range or a particular point. When representing a
-/// range either of the two bounds can be minus or positive infinity.
-pub enum Interval<P> {
-    /// A range of points
-    Range(RangeBound<P>, RangeBound<P>),
-    /// A single point
-    Point(P),
+/// A type representing an inclusive interval of type `P`, ordered under the subset relation.
+pub struct Interval<P> {
+    pub lower: P,
+    pub upper: P,
+}
+
+impl<P: Eq> Interval<P> {
+    /// Returns the contained element if it's a singleton set.
+    pub fn singleton(&self) -> Option<&P> {
+        if self.lower == self.upper {
+            Some(&self.lower)
+        } else {
+            None
+        }
+    }
 }
 
 impl<P: Ord + Eq> PartialOrder for Interval<P> {
     #[inline]
     fn less_equal(&self, other: &Self) -> bool {
-        use Interval::*;
-        match (self, other) {
-            (Range(self_lower, self_upper), Range(other_lower, other_upper)) => {
-                self_lower <= other_lower && other_upper <= self_upper
-            }
-            (Range(lower, upper), Point(p)) => lower < p && upper > p,
-            (Point(self_p), Point(other_p)) => self_p == other_p,
-            // No Point element is less than a Range element
-            (Point(_), Range(_, _)) => false,
-        }
+        self.lower <= other.lower && other.upper <= self.upper
     }
 }
 
-impl<P: Partition> PathSummary<Interval<P>> for Interval<P> {
+impl<P: Clone> PathSummary<Interval<P>> for () {
     #[inline]
     fn results_in(&self, src: &Interval<P>) -> Option<Interval<P>> {
-        use std::cmp::{max, min};
-
-        use Interval::*;
-        match (self, src) {
-            // A range followed by another range contraints the range
-            (Range(self_lower, self_upper), Range(other_lower, other_upper)) => {
-                let new_lower = max(self_lower, other_lower);
-                let new_upper = min(self_upper, other_upper);
-                if new_lower < new_upper {
-                    Some(Interval::Range(new_lower.clone(), new_upper.clone()))
-                } else {
-                    None
-                }
-            }
-            // A range followed by an in-range partition or a partition followed by a range that
-            // includes it keeps the partition
-            (Range(lower, upper), Point(p)) | (Point(p), Range(lower, upper)) => {
-                if lower < p && upper > p {
-                    Some(Interval::Point(p.clone()))
-                } else {
-                    None
-                }
-            }
-            // A partition followed by the same partition results in that partition
-            (Point(self_p), Point(other_p)) => {
-                if self_p == other_p {
-                    Some(Point(self_p.clone()))
-                } else {
-                    None
-                }
-            }
-        }
+        Some(src.clone())
     }
 
     #[inline]
-    fn followed_by(&self, other: &Self) -> Option<Self> {
-        self.results_in(other)
+    fn followed_by(&self, _other: &Self) -> Option<Self> {
+        Some(())
     }
 }
 
-impl<P: Partition> Timestamp for Interval<P> {
-    type Summary = Interval<P>;
+impl<P> Timestamp for Interval<P>
+where
+    P: Extrema + Clone + Debug + Data + Hash + Ord,
+{
+    type Summary = ();
 
     #[inline]
     fn minimum() -> Self {
-        Self::default()
-    }
-}
-
-impl<P> Default for Interval<P> {
-    #[inline]
-    fn default() -> Self {
-        Self::Range(RangeBound::Bottom, RangeBound::Top)
-    }
-}
-
-/// Type to represent the lower or upper bound of an exclusive range
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub enum RangeBound<P> {
-    /// An element that is less than any other element P
-    Bottom,
-    /// An element P
-    Elem(P),
-    /// An element that is greather than any other element P
-    Top,
-}
-
-impl<P: PartialEq> PartialEq<P> for RangeBound<P> {
-    #[inline]
-    fn eq(&self, other: &P) -> bool {
-        match self {
-            RangeBound::Bottom => false,
-            RangeBound::Elem(p) => p.eq(other),
-            RangeBound::Top => false,
+        Self {
+            lower: P::minimum(),
+            upper: P::maximum(),
         }
     }
 }
 
-impl<P: PartialOrd> PartialOrd<P> for RangeBound<P> {
-    #[inline]
-    fn partial_cmp(&self, other: &P) -> Option<Ordering> {
-        match self {
-            RangeBound::Bottom => Some(Ordering::Less),
-            RangeBound::Elem(p) => p.partial_cmp(other),
-            RangeBound::Top => Some(Ordering::Greater),
-        }
+impl<P: fmt::Display> fmt::Display for Interval<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[")?;
+        self.lower.fmt(f)?;
+        f.write_str(", ")?;
+        self.upper.fmt(f)?;
+        f.write_str("]")?;
+        Ok(())
     }
-}
-
-/// A supertrait of all the required trait a partition type must have
-pub trait Partition:
-    Clone
-    + std::fmt::Debug
-    + Send
-    + Sync
-    + Serialize
-    + DeserializeOwned
-    + std::hash::Hash
-    + Ord
-    + 'static
-{
-}
-
-impl<P> Partition for P where
-    P: Clone
-        + std::fmt::Debug
-        + Send
-        + Sync
-        + Serialize
-        + DeserializeOwned
-        + std::hash::Hash
-        + Ord
-        + 'static
-{
 }
 
 /// A helper struct for reverse partial ordering.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR is motivated by the MySQL source which will have a nicer time defining its timestamp with this simplification in place.

Previously the `Partitioned` timestamp type was opinionated about the structure of the range of partitions, enforcing the existence of positive and negative infinity elements (even if the inner type had a perfectly fine minimum and maximum value) and the distinction between singleton inclusive sets from range exclusive sets.

This PR simplifies the `Partitioned` timestamp to always encode an inclusive range of elements made up of some type `P` that must have extremas defined. The previous semantics of additional elements can then be regained by using an appropriate `P` type and this is exactly what the Kafka source timestamp has been changed to do.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

The first commit is the one that needs close reviewing since that's the one changing the API. The second commit is a mechanical change of all usages.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
