### PR TITLE
Update developer guide to encourage separate PRs for each part of the stack

### DIFF
--- a/doc/developer/guide-changes.md
+++ b/doc/developer/guide-changes.md
@@ -89,6 +89,15 @@ feature in isolation. This can be particularly problematic if the bugfix or
 feature needs to be reverted—it is much more difficult to revert just one or the
 other if they are in the same RU.
 
+You should also endeavor to limit each RU to one team's scope as defined by
+the [CODEOWNERS](/.github/CODEOWNERS) file, in particular for larger changes.
+When a single RU contains changes across multiple parts of the stack, each
+reviewer has the additional overhead of digging thru the PR to figure out which
+files require their review. Splitting up the change into multiple RUs avoids
+this.\
+Areas where this is particularly applicable:
+* Changes to the [SQL parser](/src/sql-parser)
+
 ### Change descriptions
 
 Writing good commit messages (or PR descriptions, if you use the semantic PRs
@@ -896,6 +905,9 @@ submit a PR to fix it!
 * Never include refactoring and behavior changes in the same commit.
 
 * Keep PRs small, and ideally less than 500 lines.
+
+* For larger PRs, aim to limit each RU to one team's scope as defined by the
+[CODEOWNERS](/.github/CODEOWNERS) file.
 
 * Always initiate PR reviews within one business day, and sooner if possible.
 

--- a/doc/developer/guide-changes.md
+++ b/doc/developer/guide-changes.md
@@ -92,9 +92,9 @@ other if they are in the same RU.
 You should also endeavor to limit each RU to one team's scope as defined by
 the [CODEOWNERS](/.github/CODEOWNERS) file, in particular for larger changes.
 When a single RU contains changes across multiple parts of the stack, each
-reviewer has the additional overhead of digging through the PR to figure out which
-files require their review. Splitting up the change into multiple RUs avoids
-this.\
+reviewer has the additional overhead of digging through the PR to figure out
+which files require their review. Splitting up the change into multiple RUs
+avoids this.\
 Areas where this is particularly applicable:
 * Changes to the [SQL parser](/src/sql-parser)
 * Changes to the [SQL planner](/src/sql/src/plan)

--- a/doc/developer/guide-changes.md
+++ b/doc/developer/guide-changes.md
@@ -92,7 +92,7 @@ other if they are in the same RU.
 You should also endeavor to limit each RU to one team's scope as defined by
 the [CODEOWNERS](/.github/CODEOWNERS) file, in particular for larger changes.
 When a single RU contains changes across multiple parts of the stack, each
-reviewer has the additional overhead of digging thru the PR to figure out which
+reviewer has the additional overhead of digging through the PR to figure out which
 files require their review. Splitting up the change into multiple RUs avoids
 this.\
 Areas where this is particularly applicable:

--- a/doc/developer/guide-changes.md
+++ b/doc/developer/guide-changes.md
@@ -97,6 +97,7 @@ files require their review. Splitting up the change into multiple RUs avoids
 this.\
 Areas where this is particularly applicable:
 * Changes to the [SQL parser](/src/sql-parser)
+* Changes to the [SQL planner](/src/sql/src/plan)
 
 ### Change descriptions
 


### PR DESCRIPTION
Add a section to the developer guide on changes that encourages PR authors to limit the scope of their change to one area of the stack/team as defined by CODEOWNERS.

Goal: reduce the burden on code reviewers by encouraging smaller PRs that are broken out by the team reviewing.

Open to more specific areas where this is particularly applicable. Right now the list is just the SQL parser.

Next step: sending an announcement on slack to epd-announce. 