### PR TITLE
Report hydration status for subsources

### DIFF
--- a/test/testdrive/hydration-status.td
+++ b/test/testdrive/hydration-status.td
@@ -181,7 +181,10 @@ mv  hydrated_test_3 true
 
 # Test adding new storage dataflows.
 
-> CREATE SOURCE src IN CLUSTER test FROM LOAD GENERATOR counter
+> CREATE SOURCE src
+  IN CLUSTER test
+  FROM LOAD GENERATOR auction
+  FOR ALL TABLES
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
 > CREATE CONNECTION csr_conn
@@ -193,6 +196,10 @@ mv  hydrated_test_3 true
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
 
+# Webhook sources are not backed by dataflows, so they have no concept of
+# hydration and shouldn't show up in mz_hydration_statuses.
+> CREATE SOURCE web IN CLUSTER test FROM WEBHOOK BODY FORMAT JSON
+
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
   JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
@@ -200,9 +207,14 @@ mv  hydrated_test_3 true
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
-mv  hydrated_test_3 true
-src hydrated_test_3 true
-snk hydrated_test_3 true
+accounts      hydrated_test_3 true
+auctions      hydrated_test_3 true
+bids          hydrated_test_3 true
+mv            hydrated_test_3 true
+organizations hydrated_test_3 true
+src           hydrated_test_3 true
+snk           hydrated_test_3 true
+users         hydrated_test_3 true
 
 # Test dropping replicas.
 
@@ -227,9 +239,14 @@ snk hydrated_test_3 true
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
-mv  hydrated_test_4 true
-src hydrated_test_4 true
-snk hydrated_test_4 true
+accounts      hydrated_test_4 true
+auctions      hydrated_test_4 true
+bids          hydrated_test_4 true
+mv            hydrated_test_4 true
+organizations hydrated_test_4 true
+src           hydrated_test_4 true
+snk           hydrated_test_4 true
+users         hydrated_test_4 true
 
 # Test dropping dataflows.
 


### PR DESCRIPTION
This PR adjusts the `mz_hydration_statuses` view to ensure that we also report a hydration status for subsources, not just their parents. This didn't work previously because the view assumed that `mz_sources` contains `cluster_id`s for subsources, which is actually not the case.

### Motivation

  * This PR fixes a previously unreported bug.

Subsources are missing from `mz_hydration_statuses`.

### Tips for reviewer

I also attempted to include `cluster_id`s for subsources in `mz_sources` instead, but that is more involved than it initially seems. See https://github.com/MaterializeInc/materialize/issues/24235.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A