### PR TITLE
explain: avoid panics in `Display for HumanizedExpr<'a, usize, M>`

### DIFF
--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -1174,7 +1174,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.cols {
             // We have a name inferred for the column indexed by `self.expr`. Write `ident`.
-            Some(cols) if !cols[*self.expr].is_empty() => {
+            Some(cols) if cols.len() > *self.expr && !cols[*self.expr].is_empty() => {
                 // Note: using unchecked here is okay since we're directly
                 // converting to a string afterwards.
                 let ident = Ident::new_unchecked(cols[*self.expr].clone()); // TODO: try to avoid the `.clone()` here.

--- a/test/sqllogictest/transform/notice/index_too_wide_for_literal_constraints.slt
+++ b/test/sqllogictest/transform/notice/index_too_wide_for_literal_constraints.slt
@@ -321,3 +321,40 @@ Notices:
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (z, w).
 
 EOF
+
+# Regression test for #24301
+# --------------------------
+
+statement ok
+DROP TABLE IF EXISTS t1 CASCADE;
+
+statement ok
+CREATE TABLE t1 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+statement ok
+CREATE INDEX t1i2 ON t1(f2, f1);
+
+# Recommended key has a field that is not present in any of the indexes.
+query T multiline
+EXPLAIN WITH(humanized_exprs)
+SELECT *
+  FROM (SELECT * FROM (VALUES (1, 2))) as t2(f1, f2)
+  JOIN (SELECT a1.f2 AS f1, a1.f1 + a1.f2 AS f2 FROM t1 AS a1) AS a2 USING (f1)
+WHERE
+  a2.f2 * 2 < a2.f2 + 2 AND
+  a2.f2 + a2.f2 = 7;
+----
+Explained Query (fast path):
+  Project (#4, #5, #3)
+    Filter (#0{f1} = 1) AND (7 = (#2 + #2)) AND ((#2 * 2) < (#2 + 2))
+      Map ((#1{f2} + #0{f1}), (#1{f2} + 1), 1, 2)
+        ReadIndex on=materialize.public.t1 t1i2=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t1i2 (*** full scan ***)
+
+Notices:
+  - Notice: Index materialize.public.t1i2 on t1(f2, f1) is too wide to use for literal equalities `f2 = 1`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (f2, (#2 + #2)).
+
+EOF


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug.

Fixes the issue reported in #24301

### Tips for reviewer

We still need to decide whether to emit the notice for the added regression test. See possible alternatives [in this comment](https://github.com/MaterializeInc/materialize/issues/24301#issuecomment-1883252919).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
