### PR TITLE
platform-checks: Add PersistCatalogToggle scenario

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -709,6 +709,17 @@ steps:
               composition: platform-checks
               args: [--scenario=PersistTxnFencing, "--seed=$BUILDKITE_JOB_ID"]
 
+      - id: checks-persist-catalog-toggle
+        label: "Checks + Toggle persist catalog"
+        timeout_in_minutes: 45
+        artifact_paths: junit_*.xml
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=PersistCatalogToggle, "--seed=$BUILDKITE_JOB_ID"]
+
       - id: checks-upgrade-matrix
         label: "Random upgrades over the entire matrix"
         timeout_in_minutes: 600

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -38,12 +38,13 @@ class StartMz(MzcomposeAction):
         system_parameter_defaults: dict[str, str] | None = None,
         additional_system_parameter_defaults: dict[str, str] = {},
         mz_service: str | None = None,
+        catalog_store: str | None = None,
     ) -> None:
         self.tag = tag
         self.environment_extra = environment_extra
         self.system_parameter_defaults = system_parameter_defaults
         self.additional_system_parameter_defaults = additional_system_parameter_defaults
-        self.catalog_store = (
+        self.catalog_store = catalog_store or (
             "shadow"
             if scenario.base_version() >= MzVersion.parse_mz("v0.82.0-dev")
             else "stash"

--- a/misc/python/materialize/checks/scenarios_persist_catalog.py
+++ b/misc/python/materialize/checks/scenarios_persist_catalog.py
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.checks.actions import Action, Initialize, Manipulate, Validate
+from materialize.checks.mzcompose_actions import KillMz, StartMz
+from materialize.checks.scenarios import Scenario
+
+
+class PersistCatalogToggle(Scenario):
+    """Toggle catalog_kind between `stash` and `persist`"""
+
+    def actions(self) -> list[Action]:
+        return [
+            StartMz(self, catalog_store="stash"),
+            Initialize(self),
+            KillMz(),
+            StartMz(self, catalog_store="persist"),
+            Manipulate(self, phase=1),
+            KillMz(),
+            StartMz(self, catalog_store="stash"),
+            Manipulate(self, phase=2),
+            KillMz(),
+            StartMz(self, catalog_store="persist"),
+            Validate(self),
+            KillMz(),
+            StartMz(self, catalog_store="stash"),
+            Validate(self),
+        ]

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -15,6 +15,7 @@ from materialize.checks.executors import MzcomposeExecutor, MzcomposeExecutorPar
 from materialize.checks.scenarios import *  # noqa: F401 F403
 from materialize.checks.scenarios import Scenario
 from materialize.checks.scenarios_backup_restore import *  # noqa: F401 F403
+from materialize.checks.scenarios_persist_catalog import *  # noqa: F401 F403
 from materialize.checks.scenarios_persist_txn import *  # noqa: F401 F403
 from materialize.checks.scenarios_upgrade import *  # noqa: F401 F403
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser


### PR DESCRIPTION
As discussed in https://www.notion.so/materialize/platform-v2-Persist-Catalog-61432d9517b4424d937fb54214a06322

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
