### PR TITLE
stash: When pruning storage_usage_collection wait for consolidation to complete

### DIFF
--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -200,21 +200,22 @@ where
                 // Invalidate one upper and ensure append doesn't commit partial batches.
                 let other_upper = other_batch.upper;
                 other_batch.upper = Antichain::from_elem(Timestamp::MIN);
-                assert_contains!(
-                    tx.append(vec![orders_batch.clone(), other_batch.clone()])
-                        .await
-                        .unwrap_err()
-                        .to_string(),
-                    "{-9223372036854775808}",
-                );
+                let result = tx
+                    .append(vec![orders_batch.clone(), other_batch.clone()])
+                    .await;
+                let Err(err) = result else {
+                    panic!("unexpected success!")
+                };
+                assert_contains!(err.to_string(), "{-9223372036854775808}",);
+
                 // Test batches in the other direction too.
-                assert_contains!(
-                    tx.append(vec![other_batch.clone(), orders_batch.clone()])
-                        .await
-                        .unwrap_err()
-                        .to_string(),
-                    "{-9223372036854775808}",
-                );
+                let result = tx
+                    .append(vec![other_batch.clone(), orders_batch.clone()])
+                    .await;
+                let Err(err) = result else {
+                    panic!("unexpected success!")
+                };
+                assert_contains!(err.to_string(), "{-9223372036854775808}",);
 
                 // Fix the upper, append should work now.
                 other_batch.upper = other_upper;


### PR DESCRIPTION
work in progress

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
