### PR TITLE
[persist / expr] Null handling in monotone functions

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3237,7 +3237,7 @@ impl BinaryFunc {
     /// increasing `b` will always cause the result to _decrease_.)
     ///
     /// This property describes the behaviour of the function over ranges where the function is defined:
-    /// ie. the arguments and the result are non-null (and non-error) datums.
+    /// ie. the arguments and the result are non-error datums.
     pub fn is_monotone(&self) -> (bool, bool) {
         match self {
             BinaryFunc::AddInt16
@@ -4322,7 +4322,7 @@ trait LazyUnaryFunc {
     /// determine the range of possible outputs just by mapping the endpoints.
     ///
     /// This property describes the behaviour of the function over ranges where the function is defined:
-    /// ie. the argument and the result are non-null (and non-error) datums.
+    /// ie. the argument and the result are non-error datums.
     fn is_monotone(&self) -> bool;
 }
 
@@ -7846,11 +7846,11 @@ impl VariadicFunc {
     /// This describes the *pointwise* behaviour of the function:
     /// ie. if more than one argument is provided, this describes the behaviour of
     /// any specific argument as the others are held constant. (For example, `COALESCE(a, b)` is
-    /// monotone in `a` because for any particular non-null value of `b`, increasing `a` will never
+    /// monotone in `a` because for any particular value of `b`, increasing `a` will never
     /// cause the result to decrease.)
     ///
     /// This property describes the behaviour of the function over ranges where the function is defined:
-    /// ie. the arguments and the result are non-null (and non-error) datums.
+    /// ie. the arguments and the result are non-error datums.
     pub fn is_monotone(&self) -> bool {
         match self {
             VariadicFunc::Coalesce


### PR DESCRIPTION
Concretely: the `ColumnSpecs` abstract interpreter will now assume that if both endpoints of a range are mapped to `null` by some monotone function, then all the points in that range are also mapped to `null`.

If you squint a bit, this is a fairly reasonable assumption for monotone functions: it's already true for all non-null values, and it can be given a reasonable semantics. Still, it seems a bit brazen to just add a new assumption - so I've also gone through and checked that it seems to hold for existing examples, run unit tests under `cargo stress`, and kicked off [nightlies](https://buildkite.com/materialize/nightlies/builds/5887).

### Motivation

Fixes: https://github.com/MaterializeInc/materialize/issues/24280

### Tips for reviewer

I'm a bit unsure what or how much documentation is appropriate, so I've just removed the now-incorrect bits for now. Feel free to suggest things.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
