### PR TITLE
adapter: base read policies on `implied_capability`

### DIFF
--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -347,7 +347,7 @@ impl crate::coord::Coordinator {
                 .storage
                 .collection(*id)
                 .expect("collection does not exist");
-            let read_frontier = collection.read_capabilities.frontier().to_owned();
+            let read_frontier = collection.implied_capability.clone();
             let time = time.join(&read_frontier);
             read_holds
                 .holds
@@ -362,7 +362,7 @@ impl crate::coord::Coordinator {
                 let collection = compute
                     .collection(*compute_instance, *id)
                     .expect("collection does not exist");
-                let read_frontier = collection.read_frontier().to_owned();
+                let read_frontier = collection.read_capability().clone();
                 let time = time.join(&read_frontier);
                 read_holds
                     .holds
@@ -452,10 +452,10 @@ impl crate::coord::Coordinator {
                         .storage
                         .collection(id)
                         .expect("id does not exist");
-                    assert!(collection.read_capabilities.frontier().le(&new_time.borrow()),
+                    assert!(collection.implied_capability.le(&new_time.borrow()),
                             "Storage collection {:?} has read frontier {:?} not less-equal new time {:?}; old time: {:?}",
                             id,
-                            collection.read_capabilities.frontier(),
+                            collection.implied_capability,
                             new_time,
                             old_time,
                     );
@@ -478,11 +478,11 @@ impl crate::coord::Coordinator {
                         let collection = compute
                             .collection(compute_instance, id)
                             .expect("id does not exist");
-                        assert!(collection.read_frontier().le(&new_time.borrow()),
+                        assert!(collection.read_capability().le(&new_time.borrow()),
                                 "Compute collection {:?} (instance {:?}) has read frontier {:?} not less-equal new time {:?}; old time: {:?}",
                                 id,
                                 compute_instance,
-                                collection.read_frontier(),
+                                collection.read_capability(),
                                 new_time,
                                 old_time,
                         );


### PR DESCRIPTION
This PR adjusts adapters read policy code to always use collections' `implied_capability`s, rather than `read_capabilities.frontier()`.

This fixes a potential bug where adapter might try to install a read hold on a collection based on `read_capabilities.frontier()` through a `ValidFrom` read policy but fail to do so because the read hold time is before the collection's `implied_capability`.

Note that it is not clear whether the described potential bug can ever occur in Materialize. Failures to regress the `implied_capability` when installing a read policy are silently ignored, and it's not easy to change that because some parts of the code assume that it is valid to set a `ReadPolicy::ValidFrom([0])` to disable compaction of a collection regardless of its current `implied_capability`.

### Motivation

  * This PR fixes a recognized bug.

This _might_ be the fix for #24130. I don't actually know because I didn't manage to reproduce that issue yet.

Even if it turns out to not help with #24130, it's still a good change to make, to prevent other lurking bugs. Though in the mid term, we should instead refactor the entire read capability API of the controller (#24266).

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
