### PR TITLE
catalog-debug: Print catalog epoch

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -129,6 +129,17 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// Reports if the catalog state has been initialized.
     async fn is_initialized(&mut self) -> Result<bool, CatalogError>;
 
+    /// Returns the epoch of the current durable catalog state. The epoch acts as
+    /// a fencing token to prevent split brain issues across two
+    /// [`DurableCatalogState`]s. When a new [`DurableCatalogState`] opens the
+    /// catalog, it will increment the epoch by one (or initialize it to some
+    /// value if there's no existing epoch) and store the value in memory. It's
+    /// guaranteed that no two [`DurableCatalogState`]s will return the same value
+    /// for their epoch.
+    ///
+    /// NB: We may remove this in later iterations of Pv2.
+    async fn epoch(&mut self) -> Result<Epoch, CatalogError>;
+
     /// Get the deployment generation of this instance.
     async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError>;
 

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -553,6 +553,17 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
         Ok(self.is_initialized_inner().await?.0)
     }
 
+    async fn epoch(&mut self) -> Result<Epoch, CatalogError> {
+        let (persist_shard_readable, current_upper) = self.is_persist_shard_readable().await;
+        if persist_shard_readable {
+            let as_of = self.as_of(current_upper);
+            let epoch = self.get_epoch(as_of).await;
+            Ok(epoch)
+        } else {
+            Err(CatalogError::Durable(DurableCatalogError::Uninitialized))
+        }
+    }
+
     #[tracing::instrument(level = "debug", skip(self))]
     async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError> {
         self.get_current_config(DEPLOY_GENERATION).await

--- a/src/catalog/src/durable/impls/shadow.rs
+++ b/src/catalog/src/durable/impls/shadow.rs
@@ -150,6 +150,10 @@ where
         compare_and_return_async!(self, is_initialized)
     }
 
+    async fn epoch(&mut self) -> Result<Epoch, CatalogError> {
+        compare_and_return_async!(self, epoch)
+    }
+
     async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError> {
         compare_and_return_async!(self, get_deployment_generation)
     }

--- a/src/catalog/src/durable/impls/stash.rs
+++ b/src/catalog/src/durable/impls/stash.rs
@@ -250,6 +250,22 @@ impl OpenableDurableCatalogState for OpenableConnection {
         is_stash_initialized(stash).await.err_into()
     }
 
+    async fn epoch(&mut self) -> Result<Epoch, CatalogError> {
+        let stash = match &mut self.stash {
+            None => match self.open_stash_read_only().await {
+                Ok(stash) => stash,
+                Err(e) if e.can_recover_with_write_mode() => {
+                    return Err(CatalogError::Durable(DurableCatalogError::Uninitialized))
+                }
+                Err(e) => return Err(e.into()),
+            },
+            Some(stash) => stash,
+        };
+        stash
+            .epoch()
+            .ok_or(CatalogError::Durable(DurableCatalogError::Uninitialized))
+    }
+
     async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError> {
         self.get_config(DEPLOY_GENERATION.into()).await
     }
@@ -1306,6 +1322,10 @@ impl OpenableDurableCatalogState for TestOpenableConnection<'_> {
 
     async fn is_initialized(&mut self) -> Result<bool, CatalogError> {
         self.openable_connection.is_initialized().await
+    }
+
+    async fn epoch(&mut self) -> Result<Epoch, CatalogError> {
+        self.openable_connection.epoch().await
     }
 
     async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError> {


### PR DESCRIPTION
This commit adds the ability to print the current epoch to the catalog debug tool.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
