### PR TITLE
adapter: fix tracing span plumbing

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2451,7 +2451,10 @@ fn test_isolation_level_notice() {
 fn test_emit_tracing_notice() {
     let server = test_util::TestHarness::default()
         .with_enable_tracing(true)
-        .with_system_parameter_default("opentelemetry_filter".to_string(), "debug".to_string())
+        // NB: Make sure to keep opentelemetry_filter as "info" to match the
+        // configuration in staging (and that we hope to run in prod).
+        .with_system_parameter_default("opentelemetry_filter".to_string(), "info".to_string())
+        .with_system_parameter_default("log_filter".to_string(), "info".to_string())
         .start_blocking();
 
     let (tx, mut rx) = futures::channel::mpsc::unbounded();


### PR DESCRIPTION
Looks like this was accidentally severed in #23577.

Turns out we have a test, there was just a "bug" in the test where it was asserting things worked with tracing turned on for "debug", which they did, but that's somewhat uninteresting because we can only turn tracing to always-on at "info". This also updates the test, which fails without this fix.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
