### PR TITLE
cluster tests: Allow up to 15 s runtime for queries

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2993,7 +2993,9 @@ def workflow_blue_green_deployment(
                         cursor.execute(query)
                         assert int(cursor.fetchone()[0]) > 0
                         runtime = time.time() - start_time
-                        assert runtime < 5, f"runtime: {runtime}"
+                        assert (
+                            runtime < 15
+                        ), f"query: {query}, runtime spiked to {runtime}"
                         total_runtime += runtime
                     runtimes.append(total_runtime)
         finally:


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/tests/builds/72441#_

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
