### PR TITLE
compute: use `Context` to manage regions in dataflow rendering

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -302,14 +302,6 @@ impl<S: Scope> SpecializedArrangement<S>
 where
     <S as ScopeParent>::Timestamp: Lattice + Columnation,
 {
-    /// The scope of the underlying arrangement's stream.
-    pub fn scope(&self) -> S {
-        match self {
-            SpecializedArrangement::RowUnit(inner) => inner.stream.scope(),
-            SpecializedArrangement::RowRow(inner) => inner.stream.scope(),
-        }
-    }
-
     /// Brings the underlying arrangement into a region.
     pub fn enter_region<'a>(
         &self,
@@ -657,14 +649,6 @@ where
     T: Timestamp + Lattice + Columnation,
     S::Timestamp: Lattice + Refines<T> + Columnation,
 {
-    /// The scope containing the collection bundle.
-    pub fn scope(&self) -> S {
-        match self {
-            ArrangementFlavor::Local(oks, _errs) => oks.scope(),
-            ArrangementFlavor::Trace(_gid, oks, _errs) => oks.scope(),
-        }
-    }
-
     /// Brings the arrangement flavor into a region.
     pub fn enter_region<'a>(
         &self,
@@ -751,19 +735,6 @@ where
             keys.push(MirScalarExpr::Column(column));
         }
         Self::from_expressions(keys, arrangements)
-    }
-
-    /// The scope containing the collection bundle.
-    pub fn scope(&self) -> S {
-        if let Some((oks, _errs)) = &self.collection {
-            oks.inner.scope()
-        } else {
-            self.arranged
-                .values()
-                .next()
-                .expect("Must contain a valid collection")
-                .scope()
-        }
     }
 
     /// Brings the collection bundle into a region.

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -29,6 +29,7 @@ use mz_timely_util::operator::{CollectionExt, StreamExt};
 use timely::container::columnation::Columnation;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::{Map, OkErr};
+use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 use timely::progress::timestamp::Refines;
 use timely::progress::{Antichain, Timestamp};
