### PR TITLE
feature-benchmark: Headers for scenarios

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -10,6 +10,7 @@
 import sys
 from collections.abc import Iterable
 
+from materialize import ui
 from materialize.feature_benchmark.aggregation import Aggregation
 from materialize.feature_benchmark.comparator import Comparator
 from materialize.feature_benchmark.executor import Executor
@@ -61,8 +62,8 @@ class Benchmark:
         scenario = scenario_class(scale=scale, mz_version=self._mz_version)
         name = scenario.name()
 
-        print(
-            f"Sizing in effect for scenario {name}: scale = {scenario.scale()} , N = {scenario.n()}"
+        ui.header(
+            f"Running scenario {name}, scale = {scenario.scale()}, N = {scenario.n()}"
         )
 
         # Run the shared() section once for both Mzs under measurement


### PR DESCRIPTION
Improves the output in buildkite, currently everything interesting is hidden under "Acquiring materialize/testdrive", which has led to confusion

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
