### PR TITLE
catalog: Add E2E migration tests with failures

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -103,6 +103,8 @@ IGNORE_RE = re.compile(
     | platform-checks-clusterd.* \| .* received\ persist\ state\ from\ the\ future
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage(\ to\ set\ (default|configured)\ parameter)?
     | internal\ error:\ no\ AWS\ external\ ID\ prefix\ configured
+    # For persist-catalog-migration ignore failpoint panics
+    | persist-catalog-migration-materialized.* \| .* failpoint\ .* panic
     )
     """,
     re.VERBOSE | re.MULTILINE,

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -710,7 +710,7 @@ class Composition:
             *(["--detach"] if detach else []),
             *(["--wait"] if wait else []),
             *services,
-            max_tries=2,
+            max_tries=max_tries,
         )
 
         if persistent:

--- a/test/persist-catalog-migration/mzcompose.py
+++ b/test/persist-catalog-migration/mzcompose.py
@@ -12,6 +12,7 @@ from textwrap import dedent
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.testdrive import Testdrive
+from materialize.ui import UIError
 
 SERVICES = [
     Materialized(catalog_store="stash"),
@@ -69,8 +70,228 @@ def workflow_test_migration_and_rollback(c: Composition) -> None:
     check_objects(c, 1)
 
 
-# Tests that Materialize doesn't crash due to the epoch going backwards after a migration.
+# TODO(jkosh44) There's a class of tests that are missing that do the following:
+#   1. Try to start up with catalog implementation A and panic during startup.
+#   2. Switch to catalog implementation B while Materialize is down.
+#   3. Start up successfully with catalog implementation B.
+# In order to test this scenario, we need to manually alter the catalog while Materialize is down,
+# which is not currently possible via mzcompose.
+
+
+def workflow_test_migration_panic_after_stash_fence_then_migrate(c: Composition):
+    c.down(destroy_volumes=True)
+    c.up("testdrive", persistent=True)
+
+    # Create initial objects and update flag.
+    c.up("materialized")
+    create_objects(c, 0)
+    c.testdrive(
+        input=dedent(
+            """
+    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+    ALTER SYSTEM SET catalog_kind TO 'persist'
+    """
+        )
+    )
+    c.kill("materialized")
+
+    # Panic during migration.
+    try:
+        with c.override(
+            Materialized(
+                catalog_store="stash",
+                environment_extra=["FAILPOINTS=post_stash_fence=panic"]
+            )
+        ):
+            # Note: We actually want to retry this 0 times, but we need to retry at least once so a
+            # UIError is raised instead of an AssertionError
+            c.up("materialized", max_tries=1)
+    except UIError:
+        pass
+
+    # Complete migration and check objects.
+    c.up("materialized")
+    check_objects(c, 0)
+
+
+def workflow_test_rollback_panic_after_stash_fence_then_rollback(c: Composition):
+    c.down(destroy_volumes=True)
+    c.up("testdrive", persistent=True)
+
+    # Create initial objects and update flag.
+    c.up("materialized")
+    create_objects(c, 0)
+    c.testdrive(
+        input=dedent(
+            """
+    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+    ALTER SYSTEM SET catalog_kind TO 'persist'
+    """
+        )
+    )
+    c.kill("materialized")
+
+    # Perform migration, check objects, create more objects, and update flag.
+    c.up("materialized")
+    check_objects(c, 0)
+    create_objects(c, 1)
+    c.testdrive(
+        input=dedent(
+            """
+    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+    ALTER SYSTEM SET catalog_kind TO 'stash'
+    """
+        )
+    )
+    c.kill("materialized")
+
+    # Panic during rollback.
+    try:
+        with c.override(
+            Materialized(
+                catalog_store="stash",
+                environment_extra=["FAILPOINTS=post_stash_fence=panic"]
+            )
+        ):
+            # Note: We actually want to retry this 0 times, but we need to retry at least once so a
+            # UIError is raised instead of an AssertionError
+            c.up("materialized", max_tries=1)
+    except UIError:
+        pass
+
+    # Complete migration and check objects.
+    c.up("materialized")
+    check_objects(c, 0)
+    check_objects(c, 1)
+
+
+def workflow_test_migration_panic_after_fence_then_migrate(c: Composition):
+    c.down(destroy_volumes=True)
+    c.up("testdrive", persistent=True)
+
+    # Create initial objects and update flag.
+    c.up("materialized")
+    create_objects(c, 0)
+    c.testdrive(
+        input=dedent(
+            """
+    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+    ALTER SYSTEM SET catalog_kind TO 'persist'
+    """
+        )
+    )
+    c.kill("materialized")
+
+    # Panic during migration.
+    try:
+        with c.override(
+            Materialized(
+                catalog_store="stash",
+                environment_extra=["FAILPOINTS=post_persist_fence=panic"]
+            )
+        ):
+            # Note: We actually want to retry this 0 times, but we need to retry at least once so a
+            # UIError is raised instead of an AssertionError
+            c.up("materialized", max_tries=1)
+    except UIError:
+        pass
+
+    # Complete migration and check objects.
+    c.up("materialized")
+    check_objects(c, 0)
+
+
+def workflow_test_rollback_panic_after_fence_then_rollback(c: Composition):
+    c.down(destroy_volumes=True)
+    c.up("testdrive", persistent=True)
+
+    # Create initial objects and update flag.
+    c.up("materialized")
+    create_objects(c, 0)
+    c.testdrive(
+        input=dedent(
+            """
+    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+    ALTER SYSTEM SET catalog_kind TO 'persist'
+    """
+        )
+    )
+    c.kill("materialized")
+
+    # Perform migration, check objects, create more objects, and update flag.
+    c.up("materialized")
+    check_objects(c, 0)
+    create_objects(c, 1)
+    c.testdrive(
+        input=dedent(
+            """
+    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+    ALTER SYSTEM SET catalog_kind TO 'stash'
+    """
+        )
+    )
+    c.kill("materialized")
+
+    # Panic during rollback.
+    try:
+        with c.override(
+            Materialized(
+                catalog_store="stash",
+                environment_extra=["FAILPOINTS=post_persist_fence=panic"]
+            )
+        ):
+            # Note: We actually want to retry this 0 times, but we need to retry at least once so a
+            # UIError is raised instead of an AssertionError
+            c.up("materialized", max_tries=1)
+    except UIError:
+        pass
+
+    # Complete migration and check objects.
+    c.up("materialized")
+    check_objects(c, 0)
+    check_objects(c, 1)
+
+
+def workflow_test_migration_panic_after_write_then_migrate(c: Composition):
+    c.down(destroy_volumes=True)
+    c.up("testdrive", persistent=True)
+
+    # Create initial objects and update flag.
+    c.up("materialized")
+    create_objects(c, 0)
+    c.testdrive(
+        input=dedent(
+            """
+    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+    ALTER SYSTEM SET catalog_kind TO 'persist'
+    """
+        )
+    )
+    c.kill("materialized")
+
+    # Panic during migration.
+    try:
+        with c.override(
+            Materialized(
+                catalog_store="stash",
+                environment_extra=["FAILPOINTS=migrate_post_write=panic"]
+            )
+        ):
+            # Note: We actually want to retry this 0 times, but we need to retry at least once so a
+            # UIError is raised instead of an AssertionError
+            c.up("materialized", max_tries=1)
+    except UIError:
+        pass
+
+    # Complete migration and check objects.
+    c.up("materialized")
+    check_objects(c, 0)
+
+
 def workflow_test_epoch_migration(c: Composition) -> None:
+    """
+    Tests that Materialize doesn't crash due to the epoch going backwards after a migration.
+    """
     reboots = 2
     c.down(destroy_volumes=True)
     c.up("testdrive", persistent=True)

--- a/test/persist-catalog-migration/mzcompose.py
+++ b/test/persist-catalog-migration/mzcompose.py
@@ -100,7 +100,7 @@ def workflow_test_migration_panic_after_stash_fence_then_migrate(c: Composition)
         with c.override(
             Materialized(
                 catalog_store="stash",
-                environment_extra=["FAILPOINTS=post_stash_fence=panic"]
+                environment_extra=["FAILPOINTS=post_stash_fence=panic"],
             )
         ):
             # Note: We actually want to retry this 0 times, but we need to retry at least once so a
@@ -150,7 +150,7 @@ def workflow_test_rollback_panic_after_stash_fence_then_rollback(c: Composition)
         with c.override(
             Materialized(
                 catalog_store="stash",
-                environment_extra=["FAILPOINTS=post_stash_fence=panic"]
+                environment_extra=["FAILPOINTS=post_stash_fence=panic"],
             )
         ):
             # Note: We actually want to retry this 0 times, but we need to retry at least once so a
@@ -187,7 +187,7 @@ def workflow_test_migration_panic_after_fence_then_migrate(c: Composition):
         with c.override(
             Materialized(
                 catalog_store="stash",
-                environment_extra=["FAILPOINTS=post_persist_fence=panic"]
+                environment_extra=["FAILPOINTS=post_persist_fence=panic"],
             )
         ):
             # Note: We actually want to retry this 0 times, but we need to retry at least once so a
@@ -237,7 +237,7 @@ def workflow_test_rollback_panic_after_fence_then_rollback(c: Composition):
         with c.override(
             Materialized(
                 catalog_store="stash",
-                environment_extra=["FAILPOINTS=post_persist_fence=panic"]
+                environment_extra=["FAILPOINTS=post_persist_fence=panic"],
             )
         ):
             # Note: We actually want to retry this 0 times, but we need to retry at least once so a
@@ -274,7 +274,7 @@ def workflow_test_migration_panic_after_write_then_migrate(c: Composition):
         with c.override(
             Materialized(
                 catalog_store="stash",
-                environment_extra=["FAILPOINTS=migrate_post_write=panic"]
+                environment_extra=["FAILPOINTS=migrate_post_write=panic"],
             )
         ):
             # Note: We actually want to retry this 0 times, but we need to retry at least once so a


### PR DESCRIPTION
This commit adds end-to-end tests using mzcompose that test the
catalog implementation migration and rollback processes when failures
happen during a migration or rollback.

Works towards resolving #24218


### Motivation
Adds tests

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
