### PR TITLE
slt: Fix mz_introspection_index_accounting.slt (red on main)

### DIFF
--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -96,6 +96,7 @@ tests_without_views=(
     test/sqllogictest/managed_cluster.slt
     test/sqllogictest/map.slt
     test/sqllogictest/materialized_views.slt
+    test/sqllogictest/mz_introspection_index_accounting.slt
     test/sqllogictest/mz-resolve-object-name.slt
     test/sqllogictest/mztimestamp.slt
     test/sqllogictest/name_resolution.slt

--- a/test/sqllogictest/mz_introspection_index_accounting.slt
+++ b/test/sqllogictest/mz_introspection_index_accounting.slt
@@ -67,7 +67,7 @@ mz_notices_ind  CREATE␠INDEX␠"mz_notices_ind"␠IN␠CLUSTER␠[s2]␠ON␠"
 mz_object_dependencies_ind  CREATE␠INDEX␠"mz_object_dependencies_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_object_dependencies"␠("object_id")
 mz_object_lifetimes_ind  CREATE␠INDEX␠"mz_object_lifetimes_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_object_lifetimes"␠("id")
 mz_object_transitive_dependencies_ind  CREATE␠INDEX␠"mz_object_transitive_dependencies_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_object_transitive_dependencies"␠("object_id")
-mz_peek_durations_histogram_raw_s2_primary_idx  CREATE␠INDEX␠"mz_peek_durations_histogram_raw_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_peek_durations_histogram_raw"␠("worker_id",␠"duration_ns")
+mz_peek_durations_histogram_raw_s2_primary_idx  CREATE␠INDEX␠"mz_peek_durations_histogram_raw_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_peek_durations_histogram_raw"␠("worker_id",␠"type",␠"duration_ns")
 mz_roles_ind  CREATE␠INDEX␠"mz_roles_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_catalog"."mz_roles"␠("id")
 mz_scheduling_elapsed_raw_s2_primary_idx  CREATE␠INDEX␠"mz_scheduling_elapsed_raw_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_scheduling_elapsed_raw"␠("id",␠"worker_id")
 mz_scheduling_parks_histogram_raw_s2_primary_idx  CREATE␠INDEX␠"mz_scheduling_parks_histogram_raw_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_scheduling_parks_histogram_raw"␠("worker_id",␠"slept_for_ns",␠"requested_ns")
@@ -110,8 +110,9 @@ WHERE cluster_id =
 ORDER BY 1, 2
 ----
 mz_active_peeks_per_worker  id
-mz_active_peeks_per_worker  index_id
+mz_active_peeks_per_worker  object_id
 mz_active_peeks_per_worker  time
+mz_active_peeks_per_worker  type
 mz_active_peeks_per_worker  worker_id
 mz_arrangement_batcher_allocations_raw  operator_id
 mz_arrangement_batcher_allocations_raw  worker_id
@@ -328,6 +329,7 @@ mz_optimizer_notices  redacted_action
 mz_optimizer_notices  redacted_hint
 mz_optimizer_notices  redacted_message
 mz_peek_durations_histogram_raw  duration_ns
+mz_peek_durations_histogram_raw  type
 mz_peek_durations_histogram_raw  worker_id
 mz_relations  id
 mz_relations  name


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/tests/builds/72598#018ceecc-ddc8-424c-b524-51df5601918f

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
