### PR TITLE
Catalog: Ensure epoch does not decrease

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -562,7 +562,7 @@ impl Catalog {
             .await,
         );
         let storage = openable_storage
-            .open(now(), &test_bootstrap_args(), None)
+            .open(now(), &test_bootstrap_args(), None, None)
             .await?;
         Self::open_debug_catalog_inner(storage, now, environment_id).await
     }
@@ -589,7 +589,7 @@ impl Catalog {
             stash_config,
         ));
         let storage = openable_storage
-            .open(now(), &test_bootstrap_args(), None)
+            .open(now(), &test_bootstrap_args(), None, None)
             .await?;
         Self::open_debug_catalog_inner(storage, now, environment_id).await
     }

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -393,6 +393,7 @@ async fn upgrade_check(
                 bootstrap_role: None,
             },
             None,
+            None,
         )
         .await?;
 

--- a/src/catalog/src/durable/impls/shadow.rs
+++ b/src/catalog/src/durable/impls/shadow.rs
@@ -83,13 +83,20 @@ where
         boot_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
+        epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
-        let stash =
-            self.stash
-                .open_savepoint(boot_ts.clone(), bootstrap_args, deploy_generation.clone());
-        let persist = self
-            .persist
-            .open_savepoint(boot_ts, bootstrap_args, deploy_generation);
+        let stash = self.stash.open_savepoint(
+            boot_ts.clone(),
+            bootstrap_args,
+            deploy_generation.clone(),
+            epoch_lower_bound,
+        );
+        let persist = self.persist.open_savepoint(
+            boot_ts,
+            bootstrap_args,
+            deploy_generation,
+            epoch_lower_bound,
+        );
         let (stash, persist) = futures::future::join(stash, persist).await;
         soft_assert_eq_or_log!(
             stash.is_ok(),
@@ -124,13 +131,20 @@ where
         boot_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
+        epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
-        let stash = self
-            .stash
-            .open(boot_ts.clone(), bootstrap_args, deploy_generation.clone());
-        let persist = self
-            .persist
-            .open(boot_ts, bootstrap_args, deploy_generation);
+        let stash = self.stash.open(
+            boot_ts.clone(),
+            bootstrap_args,
+            deploy_generation.clone(),
+            epoch_lower_bound,
+        );
+        let persist = self.persist.open(
+            boot_ts,
+            bootstrap_args,
+            deploy_generation,
+            epoch_lower_bound,
+        );
         let (stash, persist) = futures::future::join(stash, persist).await;
         soft_assert_eq_or_log!(
             stash.is_ok(),

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -79,7 +79,7 @@ async fn test_debug(
 
     // Use `NOW_ZERO` for consistent timestamps in the snapshots.
     let _ = Box::new(openable_state1)
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
 

--- a/src/catalog/tests/migrate.rs
+++ b/src/catalog/tests/migrate.rs
@@ -62,7 +62,7 @@ async fn test_migration() {
     let role_key = {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -94,7 +94,7 @@ async fn test_migration() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -128,7 +128,7 @@ async fn test_migration() {
             .await,
         );
         let mut persist_state = persist_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -167,7 +167,7 @@ async fn test_migration() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -206,7 +206,7 @@ async fn test_migration() {
             .await,
         );
         let mut persist_state = rollback_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -250,7 +250,7 @@ async fn test_migration() {
     {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -299,7 +299,7 @@ async fn test_migration() {
             .await,
         );
         let mut persist_state = rollback_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -362,7 +362,7 @@ async fn test_migration_panic_after_stash_fence_then_migrate() {
     let role_key = {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -400,7 +400,7 @@ async fn test_migration_panic_after_stash_fence_then_migrate() {
                 .await,
             );
             let _persist_state = migrate_openable_state
-                .open(NOW_ZERO(), &test_bootstrap_args(), None)
+                .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
                 .await
                 .unwrap();
         });
@@ -420,7 +420,7 @@ async fn test_migration_panic_after_stash_fence_then_migrate() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -445,7 +445,7 @@ async fn test_migration_panic_after_stash_fence_then_migrate() {
             .await,
         );
         let mut persist_state = persist_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -487,7 +487,7 @@ async fn test_migration_panic_after_stash_fence_then_rollback() {
     let role_key = {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -525,7 +525,7 @@ async fn test_migration_panic_after_stash_fence_then_rollback() {
                 .await,
             );
             let _persist_state = migrate_openable_state
-                .open(NOW_ZERO(), &test_bootstrap_args(), None)
+                .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
                 .await
                 .unwrap();
         });
@@ -545,7 +545,7 @@ async fn test_migration_panic_after_stash_fence_then_rollback() {
             .await,
         );
         let mut stash_state = rollback_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -563,7 +563,7 @@ async fn test_migration_panic_after_stash_fence_then_rollback() {
     {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -610,7 +610,7 @@ async fn test_rollback_panic_after_stash_fence_then_migrate() {
     let role_key = {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -641,7 +641,7 @@ async fn test_rollback_panic_after_stash_fence_then_migrate() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -683,7 +683,7 @@ async fn test_rollback_panic_after_stash_fence_then_migrate() {
                 .await,
             );
             let _stash_state = rollback_openable_state
-                .open(NOW_ZERO(), &test_bootstrap_args(), None)
+                .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
                 .await
                 .unwrap();
         });
@@ -703,7 +703,7 @@ async fn test_rollback_panic_after_stash_fence_then_migrate() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -741,7 +741,7 @@ async fn test_rollback_panic_after_stash_fence_then_migrate() {
             .await,
         );
         let mut persist_state = persist_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -800,7 +800,7 @@ async fn test_rollback_panic_after_stash_fence_then_rollback() {
     let role_key = {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -831,7 +831,7 @@ async fn test_rollback_panic_after_stash_fence_then_rollback() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -873,7 +873,7 @@ async fn test_rollback_panic_after_stash_fence_then_rollback() {
                 .await,
             );
             let _stash_state = rollback_openable_state
-                .open(NOW_ZERO(), &test_bootstrap_args(), None)
+                .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
                 .await
                 .unwrap();
         });
@@ -893,7 +893,7 @@ async fn test_rollback_panic_after_stash_fence_then_rollback() {
             .await,
         );
         let mut stash_state = rollback_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -924,7 +924,7 @@ async fn test_rollback_panic_after_stash_fence_then_rollback() {
     {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -978,7 +978,7 @@ async fn test_migration_panic_after_fence_then_migrate() {
     let role_key = {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1016,7 +1016,7 @@ async fn test_migration_panic_after_fence_then_migrate() {
                 .await,
             );
             let _persist_state = migrate_openable_state
-                .open(NOW_ZERO(), &test_bootstrap_args(), None)
+                .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
                 .await
                 .unwrap();
         });
@@ -1036,7 +1036,7 @@ async fn test_migration_panic_after_fence_then_migrate() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1061,7 +1061,7 @@ async fn test_migration_panic_after_fence_then_migrate() {
             .await,
         );
         let mut persist_state = persist_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1103,7 +1103,7 @@ async fn test_migration_panic_after_fence_then_rollback() {
     let role_key = {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1141,7 +1141,7 @@ async fn test_migration_panic_after_fence_then_rollback() {
                 .await,
             );
             let _persist_state = migrate_openable_state
-                .open(NOW_ZERO(), &test_bootstrap_args(), None)
+                .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
                 .await
                 .unwrap();
         });
@@ -1161,7 +1161,7 @@ async fn test_migration_panic_after_fence_then_rollback() {
             .await,
         );
         let mut stash_state = rollback_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1179,7 +1179,7 @@ async fn test_migration_panic_after_fence_then_rollback() {
     {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1226,7 +1226,7 @@ async fn test_rollback_panic_after_fence_then_migrate() {
     let role_key = {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1257,7 +1257,7 @@ async fn test_rollback_panic_after_fence_then_migrate() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1299,7 +1299,7 @@ async fn test_rollback_panic_after_fence_then_migrate() {
                 .await,
             );
             let _stash_state = rollback_openable_state
-                .open(NOW_ZERO(), &test_bootstrap_args(), None)
+                .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
                 .await
                 .unwrap();
         });
@@ -1319,7 +1319,7 @@ async fn test_rollback_panic_after_fence_then_migrate() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1357,7 +1357,7 @@ async fn test_rollback_panic_after_fence_then_migrate() {
             .await,
         );
         let mut persist_state = persist_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1416,7 +1416,7 @@ async fn test_rollback_panic_after_fence_then_rollback() {
     let role_key = {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1447,7 +1447,7 @@ async fn test_rollback_panic_after_fence_then_rollback() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1489,7 +1489,7 @@ async fn test_rollback_panic_after_fence_then_rollback() {
                 .await,
             );
             let _stash_state = rollback_openable_state
-                .open(NOW_ZERO(), &test_bootstrap_args(), None)
+                .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
                 .await
                 .unwrap();
         });
@@ -1509,7 +1509,7 @@ async fn test_rollback_panic_after_fence_then_rollback() {
             .await,
         );
         let mut stash_state = rollback_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1540,7 +1540,7 @@ async fn test_rollback_panic_after_fence_then_rollback() {
     {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1594,7 +1594,7 @@ async fn test_migration_panic_after_write_then_migrate() {
     let role_key = {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1632,7 +1632,7 @@ async fn test_migration_panic_after_write_then_migrate() {
                 .await,
             );
             let _persist_state = migrate_openable_state
-                .open(NOW_ZERO(), &test_bootstrap_args(), None)
+                .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
                 .await
                 .unwrap();
         });
@@ -1652,7 +1652,7 @@ async fn test_migration_panic_after_write_then_migrate() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1677,7 +1677,7 @@ async fn test_migration_panic_after_write_then_migrate() {
             .await,
         );
         let mut persist_state = persist_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1719,7 +1719,7 @@ async fn test_migration_panic_after_write_then_rollback() {
     let role_key = {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1757,7 +1757,7 @@ async fn test_migration_panic_after_write_then_rollback() {
                 .await,
             );
             let _persist_state = migrate_openable_state
-                .open(NOW_ZERO(), &test_bootstrap_args(), None)
+                .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
                 .await
                 .unwrap();
         });
@@ -1777,7 +1777,7 @@ async fn test_migration_panic_after_write_then_rollback() {
             .await,
         );
         let mut stash_state = rollback_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1795,7 +1795,7 @@ async fn test_migration_panic_after_write_then_rollback() {
     {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let mut stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1826,7 +1826,7 @@ async fn test_savepoint_persist_uninitialized() {
     {
         let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
         let _stash_state = stash_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
     }
@@ -1843,7 +1843,7 @@ async fn test_savepoint_persist_uninitialized() {
             .await,
         );
         let mut stash_state = rollback_openable_state
-            .open_savepoint(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open_savepoint(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1894,7 +1894,7 @@ async fn test_savepoint_persist_uninitialized() {
             .await,
         );
         let open_err = migrate_openable_state
-            .open_savepoint(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open_savepoint(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap_err();
         let durable_err = match open_err {
@@ -1919,7 +1919,7 @@ async fn test_savepoint_persist_uninitialized() {
             .await,
         );
         let mut stash_state = rollback_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -1952,7 +1952,7 @@ async fn test_savepoint_stash_uninitialized() {
             .await,
         );
         let _persist_state = persist_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
     }
@@ -1969,7 +1969,7 @@ async fn test_savepoint_stash_uninitialized() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open_savepoint(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open_savepoint(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -2020,7 +2020,7 @@ async fn test_savepoint_stash_uninitialized() {
             .await,
         );
         let open_err = rollback_openable_state
-            .open_savepoint(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open_savepoint(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap_err();
         let durable_err = match open_err {
@@ -2045,7 +2045,7 @@ async fn test_savepoint_stash_uninitialized() {
             .await,
         );
         let mut persist_state = migrate_openable_state
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -2079,7 +2079,7 @@ async fn test_set_emergency_stash_migrate() {
     );
     migrate_openable_state.set_catalog_kind(CatalogKind::EmergencyStash);
     let _stash_state = migrate_openable_state
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
 
@@ -2121,7 +2121,7 @@ async fn test_set_emergency_stash_rollback() {
     );
     rollback_openable_state.set_catalog_kind(CatalogKind::EmergencyStash);
     let _stash_state = rollback_openable_state
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
 
@@ -2139,6 +2139,59 @@ async fn test_set_emergency_stash_rollback() {
         .await,
     );
     assert!(!persist_openable_state.is_initialized().await.unwrap());
+
+    debug_factory.drop().await;
+}
+
+/// Test that the epoch is migrated and rolled back correctly.
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_epoch_migration() {
+    let (debug_factory, stash_config) = test_stash_config().await;
+    let persist_client = PersistClient::new_for_tests().await;
+    let organization_id = Uuid::new_v4();
+    let persist_metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
+
+    let mut epoch = 1;
+
+    // Open the catalog in the stash many times to increment the epoch.
+    for _ in 0..10 {
+        let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
+        let mut stash_state = stash_openable_state
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
+            .await
+            .unwrap();
+        epoch += 1;
+        assert_eq!(epoch, stash_state.epoch().get());
+    }
+
+    // Migrate catalog to persist many times to increment the epoch.
+    for _ in 0..10 {
+        let migrate_openable_state = Box::new(
+            migrate_from_stash_to_persist_state(
+                stash_config.clone(),
+                persist_client.clone(),
+                organization_id.clone(),
+                Arc::clone(&persist_metrics),
+            )
+            .await,
+        );
+        let mut persist_state = migrate_openable_state
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
+            .await
+            .unwrap();
+        epoch += 1;
+        assert_eq!(epoch, persist_state.epoch().get());
+    }
+
+    // Rollback the catalog to the stash.
+    let stash_openable_state = Box::new(stash_backed_catalog_state(stash_config.clone()));
+    let mut stash_state = stash_openable_state
+        .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
+        .await
+        .unwrap();
+    epoch += 1;
+    assert_eq!(epoch, stash_state.epoch().get());
 
     debug_factory.drop().await;
 }

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -66,7 +66,7 @@ async fn test_is_initialized(
     );
 
     let state = Box::new(openable_state1)
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
     state.expire().await;
@@ -127,7 +127,7 @@ async fn test_get_deployment_generation(
     );
 
     let state = Box::new(openable_state1)
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), Some(42))
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), Some(42), None)
         .await
         .unwrap();
     state.expire().await;
@@ -213,7 +213,7 @@ async fn test_open_savepoint(
     {
         // Can't open a savepoint catalog until it's been initialized.
         let err = Box::new(openable_state1)
-            .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
             .await
             .unwrap_err();
         match err {
@@ -224,7 +224,7 @@ async fn test_open_savepoint(
         // Initialize the catalog.
         {
             let mut state = Box::new(openable_state2)
-                .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+                .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
                 .await
                 .unwrap();
             assert_eq!(state.epoch(), Epoch::new(2).expect("known to be non-zero"));
@@ -233,7 +233,7 @@ async fn test_open_savepoint(
 
         // Open catalog in check mode.
         let mut state = Box::new(openable_state3)
-            .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
         // Savepoint catalogs do not increment the epoch.
@@ -260,7 +260,7 @@ async fn test_open_savepoint(
     {
         // Open catalog normally.
         let mut state = Box::new(openable_state4)
-            .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
         // Write should not have persisted.
@@ -369,7 +369,7 @@ async fn test_open_read_only(
 
     // Initialize the catalog.
     let mut state = Box::new(openable_state2)
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
     assert_eq!(state.epoch(), Epoch::new(2).expect("known to be non-zero"));
@@ -501,7 +501,7 @@ async fn test_open(
     let (snapshot, audit_log) = {
         let mut state = Box::new(openable_state1)
             // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-            .open(NOW_ZERO(), &test_bootstrap_args(), None)
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -517,7 +517,7 @@ async fn test_open(
     // Reopening the catalog will increment the epoch, but shouldn't change the initial snapshot.
     {
         let mut state = Box::new(openable_state2)
-            .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -529,7 +529,7 @@ async fn test_open(
     // Reopen the catalog a third time for good measure.
     {
         let mut state = Box::new(openable_state3)
-            .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+            .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
 
@@ -633,6 +633,7 @@ async fn test_unopened_fencing(
                 NOW_ZERO(),
                 &test_bootstrap_args(),
                 Some(deployment_generation),
+                None,
             )
             .await
             .unwrap();
@@ -652,6 +653,7 @@ async fn test_unopened_fencing(
             NOW_ZERO(),
             &test_bootstrap_args(),
             Some(deployment_generation + 1),
+            None,
         )
         .await
         .unwrap();
@@ -746,7 +748,7 @@ async fn test_tombstone(
 
     let mut state = Box::new(openable_state1)
         // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-        .open(NOW_ZERO(), &test_bootstrap_args(), None)
+        .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
     assert_eq!(state.get_tombstone().await.unwrap(), None);

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -58,13 +58,13 @@ async fn test_confirm_leadership(
     openable_state2: impl OpenableDurableCatalogState,
 ) {
     let mut state1 = Box::new(openable_state1)
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
     assert!(state1.confirm_leadership().await.is_ok());
 
     let mut state2 = Box::new(openable_state2)
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
     assert!(state2.confirm_leadership().await.is_ok());
@@ -103,7 +103,7 @@ async fn test_stash_get_and_prune_storage_usage_consolidates() {
     let boot_ts = mz_repr::Timestamp::new(23);
 
     let mut state = Box::new(openable_state)
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
     let mut txn = state.transaction().await.unwrap();
@@ -206,7 +206,7 @@ async fn test_get_and_prune_storage_usage(openable_state: impl OpenableDurableCa
     let boot_ts = mz_repr::Timestamp::new(23);
 
     let mut state = Box::new(openable_state)
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
     let mut txn = state.transaction().await.unwrap();
@@ -258,7 +258,7 @@ async fn test_timestamps(openable_state: impl OpenableDurableCatalogState) {
         ts: mz_repr::Timestamp::new(42),
     };
     let mut state = Box::new(openable_state)
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
 
@@ -305,7 +305,7 @@ async fn test_persist_allocate_id() {
 async fn test_allocate_id(openable_state: impl OpenableDurableCatalogState) {
     let id_type = USER_ITEM_ALLOC_KEY;
     let mut state = Box::new(openable_state)
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
 
@@ -382,7 +382,7 @@ async fn test_audit_logs(openable_state: impl OpenableDurableCatalogState) {
     ];
 
     let mut state = Box::new(openable_state)
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
     let mut txn = state.transaction().await.unwrap();
@@ -438,7 +438,7 @@ async fn test_items(openable_state: impl OpenableDurableCatalogState) {
     ];
 
     let mut state = Box::new(openable_state)
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
     let mut txn = state.transaction().await.unwrap();
@@ -553,7 +553,7 @@ async fn test_set_catalog(openable_state: impl OpenableDurableCatalogState) {
 
     // Open state and insert some initial items into it.
     let mut state = Box::new(openable_state)
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None)
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
     let mut txn = state.transaction().await.unwrap();

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -404,6 +404,7 @@ impl Listeners {
                             bootstrap_role: config.bootstrap_role.clone(),
                         },
                         None,
+                        None,
                     )
                     .await
                 {
@@ -462,6 +463,7 @@ impl Listeners {
                     bootstrap_role: config.bootstrap_role,
                 },
                 config.deploy_generation,
+                None,
             )
             .await?;
         // Get the value from Launch Darkly as of the last time this environment

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -141,12 +141,12 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             value,
         } => {
             // edit needs a mutable stash, so reconnect.
-            let stash = factory.open(args.postgres_url, schema, tls).await?;
+            let stash = factory.open(args.postgres_url, schema, tls, None).await?;
             edit(stash, usage, collection, key, value).await
         }
         Action::Delete { collection, key } => {
             // delete needs a mutable stash, so reconnect.
-            let stash = factory.open(args.postgres_url, schema, tls).await?;
+            let stash = factory.open(args.postgres_url, schema, tls, None).await?;
             delete(stash, usage, collection, key).await
         }
         Action::UpgradeCheck {
@@ -448,6 +448,7 @@ impl Usage {
                         default_cluster_replica_size: "1".into(),
                         bootstrap_role: None,
                     },
+                    None,
                     None,
                 )
                 .await?;

--- a/src/stash/benches/postgres.rs
+++ b/src/stash/benches/postgres.rs
@@ -30,7 +30,7 @@ fn init_bench() -> (Runtime, Stash) {
         .block_on(Stash::clear(&connstr, tls.clone()))
         .unwrap();
     let stash = runtime
-        .block_on((*FACTORY).open(connstr, None, tls))
+        .block_on((*FACTORY).open(connstr, None, tls, None))
         .unwrap();
     (runtime, stash)
 }

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -648,7 +648,7 @@ impl Stash {
                 // current epoch has been bumped exactly once, then gets recreated by another
                 // connection that also bumps it once).
                 let epoch_lower_bound = epoch_lower_bound.unwrap_or(NonZeroI64::MIN).get();
-                let row = tx.query_one(&format!("UPDATE fence SET epoch=GREATEST(epoch+1, {epoch_lower_bound}), nonce=$1 RETURNING epoch"), &[&self.nonce.to_vec()]).await?;
+                let row = tx.query_one(&format!("UPDATE fence SET epoch=GREATEST(epoch+1, $1), nonce=$2 RETURNING epoch"), &[&epoch_lower_bound, &self.nonce.to_vec()]).await?;
                 NonZeroI64::new(row.get(0)).unwrap()
             } else {
                 let row = tx.query_one("SELECT epoch, nonce FROM fence", &[]).await?;

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -648,7 +648,7 @@ impl Stash {
                 // current epoch has been bumped exactly once, then gets recreated by another
                 // connection that also bumps it once).
                 let epoch_lower_bound = epoch_lower_bound.unwrap_or(NonZeroI64::MIN).get();
-                let row = tx.query_one(&format!("UPDATE fence SET epoch=GREATEST(epoch+1, $1), nonce=$2 RETURNING epoch"), &[&epoch_lower_bound, &self.nonce.to_vec()]).await?;
+                let row = tx.query_one("UPDATE fence SET epoch=GREATEST(epoch+1, $1), nonce=$2 RETURNING epoch", &[&epoch_lower_bound, &self.nonce.to_vec()]).await?;
                 NonZeroI64::new(row.get(0)).unwrap()
             } else {
                 let row = tx.query_one("SELECT epoch, nonce FROM fence", &[]).await?;

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -648,7 +648,12 @@ impl Stash {
                 // current epoch has been bumped exactly once, then gets recreated by another
                 // connection that also bumps it once).
                 let epoch_lower_bound = epoch_lower_bound.unwrap_or(NonZeroI64::MIN).get();
-                let row = tx.query_one("UPDATE fence SET epoch=GREATEST(epoch+1, $1), nonce=$2 RETURNING epoch", &[&epoch_lower_bound, &self.nonce.to_vec()]).await?;
+                let row = tx
+                    .query_one(
+                        "UPDATE fence SET epoch=GREATEST(epoch+1, $1), nonce=$2 RETURNING epoch",
+                        &[&epoch_lower_bound, &self.nonce.to_vec()],
+                    )
+                    .await?;
                 NonZeroI64::new(row.get(0)).unwrap()
             } else {
                 let row = tx.query_one("SELECT epoch, nonce FROM fence", &[]).await?;

--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -34,7 +34,7 @@ async fn test_stash_invalid_url() {
 
     // Verify invalid URLs fail on connect.
     assert!(factory
-        .open("host=invalid".into(), None, tls)
+        .open("host=invalid".into(), None, tls, None)
         .await
         .unwrap_err()
         .to_string()

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2171,7 +2171,7 @@ where
         )
         .expect("could not make storage TLS connection");
         let mut stash = StashFactory::from_metrics(stash_metrics)
-            .open(postgres_url, None, tls)
+            .open(postgres_url, None, tls, None)
             .await
             .expect("could not connect to postgres storage stash");
 


### PR DESCRIPTION
Previously migrating from one catalog implementation to another
allowed the catalog epoch to decrease. The problem was that we were
treating the epoch as an internal implementation detail. During the
migration from the stash to persist, we would NOT copy the epoch from
the stash to persist. Instead, persist would start with a brand-new
epoch at 2 (the starting value is 2 for historical reasons). The
problem is that the epoch is exposed externally, and it's used by the
storage controller. The storage controller uses the epoch for its own
separate fencing purposes. If the epoch decreases after a migration,
then the storage controller would mistakenly think it was being fenced
out by a higher epoch and fail to boot.

This commit adds an epoch lower bound to catalog opening. When the
catalog opens, it ensures that it's epoch is at least as big as the
epoch lower bound. During a migration, we pass the old epoch plus one
as the epoch lower bound, which ensure that the epoch never decreases.

Works towards resolving #24218

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
