### PR TITLE
Add builtin roles `mz_read_sql` and `mz_read_sql_redacted`

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -48,7 +48,7 @@ logging entirely for a session, execute `SET
 statement_logging_sample_rate TO 0`. Materialize may apply a lower
 sampling rate than the one set in this variable.
 
-Only users that have been granted the `mz_read_sql` role can access
+Only superusers or users that have been granted the `mz_monitor` role can access
 this view.
 
 <!-- RELATION_SPEC mz_internal.mz_activity_log -->

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -48,6 +48,9 @@ logging entirely for a session, execute `SET
 statement_logging_sample_rate TO 0`. Materialize may apply a lower
 sampling rate than the one set in this variable.
 
+Only users that have been granted the `mz_read_sql` role can access
+this view.
+
 <!-- RELATION_SPEC mz_internal.mz_activity_log -->
 | Field                     | Type                         | Meaning                                                                                                                                                                                                                                                                       |
 |---------------------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2363,7 +2363,7 @@ impl Catalog {
                     grantor_id,
                 } => {
                     state.ensure_not_reserved_role(&member_id)?;
-                    state.ensure_not_reserved_role(&role_id)?;
+                    state.ensure_grantable_role(&role_id)?;
                     if state.collect_role_membership(&role_id).contains(&member_id) {
                         let group_role = state.get_role(&role_id);
                         let member_role = state.get_role(&member_id);
@@ -2405,7 +2405,7 @@ impl Catalog {
                     grantor_id,
                 } => {
                     state.ensure_not_reserved_role(&member_id)?;
-                    state.ensure_not_reserved_role(&role_id)?;
+                    state.ensure_grantable_role(&role_id)?;
                     builtin_table_updates
                         .push(state.pack_role_members_update(role_id, member_id, -1));
                     let member_role = state.get_role_mut(&member_id);
@@ -3645,6 +3645,10 @@ impl Catalog {
 
     pub fn ensure_not_reserved_role(&self, role_id: &RoleId) -> Result<(), Error> {
         self.state.ensure_not_reserved_role(role_id)
+    }
+
+    pub fn ensure_grantable_role(&self, role_id: &RoleId) -> Result<(), Error> {
+        self.state.ensure_grantable_role(role_id)
     }
 
     pub fn ensure_not_system_role(&self, role_id: &RoleId) -> Result<(), Error> {

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -21,8 +21,8 @@ use tracing::{info, warn, Instrument};
 use uuid::Uuid;
 
 use mz_catalog::builtin::{
-    Builtin, DataSensitivity, Fingerprint, BUILTINS, BUILTIN_CLUSTERS, BUILTIN_CLUSTER_REPLICAS,
-    BUILTIN_PREFIXES, BUILTIN_ROLES,
+    Builtin, Fingerprint, BUILTINS, BUILTIN_CLUSTERS, BUILTIN_CLUSTER_REPLICAS, BUILTIN_PREFIXES,
+    BUILTIN_ROLES,
 };
 use mz_catalog::config::StateConfig;
 use mz_catalog::durable::initialize::MZ_UNSAFE_SCHEMA_ID;
@@ -499,19 +499,7 @@ impl Catalog {
                                 mz_sql::catalog::ObjectType::Source,
                                 MZ_SYSTEM_ROLE_ID,
                             )];
-                            match log.sensitivity {
-                                DataSensitivity::Public => {
-                                    acl_items.push(rbac::default_builtin_object_privilege(
-                                        mz_sql::catalog::ObjectType::Source,
-                                    ));
-                                }
-                                DataSensitivity::SuperuserAndSupport => {
-                                    acl_items.push(rbac::support_builtin_object_privilege(
-                                        mz_sql::catalog::ObjectType::Source,
-                                    ));
-                                }
-                                DataSensitivity::Superuser => {}
-                            }
+                            acl_items.extend_from_slice(&log.access);
                             state.insert_item(
                                 id,
                                 oid,
@@ -531,19 +519,7 @@ impl Catalog {
                                 mz_sql::catalog::ObjectType::Table,
                                 MZ_SYSTEM_ROLE_ID,
                             )];
-                            match table.sensitivity {
-                                DataSensitivity::Public => {
-                                    acl_items.push(rbac::default_builtin_object_privilege(
-                                        mz_sql::catalog::ObjectType::Table,
-                                    ));
-                                }
-                                DataSensitivity::SuperuserAndSupport => {
-                                    acl_items.push(rbac::support_builtin_object_privilege(
-                                        mz_sql::catalog::ObjectType::Table,
-                                    ));
-                                }
-                                DataSensitivity::Superuser => {}
-                            }
+                            acl_items.extend_from_slice(&table.access);
 
                             state.insert_item(
                                 id,
@@ -591,19 +567,7 @@ impl Catalog {
                                 mz_sql::catalog::ObjectType::View,
                                 MZ_SYSTEM_ROLE_ID,
                             )];
-                            match view.sensitivity {
-                                DataSensitivity::Public => {
-                                    acl_items.push(rbac::default_builtin_object_privilege(
-                                        mz_sql::catalog::ObjectType::View,
-                                    ));
-                                }
-                                DataSensitivity::SuperuserAndSupport => {
-                                    acl_items.push(rbac::support_builtin_object_privilege(
-                                        mz_sql::catalog::ObjectType::View,
-                                    ));
-                                }
-                                DataSensitivity::Superuser => {}
-                            }
+                            acl_items.extend_from_slice(&view.access);
 
                             state.insert_item(
                                 id,
@@ -640,19 +604,7 @@ impl Catalog {
                                 mz_sql::catalog::ObjectType::Source,
                                 MZ_SYSTEM_ROLE_ID,
                             )];
-                            match coll.sensitivity {
-                                DataSensitivity::Public => {
-                                    acl_items.push(rbac::default_builtin_object_privilege(
-                                        mz_sql::catalog::ObjectType::Source,
-                                    ));
-                                }
-                                DataSensitivity::SuperuserAndSupport => {
-                                    acl_items.push(rbac::support_builtin_object_privilege(
-                                        mz_sql::catalog::ObjectType::Source,
-                                    ));
-                                }
-                                DataSensitivity::Superuser => {}
-                            }
+                            acl_items.extend_from_slice(&coll.access);
 
                             state.insert_item(
                                 id,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -5350,14 +5350,12 @@ impl Coordinator {
     pub(super) async fn sequence_alter_default_privileges(
         &mut self,
         session: &Session,
-        p: plan::AlterDefaultPrivilegesPlan,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        println!("plan: {p:?}");
-        let plan::AlterDefaultPrivilegesPlan {
+        plan::AlterDefaultPrivilegesPlan {
             privilege_objects,
             privilege_acl_items,
             is_grant,
-        } = p;
+        }: plan::AlterDefaultPrivilegesPlan,
+    ) -> Result<ExecuteResponse, AdapterError> {
         let mut ops = Vec::with_capacity(privilege_objects.len() * privilege_acl_items.len());
         let variant = if is_grant {
             UpdatePrivilegeVariant::Grant

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -5350,12 +5350,14 @@ impl Coordinator {
     pub(super) async fn sequence_alter_default_privileges(
         &mut self,
         session: &Session,
-        plan::AlterDefaultPrivilegesPlan {
+        p: plan::AlterDefaultPrivilegesPlan,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        println!("plan: {p:?}");
+        let plan::AlterDefaultPrivilegesPlan {
             privilege_objects,
             privilege_acl_items,
             is_grant,
-        }: plan::AlterDefaultPrivilegesPlan,
-    ) -> Result<ExecuteResponse, AdapterError> {
+        } = p;
         let mut ops = Vec::with_capacity(privilege_objects.len() * privilege_acl_items.len());
         let variant = if is_grant {
             UpdatePrivilegeVariant::Grant
@@ -5413,7 +5415,7 @@ impl Coordinator {
                     let member_name = catalog.get_role(member_id).name().to_string();
                     // We need this check so we don't accidentally return a success on a reserved role.
                     catalog.ensure_not_reserved_role(member_id)?;
-                    catalog.ensure_not_reserved_role(&role_id)?;
+                    catalog.ensure_grantable_role(&role_id)?;
                     session.add_notice(AdapterNotice::RoleMembershipAlreadyExists {
                         role_name,
                         member_name,
@@ -5457,7 +5459,7 @@ impl Coordinator {
                     let member_name = catalog.get_role(member_id).name().to_string();
                     // We need this check so we don't accidentally return a success on a reserved role.
                     catalog.ensure_not_reserved_role(member_id)?;
-                    catalog.ensure_not_reserved_role(&role_id)?;
+                    catalog.ensure_grantable_role(&role_id)?;
                     session.add_notice(AdapterNotice::RoleMembershipDoesNotExists {
                         role_name,
                         member_name,

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2685,7 +2685,7 @@ FROM
         LEFT JOIN latest_events_to_use AS e ON mz_sources.id = e.source_id
 WHERE mz_sources.id NOT LIKE 's%';",
     access: vec![PUBLIC_SELECT],
-};
+});
 
 pub static MZ_SINK_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_sink_status_history",

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -1656,13 +1656,13 @@ const SUPPORT_SELECT: MzAclItem = MzAclItem {
     acl_mode: AclMode::SELECT,
 };
 
-const MONITOR: MzAclItem = MzAclItem {
+const MONITOR_SELECT: MzAclItem = MzAclItem {
     grantee: MZ_MONITOR_ROLE_ID,
     grantor: MZ_SYSTEM_ROLE_ID,
     acl_mode: AclMode::SELECT,
 };
 
-const MONITOR_REDACTED: MzAclItem = MzAclItem {
+const MONITOR_REDACTED_SELECT: MzAclItem = MzAclItem {
     grantee: MZ_MONITOR_REDACTED_ROLE_ID,
     grantor: MZ_SYSTEM_ROLE_ID,
     acl_mode: AclMode::SELECT,
@@ -2516,7 +2516,7 @@ pub static MZ_STATEMENT_EXECUTION_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| Bu
     data_source: Some(IntrospectionType::StatementExecutionHistory),
     desc: MZ_STATEMENT_EXECUTION_HISTORY_DESC.clone(),
     is_retained_metrics_object: false,
-    access: vec![MONITOR],
+    access: vec![MONITOR_SELECT],
 });
 
 pub static MZ_STATEMENT_EXECUTION_HISTORY_REDACTED: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
@@ -2530,7 +2530,7 @@ cluster_name, transaction_isolation, execution_timestamp, transaction_id,
 transient_index_id, began_at, finished_at, finished_status,
 error_message, rows_returned, execution_strategy
 FROM mz_internal.mz_statement_execution_history",
-    access: vec![SUPPORT_SELECT, MONITOR_REDACTED, MONITOR],
+    access: vec![SUPPORT_SELECT, MONITOR_REDACTED_SELECT, MONITOR_SELECT],
 });
 
 pub static MZ_PREPARED_STATEMENT_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
@@ -2539,7 +2539,7 @@ pub static MZ_PREPARED_STATEMENT_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| Bui
     data_source: Some(IntrospectionType::PreparedStatementHistory),
     desc: MZ_PREPARED_STATEMENT_HISTORY_DESC.clone(),
     is_retained_metrics_object: false,
-    access: vec![MONITOR],
+    access: vec![MONITOR_SELECT],
 });
 
 pub static MZ_PREPARED_STATEMENT_HISTORY_REDACTED: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
@@ -2550,7 +2550,7 @@ pub static MZ_PREPARED_STATEMENT_HISTORY_REDACTED: Lazy<BuiltinView> = Lazy::new
     sql: "
 SELECT id, session_id, name, redacted_sql, prepared_at, statement_type
 FROM mz_internal.mz_prepared_statement_history",
-    access: vec![SUPPORT_SELECT, MONITOR_REDACTED, MONITOR],
+    access: vec![SUPPORT_SELECT, MONITOR_REDACTED_SELECT, MONITOR_SELECT],
 });
 
 pub static MZ_SESSION_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
@@ -2575,7 +2575,7 @@ mpsh.id AS prepared_statement_id, sql, mpsh.name AS prepared_statement_name,
 session_id, redacted_sql, prepared_at, statement_type
 FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh
 WHERE mseh.prepared_statement_id = mpsh.id",
-    access: vec![MONITOR],
+    access: vec![MONITOR_SELECT],
 }
 });
 
@@ -2590,7 +2590,7 @@ transaction_isolation, execution_timestamp, transient_index_id, began_at, finish
 error_message, rows_returned, execution_strategy, transaction_id, prepared_statement_id,
 prepared_statement_name, session_id, redacted_sql, prepared_at, statement_type
 FROM mz_internal.mz_activity_log",
-    access: vec![SUPPORT_SELECT, MONITOR_REDACTED, MONITOR],
+    access: vec![SUPPORT_SELECT, MONITOR_REDACTED_SELECT, MONITOR_SELECT],
     }
 });
 
@@ -2609,7 +2609,7 @@ pub static MZ_STATEMENT_LIFECYCLE_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| Bu
     // TODO[btv]: Maybe this should be public instead of
     // `MONITOR_REDACTED`, but since that would be a backwards-compatible
     // chagne, we probably don't need to worry about it now.
-    access: vec![SUPPORT_SELECT, MONITOR_REDACTED, MONITOR],
+    access: vec![SUPPORT_SELECT, MONITOR_REDACTED_SELECT, MONITOR_SELECT],
 });
 
 pub static MZ_SOURCE_STATUSES: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {

--- a/src/catalog/src/builtin/notice.rs
+++ b/src/catalog/src/builtin/notice.rs
@@ -12,9 +12,9 @@ use mz_repr::{RelationDesc, ScalarType};
 use mz_sql::catalog::NameReference;
 use once_cell::sync::Lazy;
 
-use crate::builtin::{Builtin, BuiltinIndex, BuiltinTable, BuiltinView, READ_SQL};
+use crate::builtin::{Builtin, BuiltinIndex, BuiltinTable, BuiltinView, MONITOR};
 
-use super::{READ_REDACTED_SQL, SUPPORT_SELECT};
+use super::{MONITOR_REDACTED, SUPPORT_SELECT};
 
 pub static MZ_OPTIMIZER_NOTICES: Lazy<BuiltinTable> = Lazy::new(|| {
     use ScalarType::{List, String, TimestampTz};
@@ -46,7 +46,7 @@ pub static MZ_OPTIMIZER_NOTICES: Lazy<BuiltinTable> = Lazy::new(|| {
             )
             .without_keys(),
         is_retained_metrics_object: false,
-        access: vec![READ_SQL],
+        access: vec![MONITOR],
     }
 });
 
@@ -76,7 +76,7 @@ pub static MZ_NOTICES: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
 FROM
     mz_internal.mz_optimizer_notices n
 ",
-    access: vec![READ_SQL],
+    access: vec![MONITOR],
 });
 
 /// A redacted version of [`MZ_NOTICES`] that is made safe to be viewed by
