### PR TITLE
adapter: move `EXPLAIN CREATE MATERIALIZED VIEW` optimization off the coordinator thread

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -78,6 +78,8 @@ IGNORE_RE = re.compile(
     | cluster-clusterd[12]-1\ .*\ halting\ process:\ new\ timely\ configuration\ does\ not\ match\ existing\ timely\ configuration
     # Emitted by tests employing explicit mz_panic()
     | forced\ panic
+    # Emitted by broken_statements.slt in order to stop panic propagation, as 'forced panic' will unwantedly panic the `environmentd` thread.
+    | forced\ optimizer\ panic
     # Expected once compute cluster has panicked, brings no new information
     | timely\ communication\ error:
     # Expected once compute cluster has panicked, only happens in CI
@@ -86,8 +88,10 @@ IGNORE_RE = re.compile(
     | restart-materialized-1\ .*relation\ \\"fence\\"\ does\ not\ exist
     # Expected when CRDB is corrupted
     | restart-materialized-1\ .*relation\ "consensus"\ does\ not\ exist
-    # Will print a separate panic line which will be handled and contains the relevant information
+    # Will print a separate panic line which will be handled and contains the relevant information (old style) TODO(#24260): remove this
     | internal\ error:\ panic\ at\ the\ `.*`\ optimization\ stage
+    # Will print a separate panic line which will be handled and contains the relevant information (new style)
+    | internal\ error:\ unexpected\ panic\ during\ query\ optimization
     # redpanda INFO logging
     | larger\ sizes\ prevent\ running\ out\ of\ memory
     # Old versions won't support new parameters

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -175,7 +175,7 @@ impl Coordinator {
                     stage,
                 } => {
                     otel_ctx.attach_as_parent();
-                    self.sequence_create_materialized_view_stage(ctx, stage, otel_ctx)
+                    self.execute_create_materialized_view_stage(ctx, stage, otel_ctx)
                         .await;
                 }
                 Message::SubscribeStageReady {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2769,18 +2769,26 @@ impl Coordinator {
                 .await
             }
             plan::ExplaineeStatement::CreateMaterializedView {
-                name,
-                raw_plan,
-                column_names,
-                cluster_id,
                 broken,
-                non_null_assertions,
-                refresh_schedule,
+                plan:
+                    plan::CreateMaterializedViewPlan {
+                        name,
+                        materialized_view:
+                            plan::MaterializedView {
+                                expr,
+                                column_names,
+                                cluster_id,
+                                non_null_assertions,
+                                refresh_schedule,
+                                ..
+                            },
+                        ..
+                    },
             } => {
                 // Please see the docs on `explain_query_optimizer_pipeline` above.
                 self.explain_create_materialized_view_optimizer_pipeline(
                     name,
-                    raw_plan,
+                    expr,
                     column_names,
                     cluster_id,
                     broken,

--- a/src/adapter/src/explain/optimizer_trace.rs
+++ b/src/adapter/src/explain/optimizer_trace.rs
@@ -44,6 +44,12 @@ use crate::explain::Explainable;
 /// the collected trace as a vector of [`TraceEntry`] instances.
 pub(crate) struct OptimizerTrace(dispatcher::Dispatch);
 
+impl std::fmt::Debug for OptimizerTrace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("OptimizerTrace").finish() // Skip the dispatch field
+    }
+}
+
 impl OptimizerTrace {
     /// Create a new [`OptimizerTrace`].
     ///

--- a/src/repr/src/explain/tracing.rs
+++ b/src/repr/src/explain/tracing.rs
@@ -38,7 +38,7 @@ pub struct PlanTrace<T> {
 }
 
 /// A struct created as a reflection of a [`trace_plan`] call.
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct TraceEntry<T> {
     /// The instant at which an entry was created.
     ///

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -356,31 +356,15 @@ pub fn plan_explain_plan(
                 );
             }
 
-            let Plan::CreateMaterializedView(plan::CreateMaterializedViewPlan {
-                name,
-                materialized_view:
-                    plan::MaterializedView {
-                        expr: raw_plan,
-                        column_names,
-                        cluster_id,
-                        non_null_assertions,
-                        refresh_schedule,
-                        ..
-                    },
-                ..
-            }) = ddl::plan_create_materialized_view(scx, *stmt, params)?
+            let Plan::CreateMaterializedView(plan) =
+                ddl::plan_create_materialized_view(scx, *stmt, params)?
             else {
                 sql_bail!("expected CreateMaterializedViewPlan plan");
             };
 
             crate::plan::Explainee::Statement(ExplaineeStatement::CreateMaterializedView {
-                name,
-                raw_plan,
-                column_names,
-                cluster_id,
                 broken,
-                non_null_assertions,
-                refresh_schedule,
+                plan,
             })
         }
         Explainee::CreateIndex(mut stmt, broken) => {

--- a/test/sqllogictest/explain/broken_statements.slt
+++ b/test/sqllogictest/explain/broken_statements.slt
@@ -39,27 +39,27 @@ mode cockroach
 # EXPLAIN RAW PLAN
 statement ok
 EXPLAIN RAW PLAN FOR BROKEN
-SELECT mz_unsafe.mz_panic('forced panic');
+SELECT mz_unsafe.mz_panic('forced optimizer panic');
 
 # EXPLAIN DECORRELATED PLAN
 statement ok
 EXPLAIN DECORRELATED PLAN FOR BROKEN
-SELECT mz_unsafe.mz_panic('forced panic');
+SELECT mz_unsafe.mz_panic('forced optimizer panic');
 
 # EXPLAIN OPTIMIZED PLAN
 statement error internal error: stage `optimize/global` not present
 EXPLAIN OPTIMIZED PLAN FOR BROKEN
-SELECT mz_unsafe.mz_panic('forced panic');
+SELECT mz_unsafe.mz_panic('forced optimizer panic');
 
 # EXPLAIN PHYSICAL PLAN
 statement error internal error: stage `optimize/finalize_dataflow` not present
 EXPLAIN PHYSICAL PLAN FOR BROKEN
-SELECT mz_unsafe.mz_panic('forced panic');
+SELECT mz_unsafe.mz_panic('forced optimizer panic');
 
 # EXPLAIN OPTIMIZER TRACE
 statement ok
 EXPLAIN OPTIMIZER TRACE FOR BROKEN
-SELECT mz_unsafe.mz_panic('forced panic');
+SELECT mz_unsafe.mz_panic('forced optimizer panic');
 
 
 # EXPLAIN ... BROKEN CREATE MATERIALIZED VIEW
@@ -69,31 +69,31 @@ SELECT mz_unsafe.mz_panic('forced panic');
 statement ok
 EXPLAIN RAW PLAN FOR BROKEN
 CREATE MATERIALIZED VIEW mv AS
-SELECT mz_unsafe.mz_panic('forced panic');
+SELECT mz_unsafe.mz_panic('forced optimizer panic');
 
 # EXPLAIN DECORRELATED PLAN
 statement ok
 EXPLAIN DECORRELATED PLAN FOR BROKEN
 CREATE MATERIALIZED VIEW mv AS
-SELECT mz_unsafe.mz_panic('forced panic');
+SELECT mz_unsafe.mz_panic('forced optimizer panic');
 
 # EXPLAIN OPTIMIZED PLAN
 statement error internal error: stage `optimize/global` not present
 EXPLAIN OPTIMIZED PLAN FOR BROKEN
 CREATE MATERIALIZED VIEW mv AS
-SELECT mz_unsafe.mz_panic('forced panic');
+SELECT mz_unsafe.mz_panic('forced optimizer panic');
 
 # EXPLAIN PHYSICAL PLAN
 statement error internal error: stage `optimize/finalize_dataflow` not present
 EXPLAIN PHYSICAL PLAN FOR BROKEN
 CREATE MATERIALIZED VIEW mv AS
-SELECT mz_unsafe.mz_panic('forced panic');
+SELECT mz_unsafe.mz_panic('forced optimizer panic');
 
 # EXPLAIN OPTIMIZER TRACE
 statement ok
 EXPLAIN OPTIMIZER TRACE FOR BROKEN
 CREATE MATERIALIZED VIEW mv AS
-SELECT mz_unsafe.mz_panic('forced panic');
+SELECT mz_unsafe.mz_panic('forced optimizer panic');
 
 
 # EXPLAIN ... BROKEN CREATE INDEX


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature.

This is the first step towards resolving #24260. This is done by unifying the `sequence_` and `explain_` code paths for `CREATE MATERIALIZED VIEW`, as proposed by @mjibson when we were discussing alternative solutions for some of the problems listed in #20569.

### Tips for reviewer

The first commit just prepares for the actual refactor by putting the entire `plan: plan::CreateMaterializedViewPlan` in the `ExplaineeStatement::CreateMaterializedView` structure.

Similar to `sequence_create_materialized_view`, we want `EXPLAIN CREATE MATERIALIZED VIEW` statements to be executed in a way where the optimization step happens off-thread. In order to do that, we extend the `CreateMaterializedViewStage` enum with a new terminal `Explain` stage which is selected instead of the `Finish` stage iff the `Optimize` stage is entered with a populated `ExplainContext` parameter.

See the second commit message for details.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. (Relying on existing coverage)
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
