### PR TITLE
catalog: Read LD before catalog open

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -158,7 +158,7 @@ use crate::util::{ClientTransmitter, CompletedClientTransmitter, ComputeSinkId, 
 use crate::webhook::{WebhookAppenderInvalidator, WebhookConcurrencyLimiter};
 use crate::{flags, AdapterNotice, TimestampProvider};
 use mz_catalog::builtin::BUILTINS;
-use mz_catalog::durable::DurableCatalogState;
+use mz_catalog::durable::OpenableDurableCatalogState;
 use mz_expr::refresh_schedule::RefreshSchedule;
 use mz_timestamp_oracle::postgres_oracle::{
     PostgresTimestampOracle, PostgresTimestampOracleConfig,
@@ -751,7 +751,7 @@ pub struct Config {
     pub storage_usage_retention_period: Option<Duration>,
     pub segment_client: Option<mz_segment::Client>,
     pub egress_ips: Vec<Ipv4Addr>,
-    pub system_parameter_sync_config: Option<SystemParameterSyncConfig>,
+    pub remote_system_parameters: Option<BTreeMap<String, OwnedVarInput>>,
     pub aws_account_id: Option<String>,
     pub aws_privatelink_availability_zones: Option<Vec<String>>,
     pub connection_context: ConnectionContext,
@@ -2589,7 +2589,7 @@ pub fn serve(
         controller_config,
         controller_envd_epoch,
         controller_persist_txn_tables,
-        mut storage,
+        storage,
         timestamp_oracle_url,
         unsafe_mode,
         all_features,
@@ -2612,7 +2612,7 @@ pub fn serve(
         aws_account_id,
         aws_privatelink_availability_zones,
         connection_context,
-        system_parameter_sync_config,
+        remote_system_parameters,
         active_connection_count,
         webhook_concurrency_limit,
         http_host_name,
@@ -2648,8 +2648,6 @@ pub fn serve(
             .map(|azs_vec| BTreeSet::from_iter(azs_vec.iter().cloned()));
 
         info!("coordinator init: opening catalog");
-        let remote_system_parameters =
-            load_remote_system_parameters(&mut storage, system_parameter_sync_config).await?;
         let (catalog, builtin_migration_metadata, builtin_table_updates, _last_catalog_version) =
             Catalog::open(mz_catalog::config::Config {
                 storage,
@@ -2906,10 +2904,9 @@ async fn get_initial_oracle_timestamps(
     Ok(initial_timestamps)
 }
 
-/// Potentially load system parameters from a remote frontend server.
 #[tracing::instrument(level = "info", skip_all)]
-async fn load_remote_system_parameters(
-    storage: &mut Box<dyn DurableCatalogState>,
+pub async fn load_remote_system_parameters(
+    storage: &mut Box<dyn OpenableDurableCatalogState>,
     system_parameter_sync_config: Option<SystemParameterSyncConfig>,
 ) -> Result<Option<BTreeMap<String, OwnedVarInput>>, AdapterError> {
     if let Some(system_parameter_sync_config) = system_parameter_sync_config {
@@ -2953,9 +2950,7 @@ async fn load_remote_system_parameters(
         //       LaunchDarkly configuration, for when LaunchDarkly comes
         //       back online.
         //    6. Reboot environmentd.
-        if storage.is_read_only() {
-            tracing::info!("parameter sync on boot: skipping sync as catalog is read-only");
-        } else if !storage.has_system_config_synced_once().await? {
+        if !storage.has_system_config_synced_once().await? {
             let mut params = SynchronizedParameters::new(SystemVars::default());
             let frontend = SystemParameterFrontend::from(&system_parameter_sync_config).await?;
             frontend.pull(&mut params);

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -69,7 +69,7 @@ pub use crate::coord::timestamp_selection::{
 };
 pub use crate::coord::ExecuteContext;
 pub use crate::coord::ExecuteContextExtra;
-pub use crate::coord::{serve, Config};
+pub use crate::coord::{load_remote_system_parameters, serve, Config};
 pub use crate::error::AdapterError;
 pub use crate::notice::AdapterNotice;
 pub use crate::webhook::{

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -143,6 +143,9 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// Get the deployment generation of this instance.
     async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError>;
 
+    /// Reports if the remote configuration was synchronized at least once.
+    async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError>;
+
     /// Get the tombstone value of this instance.
     async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError>;
 
@@ -198,9 +201,6 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
     async fn get_next_system_replica_id(&mut self) -> Result<u64, CatalogError> {
         self.get_next_id(SYSTEM_REPLICA_ID_ALLOC_KEY).await
     }
-
-    /// Reports if the remote configuration was synchronized at least once.
-    async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError>;
 
     /// Get the next user replica id without allocating it.
     async fn get_next_user_replica_id(&mut self) -> Result<u64, CatalogError> {

--- a/src/catalog/src/durable/impls/migrate.rs
+++ b/src/catalog/src/durable/impls/migrate.rs
@@ -189,6 +189,15 @@ impl OpenableDurableCatalogState for CatalogMigrator {
         }
     }
 
+    async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError> {
+        let tombstone = self.get_tombstone().await?;
+        if tombstone == Some(true) {
+            self.openable_persist.has_system_config_synced_once().await
+        } else {
+            self.openable_stash.has_system_config_synced_once().await
+        }
+    }
+
     async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {
         self.openable_stash.get_tombstone().await
     }

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -569,6 +569,13 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
         self.get_current_config(DEPLOY_GENERATION).await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError> {
+        self.get_current_config(SYSTEM_CONFIG_SYNCED_KEY)
+            .await
+            .map(|value| value.map(|value| value > 0).unwrap_or(false))
+    }
+
     async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {
         panic!("Persist implementation does not have a tombstone")
     }
@@ -939,21 +946,6 @@ impl ReadOnlyDurableCatalogState for PersistCatalogState {
         };
         self.with_snapshot(|snapshot| {
             Ok(snapshot.id_allocator.get(&key).expect("must exist").next_id)
-        })
-        .await
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError> {
-        let key = proto::ConfigKey {
-            key: SYSTEM_CONFIG_SYNCED_KEY.to_string(),
-        };
-        self.with_snapshot(|snapshot| {
-            Ok(snapshot
-                .configs
-                .get(&key)
-                .map(|value| value.value > 0)
-                .unwrap_or(false))
         })
         .await
     }

--- a/src/catalog/src/durable/impls/shadow.rs
+++ b/src/catalog/src/durable/impls/shadow.rs
@@ -158,6 +158,10 @@ where
         compare_and_return_async!(self, get_deployment_generation)
     }
 
+    async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError> {
+        compare_and_return_async!(self, has_system_config_synced_once)
+    }
+
     async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {
         compare_and_return_async!(self, get_tombstone)
     }
@@ -357,10 +361,6 @@ impl ReadOnlyDurableCatalogState for ShadowCatalogState {
         &mut self,
     ) -> Result<Option<PersistTxnTablesImpl>, CatalogError> {
         compare_and_return_async!(self, get_persist_txn_tables)
-    }
-
-    async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError> {
-        compare_and_return_async!(self, has_system_config_synced_once)
     }
 
     async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {

--- a/src/catalog/src/durable/impls/stash.rs
+++ b/src/catalog/src/durable/impls/stash.rs
@@ -270,6 +270,14 @@ impl OpenableDurableCatalogState for OpenableConnection {
         self.get_config(DEPLOY_GENERATION.into()).await
     }
 
+    async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError> {
+        Ok(self
+            .get_config(SYSTEM_CONFIG_SYNCED_KEY.into())
+            .await?
+            .map(|value| value > 0)
+            .unwrap_or(false))
+    }
+
     async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {
         Ok(self.get_config(TOMBSTONE_KEY.into()).await?.map(|v| v > 0))
     }
@@ -642,13 +650,6 @@ impl ReadOnlyDurableCatalogState for Connection {
                 DurableCatalogError::from(TryFromProtoError::UnknownEnumVariant(err.to_string()))
                     .into()
             })
-    }
-
-    async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError> {
-        Ok(get_config(&mut self.stash, SYSTEM_CONFIG_SYNCED_KEY.into())
-            .await?
-            .map(|value| value > 0)
-            .unwrap_or(false))
     }
 
     async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {
@@ -1346,6 +1347,12 @@ impl OpenableDurableCatalogState for TestOpenableConnection<'_> {
 
     async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError> {
         self.openable_connection.get_deployment_generation().await
+    }
+
+    async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError> {
+        self.openable_connection
+            .has_system_config_synced_once()
+            .await
     }
 
     async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {


### PR DESCRIPTION
This commit moves the sync with LaunchDarkly on startup from after opening the durable catalog to before opening the durable catalog. This allows us to use LaunchDarkly flags to determine how to open the durable catalog. Specifically this allows brand-new environments to use the catalog implementation specified in LaunchDarkly, without needing to reboot.

Works towards resolving #24218

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