@@ -97,7 +97,7 @@ pub static MZ_NOTICES_REDACTED: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
 FROM
     mz_internal.mz_notices
 ",
-    access: vec![SUPPORT_SELECT, READ_REDACTED_SQL],
+    access: vec![SUPPORT_SELECT, MONITOR_REDACTED],
 });
 
 pub const MZ_NOTICES_IND: BuiltinIndex = BuiltinIndex {

--- a/src/catalog/src/builtin/notice.rs
+++ b/src/catalog/src/builtin/notice.rs
@@ -12,9 +12,9 @@ use mz_repr::{RelationDesc, ScalarType};
 use mz_sql::catalog::NameReference;
 use once_cell::sync::Lazy;
 
-use crate::builtin::{Builtin, BuiltinIndex, BuiltinTable, BuiltinView, MONITOR};
+use crate::builtin::{Builtin, BuiltinIndex, BuiltinTable, BuiltinView, MONITOR_SELECT};
 
-use super::{MONITOR_REDACTED, SUPPORT_SELECT};
+use super::{MONITOR_REDACTED_SELECT, SUPPORT_SELECT};
 
 pub static MZ_OPTIMIZER_NOTICES: Lazy<BuiltinTable> = Lazy::new(|| {
     use ScalarType::{List, String, TimestampTz};
@@ -46,7 +46,7 @@ pub static MZ_OPTIMIZER_NOTICES: Lazy<BuiltinTable> = Lazy::new(|| {
             )
             .without_keys(),
         is_retained_metrics_object: false,
-        access: vec![MONITOR],
+        access: vec![MONITOR_SELECT],
     }
 });
 
@@ -76,7 +76,7 @@ pub static MZ_NOTICES: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
 FROM
     mz_internal.mz_optimizer_notices n
 ",
-    access: vec![MONITOR],
+    access: vec![MONITOR_SELECT],
 });
 
 /// A redacted version of [`MZ_NOTICES`] that is made safe to be viewed by
