### PR TITLE
blue-green deployment test: Increase tick interval

### DIFF
--- a/test/cluster/blue-green-deployment/setup.td
+++ b/test/cluster/blue-green-deployment/setup.td
@@ -29,7 +29,7 @@ ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
 
 # For now sources are not considered in blue-green deployments, so create them separately
 > DROP SOURCE IF EXISTS counter
-> CREATE SOURCE counter FROM LOAD GENERATOR counter (TICK INTERVAL '0.1s')
+> CREATE SOURCE counter FROM LOAD GENERATOR counter (TICK INTERVAL '1s')
 
 > DROP SOURCE IF EXISTS tpch
 > CREATE SOURCE tpch


### PR DESCRIPTION
Again seen failing flakily:
https://buildkite.com/materialize/tests/builds/72801

Sorry about this mess, seems like CI performance is not very consistent.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
