### PR TITLE
tracing: update tracing-opentelemetry with panic fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4297,7 +4297,7 @@ dependencies = [
  "num",
  "num_enum",
  "once_cell",
- "ordered-float 3.4.0",
+ "ordered-float",
  "paste",
  "proc-macro2",
  "proptest",
@@ -4477,7 +4477,7 @@ dependencies = [
  "mz-ore",
  "mz-repr",
  "once_cell",
- "ordered-float 3.4.0",
+ "ordered-float",
  "prost",
  "prost-build",
  "prost-reflect",
@@ -5215,7 +5215,7 @@ dependencies = [
  "num-traits",
  "num_enum",
  "once_cell",
- "ordered-float 3.4.0",
+ "ordered-float",
  "postgres-protocol",
  "proptest",
  "proptest-derive",
@@ -6109,7 +6109,7 @@ dependencies = [
  "mz-persist-client",
  "mz-repr",
  "num-traits",
- "ordered-float 3.4.0",
+ "ordered-float",
  "paste",
  "proc-macro2",
  "serde_json",
@@ -6510,7 +6510,7 @@ dependencies = [
  "glob",
  "once_cell",
  "opentelemetry",
- "ordered-float 4.2.0",
+ "ordered-float",
  "percent-encoding",
  "rand",
  "thiserror",
@@ -6526,21 +6526,13 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84eb1409416d254e4a9c8fa56cc24701755025b458f0fcd8e59e1f5f40c23bf"
-dependencies = [
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "ordered-float"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
+ "rand",
+ "serde",
 ]
 
 [[package]]
@@ -7296,6 +7288,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -7315,6 +7308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]
@@ -7963,9 +7957,9 @@ dependencies = [
 [[package]]
 name = "serde-value"
 version = "0.7.0"
-source = "git+https://github.com/MaterializeInc/serde-value.git#62c7e5f84ace6b7b5da48c46cb963be95d43aaab"
+source = "git+https://github.com/MaterializeInc/serde-value.git#a84c6b71825efaffb332c0d19f18c2bdf9ee7b40"
 dependencies = [
- "ordered-float 3.4.0",
+ "ordered-float",
  "serde",
 ]
 
@@ -9839,7 +9833,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "openssl-sys",
- "ordered-float 3.4.0",
+ "ordered-float",
  "parking_lot",
  "phf",
  "phf_shared",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,9 +2359,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
@@ -4220,6 +4220,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "opentelemetry",
+ "opentelemetry_sdk",
  "pin-project",
  "postgres",
  "postgres-openssl",
@@ -4296,7 +4297,7 @@ dependencies = [
  "num",
  "num_enum",
  "once_cell",
- "ordered-float",
+ "ordered-float 3.4.0",
  "paste",
  "proc-macro2",
  "proptest",
@@ -4476,7 +4477,7 @@ dependencies = [
  "mz-ore",
  "mz-repr",
  "once_cell",
- "ordered-float",
+ "ordered-float 3.4.0",
  "prost",
  "prost-build",
  "prost-reflect",
@@ -4714,6 +4715,7 @@ dependencies = [
  "mz-service",
  "mz-tracing",
  "opentelemetry",
+ "opentelemetry_sdk",
  "sentry-tracing",
  "tracing",
  "tracing-subscriber",
@@ -4746,6 +4748,7 @@ dependencies = [
  "openssl",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "paste",
  "pin-project",
  "prometheus",
@@ -5212,7 +5215,7 @@ dependencies = [
  "num-traits",
  "num_enum",
  "once_cell",
- "ordered-float",
+ "ordered-float 3.4.0",
  "postgres-protocol",
  "proptest",
  "proptest-derive",
@@ -6106,7 +6109,7 @@ dependencies = [
  "mz-persist-client",
  "mz-repr",
  "num-traits",
- "ordered-float",
+ "ordered-float 3.4.0",
  "paste",
  "proc-macro2",
  "serde_json",
@@ -6439,26 +6442,32 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
+ "futures-core",
+ "futures-sink",
+ "indexmap 2.0.0",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
+checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
 dependencies = [
  "async-trait",
  "futures-core",
  "http",
+ "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
- "opentelemetry_api",
  "opentelemetry_sdk",
  "prost",
  "thiserror",
@@ -6468,11 +6477,11 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e3f814aa9f8c905d0ee4bde026afd3b2577a97c10e1699912e3e44f0c4cbeb"
+checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
 dependencies = [
- "opentelemetry_api",
+ "opentelemetry",
  "opentelemetry_sdk",
  "prost",
  "tonic",
@@ -6480,47 +6489,30 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
+checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
  "opentelemetry",
 ]
 
 [[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.1",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
 name = "opentelemetry_sdk"
-version = "0.20.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "once_cell",
- "opentelemetry_api",
- "ordered-float",
+ "opentelemetry",
+ "ordered-float 4.2.0",
  "percent-encoding",
  "rand",
- "regex",
- "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -6540,6 +6532,15 @@ checksum = "d84eb1409416d254e4a9c8fa56cc24701755025b458f0fcd8e59e1f5f40c23bf"
 dependencies = [
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -7964,7 +7965,7 @@ name = "serde-value"
 version = "0.7.0"
 source = "git+https://github.com/MaterializeInc/serde-value.git#62c7e5f84ace6b7b5da48c46cb963be95d43aaab"
 dependencies = [
- "ordered-float",
+ "ordered-float 3.4.0",
  "serde",
 ]
 
@@ -9140,26 +9141,30 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.20.0"
-source = "git+https://github.com/MaterializeInc/tracing-opentelemetry.git#405437e84fa3b0f34b91b8655d45a229265a6f14"
+version = "0.22.0"
+source = "git+https://github.com/MaterializeInc/tracing-opentelemetry.git#7035e641b683985cc3b8630f3b61d53c96f83695"
 dependencies = [
+ "js-sys",
  "once_cell",
  "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
  "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -9174,9 +9179,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -9566,6 +9571,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "which"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9824,7 +9839,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "openssl-sys",
- "ordered-float",
+ "ordered-float 3.4.0",
  "parking_lot",
  "phf",
  "phf_shared",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -65,6 +65,36 @@ who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
 delta = "1.17.1 -> 1.19.0"
 
+[[audits.opentelemetry]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "0.21.0"
+
+[[audits.opentelemetry-otlp]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "0.14.0"
+
+[[audits.opentelemetry-proto]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "0.4.0"
+
+[[audits.opentelemetry-semantic-conventions]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "0.13.0"
+
+[[audits.opentelemetry_sdk]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "0.21.2"
+
+[[audits.ordered-float]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "4.2.0"
+
 [[audits.quanta]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
@@ -130,10 +160,35 @@ who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.12.0@git:de20aa88cc6df3de910e9befbe68408d31e287be"
 
+[[audits.tracing-log]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "0.2.0"
+
+[[audits.tracing-opentelemetry]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "0.22.0@git:1e0cf8be6360b16096121ccbf266eba4f38e307e"
+
+[[audits.tracing-opentelemetry]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "0.22.0@git:7035e641b683985cc3b8630f3b61d53c96f83695"
+
+[[audits.tracing-subscriber]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "0.3.18"
+
 [[audits.untrusted]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
 delta = "0.7.1 -> 0.9.0"
+
+[[audits.web-time]]
+who = "Gus Wynn <gus@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "0.2.4"
 
 [[audits.zstd]]
 who = "Parker Timmerman <parker.timmerman@materialize.com>"

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -930,27 +930,7 @@ criteria = "safe-to-deploy"
 version = "0.9.90"
 criteria = "safe-to-deploy"
 
-[[exemptions.opentelemetry]]
-version = "0.20.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.opentelemetry-otlp]]
-version = "0.13.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.opentelemetry-proto]]
-version = "0.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.opentelemetry-semantic-conventions]]
-version = "0.12.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.opentelemetry_api]]
-version = "0.20.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.opentelemetry_sdk]]
 version = "0.20.0"
 criteria = "safe-to-deploy"
 
@@ -1370,6 +1350,10 @@ criteria = "safe-to-deploy"
 version = "0.7.0@git:62c7e5f84ace6b7b5da48c46cb963be95d43aaab"
 criteria = "safe-to-deploy"
 
+[[exemptions.serde-value]]
+version = "0.7.0@git:a84c6b71825efaffb332c0d19f18c2bdf9ee7b40"
+criteria = "safe-to-deploy"
+
 [[exemptions.serde_plain]]
 version = "1.0.1"
 criteria = "safe-to-deploy"
@@ -1654,16 +1638,8 @@ criteria = "safe-to-deploy"
 version = "0.1.30"
 criteria = "safe-to-deploy"
 
-[[exemptions.tracing-opentelemetry]]
-version = "0.20.0@git:405437e84fa3b0f34b91b8655d45a229265a6f14"
-criteria = "safe-to-deploy"
-
 [[exemptions.tracing-serde]]
 version = "0.1.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.tracing-subscriber]]
-version = "0.3.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.treediff]]

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -69,7 +69,7 @@ mz-tls-util = { path = "../tls-util" }
 mz-tracing = { path = "../tracing" }
 mz-transform = { path = "../transform" }
 mz-timestamp-oracle = { path = "../timestamp-oracle" }
-opentelemetry = { version = "0.20.0", features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.21.0", features = ["trace"] }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
@@ -99,7 +99,7 @@ tokio-postgres = { version = "0.7.8" }
 tokio-stream = "0.1.11"
 tracing = "0.1.37"
 tracing-core = "0.1.30"
-tracing-opentelemetry = { version = "0.20.0" }
+tracing-opentelemetry = { version = "0.22.0" }
 tracing-subscriber = "0.3.16"
 thiserror = "1.0.37"
 uncased = "0.9.7"

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -79,7 +79,8 @@ nix = "0.26.1"
 num_cpus = "1.14.0"
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
-opentelemetry = { version = "0.20.0", features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.21.0", features = ["trace"] }
+opentelemetry_sdk = { version = "0.21.2", features = ["rt-tokio"] }
 pin-project = "1.0.12"
 postgres = { version = "0.19.5", optional = true }
 postgres-openssl = { version = "0.5.0", optional = true }
@@ -110,7 +111,7 @@ tower = { version = "0.4.13", features = ["buffer", "limit", "load-shed"] }
 tower-http = { version = "0.4.2", features = ["cors"] }
 tracing = "0.1.37"
 tracing-core = "0.1.30"
-tracing-opentelemetry = { version = "0.20.0" }
+tracing-opentelemetry = { version = "0.22.0" }
 tracing-subscriber = "0.3.16"
 tungstenite = { version = "0.20.0" }
 url = "2.3.1"

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -385,7 +385,7 @@ impl Listeners {
                     endpoint: "http://fake_address_for_testing:8080".to_string(),
                     headers: http::HeaderMap::new(),
                     filter: EnvFilter::default().add_directive(Level::DEBUG.into()),
-                    resource: opentelemetry::sdk::resource::Resource::default(),
+                    resource: opentelemetry_sdk::resource::Resource::default(),
                 }),
                 #[cfg(feature = "tokio-console")]
                 tokio_console: None,

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -43,7 +43,7 @@ mz-sql-parser = { path = "../sql-parser" }
 mz-sql-pretty = { path = "../sql-pretty" }
 num = "0.4.0"
 num_enum = "0.5.7"
-ordered-float = { version = "3.4.0", features = ["serde"] }
+ordered-float = { version = "4.2.0", features = ["serde"] }
 paste = "1.0.11"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 regex = "1.7.0"

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -28,7 +28,7 @@ mz-avro-derive = { path = "../avro-derive" }
 mz-ccsr = { path = "../ccsr" }
 mz-ore = { path = "../ore", features = ["network"] }
 mz-repr = { path = "../repr" }
-ordered-float = { version = "3.4.0", features = ["serde"] }
+ordered-float = { version = "4.2.0", features = ["serde"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 prost-reflect = "0.11.4"
 serde_json = "1.0.89"

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -25,7 +25,8 @@ mz-tracing = { path = "../tracing" }
 sentry-tracing = { version = "0.29.1" }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.16", default-features = false }
-opentelemetry = { version = "0.20.0", features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.21.0", features = ["trace"] }
+opentelemetry_sdk = { version = "0.21.2", features = ["rt-tokio"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -38,8 +38,8 @@ use mz_ore::tracing::{
     TracingGuard, TracingHandle,
 };
 use mz_tracing::CloneableEnvFilter;
-use opentelemetry::sdk::resource::Resource;
 use opentelemetry::KeyValue;
+use opentelemetry_sdk::resource::Resource;
 
 /// Command line arguments for application tracing.
 ///

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -68,17 +68,15 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 atty = { version = "0.2.14", optional = true }
 http = { version = "0.2.8", optional = true }
 tracing = { version = "0.1.37", optional = true }
-tracing-opentelemetry = { version = "0.20.0", optional = true }
+tracing-opentelemetry = { version = "0.22.0", optional = true }
 tonic = { version = "0.9.2", features = ["transport"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 native-tls = { version = "0.2.11", features = ["alpn"], optional = true }
 hyper = { version = "0.14.23", features = ["http1", "server"], optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
-opentelemetry = { version = "0.20.0", features = [
-  "rt-tokio",
-  "trace",
-], optional = true }
-opentelemetry-otlp = { version = "0.13.0", optional = true }
+opentelemetry = { version = "0.21.0", features = ["trace"], optional = true }
+opentelemetry-otlp = { version = "0.14.0", optional = true }
+opentelemetry_sdk = { version = "0.21.2", features = ["rt-tokio"], optional = true }
 console-subscriber = { version = "0.1.10", optional = true }
 sentry-tracing = { version = "0.29.1", optional = true }
 yansi = { version = "0.5.1", optional = true }
@@ -118,6 +116,7 @@ tracing_ = [
   "metrics",
   "opentelemetry",
   "opentelemetry-otlp",
+  "opentelemetry_sdk",
   "tonic",
   "sentry",
   "sentry-tracing",

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -33,9 +33,9 @@ use hyper::client::HttpConnector;
 use hyper_tls::HttpsConnector;
 use opentelemetry::global::Error;
 use opentelemetry::propagation::{Extractor, Injector};
-use opentelemetry::sdk::propagation::TraceContextPropagator;
-use opentelemetry::sdk::{trace, Resource};
 use opentelemetry::{global, KeyValue};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::{trace, Resource};
 use prometheus::IntCounter;
 use sentry::integrations::debug_images::DebugImagesIntegration;
 use tonic::metadata::MetadataMap;
@@ -318,7 +318,7 @@ where
                 ),
             )
             .with_exporter(exporter)
-            .install_batch(opentelemetry::runtime::Tokio)
+            .install_batch(opentelemetry_sdk::runtime::Tokio)
             .unwrap();
 
         // Create our own error handler to:
@@ -349,10 +349,8 @@ where
                     Error::Trace(err) => {
                         warn!("OpenTelemetry error: {}", err.display_with_causes());
                     }
+                    // TODO(guswynn): turn off the metrics feature?
                     Error::Metric(err) => {
-                        warn!("OpenTelemetry error: {}", err.display_with_causes());
-                    }
-                    Error::Log(err) => {
                         warn!("OpenTelemetry error: {}", err.display_with_causes());
                     }
                     Error::Other(err) => {

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -42,7 +42,7 @@ mz-proto = { path = "../proto", features = ["chrono"] }
 mz-sql-parser = { path = "../sql-parser" }
 num-traits = "0.2.15"
 num_enum = "0.5.7"
-ordered-float = { version = "3.4.0", features = ["serde"] }
+ordered-float = { version = "4.2.0", features = ["serde"] }
 postgres-protocol = { version = "0.6.5" }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 regex = "1.7.0"

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -19,7 +19,7 @@ mz-ore = { path = "../ore" }
 mz-persist-client = { path = "../persist-client" }
 mz-repr = { path = "../repr", features = ["tracing_"] }
 num-traits = "0.2"
-ordered-float = { version = "3.4.0", features = ["serde"] }
+ordered-float = { version = "4.2.0", features = ["serde"] }
 paste = "1.0.11"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -117,7 +117,7 @@ tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit"
 tower-http = { version = "0.4.3", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
-tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 tungstenite = { version = "0.20.1" }
 uncased = { version = "0.9.7" }
 url = { version = "2.3.1", features = ["serde"] }
@@ -231,7 +231,7 @@ tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit"
 tower-http = { version = "0.4.3", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
-tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 tungstenite = { version = "0.20.1" }
 uncased = { version = "0.9.7" }
 url = { version = "2.3.1", features = ["serde"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -73,7 +73,7 @@ num-bigint = { version = "0.4.3" }
 num-integer = { version = "0.1.44", features = ["i128"] }
 num-traits = { version = "0.2.15", features = ["i128"] }
 openssl = { version = "0.10.55", features = ["vendored"] }
-ordered-float = { version = "3.4.0", features = ["serde"] }
+ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
@@ -186,7 +186,7 @@ num-bigint = { version = "0.4.3" }
 num-integer = { version = "0.1.44", features = ["i128"] }
 num-traits = { version = "0.2.15", features = ["i128"] }
 openssl = { version = "0.10.55", features = ["vendored"] }
-ordered-float = { version = "3.4.0", features = ["serde"] }
+ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }


### PR DESCRIPTION
Alright, this is a doozy:

The bottom commit is primarily bringing in https://github.com/tokio-rs/tracing-opentelemetry/pull/86, through:
- this cherry-pick on our fork: https://github.com/MaterializeInc/tracing-opentelemetry/commit/1e0cf8be6360b16096121ccbf266eba4f38e307e
- a merge to get back to upstream: https://github.com/MaterializeInc/tracing-opentelemetry/commit/1c87231459e14cfab45e37ad3f5f6bcfbccb60e5 @ParkMyCar this has some changes in `src/layer.rs` that I needed to refactor, particularly your tests and the `on_event` code!

the bottom commit also updates various related crates to the new version that `tracing-opentelemetry` uses.

The second commit attempts to resolve conflicts for `ordered-float`;

The 3rd commit certifies the new deps with `cargo-vet` (it adds an exemption for the new `serde-value` version from our fork that just bumps its `ordered-float` dep)



### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/15223

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
