### PR TITLE
Attempt to remove lifetimes from `IntoRowByTypes`

### DIFF
--- a/src/compute-types/src/plan/join/mod.rs
+++ b/src/compute-types/src/plan/join/mod.rs
@@ -125,10 +125,10 @@ impl JoinClosure {
     /// Applies per-row filtering and logic.
     #[inline(always)]
     pub fn apply<'a>(
-        &'a self,
+        &self,
         datums: &mut Vec<Datum<'a>>,
         temp_storage: &'a RowArena,
-        row: &'a mut Row,
+        row: &mut Row,
     ) -> Result<Option<Row>, mz_expr::EvalError> {
         for exprs in self.ready_equivalences.iter() {
             // Each list of expressions should be equal to the same value.

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1024,9 +1024,7 @@ impl IndexPeek {
         for<'a> Tr::Key<'a>: IntoRowByTypes<'a>,
         for<'a> Tr::Val<'a>: IntoRowByTypes<'a>,
         Tr::KeyOwned: Columnation + Data + FromRowByTypes,
-        for<'a> &'a Tr::KeyOwned: IntoRowByTypes<'a>,
         Tr::ValOwned: Columnation + Data,
-        for<'a> &'a Tr::ValOwned: IntoRowByTypes<'a>,
     {
         let max_result_size = usize::cast_from(max_result_size);
         let count_byte_size = std::mem::size_of::<NonZeroUsize>();

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1021,10 +1021,12 @@ impl IndexPeek {
     ) -> Result<Vec<(Row, NonZeroUsize)>, String>
     where
         Tr: TraceReader<Time = Timestamp, Diff = Diff>,
-        for<'a> Tr::Key<'a>: IntoRowByTypes,
-        for<'a> Tr::Val<'a>: IntoRowByTypes,
-        Tr::KeyOwned: Columnation + Data + FromRowByTypes + IntoRowByTypes,
-        Tr::ValOwned: Columnation + Data + IntoRowByTypes,
+        for<'a> Tr::Key<'a>: IntoRowByTypes<'a>,
+        for<'a> Tr::Val<'a>: IntoRowByTypes<'a>,
+        Tr::KeyOwned: Columnation + Data + FromRowByTypes,
+        for<'a> &'a Tr::KeyOwned: IntoRowByTypes<'a>,
+        Tr::ValOwned: Columnation + Data,
+        for<'a> &'a Tr::ValOwned: IntoRowByTypes<'a>,
     {
         let max_result_size = usize::cast_from(max_result_size);
         let count_byte_size = std::mem::size_of::<NonZeroUsize>();

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1024,7 +1024,9 @@ impl IndexPeek {
         for<'a> Tr::Key<'a>: IntoRowByTypes<'a>,
         for<'a> Tr::Val<'a>: IntoRowByTypes<'a>,
         Tr::KeyOwned: Columnation + Data + FromRowByTypes,
+        for<'a> &'a Tr::KeyOwned: IntoRowByTypes<'a>,
         Tr::ValOwned: Columnation + Data,
+        for<'a> &'a Tr::ValOwned: IntoRowByTypes<'a>,
     {
         let max_result_size = usize::cast_from(max_result_size);
         let count_byte_size = std::mem::size_of::<NonZeroUsize>();

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -825,8 +825,8 @@ where
         refuel: usize,
     ) -> timely::dataflow::Stream<S, I::Item>
     where
-        for<'a> Tr::Key<'a>: IntoRowByTypes,
-        for<'a> Tr::Val<'a>: IntoRowByTypes,
+        for<'a> Tr::Key<'a>: IntoRowByTypes<'a>,
+        for<'a> Tr::Val<'a>: IntoRowByTypes<'a>,
         Tr: TraceReader<Time = S::Timestamp, Diff = mz_repr::Diff> + Clone + 'static,
         I: IntoIterator,
         I::Item: Data,

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -434,9 +434,8 @@ where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
     Tr: TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
-    Tr::KeyOwned: ExchangeData + Hashable + Default + FromRowByTypes,
-    for<'a> &'a Tr::KeyOwned: IntoRowByTypes<'a>,
-    for<'a> Tr::Val<'a>: IntoRowByTypes<'a>,
+    Tr::KeyOwned: ExchangeData + Hashable + Default + FromRowByTypes + IntoRowByTypes,
+    for<'a> Tr::Val<'a>: IntoRowByTypes,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
 {
     let updates_key_types = trace_key_types.clone();
@@ -639,8 +638,8 @@ where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
     Tr: for<'a> TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
-    for<'a> Tr::Key<'a>: IntoRowByTypes<'a>,
-    for<'a> Tr::Val<'a>: IntoRowByTypes<'a>,
+    for<'a> Tr::Key<'a>: IntoRowByTypes,
+    for<'a> Tr::Val<'a>: IntoRowByTypes,
 {
     let mut inner_as_of = Antichain::new();
     for event_time in as_of.elements().iter() {

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -434,8 +434,9 @@ where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
     Tr: TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
-    Tr::KeyOwned: ExchangeData + Hashable + Default + FromRowByTypes + IntoRowByTypes,
-    for<'a> Tr::Val<'a>: IntoRowByTypes,
+    Tr::KeyOwned: ExchangeData + Hashable + Default + FromRowByTypes,
+    for<'a> &'a Tr::KeyOwned: IntoRowByTypes<'a>,
+    for<'a> Tr::Val<'a>: IntoRowByTypes<'a>,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
 {
     let updates_key_types = trace_key_types.clone();
@@ -638,8 +639,8 @@ where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
     Tr: for<'a> TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
-    for<'a> Tr::Key<'a>: IntoRowByTypes,
-    for<'a> Tr::Val<'a>: IntoRowByTypes,
+    for<'a> Tr::Key<'a>: IntoRowByTypes<'a>,
+    for<'a> Tr::Val<'a>: IntoRowByTypes<'a>,
 {
     let mut inner_as_of = Antichain::new();
     for event_time in as_of.elements().iter() {

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -494,9 +494,9 @@ where
         Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = G::Timestamp, Diff = Diff>
             + Clone
             + 'static,
-        for<'a> Tr1::Key<'a>: IntoRowByTypes<'a>,
-        for<'a> Tr1::Val<'a>: IntoRowByTypes<'a>,
-        for<'a> Tr2::Val<'a>: IntoRowByTypes<'a>,
+        for<'a> Tr1::Key<'a>: IntoRowByTypes,
+        for<'a> Tr1::Val<'a>: IntoRowByTypes,
+        for<'a> Tr2::Val<'a>: IntoRowByTypes,
     {
         // Reuseable allocation for unpacking.
         let mut datums = DatumVec::new();

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -494,9 +494,9 @@ where
         Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = G::Timestamp, Diff = Diff>
             + Clone
             + 'static,
-        for<'a> Tr1::Key<'a>: IntoRowByTypes,
-        for<'a> Tr1::Val<'a>: IntoRowByTypes,
-        for<'a> Tr2::Val<'a>: IntoRowByTypes,
+        for<'a> Tr1::Key<'a>: IntoRowByTypes<'a>,
+        for<'a> Tr1::Val<'a>: IntoRowByTypes<'a>,
+        for<'a> Tr2::Val<'a>: IntoRowByTypes<'a>,
     {
         // Reuseable allocation for unpacking.
         let mut datums = DatumVec::new();

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -533,7 +533,7 @@ where
         T1: Trace<KeyOwned = Row, Time = G::Timestamp, Diff = Diff> + 'static,
         T1::Batch: Batch,
         T1::Batcher: Batcher<Item = ((Row, T1::ValOwned), G::Timestamp, Diff)>,
-        for<'a> T1::Key<'a>: std::fmt::Debug + IntoRowByTypes,
+        for<'a> T1::Key<'a>: std::fmt::Debug + IntoRowByTypes<'a>,
         T1::ValOwned: Columnation + ExchangeData + Default,
         Arranged<S, TraceAgent<T1>>: ArrangementSize,
         T2: for<'a> Trace<

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -533,7 +533,7 @@ where
         T1: Trace<KeyOwned = Row, Time = G::Timestamp, Diff = Diff> + 'static,
         T1::Batch: Batch,
         T1::Batcher: Batcher<Item = ((Row, T1::ValOwned), G::Timestamp, Diff)>,
-        for<'a> T1::Key<'a>: std::fmt::Debug + IntoRowByTypes<'a>,
+        for<'a> T1::Key<'a>: std::fmt::Debug + IntoRowByTypes,
         T1::ValOwned: Columnation + ExchangeData + Default,
         Arranged<S, TraceAgent<T1>>: ArrangementSize,
         T2: for<'a> Trace<

--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -312,13 +312,10 @@ mod container {
 
     use mz_repr::fixed_length::IntoRowByTypes;
     use mz_repr::ColumnType;
-    impl<'long> IntoRowByTypes for DatumSeq<'long> {
-        type DatumIter<'short> = DatumSeq<'short> where Self: 'short;
-        fn into_datum_iter<'short>(
-            &'short self,
-            _types: Option<&[ColumnType]>,
-        ) -> Self::DatumIter<'short> {
-            *self
+    impl<'long: 'short, 'short> IntoRowByTypes<'short> for DatumSeq<'long> {
+        type DatumIter = DatumSeq<'short>;
+        fn into_datum_iter(self, _types: Option<&[ColumnType]>) -> Self::DatumIter {
+            self
         }
     }
 }

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1480,11 +1480,11 @@ pub mod plan {
         /// The `row` is not cleared first, but emptied if the function
         /// returns `Ok(Some(row)).
         #[inline(always)]
-        pub fn evaluate_into<'a, 'row>(
+        pub fn evaluate_into<'a>(
             &self,
             datums: &mut Vec<Datum<'a>>,
             arena: &'a RowArena,
-            row_buf: &'row mut Row,
+            row_buf: &mut Row,
         ) -> Result<Option<Row>, EvalError> {
             let passed_predicates = self.evaluate_inner(datums, arena)?;
             if !passed_predicates {

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1481,7 +1481,7 @@ pub mod plan {
         /// returns `Ok(Some(row)).
         #[inline(always)]
         pub fn evaluate_into<'a, 'row>(
-            &'a self,
+            &self,
             datums: &mut Vec<Datum<'a>>,
             arena: &'a RowArena,
             row_buf: &'row mut Row,
@@ -1520,7 +1520,7 @@ pub mod plan {
         ///
         /// This does not apply `self.projection`, which is up to the calling method.
         pub fn evaluate_inner<'b, 'a: 'b>(
-            &'a self,
+            &self,
             datums: &'b mut Vec<Datum<'a>>,
             arena: &'a RowArena,
         ) -> Result<bool, EvalError> {

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -24,11 +24,11 @@ use crate::{EvalError, MirScalarExpr};
 pub struct CastArrayToListOneDim;
 
 impl LazyUnaryFunc for CastArrayToListOneDim {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -97,11 +97,11 @@ pub struct CastArrayToString {
 }
 
 impl LazyUnaryFunc for CastArrayToString {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -157,11 +157,11 @@ pub struct CastArrayToArray {
 }
 
 impl LazyUnaryFunc for CastArrayToArray {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {

--- a/src/expr/src/scalar/func/impls/int2vector.rs
+++ b/src/expr/src/scalar/func/impls/int2vector.rs
@@ -25,11 +25,11 @@ pub struct CastInt2VectorToArray;
 // This could be simplified to an EagerUnaryFunc once we have
 // auto-parameterization of array built-in functions.
 impl LazyUnaryFunc for CastInt2VectorToArray {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         a.eval(datums, temp_storage)
     }
@@ -75,11 +75,11 @@ impl fmt::Display for CastInt2VectorToArray {
 pub struct CastInt2VectorToString;
 
 impl LazyUnaryFunc for CastInt2VectorToString {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {

--- a/src/expr/src/scalar/func/impls/list.rs
+++ b/src/expr/src/scalar/func/impls/list.rs
@@ -25,11 +25,11 @@ pub struct CastListToString {
 }
 
 impl LazyUnaryFunc for CastListToString {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -83,11 +83,11 @@ pub struct CastList1ToList2 {
 }
 
 impl LazyUnaryFunc for CastList1ToList2 {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -144,11 +144,11 @@ impl fmt::Display for CastList1ToList2 {
 pub struct ListLength;
 
 impl LazyUnaryFunc for ListLength {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {

--- a/src/expr/src/scalar/func/impls/map.rs
+++ b/src/expr/src/scalar/func/impls/map.rs
@@ -25,11 +25,11 @@ pub struct CastMapToString {
 }
 
 impl LazyUnaryFunc for CastMapToString {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -78,11 +78,11 @@ impl fmt::Display for CastMapToString {
 pub struct MapLength;
 
 impl LazyUnaryFunc for MapLength {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {

--- a/src/expr/src/scalar/func/impls/range.rs
+++ b/src/expr/src/scalar/func/impls/range.rs
@@ -26,11 +26,11 @@ pub struct CastRangeToString {
 }
 
 impl LazyUnaryFunc for CastRangeToString {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -79,11 +79,11 @@ impl fmt::Display for CastRangeToString {
 pub struct RangeLower;
 
 impl LazyUnaryFunc for RangeLower {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -136,11 +136,11 @@ impl fmt::Display for RangeLower {
 pub struct RangeUpper;
 
 impl LazyUnaryFunc for RangeUpper {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {

--- a/src/expr/src/scalar/func/impls/record.rs
+++ b/src/expr/src/scalar/func/impls/record.rs
@@ -26,11 +26,11 @@ pub struct CastRecordToString {
 }
 
 impl LazyUnaryFunc for CastRecordToString {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -82,11 +82,11 @@ pub struct CastRecord1ToRecord2 {
 }
 
 impl LazyUnaryFunc for CastRecord1ToRecord2 {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -142,11 +142,11 @@ impl fmt::Display for CastRecord1ToRecord2 {
 pub struct RecordGet(pub usize);
 
 impl LazyUnaryFunc for RecordGet {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -310,11 +310,11 @@ pub struct CastStringToArray {
 }
 
 impl LazyUnaryFunc for CastStringToArray {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -383,11 +383,11 @@ pub struct CastStringToList {
 }
 
 impl LazyUnaryFunc for CastStringToList {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -460,11 +460,11 @@ pub struct CastStringToMap {
 }
 
 impl LazyUnaryFunc for CastStringToMap {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -587,11 +587,11 @@ pub struct CastStringToRange {
 }
 
 impl LazyUnaryFunc for CastStringToRange {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -712,11 +712,11 @@ static INT2VECTOR_CAST_EXPR: Lazy<MirScalarExpr> = Lazy::new(|| MirScalarExpr::C
 pub struct CastStringToInt2Vector;
 
 impl LazyUnaryFunc for CastStringToInt2Vector {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
@@ -907,11 +907,11 @@ impl fmt::Display for IsRegexpMatch {
 pub struct RegexpMatch(pub Regex);
 
 impl LazyUnaryFunc for RegexpMatch {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let haystack = a.eval(datums, temp_storage)?;
         if haystack.is_null() {
@@ -965,11 +965,11 @@ impl fmt::Display for RegexpMatch {
 pub struct RegexpSplitToArray(pub Regex);
 
 impl LazyUnaryFunc for RegexpSplitToArray {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let haystack = a.eval(datums, temp_storage)?;
         if haystack.is_null() {
@@ -1032,11 +1032,11 @@ sqlfunc!(
 pub struct QuoteIdent;
 
 impl LazyUnaryFunc for QuoteIdent {
-    fn eval<'a>(
-        &'a self,
+    fn eval<'a, 'b>(
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a MirScalarExpr,
+        a: &'b MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let d = a.eval(datums, temp_storage)?;
         if d.is_null() {

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -333,11 +333,11 @@ macro_rules! derive_unary {
         }
 
         impl UnaryFunc {
-            pub fn eval<'a>(
-                &'a self,
+            pub fn eval<'a, 'b>(
+                &self,
                 datums: &[Datum<'a>],
                 temp_storage: &'a RowArena,
-                a: &'a MirScalarExpr,
+                a: &'b MirScalarExpr,
             ) -> Result<Datum<'a>, EvalError> {
                 match self {
                     $(Self::$name(f) => f.eval(datums, temp_storage, a),)*

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1821,14 +1821,14 @@ impl MirScalarExpr {
     }
 
     pub fn eval<'a>(
-        &'a self,
+        &self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
     ) -> Result<Datum<'a>, EvalError> {
         match self {
             MirScalarExpr::Column(index) => Ok(datums[*index].clone()),
             MirScalarExpr::Literal(res, _column_type) => match res {
-                Ok(row) => Ok(row.unpack_first()),
+                Ok(row) => Ok(temp_storage.make_datum(|p| p.push(row.unpack_first()))),
                 Err(e) => Err(e.clone()),
             },
             // Unmaterializable functions must be transformed away before

--- a/src/repr/src/fixed_length.rs
+++ b/src/repr/src/fixed_length.rs
@@ -18,13 +18,26 @@ use std::borrow::Borrow;
 use std::iter::{empty, Empty};
 
 use crate::row::DatumListIter;
-use crate::{ColumnType, Datum, Row, RowRef};
+use crate::{ColumnType, Datum, Row};
 
 /// A helper trait to get references to `Row` based on type information that only manifests
 /// at runtime (typically originating from inferred schemas).
-pub trait IntoRowByTypes<'a> {
+pub trait IntoRowByTypes<'a>: Sized {
     /// An iterator type for use in `into_datum_iter`.
     type DatumIter: IntoIterator<Item = Datum<'a>>;
+
+    /// Obtains a reference to `Row` for an instance of `Self`, given a `Row` buffer and
+    /// a schema provided by `types`.
+    ///
+    /// Implementations are free to not use `row_buf` if a zero-copy implementation
+    /// can be provided. If the Row buffer is used, then the reference returned is to it.
+    /// Implementations are also free to place specific requirements on the given schema.
+    // #[inline]
+    // fn into_row(self, row_buf: &'a mut Row, types: Option<&[ColumnType]>) -> &'a Row {
+    //     let mut packer = row_buf.packer();
+    //     packer.extend(self.into_datum_iter(types));
+    //     row_buf
+    // }
 
     /// Obtains an iterator of datums out of an instance of `Self`, given a schema provided
     /// by `types`.
@@ -35,15 +48,26 @@ pub trait IntoRowByTypes<'a> {
 
 // impl<'b, T: IntoRowByTypes<'b>> IntoRowByTypes<'b> for &'b T {
 //     type DatumIter = T::DatumIter;
-//     fn into_datum_iter<'a>(&'a self, types: Option<&[ColumnType]>) -> Self::DatumIter {
-//         (**self).into_datum_iter(types)
+//     fn into_datum_iter(self, types: Option<&[ColumnType]>) -> Self::DatumIter {
+//         self.into_datum_iter(types)
 //     }
 // }
 
 // Blanket identity implementation for Row.
-impl<'a, I: IntoIterator<Item = Datum<'a>>> IntoRowByTypes<'a> for I {
+impl<'b> IntoRowByTypes<'b> for &'b Row {
     /// Datum iterator for `Row`.
-    type DatumIter = I::IntoIter;
+    type DatumIter = DatumListIter<'b>;
+
+    /// Performs a zero-copy reference forwarding without employing the `Row` buffer.
+    ///
+    /// This implementation panics if `types` other than `None` are provided. This is because
+    /// `Row` is already self-describing and can use variable-length types, so we are
+    /// explicitly not validating the given schema.
+    // #[inline]
+    // fn into_row(self, _row_buf: &mut Row, types: Option<&[ColumnType]>) -> &'b Row {
+    //     assert!(types.is_none());
+    //     self
+    // }
 
     /// Borrows `self` and gets an iterator from it.
     ///
@@ -53,7 +77,7 @@ impl<'a, I: IntoIterator<Item = Datum<'a>>> IntoRowByTypes<'a> for I {
     #[inline]
     fn into_datum_iter(self, types: Option<&[ColumnType]>) -> Self::DatumIter {
         assert!(types.is_none());
-        self.into_iter()
+        self.iter()
     }
 }
 
@@ -147,9 +171,22 @@ impl FromRowByTypes for Row {
     }
 }
 
-impl<'a> IntoRowByTypes<'a> for &'a () {
+impl<'b> IntoRowByTypes<'b> for &'b () {
     /// Empty iterator for unit.
-    type DatumIter = Empty<Datum<'a>>;
+    type DatumIter = Empty<Datum<'b>>;
+
+    /// Returns the `Row` buffer, which is assumed to be empty, without touching it.
+    ///
+    /// This implementation panics if `types` other than `Some(&[])` are provided. This is because
+    /// unit values need to have an empty schema.
+    // #[inline]
+    // fn into_row(self, row_buf: &'b mut Row, types: Option<&[ColumnType]>) -> &'b Row {
+    //     let Some(&[]) = types else {
+    //         panic!("Non-empty schema with unit values")
+    //     };
+    //     debug_assert!(row_buf.is_empty());
+    //     row_buf
+    // }
 
     /// Returns an empty iterator.
     ///

--- a/src/repr/src/fixed_length.rs
+++ b/src/repr/src/fixed_length.rs
@@ -22,11 +22,9 @@ use crate::{ColumnType, Datum, Row};
 
 /// A helper trait to get references to `Row` based on type information that only manifests
 /// at runtime (typically originating from inferred schemas).
-pub trait IntoRowByTypes: Sized {
+pub trait IntoRowByTypes<'a>: Sized {
     /// An iterator type for use in `into_datum_iter`.
-    type DatumIter<'a>: IntoIterator<Item = Datum<'a>>
-    where
-        Self: 'a;
+    type DatumIter: IntoIterator<Item = Datum<'a>>;
 
     /// Obtains a reference to `Row` for an instance of `Self`, given a `Row` buffer and
     /// a schema provided by `types`.
@@ -34,42 +32,42 @@ pub trait IntoRowByTypes: Sized {
     /// Implementations are free to not use `row_buf` if a zero-copy implementation
     /// can be provided. If the Row buffer is used, then the reference returned is to it.
     /// Implementations are also free to place specific requirements on the given schema.
-    #[inline]
-    fn into_row<'a>(&'a self, row_buf: &'a mut Row, types: Option<&[ColumnType]>) -> &'a Row {
-        let mut packer = row_buf.packer();
-        packer.extend(self.into_datum_iter(types));
-        row_buf
-    }
+    // #[inline]
+    // fn into_row(self, row_buf: &'a mut Row, types: Option<&[ColumnType]>) -> &'a Row {
+    //     let mut packer = row_buf.packer();
+    //     packer.extend(self.into_datum_iter(types));
+    //     row_buf
+    // }
 
     /// Obtains an iterator of datums out of an instance of `Self`, given a schema provided
     /// by `types`.
     ///
     /// Implementations are free to place specific requirements on the given schema.
-    fn into_datum_iter<'a>(&'a self, types: Option<&[ColumnType]>) -> Self::DatumIter<'a>;
+    fn into_datum_iter(self, types: Option<&[ColumnType]>) -> Self::DatumIter;
 }
 
-impl<'b, T: IntoRowByTypes> IntoRowByTypes for &'b T {
-    type DatumIter<'a> = T::DatumIter<'a> where T: 'a, Self: 'a;
-    fn into_datum_iter<'a>(&'a self, types: Option<&[ColumnType]>) -> Self::DatumIter<'a> {
-        (**self).into_datum_iter(types)
-    }
-}
+// impl<'b, T: IntoRowByTypes<'b>> IntoRowByTypes<'b> for &'b T {
+//     type DatumIter = T::DatumIter;
+//     fn into_datum_iter(self, types: Option<&[ColumnType]>) -> Self::DatumIter {
+//         self.into_datum_iter(types)
+//     }
+// }
 
 // Blanket identity implementation for Row.
-impl IntoRowByTypes for Row {
+impl<'b> IntoRowByTypes<'b> for &'b Row {
     /// Datum iterator for `Row`.
-    type DatumIter<'a> = DatumListIter<'a>;
+    type DatumIter = DatumListIter<'b>;
 
     /// Performs a zero-copy reference forwarding without employing the `Row` buffer.
     ///
     /// This implementation panics if `types` other than `None` are provided. This is because
     /// `Row` is already self-describing and can use variable-length types, so we are
     /// explicitly not validating the given schema.
-    #[inline]
-    fn into_row<'a>(&'a self, _row_buf: &'a mut Row, types: Option<&[ColumnType]>) -> &'a Row {
-        assert!(types.is_none());
-        self
-    }
+    // #[inline]
+    // fn into_row(self, _row_buf: &mut Row, types: Option<&[ColumnType]>) -> &'b Row {
+    //     assert!(types.is_none());
+    //     self
+    // }
 
     /// Borrows `self` and gets an iterator from it.
     ///
@@ -77,7 +75,7 @@ impl IntoRowByTypes for Row {
     /// `Row` is already self-describing and can use variable-length types, so we are
     /// explicitly not validating the given schema.
     #[inline]
-    fn into_datum_iter<'a>(&'a self, types: Option<&[ColumnType]>) -> Self::DatumIter<'a> {
+    fn into_datum_iter(self, types: Option<&[ColumnType]>) -> Self::DatumIter {
         assert!(types.is_none());
         self.iter()
     }
@@ -173,29 +171,29 @@ impl FromRowByTypes for Row {
     }
 }
 
-impl IntoRowByTypes for () {
+impl<'b> IntoRowByTypes<'b> for &'b () {
     /// Empty iterator for unit.
-    type DatumIter<'a> = Empty<Datum<'a>>;
+    type DatumIter = Empty<Datum<'b>>;
 
     /// Returns the `Row` buffer, which is assumed to be empty, without touching it.
     ///
     /// This implementation panics if `types` other than `Some(&[])` are provided. This is because
     /// unit values need to have an empty schema.
-    #[inline]
-    fn into_row<'a>(&'a self, row_buf: &'a mut Row, types: Option<&[ColumnType]>) -> &'a Row {
-        let Some(&[]) = types else {
-            panic!("Non-empty schema with unit values")
-        };
-        debug_assert!(row_buf.is_empty());
-        row_buf
-    }
+    // #[inline]
+    // fn into_row(self, row_buf: &'b mut Row, types: Option<&[ColumnType]>) -> &'b Row {
+    //     let Some(&[]) = types else {
+    //         panic!("Non-empty schema with unit values")
+    //     };
+    //     debug_assert!(row_buf.is_empty());
+    //     row_buf
+    // }
 
     /// Returns an empty iterator.
     ///
     /// This implementation panics if `types` other than `Some(&[])` are provided. This is because
     /// unit values need to have an empty schema.
     #[inline]
-    fn into_datum_iter<'a>(&'a self, types: Option<&[ColumnType]>) -> Self::DatumIter<'a> {
+    fn into_datum_iter(self, types: Option<&[ColumnType]>) -> Self::DatumIter {
         let Some(&[]) = types else {
             panic!("Non-empty schema with unit values")
         };

--- a/src/repr/src/fixed_length.rs
+++ b/src/repr/src/fixed_length.rs
@@ -18,26 +18,13 @@ use std::borrow::Borrow;
 use std::iter::{empty, Empty};
 
 use crate::row::DatumListIter;
-use crate::{ColumnType, Datum, Row};
+use crate::{ColumnType, Datum, Row, RowRef};
 
 /// A helper trait to get references to `Row` based on type information that only manifests
 /// at runtime (typically originating from inferred schemas).
-pub trait IntoRowByTypes<'a>: Sized {
+pub trait IntoRowByTypes<'a> {
     /// An iterator type for use in `into_datum_iter`.
     type DatumIter: IntoIterator<Item = Datum<'a>>;
-
-    /// Obtains a reference to `Row` for an instance of `Self`, given a `Row` buffer and
-    /// a schema provided by `types`.
-    ///
-    /// Implementations are free to not use `row_buf` if a zero-copy implementation
-    /// can be provided. If the Row buffer is used, then the reference returned is to it.
-    /// Implementations are also free to place specific requirements on the given schema.
-    // #[inline]
-    // fn into_row(self, row_buf: &'a mut Row, types: Option<&[ColumnType]>) -> &'a Row {
-    //     let mut packer = row_buf.packer();
-    //     packer.extend(self.into_datum_iter(types));
-    //     row_buf
-    // }
 
     /// Obtains an iterator of datums out of an instance of `Self`, given a schema provided
     /// by `types`.
@@ -48,26 +35,15 @@ pub trait IntoRowByTypes<'a>: Sized {
 
 // impl<'b, T: IntoRowByTypes<'b>> IntoRowByTypes<'b> for &'b T {
 //     type DatumIter = T::DatumIter;
-//     fn into_datum_iter(self, types: Option<&[ColumnType]>) -> Self::DatumIter {
-//         self.into_datum_iter(types)
+//     fn into_datum_iter<'a>(&'a self, types: Option<&[ColumnType]>) -> Self::DatumIter {
+//         (**self).into_datum_iter(types)
 //     }
 // }
 
 // Blanket identity implementation for Row.
-impl<'b> IntoRowByTypes<'b> for &'b Row {
+impl<'a, I: IntoIterator<Item = Datum<'a>>> IntoRowByTypes<'a> for I {
     /// Datum iterator for `Row`.
-    type DatumIter = DatumListIter<'b>;
-
-    /// Performs a zero-copy reference forwarding without employing the `Row` buffer.
-    ///
-    /// This implementation panics if `types` other than `None` are provided. This is because
-    /// `Row` is already self-describing and can use variable-length types, so we are
-    /// explicitly not validating the given schema.
-    // #[inline]
-    // fn into_row(self, _row_buf: &mut Row, types: Option<&[ColumnType]>) -> &'b Row {
-    //     assert!(types.is_none());
-    //     self
-    // }
+    type DatumIter = I::IntoIter;
 
     /// Borrows `self` and gets an iterator from it.
     ///
@@ -77,7 +53,7 @@ impl<'b> IntoRowByTypes<'b> for &'b Row {
     #[inline]
     fn into_datum_iter(self, types: Option<&[ColumnType]>) -> Self::DatumIter {
         assert!(types.is_none());
-        self.iter()
+        self.into_iter()
     }
 }
 
@@ -171,22 +147,9 @@ impl FromRowByTypes for Row {
     }
 }
 
-impl<'b> IntoRowByTypes<'b> for &'b () {
+impl<'a> IntoRowByTypes<'a> for &'a () {
     /// Empty iterator for unit.
-    type DatumIter = Empty<Datum<'b>>;
-
-    /// Returns the `Row` buffer, which is assumed to be empty, without touching it.
-    ///
-    /// This implementation panics if `types` other than `Some(&[])` are provided. This is because
-    /// unit values need to have an empty schema.
-    // #[inline]
-    // fn into_row(self, row_buf: &'b mut Row, types: Option<&[ColumnType]>) -> &'b Row {
-    //     let Some(&[]) = types else {
-    //         panic!("Non-empty schema with unit values")
-    //     };
-    //     debug_assert!(row_buf.is_empty());
-    //     row_buf
-    // }
+    type DatumIter = Empty<Datum<'a>>;
 
     /// Returns an empty iterator.
     ///


### PR DESCRIPTION
Failed, because I don't know how to express enough lifetime information within closures. :/

cc @frankmcsherry 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
