### PR TITLE
tracing: support default directives for logging, otel, and sentry

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -186,6 +186,7 @@ case "$cmd" in
             --env POLAR_SIGNALS_API_TOKEN
             --env PYPI_TOKEN
             --env MZ_DEV_BUILD_SHA
+            --env BUILDKITE_SENTRY_DSN
             # For Miri with nightly Rust
             --env ZOOKEEPER_ADDR
             --env KAFKA_ADDRS

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -185,6 +185,7 @@ pub fn tracing_config(config: &SystemVars) -> TracingParameters {
         opentelemetry_filter: Some(config.opentelemetry_filter()),
         log_filter_defaults: config.logging_filter_defaults(),
         opentelemetry_filter_defaults: config.opentelemetry_filter_defaults(),
+        sentry_filters: config.sentry_filters(),
     }
 }
 

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -183,6 +183,8 @@ pub fn tracing_config(config: &SystemVars) -> TracingParameters {
     TracingParameters {
         log_filter: Some(config.logging_filter()),
         opentelemetry_filter: Some(config.opentelemetry_filter()),
+        log_filter_defaults: config.logging_filter_defaults(),
+        opentelemetry_filter_defaults: config.opentelemetry_filter_defaults(),
     }
 }
 

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -164,12 +164,14 @@ pub struct TokioConsoleConfig {
 }
 
 type Reloader = Arc<dyn Fn(EnvFilter, Vec<Directive>) -> Result<(), anyhow::Error> + Send + Sync>;
+type DirectiveReloader = Arc<dyn Fn(Vec<Directive>) -> Result<(), anyhow::Error> + Send + Sync>;
 
 /// A handle to the tracing infrastructure configured with [`configure`].
 #[derive(Clone)]
 pub struct TracingHandle {
     stderr_log: Reloader,
     opentelemetry: Reloader,
+    sentry: DirectiveReloader,
 }
 
 impl TracingHandle {
@@ -180,6 +182,7 @@ impl TracingHandle {
         TracingHandle {
             stderr_log: Arc::new(|_, _| Ok(())),
             opentelemetry: Arc::new(|_, _| Ok(())),
+            sentry: Arc::new(|_| Ok(())),
         }
     }
 
@@ -199,6 +202,11 @@ impl TracingHandle {
         defaults: Vec<Directive>,
     ) -> Result<(), anyhow::Error> {
         (self.opentelemetry)(filter, defaults)
+    }
+
+    /// Dynamically reloads the additional sentry directives.
+    pub fn reload_sentry_directives(&self, defaults: Vec<Directive>) -> Result<(), anyhow::Error> {
+        (self.sentry)(defaults)
     }
 }
 
@@ -250,6 +258,12 @@ pub static OPENTELEMETRY_DEFAULTS: Lazy<Vec<Directive>> = Lazy::new(|| {
         Directive::from_str("h2=off").expect("valid directive"),
         Directive::from_str("hyper=off").expect("valid directive"),
     ]
+});
+
+/// By default we turn off tracing from the following crates, because they
+/// have error spans which are noisy.
+pub static SENTRY_DEFAULTS: Lazy<Vec<Directive>> = Lazy::new(|| {
+    vec![Directive::from_str("kube_client::client::builder=off").expect("valid directive")]
 });
 
 /// Enables application tracing via the [`tracing`] and [`opentelemetry`]
@@ -457,66 +471,77 @@ where
         None
     };
 
