### PR TITLE
*: remove RowRef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5220,7 +5220,6 @@ dependencies = [
  "prost-build",
  "protobuf-src",
  "rand",
- "ref-cast",
  "regex",
  "ryu",
  "serde",
@@ -7417,26 +7416,6 @@ checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
  "redox_syscall 0.2.10",
-]
-
-[[package]]
-name = "ref-cast"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85d07b1a5f16b5548f4255a978c94259971aff73f39e8d67e8250e8b2f6667c3"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a930b010d9effee5834317bb7ff406b76af7724348fd572b38705b4bd099fa92"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
 ]
 
 [[package]]

--- a/src/interchange/src/avro/envelope_cdc_v2.rs
+++ b/src/interchange/src/avro/envelope_cdc_v2.rs
@@ -256,7 +256,7 @@ mod tests {
         pub fn encode_updates(&self, updates: &[(Row, i64, i64)]) -> Value {
             let mut enc_updates = Vec::new();
             for (data, time, diff) in updates {
-                let enc_data = encode_datums_as_avro(&**data, &self.columns);
+                let enc_data = encode_datums_as_avro(&*data, &self.columns);
                 let enc_time = Value::Long(time.clone());
                 let enc_diff = Value::Long(diff.clone());
                 enc_updates.push(Value::Record(vec![

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -45,7 +45,6 @@ num_enum = "0.5.7"
 ordered-float = { version = "3.4.0", features = ["serde"] }
 postgres-protocol = { version = "0.6.5" }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
-ref-cast = "1.0"
 regex = "1.7.0"
 ryu = "1.0.12"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -68,7 +68,7 @@ fn bench_sort_unpacked(rows: Vec<Vec<Datum>>, b: &mut Bencher) {
         |rows| {
             let mut unpacked = vec![];
             for row in &rows {
-                unpacked.extend(&**row);
+                unpacked.extend(&*row);
             }
             let mut slices = unpacked.chunks(arity).collect::<Vec<_>>();
             slices.sort();

--- a/src/repr/src/datum_vec.rs
+++ b/src/repr/src/datum_vec.rs
@@ -98,8 +98,8 @@ mod test {
             // different lifetime, so that rust is happy with the reference lifetimes
             let r2 = Row::pack_slice(&[Datum::String("second")]);
             let mut borrow = d.borrow();
-            borrow.extend(&*r);
-            borrow.extend(&*r2);
+            borrow.extend(&r);
+            borrow.extend(&r2);
             assert_eq!(borrow.len(), 3);
             assert_eq!(borrow[2], Datum::String("second"));
         }

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -55,7 +55,7 @@ pub use crate::row::encoding::{
 };
 pub use crate::row::{
     datum_list_size, datum_size, datums_size, read_datum, row_size, DatumList, DatumMap, ProtoRow,
-    Row, RowArena, RowPacker, RowRef, SharedRow,
+    Row, RowArena, RowPacker, SharedRow,
 };
 pub use crate::scalar::{
     arb_datum, arb_range_type, ArrayRustType, AsColumnType, Datum, DatumType, PropArray, PropDatum,

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -616,7 +616,7 @@ fn append_metadata_to_value<G: Scope>(
         let val = res.value.map(|val_result| {
             val_result.map(|mut val| {
                 if !res.metadata.is_empty() {
-                    RowPacker::for_existing_row(&mut val).extend(&*res.metadata);
+                    RowPacker::for_existing_row(&mut val).extend(&res.metadata);
                 }
                 val
             })


### PR DESCRIPTION
As @frankmcsherry pointed out in https://github.com/MaterializeInc/materialize/pull/24247, `RowRef` is vestigial, and doesn't need to exist!

### Motivation

   * This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
