### PR TITLE
DO NOT MERGE -- test whether #24298 fixed #24288

### DIFF
--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -296,7 +296,7 @@ class View(DBObject):
                     f"EVERY '{rng.randint(1, 60)} seconds {rng.randint(0, 60)} minutes'",
                     f"EVERY '{rng.randint(1, 60)} seconds {rng.randint(0, 60)} minutes' ALIGNED TO (mz_now())",
                     # TODO(def-): Allow smaller times again when #24288 is fixed
-                    f"AT mz_now()::string::int8 + {rng.randint(0, 10000)}", # (this is milliseconds)
+                    f"AT mz_now()::string::int8 + {rng.randint(0, 3600000)}",  # (this is milliseconds)
                 ]
             )
             if self.materialized

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -296,7 +296,7 @@ class View(DBObject):
                     f"EVERY '{rng.randint(1, 60)} seconds {rng.randint(0, 60)} minutes'",
                     f"EVERY '{rng.randint(1, 60)} seconds {rng.randint(0, 60)} minutes' ALIGNED TO (mz_now())",
                     # TODO(def-): Allow smaller times again when #24288 is fixed
-                    f"AT mz_now()::string::int8 + {rng.randint(1800000, 3600000)}",
+                    f"AT mz_now()::string::int8 + {rng.randint(0, 10000)}", # (this is milliseconds)
                 ]
             )
             if self.materialized


### PR DESCRIPTION
This is just to run "parallel workload" a bunch of times, with undoing the change from https://github.com/MaterializeInc/materialize/pull/24276

See https://github.com/MaterializeInc/materialize/pull/24298#issuecomment-1884473271

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
