### PR TITLE
scalability framework: fix assessment of regressions

### DIFF
--- a/misc/python/materialize/scalability/regression_assessment.py
+++ b/misc/python/materialize/scalability/regression_assessment.py
@@ -32,7 +32,7 @@ class RegressionAssessment:
         self.endpoints_with_regressions_and_justifications: dict[
             Endpoint, str | None
         ] = {}
-        self.check_targets()
+        self.determine_whether_regressions_are_justified()
         # See #24147
         # assert len(comparison_outcome.endpoints_with_regressions) == len(
         #     self.endpoints_with_regressions_and_justifications
@@ -50,7 +50,7 @@ class RegressionAssessment:
             for justification in self.endpoints_with_regressions_and_justifications.values()
         )
 
-    def check_targets(self) -> None:
+    def determine_whether_regressions_are_justified(self) -> None:
         if self.baseline_endpoint is None:
             return
 

--- a/misc/python/materialize/scalability/regression_assessment.py
+++ b/misc/python/materialize/scalability/regression_assessment.py
@@ -67,20 +67,9 @@ class RegressionAssessment:
         )
 
         for endpoint in self.comparison_outcome.endpoints_with_regressions:
-            if not self._endpoint_references_release_version(endpoint):
-                continue
-
-            endpoint_version = get_mz_version_from_image_tag(endpoint.resolved_target())
-
-            if baseline_version >= endpoint_version:
-                # not supported, should not be a relevant case
-                continue
-
             commits_with_accepted_regressions = (
-                get_commits_of_accepted_regressions_between_versions(
-                    ANCESTOR_OVERRIDES_FOR_SCALABILITY_REGRESSIONS,
-                    since_version_exclusive=baseline_version,
-                    to_version_inclusive=endpoint_version,
+                self.collect_accepted_regression_commits_of_endpoint(
+                    endpoint, baseline_version
                 )
             )
 
@@ -90,6 +79,29 @@ class RegressionAssessment:
                 ] = ", ".join(commits_with_accepted_regressions)
             else:
                 self.endpoints_with_regressions_and_justifications[endpoint] = None
+
+    def collect_accepted_regression_commits_of_endpoint(
+        self, endpoint: Endpoint, baseline_version: MzVersion
+    ) -> list[str]:
+        """
+        Collect known regressions (in form of commits) between the endpoint version and baseline version.
+        @returns list of commits representing known regressions
+        """
+        if not self._endpoint_references_release_version(endpoint):
+            # no explicit version referenced: not supported
+            return []
+
+        endpoint_version = get_mz_version_from_image_tag(endpoint.resolved_target())
+
+        if baseline_version >= endpoint_version:
+            # baseline more recent than endpoint: not supported, should not be relevant
+            return []
+
+        return get_commits_of_accepted_regressions_between_versions(
+            ANCESTOR_OVERRIDES_FOR_SCALABILITY_REGRESSIONS,
+            since_version_exclusive=baseline_version,
+            to_version_inclusive=endpoint_version,
+        )
 
     def _mark_all_targets_with_regressions_as_unjustified(self) -> None:
         for endpoint in self.comparison_outcome.endpoints_with_regressions:

--- a/misc/python/materialize/scalability/regression_assessment.py
+++ b/misc/python/materialize/scalability/regression_assessment.py
@@ -33,10 +33,9 @@ class RegressionAssessment:
             Endpoint, str | None
         ] = {}
         self.determine_whether_regressions_are_justified()
-        # See #24147
-        # assert len(comparison_outcome.endpoints_with_regressions) == len(
-        #     self.endpoints_with_regressions_and_justifications
-        # )
+        assert len(comparison_outcome.endpoints_with_regressions) == len(
+            self.endpoints_with_regressions_and_justifications
+        )
 
     def has_comparison_target(self) -> bool:
         return self.baseline_endpoint is not None


### PR DESCRIPTION
This addresses https://github.com/MaterializeInc/materialize/issues/24147.

The problem were entries missing in a dict caused by `continue` statements when an endpoint did not satisfy the criteria.
I reenabled the assertion.