### PR TITLE
repr: use ref_cast to ensure RowRef's transmute is correct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5215,6 +5215,7 @@ dependencies = [
  "prost-build",
  "protobuf-src",
  "rand",
+ "ref-cast",
  "regex",
  "ryu",
  "serde",
@@ -7389,6 +7390,26 @@ checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
  "redox_syscall 0.2.10",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85d07b1a5f16b5548f4255a978c94259971aff73f39e8d67e8250e8b2f6667c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a930b010d9effee5834317bb7ff406b76af7724348fd572b38705b4bd099fa92"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -80,6 +80,16 @@ who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
 delta = "0.3.5 -> 0.4.1"
 
+[[audits.ref-cast]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "1.0.17"
+
+[[audits.ref-cast-impl]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "1.0.17"
+
 [[audits.ring]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -42,6 +42,7 @@ num_enum = "0.5.7"
 ordered-float = { version = "3.4.0", features = ["serde"] }
 postgres-protocol = { version = "0.6.5" }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
+ref-cast = "1.0"
 regex = "1.7.0"
 ryu = "1.0.12"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -26,6 +26,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use ordered_float::OrderedFloat;
 use proptest::prelude::*;
 use proptest::strategy::{BoxedStrategy, Strategy};
+use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -268,6 +269,7 @@ pub struct RowPacker<'a> {
 /// need not contain a `Row`, for example large contiguous `[u8]` allocations.
 /// It is not expected that most users will use this type, especially as its
 /// only constructor is unsafe.
+#[derive(RefCast)]
 #[repr(transparent)]
 pub struct RowRef {
     data: [u8],
@@ -2059,7 +2061,7 @@ impl RowRef {
     pub unsafe fn from_bytes_unchecked(data: &[u8]) -> &Self {
         // SAFETY: RowRef just wraps [u8], and data is &[u8],
         // therefore transmuting &[u8] to &RowRef is safe.
-        std::mem::transmute(data)
+        Self::ref_cast(data)
     }
 
     /// Unpack `self` into a `Vec<Datum>` for efficient random access.


### PR DESCRIPTION
`ref_cast` ensures that we don't regress and keep doing a transmute that no longer is safe; it compiles down to the same `transmute`

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
