### PR TITLE
RQG: Assume the test needs to run against Materialize if --other-tag …

### DIFF
--- a/test/rqg/mzcompose.py
+++ b/test/rqg/mzcompose.py
@@ -155,7 +155,14 @@ def run_workload(c: Composition, args: argparse.Namespace, workload: Workload) -
 
     psql_urls = ["postgresql://materialize@mz_this:6875/materialize"]
 
-    match workload.reference_implementation:
+    # If we have --other-tag, assume we want to run a comparison test against Materialize
+    reference_implementation = (
+        ReferenceImplementation.MATERIALIZE
+        if args.other_tag and workload.reference_implementation is not None
+        else workload.reference_implementation
+    )
+
+    match reference_implementation:
         case ReferenceImplementation.MATERIALIZE:
             participants.append(
                 Materialized(
@@ -179,8 +186,8 @@ def run_workload(c: Composition, args: argparse.Namespace, workload: Workload) -
     files = [] if workload.dataset is None else workload.dataset.files()
 
     dsn2 = (
-        [f"--dsn2=dbi:Pg:{workload.reference_implementation.dsn()}"]
-        if workload.reference_implementation is not None
+        [f"--dsn2=dbi:Pg:{reference_implementation.dsn()}"]
+        if reference_implementation is not None
         else []
     )
 


### PR DESCRIPTION
…is specified

### Motivation

This is needed to facilitate the use of the RQG for detecting plan regressions. So we have two uses of the same workload:

1. In CI: normal SELECT queries, comparison between Mz and Postgres:
`mzcompose run default simple-aggregates`

3. Manual query plan testing: EXPLAIN SELECT queries from the same grammar, comparison between two Mz instances.
`mzcompose run default --other-tag=v1234 --starting-rule=explain simple-aggregates`

Both of those will be possible without any hand-editing of mzcompose or grammar files.