### PR TITLE
CI: Use smaller agent queue

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -23,7 +23,7 @@ steps:
     timeout_in_minutes: 10
     if: build.source == "ui"
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
 
   - wait: ~
 
@@ -35,7 +35,7 @@ steps:
       label: Detect references to already closed issues
       command: bin/ci-builder run stable bin/ci-closed-issues-detect
       agents:
-        queue: linux-x86_64
+        queue: linux-x86_64-small
 
     - id: unused-deps
       label: Unused dependencies
@@ -109,7 +109,7 @@ steps:
       label: Kafka multi-broker test
       timeout_in_minutes: 10
       agents:
-        queue: linux-x86_64
+        queue: linux-x86_64-small
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -171,7 +171,7 @@ steps:
         label: ":racing_car: testdrive with SIZE 1"
         timeout_in_minutes: 180
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -195,7 +195,7 @@ steps:
         label: Full Testdrive in Cloudtest (K8s)
         timeout_in_minutes: 300
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -206,7 +206,7 @@ steps:
         label: ":racing_car: testdrive with --persistent-user-tables"
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -262,7 +262,7 @@ steps:
         - ./ci/plugins/mzcompose:
             composition: upsert
       agents:
-        queue: linux-x86_64
+        queue: linux-x86_64-small
 
     - id: upsert-compaction-disabled
       label: Upsert (compaction disabled)
@@ -273,7 +273,7 @@ steps:
             composition: upsert
             args: [--compaction-disabled]
       agents:
-        queue: linux-x86_64
+        queue: linux-x86_64-small
 
   - id: ssh-connection-extended
     label: Extended SSH connection tests
@@ -395,7 +395,7 @@ steps:
         label: AWS (Real)
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -406,7 +406,7 @@ steps:
         label: AWS (Localstack)
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -416,7 +416,7 @@ steps:
         label: "Secrets Local File"
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -754,13 +754,13 @@ steps:
               composition: persist
               args: [--consensus=mem, --blob=mem]
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
 
       - id: persist-maelstrom-single-node
         label: Long single-node Maelstrom coverage of persist
         timeout_in_minutes: 20
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -771,7 +771,7 @@ steps:
         label: Long multi-node Maelstrom coverage of persist with postgres consensus
         timeout_in_minutes: 20
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -782,7 +782,7 @@ steps:
         label: Maelstrom coverage of persist-txn
         timeout_in_minutes: 10
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -794,7 +794,7 @@ steps:
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: persistence
@@ -809,7 +809,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 30
       agents:
-        queue: linux-x86_64
+        queue: linux-x86_64-small
       plugins:
         - ./ci/plugins/mzcompose:
             composition: sql-feature-flags
@@ -819,7 +819,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 30
       agents:
-        queue: linux-x86_64
+        queue: linux-x86_64-small
       plugins:
         - ./ci/plugins/mzcompose:
             composition: launchdarkly
@@ -831,7 +831,7 @@ steps:
     concurrency: 1
     concurrency_group: 'cloud-canary'
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cloud-canary
@@ -844,7 +844,7 @@ steps:
     concurrency: 1
     concurrency_group: 'mz-e2e'
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: mz-e2e
@@ -856,7 +856,7 @@ steps:
         label: "Output consistency (internal)"
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -867,7 +867,7 @@ steps:
         label: "Output consistency (Postgres)"
         timeout_in_minutes: 58
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -878,7 +878,7 @@ steps:
         label: "Output consistency (version)"
         timeout_in_minutes: 58
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -893,7 +893,7 @@ steps:
         artifact_paths: junit_*.xml
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlsmith
@@ -916,9 +916,9 @@ steps:
       - id: sqlancer-pqs
         label: "SQLancer PQS"
         artifact_paths: junit_*.xml
-        timeout_in_minutes: 30
+        timeout_in_minutes: 40
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -927,9 +927,9 @@ steps:
       - id: sqlancer-norec
         label: "SQLancer NoREC"
         artifact_paths: junit_*.xml
-        timeout_in_minutes: 30
+        timeout_in_minutes: 40
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -938,9 +938,9 @@ steps:
       - id: sqlancer-query-partitioning
         label: "SQLancer QueryPartitioning"
         artifact_paths: junit_*.xml
-        timeout_in_minutes: 30
+        timeout_in_minutes: 40
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -949,9 +949,9 @@ steps:
       - id: sqlancer-having
         label: "SQLancer Having"
         artifact_paths: junit_*.xml
-        timeout_in_minutes: 30
+        timeout_in_minutes: 40
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlancer
@@ -965,7 +965,7 @@ steps:
       artifact_paths: junit_*.xml
       timeout_in_minutes: 45
       agents:
-        queue: linux-x86_64
+        queue: linux-x86_64-small
       plugins:
         - ./ci/plugins/mzcompose:
             composition: rqg
