### PR TITLE
[persist] Make Persist's feature-flag machinery handle more than booleans

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -223,7 +223,6 @@ fn persist_config(config: &SystemVars) -> PersistParameters {
         stats_audit_percent: Some(config.persist_stats_audit_percent()),
         stats_collection_enabled: Some(config.persist_stats_collection_enabled()),
         stats_filter_enabled: Some(config.persist_stats_filter_enabled()),
-        stats_budget_bytes: Some(config.persist_stats_budget_bytes()),
         stats_untrimmable_columns: Some(config.persist_stats_untrimmable_columns()),
         pubsub_client_enabled: Some(config.persist_pubsub_client_enabled()),
         pubsub_push_diff_enabled: Some(config.persist_pubsub_push_diff_enabled()),

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -39,7 +39,7 @@ use timely::PartialOrder;
 use tracing::{debug_span, error, instrument, trace_span, warn, Instrument};
 
 use crate::async_runtime::IsolatedRuntime;
-use crate::cfg::{PersistFeatureFlag, ProtoUntrimmableColumns};
+use crate::cfg::{flags, ProtoUntrimmableColumns};
 use crate::error::InvalidUsage;
 use crate::internal::encoding::{LazyPartStats, Schemas};
 use crate::internal::machine::retry_external;
@@ -230,9 +230,7 @@ impl BatchBuilderConfig {
         BatchBuilderConfig {
             writer_key,
             blob_target_size: value.dynamic.blob_target_size(),
-            batch_delete_enabled: value
-                .dynamic
-                .enabled(PersistFeatureFlag::BATCH_DELETE_ENABLED),
+            batch_delete_enabled: value.dynamic.enabled(flags::BATCH_DELETE_ENABLED),
             batch_builder_max_outstanding_parts: value
                 .dynamic
                 .batch_builder_max_outstanding_parts(),

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -230,7 +230,7 @@ impl BatchBuilderConfig {
         BatchBuilderConfig {
             writer_key,
             blob_target_size: value.dynamic.blob_target_size(),
-            batch_delete_enabled: value.dynamic.enabled(flags::BATCH_DELETE_ENABLED),
+            batch_delete_enabled: value.dynamic.get_feature_flag(flags::BATCH_DELETE_ENABLED),
             batch_builder_max_outstanding_parts: value
                 .dynamic
                 .batch_builder_max_outstanding_parts(),

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -235,7 +235,9 @@ impl BatchBuilderConfig {
                 .dynamic
                 .batch_builder_max_outstanding_parts(),
             stats_collection_enabled: value.dynamic.stats_collection_enabled(),
-            stats_budget: value.dynamic.stats_budget_bytes(),
+            stats_budget: value
+                .dynamic
+                .get_feature_flag(flags::PERSIST_STATS_BUDGET_BYTES),
             stats_untrimmable_columns: Arc::new(value.dynamic.stats_untrimmable_columns()),
         }
     }

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -33,10 +33,9 @@ message ProtoPersistParameters {
     mz_proto.ProtoDuration consensus_connection_pool_ttl = 15;
     mz_proto.ProtoDuration consensus_connection_pool_ttl_stagger = 16;
     mz_proto.ProtoDuration reader_lease_duration = 20;
-    optional uint64 stats_budget_bytes = 17;
     optional ProtoUntrimmableColumns stats_untrimmable_columns = 18;
     repeated ProtoFlagUpdate feature_flags = 23;
-    reserved 19;
+    reserved 17, 19;
 }
 
 message ProtoRetryParameters {

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -35,7 +35,8 @@ message ProtoPersistParameters {
     mz_proto.ProtoDuration reader_lease_duration = 20;
     optional uint64 stats_budget_bytes = 17;
     optional ProtoUntrimmableColumns stats_untrimmable_columns = 18;
-    map<string, bool> feature_flags = 19;
+    repeated ProtoFlagUpdate feature_flags = 23;
+    reserved 19;
 }
 
 message ProtoRetryParameters {
@@ -48,4 +49,11 @@ message ProtoUntrimmableColumns {
     repeated string equals = 1;
     repeated string prefixes = 2;
     repeated string suffixes = 3;
+}
+
+message ProtoFlagUpdate {
+    string name = 1;
+    oneof value {
+        bool bool = 2;
+    }
 }

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -55,5 +55,6 @@ message ProtoFlagUpdate {
     string name = 1;
     oneof value {
         bool bool = 2;
+        uint64 usize = 3;
     }
 }

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -33,7 +33,7 @@ use tracing::{debug, debug_span, trace, warn, Instrument, Span};
 
 use crate::async_runtime::IsolatedRuntime;
 use crate::batch::{BatchBuilderConfig, BatchBuilderInternal};
-use crate::cfg::{MiB, PersistFeatureFlag};
+use crate::cfg::{flags, MiB};
 use crate::fetch::{fetch_batch_part, Cursor, EncodedPart, FetchBatchFilter};
 use crate::internal::encoding::Schemas;
 use crate::internal::gc::GarbageCollector;
@@ -87,9 +87,7 @@ impl CompactConfig {
             compaction_yield_after_n_updates: value.compaction_yield_after_n_updates,
             version: value.build_version.clone(),
             batch: BatchBuilderConfig::new(value, writer_id),
-            streaming_compact: value
-                .dynamic
-                .enabled(PersistFeatureFlag::STREAMING_COMPACTION),
+            streaming_compact: value.dynamic.enabled(flags::STREAMING_COMPACTION),
         }
     }
 }

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -87,7 +87,7 @@ impl CompactConfig {
             compaction_yield_after_n_updates: value.compaction_yield_after_n_updates,
             version: value.build_version.clone(),
             batch: BatchBuilderConfig::new(value, writer_id),
-            streaming_compact: value.dynamic.enabled(flags::STREAMING_COMPACTION),
+            streaming_compact: value.dynamic.get_feature_flag(flags::STREAMING_COMPACTION),
         }
     }
 }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1203,7 +1203,7 @@ pub mod datadriven {
     use crate::batch::{
         validate_truncate_batch, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
     };
-    use crate::cfg::PersistFeatureFlag;
+    use crate::cfg::flags;
     use crate::fetch::{fetch_batch_part, Cursor};
     use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
     use crate::internal::datadriven::DirectiveArgs;
@@ -1245,11 +1245,11 @@ pub mod datadriven {
             client
                 .cfg
                 .dynamic
-                .set_feature_flag(PersistFeatureFlag::STREAMING_COMPACTION, true);
+                .set_feature_flag(flags::STREAMING_COMPACTION, true);
             client
                 .cfg
                 .dynamic
-                .set_feature_flag(PersistFeatureFlag::STREAMING_SNAPSHOT_AND_FETCH, true);
+                .set_feature_flag(flags::STREAMING_SNAPSHOT_AND_FETCH, true);
             let state_versions = Arc::new(StateVersions::new(
                 client.cfg.clone(),
                 Arc::clone(&client.consensus),

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1005,7 +1005,7 @@ where
             .applier
             .cfg
             .dynamic
-            .enabled(flags::STREAMING_SNAPSHOT_AND_FETCH)
+            .get_feature_flag(flags::STREAMING_SNAPSHOT_AND_FETCH)
         {
             return self.snapshot_and_fetch_streaming(as_of).await;
         }

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -32,7 +32,7 @@ use tokio::runtime::Handle;
 use tracing::{debug_span, instrument, warn, Instrument};
 use uuid::Uuid;
 
-use crate::cfg::{PersistFeatureFlag, RetryParameters};
+use crate::cfg::{flags, RetryParameters};
 use crate::fetch::{
     fetch_leased_part, FetchBatchFilter, FetchedPart, LeasedBatchPart, SerdeLeasedBatchPart,
     SerdeLeasedBatchPartMetadata,
@@ -1005,7 +1005,7 @@ where
             .applier
             .cfg
             .dynamic
-            .enabled(PersistFeatureFlag::STREAMING_SNAPSHOT_AND_FETCH)
+            .enabled(flags::STREAMING_SNAPSHOT_AND_FETCH)
         {
             return self.snapshot_and_fetch_streaming(as_of).await;
         }

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -33,7 +33,7 @@ use crate::batch::{
     validate_truncate_batch, Added, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
     ProtoBatch,
 };
-use crate::cfg::PersistFeatureFlag;
+use crate::cfg::flags;
 use crate::error::{InvalidUsage, UpperMismatch};
 use crate::internal::compact::Compactor;
 use crate::internal::encoding::{check_data_version, Schemas};
@@ -537,10 +537,7 @@ where
     /// to append it to this shard.
     pub fn batch_from_transmittable_batch(&self, batch: ProtoBatch) -> Batch<K, V, T, D> {
         let ret = Batch {
-            batch_delete_enabled: self
-                .cfg
-                .dynamic
-                .enabled(PersistFeatureFlag::BATCH_DELETE_ENABLED),
+            batch_delete_enabled: self.cfg.dynamic.enabled(flags::BATCH_DELETE_ENABLED),
             metrics: Arc::clone(&self.metrics),
             shard_id: batch
                 .shard_id

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -537,7 +537,10 @@ where
     /// to append it to this shard.
     pub fn batch_from_transmittable_batch(&self, batch: ProtoBatch) -> Batch<K, V, T, D> {
         let ret = Batch {
-            batch_delete_enabled: self.cfg.dynamic.enabled(flags::BATCH_DELETE_ENABLED),
+            batch_delete_enabled: self
+                .cfg
+                .dynamic
+                .get_feature_flag(flags::BATCH_DELETE_ENABLED),
             metrics: Arc::clone(&self.metrics),
             shard_id: batch
                 .shard_id

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2878,6 +2878,7 @@ impl Default for SystemVars {
 
 enum PersistVar {
     Bool(ServerVar<bool>),
+    Usize(ServerVar<usize>),
 }
 
 impl From<PersistFeatureFlag> for PersistVar {
@@ -2887,6 +2888,12 @@ impl From<PersistFeatureFlag> for PersistVar {
         let internal = true;
         match flag.default {
             FlagValue::Bool(value) => PersistVar::Bool(ServerVar {
+                name,
+                value,
+                description,
+                internal,
+            }),
+            FlagValue::Usize(value) => PersistVar::Usize(ServerVar {
                 name,
                 value,
                 description,
@@ -3090,6 +3097,7 @@ impl SystemVars {
         for flag in persist_flags::all() {
             match flag.into() {
                 PersistVar::Bool(var) => vars = vars.with_var(&var),
+                PersistVar::Usize(var) => vars = vars.with_var(&var),
             };
         }
 
@@ -3770,7 +3778,8 @@ impl SystemVars {
             .map(|f| {
                 let name = f.name.to_owned();
                 let value = match f.into() {
-                    PersistVar::Bool(bool) => FlagValue::Bool(*self.expect_value(&bool)),
+                    PersistVar::Bool(var) => FlagValue::Bool(*self.expect_value(&var)),
+                    PersistVar::Usize(var) => FlagValue::Usize(self.expect_value(&var).clone()),
                 };
                 (name, value)
             })

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1324,14 +1324,6 @@ const PERSIST_STATS_FILTER_ENABLED: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
-/// Controls [`mz_persist_client::cfg::DynamicConfig::stats_budget_bytes`].
-const PERSIST_STATS_BUDGET_BYTES: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("persist_stats_budget_bytes"),
-    value: PersistConfig::DEFAULT_STATS_BUDGET_BYTES,
-    description: "The budget (in bytes) of how many stats to maintain per batch part.",
-    internal: true,
-};
-
 /// Controls [`mz_persist_client::cfg::DynamicConfig::stats_untrimmable_columns`].
 static PERSIST_STATS_UNTRIMMABLE_COLUMNS: Lazy<ServerVar<UntrimmableColumns>> =
     Lazy::new(|| ServerVar {
@@ -3019,7 +3011,6 @@ impl SystemVars {
             .with_var(&PERSIST_STATS_AUDIT_PERCENT)
             .with_var(&PERSIST_STATS_COLLECTION_ENABLED)
             .with_var(&PERSIST_STATS_FILTER_ENABLED)
-            .with_var(&PERSIST_STATS_BUDGET_BYTES)
             .with_var(&PERSIST_STATS_UNTRIMMABLE_COLUMNS)
             .with_var(&PERSIST_PUBSUB_CLIENT_ENABLED)
             .with_var(&PERSIST_PUBSUB_PUSH_DIFF_ENABLED)
@@ -3745,11 +3736,6 @@ impl SystemVars {
     /// Returns the `persist_stats_filter_enabled` configuration parameter.
     pub fn persist_stats_filter_enabled(&self) -> bool {
         *self.expect_value(&PERSIST_STATS_FILTER_ENABLED)
-    }
-
-    /// Returns the `persist_stats_budget_bytes` configuration parameter.
-    pub fn persist_stats_budget_bytes(&self) -> usize {
-        *self.expect_value(&PERSIST_STATS_BUDGET_BYTES)
     }
 
     /// Returns the `persist_stats_untrimmable_columns` configuration parameter.
@@ -5623,7 +5609,6 @@ fn is_persist_config_var(name: &str) -> bool {
         || name == PERSIST_STATS_AUDIT_PERCENT.name()
         || name == PERSIST_STATS_COLLECTION_ENABLED.name()
         || name == PERSIST_STATS_FILTER_ENABLED.name()
-        || name == PERSIST_STATS_BUDGET_BYTES.name()
         || name == PERSIST_STATS_UNTRIMMABLE_COLUMNS.name()
         || name == PERSIST_PUBSUB_CLIENT_ENABLED.name()
         || name == PERSIST_PUBSUB_PUSH_DIFF_ENABLED.name()

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -3765,14 +3765,14 @@ impl SystemVars {
         *self.expect_value(&PERSIST_ROLLUP_THRESHOLD)
     }
 
-    pub fn persist_flags(&self) -> BTreeMap<String, bool> {
+    pub fn persist_flags(&self) -> BTreeMap<String, FlagValue> {
         persist_flags::all()
             .map(|f| {
                 let name = f.name.to_owned();
                 let value = match f.into() {
-                    PersistVar::Bool(bool) => self.expect_value(&bool),
+                    PersistVar::Bool(bool) => FlagValue::Bool(*self.expect_value(&bool)),
                 };
-                (name, *value)
+                (name, value)
             })
             .collect()
     }


### PR DESCRIPTION
### Motivation

This PR refactors existing code. This is inspired by [@danhhz's branch](https://github.com/MaterializeInc/materialize/compare/main...danhhz:materialize:flag), but without the `inventory` crate, using our existing flags as a base, and finishing the wiring-up to system vars. (We could use `inventory` in the future if we want - this approach should be compatible with that; just starting with the more minimal version for now.)

Personally I am motivated because I find it very annoying to do this wiring manually. I've only converted a single flag so far, to show how it looks, but it looks like this should pay for itself in LOC terms with a couple more flags.

### Tips for reviewer

Naming is mostly stolen from the other branch; generally happy to take suggestions.

Changes mostly follow commit-by-commit, but there's a little sloppiness early on that gets cleaned up later. I plan to squash before merging.

This is a noop. I think Testing has been pinged as a code owner because of the vars change, but in practice no "actual" vars are changing here.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
