### PR TITLE
catalog: Fix tombstone value for emergency stash

### DIFF
--- a/src/catalog/src/durable/impls/migrate.rs
+++ b/src/catalog/src/durable/impls/migrate.rs
@@ -221,12 +221,11 @@ impl OpenableDurableCatalogState for CatalogMigrator {
     }
 
     async fn is_initialized(&mut self) -> Result<bool, CatalogError> {
-        match self.target {
-            if tombstone == Some(true) {
-                self.openable_persist.is_initialized().await
-            } else {
+        let tombstone = self.get_tombstone().await?;
+        if tombstone == Some(true) {
+            self.openable_persist.is_initialized().await
+        } else {
             self.openable_stash.is_initialized().await
-            }
         }
     }
 

--- a/src/catalog/tests/migrate.rs
+++ b/src/catalog/tests/migrate.rs
@@ -2153,7 +2153,7 @@ async fn test_emergency_stash_tombstone() {
 
     {
         // Open a persist catalog.
-        let mut persist_openable_state = Box::new(
+        let persist_openable_state = Box::new(
             migrate_from_stash_to_persist_state(
                 stash_config.clone(),
                 persist_client.clone(),
@@ -2175,7 +2175,7 @@ async fn test_emergency_stash_tombstone() {
     }
 
     {
-        // Open an emergency stash catalog (It doesn't matter if we start with a migrate or rollback
+        // Open an emergency stash catalog (it doesn't matter if we start with a migrate or rollback
         // catalog because we change it to emergency-stash).
         let mut emergency_stash_openable_state = Box::new(
             rollback_from_persist_to_stash_state(

--- a/src/catalog/tests/migrate.rs
+++ b/src/catalog/tests/migrate.rs
@@ -2143,6 +2143,106 @@ async fn test_set_emergency_stash_rollback() {
     debug_factory.drop().await;
 }
 
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_emergency_stash_tombstone() {
+    let (debug_factory, stash_config) = test_stash_config().await;
+    let persist_client = PersistClient::new_for_tests().await;
+    let organization_id = Uuid::new_v4();
+    let persist_metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
+
+    {
+        // Open a persist catalog.
+        let mut persist_openable_state = Box::new(
+            migrate_from_stash_to_persist_state(
+                stash_config.clone(),
+                persist_client.clone(),
+                organization_id.clone(),
+                Arc::clone(&persist_metrics),
+            )
+            .await,
+        );
+        let mut persist_state = persist_openable_state
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
+            .await
+            .unwrap();
+
+        // Update catalog_kind (in persist) to emergency-stash.
+        let mut txn = persist_state.transaction().await.unwrap();
+        txn.set_catalog_kind(Some(CatalogKind::EmergencyStash))
+            .unwrap();
+        txn.commit().await.unwrap();
+    }
+
+    {
+        // Open an emergency stash catalog (It doesn't matter if we start with a migrate or rollback
+        // catalog because we change it to emergency-stash).
+        let mut emergency_stash_openable_state = Box::new(
+            rollback_from_persist_to_stash_state(
+                stash_config.clone(),
+                persist_client.clone(),
+                organization_id.clone(),
+                Arc::clone(&persist_metrics),
+            )
+            .await,
+        );
+        emergency_stash_openable_state.set_catalog_kind(CatalogKind::EmergencyStash);
+        let mut emergency_stash_state = emergency_stash_openable_state
+            .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
+            .await
+            .unwrap();
+
+        // Update catalog_kind (in the stash) to persist.
+        let mut txn = emergency_stash_state.transaction().await.unwrap();
+        txn.set_catalog_kind(Some(CatalogKind::Persist)).unwrap();
+        txn.commit().await.unwrap();
+    }
+
+    // Check that a migrate implementation reads from the correct location pre-boot.
+    {
+        let mut openable_state = Box::new(
+            migrate_from_stash_to_persist_state(
+                stash_config.clone(),
+                persist_client.clone(),
+                organization_id.clone(),
+                Arc::clone(&persist_metrics),
+            )
+            .await,
+        );
+        assert_eq!(
+            CatalogKind::Persist,
+            openable_state
+                .get_catalog_kind_config()
+                .await
+                .unwrap()
+                .unwrap()
+        )
+    }
+
+    // Check that a rollback implementation reads from the correct location pre-boot.
+    {
+        let mut openable_state = Box::new(
+            rollback_from_persist_to_stash_state(
+                stash_config.clone(),
+                persist_client.clone(),
+                organization_id.clone(),
+                Arc::clone(&persist_metrics),
+            )
+            .await,
+        );
+        assert_eq!(
+            CatalogKind::Persist,
+            openable_state
+                .get_catalog_kind_config()
+                .await
+                .unwrap()
+                .unwrap()
+        )
+    }
+
+    debug_factory.drop().await;
+}
+
 /// Test that the epoch is migrated and rolled back correctly.
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`


### PR DESCRIPTION
The emergency stash implementation is an escape hatch which allows us to use the stash catalog in a customer's environment without performing a rollback. It's meant for emergency situations when a rollback is impossible. Previously, when using the emergency-stash Materialize would not update the catalog tombstone value in the stash. The tombstone value is used to determine which catalog implementation to use during start up. As a consequence Materialize could end up in a situation where Materialize looks at the wrong catalog during start up. For example:

  1. The tombstone value is true, i.e. use the persist catalog.
  2. Start the environment with the emergency stash catalog.
  3. Make changes to the catalog in the stash that are expected to be visible on restart.
  4. Restart.
  5. The tombstone value is still true, so perform all reads against persist during startup.

This commit updates the emergency stash implementation such that it ensures the tombstone value is false, which causes materialize to read from the stash during start up.

Works towards resolving #24218

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
