### PR TITLE
Use more robust row batch sizing

### DIFF
--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -275,7 +275,7 @@ true true true
 
 > CREATE DEFAULT INDEX ii_empty ON t3
 
-> SELECT records, batches, size < 16 * 1024, capacity < 16 * 1024, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_empty'
+> SELECT records, batches, size < 16 * 1024, capacity > 0, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_empty'
 0 32 true true true
 
 # Tests that arrangement sizes are approximate
@@ -286,7 +286,7 @@ true true true
 
 # We have 16 workers, and only want to ensure that the sizes are not egregious.
 
-> SELECT records, batches, size < 16 * 1024, capacity < 16 * 1024, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+> SELECT records, batches, size < 16 * 1024, capacity > 0, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
 0 32 true true true
 
 > INSERT INTO t4 SELECT 1
@@ -354,11 +354,10 @@ true true true true true
     size > 0,
     size < 4 * 130 * 1000,
     capacity > 0,
-    capacity < 4 * 130 * 1000,
     allocations > 0
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%c1%';
-true true true true true true true
+true true true true true true
 
 > SELECT
     records > 1000,
@@ -366,11 +365,10 @@ true true true true true true true
     size > 0,
     size < 4 * 100 * 1024,
     capacity > 0,
-    capacity < 4 * 100 * 1024,
     allocations > 100
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%c2%';
-true true true true true true true
+true true true true true true
 
 # For coverage, we also include a recursive materialized view to account for dynamic timestamps.
 > CREATE MATERIALIZED VIEW rec AS
@@ -395,11 +393,10 @@ true true true true true true true
     size > 0,
     size < 4 * 1000 * 1000,
     capacity > 0,
-    capacity < 4 * 1000 * 1000,
     allocations > 0
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%rec%';
-true true true true true true true
+true true true true true true
 
 > DROP TABLE ten CASCADE;
 
@@ -429,11 +426,10 @@ true true true true true true true
     size > 0,
     size < 4 * 200 * 1000,
     capacity > 0,
-    capacity < 4 * 200 * 1000,
     allocations > 100
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%m_minmax%';
-true true true true true true true
+true true true true true true
 
 > SELECT
     records >= 2 * 1000,
@@ -441,11 +437,10 @@ true true true true true true true
     size > 0,
     size < 4 * 172 * 1000,
     capacity > 0,
-    capacity < 4 * 172 * 1000,
     allocations > 100
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%m_top1%';
-true true true true true true true
+true true true true true true
 
 > DROP SOURCE counter CASCADE;
 


### PR DESCRIPTION
This PR starts the batching for `row_spine` at 2 << 20, and grows geometrically up to 128 << 20. These are made up numbers that I heard before. It also switches to binary search to determine in which batch an index lies, and this should generally be fine even with relatively smaller batch that do not grow geometrically, though it's a bit of a smell if it ends up doing too much work.

cc: @antiguru 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
