### PR TITLE
ci: Make zippy in release qualification larger again

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -36,7 +36,7 @@ steps:
     # 48h
     timeout_in_minutes: 2880
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-large
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -48,7 +48,7 @@ steps:
     # 48h
     timeout_in_minutes: 2880
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-large
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -59,7 +59,7 @@ steps:
     label: "Large Zippy PogresCdc"
     timeout_in_minutes: 2880
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-large
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -70,7 +70,7 @@ steps:
     label: "Longer Zippy ClusterReplicas"
     timeout_in_minutes: 2880
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-large
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -82,7 +82,7 @@ steps:
     label: "Large Zippy w/ user tables"
     timeout_in_minutes: 2880
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-large
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -116,7 +116,7 @@ steps:
     label: "Longer Zippy Kafka Parallel Insert"
     timeout_in_minutes: 2880
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-large
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
We have seen some OOMs and wrong results as consequences, see for example https://github.com/MaterializeInc/materialize/issues/24250

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