@@ -97,7 +97,7 @@ pub static MZ_NOTICES_REDACTED: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
 FROM
     mz_internal.mz_notices
 ",
-    access: vec![SUPPORT_SELECT, MONITOR_REDACTED],
+    access: vec![SUPPORT_SELECT, MONITOR_REDACTED_SELECT, MONITOR_SELECT],
 });
 
 pub const MZ_NOTICES_IND: BuiltinIndex = BuiltinIndex {

--- a/src/catalog/src/builtin/notice.rs
+++ b/src/catalog/src/builtin/notice.rs
@@ -12,7 +12,9 @@ use mz_repr::{RelationDesc, ScalarType};
 use mz_sql::catalog::NameReference;
 use once_cell::sync::Lazy;
 
-use crate::builtin::{Builtin, BuiltinIndex, BuiltinTable, BuiltinView, DataSensitivity};
+use crate::builtin::{Builtin, BuiltinIndex, BuiltinTable, BuiltinView, READ_SQL};
+
+use super::{READ_REDACTED_SQL, SUPPORT_SELECT};
 
 pub static MZ_OPTIMIZER_NOTICES: Lazy<BuiltinTable> = Lazy::new(|| {
     use ScalarType::{List, String, TimestampTz};
@@ -44,7 +46,7 @@ pub static MZ_OPTIMIZER_NOTICES: Lazy<BuiltinTable> = Lazy::new(|| {
             )
             .without_keys(),
         is_retained_metrics_object: false,
-        sensitivity: DataSensitivity::Superuser,
+        access: vec![READ_SQL],
     }
 });
 
@@ -56,7 +58,7 @@ pub static MZ_OPTIMIZER_NOTICES: Lazy<BuiltinTable> = Lazy::new(|| {
 /// notices, the idea is to evolve it over time as sketched in the design doc[^1].
 ///
 /// [^1] <https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20231113_optimizer_notice_catalog.md>
-pub static MZ_NOTICES: BuiltinView = BuiltinView {
+pub static MZ_NOTICES: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
     name: "mz_notices",
     schema: MZ_INTERNAL_SCHEMA,
     column_defs: None,
@@ -74,13 +76,13 @@ pub static MZ_NOTICES: BuiltinView = BuiltinView {
 FROM
     mz_internal.mz_optimizer_notices n
 ",
-    sensitivity: DataSensitivity::Superuser,
-};
+    access: vec![READ_SQL],
+});
 
 /// A redacted version of [`MZ_NOTICES`] that is made safe to be viewed by
 /// Materialize staff because it binds the `redacted_~` from [`MZ_NOTICES`] as
 /// `~`.
-pub static MZ_NOTICES_REDACTED: BuiltinView = BuiltinView {
+pub static MZ_NOTICES_REDACTED: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
     name: "mz_notices_redacted",
     schema: MZ_INTERNAL_SCHEMA,
     column_defs: None,
@@ -95,8 +97,8 @@ pub static MZ_NOTICES_REDACTED: BuiltinView = BuiltinView {
 FROM
     mz_internal.mz_notices
 ",
-    sensitivity: DataSensitivity::SuperuserAndSupport,
-};
+    access: vec![SUPPORT_SELECT, READ_REDACTED_SQL],
+});
 
 pub const MZ_NOTICES_IND: BuiltinIndex = BuiltinIndex {
     name: "mz_notices_ind",

--- a/src/catalog/src/memory/error.rs
+++ b/src/catalog/src/memory/error.rs
@@ -35,6 +35,8 @@ pub enum ErrorKind {
     ReservedRoleName(String),
     #[error("role name {} is reserved", .0.quoted())]
     ReservedSystemRoleName(String),
+    #[error("role name {} cannot be granted", .0.quoted())]
+    UngrantableRoleName(String),
     #[error("cluster name {} is reserved", .0.quoted())]
     ReservedClusterName(String),
     #[error("replica name {} is reserved", .0.quoted())]

--- a/src/catalog/tests/snapshots/debug__persist_opened_trace.snap
+++ b/src/catalog/tests/snapshots/debug__persist_opened_trace.snap
@@ -1119,6 +1119,76 @@ Trace {
                         id: Some(
                             RoleId {
                                 value: Some(
+                                    System(
+                                        3,
+                                    ),
+                                ),
+                            },
+                        ),
+                    },
+                    RoleValue {
+                        name: "mz_monitor",
+                        attributes: Some(
+                            RoleAttributes {
+                                inherit: true,
+                            },
+                        ),
+                        membership: Some(
+                            RoleMembership {
+                                map: [],
+                            },
+                        ),
+                        vars: Some(
+                            RoleVars {
+                                entries: [],
+                            },
+                        ),
+                    },
+                ),
+                "1",
+                1,
+            ),
+            (
+                (
+                    RoleKey {
+                        id: Some(
+                            RoleId {
+                                value: Some(
+                                    System(
+                                        4,
+                                    ),
+                                ),
+                            },
+                        ),
+                    },
+                    RoleValue {
+                        name: "mz_monitor_redacted",
+                        attributes: Some(
+                            RoleAttributes {
+                                inherit: true,
+                            },
+                        ),
+                        membership: Some(
+                            RoleMembership {
+                                map: [],
+                            },
+                        ),
+                        vars: Some(
+                            RoleVars {
+                                entries: [],
+                            },
+                        ),
+                    },
+                ),
+                "1",
+                1,
+            ),
+            (
+                (
+                    RoleKey {
+                        id: Some(
+                            RoleId {
+                                value: Some(
                                     Public(
                                         Empty,
                                     ),

--- a/src/catalog/tests/snapshots/debug__stash_opened_trace.snap
+++ b/src/catalog/tests/snapshots/debug__stash_opened_trace.snap
@@ -1119,6 +1119,76 @@ Trace {
                         id: Some(
                             RoleId {
                                 value: Some(
+                                    System(
+                                        3,
+                                    ),
+                                ),
+                            },
+                        ),
+                    },
+                    RoleValue {
+                        name: "mz_monitor",
+                        attributes: Some(
+                            RoleAttributes {
+                                inherit: true,
+                            },
+                        ),
+                        membership: Some(
+                            RoleMembership {
+                                map: [],
+                            },
+                        ),
+                        vars: Some(
+                            RoleVars {
+                                entries: [],
+                            },
+                        ),
+                    },
+                ),
+                "-9223372036854775808",
+                1,
+            ),
+            (
+                (
+                    RoleKey {
+                        id: Some(
+                            RoleId {
+                                value: Some(
+                                    System(
+                                        4,
+                                    ),
+                                ),
+                            },
+                        ),
+                    },
+                    RoleValue {
+                        name: "mz_monitor_redacted",
+                        attributes: Some(
+                            RoleAttributes {
+                                inherit: true,
+                            },
+                        ),
+                        membership: Some(
+                            RoleMembership {
+                                map: [],
+                            },
+                        ),
+                        vars: Some(
+                            RoleVars {
+                                entries: [],
+                            },
+                        ),
+                    },
+                ),
+                "-9223372036854775808",
+                1,
+            ),
+            (
+                (
+                    RoleKey {
+                        id: Some(
+                            RoleId {
+                                value: Some(
                                     Public(
                                         Empty,
                                     ),

--- a/src/catalog/tests/snapshots/open__initial_snapshot.snap
+++ b/src/catalog/tests/snapshots/open__initial_snapshot.snap
@@ -775,6 +775,62 @@ Snapshot {
             id: Some(
                 RoleId {
                     value: Some(
+                        System(
+                            3,
+                        ),
+                    ),
+                },
+            ),
+        }: RoleValue {
+            name: "mz_monitor",
+            attributes: Some(
+                RoleAttributes {
+                    inherit: true,
+                },
+            ),
+            membership: Some(
+                RoleMembership {
+                    map: [],
+                },
+            ),
+            vars: Some(
+                RoleVars {
+                    entries: [],
+                },
+            ),
+        },
+        RoleKey {
+            id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            4,
+                        ),
+                    ),
+                },
+            ),
+        }: RoleValue {
+            name: "mz_monitor_redacted",
+            attributes: Some(
+                RoleAttributes {
+                    inherit: true,
+                },
+            ),
+            membership: Some(
+                RoleMembership {
+                    map: [],
+                },
+            ),
+            vars: Some(
+                RoleVars {
+                    entries: [],
+                },
+            ),
+        },
+        RoleKey {
+            id: Some(
+                RoleId {
+                    value: Some(
                         Public(
                             Empty,
                         ),

--- a/src/sql/src/session/user.rs
+++ b/src/sql/src/session/user.rs
@@ -111,6 +111,8 @@ pub enum UserKind {
 
 pub const MZ_SYSTEM_ROLE_ID: RoleId = RoleId::System(1);
 pub const MZ_SUPPORT_ROLE_ID: RoleId = RoleId::System(2);
+pub const MZ_READ_SQL_ROLE_ID: RoleId = RoleId::System(3);
+pub const MZ_READ_REDACTED_SQL_ROLE_ID: RoleId = RoleId::System(4);
 
 /// Metadata about a Session's role.
 ///

--- a/src/sql/src/session/user.rs
+++ b/src/sql/src/session/user.rs
@@ -111,8 +111,8 @@ pub enum UserKind {
 
 pub const MZ_SYSTEM_ROLE_ID: RoleId = RoleId::System(1);
 pub const MZ_SUPPORT_ROLE_ID: RoleId = RoleId::System(2);
-pub const MZ_READ_SQL_ROLE_ID: RoleId = RoleId::System(3);
-pub const MZ_READ_REDACTED_SQL_ROLE_ID: RoleId = RoleId::System(4);
+pub const MZ_MONITOR_ROLE_ID: RoleId = RoleId::System(3);
+pub const MZ_MONITOR_REDACTED_ROLE_ID: RoleId = RoleId::System(4);
 
 /// Metadata about a Session's role.
 ///

--- a/test/legacy-upgrade/check-from-v0.53.0-role.td
+++ b/test/legacy-upgrade/check-from-v0.53.0-role.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ skip-if
-SELECT mz_version_num() < 5200 || mz_version_num() >= 8300;
+SELECT mz_version_num() < 5200 OR mz_version_num() >= 8300;
 
 > SELECT name FROM mz_roles;
 group

--- a/test/legacy-upgrade/check-from-v0.53.0-role.td
+++ b/test/legacy-upgrade/check-from-v0.53.0-role.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ skip-if
-SELECT mz_version_num() < 5200;
+SELECT mz_version_num() < 5200 || mz_version_num() >= 8300;
 
 > SELECT name FROM mz_roles;
 group

--- a/test/legacy-upgrade/check-from-v0.83.0-role.td
+++ b/test/legacy-upgrade/check-from-v0.83.0-role.td
@@ -1,0 +1,38 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ skip-if
+SELECT mz_version_num() < 8300;
+
+> SELECT name FROM mz_roles;
+group
+joe
+mz_monitor
+mz_monitor_redacted
+mz_system
+mz_support
+materialize
+superuser_login
+"space role"
+
+$ postgres-execute connection=postgres://superuser_login:some_bogus_password@${testdrive.materialize-sql-addr}
+SELECT 1;
+
+> SELECT name FROM mz_roles WHERE name = 'joe' OR name = 'group';
+joe
+group
+
+> SELECT role.name AS role, member.name AS member, grantor.name AS grantor FROM mz_role_members membership LEFT JOIN mz_roles role ON membership.role_id = role.id LEFT JOIN mz_roles member ON membership.member = member.id LEFT JOIN mz_roles grantor ON membership.grantor = grantor.id;
+group  joe  mz_system
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+DROP ROLE superuser_login;
+DROP ROLE "space role";
+DROP ROLE joe;
+DROP ROLE group;

--- a/test/sqllogictest/builtin_roles.slt
+++ b/test/sqllogictest/builtin_roles.slt
@@ -1,0 +1,120 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+reset-server
+
+# Test that by default, nobody is allowed to access statement log
+# objects
+
+statement error permission denied for SOURCE
+SELECT 1 FROM mz_internal.mz_prepared_statement_history WHERE 1 = 0
+
+statement error permission denied for SOURCE
+SELECT 1 FROM mz_internal.mz_statement_execution_history WHERE 1 = 0
+
+statement error permission denied for VIEW
+SELECT 1 FROM mz_internal.mz_activity_log WHERE 1 = 0
+
+statement error permission denied for VIEW
+SELECT 1 FROM mz_internal.mz_prepared_statement_history_redacted WHERE 1 = 0
+
+statement error permission denied for VIEW
+SELECT 1 FROM mz_internal.mz_statement_execution_history_redacted WHERE 1 = 0
+
+statement error permission denied for VIEW
+SELECT 1 FROM mz_internal.mz_activity_log_redacted WHERE 1 = 0
+
+# Test that after granting the less-privileged
+# `read_sql_redacted` role, we can
+# query the redacted objects, but not the unredacted ones.
+
+simple conn=mz_system,user=mz_system
+GRANT mz_read_redacted_sql TO materialize
+----
+COMPLETE 0
+
+statement error permission denied for SOURCE
+SELECT 1 FROM mz_internal.mz_prepared_statement_history WHERE 1 = 0
+
+statement error permission denied for SOURCE
+SELECT 1 FROM mz_internal.mz_statement_execution_history WHERE 1 = 0
+
+statement error permission denied for VIEW
+SELECT 1 FROM mz_internal.mz_activity_log WHERE 1 = 0
+
+query I
+SELECT 1 FROM mz_internal.mz_prepared_statement_history_redacted WHERE 1 = 0
+----
+
+query I
+SELECT 1 FROM mz_internal.mz_statement_execution_history_redacted WHERE 1 = 0
+----
+
+query I
+SELECT 1 FROM mz_internal.mz_activity_log_redacted WHERE 1 = 0
+----
+
+# Test that revocation does something
+simple conn=mz_system,user=mz_system
+REVOKE mz_read_redacted_sql FROM materialize
+----
+COMPLETE 0
+
+statement error permission denied for SOURCE
+SELECT 1 FROM mz_internal.mz_prepared_statement_history WHERE 1 = 0
+
+statement error permission denied for SOURCE
+SELECT 1 FROM mz_internal.mz_statement_execution_history WHERE 1 = 0
+
+statement error permission denied for VIEW
+SELECT 1 FROM mz_internal.mz_activity_log WHERE 1 = 0
+
+statement error permission denied for VIEW
+SELECT 1 FROM mz_internal.mz_prepared_statement_history_redacted WHERE 1 = 0
+
+statement error permission denied for VIEW
+SELECT 1 FROM mz_internal.mz_statement_execution_history_redacted WHERE 1 = 0
+
+statement error permission denied for VIEW
+SELECT 1 FROM mz_internal.mz_activity_log_redacted WHERE 1 = 0
+
+# Test that we can read all tables with the more powerful permission
+# (`mz_read_sql`)
+
+simple conn=mz_system,user=mz_system
+GRANT mz_read_sql TO materialize
+----
+COMPLETE 0
+
+query I
+SELECT 1 FROM mz_internal.mz_prepared_statement_history WHERE 1 = 0
+----
+
+query I
+SELECT 1 FROM mz_internal.mz_statement_execution_history WHERE 1 = 0
+----
+
+query I
+SELECT 1 FROM mz_internal.mz_activity_log WHERE 1 = 0
+----
+
+query I
+SELECT 1 FROM mz_internal.mz_prepared_statement_history_redacted WHERE 1 = 0
+----
+
+query I
+SELECT 1 FROM mz_internal.mz_statement_execution_history_redacted WHERE 1 = 0
+----
+
+query I
+SELECT 1 FROM mz_internal.mz_activity_log_redacted WHERE 1 = 0
+----
+

--- a/test/sqllogictest/builtin_roles.slt
+++ b/test/sqllogictest/builtin_roles.slt
@@ -117,4 +117,3 @@ SELECT 1 FROM mz_internal.mz_statement_execution_history_redacted WHERE 1 = 0
 query I
 SELECT 1 FROM mz_internal.mz_activity_log_redacted WHERE 1 = 0
 ----
-

--- a/test/sqllogictest/builtin_roles.slt
+++ b/test/sqllogictest/builtin_roles.slt
@@ -33,11 +33,11 @@ statement error permission denied for VIEW
 SELECT 1 FROM mz_internal.mz_activity_log_redacted WHERE 1 = 0
 
 # Test that after granting the less-privileged
-# `read_sql_redacted` role, we can
+# `mz_monitor_redacted` role, we can
 # query the redacted objects, but not the unredacted ones.
 
 simple conn=mz_system,user=mz_system
-GRANT mz_read_redacted_sql TO materialize
+GRANT mz_monitor_redacted TO materialize
 ----
 COMPLETE 0
 
@@ -64,7 +64,7 @@ SELECT 1 FROM mz_internal.mz_activity_log_redacted WHERE 1 = 0
 
 # Test that revocation does something
 simple conn=mz_system,user=mz_system
-REVOKE mz_read_redacted_sql FROM materialize
+REVOKE mz_monitor_redacted FROM materialize
 ----
 COMPLETE 0
 
@@ -87,10 +87,10 @@ statement error permission denied for VIEW
 SELECT 1 FROM mz_internal.mz_activity_log_redacted WHERE 1 = 0
 
 # Test that we can read all tables with the more powerful permission
-# (`mz_read_sql`)
+# (`mz_monitor`)
 
 simple conn=mz_system,user=mz_system
-GRANT mz_read_sql TO materialize
+GRANT mz_monitor TO materialize
 ----
 COMPLETE 0
 

--- a/test/sqllogictest/id_reuse.slt
+++ b/test/sqllogictest/id_reuse.slt
@@ -77,6 +77,8 @@ SELECT id, name FROM mz_roles
 ----
 s1  mz_system
 s2  mz_support
+s3  mz_monitor
+s4  mz_monitor_redacted
 u1  materialize
 u2  foo
 
@@ -94,6 +96,8 @@ SELECT id, name FROM mz_roles
 ----
 s1  mz_system
 s2  mz_support
+s3  mz_monitor
+s4  mz_monitor_redacted
 u1  materialize
 u3  bar
 

--- a/test/sqllogictest/pg_catalog_roles.slt
+++ b/test/sqllogictest/pg_catalog_roles.slt
@@ -15,6 +15,8 @@ reset-server
 query T rowsort
 SELECT rolname FROM pg_roles ORDER BY oid
 ----
-mz_system
-mz_support
 materialize
+mz_monitor
+mz_monitor_redacted
+mz_support
+mz_system

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -100,13 +100,16 @@ SELECT DISTINCT(privilege) FROM item_privileges WHERE type = 'view' OR type = 'm
 ----
 =r/mz_system
 mz_system=r/mz_system
+mz_monitor=r/mz_system
 mz_support=r/mz_system
 materialize=r/materialize
+mz_monitor_redacted=r/mz_system
 
 query T
 SELECT DISTINCT(privilege) FROM item_privileges WHERE type = 'table'
 ----
 =r/mz_system
+mz_monitor=r/mz_system
 mz_system=arwd/mz_system
 
 query T
@@ -4713,13 +4716,28 @@ materialize,materialize,materialize,public,t,SELECT,NO,YES
 materialize,materialize,materialize,public,v,SELECT,NO,YES
 materialize,mz_support,materialize,public,s_progress,SELECT,NO,YES
 materialize,materialize,materialize,public,s_progress,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_notices,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_activity_log,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_session_history,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_notices_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_notices_redacted,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_optimizer_notices,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_activity_log_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_activity_log_redacted,SELECT,NO,YES
+mz_system,mz_monitor_redacted,materialize,mz_internal,mz_notices_redacted,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_prepared_statement_history,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_statement_execution_history,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
+mz_system,mz_monitor_redacted,materialize,mz_internal,mz_activity_log_redacted,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_prepared_statement_history_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_prepared_statement_history_redacted,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
-COMPLETE 20
+mz_system,mz_monitor_redacted,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
+mz_system,mz_monitor_redacted,materialize,mz_internal,mz_prepared_statement_history_redacted,SELECT,NO,YES
+mz_system,mz_monitor_redacted,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
+COMPLETE 35
 
 simple conn=mz_system,user=mz_system
 SELECT COUNT(*) >= 166 FROM information_schema.table_privileges WHERE grantee = 'PUBLIC'
@@ -4762,13 +4780,28 @@ materialize,materialize,materialize,public,t,SELECT,NO,YES
 materialize,materialize,materialize,public,v,SELECT,NO,YES
 materialize,mz_support,materialize,public,s_progress,SELECT,NO,YES
 materialize,materialize,materialize,public,s_progress,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_notices,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_activity_log,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_session_history,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_notices_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_notices_redacted,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_optimizer_notices,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_activity_log_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_activity_log_redacted,SELECT,NO,YES
+mz_system,mz_monitor_redacted,materialize,mz_internal,mz_notices_redacted,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_prepared_statement_history,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_statement_execution_history,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
+mz_system,mz_monitor_redacted,materialize,mz_internal,mz_activity_log_redacted,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_prepared_statement_history_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_prepared_statement_history_redacted,SELECT,NO,YES
+mz_system,mz_monitor,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
-COMPLETE 20
+mz_system,mz_monitor_redacted,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
+mz_system,mz_monitor_redacted,materialize,mz_internal,mz_prepared_statement_history_redacted,SELECT,NO,YES
+mz_system,mz_monitor_redacted,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
+COMPLETE 35
 
 simple conn=mz_system,user=mz_system
 SELECT COUNT(*) >= 166 FROM information_schema.role_table_grants WHERE grantee = 'PUBLIC'

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -17,6 +17,8 @@ SELECT id, name, inherit FROM mz_roles WHERE id LIKE 's%'
 ----
 s1  mz_system  true
 s2  mz_support  true
+s3  mz_monitor  true
+s4  mz_monitor_redacted  true
 
 query TB
 SELECT name, inherit FROM mz_roles WHERE id LIKE 'u%'
@@ -73,6 +75,8 @@ query TB rowsort
 SELECT name, inherit FROM mz_roles
 ----
 materialize  true
+mz_monitor  true
+mz_monitor_redacted  true
 mz_support  true
 mz_system  true
 rj  true
@@ -86,6 +90,8 @@ query T rowsort
 SELECT name FROM mz_roles
 ----
 materialize
+mz_monitor
+mz_monitor_redacted
 mz_support
 mz_system
 rj
@@ -98,6 +104,8 @@ query T rowsort
 SELECT name FROM mz_roles
 ----
 materialize
+mz_monitor
+mz_monitor_redacted
 mz_support
 mz_system
 
@@ -109,6 +117,8 @@ query T rowsort
 SELECT name FROM mz_roles
 ----
 materialize
+mz_monitor
+mz_monitor_redacted
 mz_support
 mz_system
 nlb
@@ -120,8 +130,10 @@ query T
 SELECT name FROM mz_roles
 ----
 mz_system
+mz_monitor
 mz_support
 materialize
+mz_monitor_redacted
 
 statement ok
 DROP ROLE IF EXISTS nlb

--- a/test/sqllogictest/role_membership.slt
+++ b/test/sqllogictest/role_membership.slt
@@ -396,13 +396,13 @@ CREATE ROLE joe
 
 # Cannot grant or revoke system role
 
-statement error role name "mz_system" is reserved
+statement error db error: ERROR: role name "mz_system" cannot be granted
 GRANT mz_system TO joe
 
 statement error role name "mz_system" is reserved
 GRANT joe TO mz_system
 
-statement error role name "mz_system" is reserved
+statement error db error: ERROR: role name "mz_system" cannot be granted
 REVOKE mz_system FROM joe
 
 statement error role name "mz_system" is reserved
@@ -413,13 +413,13 @@ REVOKE joe FROM mz_system
 statement error role name "public" is reserved
 GRANT group1 TO public
 
-statement error role name "public" is reserved
+statement error db error: ERROR: role name "public" cannot be granted
 GRANT public TO group1
 
 statement error role name "public" is reserved
 REVOKE group1 FROM public
 
-statement error role name "public" is reserved
+statement error db error: ERROR: role name "public" cannot be granted
 REVOKE public FROM group1
 
 statement ok
@@ -914,9 +914,11 @@ r2
 r3
 r4
 mz_system
+mz_monitor
 mz_support
 materialize
-COMPLETE 7
+mz_monitor_redacted
+COMPLETE 9
 
 statement ok
 DROP ROLE r1, r2, r3, r4


### PR DESCRIPTION
This PR extends the `sensitivity` mechanism for builtin objects to be an arbitrary list of ACLs to assign to each such object. It then uses that to assign two new builtin roles: `mz_read_sql` and `mz_read_redacted_sql`, as described [here](https://github.com/MaterializeInc/materialize/issues/24267). 

### Motivation



  * This PR adds a known-desirable feature.

Fixes #24267

### Tips for reviewer

As part of this change, I am changing a bunch of the builtin objects (that don't already do so) to use the `Lazy` pattern, because it's not possible for them to contain non-empty vectors otherwise.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add builtin role `mz_read_sql` whose members can query the activity log