@@ -55,254 +56,273 @@ where
     ) -> CollectionBundle<G> {
         // We create a new region to contain the dataflow paths for the delta join.
         let (oks, errs) = self.scope.clone().region_named("Join(Delta)", |inner| {
-            // Collects error streams for the ambient scope.
-            let mut inner_errs = Vec::new();
-
-            // Deduplicate the error streams of multiply used arrangements.
-            let mut err_dedup = BTreeSet::new();
-
-            // Our plan is to iterate through each input relation, and attempt
-            // to find a plan that maximally uses existing keys (better: uses
-            // existing arrangements, to which we have access).
-            let mut join_results = Vec::new();
-
-            // First let's prepare the input arrangements we will need.
-            // This reduces redundant imports, and simplifies the dataflow structure.
-            // As the arrangements are all shared, it should not dramatically improve
-            // the efficiency, but the dataflow simplification is worth doing.
-            let mut arrangements = BTreeMap::new();
-            for path_plan in join_plan.path_plans.iter() {
-                for stage_plan in path_plan.stage_plans.iter() {
-                    let lookup_idx = stage_plan.lookup_relation;
-                    let lookup_key = stage_plan.lookup_key.clone();
-                    arrangements
-                        .entry((lookup_idx, lookup_key.clone()))
-                        .or_insert_with(|| {
-                            match inputs[lookup_idx]
-                                .arrangement(&lookup_key)
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "Arrangement alarmingly absent!: {}, {:?}",
-                                        lookup_idx, lookup_key,
-                                    )
-                                }) {
-                                ArrangementFlavor::Local(oks, errs) => {
-                                    if err_dedup.insert((lookup_idx, lookup_key)) {
-                                        inner_errs.push(
-                                            errs.enter_region(inner)
-                                                .as_collection(|k, _v| k.clone()),
-                                        );
-                                    }
-                                    Ok(oks.enter_region(inner))
-                                }
-                                ArrangementFlavor::Trace(_gid, oks, errs) => {
-                                    if err_dedup.insert((lookup_idx, lookup_key)) {
-                                        inner_errs.push(
-                                            errs.enter_region(inner)
-                                                .as_collection(|k, _v| k.clone()),
-                                        );
-                                    }
-                                    Err(oks.enter_region(inner))
-                                }
-                            }
-                        });
-                }
-            }
-
-            for path_plan in join_plan.path_plans {
-                // Deconstruct the stages of the path plan.
-                let DeltaPathPlan {
-                    source_relation,
-                    initial_closure,
-                    stage_plans,
-                    final_closure,
-                    source_key,
-                } = path_plan;
-
-                // This collection determines changes that result from updates inbound
-                // from `inputs[relation]` and reflects all strictly prior updates and
-                // concurrent updates from relations prior to `relation`.
-                let name = format!("delta path {}", source_relation);
-                let path_results = inner.clone().region_named(&name, |region| {
-                    // The plan is to move through each relation, starting from `relation` and in the order
-                    // indicated in `orders[relation]`. At each moment, we will have the columns from the
-                    // subset of relations encountered so far, and we will have applied as much as we can
-                    // of the filters in `equivalences` and the logic in `map_filter_project`, based on the
-                    // available columns.
-                    //
-                    // As we go, we will track the physical locations of each intended output column, as well
-                    // as the locations of intermediate results from partial application of `map_filter_project`.
-                    //
-                    // Just before we apply the `lookup` function to perform a join, we will first use our
-                    // available information to determine the filtering and logic that we can apply, and
-                    // introduce that in to the `lookup` logic to cause it to happen in that operator.
-
-                    // Collects error streams for the region scope. Concats before leaving.
-                    let mut region_errs = Vec::with_capacity(inputs.len());
-
-                    // Ensure this input is rendered, and extract its update stream.
-                    let val = arrangements
-                        .get(&(source_relation, source_key))
-                        .expect("Arrangement promised by the planner is absent!");
-                    let as_of = self.as_of_frontier.clone();
-                    let update_stream = match val {
-                        Ok(local) => {
-                            let arranged = local.enter_region(region);
-                            let (update_stream, err_stream) = dispatch_build_update_stream_local(
-                                arranged,
-                                as_of,
-                                source_relation,
-                                initial_closure,
-                            );
-                            region_errs.push(err_stream);
-                            update_stream
-                        }
-                        Err(trace) => {
-                            let arranged = trace.enter_region(region);
-                            let (update_stream, err_stream) = dispatch_build_update_stream_trace(
-                                arranged,
-                                as_of,
-                                source_relation,
-                                initial_closure,
-                            );
-                            region_errs.push(err_stream);
-                            update_stream
-                        }
-                    };
-                    // Promote `time` to a datum element.
-                    //
-                    // The `half_join` operator manipulates as "data" a pair `(data, time)`,
-                    // while tracking the initial time `init_time` separately and without
-                    // modification. The initial value for both times is the initial time.
-                    let mut update_stream = update_stream
-                        .inner
-                        .map(|(v, t, d)| ((v, t.clone()), t, d))
-                        .as_collection();
-
-                    // Repeatedly update `update_stream` to reflect joins with more and more
-                    // other relations, in the specified order.
-                    for stage_plan in stage_plans {
-                        let DeltaStagePlan {
-                            lookup_relation,
-                            stream_key,
-                            stream_thinning,
-                            lookup_key,
-                            closure,
-                        } = stage_plan;
-
-                        // We require different logic based on the relative order of the two inputs.
-                        // If the `source` relation precedes the `lookup` relation, we present all
-                        // updates with less or equal `time`, and otherwise we present only updates
-                        // with strictly less `time`.
-                        //
-                        // We need to write the logic twice, as there are two types of arrangement
-                        // we might have: either dataflow-local or an imported trace.
-                        let (oks, errs) =
-                            match arrangements.get(&(lookup_relation, lookup_key)).unwrap() {
-                                Ok(local) => {
-                                    if source_relation < lookup_relation {
-                                        dispatch_build_halfjoin_local(
-                                            update_stream,
-                                            local.enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.le(t2),
-                                            closure,
-                                            self.shutdown_token.clone(),
-                                        )
-                                    } else {
-                                        dispatch_build_halfjoin_local(
-                                            update_stream,
-                                            local.enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.lt(t2),
-                                            closure,
-                                            self.shutdown_token.clone(),
-                                        )
-                                    }
-                                }
-                                Err(trace) => {
-                                    if source_relation < lookup_relation {
-                                        dispatch_build_halfjoin_trace(
-                                            update_stream,
-                                            trace.enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.le(t2),
-                                            closure,
-                                            self.shutdown_token.clone(),
-                                        )
-                                    } else {
-                                        dispatch_build_halfjoin_trace(
-                                            update_stream,
-                                            trace.enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.lt(t2),
-                                            closure,
-                                            self.shutdown_token.clone(),
-                                        )
-                                    }
-                                }
-                            };
-                        update_stream = oks;
-                        region_errs.push(errs);
-                    }
-
-                    // Delay updates as appropriate.
-                    //
-                    // The `half_join` operator maintains a time that we now discard (the `_`),
-                    // and replace with the `time` that is maintained with the data. The former
-                    // exists to pin a consistent total order on updates throughout the process,
-                    // while allowing `time` to vary upwards as a result of actions on time.
-                    let mut update_stream = update_stream
-                        .inner
-                        .map(|((row, time), _, diff)| (row, time, diff))
-                        .as_collection();
-
-                    // We have completed the join building, but may have work remaining.
-                    // For example, we may have expressions not pushed down (e.g. literals)
-                    // and projections that could not be applied (e.g. column repetition).
-                    if let Some(final_closure) = final_closure {
-                        let (updates, errors) =
-                            update_stream.flat_map_fallible("DeltaJoinFinalization", {
-                                // Reuseable allocation for unpacking.
-                                let mut datums = DatumVec::new();
-                                move |row| {
-                                    let binding = SharedRow::get();
-                                    let mut row_builder = binding.borrow_mut();
-                                    let temp_storage = RowArena::new();
-                                    let mut datums_local = datums.borrow_with(&row);
-                                    // TODO(mcsherry): re-use `row` allocation.
-                                    final_closure
-                                        .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                                        .map_err(DataflowError::from)
-                                        .transpose()
-                                }
-                            });
-
-                        update_stream = updates;
-                        region_errs.push(errors);
-                    }
-
-                    inner_errs.push(
-                        differential_dataflow::collection::concatenate(region, region_errs)
-                            .leave_region(),
-                    );
-                    update_stream.leave_region()
-                });
-
-                join_results.push(path_results);
-            }
-
-            // Concatenate the results of each delta query as the accumulated results.
-            (
-                differential_dataflow::collection::concatenate(inner, join_results).leave_region(),
-                differential_dataflow::collection::concatenate(inner, inner_errs).leave_region(),
-            )
+            self.render_delta_join_inner(inputs, join_plan, inner)
         });
         CollectionBundle::from_collections(oks, errs)
