### PR TITLE
ore: randomize connection ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,16 +2523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
-name = "hi_sparse_bitset"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d608d5f3820f93ce18d242a48ebc108125a9660bad78f2c809fef210da12b5"
-dependencies = [
- "num-traits",
- "wide",
-]
-
-[[package]]
 name = "hibitset"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4769,12 +4759,12 @@ dependencies = [
  "ctor",
  "either",
  "futures",
- "hi_sparse_bitset",
  "hibitset",
  "http",
  "hyper",
  "hyper-tls",
  "lgalloc",
+ "mz-ore",
  "mz-test-macro",
  "native-tls",
  "num",
@@ -4788,7 +4778,6 @@ dependencies = [
  "prometheus",
  "proptest",
  "rand",
- "roaring",
  "scopeguard",
  "sentry",
  "sentry-tracing",
@@ -7554,9 +7543,9 @@ dependencies = [
 
 [[package]]
 name = "retain_mut"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31b5c4033f8fdde8700e4657be2c497e7288f01515be52168c631e2e4d4086"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "retry-policies"
@@ -7590,17 +7579,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7278a1ec8bfd4a4e07515c589f5ff7b309a373f987393aef44813d9dcf87aa3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "roaring"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6106b5cf8587f5834158895e9715a3c6c9716c8aefab57f1f7680917191c7873"
-dependencies = [
- "bytemuck",
- "byteorder",
- "retain_mut",
 ]
 
 [[package]]
@@ -7702,15 +7680,6 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
-
-[[package]]
-name = "safe_arch"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "same-file"
@@ -9635,16 +9604,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wide"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68938b57b33da363195412cfc5fc37c9ed49aa9cfe2156fde64b8d2c9498242"
-dependencies = [
- "bytemuck",
- "safe_arch",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9845,21 +9804,22 @@ dependencies = [
  "axum",
  "bitflags 2.4.1",
  "bstr 0.2.14",
- "bytemuck",
+ "byteorder",
  "bytes",
  "cc",
  "chrono",
  "clap",
  "console",
  "criterion",
+ "crossbeam-deque",
  "crossbeam-epoch",
+ "crossbeam-utils",
  "crypto-common",
  "debugid",
  "dec",
  "digest",
  "either",
  "flate2",
- "futures",
  "futures-channel",
  "futures-core",
  "futures-executor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,6 +2523,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hi_sparse_bitset"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d608d5f3820f93ce18d242a48ebc108125a9660bad78f2c809fef210da12b5"
+dependencies = [
+ "num-traits",
+ "wide",
+]
+
+[[package]]
+name = "hibitset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ede5cfa60c958e60330d65163adbc4211e15a2653ad80eb0cce878de120121"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4746,9 +4765,12 @@ dependencies = [
  "clap",
  "compact_bytes",
  "console-subscriber",
+ "criterion",
  "ctor",
  "either",
  "futures",
+ "hi_sparse_bitset",
+ "hibitset",
  "http",
  "hyper",
  "hyper-tls",
@@ -4765,6 +4787,8 @@ dependencies = [
  "pin-project",
  "prometheus",
  "proptest",
+ "rand",
+ "roaring",
  "scopeguard",
  "sentry",
  "sentry-tracing",
@@ -7530,9 +7554,9 @@ dependencies = [
 
 [[package]]
 name = "retain_mut"
-version = "0.1.9"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+checksum = "8c31b5c4033f8fdde8700e4657be2c497e7288f01515be52168c631e2e4d4086"
 
 [[package]]
 name = "retry-policies"
@@ -7566,6 +7590,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7278a1ec8bfd4a4e07515c589f5ff7b309a373f987393aef44813d9dcf87aa3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "roaring"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6106b5cf8587f5834158895e9715a3c6c9716c8aefab57f1f7680917191c7873"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "retain_mut",
 ]
 
 [[package]]
@@ -7667,6 +7702,15 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -9591,6 +9635,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68938b57b33da363195412cfc5fc37c9ed49aa9cfe2156fde64b8d2c9498242"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9791,22 +9845,21 @@ dependencies = [
  "axum",
  "bitflags 2.4.1",
  "bstr 0.2.14",
- "byteorder",
+ "bytemuck",
  "bytes",
  "cc",
  "chrono",
  "clap",
  "console",
  "criterion",
- "crossbeam-deque",
  "crossbeam-epoch",
- "crossbeam-utils",
  "crypto-common",
  "debugid",
  "dec",
  "digest",
  "either",
  "flate2",
+ "futures",
  "futures-channel",
  "futures-core",
  "futures-executor",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -45,6 +45,11 @@ who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.6.0"
 
+[[audits.hibitset]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.6.4"
+
 [[audits.jsonwebtoken]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"

--- a/src/adapter-types/src/connection.rs
+++ b/src/adapter-types/src/connection.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_ore::id_gen::IdHandle;
+use mz_ore::id_gen::{IdAllocatorInnerBitSet, IdHandle};
 
 /// Inner type of a [`ConnectionId`], `u32` for postgres compatibility.
 ///
@@ -15,4 +15,4 @@ use mz_ore::id_gen::IdHandle;
 pub type ConnectionIdType = u32;
 
 /// An abstraction allowing us to name different connections.
-pub type ConnectionId = IdHandle<ConnectionIdType>;
+pub type ConnectionId = IdHandle<ConnectionIdType, IdAllocatorInnerBitSet>;

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -32,7 +32,7 @@ itertools = "0.10.5"
 once_cell = "1.16.0"
 md-5 = "0.10.5"
 mz-lowertest = { path = "../lowertest" }
-mz-ore = { path = "../ore", features = ["network", "proptest"] }
+mz-ore = { path = "../ore", features = ["network", "proptest", "id_gen"] }
 mz-persist-types = { path = "../persist-types" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-pgtz = { path = "../pgtz" }
@@ -54,7 +54,9 @@ serde_regex = "1.1.0"
 sha1 = "0.10.5"
 sha2 = "0.10.6"
 subtle = "2.4.1"
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = [
+  "bincode",
+] }
 tracing = "0.1.37"
 uncased = "0.9.7"
 uuid = { version = "1.2.2", features = ["v5"] }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -28,6 +28,9 @@ compact_bytes = { version = "0.1.1", optional = true }
 ctor = { version = "0.1.26", optional = true }
 either = "1.8.0"
 futures = { version = "0.3.25", optional = true }
+hibitset = "0.6.4"
+hi_sparse_bitset = "0.4.0"
+roaring = "0.10.2"
 lgalloc = { version = "0.1", optional = true }
 mz-test-macro = { path = "../test-macro", default-features = false }
 num = "0.4.0"
@@ -40,6 +43,7 @@ prometheus = { version = "0.13.3", default-features = false, optional = true }
 proptest = { version = "1.0.0", default-features = false, features = [
   "std",
 ], optional = true }
+rand = "0.8.5"
 smallvec = { version = "1.10.0", optional = true }
 stacker = { version = "0.1.15", optional = true }
 sentry = { version = "0.29.1", optional = true, features = ["debug-images"] }
@@ -78,13 +82,16 @@ hyper = { version = "0.14.23", features = ["http1", "server"], optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 opentelemetry = { version = "0.21.0", features = ["trace"], optional = true }
 opentelemetry-otlp = { version = "0.14.0", optional = true }
-opentelemetry_sdk = { version = "0.21.2", features = ["rt-tokio"], optional = true }
+opentelemetry_sdk = { version = "0.21.2", features = [
+  "rt-tokio",
+], optional = true }
 console-subscriber = { version = "0.1.10", optional = true }
 sentry-tracing = { version = "0.29.1", optional = true }
 yansi = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
 anyhow = { version = "1.0.66" }
+criterion = { version = "0.4.0", features = ["async_tokio"] }
 scopeguard = "1.1.0"
 serde_json = "1.0.89"
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }
@@ -138,6 +145,10 @@ required-features = ["async"]
 [[test]]
 name = "task"
 required-features = ["async"]
+
+[[bench]]
+name = "id_gen"
+harness = false
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -28,9 +28,7 @@ compact_bytes = { version = "0.1.1", optional = true }
 ctor = { version = "0.1.26", optional = true }
 either = "1.8.0"
 futures = { version = "0.3.25", optional = true }
-hibitset = "0.6.4"
-hi_sparse_bitset = "0.4.0"
-roaring = "0.10.2"
+hibitset = { version = "0.6.4", optional = true }
 lgalloc = { version = "0.1", optional = true }
 mz-test-macro = { path = "../test-macro", default-features = false }
 num = "0.4.0"
@@ -43,7 +41,7 @@ prometheus = { version = "0.13.3", default-features = false, optional = true }
 proptest = { version = "1.0.0", default-features = false, features = [
   "std",
 ], optional = true }
-rand = "0.8.5"
+rand = { version = "0.8.5", optional = true }
 smallvec = { version = "1.10.0", optional = true }
 stacker = { version = "0.1.15", optional = true }
 sentry = { version = "0.29.1", optional = true, features = ["debug-images"] }
@@ -92,6 +90,7 @@ yansi = { version = "0.5.1", optional = true }
 [dev-dependencies]
 anyhow = { version = "1.0.66" }
 criterion = { version = "0.4.0", features = ["async_tokio"] }
+mz-ore = { path = "../ore", features = ["id_gen"] }
 scopeguard = "1.1.0"
 serde_json = "1.0.89"
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }
@@ -137,6 +136,7 @@ cli = ["clap"]
 stack = ["stacker"]
 test = ["anyhow", "ctor", "tracing-subscriber"]
 metrics = ["prometheus"]
+id_gen = ["hibitset", "rand"]
 
 [[test]]
 name = "future"

--- a/src/ore/benches/id_gen.rs
+++ b/src/ore/benches/id_gen.rs
@@ -8,13 +8,11 @@
 // by the Apache License, Version 2.0.
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use mz_ore::id_gen::{
-    IdAllocator, IdAllocatorInner, IdAllocatorInnerBitSet, IdAllocatorInnerHashSet,
-    IdAllocatorInnerRoaring, IdAllocatorInnerRoaringLoop, IdAllocatorInnerSparseBitSet,
-};
+use mz_ore::id_gen::{IdAllocator, IdAllocatorInner, IdAllocatorInnerBitSet};
 
 fn bench_id_gen(c: &mut Criterion) {
     bench_id_allocators(c, 0, 1_000);
+    bench_id_allocators(c, 100_000, 1);
     bench_id_allocators(c, 1_000, 1_000);
     bench_id_allocators(c, 0, 100_000);
     bench_id_allocators(c, 50_000, 50_000);
@@ -23,11 +21,7 @@ fn bench_id_gen(c: &mut Criterion) {
 // Creates an allocator with permanent initial_conns. Then makes bench_conns and drops those in a
 // loop.
 fn bench_id_allocators(c: &mut Criterion, initial_conns: usize, bench_conns: usize) {
-    bench_id_allocator::<IdAllocatorInnerHashSet>(c, initial_conns, bench_conns);
     bench_id_allocator::<IdAllocatorInnerBitSet>(c, initial_conns, bench_conns);
-    bench_id_allocator::<IdAllocatorInnerRoaring>(c, initial_conns, bench_conns);
-    bench_id_allocator::<IdAllocatorInnerRoaringLoop>(c, initial_conns, bench_conns);
-    bench_id_allocator::<IdAllocatorInnerSparseBitSet>(c, initial_conns, bench_conns);
 }
 
 fn bench_id_allocator<A: IdAllocatorInner>(
@@ -35,24 +29,21 @@ fn bench_id_allocator<A: IdAllocatorInner>(
     initial_conns: usize,
     bench_conns: usize,
 ) {
-    c.bench_function(
-        &format!("id_allocator_{}_{initial_conns}_{bench_conns}", A::NAME),
-        |b| {
-            let allocator = IdAllocator::<A>::new(1, 1 << 20);
-            let permanent = (0..initial_conns)
-                .map(|_| allocator.alloc().unwrap())
-                .collect::<Vec<_>>();
-            let mut tmp = Vec::with_capacity(bench_conns);
-            b.iter(|| {
-                for _ in 0..bench_conns {
-                    tmp.push(allocator.alloc().unwrap());
-                }
-                //std::hint::black_box(&tmp);
-                tmp.clear();
-            });
-            drop(permanent);
-        },
-    );
+    let name = format!("id_allocator_{}_{initial_conns}_{bench_conns}", A::NAME);
+    c.bench_function(&name, |b| {
+        let allocator = IdAllocator::<A>::new(1, 1 << 20);
+        let permanent = (0..initial_conns)
+            .map(|_| allocator.alloc().unwrap())
+            .collect::<Vec<_>>();
+        let mut tmp = Vec::with_capacity(bench_conns);
+        b.iter(|| {
+            for _ in 0..bench_conns {
+                tmp.push(allocator.alloc().unwrap());
+            }
+            tmp.clear();
+        });
+        drop(permanent);
+    });
 }
 
 criterion_group!(benches, bench_id_gen);

--- a/src/ore/benches/id_gen.rs
+++ b/src/ore/benches/id_gen.rs
@@ -1,0 +1,59 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use mz_ore::id_gen::{
+    IdAllocator, IdAllocatorInner, IdAllocatorInnerBitSet, IdAllocatorInnerHashSet,
+    IdAllocatorInnerRoaring, IdAllocatorInnerRoaringLoop, IdAllocatorInnerSparseBitSet,
+};
+
+fn bench_id_gen(c: &mut Criterion) {
+    bench_id_allocators(c, 0, 1_000);
+    bench_id_allocators(c, 1_000, 1_000);
+    bench_id_allocators(c, 0, 100_000);
+    bench_id_allocators(c, 50_000, 50_000);
+}
+
+// Creates an allocator with permanent initial_conns. Then makes bench_conns and drops those in a
+// loop.
+fn bench_id_allocators(c: &mut Criterion, initial_conns: usize, bench_conns: usize) {
+    bench_id_allocator::<IdAllocatorInnerHashSet>(c, initial_conns, bench_conns);
+    bench_id_allocator::<IdAllocatorInnerBitSet>(c, initial_conns, bench_conns);
+    bench_id_allocator::<IdAllocatorInnerRoaring>(c, initial_conns, bench_conns);
+    bench_id_allocator::<IdAllocatorInnerRoaringLoop>(c, initial_conns, bench_conns);
+    bench_id_allocator::<IdAllocatorInnerSparseBitSet>(c, initial_conns, bench_conns);
+}
+
+fn bench_id_allocator<A: IdAllocatorInner>(
+    c: &mut Criterion,
+    initial_conns: usize,
+    bench_conns: usize,
+) {
+    c.bench_function(
+        &format!("id_allocator_{}_{initial_conns}_{bench_conns}", A::NAME),
+        |b| {
+            let allocator = IdAllocator::<A>::new(1, 1 << 20);
+            let permanent = (0..initial_conns)
+                .map(|_| allocator.alloc().unwrap())
+                .collect::<Vec<_>>();
+            let mut tmp = Vec::with_capacity(bench_conns);
+            b.iter(|| {
+                for _ in 0..bench_conns {
+                    tmp.push(allocator.alloc().unwrap());
+                }
+                //std::hint::black_box(&tmp);
+                tmp.clear();
+            });
+            drop(permanent);
+        },
+    );
+}
+
+criterion_group!(benches, bench_id_gen);
+criterion_main!(benches);

--- a/src/ore/src/id_gen.rs
+++ b/src/ore/src/id_gen.rs
@@ -15,12 +15,20 @@
 
 //! ID generation utilities.
 
+use hibitset::BitSet;
+use roaring::RoaringBitmap;
 use std::borrow::Borrow;
-use std::collections::VecDeque;
 use std::fmt;
+use std::hash::Hash;
 use std::marker::PhantomData;
-use std::ops::AddAssign;
+use std::ops::{AddAssign, Sub};
 use std::sync::{Arc, Mutex};
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+use crate::cast::CastFrom;
+use crate::collections::HashSet;
 
 /// Manages the allocation of unique IDs.
 #[derive(Debug, Default, Clone)]
@@ -41,66 +49,323 @@ impl<Id: From<u64> + Default> Gen<Id> {
 /// A generator of u64-bit IDs.
 pub type IdGen = Gen<u64>;
 
-/// Manages allocation of numeric IDs.
-///
-/// Note that the current implementation wastes memory. It would be far more
-/// efficient to use a compressed bitmap, like <https://roaringbitmap.org> or
-/// the hibitset crate, but neither presently supports a fast "find first zero"
-/// operation.
-#[derive(Debug, Clone)]
-pub struct IdAllocator<T>(Arc<Mutex<IdAllocatorInner<T>>>);
-
-#[derive(Debug)]
-struct IdAllocatorInner<T> {
-    next: T,
-    max: T,
-    free: VecDeque<T>,
+/// IdAllocator common traits.
+pub trait IdGenerator:
+    From<u8>
+    + AddAssign
+    + Sub
+    + PartialOrd
+    + Copy
+    + Eq
+    + Hash
+    + Ord
+    + rand::distributions::uniform::SampleUniform
+    + serde::Serialize
+    + fmt::Display
+{
 }
 
-impl<T> IdAllocator<T>
-where
-    T: From<u8> + AddAssign + PartialOrd + Copy,
+impl<T> IdGenerator for T where
+    T: From<u8>
+        + AddAssign
+        + Sub
+        + PartialOrd
+        + Copy
+        + Eq
+        + Hash
+        + Ord
+        + rand::distributions::uniform::SampleUniform
+        + serde::Serialize
+        + fmt::Display
 {
+}
+
+/// Manages allocation of numeric IDs.
+#[derive(Debug, Clone)]
+pub struct IdAllocator<A: IdAllocatorInner>(Arc<Mutex<A>>);
+
+/// Common trait for id allocators.
+pub trait IdAllocatorInner: std::fmt::Debug + Send {
+    /// Name of the allocator.
+    const NAME: &'static str;
+    /// Constructor.
+    fn new(min: u32, max: u32) -> Self;
+    /// Allocate a new id.
+    fn alloc(&mut self) -> Option<u32>;
+    /// Deallocate a used id, making it available for reuse.
+    fn remove(&mut self, id: u32);
+}
+
+/// IdAllocator using a sparse hibitset.
+#[derive(Debug)]
+pub struct IdAllocatorInnerSparseBitSet {
+    next: StdRng,
+    min: u32,
+    max: u32,
+    used: hi_sparse_bitset::BitSet<hi_sparse_bitset::config::_256bit>,
+}
+
+impl IdAllocatorInner for IdAllocatorInnerSparseBitSet {
+    const NAME: &'static str = "sparse_bit_set";
+
+    fn alloc(&mut self) -> Option<u32> {
+        let range = self.min..=self.max;
+        let init = self.next.gen_range(range);
+        let mut next = init;
+        loop {
+            // Because bitset has a hard maximum of 64**4 (~16 million), subtract the min in case
+            // max is above that. This is safe because we already asserted above that `max - min <
+            // 64**4`.
+            let stored = usize::cast_from(next - self.min);
+            if !self.used.contains(stored) {
+                self.used.insert(stored);
+                return Some(next);
+            }
+            // Existing value, increment and try again. Wrap once we hit max back to min.
+            next = if next == self.max { self.min } else { next + 1 };
+            // We fully wrapped around. BitSet doesn't have a rank or count method, so we can't
+            // compute this early.
+            if next == init {
+                return None;
+            }
+        }
+    }
+
+    fn remove(&mut self, id: u32) {
+        let stored = id - self.min;
+        self.used.remove(usize::cast_from(stored));
+    }
+
+    fn new(min: u32, max: u32) -> Self {
+        let total = usize::cast_from(max - min);
+        assert!(total < BitSet::BITS_PER_USIZE.pow(4));
+        IdAllocatorInnerSparseBitSet {
+            next: StdRng::from_entropy(),
+            min,
+            max,
+            used: hi_sparse_bitset::BitSet::new(),
+        }
+    }
+}
+
+/// IdAllocator using a HiBitSet.
+#[derive(Debug, Clone)]
+pub struct IdAllocatorInnerBitSet {
+    next: StdRng,
+    min: u32,
+    max: u32,
+    used: BitSet,
+}
+
+impl IdAllocatorInner for IdAllocatorInnerBitSet {
+    const NAME: &'static str = "hibitset";
+
+    fn new(min: u32, max: u32) -> Self {
+        let total = usize::cast_from(max - min);
+        assert!(total < BitSet::BITS_PER_USIZE.pow(4));
+        IdAllocatorInnerBitSet {
+            next: StdRng::from_entropy(),
+            min,
+            max,
+            used: BitSet::new(),
+        }
+    }
+
+    fn alloc(&mut self) -> Option<u32> {
+        let range = self.min..=self.max;
+        let init = self.next.gen_range(range);
+        let mut next = init;
+        loop {
+            // Because hibitset has a hard maximum of 64**4 (~16 million), subtract the min in case
+            // max is above that. This is safe because we already asserted above that `max - min <
+            // 64**4`.
+            let stored = next - self.min;
+            if !self.used.add(stored) {
+                return Some(next);
+            }
+            // Existing value, increment and try again. Wrap once we hit max back to min.
+            next = if next == self.max { self.min } else { next + 1 };
+            // We fully wrapped around. BitSet doesn't have a rank or count method, so we can't
+            // compute this early.
+            if next == init {
+                return None;
+            }
+        }
+    }
+
+    fn remove(&mut self, id: u32) {
+        let stored = id - self.min;
+        self.used.remove(stored);
+    }
+}
+
+/// IdAllocator using a RoaringBitmap.
+#[derive(Debug)]
+pub struct IdAllocatorInnerRoaring {
+    next: StdRng,
+    min: u32,
+    max: u32,
+    len: u32,
+    used: RoaringBitmap,
+}
+
+impl IdAllocatorInner for IdAllocatorInnerRoaring {
+    const NAME: &'static str = "roaring_bitmap";
+
+    fn new(min: u32, max: u32) -> Self {
+        let mut used = RoaringBitmap::new();
+        used.insert_range(min..=max);
+        IdAllocatorInnerRoaring {
+            next: StdRng::from_entropy(),
+            min,
+            max,
+            len: 0,
+            used,
+        }
+    }
+
+    fn alloc(&mut self) -> Option<u32> {
+        let range = self.min..=(self.max - self.len);
+        if range.is_empty() {
+            return None;
+        }
+        let init = self.next.gen_range(range);
+        let select = init - self.min;
+        let chosen = self
+            .used
+            .select(select)
+            .expect("must exist; verified above");
+        assert!(self.used.remove(chosen));
+        self.len += 1;
+        Some(chosen)
+    }
+
+    fn remove(&mut self, id: u32) {
+        assert!(self.used.insert(id));
+        self.len -= 1;
+    }
+}
+
+/// IdAllocator using a RoaringBitmap.
+#[derive(Debug)]
+pub struct IdAllocatorInnerRoaringLoop {
+    next: StdRng,
+    min: u32,
+    max: u32,
+    used: RoaringBitmap,
+}
+
+impl IdAllocatorInner for IdAllocatorInnerRoaringLoop {
+    const NAME: &'static str = "roaring_bitmap_loop";
+
+    fn new(min: u32, max: u32) -> Self {
+        let used = RoaringBitmap::new();
+        IdAllocatorInnerRoaringLoop {
+            next: StdRng::from_entropy(),
+            min,
+            max,
+            used,
+        }
+    }
+
+    fn alloc(&mut self) -> Option<u32> {
+        let range = self.min..=self.max;
+        let init = self.next.gen_range(range);
+        let mut next = init;
+        loop {
+            let stored = next - self.min;
+            if self.used.insert(stored) {
+                return Some(next);
+            }
+            next = if next == self.max { self.min } else { next + 1 };
+            if next == init {
+                return None;
+            }
+        }
+    }
+
+    fn remove(&mut self, id: u32) {
+        let stored = id - self.min;
+        self.used.remove(stored);
+    }
+}
+
+/// IdAllocator using a naive HashSet.
+#[derive(Debug)]
+pub struct IdAllocatorInnerHashSet {
+    next: StdRng,
+    min: u32,
+    max: u32,
+    used: HashSet<u32>,
+}
+
+impl IdAllocatorInner for IdAllocatorInnerHashSet {
+    const NAME: &'static str = "hashset";
+
+    fn new(min: u32, max: u32) -> Self {
+        IdAllocatorInnerHashSet {
+            next: StdRng::from_entropy(),
+            min,
+            max,
+            used: HashSet::new(),
+        }
+    }
+
+    fn alloc(&mut self) -> Option<u32> {
+        let range = self.min..=self.max;
+        let mut next = self.next.gen_range(range);
+        loop {
+            if self.used.insert(next) {
+                return Some(next);
+            }
+            if self.used.len() == usize::cast_from(self.max - self.min + 1) {
+                return None;
+            }
+            // Existing value, increment and try again. Wrap once we hit max back to min.
+            next = if next == self.max { self.min } else { next + 1 };
+        }
+    }
+
+    fn remove(&mut self, id: u32) {
+        self.used.remove(&id);
+    }
+}
+
+impl<A: IdAllocatorInner> IdAllocator<A> {
     /// Creates a new `IdAllocator` that will assign IDs between `min` and
     /// `max`, both inclusive.
-    pub fn new(min: T, max: T) -> IdAllocator<T> {
-        let inner = IdAllocatorInner {
-            next: min,
-            max,
-            free: VecDeque::new(),
-        };
+    pub fn new(min: u32, max: u32) -> IdAllocator<A> {
+        assert!(min <= max);
+        let inner = A::new(min, max);
         IdAllocator(Arc::new(Mutex::new(inner)))
     }
 
-    /// Allocates a new ID.
+    /// Allocates a new ID randomly distributed between min and max.
     ///
     /// Returns `None` if the allocator is exhausted.
     ///
     /// The ID associated with the [`IdHandle`] will be freed when all of the
     /// outstanding [`IdHandle`]s have been dropped.
-    pub fn alloc(&self) -> Option<IdHandle<T>> {
+    pub fn alloc(&self) -> Option<IdHandle<u32, A>> {
         let inner = Arc::new(internal::IdHandleInner::new(self)?);
         Some(IdHandle::Dynamic(inner))
     }
 
-    fn alloc_internal(&self) -> Option<T> {
+    // Attempt to allocate a new ID. We want the ID to be randomly distributed in the range. To do
+    // this, choose a random candidate. Check if it's already in the used set, and increment in a
+    // loop until an unused slot is found. Ideally we could ask used set what its next used or
+    // unused id is after some given X, but that's not part of the API. This means that when the
+    // range is large and the used set is near full, we will spend a lot of cycles looking for an
+    // open slot. However, we limit the number of connections to the thousands, and connection IDs
+    // have 20 bits (~1 million) of space, so it is not currently possible to enter that state.
+    fn alloc_internal(&self) -> Option<u32> {
         let mut inner = self.0.lock().expect("lock poisoned");
-        if let Some(id) = inner.free.pop_front() {
-            Some(id)
-        } else {
-            let id = inner.next;
-            if id > inner.max {
-                None
-            } else {
-                inner.next += 1.into();
-                Some(id)
-            }
-        }
+        inner.alloc()
     }
 
-    fn free_internal(&self, id: T) {
+    fn free_internal(&self, id: u32) {
         let mut inner = self.0.lock().expect("lock poisoned");
-        inner.free.push_back(id);
+        inner.remove(id);
     }
 }
 
@@ -108,21 +373,27 @@ where
 ///
 /// Once all of the [`IdHandle`]s referencing an ID have been dropped, we will then free the ID
 /// for later re-use.
-#[derive(Clone, Debug)]
-pub enum IdHandle<T: From<u8> + AddAssign + PartialOrd + Copy> {
-    /// An ID "allocated" a compile time.
+#[derive(Debug)]
+pub enum IdHandle<T, A: IdAllocatorInner> {
+    /// An ID "allocated" at compile time.
     ///
     /// Note: It is *entirely* up to the caller to make sure the provided ID is
     /// not used by a dynamic ID allocator.
     Static(T),
     /// An ID allocated at runtime, gets freed once all handles have been dropped.
-    Dynamic(Arc<internal::IdHandleInner<T>>),
+    Dynamic(Arc<internal::IdHandleInner<T, A>>),
 }
 
-impl<T> IdHandle<T>
-where
-    T: From<u8> + AddAssign + PartialOrd + Copy,
-{
+impl<T: Clone, A: IdAllocatorInner> Clone for IdHandle<T, A> {
+    fn clone(&self) -> Self {
+        match self {
+            IdHandle::Static(t) => IdHandle::Static(t.clone()),
+            IdHandle::Dynamic(handle) => IdHandle::Dynamic(Arc::clone(handle)),
+        }
+    }
+}
+
+impl<T: IdGenerator, A: IdAllocatorInner> IdHandle<T, A> {
     /// Returns the raw ID inside of this handle.
     ///
     /// Use with caution! It is easy for a raw ID to outlive the handle from
@@ -133,38 +404,26 @@ where
     }
 }
 
-impl<T> PartialEq for IdHandle<T>
-where
-    T: PartialEq + From<u8> + AddAssign + PartialOrd + Copy,
-{
+impl<T: IdGenerator, A: IdAllocatorInner> PartialEq for IdHandle<T, A> {
     fn eq(&self, other: &Self) -> bool {
         self.unhandled() == other.unhandled()
     }
 }
-impl<T> Eq for IdHandle<T> where T: PartialEq + From<u8> + AddAssign + PartialOrd + Copy {}
+impl<T: IdGenerator, A: IdAllocatorInner> Eq for IdHandle<T, A> {}
 
-impl<T> PartialOrd for IdHandle<T>
-where
-    T: PartialOrd + From<u8> + AddAssign + Copy,
-{
+impl<T: IdGenerator, A: IdAllocatorInner> PartialOrd for IdHandle<T, A> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.unhandled().partial_cmp(&other.unhandled())
+        Some(self.cmp(other))
     }
 }
 
-impl<T> Ord for IdHandle<T>
-where
-    T: Ord + From<u8> + AddAssign + PartialOrd + Copy,
-{
+impl<T: IdGenerator, A: IdAllocatorInner> Ord for IdHandle<T, A> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.unhandled().cmp(&other.unhandled())
     }
 }
 
-impl<T> Borrow<T> for IdHandle<T>
-where
-    T: From<u8> + AddAssign + PartialOrd + Copy,
-{
+impl<T, A: IdAllocatorInner> Borrow<T> for IdHandle<T, A> {
     fn borrow(&self) -> &T {
         match self {
             IdHandle::Static(id) => id,
@@ -173,19 +432,13 @@ where
     }
 }
 
-impl<T> fmt::Display for IdHandle<T>
-where
-    T: fmt::Display + From<u8> + AddAssign + PartialOrd + Copy,
-{
+impl<T: IdGenerator, A: IdAllocatorInner> fmt::Display for IdHandle<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.unhandled().fmt(f)
     }
 }
 
-impl<T> serde::Serialize for IdHandle<T>
-where
-    T: serde::Serialize + From<u8> + AddAssign + PartialOrd + Copy,
-{
+impl<T: IdGenerator, A: IdAllocatorInner> serde::Serialize for IdHandle<T, A> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -195,41 +448,38 @@ where
 }
 
 mod internal {
-    use std::ops::AddAssign;
+    use std::sync::Arc;
 
-    use crate::id_gen::IdAllocator;
+    use crate::cast::CastFrom;
+    use crate::id_gen::{IdAllocator, IdAllocatorInner};
 
     #[derive(Debug)]
-    pub struct IdHandleInner<T>
-    where
-        T: From<u8> + AddAssign + PartialOrd + Copy,
-    {
+    pub struct IdHandleInner<T, A: IdAllocatorInner> {
         /// A handle to the [`IdAllocator`] used to allocated the provided id.
-        pub(super) allocator: IdAllocator<T>,
+        pub(super) allocator: IdAllocator<A>,
         /// The actual ID that was allocated.
         pub(super) id: T,
+        stored: u32,
     }
 
-    impl<T> IdHandleInner<T>
+    impl<T, A: IdAllocatorInner> IdHandleInner<T, A>
     where
-        T: From<u8> + AddAssign + PartialOrd + Copy,
+        T: CastFrom<u32>,
     {
-        pub fn new(allocator: &IdAllocator<T>) -> Option<Self> {
-            let id = allocator.alloc_internal()?;
+        pub fn new(allocator: &IdAllocator<A>) -> Option<Self> {
+            let stored = allocator.alloc_internal()?;
             Some(IdHandleInner {
-                allocator: allocator.clone(),
-                id,
+                allocator: IdAllocator(Arc::clone(&allocator.0)),
+                id: T::cast_from(stored),
+                stored,
             })
         }
     }
 
-    impl<T> Drop for IdHandleInner<T>
-    where
-        T: From<u8> + AddAssign + PartialOrd + Copy,
-    {
+    impl<T, A: IdAllocatorInner> Drop for IdHandleInner<T, A> {
         fn drop(&mut self) {
             // Release our ID for later re-use.
-            self.allocator.free_internal(self.id);
+            self.allocator.free_internal(self.stored);
         }
     }
 }
@@ -241,24 +491,37 @@ mod tests {
     use super::*;
 
     #[mz_test_macro::test]
-    fn test_id_alloc() {
-        let ida = IdAllocator::new(3, 5);
+    fn test_id_gen() {
+        test_ad_allocator::<IdAllocatorInnerHashSet>();
+        test_ad_allocator::<IdAllocatorInnerBitSet>();
+        test_ad_allocator::<IdAllocatorInnerRoaring>();
+        test_ad_allocator::<IdAllocatorInnerRoaringLoop>();
+        test_ad_allocator::<IdAllocatorInnerSparseBitSet>();
+    }
+
+    fn test_ad_allocator<A: IdAllocatorInner>() {
+        test_id_alloc::<A>();
+        test_static_id_sorting::<A>();
+        test_id_reuse::<A>();
+        test_display::<A>();
+        test_map_lookup::<A>();
+        test_serialization::<A>();
+    }
+
+    fn test_id_alloc<A: IdAllocatorInner>() {
+        let ida = IdAllocator::<A>::new(3, 5);
         let id3 = ida.alloc().unwrap();
         let id4 = ida.alloc().unwrap();
         let id5 = ida.alloc().unwrap();
-        assert_eq!(id3, id3);
-        assert_eq!(id3.unhandled(), 3);
-        assert_eq!(id4.unhandled(), 4);
-        assert_eq!(id5.unhandled(), 5);
+        assert_ne!(id3, id4);
+        assert_ne!(id3, id5);
+        assert_ne!(id4, id5);
         drop(id4);
-        let id4 = ida.alloc().unwrap();
-        assert_eq!(id4.unhandled(), 4);
+        let _id4 = ida.alloc().unwrap();
         drop(id5);
         drop(id3);
-        let id5 = ida.alloc().unwrap();
-        let id3 = ida.alloc().unwrap();
-        assert_eq!(id5.unhandled(), 5);
-        assert_eq!(id3.unhandled(), 3);
+        let _id5 = ida.alloc().unwrap();
+        let _id3 = ida.alloc().unwrap();
         match ida.alloc() {
             Some(id) => panic!(
                 "id allocator returned {}, not expected id exhaustion error",
@@ -268,46 +531,41 @@ mod tests {
         }
     }
 
-    #[mz_test_macro::test]
-    fn test_static_id_sorting() {
-        let ida = IdAllocator::new(0, 0);
+    fn test_static_id_sorting<A: IdAllocatorInner>() {
+        let ida = IdAllocator::<A>::new(0, 0);
         let id0 = ida.alloc().unwrap();
         let id1 = IdHandle::Static(1);
         assert!(id0 < id1);
 
-        let ida = IdAllocator::new(1, 1);
+        let ida = IdAllocator::<A>::new(1, 1);
         let id0 = IdHandle::Static(0);
         let id1 = ida.alloc().unwrap();
         assert!(id0 < id1);
     }
 
-    #[mz_test_macro::test]
-    fn test_id_reuse() {
-        let allocator = IdAllocator::new(10, 13);
+    fn test_id_reuse<A: IdAllocatorInner>() {
+        let allocator = IdAllocator::<A>::new(10, 11);
 
         let id_a = allocator.alloc().unwrap();
-        assert_eq!(id_a.unhandled(), 10);
-
+        let a = id_a.unhandled();
         let id_a_clone = id_a.clone();
-        assert_eq!(id_a_clone.unhandled(), 10);
-
-        // 10 should not get freed.
+        // a should not get freed.
         drop(id_a);
 
-        let id_b = allocator.alloc().unwrap();
-        assert_eq!(id_b.unhandled(), 11);
+        // There are only two slots, so trying to allocate 2 more should fail the second time.
+        let _id_b = allocator.alloc().unwrap();
+        assert!(allocator.alloc().is_none());
 
-        // 10 should get freed since all outstanding references have been dropped.
+        // a should get freed since all outstanding references have been dropped.
         drop(id_a_clone);
 
-        // We should re-use 10.
+        // We should re-use a.
         let id_c = allocator.alloc().unwrap();
-        assert_eq!(id_c.unhandled(), 10);
+        assert_eq!(id_c.unhandled(), a);
     }
 
-    #[mz_test_macro::test]
-    fn test_display() {
-        let allocator = IdAllocator::<u32>::new(65_000, 65_101);
+    fn test_display<A: IdAllocatorInner>() {
+        let allocator = IdAllocator::<A>::new(65_000, 65_000);
 
         let id_a = allocator.alloc().unwrap();
         assert_eq!(id_a.unhandled(), 65_000);
@@ -319,26 +577,24 @@ mod tests {
         assert_eq!(id_display, val_display);
     }
 
-    #[mz_test_macro::test]
-    fn test_map_lookup() {
-        let allocator = IdAllocator::<u32>::new(99, 101);
+    fn test_map_lookup<A: IdAllocatorInner>() {
+        let allocator = IdAllocator::<A>::new(99, 101);
 
         let id_a = allocator.alloc().unwrap();
-        assert_eq!(id_a.unhandled(), 99);
+        let a = id_a.unhandled();
 
         let mut btree = BTreeMap::new();
         btree.insert(id_a, "hello world");
 
         // We should be able to lookup an IdHandle, based on just the value.
-        let entry = btree.remove(&99).unwrap();
+        let entry = btree.remove(&a).unwrap();
         assert_eq!(entry, "hello world");
 
         assert!(btree.is_empty());
     }
 
-    #[mz_test_macro::test]
-    fn test_serialization() {
-        let allocator = IdAllocator::<u32>::new(42, 43);
+    fn test_serialization<A: IdAllocatorInner>() {
+        let allocator = IdAllocator::<A>::new(42, 42);
 
         let id_a = allocator.alloc().unwrap();
         assert_eq!(id_a.unhandled(), 42);

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -47,6 +47,7 @@ pub mod future;
 pub mod graph;
 pub mod hash;
 pub mod hint;
+#[cfg(feature = "id_gen")]
 pub mod id_gen;
 pub mod iter;
 pub mod lex;

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -29,20 +29,21 @@ aws-smithy-runtime-api = { version = "1.1.1", features = ["client", "http-02x", 
 aws-smithy-types = { version = "1.1.1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "rt-tokio"] }
 axum = { version = "0.6.20", features = ["headers", "ws"] }
 bstr = { version = "0.2.14" }
-bytemuck = { version = "1.9.1", default-features = false, features = ["derive"] }
+byteorder = { version = "1.4.3" }
 bytes = { version = "1.4.0", features = ["serde"] }
 chrono = { version = "0.4.25", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 console = { version = "0.15.5", default-features = false, features = ["ansi-parsing", "unicode-width"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
+crossbeam-deque = { version = "0.8.3" }
 crossbeam-epoch = { version = "0.9.13" }
+crossbeam-utils = { version = "0.8.7" }
 crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
 debugid = { version = "0.8.0", default-features = false, features = ["serde"] }
 dec = { version = "0.4.8", default-features = false, features = ["serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
 either = { version = "1.8.0", features = ["serde"] }
 flate2 = { version = "1.0.24", features = ["zlib"] }
-futures = { version = "0.3.25" }
 futures-channel = { version = "0.3.28", features = ["sink"] }
 futures-core = { version = "0.3.28" }
 futures-executor = { version = "0.3.25" }
@@ -140,21 +141,22 @@ aws-smithy-runtime-api = { version = "1.1.1", features = ["client", "http-02x", 
 aws-smithy-types = { version = "1.1.1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "rt-tokio"] }
 axum = { version = "0.6.20", features = ["headers", "ws"] }
 bstr = { version = "0.2.14" }
-bytemuck = { version = "1.9.1", default-features = false, features = ["derive"] }
+byteorder = { version = "1.4.3" }
 bytes = { version = "1.4.0", features = ["serde"] }
 cc = { version = "1.0.83", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.25", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 console = { version = "0.15.5", default-features = false, features = ["ansi-parsing", "unicode-width"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
+crossbeam-deque = { version = "0.8.3" }
 crossbeam-epoch = { version = "0.9.13" }
+crossbeam-utils = { version = "0.8.7" }
 crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
 debugid = { version = "0.8.0", default-features = false, features = ["serde"] }
 dec = { version = "0.4.8", default-features = false, features = ["serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
 either = { version = "1.8.0", features = ["serde"] }
 flate2 = { version = "1.0.24", features = ["zlib"] }
-futures = { version = "0.3.25" }
 futures-channel = { version = "0.3.28", features = ["sink"] }
 futures-core = { version = "0.3.28" }
 futures-executor = { version = "0.3.25" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -29,21 +29,20 @@ aws-smithy-runtime-api = { version = "1.1.1", features = ["client", "http-02x", 
 aws-smithy-types = { version = "1.1.1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "rt-tokio"] }
 axum = { version = "0.6.20", features = ["headers", "ws"] }
 bstr = { version = "0.2.14" }
-byteorder = { version = "1.4.3" }
+bytemuck = { version = "1.9.1", default-features = false, features = ["derive"] }
 bytes = { version = "1.4.0", features = ["serde"] }
 chrono = { version = "0.4.25", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 console = { version = "0.15.5", default-features = false, features = ["ansi-parsing", "unicode-width"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
-crossbeam-deque = { version = "0.8.3" }
 crossbeam-epoch = { version = "0.9.13" }
-crossbeam-utils = { version = "0.8.7" }
 crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
 debugid = { version = "0.8.0", default-features = false, features = ["serde"] }
 dec = { version = "0.4.8", default-features = false, features = ["serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
 either = { version = "1.8.0", features = ["serde"] }
 flate2 = { version = "1.0.24", features = ["zlib"] }
+futures = { version = "0.3.25" }
 futures-channel = { version = "0.3.28", features = ["sink"] }
 futures-core = { version = "0.3.28" }
 futures-executor = { version = "0.3.25" }
@@ -141,22 +140,21 @@ aws-smithy-runtime-api = { version = "1.1.1", features = ["client", "http-02x", 
 aws-smithy-types = { version = "1.1.1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "rt-tokio"] }
 axum = { version = "0.6.20", features = ["headers", "ws"] }
 bstr = { version = "0.2.14" }
-byteorder = { version = "1.4.3" }
+bytemuck = { version = "1.9.1", default-features = false, features = ["derive"] }
 bytes = { version = "1.4.0", features = ["serde"] }
 cc = { version = "1.0.83", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.25", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 console = { version = "0.15.5", default-features = false, features = ["ansi-parsing", "unicode-width"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
-crossbeam-deque = { version = "0.8.3" }
 crossbeam-epoch = { version = "0.9.13" }
-crossbeam-utils = { version = "0.8.7" }
 crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
 debugid = { version = "0.8.0", default-features = false, features = ["serde"] }
 dec = { version = "0.4.8", default-features = false, features = ["serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
 either = { version = "1.8.0", features = ["serde"] }
 flate2 = { version = "1.0.24", features = ["zlib"] }
+futures = { version = "0.3.25" }
 futures-channel = { version = "0.3.28", features = ["sink"] }
 futures-core = { version = "0.3.28" }
 futures-executor = { version = "0.3.25" }


### PR DESCRIPTION
This will decrease their predictability, which is desirable for the balancer.

See https://github.com/MaterializeInc/materialize/issues/24081#issuecomment-1874880062

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a