### PR TITLE
ci: Fix some nightly fallout from smaller agents

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -256,7 +256,7 @@ steps:
     steps:
     - id: upsert-compaction-enabled
       label: Upsert (compaction enabled)
-      timeout_in_minutes: 30
+      timeout_in_minutes: 60
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -266,7 +266,7 @@ steps:
 
     - id: upsert-compaction-disabled
       label: Upsert (compaction disabled)
-      timeout_in_minutes: 30
+      timeout_in_minutes: 60
       artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
@@ -891,7 +891,7 @@ steps:
       - id: sqlsmith
         label: "SQLsmith"
         artifact_paths: junit_*.xml
-        timeout_in_minutes: 30
+        timeout_in_minutes: 60
         agents:
           queue: linux-x86_64-small
         plugins:
@@ -902,7 +902,7 @@ steps:
       - id: sqlsmith-explain
         label: "SQLsmith explain"
         artifact_paths: junit_*.xml
-        timeout_in_minutes: 30
+        timeout_in_minutes: 60
         agents:
           queue: linux-x86_64
         plugins:
@@ -1064,7 +1064,7 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64-small
+          queue: linux-x86_64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1075,7 +1075,7 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64-small
+          queue: linux-x86_64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/5917

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
