### PR TITLE
coverage: Respect ignores in unit-test-only report

### DIFF
--- a/misc/python/materialize/cli/ci_coverage_pr_report.py
+++ b/misc/python/materialize/cli/ci_coverage_pr_report.py
@@ -190,7 +190,10 @@ ci-coverage-pr-report creates a code coverage report for CI.""",
             test_cases.append(test_case)
 
     unit_test_only_report = get_report(
-        coverage, lambda lines, i, line: (lines.get(i + 1) or 0) >= 0
+        coverage,
+        lambda lines, i, line: bool(
+            (lines.get(i + 1) or 0) >= 0 or IGNORE_SRC_LINE_RE.search(line)
+        ),
     )
     # If a line has "None" marker, then it can't be covered, print it out.
     # If a line has positive or negative coverage then it is


### PR DESCRIPTION
As discussed in https://materializeinc.slack.com/archives/C057X0NG91B/p1704797040108939

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
