### PR TITLE
Improve representation in bucketed reductions

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -947,18 +947,17 @@ where
         let arranged_output = input.scope().region_named("ReduceHierarchical", |inner| {
             let input = input.enter(inner);
 
-            // Gather the relevant values into a vec of rows ordered by aggregation_index
+            // Gather the relevant values ordered by aggregation_index
             let input = input.map(move |(key, row)| {
                 let binding = SharedRow::get();
                 let mut row_builder = binding.borrow_mut();
-                let mut values = Vec::with_capacity(skips.len());
+                let mut row_packer = row_builder.packer();
                 let mut row_iter = row.iter();
                 for skip in skips.iter() {
-                    row_builder.packer().push(row_iter.nth(*skip).unwrap());
-                    values.push(row_builder.clone());
+                    row_packer.push(row_iter.nth(*skip).unwrap());
                 }
 
-                (key, values)
+                (key, row_builder.clone())
             });
 
             // Repeatedly apply hierarchical reduction with a progressively coarser key.
@@ -971,7 +970,7 @@ where
                 // stream or produce correct data in the output stream.
                 let negated_output = if err_output.is_none() {
                     let (oks, errs) = self
-                        .build_bucketed_negated_output::<_, Result<Vec<Row>, (Row, u64)>>(
+                        .build_bucketed_negated_output::<_, Result<Row, (Row, u64)>>(
                             &input,
                             aggr_funcs.clone(),
                         )
@@ -991,7 +990,7 @@ where
                     err_output = Some(errs.leave_region());
                     oks
                 } else {
-                    self.build_bucketed_negated_output::<_, Vec<Row>>(&input, aggr_funcs.clone())
+                    self.build_bucketed_negated_output::<_, Row>(&input, aggr_funcs.clone())
                 };
 
                 stage = negated_output
@@ -1015,8 +1014,7 @@ where
             let error_logger = self.error_logger();
             // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
             // view mz_internal.mz_expected_group_size_advice.
-            let arranged =
-                partial.mz_arrange::<RowValSpine<Vec<Row>, _, _>>("Arrange ReduceMinsMaxes");
+            let arranged = partial.mz_arrange::<RowRowSpine<_, _>>("Arrange ReduceMinsMaxes");
             // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
             // but we then wouldn't be able to do this error check conditionally.  See its documentation
             // for the rationale around using a second reduction here.
@@ -1050,11 +1048,15 @@ where
                             let datum_iter = key.into_datum_iter(None);
                             let mut datums_local = datums2.borrow();
                             datums_local.extend(datum_iter);
-                            for (aggr_index, func) in aggr_funcs2.iter().enumerate() {
-                                let iter = source.iter().map(|(values, _cnt)| {
-                                    values[aggr_index].iter().next().unwrap()
-                                });
-                                datums_local.push(func.eval(iter, &temp_storage));
+
+                            let mut source_iters = source
+                                .iter()
+                                .map(|(values, _cnt)| *values)
+                                .collect::<Vec<_>>();
+                            for func in aggr_funcs2.iter() {
+                                let column_iter = (0..source_iters.len())
+                                    .map(|i| source_iters[i].next().unwrap());
+                                datums_local.push(func.eval(column_iter, &temp_storage));
                             }
                             if let Result::Err(e) =
                                 mfp.evaluate_inner(&mut datums_local, &temp_storage)
@@ -1079,11 +1081,15 @@ where
                         let mut datums_local = datums1.borrow();
                         datums_local.extend(datum_iter);
                         let key_len = datums_local.len();
-                        for (aggr_index, func) in aggr_funcs.iter().enumerate() {
-                            let iter = source
-                                .iter()
-                                .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
-                            datums_local.push(func.eval(iter, &temp_storage));
+
+                        let mut source_iters = source
+                            .iter()
+                            .map(|(values, _cnt)| *values)
+                            .collect::<Vec<_>>();
+                        for func in aggr_funcs.iter() {
+                            let column_iter =
+                                (0..source_iters.len()).map(|i| source_iters[i].next().unwrap());
+                            datums_local.push(func.eval(column_iter, &temp_storage));
                         }
 
                         if let Some(row) = evaluate_mfp_after(
@@ -1117,18 +1123,18 @@ where
     /// stages can skip validation.
     fn build_bucketed_negated_output<S, R>(
         &self,
-        input: &Collection<S, ((Row, u64), Vec<Row>), Diff>,
+        input: &Collection<S, ((Row, u64), Row), Diff>,
         aggrs: Vec<AggregateFunc>,
     ) -> Collection<S, ((Row, u64), R), Diff>
     where
         S: Scope<Timestamp = G::Timestamp>,
-        R: MaybeValidatingRow<Vec<Row>, (Row, u64)>,
+        R: MaybeValidatingRow<Row, (Row, u64)>,
     {
         let error_logger = self.error_logger();
         // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
         // view mz_internal.mz_expected_group_size_advice.
-        let arranged_input = input
-            .mz_arrange::<KeyValSpine<_, Vec<Row>, _, _>>("Arranged MinsMaxesHierarchical input");
+        let arranged_input =
+            input.mz_arrange::<KeyValSpine<_, Row, _, _>>("Arranged MinsMaxesHierarchical input");
 
         arranged_input
             .mz_reduce_abelian::<_, KeyValSpine<_, _, _, _>>(
@@ -1152,20 +1158,22 @@ where
                     }
                     let binding = SharedRow::get();
                     let mut row_builder = binding.borrow_mut();
-                    let mut output = Vec::with_capacity(aggrs.len());
-                    for (aggr_index, func) in aggrs.iter().enumerate() {
-                        let iter = source
-                            .iter()
-                            .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
-                        row_builder.packer().push(func.eval(iter, &RowArena::new()));
-                        output.push(row_builder.clone());
+                    let mut row_packer = row_builder.packer();
+                    let mut source_iters = source
+                        .iter()
+                        .map(|(values, _cnt)| values.iter())
+                        .collect::<Vec<_>>();
+                    for func in aggrs.iter() {
+                        let column_iter =
+                            (0..source_iters.len()).map(|i| source_iters[i].next().unwrap());
+                        row_packer.push(func.eval(column_iter, &RowArena::new()));
                     }
                     // We only want to arrange the parts of the input that are not part of the output.
                     // More specifically, we want to arrange it so that `input.concat(&output.negate())`
                     // gives us the intended value of this aggregate function. Also we assume that regardless
                     // of the multiplicity of the final result in the input, we only want to have one copy
                     // in the output.
-                    target.push((R::ok(output), -1));
+                    target.push((R::ok(row_builder.clone()), -1));
                     target.extend(
                         source
                             .iter()


### PR DESCRIPTION
This PR improves the data representation used in bucketed reductions by:

1. Packing the aggregates in a `Row` instead of a `Vec<Row>`. This improves the memory usage at some potential extra CPU overhead by removing the fixed representation overheads of one `Vec` and multiple `Row` instances.
2. Packing a `Row` instead of using a `(Row, u64)` representation for the reduction stages. The transformation allows us to use a `RowRowSpine` instead of a general `KeyValSpine` when arranging the input to a stage, leading to potential memory savings. This is because we then allow our container types to efficiently represent multiple `Row` instances at once.

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/20332

By looking through past issues, I would argue that this PR would also address https://github.com/MaterializeInc/materialize/issues/5007, as these seem to be duplicate issues.

Fixes https://github.com/MaterializeInc/materialize/issues/5007.

### Tips for reviewer

The commits can be looked at individually.

I assumed that inverting the order of the tuple `(key, hash)` to conceptually `(hash, key)` (but packed in a `Row`) was OK in the second commit due to the semantic property being partitioning by this joint key here and not sorting. This is easier to do because then we do not have to plumb through the `key_arity`. Happy to change this if we find it controversial.

You will find a couple of comments on some minor changes below too.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
