### PR TITLE
parallel-workload: Don't refresh too early

### DIFF
--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -295,7 +295,8 @@ class View(DBObject):
                     "ON COMMIT",
                     f"EVERY '{rng.randint(1, 60)} seconds {rng.randint(0, 60)} minutes'",
                     f"EVERY '{rng.randint(1, 60)} seconds {rng.randint(0, 60)} minutes' ALIGNED TO (mz_now())",
-                    f"AT mz_now()::string::int8 + {rng.randint(0, 3600000)}",
+                    # TODO(def-): Allow smaller times again when #24288 is fixed
+                    f"AT mz_now()::string::int8 + {rng.randint(1800000, 3600000)}",
                 ]
             )
             if self.materialized


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/5881#018ce922-1007-45fc-b960-02dc00d1d353

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
