### PR TITLE
[persist / storage] Fix up some time-range handling in the source

### DIFF
--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -196,10 +196,13 @@ impl<'a> ResultSpec<'a> {
     pub fn value_between(min: Datum<'a>, max: Datum<'a>) -> ResultSpec<'a> {
         assert!(!min.is_null());
         assert!(!max.is_null());
-        assert!(min <= max);
-        ResultSpec {
-            values: Values::Within(min, max),
-            ..ResultSpec::nothing()
+        if min <= max {
+            ResultSpec {
+                values: Values::Within(min, max),
+                ..ResultSpec::nothing()
+            }
+        } else {
+            ResultSpec::nothing()
         }
     }
 


### PR DESCRIPTION
Three semi-related changes.
- Unify two related variables in shard_source. Aside from the cleanup value, this fixes an issue on the first iteration when the as-of is larger than then until. (A weird but apparently valid case!)
- In the should-filter function, explicitly filter batches that can't ever lead to any output.
- Make the `ResultSpec::value_between` function defined when min > max, matching Rust's semantics for `min..=max`. (In practice I've seen this assert fail twice now; in both cases this new behaviour would have been fine, and the assertion was misleading.)

### Motivation

https://github.com/MaterializeInc/materialize/issues/24323

### Tips for reviewer

Any of these commits would have avoided the panic in the ticket, so this is in some sense overkill, but I think each of them is an improvement. The only one I feel strongly about is the first one; if folks don't like the others I can probably just rebase them out.

It would be good to have more test coverage for the as-of > until case. (The original failure was found by our randomized stress testing and may be hard to reproduce on main.) It sounds like this may happen when using `REFRESH AT` and restarting the cluster, but I'm not clear on whether there's a reliable way to provoke this in tests.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
