### PR TITLE
adapter: wrap materialized view optimization in `catch_unwind`

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2145,9 +2145,9 @@ impl Coordinator {
             mut optimizer,
         }: PeekStageOptimize,
     ) -> Result<PeekStageRealTimeRecency, AdapterError> {
-        let local_mir_plan = optimizer.optimize(source)?;
+        let local_mir_plan = optimizer.catch_unwind_optimize(source)?;
         let local_mir_plan = local_mir_plan.resolve(session, stats);
-        let global_mir_plan = optimizer.optimize(local_mir_plan)?;
+        let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
 
         Ok(PeekStageRealTimeRecency {
             validity,
@@ -2500,7 +2500,7 @@ impl Coordinator {
         let timestamp_context = determination.clone().timestamp_context;
 
         let global_mir_plan = global_mir_plan.resolve(timestamp_context, session);
-        let global_lir_plan = optimizer.optimize(global_mir_plan)?;
+        let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan)?;
 
         let key = global_lir_plan.key();
         let arity = global_lir_plan.typ().arity();

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -149,10 +149,13 @@ impl Coordinator {
                 // MIR ⇒ MIR optimization (global)
                 let index_plan =
                     optimize::index::Index::new(&plan.name, &plan.index.on, &plan.index.keys);
-                let global_mir_plan = return_if_err!(optimizer.optimize(index_plan), ctx);
+                let global_mir_plan =
+                    return_if_err!(optimizer.catch_unwind_optimize(index_plan), ctx);
                 // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                let global_lir_plan =
-                    return_if_err!(optimizer.optimize(global_mir_plan.clone()), ctx);
+                let global_lir_plan = return_if_err!(
+                    optimizer.catch_unwind_optimize(global_mir_plan.clone()),
+                    ctx
+                );
 
                 let stage = CreateIndexStage::Finish(CreateIndexFinish {
                     validity,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -202,12 +202,14 @@ impl Coordinator {
 
                 // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local and global)
                 let raw_expr = plan.materialized_view.expr.clone();
-                let local_mir_plan = return_if_err!(optimizer.optimize(raw_expr), ctx);
+                let local_mir_plan = return_if_err!(optimizer.catch_unwind_optimize(raw_expr), ctx);
                 let global_mir_plan =
-                    return_if_err!(optimizer.optimize(local_mir_plan.clone()), ctx);
+                    return_if_err!(optimizer.catch_unwind_optimize(local_mir_plan.clone()), ctx);
                 // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                let global_lir_plan =
-                    return_if_err!(optimizer.optimize(global_mir_plan.clone()), ctx);
+                let global_lir_plan = return_if_err!(
+                    optimizer.catch_unwind_optimize(global_mir_plan.clone()),
+                    ctx
+                );
 
                 let stage = CreateMaterializedViewStage::Finish(CreateMaterializedViewFinish {
                     validity,

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -143,7 +143,7 @@ impl Coordinator {
 
                 // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
                 let raw_expr = plan.view.expr.clone();
-                let optimized_expr = return_if_err!(optimizer.optimize(raw_expr), ctx);
+                let optimized_expr = return_if_err!(optimizer.catch_unwind_optimize(raw_expr), ctx);
 
                 let stage = CreateViewStage::Finish(CreateViewFinish {
                     validity,

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -218,7 +218,8 @@ impl Coordinator {
                 let _guard = span.enter();
 
                 // MIR ⇒ MIR optimization (global)
-                let global_mir_plan = return_if_err!(optimizer.optimize(plan.from.clone()), ctx);
+                let global_mir_plan =
+                    return_if_err!(optimizer.catch_unwind_optimize(plan.from.clone()), ctx);
 
                 let stage = SubscribeStage::Timestamp(SubscribeTimestamp {
                     validity,
@@ -310,8 +311,10 @@ impl Coordinator {
                 let _guard = span.enter();
 
                 // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                let global_lir_plan =
-                    return_if_err!(optimizer.optimize(global_mir_plan.clone()), ctx);
+                let global_lir_plan = return_if_err!(
+                    optimizer.catch_unwind_optimize(global_mir_plan.clone()),
+                    ctx
+                );
 
                 let stage = SubscribeStage::Finish(SubscribeFinish {
                     validity,

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -392,7 +392,9 @@ impl ShouldHalt for SubscribeTargetError {
 impl ShouldHalt for TransformError {
     fn should_halt(&self) -> bool {
         match self {
-            TransformError::Internal(_) | TransformError::IdentifierMissing(_) => false,
+            TransformError::Internal(_)
+            | TransformError::IdentifierMissing(_)
+            | TransformError::CallerShouldPanic(_) => false,
         }
     }
 }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -788,7 +788,7 @@ impl MirScalarExpr {
                     | MirScalarExpr::Literal(_, _)
                     | MirScalarExpr::CallUnmaterializable(_) => (),
                     MirScalarExpr::CallUnary { func, expr } => {
-                        if expr.is_literal() {
+                        if expr.is_literal() && *func != UnaryFunc::Panic(func::Panic) {
                             *e = eval(e);
                         } else if let UnaryFunc::RecordGet(func::RecordGet(i)) = *func {
                             if let MirScalarExpr::CallVariadic {

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -148,6 +148,12 @@ pub enum TransformError {
     Internal(String),
     /// A reference to an apparently unbound identifier.
     IdentifierMissing(mz_expr::LocalId),
+    /// Notify the caller to panic with the given message.
+    ///
+    /// This is used to bypass catch_unwind-wrapped calls of the optimizer and
+    /// support `SELECT mz_unsafe.mz_panic(<literal>)` statements as a mechanism to kill
+    /// environmentd in various tests.
+    CallerShouldPanic(String),
 }
 
 impl fmt::Display for TransformError {
@@ -156,6 +162,9 @@ impl fmt::Display for TransformError {
             TransformError::Internal(msg) => write!(f, "internal transform error: {}", msg),
             TransformError::IdentifierMissing(i) => {
                 write!(f, "apparently unbound identifier: {:?}", i)
+            }
+            TransformError::CallerShouldPanic(msg) => {
+                write!(f, "caller should panic with message: {}", msg)
             }
         }
     }


### PR DESCRIPTION
Fixes #16324.
 
### Motivation

  * This PR adds a known-desirable feature.

This fixes #16324 as proposed in an issue -- by wrapping all `optimize` calls in `catch_unwind`. However, fixing this will introduces some test failures because now tests that rely on `mz_unsafe.mz_panic('forced panic')` to break `environmentd` will fail.

### Tips for reviewer

This is ready for review, but needs some more work to fix the broken tests before it can be merged.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