@@ -998,7 +998,7 @@ steps:
     timeout_in_minutes: 15
     artifact_paths: junit_*.xml
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: crdb-restarts
@@ -1031,7 +1031,7 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1064,7 +1064,7 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1075,7 +1075,7 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1087,7 +1087,7 @@ steps:
         timeout_in_minutes: 60
         skip: "TODO(def-): Reenable when #2392 is fixed"
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1098,7 +1098,7 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1110,7 +1110,7 @@ steps:
         timeout_in_minutes: 60
         skip: "TODO(def-): Properly stop all db actions during backup & restore"
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1157,7 +1157,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: restart
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
 
   - id: legacy-upgrade
     label: Legacy upgrade tests (last version from git)
@@ -1192,7 +1192,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: csharp
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
 
       - id: lang-js
         label: ":js: tests"
@@ -1202,7 +1202,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: js
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
 
       - id: lang-java
         label: ":java: tests"
@@ -1212,7 +1212,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: java
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
 
       - id: lang-python
         label: ":python: tests"
@@ -1222,7 +1222,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: python
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
 
       - id: lang-ruby
         label: ":ruby: tests"
@@ -1232,7 +1232,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: ruby
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
 
   - wait: ~
     continue_on_failure: true
@@ -1246,4 +1246,4 @@ steps:
           job-uuid-file-pattern: _([^_]*).xml
     priority: 1
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -27,7 +27,7 @@ steps:
     timeout_in_minutes: 10
     if: build.source == "ui"
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
 
   - wait: ~
 
@@ -168,4 +168,4 @@ steps:
           job-uuid-file-pattern: _([^_]*).xml
     priority: 1
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small

--- a/ci/slt/pipeline.template.yml
+++ b/ci/slt/pipeline.template.yml
@@ -55,4 +55,4 @@ steps:
           job-uuid-file-pattern: _([^_]*).xml
     priority: 1
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -57,7 +57,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 10
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         coverage: skip
 
       - id: check-merge-with-target
@@ -84,7 +84,7 @@ steps:
           - build-aarch64
         timeout_in_minutes: 10
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         coverage: skip
         # Fortify against intermittent DockerHub issues
         retry:
@@ -103,7 +103,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 10
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         coverage: skip
 
       - id: lint-slow
@@ -145,7 +145,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         coverage: skip
 
       - id: vet-check
@@ -157,7 +157,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 5
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         coverage: skip
 
       - id: lint-docs
@@ -170,7 +170,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         coverage: skip
 
       - id: preview-docs
@@ -180,7 +180,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
         coverage: skip
 
   - group: "Cargo tests"
@@ -264,7 +264,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
 
   - id: restarts
     label: Restart test
@@ -275,7 +275,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: restart
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
 
   - id: legacy-upgrade
     label: Legacy upgrade tests (last version from docs)
@@ -329,7 +329,7 @@ steps:
               composition: debezium
               run: mysql
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
 
   - group: "MySQL tests"
     key: mysql-tests
@@ -344,7 +344,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
 
   - group: "Postgres tests"
     key: postgres-tests
@@ -359,7 +359,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64 # TODO(def-) Switch to small when #24324 is fixed
 
       - id: pg-cdc-resumption
         label: Postgres CDC resumption tests
@@ -398,7 +398,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-resumption
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
 
       - id: kafka-auth
         label: Kafka auth test
@@ -421,7 +421,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-exactly-once
         agents:
-          queue: linux-x86_64
+          queue: linux-x86_64-small
 
   - id: zippy-kafka-sources-short
     label: "Short Zippy"
@@ -481,6 +481,8 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
           args: [--exitfirst, -m, "not long", --aws-region=us-east-1, test/cloudtest/]
+    agents:
+      queue: linux-x86_64
 
   - id: source-sink-errors
     label: "Source/Sink Error Reporting"
@@ -488,7 +490,7 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: source-sink-errors
@@ -499,7 +501,7 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 10
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: backup-restore
@@ -514,6 +516,8 @@ steps:
           composition: feature-benchmark
           args: [--scenario=KafkaUpsertUnique]
     coverage: skip
+    agents:
+      queue: linux-x86_64-small
 
   # Fast tests closer to the end, doesn't matter as much if they have to wait
   # for an agent
@@ -550,7 +554,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: cluster-isolation
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
 
   - id: chbench-demo
     label: chbench smoke test
@@ -562,7 +566,7 @@ steps:
           args: [--run-seconds=10, --wait]
     timeout_in_minutes: 30
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
 
   - id: metabase-demo
     label: Metabase smoke test
@@ -573,7 +577,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: metabase
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
 
   - id: dbt-materialize
     label: dbt-materialize tests
@@ -592,7 +596,7 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: storage-usage
@@ -607,7 +611,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: tracing
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
 
   - id: deploy-website
     label: Deploy website
@@ -720,7 +724,7 @@ steps:
           job-uuid-file-pattern: _([^_]*).xml
     priority: 1
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
 
   - wait: ~
 


### PR DESCRIPTION
Depends on https://github.com/MaterializeInc/i2/pull/1522

2 cores, 4 GB RAM compared to 8 cores, 16 GB RAM right now

The main disadvantage is that we have yet another kind of queue, so agents will wait around uselessly and spin up more often. We hope that the tradeoff is still worth it.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
