### PR TITLE
*: Add a new mzimage that contains bazel

### DIFF
--- a/misc/images/bazel/Dockerfile
+++ b/misc/images/bazel/Dockerfile
@@ -22,9 +22,7 @@ RUN apt-get update \
 
 # Download the bazel binary from the official GitHub releases since the apt repositories do not
 # contain arm64 releases.
-RUN ARCH_BAZEL=$(echo "$ARCH_GCC" | sed "s/aarch64/arm64/") \
-    && curl -fsSL -o /tmp/bazel https://github.com/bazelbuild/bazel/releases/download/6.3.2/bazel-6.3.2-linux-$ARCH_BAZEL \
-    && if [ $ARCH_BAZEL = arm64 ]; then echo '9d88a0b206e22cceb4afe0060be7f294b423f5f49b18750fbbd7abd47cea4054 /tmp/bazel' | sha256sum --check; fi \
-    && if [ $ARCH_BAZEL = amd64 ]; then echo 'e78fc3394deae5408d6f49a15c7b1e615901969ecf6e50d55ef899996b0b8458 /tmp/bazel' | sha256sum --check; fi \
-    && mv /tmp/bazel /usr/local/bin/bazel \
-    && chmod +x /usr/local/bin/bazel
+RUN arch_bazel=$(echo "$ARCH_GCC" | sed "s/aarch64/arm64/") \
+    && curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/6.3.2/bazel-6.3.2-linux-$arch_bazel \
+    && if [[ "$arch_bazel" = arm64 ]]; then echo '9d88a0b206e22cceb4afe0060be7f294b423f5f49b18750fbbd7abd47cea4054 /usr/local/bin/bazel' | sha256sum --check; fi \
+    && if [[ "$arch_bazel" = amd64 ]]; then echo 'e78fc3394deae5408d6f49a15c7b1e615901969ecf6e50d55ef899996b0b8458 /usr/local/bin/bazel' | sha256sum --check; fi

--- a/misc/images/bazel/Dockerfile
+++ b/misc/images/bazel/Dockerfile
@@ -16,13 +16,12 @@ RUN apt-get update \
         ca-certificates \
         curl \
         g++ \
-        gcc \
-    && groupadd --system --gid=999 materialize \
-    && useradd --system --gid=999 --uid=999 --create-home materialize
+        gcc
 
 # Download the bazel binary from the official GitHub releases since the apt repositories do not
 # contain arm64 releases.
 RUN arch_bazel=$(echo "$ARCH_GCC" | sed "s/aarch64/arm64/") \
     && curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/6.3.2/bazel-6.3.2-linux-$arch_bazel \
     && if [[ "$arch_bazel" = arm64 ]]; then echo '9d88a0b206e22cceb4afe0060be7f294b423f5f49b18750fbbd7abd47cea4054 /usr/local/bin/bazel' | sha256sum --check; fi \
-    && if [[ "$arch_bazel" = amd64 ]]; then echo 'e78fc3394deae5408d6f49a15c7b1e615901969ecf6e50d55ef899996b0b8458 /usr/local/bin/bazel' | sha256sum --check; fi
+    && if [[ "$arch_bazel" = amd64 ]]; then echo 'e78fc3394deae5408d6f49a15c7b1e615901969ecf6e50d55ef899996b0b8458 /usr/local/bin/bazel' | sha256sum --check; fi \
+    && chmod +x /usr/local/bin/bazel

--- a/misc/images/bazel/Dockerfile
+++ b/misc/images/bazel/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+MZFROM ubuntu-base
+
+ARG ARCH_GCC
+
+RUN apt-get update \
+    && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        g++ \
+        gcc \
+    && groupadd --system --gid=999 materialize \
+    && useradd --system --gid=999 --uid=999 --create-home materialize
+
+# Download the bazel binary from the official GitHub releases since the apt repositories do not
+# contain arm64 releases.
+RUN ARCH_BAZEL=$(echo "$ARCH_GCC" | sed "s/aarch64/arm64/") \
+    && curl -fsSL -o /tmp/bazel https://github.com/bazelbuild/bazel/releases/download/6.3.2/bazel-6.3.2-linux-$ARCH_BAZEL \
+    && if [ $ARCH_BAZEL = arm64 ]; then echo '9d88a0b206e22cceb4afe0060be7f294b423f5f49b18750fbbd7abd47cea4054 /tmp/bazel' | sha256sum --check; fi \
+    && if [ $ARCH_BAZEL = amd64 ]; then echo 'e78fc3394deae5408d6f49a15c7b1e615901969ecf6e50d55ef899996b0b8458 /tmp/bazel' | sha256sum --check; fi \
+    && mv /tmp/bazel /usr/local/bin/bazel \
+    && chmod +x /usr/local/bin/bazel

--- a/misc/images/bazel/mzbuild.yml
+++ b/misc/images/bazel/mzbuild.yml
@@ -7,16 +7,5 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM bazel
-
-WORKDIR /home/ubuntu
-
-COPY --chown=materialize:materialize build build
-
-RUN cd build \
-    && bazel build //testers:run_sdk_destination_tester_deploy.jar
-
-RUN apt-get update \
-    && apt-get -qy install openjdk-17-jre
-
-ENTRYPOINT ["java", "-jar", "/home/ubuntu/build/bazel-bin/testers/run_sdk_destination_tester_deploy.jar", "--working-dir=/data"]
+name: bazel
+publish: false

--- a/misc/images/bazel/mzbuild.yml
+++ b/misc/images/bazel/mzbuild.yml
@@ -8,4 +8,4 @@
 # by the Apache License, Version 2.0.
 
 name: bazel
-publish: false
+publish: true

--- a/misc/images/fivetran-destination-tester/Dockerfile
+++ b/misc/images/fivetran-destination-tester/Dockerfile
@@ -11,7 +11,7 @@ MZFROM bazel
 
 WORKDIR /home/ubuntu
 
-COPY --chown=materialize:materialize build build
+COPY build build
 
 RUN cd build \
     && bazel build //testers:run_sdk_destination_tester_deploy.jar


### PR DESCRIPTION
This PR adds a new mzimage that contains `bazel`, and then uses this new image for the `fivetran-destination-tester`. We can't use the Docker image from Google because they don't publish a version for arm64.

Note: To get the fivetran destination tester working, I also had to update our fork of the SDK to use the correct JDK urls, see https://github.com/MaterializeInc/fivetran_sdk/pull/1.

### Motivation

Fixes the currently broken aarch64 build.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a, build and testing related changes
