### PR TITLE
make mz_session_history public

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2559,7 +2559,7 @@ pub static MZ_SESSION_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource 
     data_source: Some(IntrospectionType::SessionHistory),
     desc: MZ_SESSION_HISTORY_DESC.clone(),
     is_retained_metrics_object: false,
-    access: vec![SUPPORT_SELECT],
+    access: vec![PUBLIC_SELECT],
 });
 
 pub static MZ_ACTIVITY_LOG: Lazy<BuiltinView> = Lazy::new(|| {

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -4718,7 +4718,6 @@ materialize,mz_support,materialize,public,s_progress,SELECT,NO,YES
 materialize,materialize,materialize,public,s_progress,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_notices,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_activity_log,SELECT,NO,YES
-mz_system,mz_support,materialize,mz_internal,mz_session_history,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_notices_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_notices_redacted,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_optimizer_notices,SELECT,NO,YES
@@ -4737,7 +4736,7 @@ mz_system,mz_support,materialize,mz_internal,mz_statement_execution_history_reda
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_prepared_statement_history_redacted,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
-COMPLETE 35
+COMPLETE 34
 
 simple conn=mz_system,user=mz_system
 SELECT COUNT(*) >= 166 FROM information_schema.table_privileges WHERE grantee = 'PUBLIC'
@@ -4782,7 +4781,6 @@ materialize,mz_support,materialize,public,s_progress,SELECT,NO,YES
 materialize,materialize,materialize,public,s_progress,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_notices,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_activity_log,SELECT,NO,YES
-mz_system,mz_support,materialize,mz_internal,mz_session_history,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_notices_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_notices_redacted,SELECT,NO,YES
 mz_system,mz_monitor,materialize,mz_internal,mz_optimizer_notices,SELECT,NO,YES
@@ -4801,7 +4799,7 @@ mz_system,mz_support,materialize,mz_internal,mz_statement_execution_history_reda
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_statement_lifecycle_history,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_prepared_statement_history_redacted,SELECT,NO,YES
 mz_system,mz_monitor_redacted,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
-COMPLETE 35
+COMPLETE 34
 
 simple conn=mz_system,user=mz_system
 SELECT COUNT(*) >= 166 FROM information_schema.role_table_grants WHERE grantee = 'PUBLIC'


### PR DESCRIPTION
We decided to make `mz_session_history` public, because the only possibly sensitive information in it is the user name, which is already available from `mz_roles`.

### Motivation

  * This PR fixes a recognized bug.

   discussed in Slack: https://materializeinc.slack.com/archives/C0637RN7PKQ/p1704743849188649 and in-person with Graham

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - it's debatable whether this is user-facing as it's just changing the access policy for an undocumented table.
