### PR TITLE
ci: Bump Product Limits timeout

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -226,7 +226,7 @@ steps:
       plugins:
         - ./ci/plugins/mzcompose:
             composition: limits
-      timeout_in_minutes: 90
+      timeout_in_minutes: 120
 
     - id: limits-instance-size
       label: "Instance size limits"


### PR DESCRIPTION
The test got slower with always_use_disk: https://github.com/MaterializeInc/materialize/pull/24239

This seems expected as we are now swapping out the lgalloc files.

An alternative would be to disable disk for this test, but I don't think that's the proper way forward as we want to enable disk on production too. Long-term we should rather evaluate which tests still make sense and which will just be swapping to disk.

Seen in https://buildkite.com/materialize/nightlies/builds/5875

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