+    }
+
+    fn render_delta_join_inner(
+        &mut self,
+        inputs: Vec<CollectionBundle<G>>,
+        join_plan: DeltaJoinPlan,
+        inner: &mut Child<G, G::Timestamp>,
+    ) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>) {
+        // Collects error streams.
+        let mut errors = Vec::new();
+
+        // Deduplicate the error streams of multiply used arrangements.
+        let mut err_dedup = BTreeSet::new();
+
+        // Our plan is to iterate through each input relation, and attempt
+        // to find a plan that maximally uses existing keys (better: uses
+        // existing arrangements, to which we have access).
+        let mut join_results = Vec::new();
+
+        // First let's prepare the input arrangements we will need.
+        // This reduces redundant imports, and simplifies the dataflow structure.
+        // As the arrangements are all shared, it should not dramatically improve
+        // the efficiency, but the dataflow simplification is worth doing.
+        let mut arrangements = BTreeMap::new();
+        for path_plan in join_plan.path_plans.iter() {
+            for stage_plan in path_plan.stage_plans.iter() {
+                let lookup_idx = stage_plan.lookup_relation;
+                let lookup_key = stage_plan.lookup_key.clone();
+                arrangements
+                    .entry((lookup_idx, lookup_key.clone()))
+                    .or_insert_with(|| {
+                        match inputs[lookup_idx]
+                            .arrangement(&lookup_key)
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "Arrangement alarmingly absent!: {}, {:?}",
+                                    lookup_idx, lookup_key,
+                                )
+                            }) {
+                            ArrangementFlavor::Local(oks, errs) => {
+                                if err_dedup.insert((lookup_idx, lookup_key)) {
+                                    errors.push(
+                                        errs.enter_region(inner).as_collection(|k, _v| k.clone()),
+                                    );
+                                }
+                                Ok(oks.enter_region(inner))
+                            }
+                            ArrangementFlavor::Trace(_gid, oks, errs) => {
+                                if err_dedup.insert((lookup_idx, lookup_key)) {
+                                    errors.push(
+                                        errs.enter_region(inner).as_collection(|k, _v| k.clone()),
+                                    );
+                                }
+                                Err(oks.enter_region(inner))
+                            }
+                        }
+                    });
+            }
+        }
+
+        for path_plan in join_plan.path_plans {
+            // This collection determines changes that result from updates inbound
+            // from `inputs[relation]` and reflects all strictly prior updates and
+            // concurrent updates from relations prior to `relation`.
+            let name = format!("delta path {}", path_plan.source_relation);
+            inner.clone().region_named(&name, |region| {
+                let (oks, errs) = self.render_join_path(&arrangements, path_plan, region);
+
+                join_results.push(oks);
+                errors.push(errs);
+            });
+        }
+
+        // Concatenate the results of each delta query as the accumulated results.
+        (
+            differential_dataflow::collection::concatenate(inner, join_results).leave_region(),
+            differential_dataflow::collection::concatenate(inner, errors).leave_region(),
+        )
+    }
+
+    fn render_join_path<S>(
+        &mut self,
+        arrangements: &BTreeMap<
+            (usize, Vec<MirScalarExpr>),
+            Result<SpecializedArrangement<S>, SpecializedArrangementImport<S>>,
+        >,
+        path_plan: DeltaPathPlan,
+        region: &mut Child<S, S::Timestamp>,
+    ) -> (Collection<S, Row, Diff>, Collection<S, DataflowError, Diff>)
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        let DeltaPathPlan {
+            source_relation,
+            initial_closure,
+            stage_plans,
+            final_closure,
+            source_key,
+        } = path_plan;
+
+        // The plan is to move through each relation, starting from `relation` and in the order
+        // indicated in `orders[relation]`. At each moment, we will have the columns from the
+        // subset of relations encountered so far, and we will have applied as much as we can
+        // of the filters in `equivalences` and the logic in `map_filter_project`, based on the
+        // available columns.
+        //
+        // As we go, we will track the physical locations of each intended output column, as well
+        // as the locations of intermediate results from partial application of `map_filter_project`.
+        //
+        // Just before we apply the `lookup` function to perform a join, we will first use our
+        // available information to determine the filtering and logic that we can apply, and
+        // introduce that in to the `lookup` logic to cause it to happen in that operator.
+
+        // Collects error streams. Concats before leaving.
+        let mut errors = Vec::new();
+
+        // Ensure this input is rendered, and extract its update stream.
+        let val = arrangements
+            .get(&(source_relation, source_key))
+            .expect("Arrangement promised by the planner is absent!");
+        let as_of = self.as_of_frontier.clone();
+        let update_stream = match val {
+            Ok(local) => {
+                let arranged = local.enter_region(region);
+                let (update_stream, err_stream) = dispatch_build_update_stream_local(
+                    arranged,
+                    as_of,
+                    source_relation,
+                    initial_closure,
+                );
+                errors.push(err_stream);
+                update_stream
+            }
+            Err(trace) => {
+                let arranged = trace.enter_region(region);
+                let (update_stream, err_stream) = dispatch_build_update_stream_trace(
+                    arranged,
+                    as_of,
+                    source_relation,
+                    initial_closure,
+                );
+                errors.push(err_stream);
+                update_stream
+            }
+        };
+        // Promote `time` to a datum element.
+        //
+        // The `half_join` operator manipulates as "data" a pair `(data, time)`,
+        // while tracking the initial time `init_time` separately and without
+        // modification. The initial value for both times is the initial time.
+        let mut update_stream = update_stream
+            .inner
+            .map(|(v, t, d)| ((v, t.clone()), t, d))
+            .as_collection();
+
+        // Repeatedly update `update_stream` to reflect joins with more and more
+        // other relations, in the specified order.
+        for stage_plan in stage_plans {
+            let DeltaStagePlan {
+                lookup_relation,
+                stream_key,
+                stream_thinning,
+                lookup_key,
+                closure,
+            } = stage_plan;
+
+            // We require different logic based on the relative order of the two inputs.
+            // If the `source` relation precedes the `lookup` relation, we present all
+            // updates with less or equal `time`, and otherwise we present only updates
+            // with strictly less `time`.
+            //
+            // We need to write the logic twice, as there are two types of arrangement
+            // we might have: either dataflow-local or an imported trace.
+            let (oks, errs) = match arrangements.get(&(lookup_relation, lookup_key)).unwrap() {
+                Ok(local) => {
+                    if source_relation < lookup_relation {
+                        dispatch_build_halfjoin_local(
+                            update_stream,
+                            local.enter_region(region),
+                            stream_key,
+                            stream_thinning,
+                            |t1, t2| t1.le(t2),
+                            closure,
+                            self.shutdown_token.clone(),
+                        )
+                    } else {
+                        dispatch_build_halfjoin_local(
+                            update_stream,
+                            local.enter_region(region),
+                            stream_key,
+                            stream_thinning,
+                            |t1, t2| t1.lt(t2),
+                            closure,
+                            self.shutdown_token.clone(),
+                        )
+                    }
+                }
+                Err(trace) => {
+                    if source_relation < lookup_relation {
+                        dispatch_build_halfjoin_trace(
+                            update_stream,
+                            trace.enter_region(region),
+                            stream_key,
+                            stream_thinning,
+                            |t1, t2| t1.le(t2),
+                            closure,
+                            self.shutdown_token.clone(),
+                        )
+                    } else {
+                        dispatch_build_halfjoin_trace(
+                            update_stream,
+                            trace.enter_region(region),
+                            stream_key,
+                            stream_thinning,
+                            |t1, t2| t1.lt(t2),
+                            closure,
+                            self.shutdown_token.clone(),
+                        )
+                    }
+                }
+            };
+            update_stream = oks;
+            errors.push(errs);
+        }
+
+        // Delay updates as appropriate.
+        //
+        // The `half_join` operator maintains a time that we now discard (the `_`),
+        // and replace with the `time` that is maintained with the data. The former
+        // exists to pin a consistent total order on updates throughout the process,
+        // while allowing `time` to vary upwards as a result of actions on time.
+        let mut update_stream = update_stream
+            .inner
+            .map(|((row, time), _, diff)| (row, time, diff))
+            .as_collection();
+
+        // We have completed the join building, but may have work remaining.
+        // For example, we may have expressions not pushed down (e.g. literals)
+        // and projections that could not be applied (e.g. column repetition).
+        if let Some(final_closure) = final_closure {
+            let (oks, errs) = update_stream.flat_map_fallible("DeltaJoinFinalization", {
+                // Reuseable allocation for unpacking.
+                let mut datums = DatumVec::new();
+                move |row| {
+                    let binding = SharedRow::get();
+                    let mut row_builder = binding.borrow_mut();
+                    let temp_storage = RowArena::new();
+                    let mut datums_local = datums.borrow_with(&row);
+                    // TODO(mcsherry): re-use `row` allocation.
+                    final_closure
+                        .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                        .map_err(DataflowError::from)
+                        .transpose()
+                }
+            });
+
+            update_stream = oks;
+            errors.push(errs);
+        }
+
+        (
+            update_stream.leave_region(),
+            differential_dataflow::collection::concatenate(region, errors).leave_region(),
+        )
     }
 }
 

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -26,6 +26,7 @@ use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
 use timely::container::columnation::Columnation;
 use timely::dataflow::operators::OkErr;
