### PR TITLE
add feature flag to always enable disk on kube replicas

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -270,5 +270,6 @@ pub fn orchestrator_scheduling_config(config: &SystemVars) -> ServiceSchedulingC
         },
         soften_az_affinity: config.cluster_soften_az_affinity(),
         soften_az_affinity_weight: config.cluster_soften_az_affinity_weight(),
+        always_use_disk: config.cluster_always_use_disk(),
     }
 }

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -772,6 +772,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         // This is extremely cheap to clone, so just look into the lock once.
         let scheduling_config: ServiceSchedulingConfig =
             self.scheduling_config.read().expect("poisoned").clone();
+        let disk = scheduling_config.always_use_disk || disk;
 
         let name = format!("{}-{id}", self.namespace);
         // The match labels should be the minimal set of labels that uniquely

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -504,6 +504,11 @@ pub mod scheduling_config {
         ///
         /// Defaults to `100`.
         pub soften_az_affinity_weight: i32,
+        /// Whether to always provision a replica with disk,
+        /// regardless of `DISK` DDL option.
+        ///
+        /// Defaults to `false`.
+        pub always_use_disk: bool,
     }
 
     pub const DEFAULT_POD_AZ_AFFINITY_WEIGHT: Option<i32> = Some(100);
@@ -517,6 +522,7 @@ pub mod scheduling_config {
 
     pub const DEFAULT_SOFTEN_AZ_AFFINITY: bool = false;
     pub const DEFAULT_SOFTEN_AZ_AFFINITY_WEIGHT: i32 = 100;
+    pub const DEFAULT_ALWAYS_USE_DISK: bool = false;
 
     impl Default for ServiceSchedulingConfig {
         fn default() -> Self {
@@ -533,6 +539,7 @@ pub mod scheduling_config {
                 },
                 soften_az_affinity: DEFAULT_SOFTEN_AZ_AFFINITY,
                 soften_az_affinity_weight: DEFAULT_SOFTEN_AZ_AFFINITY_WEIGHT,
+                always_use_disk: DEFAULT_ALWAYS_USE_DISK,
             }
         }
     }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1738,6 +1738,13 @@ mod cluster_scheduling {
         description: "The preference weight for `cluster_soften_az_affinity` (Materialize).",
         internal: true,
     };
+
+    pub const CLUSTER_ALWAYS_USE_DISK: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("cluster_always_use_disk"),
+        value: DEFAULT_ALWAYS_USE_DISK,
+        description: "Always provisions a replica with disk, regardless of `DISK` DDL option.",
+        internal: true,
+    };
 }
 
 /// Macro to simplify creating feature flags, i.e. boolean flags that we use to toggle the
@@ -3022,6 +3029,7 @@ impl SystemVars {
             .with_var(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT)
             .with_var(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY)
             .with_var(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT)
+            .with_var(&cluster_scheduling::CLUSTER_ALWAYS_USE_DISK)
             .with_var(&grpc_client::HTTP2_KEEP_ALIVE_TIMEOUT)
             .with_value_constrained_var(
                 &STATEMENT_LOGGING_MAX_SAMPLE_RATE,
@@ -3867,6 +3875,10 @@ impl SystemVars {
 
     pub fn cluster_soften_az_affinity_weight(&self) -> i32 {
         *self.expect_value(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT)
+    }
+
+    pub fn cluster_always_use_disk(&self) -> bool {
+        *self.expect_value(&cluster_scheduling::CLUSTER_ALWAYS_USE_DISK)
     }
 
     /// Returns the `privatelink_status_update_quota_per_minute` configuration parameter.
@@ -5599,6 +5611,7 @@ pub fn is_cluster_scheduling_var(name: &str) -> bool {
         || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT.name()
         || name == cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY.name()
         || name == cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT.name()
+        || name == cluster_scheduling::CLUSTER_ALWAYS_USE_DISK.name()
 }
 
 /// Returns whether the named variable is an HTTP server related config var.

--- a/test/cloudtest/test_disk.py
+++ b/test/cloudtest/test_disk.py
@@ -166,6 +166,7 @@ def test_always_use_disk_replica(mz: MaterializeApplication) -> None:
         )
     )
 
+
 def test_no_disk_replica(mz: MaterializeApplication) -> None:
     """Testing `DISK = false` cluster replicas"""
     mz.testdrive.run(

--- a/test/cloudtest/test_disk.py
+++ b/test/cloudtest/test_disk.py
@@ -88,6 +88,84 @@ def test_disk_replica(mz: MaterializeApplication) -> None:
     )
 
 
+def test_always_use_disk_replica(mz: MaterializeApplication) -> None:
+    """Testing `DISK = false, cluster_always_use_disk = true` cluster replicas"""
+    mz.environmentd.sql(
+        "ALTER SYSTEM SET cluster_always_use_disk = true",
+        port="internal",
+        user="mz_system",
+    )
+
+    mz.testdrive.run(
+        input=dedent(
+            """
+            $ kafka-create-topic topic=test
+
+            $ kafka-ingest key-format=bytes format=bytes topic=test
+            key1:val1
+            key2:val2
+
+            > CREATE CLUSTER disk_cluster2
+                REPLICAS (r1 (SIZE '1'))
+
+            > CREATE CONNECTION IF NOT EXISTS kafka TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
+
+            > CREATE SOURCE source1
+              IN CLUSTER disk_cluster2
+              FROM KAFKA CONNECTION kafka
+              (TOPIC 'testdrive-test-${testdrive.seed}')
+              KEY FORMAT TEXT
+              VALUE FORMAT TEXT
+              ENVELOPE UPSERT;
+
+
+            > SELECT * FROM source1;
+            key           text
+            ------------------
+            key1          val1
+            key2          val2
+
+            $ kafka-ingest key-format=bytes format=bytes topic=test
+            key1:val3
+
+            > SELECT * FROM source1;
+            key           text
+            ------------------
+            key1          val3
+            key2          val2
+            """
+        )
+    )
+
+    cluster_id, replica_id = mz.environmentd.sql_query(
+        "SELECT r.cluster_id, r.id as replica_id FROM mz_cluster_replicas r, mz_clusters c WHERE c.id = r.cluster_id AND c.name = 'disk_cluster2';"
+    )[0]
+
+    source_global_id = mz.environmentd.sql_query(
+        "SELECT id FROM mz_sources WHERE name = 'source1';"
+    )[0][0]
+
+    # verify that the replica's scratch directory contains data files for source1
+    on_disk_sources = mz.kubectl(
+        "exec",
+        cluster_pod_name(cluster_id, replica_id),
+        "-c",
+        "clusterd",
+        "--",
+        "bash",
+        "-c",
+        "ls /scratch/storage/upsert",
+    )
+    assert source_global_id in on_disk_sources
+
+    mz.testdrive.run(
+        input=dedent(
+            """
+            > DROP CLUSTER disk_cluster2 CASCADE
+            """
+        )
+    )
+
 def test_no_disk_replica(mz: MaterializeApplication) -> None:
     """Testing `DISK = false` cluster replicas"""
     mz.testdrive.run(


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Adds a quick feature flag, `cluster_always_use_disk` that informs the KubernetesOrchestrator to always provision a cluster with disk, even without the `DISK` option. This will make it easier to roll out `lgalloc`, though we'll want to be mindful of how it impacts upsert sources, since they switch to using spill2disk if they detect the scratch directory.

I'm not 100% sure I grok all the implications of forcing disk within the Orchestrator, rather than doing it within the catalog. Would appreciate if someone could double check that it's reasonable to do!

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
