### PR TITLE
timely-util: poll async input handles on every scheduling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6027,7 +6027,6 @@ dependencies = [
  "futures-util",
  "mz-ore",
  "num-traits",
- "polonius-the-crab",
  "proptest",
  "serde",
  "timely",
@@ -6836,12 +6835,6 @@ checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
 dependencies = [
  "plotters-backend",
 ]
-
-[[package]]
-name = "polonius-the-crab"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0119ad75060c93b2017796396280ab9c1870738bf3b66a8cb20deb3c9075426"
 
 [[package]]
 name = "portable-atomic"

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -292,14 +292,12 @@ where
 
     // The description and the data-passthrough outputs are both driven by this input, so
     // they use a standard input connection.
-    let mut desired_input = mint_op.new_input(desired_stream, Pipeline);
+    let mut desired_input =
+        mint_op.new_input_for_many(desired_stream, Pipeline, [&output, &data_output]);
 
-    let mut persist_feedback_input = mint_op.new_input_connection(
-        persist_feedback_stream,
-        Pipeline,
-        // Neither output's capabilities should depend on the feedback input.
-        vec![Antichain::new(), Antichain::new()],
-    );
+    // Neither output's capabilities should depend on the feedback input.
+    let mut persist_feedback_input =
+        mint_op.new_disconnected_input(persist_feedback_stream, Pipeline);
 
     let shutdown_button = mint_op.build(move |capabilities| async move {
         // Non-active workers should just pass the data through.
@@ -308,10 +306,12 @@ where
             // its capability here. The data-passthrough output just uses the data
             // capabilities.
             drop(capabilities);
-            while let Some(event) = desired_input.next_mut().await {
+            while let Some(event) = desired_input.next().await {
                 match event {
-                    Event::Data(cap, data) => {
-                        data_output.give_container(&cap, data).await;
+                    Event::Data([_output_cap, data_output_cap], mut data) => {
+                        data_output
+                            .give_container(&data_output_cap, &mut data)
+                            .await;
                     }
                     Event::Progress(_) => {}
                 }
@@ -398,11 +398,11 @@ where
 
         loop {
             tokio::select! {
-                Some(event) = desired_input.next_mut() => {
+                Some(event) = desired_input.next() => {
                     match event {
-                        Event::Data(cap, data) => {
+                        Event::Data([_output_cap, data_output_cap], mut data) => {
                             // Just passthrough the data.
-                            data_output.give_container(&cap, data).await;
+                            data_output.give_container(&data_output_cap, &mut data).await;
                             continue;
                         }
                         Event::Progress(frontier) => {
@@ -588,28 +588,27 @@ where
 
     let (mut output, output_stream) = write_op.new_output();
 
-    let mut descriptions_input = write_op.new_input(&batch_descriptions.broadcast(), Pipeline);
-    let mut desired_input = write_op.new_input(
+    let mut descriptions_input =
+        write_op.new_input_for(&batch_descriptions.broadcast(), Pipeline, &output);
+    let mut desired_input = write_op.new_input_for(
         desired_stream,
         Exchange::new(
             move |(row, _ts, _diff): &(Result<Row, DataflowError>, Timestamp, Diff)| row.hashed(),
         ),
+        &output,
     );
-    let mut persist_input = write_op.new_input_connection(
+    // This input is disconnected so that the persist frontier is not taken into account when
+    // determining downstream implications. We're only interested in the frontier to know when we
+    // are ready to write out new data (when the corrections have "settled"). But the persist
+    // frontier must not hold back the downstream frontier, otherwise the `append_batches` operator
+    // would never append batches because it waits for its input frontier to advance before it does
+    // so. The input frontier would never advance if we don't write new updates to persist, leading
+    // to a Catch-22-type situation.
+    let mut persist_input = write_op.new_disconnected_input(
         persist_stream,
         Exchange::new(
             move |(row, _ts, _diff): &(Result<Row, DataflowError>, Timestamp, Diff)| row.hashed(),
         ),
-        // This connection specification makes sure that the persist frontier is
-        // not taken into account when determining downstream implications.
-        // We're only interested in the frontier to know when we are ready to
-        // write out new data (when the corrections have "settled"). But the
-        // persist frontier must not hold back the downstream frontier,
-        // otherwise the `append_batches` operator would never append batches
-        // because it waits for its input frontier to advance before it does so.
-        // The input frontier would never advance if we don't write new updates
-        // to persist, leading to a Catch-22-type situation.
-        vec![Antichain::new()],
     );
 
     // This operator accepts the current and desired update streams for a `persist` shard.
@@ -662,11 +661,11 @@ where
 
         loop {
             tokio::select! {
-                Some(event) = descriptions_input.next_mut() => {
+                Some(event) = descriptions_input.next() => {
                     match event {
                         Event::Data(cap, data) => {
                             // Ingest new batch descriptions.
-                            for description in data.drain(..) {
+                            for description in data {
                                 if sink_id.is_user() {
                                     trace!(
                                         "persist_sink {sink_id}/{shard_id}: \
@@ -702,9 +701,9 @@ where
                         }
                     }
                 }
-                Some(event) = desired_input.next_mut() => {
+                Some(event) = desired_input.next() => {
                     match event {
-                        Event::Data(_cap, data) => {
+                        Event::Data(_cap, mut data) => {
                             // Extract desired rows as positive contributions to `correction`.
                             if sink_id.is_user() && !data.is_empty() {
                                 trace!(
@@ -721,7 +720,7 @@ where
                                     persist_frontier
                                 );
                             }
-                            correction.with_correction_buffer(sink_metrics, sink_worker_metrics, |buffer| buffer.append(data));
+                            correction.with_correction_buffer(sink_metrics, sink_worker_metrics, |buffer| buffer.append(&mut data));
 
                             continue;
                         }
@@ -730,9 +729,9 @@ where
                         }
                     }
                 }
-                Some(event) = persist_input.next_mut() => {
+                Some(event) = persist_input.next() => {
                     match event {
-                        Event::Data(_cap, data) => {
+                        Event::Data(_cap, mut data) => {
                             // Extract persist rows as negative contributions to `correction`.
                             correction.with_correction_buffer(sink_metrics, sink_worker_metrics, |buffer| buffer.extend(data.drain(..).map(|(d, t, r)| (d, t, -r))));
 
@@ -950,16 +949,10 @@ where
     // when we either append to persist successfully or when we learn about a
     // new current frontier because a `compare_and_append` failed. That's why
     // input capability tracking is not connected to the output.
-    let mut descriptions_input = append_op.new_input_connection(
-        batch_descriptions,
-        Exchange::new(move |_| hashed_id),
-        vec![Antichain::new()],
-    );
-    let mut batches_input = append_op.new_input_connection(
-        batches,
-        Exchange::new(move |_| hashed_id),
-        vec![Antichain::new()],
-    );
+    let mut descriptions_input =
+        append_op.new_disconnected_input(batch_descriptions, Exchange::new(move |_| hashed_id));
+    let mut batches_input =
+        append_op.new_disconnected_input(batches, Exchange::new(move |_| hashed_id));
 
     // This operator accepts the batch descriptions and tokens that represent
     // written batches. Written batches get appended to persist when we learn
@@ -1020,11 +1013,11 @@ where
 
         loop {
             tokio::select! {
-                Some(event) = descriptions_input.next_mut() => {
+                Some(event) = descriptions_input.next() => {
                     match event {
                         Event::Data(_cap, data) => {
                             // Ingest new batch descriptions.
-                            for batch_description in data.drain(..) {
+                            for batch_description in data {
                                 if sink_id.is_user() {
                                     trace!(
                                         "persist_sink {sink_id}/{shard_id}: \
@@ -1054,11 +1047,11 @@ where
                         }
                     }
                 }
-                Some(event) = batches_input.next_mut() => {
+                Some(event) = batches_input.next() => {
                     match event {
                         Event::Data(_cap, data) => {
                             // Ingest new written batches
-                            for batch in data.drain(..) {
+                            for batch in data {
                                 match batch {
                                     BatchOrData::Batch(batch) => {
                                         let batch = write.batch_from_transmittable_batch(batch);

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -646,9 +646,8 @@ where
     );
     let (mut data_output, data_stream) = builder.new_output();
 
-    let mut data_input = builder.new_input_connection(data, Pipeline, vec![Antichain::new()]);
-    let mut flow_control_input =
-        builder.new_input_connection(&summaried_flow, Pipeline, vec![Antichain::new()]);
+    let mut data_input = builder.new_disconnected_input(data, Pipeline);
+    let mut flow_control_input = builder.new_disconnected_input(&summaried_flow, Pipeline);
 
     // Helper method used to synthesize current and next frontier for ordered times.
     fn synthesize_frontiers<T: PartialOrder + Clone>(
@@ -676,7 +675,7 @@ where
         let mut part_number = 0;
         let mut parts: Vec<((T, Subtime), O)> = Vec::new();
         loop {
-            match data_input.next_mut().await {
+            match data_input.next().await {
                 None => {
                     let empty = Antichain::new();
                     parts.sort_by_key(|val| val.0.clone());
@@ -690,9 +689,9 @@ where
                     }
                     break;
                 }
-                Some(Event::Data(cap, data)) => {
-                    for d in data.drain(..) {
-                        parts.push((cap.time().clone(), d));
+                Some(Event::Data(time, data)) => {
+                    for d in data {
+                        parts.push((time.clone(), d));
                     }
                 }
                 Some(Event::Progress(prog)) => {
@@ -1336,8 +1335,8 @@ mod tests {
     ) -> UnboundedSender<()> {
         let (tx, mut rx) = unbounded_channel::<()>();
         let mut consumer = AsyncOperatorBuilder::new("consumer".to_string(), scope);
-        let mut input = consumer.new_input(input, Pipeline);
-        let (_output_handle, output) = consumer.new_output::<Vec<std::convert::Infallible>>();
+        let (output_handle, output) = consumer.new_output::<Vec<std::convert::Infallible>>();
+        let mut input = consumer.new_input_for(input, Pipeline, &output_handle);
 
         consumer.build(|_caps| async move {
             while let Some(()) = rx.recv().await {

--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -68,7 +68,7 @@ pub fn render_decode_cdcv2<G: Scope<Timestamp = Timestamp>>(
 
     let mut builder = AsyncOperatorBuilder::new("CDCv2-Decode".to_owned(), input.scope());
 
-    let mut input_handle = builder.new_input(
+    let mut input_handle = builder.new_disconnected_input(
         &input.inner,
         Exchange::new(|(x, _, _): &(SourceOutput<Option<Vec<u8>>, _>, _, _)| x.key.hashed()),
     );
@@ -91,12 +91,12 @@ pub fn render_decode_cdcv2<G: Scope<Timestamp = Timestamp>>(
         let mut resolver =
             ConfluentAvroResolver::new(&schema, registry, confluent_wire_format).unwrap();
 
-        while let Some(event) = input_handle.next_mut().await {
+        while let Some(event) = input_handle.next().await {
             let AsyncEvent::Data(_time, data) = event else {
                 continue;
             };
 
-            for (data, _time, _diff) in data.drain(..) {
+            for (data, _time, _diff) in data {
                 let value = match &data.value {
                     Some(value) => value,
                     None => continue,
@@ -433,8 +433,8 @@ where
 
     let mut builder = AsyncOperatorBuilder::new(op_name, input.scope());
 
-    let mut input = builder.new_input(&input.inner, Exchange::new(dist));
     let (mut output_handle, output) = builder.new_output();
+    let mut input = builder.new_input_for(&input.inner, Exchange::new(dist), &output_handle);
 
     let (_, transient_errors) = builder.build_fallible(move |caps| {
         Box::pin(async move {

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -353,7 +353,7 @@ where
 
     let health = health_stream.enter(scope);
 
-    let mut input = health_op.new_input(
+    let mut input = health_op.new_disconnected_input(
         &health,
         Exchange::new(move |_| u64::cast_from(chosen_worker_id)),
     );
@@ -388,17 +388,14 @@ where
         }
 
         let mut outputs_seen = BTreeMap::<usize, BTreeSet<_>>::new();
-        while let Some(event) = input.next_mut().await {
+        while let Some(event) = input.next().await {
             if let AsyncEvent::Data(_cap, rows) = event {
-                for (
-                    worker_id,
-                    HealthStatusMessage {
+                for (worker_id, message) in rows {
+                    let HealthStatusMessage {
                         index: output_index,
                         namespace: ns,
                         update: health_event,
-                    },
-                ) in rows.drain(..)
-                {
+                    } = message;
                     let HealthState {
                         id,
                         healths,

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -16,7 +16,6 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 serde = { version = "1.0.152", features = ["derive"] }
 mz-ore = { path = "../ore", features = ["tracing_", "test"] }
-polonius-the-crab = "0.3.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "time"] }
 num-traits = "0.2"

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -10,8 +10,8 @@
 //! Types to build async operators with general shapes.
 
 use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
 use std::future::Future;
-use std::mem::ManuallyDrop;
 use std::pin::Pin;
 use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -19,9 +19,6 @@ use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 
 use futures_util::task::ArcWake;
-use futures_util::FutureExt;
-use polonius_the_crab::{polonius, WithLifetime};
-use timely::communication::message::RefOrMut;
 use timely::communication::{Message, Pull, Push};
 use timely::dataflow::channels::pact::ParallelizationContractCore;
 use timely::dataflow::channels::pushers::buffer::Session;
@@ -41,18 +38,16 @@ use timely::{Container, Data, PartialOrder};
 /// Builds async operators with generic shape.
 pub struct OperatorBuilder<G: Scope> {
     builder: OperatorBuilderRc<G>,
-    /// Frontier information of input streams shared with the handles. Each frontier is paired with
-    /// a flag indicating whether or not the input handle has seen the updated frontier.
-    shared_frontiers: Rc<RefCell<Vec<(Antichain<G::Timestamp>, bool)>>>,
     /// Wakers registered by input handles
     registered_wakers: Rc<RefCell<Vec<Waker>>>,
     /// The activator for this operator
     activator: Activator,
     /// The waker set up to activate this timely operator when woken
     operator_waker: Arc<TimelyWaker>,
-    /// Holds type erased closures that drain an input handle when called. These handles will be
-    /// automatically drained when the operator is scheduled and the logic future has exited
-    drain_pipe: Rc<RefCell<Vec<Box<dyn FnMut()>>>>,
+    /// The currently known upper frontier of each of the input handles.
+    input_frontiers: Vec<Antichain<G::Timestamp>>,
+    /// Input queues for each of the declared inputs of the operator.
+    input_queues: Vec<Box<dyn InputQueue<G::Timestamp>>>,
     /// Holds type erased closures that flush an output handle when called. These handles will be
     /// automatically drained when the operator is scheduled after the logic future has been polled
     output_flushes: Vec<Box<dyn FnMut()>>,
@@ -60,6 +55,55 @@ pub struct OperatorBuilder<G: Scope> {
     shutdown_handle: ButtonHandle,
     /// A button to coordinate shutdown of this operator among workers.
     shutdown_button: Button,
+}
+
+/// A helper trait abstracting over an input handle. It facilitates keeping around type erased
+/// handles for each of the operator inputs.
+trait InputQueue<T: Timestamp> {
+    /// Accepts all available input into local queues.
+    fn accept_input(&mut self);
+
+    /// Drains all available input and empties the local queue.
+    fn drain_input(&mut self);
+
+    /// Registers a frontier notification to be delivered.
+    fn notify_progress(&mut self, upper: Antichain<T>);
+}
+
+impl<T, D, C, P> InputQueue<T> for InputHandleQueue<T, D, C, P>
+where
+    T: Timestamp,
+    D: Container,
+    C: InputConnection<T> + 'static,
+    P: Pull<BundleCore<T, D>> + 'static,
+{
+    fn accept_input(&mut self) {
+        let mut queue = self.queue.borrow_mut();
+        while let Some((cap, data)) = self.handle.next() {
+            let cap = self.connection.accept(cap);
+            queue.push_back(Event::Data(cap, data.take()));
+        }
+    }
+
+    fn drain_input(&mut self) {
+        self.queue.borrow_mut().clear();
+        self.handle.for_each(|_, _| {});
+    }
+
+    fn notify_progress(&mut self, upper: Antichain<T>) {
+        self.queue.borrow_mut().push_back(Event::Progress(upper));
+    }
+}
+
+struct InputHandleQueue<
+    T: Timestamp,
+    D: Container,
+    C: InputConnection<T>,
+    P: Pull<BundleCore<T, D>> + 'static,
+> {
+    queue: Rc<RefCell<VecDeque<Event<T, C::Capability, D>>>>,
+    connection: C,
+    handle: InputHandleCore<T, D, P>,
 }
 
 /// An async Waker that activates a specific operator when woken and marks the task as ready
@@ -84,147 +128,54 @@ impl ArcWake for TimelyWaker {
 }
 
 /// Async handle to an operator's input stream
-pub struct AsyncInputHandle<T: Timestamp, D: Container, P: Pull<BundleCore<T, D>> + 'static> {
-    state: NextFutState<T, D, P>,
-    /// A scratch container used to gain mutable access to batches
-    buffer: D,
-}
-
-/// This struct holds the state that is captured by the `NextFut` future. This definition is
-/// mandatory for the implementation of `AsyncInputHandle::next_mut` which needs to perform a
-/// disjoint capture on this state and the buffer that is about to be swapped.
-struct NextFutState<T: Timestamp, D: Container, P: Pull<BundleCore<T, D>> + 'static> {
-    /// The underying synchronous input handle
-    sync_handle: ManuallyDrop<InputHandleCore<T, D, P>>,
-    /// Frontier information of input streams shared with the operator. Each frontier is paired
-    /// with a flag indicating whether or not the handle has seen the updated frontier.
-    shared_frontiers: Rc<RefCell<Vec<(Antichain<T>, bool)>>>,
-    /// The index of this handle into the shared frontiers vector
-    index: usize,
+pub struct AsyncInputHandle<T: Timestamp, D: Container, C: InputConnection<T>> {
+    queue: Rc<RefCell<VecDeque<Event<T, C::Capability, D>>>>,
     /// Reference to the reactor queue of this input handle where Wakers can be registered
     reactor_registry: Weak<RefCell<Vec<Waker>>>,
-    /// Holds type erased closures that should drain a handle when called. These handles will be
-    /// automatically drained when the operator is scheduled and the logic future has exited
-    drain_pipe: Rc<RefCell<Vec<Box<dyn FnMut()>>>>,
+    /// Whether this handle has finished producing data
+    done: bool,
 }
 
-impl<T: Timestamp, D: Container, P: Pull<BundleCore<T, D>> + 'static> AsyncInputHandle<T, D, P> {
-    /// Produces a future that will resolve to the next event of this input stream with shared
-    /// access to the data.
+impl<T: Timestamp, D: Container, C: InputConnection<T>> AsyncInputHandle<T, D, C> {
+    /// Produces a future that will resolve to the next event of this input stream.
     ///
     /// # Cancel safety
     ///
     /// The returned future is cancel-safe
-    pub fn next(&mut self) -> impl Future<Output = Option<Event<T, &D>>> + '_ {
-        let fut = NextFut {
-            state: Some(&mut self.state),
-        };
-        fut.map(|event| {
-            Some(match event? {
-                Event::Data(cap, data) => match data {
-                    RefOrMut::Ref(data) => Event::Data(cap, data),
-                    RefOrMut::Mut(data) => Event::Data(cap, &*data),
-                },
-                Event::Progress(frontier) => Event::Progress(frontier),
-            })
-        })
-    }
-
-    /// Produces a future that will resolve to the next event of this input stream with mutable
-    /// access to the data.
-    ///
-    /// # Cancel safety
-    ///
-    /// The returned future is cancel-safe
-    pub fn next_mut(&mut self) -> impl Future<Output = Option<Event<T, &mut D>>> + '_ {
-        let fut = NextFut {
-            state: Some(&mut self.state),
-        };
-        fut.map(|event| {
-            Some(match event? {
-                Event::Data(cap, data) => {
-                    data.swap(&mut self.buffer);
-                    Event::Data(cap, &mut self.buffer)
+    pub async fn next(&mut self) -> Option<Event<T, C::Capability, D>> {
+        std::future::poll_fn(|cx| {
+            if self.done {
+                return Poll::Ready(None);
+            }
+            let mut queue = self.queue.borrow_mut();
+            match queue.pop_front() {
+                Some(event @ Event::Data(_, _)) => Poll::Ready(Some(event)),
+                Some(Event::Progress(frontier)) => {
+                    self.done = frontier.is_empty();
+                    Poll::Ready(Some(Event::Progress(frontier)))
                 }
-                Event::Progress(frontier) => Event::Progress(frontier),
-            })
+                None => {
+                    // Nothing else to produce so install the provided waker in the reactor
+                    self.reactor_registry
+                        .upgrade()
+                        .expect("handle outlived its operator")
+                        .borrow_mut()
+                        .push(cx.waker().clone());
+                    Poll::Pending
+                }
+            }
         })
+        .await
     }
-}
-
-impl<T: Timestamp, D: Container, P: Pull<BundleCore<T, D>> + 'static> Drop
-    for NextFutState<T, D, P>
-{
-    fn drop(&mut self) {
-        // SAFETY: We're in a Drop impl so this runs only once
-        let mut sync_handle = unsafe { ManuallyDrop::take(&mut self.sync_handle) };
-        self.drain_pipe
-            .borrow_mut()
-            .push(Box::new(move || sync_handle.for_each(|_, _| {})));
-    }
-}
-
-/// The future returned by `AsyncInputHandle::next`
-struct NextFut<'handle, T: Timestamp, D: Container, P: Pull<BundleCore<T, D>> + 'static> {
-    state: Option<&'handle mut NextFutState<T, D, P>>,
 }
 
 /// An event of an input stream
 #[derive(Debug)]
-pub enum Event<T: Timestamp, D> {
+pub enum Event<T: Timestamp, C, D> {
     /// A data event
-    Data(InputCapability<T>, D),
+    Data(C, D),
     /// A progress event
     Progress(Antichain<T>),
-}
-
-impl<'handle, T: Timestamp, D: Container, P: Pull<BundleCore<T, D>>> Future
-    for NextFut<'handle, T, D, P>
-{
-    type Output = Option<Event<T, RefOrMut<'handle, D>>>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        let state: &'handle mut NextFutState<T, D, P> =
-            self.state.take().expect("future polled after completion");
-
-        // Check for frontier notifications first, to urge operators to retire pending work
-        let mut shared_frontiers = state.shared_frontiers.borrow_mut();
-        let (ref frontier, ref mut pending) = shared_frontiers[state.index];
-        if *pending {
-            *pending = false;
-            return Poll::Ready(Some(Event::Progress(frontier.clone())));
-        } else if frontier.is_empty() {
-            // If the frontier is empty and is not pending it means that there is no more data left
-            return Poll::Ready(None);
-        };
-        drop(shared_frontiers);
-
-        // This type serves as a type-level function that "shows" the `polonius` function how to
-        // create a version of the output type with a specific lifetime 'lt. It does this by
-        // implementing the `WithLifetime` trait for all lifetimes 'lt and setting the associated
-        // type to the output type with all lifetimes set to 'lt.
-        type NextHTB<T, D> =
-            dyn for<'lt> WithLifetime<'lt, T = (InputCapability<T>, RefOrMut<'lt, D>)>;
-
-        // The polonius function encodes a safe but rejected pattern by the current borrow checker.
-        // Explaining is beyond the scope of this comment but the docs have a great explanation:
-        // https://docs.rs/polonius-the-crab/latest/polonius_the_crab/index.html
-        match polonius::<NextHTB<T, D>, _, _, _>(state, |state| state.sync_handle.next().ok_or(()))
-        {
-            Ok((cap, data)) => Poll::Ready(Some(Event::Data(cap, data))),
-            Err((state, ())) => {
-                // Nothing else to produce so install the provided waker in the reactor
-                state
-                    .reactor_registry
-                    .upgrade()
-                    .expect("handle outlived its operator")
-                    .borrow_mut()
-                    .push(cx.waker().clone());
-                self.state = Some(state);
-                Poll::Pending
-            }
-        }
-    }
 }
 
 // TODO: delete and use CapabilityTrait instead once TimelyDataflow/timely-dataflow#512 gets merged
@@ -271,6 +222,7 @@ pub struct AsyncOutputHandle<T: Timestamp, D: Container, P: Push<BundleCore<T, D
     // safety argument in the constructor
     handle: Rc<RefCell<OutputHandleCore<'static, T, D, P>>>,
     wrapper: Rc<Pin<Box<OutputWrapper<T, D, P>>>>,
+    index: usize,
 }
 
 impl<T, D, P> AsyncOutputHandle<T, D, P>
@@ -279,7 +231,7 @@ where
     D: Container,
     P: Push<BundleCore<T, D>> + 'static,
 {
-    fn new(wrapper: OutputWrapper<T, D, P>) -> Self {
+    fn new(wrapper: OutputWrapper<T, D, P>, index: usize) -> Self {
         let mut wrapper = Rc::new(Box::pin(wrapper));
         // SAFETY:
         // get_unchecked_mut is safe because we are not moving the wrapper
@@ -301,6 +253,7 @@ where
         Self {
             wrapper,
             handle: Rc::new(RefCell::new(handle)),
+            index,
         }
     }
 
@@ -336,7 +289,87 @@ impl<T: Timestamp, D: Container, P: Push<BundleCore<T, D>> + 'static> Clone
         Self {
             handle: Rc::clone(&self.handle),
             wrapper: Rc::clone(&self.wrapper),
+            index: self.index,
         }
+    }
+}
+
+/// A trait describing the connection behavior between an input of an operator and zero or more of
+/// its outputs.
+pub trait InputConnection<T: Timestamp> {
+    /// The capability type associated with this connection behavior.
+    type Capability;
+
+    /// Generates a summary description of the connection behavior given the number of outputs.
+    fn describe(&self, outputs: usize) -> Vec<Antichain<T::Summary>>;
+
+    /// Accepts an input capability.
+    fn accept(&self, input_cap: InputCapability<T>) -> Self::Capability;
+}
+
+/// A marker type representing a disconnected input.
+pub struct Disconnected;
+
+impl<T: Timestamp> InputConnection<T> for Disconnected {
+    type Capability = T;
+
+    fn describe(&self, outputs: usize) -> Vec<Antichain<T::Summary>> {
+        vec![Antichain::new(); outputs]
+    }
+
+    fn accept(&self, input_cap: InputCapability<T>) -> Self::Capability {
+        input_cap.time().clone()
+    }
+}
+
+/// A marker type representing an input connected to exactly one output.
+pub struct ConnectedToOne(usize);
+
+impl<T: Timestamp> InputConnection<T> for ConnectedToOne {
+    type Capability = Capability<T>;
+
+    fn describe(&self, outputs: usize) -> Vec<Antichain<T::Summary>> {
+        let mut summary = vec![Antichain::new(); outputs];
+        summary[self.0] = Antichain::from_elem(T::Summary::default());
+        summary
+    }
+
+    fn accept(&self, input_cap: InputCapability<T>) -> Self::Capability {
+        input_cap.retain_for_output(self.0)
+    }
+}
+
+/// A marker type representing an input connected to many outputs.
+pub struct ConnectedToMany<const N: usize>([usize; N]);
+
+impl<const N: usize, T: Timestamp> InputConnection<T> for ConnectedToMany<N> {
+    type Capability = [Capability<T>; N];
+
+    fn describe(&self, outputs: usize) -> Vec<Antichain<T::Summary>> {
+        let mut summary = vec![Antichain::new(); outputs];
+        for output in self.0 {
+            summary[output] = Antichain::from_elem(T::Summary::default());
+        }
+        summary
+    }
+
+    fn accept(&self, input_cap: InputCapability<T>) -> Self::Capability {
+        self.0
+            .map(|output| input_cap.delayed_for_output(input_cap.time(), output))
+    }
+}
+
+/// A helper trait abstracting over an output handle. It facilitates passing type erased
+/// output handles during operator construction.
+/// It is not meant to be implemented by users.
+pub trait OutputIndex {
+    /// The output index of this handle.
+    fn index(&self) -> usize;
+}
+
+impl<T: Timestamp, D: Container> OutputIndex for AsyncOutputHandle<T, D, TeeCore<T, D>> {
+    fn index(&self) -> usize {
+        self.index
     }
 }
 
@@ -356,66 +389,92 @@ impl<G: Scope> OperatorBuilder<G> {
 
         OperatorBuilder {
             builder,
-            shared_frontiers: Default::default(),
             registered_wakers: Default::default(),
             activator,
             operator_waker: Arc::new(operator_waker),
-            drain_pipe: Default::default(),
+            input_frontiers: Default::default(),
+            input_queues: Default::default(),
             output_flushes: Default::default(),
             shutdown_handle,
             shutdown_button,
         }
     }
 
-    /// Adds a new input, returning the async input handle to use.
-    pub fn new_input<D: Container, P>(
+    /// Adds a new input that is connected to the specified output, returning the async input handle to use.
+    pub fn new_input_for<D: Container, P>(
         &mut self,
         stream: &StreamCore<G, D>,
         pact: P,
-    ) -> AsyncInputHandle<G::Timestamp, D, P::Puller>
+        output: &dyn OutputIndex,
+    ) -> AsyncInputHandle<G::Timestamp, D, ConnectedToOne>
     where
         P: ParallelizationContractCore<G::Timestamp, D>,
     {
-        let connection =
-            vec![Antichain::from_elem(Default::default()); self.builder.shape().outputs()];
-        self.new_input_connection(stream, pact, connection)
+        let index = output.index();
+        assert!(index < self.builder.shape().outputs());
+        self.new_input_connection(stream, pact, ConnectedToOne(index))
+    }
+
+    /// Adds a new input that is connected to the specified outputs, returning the async input handle to use.
+    pub fn new_input_for_many<const N: usize, D: Container, P>(
+        &mut self,
+        stream: &StreamCore<G, D>,
+        pact: P,
+        outputs: [&dyn OutputIndex; N],
+    ) -> AsyncInputHandle<G::Timestamp, D, ConnectedToMany<N>>
+    where
+        P: ParallelizationContractCore<G::Timestamp, D>,
+    {
+        let indices = outputs.map(|output| output.index());
+        for index in indices {
+            assert!(index < self.builder.shape().outputs());
+        }
+        self.new_input_connection(stream, pact, ConnectedToMany(indices))
+    }
+
+    /// Adds a new input that is not connected to any output, returning the async input handle to use.
+    pub fn new_disconnected_input<D: Container, P>(
+        &mut self,
+        stream: &StreamCore<G, D>,
+        pact: P,
+    ) -> AsyncInputHandle<G::Timestamp, D, Disconnected>
+    where
+        P: ParallelizationContractCore<G::Timestamp, D>,
+    {
+        self.new_input_connection(stream, pact, Disconnected)
     }
 
     /// Adds a new input with connection information, returning the async input handle to use.
-    ///
-    /// The `connection` parameter contains promises made by the operator for each of the existing
-    /// *outputs*, that any timestamp appearing at the input, any output timestamp will be greater
-    /// than or equal to the input timestamp subjected to a `Summary` greater or equal to some
-    /// element of the corresponding antichain in `connection`.
-    ///
-    /// Commonly the connections are either the unit summary, indicating the same timestamp might
-    /// be produced as output, or an empty antichain indicating that there is no connection from
-    /// the input to the output.
-    pub fn new_input_connection<D: Container, P>(
+    pub fn new_input_connection<D: Container, P, C>(
         &mut self,
         stream: &StreamCore<G, D>,
         pact: P,
-        connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>,
-    ) -> AsyncInputHandle<G::Timestamp, D, P::Puller>
+        connection: C,
+    ) -> AsyncInputHandle<G::Timestamp, D, C>
     where
         P: ParallelizationContractCore<G::Timestamp, D>,
+        C: InputConnection<G::Timestamp> + 'static,
     {
-        let index = self.builder.shape().inputs();
-        self.shared_frontiers
-            .borrow_mut()
-            .push((Antichain::from_elem(G::Timestamp::minimum()), false));
+        self.input_frontiers
+            .push(Antichain::from_elem(G::Timestamp::minimum()));
 
-        let sync_handle = self.builder.new_input_connection(stream, pact, connection);
+        let outputs = self.builder.shape().outputs();
+        let handle = self
+            .builder
+            .new_input_connection(stream, pact, connection.describe(outputs));
+
+        let queue = Default::default();
+        let input_queue = InputHandleQueue {
+            queue: Rc::clone(&queue),
+            connection,
+            handle,
+        };
+        self.input_queues.push(Box::new(input_queue));
 
         AsyncInputHandle {
-            state: NextFutState {
-                sync_handle: ManuallyDrop::new(sync_handle),
-                shared_frontiers: Rc::clone(&self.shared_frontiers),
-                reactor_registry: Rc::downgrade(&self.registered_wakers),
-                index,
-                drain_pipe: Rc::clone(&self.drain_pipe),
-            },
-            buffer: D::default(),
+            queue,
+            reactor_registry: Rc::downgrade(&self.registered_wakers),
+            done: false,
         }
     }
 
@@ -426,31 +485,12 @@ impl<G: Scope> OperatorBuilder<G> {
         AsyncOutputHandle<G::Timestamp, D, TeeCore<G::Timestamp, D>>,
         StreamCore<G, D>,
     ) {
-        let connection =
-            vec![Antichain::from_elem(Default::default()); self.builder.shape().inputs()];
-        self.new_output_connection(connection)
-    }
+        let index = self.builder.shape().outputs();
 
-    /// Adds a new output with connetion information, returning the output handle and stream.
-    ///
-    /// The `connection` parameter contains promises made by the operator for each of the existing
-    /// *inputs*, that any timestamp appearing at the input, any output timestamp will be greater
-    /// than or equal to the input timestamp subjected to a `Summary` greater or equal to some
-    /// element of the corresponding antichain in `connection`.
-    ///
-    /// Commonly the connections are either the unit summary, indicating the same timestamp might
-    /// be produced as output, or an empty antichain indicating that there is no connection from
-    /// the input to the output.
-    pub fn new_output_connection<D: Container>(
-        &mut self,
-        connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>,
-    ) -> (
-        AsyncOutputHandle<G::Timestamp, D, TeeCore<G::Timestamp, D>>,
-        StreamCore<G, D>,
-    ) {
+        let connection = vec![Antichain::new(); self.builder.shape().inputs()];
         let (wrapper, stream) = self.builder.new_output_connection(connection);
 
-        let handle = AsyncOutputHandle::new(wrapper);
+        let handle = AsyncOutputHandle::new(wrapper, index);
 
         let mut flush_handle = handle.clone();
         self.output_flushes
@@ -470,35 +510,36 @@ impl<G: Scope> OperatorBuilder<G> {
     {
         let operator_waker = self.operator_waker;
         let registered_wakers = self.registered_wakers;
-        let shared_frontiers = self.shared_frontiers;
-        let drain_pipe = self.drain_pipe;
+        let mut input_frontiers = self.input_frontiers;
+        let mut input_queues = self.input_queues;
         let mut output_flushes = self.output_flushes;
         let mut shutdown_handle = self.shutdown_handle;
         self.builder.build_reschedule(move |caps| {
             let mut logic_fut = Some(Box::pin(constructor(caps)));
             move |new_frontiers| {
-                // First, discover if there are any frontier notifications
-                {
-                    let mut old_frontiers = shared_frontiers.borrow_mut();
-                    for ((old, pending), new) in old_frontiers.iter_mut().zip(new_frontiers) {
-                        if PartialOrder::less_than(&old.borrow(), &new.frontier()) {
-                            *old = new.frontier().to_owned();
-                            *pending = true;
-                        }
+                for (i, queue) in input_queues.iter_mut().enumerate() {
+                    // First, discover if there are any frontier notifications
+                    let cur = &mut input_frontiers[i];
+                    let new = new_frontiers[i].frontier();
+                    if PartialOrder::less_than(&cur.borrow(), &new) {
+                        queue.notify_progress(new.to_owned());
+                        *cur = new.to_owned();
                     }
+                    // Then accept all input into local queues. This step registers the received
+                    // messages with progress tracking.
+                    queue.accept_input();
                 }
 
                 // If our worker pressed the button we stop scheduling the logic future and/or
                 // draining the input handles to stop producing data and frontier updates
                 // downstream.
                 if shutdown_handle.local_pressed() {
-                    // When all workers press their buttons we drop the logic future which will
-                    // also register all the handles for drainage
+                    // When all workers press their buttons we drop the logic future and start
+                    // draining the input handles.
                     if shutdown_handle.all_pressed() {
                         logic_fut = None;
-                        let mut drains = drain_pipe.borrow_mut();
-                        for drain in drains.iter_mut() {
-                            (drain)()
+                        for queue in input_queues.iter_mut() {
+                            queue.drain_input();
                         }
                         false
                     } else {
@@ -539,10 +580,9 @@ impl<G: Scope> OperatorBuilder<G> {
                     if logic_fut.is_some() {
                         true
                     } else {
-                        // Othewise we should drain any dropped handles
-                        let mut drains = drain_pipe.borrow_mut();
-                        for drain in drains.iter_mut() {
-                            (drain)()
+                        // Othewise we should keep draining all inputs
+                        for queue in input_queues.iter_mut() {
+                            queue.drain_input();
                         }
                         false
                     }
@@ -600,8 +640,7 @@ impl<G: Scope> OperatorBuilder<G> {
             + 'static,
     {
         // Create a new completely disconnected output
-        let disconnected = vec![Antichain::new(); self.builder.shape().inputs()];
-        let (mut error_output, error_stream) = self.new_output_connection(disconnected);
+        let (mut error_output, error_stream) = self.new_output();
         let button = self.build(|mut caps| async move {
             let error_cap = caps.pop().unwrap();
             let mut caps = caps
@@ -720,15 +759,14 @@ mod test {
             let input = (0..10).to_stream(scope);
 
             let mut op = OperatorBuilder::new("async_passthru".to_string(), input.scope());
-            let mut input_handle = op.new_input(&input, Pipeline);
             let (mut output, output_stream) = op.new_output();
+            let mut input_handle = op.new_input_for(&input, Pipeline, &output);
 
             op.build(move |_capabilities| async move {
                 tokio::task::yield_now().await;
                 while let Some(event) = input_handle.next().await {
                     match event {
                         Event::Data(cap, data) => {
-                            let cap = cap.retain();
                             for item in data.iter().copied() {
                                 tokio::task::yield_now().await;
                                 output.give(&cap, item).await;
@@ -765,7 +803,7 @@ mod test {
                 });
 
                 let mut consumer = OperatorBuilder::new("consumer".to_string(), scope.clone());
-                let mut input_handle = consumer.new_input(&output_stream, Pipeline);
+                let mut input_handle = consumer.new_disconnected_input(&output_stream, Pipeline);
                 let consumer_button = consumer.build(move |_| async move {
                     while let Some(event) = input_handle.next().await {
                         if let Event::Progress(frontier) = event {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR changes the API provided by the `AsyncOperatorBuilder` to prevent accidentally writing an operator that has the potential to deadlock.

#### Details

The condition that opens the possibility for a deadlock is when the operator is not draining its input handles every time it gets scheduled or, equivalently, when draining them but holding onto `InputCapability` objects across schedulings. When any of these two happen they cause *every worker* to consider the frontier on that input blocked. The reason for this is because each worker computes a **global** lower bound of progress which is what drives frontier notifications. So if any worker has not accepted its input yet, all workers consider that input pending.

Async operators make it particularly easy to leave input unconsumed because they encourage code of the following form:

```rust
while let Some(event) = input.next().await {
    // do some async work
}
```

The async work done inside each iteration of the loop might take a long time to complete, and the operator might get scheduled multiple times before the futures resolve. During all this time data might be accumulating on the input handle, adding unwanted latency to frontier notifications in the best case and potentially leading to deadlocks in the worst case.

This PR changes the API of the async operator builder such that it is impossible to cause delays from the operator logic. The way this is accomplished is by eagerly polling all input handles on every invocation regardless of where exactly the logic future is at. `InputCapabilities` are now never exposed to user logic so it's impossible to accidentally hold onto them. A few APIs had to be adjusted for this to become possible, most notably around dataflow construction. The changes are described below.

#### Changes to dataflow construction

In order make sure that `InputCapabilities` are never exposed to the future logic they need to be synchronously converted into the corresponding output `Capability` objects. Since the number of outputs is dynamic the naive implementation would be forced to give out a `Vec<Option<Capability<T>>` for every data event according to the connection summaries of that particular input. This API would be very annoying to use as the vast majority of the time there is a very specific connection pattern.

In order to alleviate this issue this PR uses type markers to describe the most common connection patterns for inputs:

1. completely disconnected
2. connected to one output with default summary
3. connected to multiple outputs with default summaries

These type markers make it so the actual capability type associated with each data event is a `T`, `Capability<T>`, or a `[Capability<T>; N]` respectively.

A consequence of this is that outputs must be declared before inputs during dataflow construction. This is a small price to pay for the simpler capability types.


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

The first commit has the changes to `timely-util` that implement what was described above. The second commit adjust all uses in the codebase to adhere to this new API
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
