### PR TITLE
sql: error when referencing ungrouped column that also exists in outer scope

### DIFF
--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -38,6 +38,15 @@ SELECT DISTINCT ON (b) a FROM t GROUP BY a ORDER BY b
 query error column "t.b" must appear in the GROUP BY clause or be used in an aggregate function
 SELECT t.b FROM t GROUP BY a
 
+query error column "t.a" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT (SELECT a FROM t GROUP BY b) FROM t
+
+query error column "t1.b" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT (SELECT t2.a FROM t t2 WHERE t1.b = t2.b) FROM t t1 GROUP BY t1.a;
+
+query error column "t1.b" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT sum(t1.a), (SELECT t2.a FROM t t2 WHERE t1.b = t2.b) FROM t t1;
+
 query error column "c" does not exist
 SELECT c FROM t GROUP BY a
 
@@ -61,6 +70,21 @@ SELECT a + 1 FROM t GROUP BY a + 1 HAVING sum(b) = 3
 ----
 2
 3
+
+query II
+SELECT t1.a, (SELECT t2.a FROM t t2 WHERE t2.b = 2 AND t1.b = t2.b GROUP BY t2.a) FROM t t1;
+----
+1 NULL
+2 NULL
+3 NULL
+1 1
+
+query I
+SELECT (SELECT sum(b) FROM t WHERE b = 2 GROUP BY a) FROM t t1 GROUP BY t1.b;
+----
+2
+2
+2
 
 # Simple column names in GROUP BY can refer to columns from the output list...
 query TII rowsort


### PR DESCRIPTION
Our existing code for detecting references to columns that did not appear in the GROUP BY clause or an aggregate function did not consider the case that a column of the same name existed in the outer scope. Per PostgreSQL, the correct behavior is to bind to the column reference in the inner scope and error due to the lack of grouping, rather than to successfully bind to the column reference in the outer scope.

Fix #23748.
Fix #24328.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix a correctness issue with subqueries that referred to ungrouped columns when columns of the same name existed in an outer scope.
