### PR TITLE
Improve representation in distinct aggregates

### DIFF
--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 pub use self::container::DatumContainer;
+pub use self::container::DatumSeq;
 pub use self::spines::{RowRowSpine, RowSpine, RowValSpine};
 
 /// Spines specialized to contain `Row` types in keys and values.


### PR DESCRIPTION
This PR improves the representation employed in distinct aggregates from `(Row, Row)` to `Row`, thus allowing us to employ `Row*Spine` types. We expect this representation to be more memory efficient due to enabling the use of `DatumContainer`.

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/24336

### Tips for reviewer

To avoid repeating boilerplate code, I introduced a `Pairer` struct to `merge` and `split` pair to/from `Row`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
