### PR TITLE
adapter: move `EXPLAIN CREATE INDEX` optimization off the coordinator thread

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -469,6 +469,7 @@ pub enum CreateIndexStage {
     Validate(CreateIndexValidate),
     Optimize(CreateIndexOptimize),
     Finish(CreateIndexFinish),
+    Explain(CreateIndexExplain),
 }
 
 impl CreateIndexStage {
@@ -477,6 +478,7 @@ impl CreateIndexStage {
             Self::Validate(_) => None,
             Self::Optimize(stage) => Some(&mut stage.validity),
             Self::Finish(stage) => Some(&mut stage.validity),
+            Self::Explain(stage) => Some(&mut stage.validity),
         }
     }
 }
@@ -485,6 +487,9 @@ impl CreateIndexStage {
 pub struct CreateIndexValidate {
     plan: plan::CreateIndexPlan,
     resolved_ids: ResolvedIds,
+    /// An optional context set iff the state machine is initiated from
+    /// sequencing an EXPALIN for this statement.
+    explain_ctx: Option<ExplainContext>,
 }
 
 #[derive(Debug)]
@@ -492,16 +497,29 @@ pub struct CreateIndexOptimize {
     validity: PlanValidity,
     plan: plan::CreateIndexPlan,
     resolved_ids: ResolvedIds,
+    /// An optional context set iff the state machine is initiated from
+    /// sequencing an EXPALIN for this statement.
+    explain_ctx: Option<ExplainContext>,
 }
 
 #[derive(Debug)]
 pub struct CreateIndexFinish {
     validity: PlanValidity,
-    id: GlobalId,
+    exported_index_id: GlobalId,
     plan: plan::CreateIndexPlan,
     resolved_ids: ResolvedIds,
     global_mir_plan: optimize::index::GlobalMirPlan,
     global_lir_plan: optimize::index::GlobalLirPlan,
+}
+
+#[derive(Debug)]
+pub struct CreateIndexExplain {
+    validity: PlanValidity,
+    exported_index_id: GlobalId,
+    plan: plan::CreateIndexPlan,
+    df_meta: DataflowMetainfo,
+    used_indexes: UsedIndexes,
+    explain_ctx: ExplainContext,
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -159,7 +159,7 @@ impl Coordinator {
                     stage,
                 } => {
                     otel_ctx.attach_as_parent();
-                    self.sequence_create_index_stage(ctx, stage, otel_ctx).await;
+                    self.execute_create_index_stage(ctx, stage, otel_ctx).await;
                 }
                 Message::CreateViewStageReady {
                     ctx,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2570,6 +2570,9 @@ impl Coordinator {
                         plan::ExplaineeStatement::CreateMaterializedView { .. } => {
                             self.explain_create_materialized_view(ctx, plan).await;
                         }
+                        plan::ExplaineeStatement::CreateIndex { .. } => {
+                            self.explain_create_index(ctx, plan).await;
+                        }
                         _ => {
                             let result =
                                 self.explain_statement(&mut ctx, plan, target_cluster).await;

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2817,9 +2817,8 @@ impl Coordinator {
                 .await
             }
             plan::ExplaineeStatement::CreateIndex {
-                name,
-                index,
                 broken,
+                plan: plan::CreateIndexPlan { name, index, .. },
             } => {
                 // Please see the docs on `explain_query_optimizer_pipeline` above.
                 self.explain_create_index_optimizer_pipeline(

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -9,8 +9,11 @@
 
 use std::collections::BTreeSet;
 
+use maplit::btreemap;
 use mz_catalog::memory::objects::{CatalogItem, Index};
 use mz_ore::tracing::OpenTelemetryContext;
+use mz_repr::explain::{trace_plan, ExprHumanizerExt, TransientItem, UsedIndexes};
+use mz_repr::{Datum, Row};
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan;
@@ -18,10 +21,11 @@ use mz_sql::plan;
 use crate::command::ExecuteResponse;
 use crate::coord::sequencer::inner::return_if_err;
 use crate::coord::{
-    Coordinator, CreateIndexFinish, CreateIndexOptimize, CreateIndexStage, CreateIndexValidate,
-    Message, PlanValidity,
+    Coordinator, CreateIndexExplain, CreateIndexFinish, CreateIndexOptimize, CreateIndexStage,
+    CreateIndexValidate, ExplainContext, Message, PlanValidity,
 };
 use crate::error::AdapterError;
+use crate::explain::optimizer_trace::OptimizerTrace;
 use crate::optimize::dataflows::dataflow_import_id_bundle;
 use crate::optimize::{self, Optimize};
 use crate::session::Session;
@@ -35,9 +39,60 @@ impl Coordinator {
         plan: plan::CreateIndexPlan,
         resolved_ids: ResolvedIds,
     ) {
-        self.sequence_create_index_stage(
+        self.execute_create_index_stage(
             ctx,
-            CreateIndexStage::Validate(CreateIndexValidate { plan, resolved_ids }),
+            CreateIndexStage::Validate(CreateIndexValidate {
+                plan,
+                resolved_ids,
+                explain_ctx: None,
+            }),
+            OpenTelemetryContext::obtain(),
+        )
+        .await;
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) async fn explain_create_index(
+        &mut self,
+        ctx: ExecuteContext,
+        plan::ExplainPlanPlan {
+            stage,
+            format,
+            config,
+            explainee,
+        }: plan::ExplainPlanPlan,
+    ) {
+        let plan::Explainee::Statement(stmt) = explainee else {
+            // This is currently asserted in the `sequence_explain_plan` code that
+            // calls this method.
+            unreachable!()
+        };
+        let plan::ExplaineeStatement::CreateIndex { broken, plan } = stmt else {
+            // This is currently asserted in the `sequence_explain_plan` code that
+            // calls this method.
+            unreachable!()
+        };
+
+        // Create an OptimizerTrace instance to collect plans emitted when
+        // executing the optimizer pipeline.
+        let optimizer_trace = OptimizerTrace::new(broken, stage.path());
+
+        // Not used in the EXPLAIN path so it's OK to generate a dummy value.
+        let resolved_ids = ResolvedIds(Default::default());
+
+        self.execute_create_index_stage(
+            ctx,
+            CreateIndexStage::Validate(CreateIndexValidate {
+                plan,
+                resolved_ids,
+                explain_ctx: Some(ExplainContext {
+                    broken,
+                    config,
+                    format,
+                    stage,
+                    optimizer_trace,
+                }),
+            }),
             OpenTelemetryContext::obtain(),
         )
         .await;
@@ -45,7 +100,7 @@ impl Coordinator {
 
     /// Processes as many `create index` stages as possible.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) async fn sequence_create_index_stage(
+    pub(crate) async fn execute_create_index_stage(
         &mut self,
         mut ctx: ExecuteContext,
         mut stage: CreateIndexStage,
@@ -76,6 +131,11 @@ impl Coordinator {
                     ctx.retire(result);
                     return;
                 }
+                Explain(stage) => {
+                    let result = self.create_index_explain(&mut ctx, stage);
+                    ctx.retire(result);
+                    return;
+                }
             }
         }
     }
@@ -83,7 +143,11 @@ impl Coordinator {
     fn create_index_validate(
         &mut self,
         session: &Session,
-        CreateIndexValidate { plan, resolved_ids }: CreateIndexValidate,
+        CreateIndexValidate {
+            plan,
+            resolved_ids,
+            explain_ctx,
+        }: CreateIndexValidate,
     ) -> Result<CreateIndexOptimize, AdapterError> {
         let plan::CreateIndexPlan {
             index: plan::Index { on, cluster_id, .. },
@@ -102,6 +166,7 @@ impl Coordinator {
             validity,
             plan,
             resolved_ids,
+            explain_ctx,
         })
     }
 
@@ -112,6 +177,7 @@ impl Coordinator {
             validity,
             plan,
             resolved_ids,
+            explain_ctx,
         }: CreateIndexOptimize,
         otel_ctx: OpenTelemetryContext,
     ) {
@@ -128,43 +194,117 @@ impl Coordinator {
         let compute_instance = self
             .instance_snapshot(*cluster_id)
             .expect("compute instance does not exist");
-        let id = return_if_err!(self.catalog_mut().allocate_user_id().await, ctx);
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
+        let exported_index_id = if explain_ctx.is_some() {
+            return_if_err!(self.allocate_transient_id(), ctx)
+        } else {
+            return_if_err!(self.catalog_mut().allocate_user_id().await, ctx)
+        };
+        let optimizer_config = if let Some(explain_ctx) = explain_ctx.as_ref() {
+            optimize::OptimizerConfig::from((self.catalog().system_config(), &explain_ctx.config))
+        } else {
+            optimize::OptimizerConfig::from(self.catalog().system_config())
+        };
 
         // Build an optimizer for this INDEX.
         let mut optimizer = optimize::index::Optimizer::new(
             self.owned_catalog(),
             compute_instance,
-            id,
+            exported_index_id,
             optimizer_config,
         );
-
-        let span = tracing::debug_span!("optimize create index task");
 
         mz_ore::task::spawn_blocking(
             || "optimize create index",
             move || {
-                let _guard = span.enter();
+                let mut pipeline = || -> Result<(
+                    optimize::index::GlobalMirPlan,
+                    optimize::index::GlobalLirPlan,
+                    UsedIndexes,
+                ), AdapterError> {
+                    // In `explain_~` contexts, set the trace-derived dispatch
+                    // as default while optimizing.
+                    let _dispatch_guard = if let Some(explain_ctx) = explain_ctx.as_ref() {
+                        let dispatch = tracing::Dispatch::from(&explain_ctx.optimizer_trace);
+                        Some(tracing::dispatcher::set_default(&dispatch))
+                    } else {
+                        None
+                    };
 
-                // MIR ⇒ MIR optimization (global)
-                let index_plan =
-                    optimize::index::Index::new(&plan.name, &plan.index.on, &plan.index.keys);
-                let global_mir_plan =
-                    return_if_err!(optimizer.catch_unwind_optimize(index_plan), ctx);
-                // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                let global_lir_plan = return_if_err!(
-                    optimizer.catch_unwind_optimize(global_mir_plan.clone()),
-                    ctx
-                );
+                    let _span_guard = tracing::debug_span!(target: "optimizer", "optimize").entered();
 
-                let stage = CreateIndexStage::Finish(CreateIndexFinish {
-                    validity,
-                    id,
-                    plan,
-                    resolved_ids,
-                    global_mir_plan,
-                    global_lir_plan,
-                });
+                    // MIR ⇒ MIR optimization (global)
+                    let index_plan =
+                        optimize::index::Index::new(&plan.name, &plan.index.on, &plan.index.keys);
+                    let global_mir_plan = optimizer.catch_unwind_optimize(index_plan)?;
+
+                    // Collect the list of indexes used by the dataflow at this point
+                    let used_indexes = {
+                        let df_desc = global_mir_plan.df_desc();
+                        let df_meta = global_mir_plan.df_meta();
+                        UsedIndexes::new(
+                            df_desc
+                                .index_imports
+                                .iter()
+                                .map(|(id, _index_import)| {
+                                    (*id, df_meta.index_usage_types.get(id).expect("prune_and_annotate_dataflow_index_imports should have been called already").clone())
+                                })
+                                .collect(),
+                        )
+                    };
+
+                    // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
+                    let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan.clone())?;
+
+                    // Trace the resulting plan for the top-level `optimize` path.
+                    trace_plan(global_lir_plan.df_desc());
+
+                    Ok((global_mir_plan, global_lir_plan, used_indexes))
+                };
+
+                let stage = match pipeline() {
+                    Ok((global_mir_plan, global_lir_plan, used_indexes)) => {
+                        if let Some(explain_ctx) = explain_ctx {
+                            let (_, df_meta) = global_lir_plan.unapply();
+                            CreateIndexStage::Explain(CreateIndexExplain {
+                                validity,
+                                exported_index_id,
+                                plan,
+                                df_meta,
+                                used_indexes,
+                                explain_ctx,
+                            })
+                        } else {
+                            CreateIndexStage::Finish(CreateIndexFinish {
+                                validity,
+                                exported_index_id,
+                                plan,
+                                resolved_ids,
+                                global_mir_plan,
+                                global_lir_plan,
+                            })
+                        }
+                    }
+                    // Pipeline errors are handled fifferently depending on the caller.
+                    Err(err) => {
+                        if let Some(explain_ctx) = explain_ctx {
+                            // In `explain_~` contexts, just move to the next
+                            // stage with default parameters.
+                            tracing::error!("error while handling EXPLAIN statement: {}", err);
+                            CreateIndexStage::Explain(CreateIndexExplain {
+                                validity,
+                                exported_index_id,
+                                plan,
+                                df_meta: Default::default(),
+                                used_indexes: Default::default(),
+                                explain_ctx,
+                            })
+                        } else {
+                            // In `sequence_~` contexts, immediately retire the
+                            // execution with the error.
+                            return ctx.retire(Err(err));
+                        }
+                    }
+                };
 
                 let _ = internal_cmd_tx.send(Message::CreateIndexStageReady {
                     ctx,
@@ -179,7 +319,7 @@ impl Coordinator {
         &mut self,
         ctx: &mut ExecuteContext,
         CreateIndexFinish {
-            id,
+            exported_index_id,
             plan:
                 plan::CreateIndexPlan {
                     name,
@@ -200,7 +340,7 @@ impl Coordinator {
         }: CreateIndexFinish,
     ) -> Result<ExecuteResponse, AdapterError> {
         let ops = vec![catalog::Op::CreateItem {
-            id,
+            id: exported_index_id,
             oid: self.catalog_mut().allocate_oid()?,
             name: name.clone(),
             item: CatalogItem::Index(Index {
@@ -221,10 +361,10 @@ impl Coordinator {
                 // Save plan structures.
                 coord
                     .catalog_mut()
-                    .set_optimized_plan(id, global_mir_plan.df_desc().clone());
+                    .set_optimized_plan(exported_index_id, global_mir_plan.df_desc().clone());
                 coord
                     .catalog_mut()
-                    .set_physical_plan(id, global_lir_plan.df_desc().clone());
+                    .set_physical_plan(exported_index_id, global_lir_plan.df_desc().clone());
 
                 let (mut df_desc, df_meta) = global_lir_plan.unapply();
 
@@ -237,10 +377,12 @@ impl Coordinator {
                 coord.emit_optimizer_notices(ctx.session(), &df_meta.optimizer_notices);
 
                 // Notices rendering
-                let df_meta = coord.catalog().render_notices(df_meta, Some(id));
+                let df_meta = coord
+                    .catalog()
+                    .render_notices(df_meta, Some(exported_index_id));
                 coord
                     .catalog_mut()
-                    .set_dataflow_metainfo(id, df_meta.clone());
+                    .set_dataflow_metainfo(exported_index_id, df_meta.clone());
 
                 if coord.catalog().state().system_config().enable_mz_notices() {
                     // Initialize a container for builtin table updates.
@@ -265,7 +407,9 @@ impl Coordinator {
                     coord.ship_dataflow(df_desc, cluster_id).await;
                 }
 
-                coord.set_index_options(id, options).expect("index enabled");
+                coord
+                    .set_index_options(exported_index_id, options)
+                    .expect("index enabled");
             })
             .await;
 
@@ -284,5 +428,102 @@ impl Coordinator {
             }
             Err(err) => Err(err),
         }
+    }
+
+    fn create_index_explain(
+        &mut self,
+        ctx: &mut ExecuteContext,
+        CreateIndexExplain {
+            exported_index_id,
+            plan: plan::CreateIndexPlan { name, index, .. },
+            df_meta,
+            used_indexes,
+            explain_ctx:
+                ExplainContext {
+                    broken,
+                    config,
+                    format,
+                    stage,
+                    optimizer_trace,
+                },
+            ..
+        }: CreateIndexExplain,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        let session_catalog = self.catalog().for_session(ctx.session());
+        let expr_humanizer = {
+            let on_entry = self.catalog.get_entry(&index.on);
+            let full_name = self.catalog.resolve_full_name(&name, on_entry.conn_id());
+            let on_desc = on_entry
+                .desc(&full_name)
+                .expect("can only create indexes on items with a valid description");
+
+            let transient_items = btreemap! {
+                exported_index_id => TransientItem::new(
+                    Some(full_name.to_string()),
+                    Some(full_name.item.to_string()),
+                    Some(on_desc.iter_names().map(|c| c.to_string()).collect()),
+                )
+            };
+            ExprHumanizerExt::new(transient_items, &session_catalog)
+        };
+
+        let trace = optimizer_trace.drain_all(
+            format,
+            &config,
+            &expr_humanizer,
+            None,
+            used_indexes,
+            None,
+            df_meta,
+        )?;
+
+        let rows = match stage.path() {
+            None => {
+                // For the `Trace` (pseudo-)stage, return the entire trace as
+                // triples of (time, path, plan) values.
+                let rows = trace
+                    .into_iter()
+                    .map(|entry| {
+                        // The trace would have to take over 584 years to overflow a u64.
+                        let span_duration = u64::try_from(entry.span_duration.as_nanos());
+                        Row::pack_slice(&[
+                            Datum::from(span_duration.unwrap_or(u64::MAX)),
+                            Datum::from(entry.path.as_str()),
+                            Datum::from(entry.plan.as_str()),
+                        ])
+                    })
+                    .collect();
+                rows
+            }
+            Some(path) => {
+                // For everything else, return the plan for the stage identified
+                // by the corresponding path.
+                let row = trace
+                    .into_iter()
+                    .find(|entry| entry.path == path)
+                    .map(|entry| Row::pack_slice(&[Datum::from(entry.plan.as_str())]))
+                    .ok_or_else(|| {
+                        let stmt_kind = plan::ExplaineeStatementKind::CreateIndex;
+                        if !stmt_kind.supports(&stage) {
+                            // Print a nicer error for unsupported stages.
+                            AdapterError::Unstructured(anyhow::anyhow!(format!(
+                                "cannot EXPLAIN {stage} FOR {stmt_kind}"
+                            )))
+                        } else {
+                            // We don't expect this stage to be missing.
+                            AdapterError::Internal(format!(
+                                "stage `{path}` not present in the collected optimizer trace",
+                            ))
+                        }
+                    })?;
+                vec![row]
+            }
+        };
+
+        if broken {
+            tracing_core::callsite::rebuild_interest_cache();
+        }
+
+        Ok(Self::send_immediate_rows(rows))
     }
 }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -629,7 +629,7 @@ pub struct CreateMaterializedViewPlan {
     pub ambiguous_columns: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CreateIndexPlan {
     pub name: QualifiedItemName,
     pub index: Index,
@@ -821,10 +821,9 @@ pub enum ExplaineeStatement {
     },
     /// The object to be explained is a CREATE INDEX.
     CreateIndex {
-        name: QualifiedItemName,
-        index: Index,
         /// Broken flag (see [`ExplaineeStatement::broken()`]).
         broken: bool,
+        plan: plan::CreateIndexPlan,
     },
 }
 
@@ -833,7 +832,7 @@ impl ExplaineeStatement {
         match self {
             Self::Select { raw_plan, .. } => raw_plan.depends_on(),
             Self::CreateMaterializedView { plan, .. } => plan.materialized_view.expr.depends_on(),
-            Self::CreateIndex { index, .. } => btreeset! {index.on},
+            Self::CreateIndex { plan, .. } => btreeset! {plan.index.on},
         }
     }
 

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -379,17 +379,11 @@ pub fn plan_explain_plan(
                 );
             }
 
-            let Plan::CreateIndex(plan::CreateIndexPlan { name, index, .. }) =
-                ddl::plan_create_index(scx, *stmt)?
-            else {
+            let Plan::CreateIndex(plan) = ddl::plan_create_index(scx, *stmt)? else {
                 sql_bail!("expected CreateIndexPlan plan");
             };
 
-            crate::plan::Explainee::Statement(ExplaineeStatement::CreateIndex {
-                name,
-                index,
-                broken,
-            })
+            crate::plan::Explainee::Statement(ExplaineeStatement::CreateIndex { broken, plan })
         }
     };
 


### PR DESCRIPTION
This is similarly structured to #24331.

### Motivation

  * This PR adds a known-desirable feature.

The second step towards resolving #24260.

### Tips for reviewer

This is structured identically to #24331. The first two commits are part of #24331 and should be reviewed there.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. (Relying on existing tests for coverage)
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
