### PR TITLE
Source replication factor

### DIFF
--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1980,6 +1980,10 @@ impl mz_sql::catalog::CatalogClusterReplica<'_> for ClusterReplica {
     fn owner_id(&self) -> RoleId {
         self.owner_id
     }
+
+    fn internal(&self) -> bool {
+        self.config.location.internal()
+    }
 }
 
 impl mz_sql::catalog::CatalogItem for CatalogEntry {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -537,7 +537,7 @@ pub trait CatalogCluster<'a> {
 }
 
 /// A cluster replica in a [`SessionCatalog`]
-pub trait CatalogClusterReplica<'a> {
+pub trait CatalogClusterReplica<'a>: Debug {
     /// Returns the name of the cluster replica.
     fn name(&self) -> &str;
 
@@ -549,6 +549,9 @@ pub trait CatalogClusterReplica<'a> {
 
     /// Returns the ID of the owning role.
     fn owner_id(&self) -> RoleId;
+
+    /// Returns whether or not the replica is internal
+    fn internal(&self) -> bool;
 }
 
 /// An item in a [`SessionCatalog`].

--- a/test/testdrive/github-24310.td
+++ b/test/testdrive/github-24310.td
@@ -1,0 +1,48 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE CLUSTER sources (SIZE '1', REPLICATION FACTOR = 0);
+
+> CREATE SOURCE counter IN CLUSTER sources FROM LOAD GENERATOR COUNTER;
+
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+
+$ postgres-execute connection=mz_system
+CREATE CLUSTER REPLICA sources.unbilled SIZE '2', BILLED AS 'free', INTERNAL;
+
+! ALTER CLUSTER sources SET (REPLICATION FACTOR = 1);
+contains:cannot create more than one replica of a cluster containing sources or sinks
+detail:Currently have 1 replica (1 internal); command would result in 2
+
+# Work has been scheduled
+> SELECT max(counter) > 3 FROM counter;
+true
+
+$ postgres-execute connection=mz_system
+DROP CLUSTER REPLICA sources.unbilled;
+
+> ALTER CLUSTER sources SET (REPLICATION FACTOR = 1);
+
+# Reset
+> ALTER CLUSTER sources SET (REPLICATION FACTOR = 0);
+
+$ postgres-execute connection=mz_system
+CREATE CLUSTER REPLICA sources.unbilled SIZE '2', BILLED AS 'free', INTERNAL;
+
+! CREATE CLUSTER REPLICA sources.r1 SIZE '1';
+contains:cannot create more than one replica of a cluster containing sources or sinks
+detail:Currently have 1 replica (1 internal); command would result in 2
+
+$ postgres-execute connection=mz_system
+DROP CLUSTER REPLICA sources.unbilled;
+
+! CREATE CLUSTER REPLICA sources.r1 SIZE '1'
+contains:cannot modify managed cluster sources
+
+> DROP SOURCE counter CASCADE;


### PR DESCRIPTION
We weren't properly accounting for internal replicas when assessing the total number of replicas that changing a cluster's replication factor. Also tidied up a few other things in light of linked clusters imminently getting deprecated.

cc @antiguru 

### Motivation

Fixes #24310

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix a bug that let clusters containing storage objects (sources, sinks) have more than 1 replica, which is an unsupported state.
