### PR TITLE
Remove unused imports, which Rust 1.75 newly detects

### DIFF
--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -24,7 +24,6 @@ use mz_expr::{func, CollectionPlan, Id, LetRecLimit, RowSetFinishing};
 use mz_expr::AggregateFunc::WindowAggregate;
 pub use mz_expr::{
     BinaryFunc, ColumnOrder, TableFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc, WindowFrame,
-    WindowFrameBound, WindowFrameUnits,
 };
 use mz_ore::collections::CollectionExt;
 use mz_ore::stack;

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -28,7 +28,7 @@ use chrono::NaiveDate;
 // testdrive modules can import just this one.
 pub use mz_avro::schema::{Schema, SchemaKind, SchemaNode, SchemaPiece, SchemaPieceOrNamed};
 pub use mz_avro::types::{DecimalValue, ToAvro, Value};
-pub use mz_avro::{from_avro_datum, to_avro_datum, Codec, Reader, Writer};
+pub use mz_avro::{from_avro_datum, to_avro_datum};
 pub use mz_interchange::avro::parse_schema;
 use serde_json::Value as JsonValue;
 


### PR DESCRIPTION
I've switched to Rust 1.75.0, and `cargo check` is failing due to some unused imports that 1.74.0 was not detecting as unused:
```
warning: unused imports: `WindowFrameBound`, `WindowFrameUnits`
  --> src/sql/src/plan/expr.rs:27:5
   |
27 |     WindowFrameBound, WindowFrameUnits,
   |     ^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^
```
and
```
warning: unused imports: `Codec`, `Reader`, `Writer`
  --> src/testdrive/src/format/avro.rs:31:51
   |
31 | pub use mz_avro::{from_avro_datum, to_avro_datum, Codec, Reader, Writer};
   |                                                   ^^^^^  ^^^^^^  ^^^^^^
```
It seems like they are genuinely unused, because the code compiles without them (even if I switch back to 1.74.0), so I removed them.

### Motivation

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
