### PR TITLE
persist: Use Cow<str> for Stats, make _fivetran_deleted untrimmable

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -9,6 +9,7 @@
 
 //! A handle to a batch of updates
 
+use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -29,7 +30,7 @@ use mz_persist::indexed::encoding::BlobTraceBatchPart;
 use mz_persist::location::{Atomicity, Blob};
 use mz_persist_types::stats::{trim_to_budget, truncate_bytes, TruncateBound, TRUNCATE_LEN};
 use mz_persist_types::{Codec, Codec64};
-use mz_proto::{RustType, TryFromProtoError};
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use mz_timely_util::order::Reverse;
 use proptest_derive::Arbitrary;
 use semver::Version;
@@ -247,11 +248,11 @@ impl BatchBuilderConfig {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Arbitrary)]
 pub struct UntrimmableColumns {
     /// Always retain columns whose lowercased names exactly equal any of these strings.
-    pub equals: Vec<String>,
+    pub equals: Vec<Cow<'static, str>>,
     /// Always retain columns whose lowercased names start with any of these strings.
-    pub prefixes: Vec<String>,
+    pub prefixes: Vec<Cow<'static, str>>,
     /// Always retain columns whose lowercased names end with any of these strings.
-    pub suffixes: Vec<String>,
+    pub suffixes: Vec<Cow<'static, str>>,
 }
 
 impl UntrimmableColumns {
@@ -265,12 +266,12 @@ impl UntrimmableColumns {
             }
         }
         for s in &self.prefixes {
-            if name_lower.starts_with(s) {
+            if name_lower.starts_with(s.as_ref()) {
                 return true;
             }
         }
         for s in &self.suffixes {
-            if name_lower.ends_with(s) {
+            if name_lower.ends_with(s.as_ref()) {
                 return true;
             }
         }
@@ -289,9 +290,9 @@ impl RustType<ProtoUntrimmableColumns> for UntrimmableColumns {
 
     fn from_proto(proto: ProtoUntrimmableColumns) -> Result<Self, TryFromProtoError> {
         Ok(Self {
-            equals: proto.equals.into_proto(),
-            prefixes: proto.prefixes.into_proto(),
-            suffixes: proto.suffixes.into_proto(),
+            equals: proto.equals.into_rust()?,
+            prefixes: proto.prefixes.into_rust()?,
+            suffixes: proto.suffixes.into_rust()?,
         })
     }
 }
@@ -1136,9 +1137,9 @@ mod tests {
     #[mz_ore::test]
     fn untrimmable_columns() {
         let untrimmable = UntrimmableColumns {
-            equals: vec!["abc".to_string(), "def".to_string()],
-            prefixes: vec!["123".to_string(), "234".to_string()],
-            suffixes: vec!["xyz".to_string()],
+            equals: vec!["abc".into(), "def".into()],
+            prefixes: vec!["123".into(), "234".into()],
+            suffixes: vec!["xyz".into()],
         };
 
         // equals

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -326,6 +326,10 @@ impl PersistConfig {
                 "ts".into(),
                 "receivedat".into(),
                 "createdat".into(),
+                // Fivetran created tables track deleted rows by setting this column.
+                //
+                // See <https://fivetran.com/docs/using-fivetran/features#capturedeletes>.
+                "_fivetran_deleted".into(),
             ],
             prefixes: vec!["last_".into()],
             suffixes: vec![

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -13,7 +13,6 @@
 
 use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
-use std::string::ToString;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -323,17 +322,17 @@ impl PersistConfig {
             equals: vec![
                 // If we trim the "err" column, then we can't ever use pushdown on a part
                 // (because it could have >0 errors).
-                "err".to_string(),
-                "ts".to_string(),
-                "receivedat".to_string(),
-                "createdat".to_string(),
+                "err".into(),
+                "ts".into(),
+                "receivedat".into(),
+                "createdat".into(),
             ],
-            prefixes: vec!["last_".to_string()],
+            prefixes: vec!["last_".into()],
             suffixes: vec![
-                "timestamp".to_string(),
-                "time".to_string(),
-                "_at".to_string(),
-                "_tstamp".to_string(),
+                "timestamp".into(),
+                "time".into(),
+                "_at".into(),
+                "_tstamp".into(),
             ],
         }
     });

--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -9,6 +9,7 @@
 
 //! Generated protobuf code and companion impls.
 
+use std::borrow::Cow;
 use std::char::CharTryFromError;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -503,6 +504,15 @@ impl RustType<ProtoDuration> for std::time::Duration {
 
     fn from_proto(proto: ProtoDuration) -> Result<Self, TryFromProtoError> {
         Ok(std::time::Duration::new(proto.secs, proto.nanos))
+    }
+}
+
+impl<'a> RustType<String> for Cow<'a, str> {
+    fn into_proto(&self) -> String {
+        self.to_string()
+    }
+    fn from_proto(proto: String) -> Result<Self, TryFromProtoError> {
+        Ok(Cow::Owned(proto))
     }
 }
 


### PR DESCRIPTION
This change does two small things:

1. Changes the inner types of `UntrimmableColumns` to `Cow<'static, str>` instead of `String`. For the default case this avoids an allocation. _Super_ minor, but just something I noticed while reading through code that seemed nice to do.
2. Adds `_fivetran_deleted` as an untrimmable column. While working on the Fivetran connector I discovered this is how Fivetran created tables track deleted rows. It seems like created a view on top of Fivetran tables that filters on `_fivetran_deleted is false` would be common, so supporting filter pushdown there would be nice.

### Motivation

Super low-pri, just small things I noticed while reading through code. Figured it was easier to type up a PR than file an issue. Definitely don't need to merge if Persist folks don't think it's a good idea!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Small internal changes