-    let (sentry_guard, sentry_layer) = if let Some(sentry_config) = config.sentry {
-        let guard = sentry::init((
-            sentry_config.dsn,
-            sentry::ClientOptions {
-                attach_stacktrace: true,
-                release: Some(config.build_version.into()),
-                environment: sentry_config.environment.map(Into::into),
-                integrations: vec![Arc::new(DebugImagesIntegration::new())],
-                ..Default::default()
-            },
-        ));
+    let (sentry_guard, sentry_layer, sentry_reloader): (_, _, DirectiveReloader) =
+        if let Some(sentry_config) = config.sentry {
+            let guard = sentry::init((
+                sentry_config.dsn,
+                sentry::ClientOptions {
+                    attach_stacktrace: true,
+                    release: Some(config.build_version.into()),
+                    environment: sentry_config.environment.map(Into::into),
+                    integrations: vec![Arc::new(DebugImagesIntegration::new())],
+                    ..Default::default()
+                },
+            ));
 
-        sentry::configure_scope(|scope| {
-            scope.set_tag("service_name", config.service_name);
-            scope.set_tag("build_sha", config.build_sha.to_string());
-            scope.set_tag("build_time", config.build_time.to_string());
-            for (k, v) in sentry_config.tags {
-                scope.set_tag(&k, v);
-            }
-        });
+            sentry::configure_scope(|scope| {
+                scope.set_tag("service_name", config.service_name);
+                scope.set_tag("build_sha", config.build_sha.to_string());
+                scope.set_tag("build_time", config.build_time.to_string());
+                for (k, v) in sentry_config.tags {
+                    scope.set_tag(&k, v);
+                }
+            });
 
-        let layer = sentry_tracing::layer()
-            .event_filter(sentry_config.event_filter)
-            // WARNING, ENTERING THE SPOOKY ZONE
-            //
-            // While sentry provides an event filter above that maps events to types of sentry events, its `Layer`
-            // implementation does not participate in `tracing`'s level-fast-path implementation, which depends on
-            // a hidden api (<https://github.com/tokio-rs/tracing/blob/b28c9351dd4f34ed3c7d5df88bb5c2e694d9c951/tracing-subscriber/src/layer/mod.rs#L861-L867>)
-            // which is primarily manged by filters (like below). The fast path skips verbose log
-            // (and span) levels that no layer is interested by reading a single atomic. Usually, not implementing this
-            // api means "give me everything, including `trace`, unless you attach a filter to me.
-            //
-            // The curious thing here (and a bug in tracing) is that _some configurations of our layer stack above_,
-            // if you don't have this filter can cause the fast-path to trigger, despite the fact
-            // that the sentry layer would specifically communicating that it wants to see
-            // everything. This bug appears to be related to the presence of a `reload::Layer`
-            // _around a filter, not a layer_, and guswynn is tracking investigating it here:
-            // <https://github.com/MaterializeInc/materialize/issues/16556>. Because we don't
-            // enable a reload-able filter in CI/locally, but DO in production (the otel layer), it
-            // was once possible to trigger and rely on the fast path in CI, but not notice that it
-            // was disabled in production.
-            //
-            // The behavior of this optimization is now tested in various scenarios (in
-            // `test/tracing`). Regardless, when the upstream bug is fixed/resolved,
-            // we will continue to place this here, as the sentry layer only cares about
-            // events <= INFO, so we want to use the fast-path if no other layer
-            // is interested in high-fidelity events.
-            // TODO(guswynn): make this configurable.
-            .with_filter({
+            let (filter, filter_handle) = reload::Layer::new({
+                // Please see the comment on `with_filter` below.
                 let mut filter = EnvFilter::new("info");
-                for directive in LOGGING_DEFAULTS.iter() {
+                for directive in SENTRY_DEFAULTS.iter() {
                     filter = filter.add_directive(directive.clone());
                 }
                 filter
             });
-
-        (Some(guard), Some(layer))
-    } else {
-        (None, None)
-    };
+            let layer = sentry_tracing::layer()
+                .event_filter(sentry_config.event_filter)
+                // WARNING, ENTERING THE SPOOKY ZONE
+                //
+                // While sentry provides an event filter above that maps events to types of sentry events, its `Layer`
+                // implementation does not participate in `tracing`'s level-fast-path implementation, which depends on
+                // a hidden api (<https://github.com/tokio-rs/tracing/blob/b28c9351dd4f34ed3c7d5df88bb5c2e694d9c951/tracing-subscriber/src/layer/mod.rs#L861-L867>)
+                // which is primarily manged by filters (like below). The fast path skips verbose log
+                // (and span) levels that no layer is interested by reading a single atomic. Usually, not implementing this
+                // api means "give me everything, including `trace`, unless you attach a filter to me.
+                //
+                // The curious thing here (and a bug in tracing) is that _some configurations of our layer stack above_,
+                // if you don't have this filter can cause the fast-path to trigger, despite the fact
+                // that the sentry layer would specifically communicating that it wants to see
+                // everything. This bug appears to be related to the presence of a `reload::Layer`
+                // _around a filter, not a layer_, and guswynn is tracking investigating it here:
+                // <https://github.com/MaterializeInc/materialize/issues/16556>. Because we don't
+                // enable a reload-able filter in CI/locally, but DO in production (the otel layer), it
+                // was once possible to trigger and rely on the fast path in CI, but not notice that it
+                // was disabled in production.
+                //
+                // The behavior of this optimization is now tested in various scenarios (in
+                // `test/tracing`). Regardless, when the upstream bug is fixed/resolved,
+                // we will continue to place this here, as the sentry layer only cares about
+                // events <= INFO, so we want to use the fast-path if no other layer
+                // is interested in high-fidelity events.
+                .with_filter(filter);
+            let reloader = Arc::new(move |defaults: Vec<Directive>| {
+                // Please see the comment on `with_filter` above.
+                let mut filter = EnvFilter::new("info");
+                // Re-apply our defaults on reload.
+                for directive in &defaults {
+                    filter = filter.add_directive(directive.clone());
+                }
+                Ok(filter_handle.reload(filter)?)
+            });
+            (Some(guard), Some(layer), reloader)
+        } else {
+            let reloader = Arc::new(|_| Ok(()));
+            (None, None, reloader)
+        };
 
     let stack = tracing_subscriber::registry();
     let stack = stack.with(stderr_log_layer);
@@ -538,6 +563,7 @@ where
     let handle = TracingHandle {
         stderr_log: stderr_log_reloader,
         opentelemetry: otel_reloader,
+        sentry: sentry_reloader,
     };
     let guard = TracingGuard {
         _sentry_guard: sentry_guard,

--- a/src/tracing/src/params.proto
+++ b/src/tracing/src/params.proto
@@ -14,4 +14,6 @@ package mz_tracing.params;
 message ProtoTracingParameters {
   optional string log_filter = 1;
   optional string opentelemetry_filter = 2;
+  repeated string log_filter_defaults= 3;
+  repeated string opentelemetry_filter_defaults = 4;
 }

--- a/src/tracing/src/params.proto
+++ b/src/tracing/src/params.proto
@@ -16,4 +16,5 @@ message ProtoTracingParameters {
   optional string opentelemetry_filter = 2;
   repeated string log_filter_defaults= 3;
   repeated string opentelemetry_filter_defaults = 4;
+  repeated string sentry_filters = 5;
 }


### PR DESCRIPTION
In https://materializeinc.slack.com/archives/C044M87G076/p1704492703700209 we discovered we wanted to add a `kube_client::client::builder=off` directive to our sentry layer, to prevent some noise. In looking into this, I discovered two issues:

- Our default directives (for otel and logging) are hard-coded. Fixing up every variation in LD to add a new default is not really reasonable.
- We don't actually have a controllable filter for sentry.

The first point is fixed in the first commit, and is fairly straightforward. There are new LD params that let you pass a comma-separated list of `Directives`, which are always applied. The only subtlety is that for now, the startup defaults are hardcoded until we sync from LD

The second point is fixed by the second commit. This was quite subtle, and I decided on allowing people to set additional directives on top of an `info` filter. The reason behind this is elaborated in part in the spooky zone comment. Also note that I DID test this doesn't mess up the tracing fast path (this is critical as we are adding a new rwlock read to the info/error path), with https://github.com/guswynn/materialize/commit/db1e17a7a2a3448264e7830e571469e0c86dfcf0, but _we don't have a way to test sentry in ci, so the performance and correctness of this path had to be verified locally_. I suspect we want https://develop.sentry.dev/self-hosted/ at some point added to ci (and perhaps to feature benchmarks)

As part of this change I also added the `kube_client::client::builder=off` as a default.

### Motivation

  * This PR fixes a recognized bug.

  * This PR adds a known-desirable feature.


### Tips for reviewer

I suspect @pH14 has to review this.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
