### PR TITLE
coord: Auto-route `SHOW COLUMNS` commands to `mz_introspection`

### DIFF
--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -45,6 +45,10 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
             plan.source.depends_on(),
             plan.source.could_run_expensive_function(),
         ),
+        Plan::ShowColumns(plan) => (
+            plan.select_plan.source.depends_on(),
+            plan.select_plan.source.could_run_expensive_function(),
+        ),
         Plan::Subscribe(plan) => (
             plan.from.depends_on(),
             match &plan.from {
@@ -86,7 +90,6 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
         | Plan::EmptyQuery
         | Plan::ShowAllVariables
         | Plan::ShowCreate(_)
-        | Plan::ShowColumns(_)
         | Plan::ShowVariable(_)
         | Plan::InspectShard(_)
         | Plan::SetVariable(_)

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -142,11 +142,6 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
         | Plan::SideEffectingFunc(_) => return TargetCluster::Active,
     };
 
-    // Use transaction cluster if we're mid-transaction
-    if let Some(cluster_id) = session.transaction().cluster() {
-        return TargetCluster::Transaction(cluster_id);
-    }
-
     // Bail if the user has disabled it via the SessionVar.
     if !session.vars().auto_route_introspection_queries() {
         return TargetCluster::Active;

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -1223,6 +1223,34 @@ SELECT * FROM blue_t1 LIMIT 1;
 ----
 10
 
+# Make sure SHOW COLUMNS does not use a different cluster during a transaction.
+#
+# SHOW COLUMNS is planned separately from other SHOW statements, and previously it would ignore
+# the mz_introspection auto-routing. This resulted in its dependents being outside the timedomain
+# of the transaction.
+
+statement ok
+BEGIN;
+
+query T
+SELECT name FROM mz_columns WHERE name = 'foobar';
+----
+
+query TTT
+SHOW COLUMNS IN mz_columns
+----
+id  false  text
+name  false  text
+position  false  uint8
+nullable  false  boolean
+type  false  text
+default  true  text
+type_oid  false  oid
+type_mod  false  integer
+
+statement ok
+COMMIT;
+
 # Cleanup.
 
 statement ok


### PR DESCRIPTION
This PR updates the `mz_introspection` auto-routing to include `SHOW COLUMNS` commands, and pulls the "transaction cluster checking" up one layer to avoid other possible conflicts between the current transaction cluster and auto-routing to `mz_introspection`

### Motivation

Related to https://github.com/MaterializeInc/materialize/issues/24341

I could not get a repro for the above panic, but the issue pertains to a SELECT within a transaction being run in mz_introspection, and then a second SELECT getting run on the quickstart cluster. Just by looking at the code the only case where I could see this being possible is in `SHOW COLUMNS`, where we previously skipped the auto-routing check and thus disregarded the cluster for the current transaction.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Should fix a possible panic scenario.
