### PR TITLE
catalog: Fix setting catalog to emergency stash

### DIFF
--- a/src/catalog/src/durable/impls/migrate.rs
+++ b/src/catalog/src/durable/impls/migrate.rs
@@ -139,7 +139,7 @@ impl OpenableDurableCatalogState for CatalogMigrator {
                 // Handle emergency stash before opening persist.
                 return self
                     .openable_stash
-                    .open_savepoint(boot_ts, bootstrap_args, deploy_generation)
+                    .open(boot_ts, bootstrap_args, deploy_generation)
                     .await;
             }
             TargetImplementation::MigrationDirection(direction) => direction,

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -43,7 +43,7 @@ use mz_storage_types::controller::PersistTxnTablesImpl;
 use mz_storage_types::sources::{SourceData, Timeline};
 use sha2::Digest;
 use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
-use tracing::{debug, warn};
+use tracing::{debug, error};
 use uuid::Uuid;
 
 use crate::durable::debug::{Collection, DebugCatalogState, Trace};
@@ -582,7 +582,7 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
     }
 
     fn set_catalog_kind(&mut self, catalog_kind: CatalogKind) {
-        warn!("unable to set catalog kind to {catalog_kind:?}");
+        error!("unable to set catalog kind to {catalog_kind:?}");
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/src/catalog/src/durable/impls/stash.rs
+++ b/src/catalog/src/durable/impls/stash.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use futures::StreamExt;
 use itertools::Itertools;
 use postgres_openssl::MakeTlsConnector;
-use tracing::warn;
+use tracing::error;
 
 use mz_audit_log::{VersionedEvent, VersionedStorageUsage};
 use mz_ore::metrics::MetricsFutureExt;
@@ -402,7 +402,7 @@ impl OpenableDurableCatalogState for OpenableConnection {
     }
 
     fn set_catalog_kind(&mut self, catalog_kind: CatalogKind) {
-        warn!("unable to set catalog kind to {catalog_kind:?}");
+        error!("unable to set catalog kind to {catalog_kind:?}");
     }
 
     async fn expire(self: Box<Self>) {


### PR DESCRIPTION
Previously, the Launch Darkly flag did not work with the value "emergency-stash". Only the environmentd CLI arg would accept and correctly apply the "emergency-stash" value. This commit fixes the issue so that the `catalog_kind` Launch Darkly flag also works with the value "emergency-stash".

Works towards resolving #24218

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
