### PR TITLE
[DNM] assert on invalid read policies

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1000,6 +1000,16 @@ where
                 if !update.is_empty() {
                     read_capability_changes.insert(id, update);
                 }
+            } else if !PartialOrder::less_equal(
+                &collection.implied_capability,
+                &policy.hard_frontier(),
+            ) {
+                panic!(
+                    "read policy tried to regress `implied_capability` \
+                     (implied_capability={:?}, policy_frontier={:?}",
+                    collection.implied_capability,
+                    policy.hard_frontier(),
+                );
             }
 
             collection.read_policy = policy;

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1427,6 +1427,16 @@ where
                 if !update.is_empty() {
                     read_capability_changes.insert(id, update);
                 }
+            } else if !PartialOrder::less_equal(
+                &collection.implied_capability,
+                &policy.hard_frontier(),
+            ) {
+                panic!(
+                    "read policy tried to regress `implied_capability` \
+                     (implied_capability={:?}, policy_frontier={:?}",
+                    collection.implied_capability,
+                    policy.hard_frontier(),
+                );
             }
 
             collection.read_policy = policy;

--- a/src/storage-types/src/read_policy.rs
+++ b/src/storage-types/src/read_policy.rs
@@ -110,4 +110,21 @@ impl<T: Timestamp> ReadPolicy<T> {
             }
         }
     }
+
+    pub fn hard_frontier(&self) -> Antichain<T> {
+        match self {
+            ReadPolicy::NoPolicy { .. } => Antichain::new(),
+            ReadPolicy::ValidFrom(frontier) => frontier.clone(),
+            ReadPolicy::LagWriteFrontier(_) => Antichain::new(),
+            ReadPolicy::Multiple(policies) => {
+                let mut frontier = Antichain::new();
+                for policy in policies.iter() {
+                    for time in policy.hard_frontier().iter() {
+                        frontier.insert(time.clone());
+                    }
+                }
+                frontier
+            }
+        }
+    }
 }


### PR DESCRIPTION
Dummy PR for running our CI with an additional assert.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
