### PR TITLE
compute: clean up join dispatch calls

### DIFF
--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -310,6 +310,10 @@ where
         let arrangement = lookup_relation
             .arrangement(&lookup_key[..])
             .expect("Arrangement absent despite explicit construction");
+
+        use SpecializedArrangement as A;
+        use SpecializedArrangementImport as I;
+
         match joined {
             JoinedFlavor::Collection(_) => {
                 unreachable!("JoinedFlavor::Collection variant avoided at top of method");
@@ -317,43 +321,34 @@ where
             JoinedFlavor::Local(local) => match arrangement {
                 ArrangementFlavor::Local(oks, errs1) => {
                     let (oks, errs2) = match (local, oks) {
-                        (
-                            SpecializedArrangement::RowUnit(prev_keyed),
-                            SpecializedArrangement::RowUnit(next_input),
-                        ) => self.differential_join_inner::<_, RowAgent<_, _>, RowAgent<_, _>>(
-                            prev_keyed,
-                            next_input,
-                            None,
-                            Some(vec![]),
-                            Some(vec![]),
-                            closure,
-                        ),
-                        (
-                            SpecializedArrangement::RowUnit(prev_keyed),
-                            SpecializedArrangement::RowRow(next_input),
-                        ) => self.differential_join_inner::<_, RowAgent<_, _>, RowRowAgent<_, _>>(
-                            prev_keyed,
-                            next_input,
-                            None,
-                            Some(vec![]),
-                            None,
-                            closure,
-                        ),
-                        (
-                            SpecializedArrangement::RowRow(prev_keyed),
-                            SpecializedArrangement::RowUnit(next_input),
-                        ) => self.differential_join_inner::<_, RowRowAgent<_, _>, RowAgent<_, _>>(
-                            prev_keyed,
-                            next_input,
-                            None,
-                            None,
-                            Some(vec![]),
-                            closure,
-                        ),
-                        (
-                            SpecializedArrangement::RowRow(prev_keyed),
-                            SpecializedArrangement::RowRow(next_input),
-                        ) => self
+                        (A::RowUnit(prev_keyed), A::RowUnit(next_input)) => self
+                            .differential_join_inner::<_, RowAgent<_, _>, RowAgent<_, _>>(
+                                prev_keyed,
+                                next_input,
+                                None,
+                                Some(vec![]),
+                                Some(vec![]),
+                                closure,
+                            ),
+                        (A::RowUnit(prev_keyed), A::RowRow(next_input)) => self
+                            .differential_join_inner::<_, RowAgent<_, _>, RowRowAgent<_, _>>(
+                                prev_keyed,
+                                next_input,
+                                None,
+                                Some(vec![]),
+                                None,
+                                closure,
+                            ),
+                        (A::RowRow(prev_keyed), A::RowUnit(next_input)) => self
+                            .differential_join_inner::<_, RowRowAgent<_, _>, RowAgent<_, _>>(
+                                prev_keyed,
+                                next_input,
+                                None,
+                                None,
+                                Some(vec![]),
+                                closure,
+                            ),
+                        (A::RowRow(prev_keyed), A::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowRowAgent<_, _>, RowRowAgent<_, _>>(
                                 prev_keyed, next_input, None, None, None, closure,
                             ),
@@ -365,21 +360,16 @@ where
                 }
                 ArrangementFlavor::Trace(_gid, oks, errs1) => {
                     let (oks, errs2) = match (local, oks) {
-                        (
-                            SpecializedArrangement::RowUnit(prev_keyed),
-                            SpecializedArrangementImport::RowUnit(next_input),
-                        ) => self.differential_join_inner::<_, RowAgent<_, _>, RowEnter<_, _, _>>(
-                            prev_keyed,
-                            next_input,
-                            None,
-                            Some(vec![]),
-                            Some(vec![]),
-                            closure,
-                        ),
-                        (
-                            SpecializedArrangement::RowUnit(prev_keyed),
-                            SpecializedArrangementImport::RowRow(next_input),
-                        ) => self
+                        (A::RowUnit(prev_keyed), I::RowUnit(next_input)) => self
+                            .differential_join_inner::<_, RowAgent<_, _>, RowEnter<_, _, _>>(
+                                prev_keyed,
+                                next_input,
+                                None,
+                                Some(vec![]),
+                                Some(vec![]),
+                                closure,
+                            ),
+                        (A::RowUnit(prev_keyed), I::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowAgent<_, _>, RowRowEnter<_, _, _>>(
                                 prev_keyed,
                                 next_input,
@@ -388,10 +378,7 @@ where
                                 None,
                                 closure,
                             ),
-                        (
-                            SpecializedArrangement::RowRow(prev_keyed),
-                            SpecializedArrangementImport::RowUnit(next_input),
-                        ) => self
+                        (A::RowRow(prev_keyed), I::RowUnit(next_input)) => self
                             .differential_join_inner::<_, RowRowAgent<_, _>, RowEnter<_, _, _>>(
                                 prev_keyed,
                                 next_input,
@@ -400,10 +387,7 @@ where
                                 Some(vec![]),
                                 closure,
                             ),
-                        (
-                            SpecializedArrangement::RowRow(prev_keyed),
-                            SpecializedArrangementImport::RowRow(next_input),
-                        ) => self
+                        (A::RowRow(prev_keyed), I::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowRowAgent<_, _>, RowRowEnter<_, _, _>>(
                                 prev_keyed, next_input, None, None, None, closure,
                             ),
@@ -417,21 +401,16 @@ where
             JoinedFlavor::Trace(trace) => match arrangement {
                 ArrangementFlavor::Local(oks, errs1) => {
                     let (oks, errs2) = match (trace, oks) {
-                        (
-                            SpecializedArrangementImport::RowUnit(prev_keyed),
-                            SpecializedArrangement::RowUnit(next_input),
-                        ) => self.differential_join_inner::<_, RowEnter<_, _, _>, RowAgent<_, _>>(
-                            prev_keyed,
-                            next_input,
-                            None,
-                            Some(vec![]),
-                            Some(vec![]),
-                            closure,
-                        ),
-                        (
-                            SpecializedArrangementImport::RowUnit(prev_keyed),
-                            SpecializedArrangement::RowRow(next_input),
-                        ) => self
+                        (I::RowUnit(prev_keyed), A::RowUnit(next_input)) => self
+                            .differential_join_inner::<_, RowEnter<_, _, _>, RowAgent<_, _>>(
+                                prev_keyed,
+                                next_input,
+                                None,
+                                Some(vec![]),
+                                Some(vec![]),
+                                closure,
+                            ),
+                        (I::RowUnit(prev_keyed), A::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowEnter<_, _, _>, RowRowAgent<_, _>>(
                                 prev_keyed,
                                 next_input,
@@ -440,10 +419,7 @@ where
                                 None,
                                 closure,
                             ),
-                        (
-                            SpecializedArrangementImport::RowRow(prev_keyed),
-                            SpecializedArrangement::RowUnit(next_input),
-                        ) => self
+                        (I::RowRow(prev_keyed), A::RowUnit(next_input)) => self
                             .differential_join_inner::<_, RowRowEnter<_, _, _>, RowAgent<_, _>>(
                                 prev_keyed,
                                 next_input,
@@ -452,10 +428,7 @@ where
                                 Some(vec![]),
                                 closure,
                             ),
-                        (
-                            SpecializedArrangementImport::RowRow(prev_keyed),
-                            SpecializedArrangement::RowRow(next_input),
-                        ) => self
+                        (I::RowRow(prev_keyed), A::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowAgent<_, _>>(
                                 prev_keyed, next_input, None, None, None, closure,
                             ),
@@ -467,10 +440,7 @@ where
                 }
                 ArrangementFlavor::Trace(_gid, oks, errs1) => {
                     let (oks, errs2) = match (trace, oks) {
-                        (
-                            SpecializedArrangementImport::RowUnit(prev_keyed),
-                            SpecializedArrangementImport::RowUnit(next_input),
-                        ) => self
+                        (I::RowUnit(prev_keyed), I::RowUnit(next_input)) => self
                             .differential_join_inner::<_, RowEnter<_, _, _>, RowEnter<_, _, _>>(
                                 prev_keyed,
                                 next_input,
@@ -479,10 +449,7 @@ where
                                 Some(vec![]),
                                 closure,
                             ),
-                        (
-                            SpecializedArrangementImport::RowUnit(prev_keyed),
-                            SpecializedArrangementImport::RowRow(next_input),
-                        ) => self
+                        (I::RowUnit(prev_keyed), I::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowEnter<_, _, _>, RowRowEnter<_, _, _>>(
                                 prev_keyed,
                                 next_input,
@@ -491,10 +458,7 @@ where
                                 None,
                                 closure,
                             ),
-                        (
-                            SpecializedArrangementImport::RowRow(prev_keyed),
-                            SpecializedArrangementImport::RowUnit(next_input),
-                        ) => self
+                        (I::RowRow(prev_keyed), I::RowUnit(next_input)) => self
                             .differential_join_inner::<_, RowRowEnter<_, _, _>, RowEnter<_, _, _>>(
                                 prev_keyed,
                                 next_input,
@@ -503,10 +467,7 @@ where
                                 Some(vec![]),
                                 closure,
                             ),
-                        (
-                            SpecializedArrangementImport::RowRow(prev_keyed),
-                            SpecializedArrangementImport::RowRow(next_input),
-                        ) => self
+                        (I::RowRow(prev_keyed), I::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowEnter<_, _, _>>(
                                 prev_keyed, next_input, None, None, None, closure,
                             ),


### PR DESCRIPTION
This PR cleans up the dispatch calls in join rendering code by simplifying the turbofish type annotations. Those are necessary because of compiler limitations, but they don't have to be as extensive as they previously were. Replacing most of them with `_` wildcards makes the code less boilerplate-y and also unbreaks rustfmt in one instance.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A