+use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 use timely::progress::timestamp::{Refines, Timestamp};
 
@@ -145,83 +146,52 @@ where
         linear_plan: LinearJoinPlan,
     ) -> CollectionBundle<G, T> {
         self.scope.clone().region_named("Join(Linear)", |inner| {
-            // Collect all error streams, and concatenate them at the end.
-            let mut errors = Vec::new();
+            self.render_join_inner(inputs, linear_plan, inner)
+        })
+    }
 
-            // Determine which form our maintained spine of updates will initially take.
-            // First, just check out the availability of an appropriate arrangement.
-            // This will be `None` in the degenerate single-input join case, which ensures
-            // that we do not panic if we never go around the `stage_plans` loop.
-            let arrangement = linear_plan.stage_plans.get(0).and_then(|stage| {
-                inputs[linear_plan.source_relation].arrangement(&stage.stream_key)
-            });
-            // We can use an arrangement if it exists and an initial closure does not.
-            let mut joined = match (arrangement, linear_plan.initial_closure) {
-                (Some(ArrangementFlavor::Local(oks, errs)), None) => {
-                    errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
-                    JoinedFlavor::Local(oks.enter_region(inner))
-                }
-                (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
-                    errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
-                    JoinedFlavor::Trace(oks.enter_region(inner))
-                }
-                (_, initial_closure) => {
-                    // TODO: extract closure from the first stage in the join plan, should it exist.
-                    // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
-                    let (joined, errs) = inputs[linear_plan.source_relation]
-                        .as_specific_collection(linear_plan.source_key.as_deref());
-                    errors.push(errs.enter_region(inner));
-                    let mut joined = joined.enter_region(inner);
+    fn render_join_inner(
+        &mut self,
+        inputs: Vec<CollectionBundle<G, T>>,
+        linear_plan: LinearJoinPlan,
+        inner: &mut Child<G, G::Timestamp>,
+    ) -> CollectionBundle<G, T> {
+        // Collect all error streams, and concatenate them at the end.
+        let mut errors = Vec::new();
 
-                    // In the current code this should always be `None`, but we have this here should
-                    // we change that and want to know what we should be doing.
-                    if let Some(closure) = initial_closure {
-                        // If there is no starting arrangement, then we can run filters
-                        // directly on the starting collection.
-                        // If there is only one input, we are done joining, so run filters
-                        let (j, errs) = joined.flat_map_fallible("LinearJoinInitialization", {
-                            // Reuseable allocation for unpacking.
-                            let mut datums = DatumVec::new();
-                            move |row| {
-                                let binding = SharedRow::get();
-                                let mut row_builder = binding.borrow_mut();
-                                let temp_storage = RowArena::new();
-                                let mut datums_local = datums.borrow_with(&row);
-                                // TODO(mcsherry): re-use `row` allocation.
-                                closure
-                                    .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                                    .map_err(DataflowError::from)
-                                    .transpose()
-                            }
-                        });
-                        joined = j;
-                        errors.push(errs);
-                    }
-
-                    JoinedFlavor::Collection(joined)
-                }
-            };
-
-            // progress through stages, updating partial results and errors.
-            for stage_plan in linear_plan.stage_plans.into_iter() {
-                // Different variants of `joined` implement this differently,
-                // and the logic is centralized there.
-                let stream = self.differential_join(
-                    joined,
-                    inputs[stage_plan.lookup_relation].enter_region(inner),
-                    stage_plan,
-                    &mut errors,
-                );
-                // Update joined results and capture any errors.
-                joined = JoinedFlavor::Collection(stream);
+        // Determine which form our maintained spine of updates will initially take.
+        // First, just check out the availability of an appropriate arrangement.
+        // This will be `None` in the degenerate single-input join case, which ensures
+        // that we do not panic if we never go around the `stage_plans` loop.
+        let arrangement = linear_plan
+            .stage_plans
+            .get(0)
+            .and_then(|stage| inputs[linear_plan.source_relation].arrangement(&stage.stream_key));
+        // We can use an arrangement if it exists and an initial closure does not.
+        let mut joined = match (arrangement, linear_plan.initial_closure) {
+            (Some(ArrangementFlavor::Local(oks, errs)), None) => {
+                errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
+                JoinedFlavor::Local(oks.enter_region(inner))
             }
+            (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
+                errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
+                JoinedFlavor::Trace(oks.enter_region(inner))
+            }
+            (_, initial_closure) => {
+                // TODO: extract closure from the first stage in the join plan, should it exist.
+                // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
+                let (joined, errs) = inputs[linear_plan.source_relation]
+                    .as_specific_collection(linear_plan.source_key.as_deref());
+                errors.push(errs.enter_region(inner));
+                let mut joined = joined.enter_region(inner);
 
-            // We have completed the join building, but may have work remaining.
-            // For example, we may have expressions not pushed down (e.g. literals)
-            // and projections that could not be applied (e.g. column repetition).
-            if let JoinedFlavor::Collection(mut joined) = joined {
-                if let Some(closure) = linear_plan.final_closure {
-                    let (updates, errs) = joined.flat_map_fallible("LinearJoinFinalization", {
+                // In the current code this should always be `None`, but we have this here should
+                // we change that and want to know what we should be doing.
+                if let Some(closure) = initial_closure {
+                    // If there is no starting arrangement, then we can run filters
+                    // directly on the starting collection.
+                    // If there is only one input, we are done joining, so run filters
+                    let (j, errs) = joined.flat_map_fallible("LinearJoinInitialization", {
                         // Reuseable allocation for unpacking.
                         let mut datums = DatumVec::new();
                         move |row| {
@@ -236,21 +206,62 @@ where
                                 .transpose()
                         }
                     });
-
-                    joined = updates;
+                    joined = j;
                     errors.push(errs);
                 }
 
-                // Return joined results and all produced errors collected together.
-                CollectionBundle::from_collections(
-                    joined,
-                    differential_dataflow::collection::concatenate(inner, errors),
-                )
-            } else {
-                panic!("Unexpectedly arranged join output");
+                JoinedFlavor::Collection(joined)
             }
-            .leave_region()
-        })
+        };
+
+        // progress through stages, updating partial results and errors.
+        for stage_plan in linear_plan.stage_plans.into_iter() {
+            // Different variants of `joined` implement this differently,
+            // and the logic is centralized there.
+            let stream = self.differential_join(
+                joined,
+                inputs[stage_plan.lookup_relation].enter_region(inner),
+                stage_plan,
+                &mut errors,
+            );
+            // Update joined results and capture any errors.
+            joined = JoinedFlavor::Collection(stream);
+        }
+
+        // We have completed the join building, but may have work remaining.
+        // For example, we may have expressions not pushed down (e.g. literals)
+        // and projections that could not be applied (e.g. column repetition).
+        if let JoinedFlavor::Collection(mut joined) = joined {
+            if let Some(closure) = linear_plan.final_closure {
+                let (updates, errs) = joined.flat_map_fallible("LinearJoinFinalization", {
+                    // Reuseable allocation for unpacking.
+                    let mut datums = DatumVec::new();
+                    move |row| {
+                        let binding = SharedRow::get();
+                        let mut row_builder = binding.borrow_mut();
+                        let temp_storage = RowArena::new();
+                        let mut datums_local = datums.borrow_with(&row);
+                        // TODO(mcsherry): re-use `row` allocation.
+                        closure
+                            .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                            .map_err(DataflowError::from)
+                            .transpose()
+                    }
+                });
+
+                joined = updates;
+                errors.push(errs);
+            }
+
+            // Return joined results and all produced errors collected together.
+            CollectionBundle::from_collections(
+                joined,
+                differential_dataflow::collection::concatenate(inner, errors),
+            )
+        } else {
+            panic!("Unexpectedly arranged join output");
+        }
+        .leave_region()
     }
 
     /// Looks up the arrangement for the next input and joins it to the arranged

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -37,6 +37,7 @@ use mz_timely_util::operator::CollectionExt;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use timely::container::columnation::{Columnation, CopyRegion};
+use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 use timely::progress::timestamp::Refines;
 use timely::progress::Timestamp;
@@ -68,6 +69,27 @@ where
         input_key: Option<Vec<MirScalarExpr>>,
         mfp_after: Option<MapFilterProject>,
     ) -> CollectionBundle<G, T> {
+        input.scope().region_named("Reduce", |inner| {
+            self.render_reduce_inner(
+                input,
+                key_val_plan,
+                reduce_plan,
+                input_key,
+                mfp_after,
+                inner,
+            )
+        })
+    }
+
+    fn render_reduce_inner(
+        &mut self,
+        input: CollectionBundle<G, T>,
+        key_val_plan: KeyValPlan,
+        reduce_plan: ReducePlan,
+        input_key: Option<Vec<MirScalarExpr>>,
+        mfp_after: Option<MapFilterProject>,
+        inner: &mut Child<G, G::Timestamp>,
+    ) -> CollectionBundle<G, T> {
         // Convert `mfp_after` to an actionable plan.
         let mfp_after = mfp_after.map(|m| {
             m.into_plan()
@@ -76,92 +98,82 @@ where
                 .expect("Fused Reduce MFPs do not have temporal predicates")
         });
 
-        input.scope().region_named("Reduce", |inner| {
-            let KeyValPlan {
-                mut key_plan,
-                mut val_plan,
-            } = key_val_plan;
-            let key_arity = key_plan.projection.len();
-            let mut datums = DatumVec::new();
-            let (key_val_input, err_input): (
-                timely::dataflow::Stream<_, (Result<(Row, Row), DataflowError>, _, _)>,
-                _,
-            ) = input
-                .enter_region(inner)
-                .flat_map(input_key.map(|k| (k, None)), || {
-                    // Determine the columns we'll need from the row.
-                    let mut demand = Vec::new();
-                    demand.extend(key_plan.demand());
-                    demand.extend(val_plan.demand());
-                    demand.sort();
-                    demand.dedup();
-                    // remap column references to the subset we use.
-                    let mut demand_map = BTreeMap::new();
-                    for column in demand.iter() {
-                        demand_map.insert(*column, demand_map.len());
-                    }
-                    let demand_map_len = demand_map.len();
-                    key_plan.permute(demand_map.clone(), demand_map_len);
-                    val_plan.permute(demand_map, demand_map_len);
-                    let skips = mz_compute_types::plan::reduce::convert_indexes_to_skips(demand);
-                    move |row_datums, time, diff| {
-                        let binding = SharedRow::get();
-                        let mut row_builder = binding.borrow_mut();
-                        let temp_storage = RowArena::new();
+        let KeyValPlan {
+            mut key_plan,
+            mut val_plan,
+        } = key_val_plan;
+        let key_arity = key_plan.projection.len();
+        let mut datums = DatumVec::new();
+        let (key_val_input, err_input): (
+            timely::dataflow::Stream<_, (Result<(Row, Row), DataflowError>, _, _)>,
+            _,
+        ) = input
+            .enter_region(inner)
+            .flat_map(input_key.map(|k| (k, None)), || {
+                // Determine the columns we'll need from the row.
+                let mut demand = Vec::new();
+                demand.extend(key_plan.demand());
+                demand.extend(val_plan.demand());
+                demand.sort();
+                demand.dedup();
+                // remap column references to the subset we use.
+                let mut demand_map = BTreeMap::new();
+                for column in demand.iter() {
+                    demand_map.insert(*column, demand_map.len());
+                }
+                let demand_map_len = demand_map.len();
+                key_plan.permute(demand_map.clone(), demand_map_len);
+                val_plan.permute(demand_map, demand_map_len);
+                let skips = mz_compute_types::plan::reduce::convert_indexes_to_skips(demand);
+                move |row_datums, time, diff| {
+                    let binding = SharedRow::get();
+                    let mut row_builder = binding.borrow_mut();
+                    let temp_storage = RowArena::new();
 
-                        let mut row_iter = row_datums.drain(..);
-                        let mut datums_local = datums.borrow();
-                        // Unpack only the demanded columns.
-                        for skip in skips.iter() {
-                            datums_local.push(row_iter.nth(*skip).unwrap());
+                    let mut row_iter = row_datums.drain(..);
+                    let mut datums_local = datums.borrow();
+                    // Unpack only the demanded columns.
+                    for skip in skips.iter() {
+                        datums_local.push(row_iter.nth(*skip).unwrap());
+                    }
+
+                    // Evaluate the key expressions.
+                    let key = match key_plan.evaluate_into(
+                        &mut datums_local,
+                        &temp_storage,
+                        &mut row_builder,
+                    ) {
+                        Err(e) => {
+                            return Some((Err(DataflowError::from(e)), time.clone(), diff.clone()))
                         }
+                        Ok(key) => key.expect("Row expected as no predicate was used"),
+                    };
+                    // Evaluate the value expressions.
+                    // The prior evaluation may have left additional columns we should delete.
+                    datums_local.truncate(skips.len());
+                    let val = match val_plan.evaluate_iter(&mut datums_local, &temp_storage) {
+                        Err(e) => {
+                            return Some((Err(DataflowError::from(e)), time.clone(), diff.clone()))
+                        }
+                        Ok(val) => val.expect("Row expected as no predicate was used"),
+                    };
+                    row_builder.packer().extend(val);
+                    let row = row_builder.clone();
+                    Some((Ok((key, row)), time.clone(), diff.clone()))
+                }
+            });
 
-                        // Evaluate the key expressions.
-                        let key = match key_plan.evaluate_into(
-                            &mut datums_local,
-                            &temp_storage,
-                            &mut row_builder,
-                        ) {
-                            Err(e) => {
-                                return Some((
-                                    Err(DataflowError::from(e)),
-                                    time.clone(),
-                                    diff.clone(),
-                                ))
-                            }
-                            Ok(key) => key.expect("Row expected as no predicate was used"),
-                        };
-                        // Evaluate the value expressions.
-                        // The prior evaluation may have left additional columns we should delete.
-                        datums_local.truncate(skips.len());
-                        let val = match val_plan.evaluate_iter(&mut datums_local, &temp_storage) {
-                            Err(e) => {
-                                return Some((
-                                    Err(DataflowError::from(e)),
-                                    time.clone(),
-                                    diff.clone(),
-                                ))
-                            }
-                            Ok(val) => val.expect("Row expected as no predicate was used"),
-                        };
-                        row_builder.packer().extend(val);
-                        let row = row_builder.clone();
-                        Some((Ok((key, row)), time.clone(), diff.clone()))
-                    }
-                });
+        // Demux out the potential errors from key and value selector evaluation.
+        let (ok, mut err) = key_val_input
+            .as_collection()
+            .consolidate_stream()
+            .flat_map_fallible("OkErrDemux", Some);
 
-            // Demux out the potential errors from key and value selector evaluation.
-            let (ok, mut err) = key_val_input
-                .as_collection()
-                .consolidate_stream()
-                .flat_map_fallible("OkErrDemux", Some);
+        err = err.concat(&err_input);
 
-            err = err.concat(&err_input);
-
-            // Render the reduce plan
-            self.render_reduce_plan(reduce_plan, ok, err, key_arity, mfp_after)
-                .leave_region()
-        })
+        // Render the reduce plan
+        self.render_reduce_plan(reduce_plan, ok, err, key_arity, mfp_after)
+            .leave_region()
     }
 
     /// Render a dataflow based on the provided plan.
@@ -933,171 +945,178 @@ where
     fn build_bucketed<S>(
         &self,
         input: Collection<S, (Row, Row), Diff>,
+        bucketed_plan: BucketedPlan,
+        mfp_after: Option<SafeMfpPlan>,
+    ) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
+    where
+        S: Scope<Timestamp = G::Timestamp>,
+    {
+        input.scope().region_named("ReduceHierarchical", |inner| {
+            self.build_bucketed_inner(input, bucketed_plan, mfp_after, inner)
+        })
+    }
+
+    fn build_bucketed_inner<S>(
+        &self,
+        input: Collection<S, (Row, Row), Diff>,
         BucketedPlan {
             aggr_funcs,
             skips,
             buckets,
         }: BucketedPlan,
         mfp_after: Option<SafeMfpPlan>,
+        inner: &mut Child<S, S::Timestamp>,
     ) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
     where
         S: Scope<Timestamp = G::Timestamp>,
     {
+        let input = input.enter(inner);
         let mut err_output: Option<Collection<S, _, _>> = None;
-        let arranged_output = input.scope().region_named("ReduceHierarchical", |inner| {
-            let input = input.enter(inner);
 
-            // Gather the relevant values into a vec of rows ordered by aggregation_index
-            let input = input.map(move |(key, row)| {
-                let binding = SharedRow::get();
-                let mut row_builder = binding.borrow_mut();
-                let mut values = Vec::with_capacity(skips.len());
-                let mut row_iter = row.iter();
-                for skip in skips.iter() {
-                    row_builder.packer().push(row_iter.nth(*skip).unwrap());
-                    values.push(row_builder.clone());
-                }
-
-                (key, values)
-            });
-
-            // Repeatedly apply hierarchical reduction with a progressively coarser key.
-            let mut stage = input.map(move |(key, values)| ((key, values.hashed()), values));
-            for b in buckets.into_iter() {
-                let input = stage.map(move |((key, hash), values)| ((key, hash % b), values));
-
-                // We only want the first stage to perform validation of whether invalid accumulations
-                // were observed in the input. Subsequently, we will either produce an error in the error
-                // stream or produce correct data in the output stream.
-                let negated_output = if err_output.is_none() {
-                    let (oks, errs) = self
-                        .build_bucketed_negated_output::<_, Result<Vec<Row>, (Row, u64)>>(
-                            &input,
-                            aggr_funcs.clone(),
-                        )
-                        .map_fallible(
-                            "Checked Invalid Accumulations",
-                            |(key, result)| match result {
-                                Err((key, _)) => {
-                                    let message = format!(
-                                        "Invalid data in source, saw non-positive accumulation \
-                                         for key {key:?} in hierarchical mins-maxes aggregate"
-                                    );
-                                    Err(EvalError::Internal(message).into())
-                                }
-                                Ok(values) => Ok((key, values)),
-                            },
-                        );
-                    err_output = Some(errs.leave_region());
-                    oks
-                } else {
-                    self.build_bucketed_negated_output::<_, Vec<Row>>(&input, aggr_funcs.clone())
-                };
-
-                stage = negated_output
-                    .negate()
-                    .concat(&input)
-                    .consolidate_named::<KeySpine<_, _, _>>("Consolidated MinsMaxesHierarchical");
+        // Gather the relevant values into a vec of rows ordered by aggregation_index
+        let input = input.map(move |(key, row)| {
+            let binding = SharedRow::get();
+            let mut row_builder = binding.borrow_mut();
+            let mut values = Vec::with_capacity(skips.len());
+            let mut row_iter = row.iter();
+            for skip in skips.iter() {
+                row_builder.packer().push(row_iter.nth(*skip).unwrap());
+                values.push(row_builder.clone());
             }
 
-            // Discard the hash from the key and return to the format of the input data.
-            let partial = stage.map(|((key, _hash), values)| (key, values));
+            (key, values)
+        });
 
-            // Allocations for the two closures.
-            let mut datums1 = DatumVec::new();
-            let mut datums2 = DatumVec::new();
-            let mfp_after1 = mfp_after.clone();
-            let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
-            let aggr_funcs2 = aggr_funcs.clone();
+        // Repeatedly apply hierarchical reduction with a progressively coarser key.
+        let mut stage = input.map(move |(key, values)| ((key, values.hashed()), values));
+        for b in buckets.into_iter() {
+            let input = stage.map(move |((key, hash), values)| ((key, hash % b), values));
 
-            // Build a series of stages for the reduction
-            // Arrange the final result into (key, Row)
-            let error_logger = self.error_logger();
-            // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
-            // view mz_internal.mz_expected_group_size_advice.
-            let arranged =
-                partial.mz_arrange::<RowValSpine<Vec<Row>, _, _>>("Arrange ReduceMinsMaxes");
-            // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
-            // but we then wouldn't be able to do this error check conditionally.  See its documentation
-            // for the rationale around using a second reduction here.
-            let must_validate = err_output.is_none();
-            if must_validate || mfp_after2.is_some() {
-                let errs = arranged
-                    .mz_reduce_abelian::<_, RowErrSpine<_, _>>(
-                        "ReduceMinsMaxes Error Check",
-                        move |key, source, target| {
-                            // Negative counts would be surprising, but until we are 100% certain we wont
-                            // see them, we should report when we do. We may want to bake even more info
-                            // in here in the future.
-                            if must_validate {
-                                for (val, count) in source.iter() {
-                                    if count.is_positive() {
-                                        continue;
-                                    }
-                                    let val = val.into_owned();
-                                    let message = "Non-positive accumulation in ReduceMinsMaxes";
-                                    error_logger
-                                        .log(message, &format!("val={val:?}, count={count}"));
-                                    target
-                                        .push((EvalError::Internal(message.to_string()).into(), 1));
-                                    return;
-                                }
-                            }
-
-                            // We know that `mfp_after` can error if it exists, so try to evaluate it here.
-                            let Some(mfp) = &mfp_after2 else { return };
-                            let temp_storage = RowArena::new();
-                            let datum_iter = key.into_datum_iter(None);
-                            let mut datums_local = datums2.borrow();
-                            datums_local.extend(datum_iter);
-                            for (aggr_index, func) in aggr_funcs2.iter().enumerate() {
-                                let iter = source.iter().map(|(values, _cnt)| {
-                                    values[aggr_index].iter().next().unwrap()
-                                });
-                                datums_local.push(func.eval(iter, &temp_storage));
-                            }
-                            if let Result::Err(e) =
-                                mfp.evaluate_inner(&mut datums_local, &temp_storage)
-                            {
-                                target.push((e.into(), 1));
-                            }
-                        },
+            // We only want the first stage to perform validation of whether invalid accumulations
+            // were observed in the input. Subsequently, we will either produce an error in the error
+            // stream or produce correct data in the output stream.
+            let negated_output = if err_output.is_none() {
+                let (oks, errs) = self
+                    .build_bucketed_negated_output::<_, Result<Vec<Row>, (Row, u64)>>(
+                        &input,
+                        aggr_funcs.clone(),
                     )
-                    .as_collection(|_, v| v.into_owned())
-                    .leave_region();
-                if let Some(e) = &err_output {
-                    err_output = Some(e.concat(&errs));
-                } else {
-                    err_output = Some(errs);
-                }
-            }
-            arranged
-                .mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceMinsMaxes", {
+                    .map_fallible(
+                        "Checked Invalid Accumulations",
+                        |(key, result)| match result {
+                            Err((key, _)) => {
+                                let message = format!(
+                                    "Invalid data in source, saw non-positive accumulation \
+                                         for key {key:?} in hierarchical mins-maxes aggregate"
+                                );
+                                Err(EvalError::Internal(message).into())
+                            }
+                            Ok(values) => Ok((key, values)),
+                        },
+                    );
+                err_output = Some(errs.leave_region());
+                oks
+            } else {
+                self.build_bucketed_negated_output::<_, Vec<Row>>(&input, aggr_funcs.clone())
+            };
+
+            stage = negated_output
+                .negate()
+                .concat(&input)
+                .consolidate_named::<KeySpine<_, _, _>>("Consolidated MinsMaxesHierarchical");
+        }
+
+        // Discard the hash from the key and return to the format of the input data.
+        let partial = stage.map(|((key, _hash), values)| (key, values));
+
+        // Allocations for the two closures.
+        let mut datums1 = DatumVec::new();
+        let mut datums2 = DatumVec::new();
+        let mfp_after1 = mfp_after.clone();
+        let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
+        let aggr_funcs2 = aggr_funcs.clone();
+
+        // Build a series of stages for the reduction
+        // Arrange the final result into (key, Row)
+        let error_logger = self.error_logger();
+        // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
+        // view mz_internal.mz_expected_group_size_advice.
+        let arranged = partial.mz_arrange::<RowValSpine<Vec<Row>, _, _>>("Arrange ReduceMinsMaxes");
+        // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
+        // but we then wouldn't be able to do this error check conditionally.  See its documentation
+        // for the rationale around using a second reduction here.
+        let must_validate = err_output.is_none();
+        if must_validate || mfp_after2.is_some() {
+            let errs = arranged
+                .mz_reduce_abelian::<_, RowErrSpine<_, _>>(
+                    "ReduceMinsMaxes Error Check",
                     move |key, source, target| {
+                        // Negative counts would be surprising, but until we are 100% certain we wont
+                        // see them, we should report when we do. We may want to bake even more info
+                        // in here in the future.
+                        if must_validate {
+                            for (val, count) in source.iter() {
+                                if count.is_positive() {
+                                    continue;
+                                }
+                                let val = val.into_owned();
+                                let message = "Non-positive accumulation in ReduceMinsMaxes";
+                                error_logger.log(message, &format!("val={val:?}, count={count}"));
+                                target.push((EvalError::Internal(message.to_string()).into(), 1));
+                                return;
+                            }
+                        }
+
+                        // We know that `mfp_after` can error if it exists, so try to evaluate it here.
+                        let Some(mfp) = &mfp_after2 else { return };
                         let temp_storage = RowArena::new();
                         let datum_iter = key.into_datum_iter(None);
-                        let mut datums_local = datums1.borrow();
+                        let mut datums_local = datums2.borrow();
                         datums_local.extend(datum_iter);
-                        let key_len = datums_local.len();
-                        for (aggr_index, func) in aggr_funcs.iter().enumerate() {
+                        for (aggr_index, func) in aggr_funcs2.iter().enumerate() {
                             let iter = source
                                 .iter()
                                 .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
                             datums_local.push(func.eval(iter, &temp_storage));
                         }
-
-                        if let Some(row) = evaluate_mfp_after(
-                            &mfp_after1,
-                            &mut datums_local,
-                            &temp_storage,
-                            key_len,
-                        ) {
-                            target.push((row, 1));
+                        if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage)
+                        {
+                            target.push((e.into(), 1));
                         }
+                    },
+                )
+                .as_collection(|_, v| v.into_owned())
+                .leave_region();
+            if let Some(e) = &err_output {
+                err_output = Some(e.concat(&errs));
+            } else {
+                err_output = Some(errs);
+            }
+        }
+        let arranged_output = arranged
+            .mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceMinsMaxes", {
+                move |key, source, target| {
+                    let temp_storage = RowArena::new();
+                    let datum_iter = key.into_datum_iter(None);
+                    let mut datums_local = datums1.borrow();
+                    datums_local.extend(datum_iter);
+                    let key_len = datums_local.len();
+                    for (aggr_index, func) in aggr_funcs.iter().enumerate() {
+                        let iter = source
+                            .iter()
+                            .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
+                        datums_local.push(func.eval(iter, &temp_storage));
                     }
-                })
-                .leave_region()
-        });
+
+                    if let Some(row) =
+                        evaluate_mfp_after(&mfp_after1, &mut datums_local, &temp_storage, key_len)
+                    {
+                        target.push((row, 1));
+                    }
+                }
+            })
+            .leave_region();
+
         (
             arranged_output,
             err_output.expect("expected to validate in one level of the hierarchy"),


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
