### PR TITLE
Consolidate collections without building batches

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -52,7 +52,8 @@ disallowed-methods = [
 
     # Prevent access to Differential APIs that want to use the default trace or use a default name, or where we offer
     # our own wrapper
-    { path = "differential_dataflow::Collection::consolidate", reason = "use the `differential_dataflow::Collection::consolidate_named` function instead" },
+    { path = "differential_dataflow::Collection::consolidate", reason = "use the `mz_timely_util::operator::CollectionExt::consolidate_named` function instead" },
+    { path = "differential_dataflow::Collection::consolidate_named", reason = "use the `mz_timely_util::operator::CollectionExt::consolidate_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::Arrange::arrange", reason = "use the `MzArrange::mz_arrange_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::Arrange::arrange_named", reason = "use the `MzArrange::mz_arrange_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::Arrange::arrange_core", reason = "use the `MzArrange::mz_arrange_core` function instead" },

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -139,7 +139,7 @@ use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::MzReduce;
 use crate::logging::compute::{LogDataflowErrors, LogImportFrontiers};
 use crate::render::context::{ArrangementFlavor, Context, ShutdownToken, SpecializedArrangement};
-use crate::typedefs::{ErrSpine, KeySpine};
+use crate::typedefs::{ErrSpine, KeyBatcher};
 
 pub mod context;
 mod errors;
@@ -675,7 +675,7 @@ where
                 let (oks_v, err_v) = variables.remove(&Id::Local(*id)).unwrap();
 
                 // Set oks variable to `oks` but consolidated to ensure iteration ceases at fixed point.
-                let mut oks = oks.consolidate_named::<KeySpine<_, _, _>>("LetRecConsolidation");
+                let mut oks = oks.consolidate_named::<KeyBatcher<_, _, _>>("LetRecConsolidation");
                 if let Some(token) = &self.shutdown_token.get_inner() {
                     oks = oks.with_token(Weak::clone(token));
                 }
@@ -923,7 +923,7 @@ where
                 }
                 let mut oks = differential_dataflow::collection::concatenate(&mut self.scope, oks);
                 if consolidate_output {
-                    oks = oks.consolidate_named::<KeySpine<_, _, _>>("UnionConsolidation")
+                    oks = oks.consolidate_named::<KeyBatcher<_, _, _>>("UnionConsolidation")
                 }
                 let errs = differential_dataflow::collection::concatenate(&mut self.scope, errs);
                 CollectionBundle::from_collections(oks, errs)

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -49,7 +49,8 @@ use crate::render::errors::MaybeValidatingRow;
 use crate::render::reduce::monoids::{get_monoid, ReductionMonoid};
 use crate::render::ArrangementFlavor;
 use crate::typedefs::{
-    KeySpine, KeyValSpine, RowErrSpine, RowRowArrangement, RowRowSpine, RowSpine, RowValSpine,
+    KeyBatcher, KeySpine, KeyValSpine, RowErrSpine, RowRowArrangement, RowRowSpine, RowSpine,
+    RowValSpine,
 };
 
 impl<G, T> Context<G, T>
@@ -997,7 +998,7 @@ where
                 stage = negated_output
                     .negate()
                     .concat(&input)
-                    .consolidate_named::<KeySpine<_, _, _>>("Consolidated MinsMaxesHierarchical");
+                    .consolidate_named::<KeyBatcher<_, _, _>>("Consolidated MinsMaxesHierarchical");
             }
 
             // Discard the hash from the key and return to the format of the input data.
@@ -1205,7 +1206,7 @@ where
 
                 (key, values)
             })
-            .consolidate_named_if::<KeySpine<_, _, _>>(
+            .consolidate_named_if::<KeyBatcher<_, _, _>>(
                 must_consolidate,
                 "Consolidated ReduceMonotonic input",
             );

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -37,7 +37,7 @@ use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::extensions::reduce::MzReduce;
 use crate::render::context::{CollectionBundle, Context};
 use crate::render::errors::MaybeValidatingRow;
-use crate::typedefs::{KeySpine, KeyValSpine, RowRowSpine, RowSpine};
+use crate::typedefs::{KeyBatcher, KeyValSpine, RowRowSpine, RowSpine};
 
 // The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.
 impl<G> Context<G>
@@ -136,7 +136,7 @@ where
                             };
                             (group_row, row)
                         })
-                        .consolidate_named_if::<KeySpine<_, _, _>>(
+                        .consolidate_named_if::<KeyBatcher<_, _, _>>(
                             must_consolidate,
                             "Consolidated MonotonicTopK input",
                         );
@@ -379,7 +379,7 @@ where
         (
             oks.negate()
                 .concat(&input)
-                .consolidate_named::<KeySpine<_, _, _>>("Consolidated TopK"),
+                .consolidate_named::<KeyBatcher<_, _, _>>("Consolidated TopK"),
             errs,
         )
     }
@@ -413,7 +413,7 @@ where
                     (group_key, row)
                 }
             })
-            .consolidate_named_if::<KeySpine<_, _, _>>(
+            .consolidate_named_if::<KeyBatcher<_, _, _>>(
                 must_consolidate,
                 "Consolidated MonotonicTop1 input",
             );

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -12,6 +12,7 @@
 #![allow(dead_code, missing_docs)]
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::operators::arrange::TraceAgent;
+use differential_dataflow::trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
 use differential_dataflow::trace::implementations::ord_neu::{ColKeySpine, ColValSpine};
 use differential_dataflow::trace::wrappers::enter::TraceEnter;
 use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
@@ -55,3 +56,6 @@ pub type ErrAgent<T, R> = TraceAgent<ErrSpine<T, R>>;
 pub type ErrEnter<T, TEnter> = TraceEnter<TraceFrontier<ErrAgent<T, Diff>>, TEnter>;
 pub type KeyErrSpine<K, T, R> = ColValSpine<K, DataflowError, T, R>;
 pub type RowErrSpine<T, R> = RowValSpine<DataflowError, T, R>;
+
+// Batchers for consolidation
+pub type KeyBatcher<K, T, D> = ColumnatedMergeBatcher<K, (), T, D>;

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -15,9 +15,8 @@ use std::rc::Weak;
 
 use differential_dataflow::difference::{Multiply, Semigroup};
 use differential_dataflow::lattice::Lattice;
-use differential_dataflow::operators::arrange::Arrange;
-use differential_dataflow::trace::{Batch, Batcher, Builder, Trace};
-use differential_dataflow::{AsCollection, Collection};
+use differential_dataflow::trace::{Batcher, Builder};
+use differential_dataflow::{AsCollection, Collection, Hashable};
 use timely::dataflow::channels::pact::{Exchange, ParallelizationContract, Pipeline};
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
@@ -25,7 +24,8 @@ use timely::dataflow::operators::generic::operator::{self, Operator};
 use timely::dataflow::operators::generic::{InputHandle, OperatorInfo, OutputHandle};
 use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, Stream};
-use timely::{Data, ExchangeData};
+use timely::progress::{Antichain, Timestamp};
+use timely::{Data, ExchangeData, PartialOrder};
 
 use crate::buffer::ConsolidateBuffer;
 use crate::builder_async::{
@@ -228,16 +228,20 @@ where
 
     /// Consolidates the collection if `must_consolidate` is `true` and leaves it
     /// untouched otherwise.
-    fn consolidate_named_if<Tr>(self, must_consolidate: bool, name: &str) -> Self
+    fn consolidate_named_if<Ba>(self, must_consolidate: bool, name: &str) -> Self
     where
         D1: differential_dataflow::ExchangeData + Hash,
         R: Semigroup + differential_dataflow::ExchangeData,
         G::Timestamp: Lattice,
-        Tr: Trace<KeyOwned = D1, ValOwned = (), Time = G::Timestamp, Diff = R> + 'static,
-        Tr::Batch: Batch,
-        Tr::Batcher: Batcher<Item = ((D1, ()), G::Timestamp, R), Time = G::Timestamp>,
-        Tr::Builder:
-            Builder<Item = ((D1, ()), G::Timestamp, R), Time = G::Timestamp, Output = Tr::Batch>;
+        Ba: Batcher<Item = ((D1, ()), G::Timestamp, R), Time = G::Timestamp> + 'static;
+
+    /// Consolidates the collection.
+    fn consolidate_named<Ba>(self, name: &str) -> Self
+    where
+        D1: differential_dataflow::ExchangeData + Hash,
+        R: Semigroup + differential_dataflow::ExchangeData,
+        G::Timestamp: Lattice,
+        Ba: Batcher<Item = ((D1, ()), G::Timestamp, R), Time = G::Timestamp> + 'static;
 }
 
 impl<G, D1> StreamExt<G, D1> for Stream<G, D1>
@@ -544,16 +548,12 @@ where
         self.inner.with_token(token).as_collection()
     }
 
-    fn consolidate_named_if<Tr>(self, must_consolidate: bool, name: &str) -> Self
+    fn consolidate_named_if<Ba>(self, must_consolidate: bool, name: &str) -> Self
     where
         D1: differential_dataflow::ExchangeData + Hash,
         R: Semigroup + differential_dataflow::ExchangeData,
         G::Timestamp: Lattice + Ord,
-        Tr: Trace<KeyOwned = D1, ValOwned = (), Time = G::Timestamp, Diff = R> + 'static,
-        Tr::Batch: Batch,
-        Tr::Batcher: Batcher<Item = ((D1, ()), G::Timestamp, R), Time = G::Timestamp>,
-        Tr::Builder:
-            Builder<Item = ((D1, ()), G::Timestamp, R), Time = G::Timestamp, Output = Tr::Batch>,
+        Ba: Batcher<Item = ((D1, ()), G::Timestamp, R), Time = G::Timestamp> + 'static,
     {
         if must_consolidate {
             // We employ AHash below instead of the default hasher in DD to obtain
@@ -585,14 +585,26 @@ where
                 data.hash(&mut h);
                 h.finish()
             });
-            use differential_dataflow::trace::cursor::MyTrait;
             // Access to `arrange_core` is OK because we specify the trace and don't hold on to it.
-            #[allow(clippy::disallowed_methods)]
-            self.arrange_core::<_, Tr>(exchange, name)
-                .as_collection(|k, _v| k.into_owned())
+            consolidate_pact::<Ba, _, _, _, _, _>(&self.map(|k| (k, ())), exchange, name)
+                .map(|(k, ())| k)
         } else {
             self
         }
+    }
+
+    fn consolidate_named<Ba>(self, name: &str) -> Self
+    where
+        D1: differential_dataflow::ExchangeData + Hash,
+        R: Semigroup + differential_dataflow::ExchangeData,
+        G::Timestamp: Lattice + Ord,
+        Ba: Batcher<Item = ((D1, ()), G::Timestamp, R), Time = G::Timestamp> + 'static,
+    {
+        let exchange =
+            Exchange::new(move |update: &((D1, ()), G::Timestamp, R)| (update.0).0.hashed().into());
+
+        consolidate_pact::<Ba, _, _, _, _, _>(&self.map(|k| (k, ())), exchange, name)
+            .map(|(k, ())| k)
     }
 }
 
@@ -623,4 +635,155 @@ where
     });
 
     stream
+}
+
+/// Aggregates the weights of equal records into at most one record.
+///
+/// The data are accumulated in place, each held back until their timestamp has completed.
+///
+/// This serves as a low-level building-block for more user-friendly functions.
+pub fn consolidate_pact<B, P, G, K, V, R>(
+    collection: &Collection<G, (K, V), R>,
+    pact: P,
+    name: &str,
+) -> Collection<G, (K, V), R>
+where
+    G: Scope,
+    K: Data,
+    V: Data,
+    R: Data + Semigroup,
+    B: Batcher<Item = ((K, V), G::Timestamp, R), Time = G::Timestamp> + 'static,
+    P: ParallelizationContract<G::Timestamp, ((K, V), G::Timestamp, R)>,
+{
+    collection
+        .inner
+        .unary_frontier(pact, name, |_cap, info| {
+            // Acquire a logger for arrange events.
+            let logger = {
+                let scope = collection.scope();
+                let register = scope.log_register();
+                register.get::<differential_dataflow::logging::DifferentialEvent>(
+                    "differential/arrange",
+                )
+            };
+
+            let mut batcher = B::new(logger, info.global_id);
+            // Capabilities for the lower envelope of updates in `batcher`.
+            let mut capabilities = Antichain::<Capability<G::Timestamp>>::new();
+            let mut prev_frontier = Antichain::from_elem(G::Timestamp::minimum());
+
+            move |input, output| {
+                input.for_each(|cap, data| {
+                    capabilities.insert(cap.retain());
+                    batcher.push_batch(data);
+                });
+
+                if prev_frontier.borrow() != input.frontier().frontier() {
+                    if capabilities
+                        .elements()
+                        .iter()
+                        .any(|c| !input.frontier().less_equal(c.time()))
+                    {
+                        let mut upper = Antichain::new(); // re-used allocation for sealing batches.
+
+                        // For each capability not in advance of the input frontier ...
+                        for (index, capability) in capabilities.elements().iter().enumerate() {
+                            if !input.frontier().less_equal(capability.time()) {
+                                // Assemble the upper bound on times we can commit with this capabilities.
+                                // We must respect the input frontier, and *subsequent* capabilities, as
+                                // we are pretending to retire the capability changes one by one.
+                                upper.clear();
+                                for time in input.frontier().frontier().iter() {
+                                    upper.insert(time.clone());
+                                }
+                                for other_capability in &capabilities.elements()[(index + 1)..] {
+                                    upper.insert(other_capability.time().clone());
+                                }
+
+                                // send the batch to downstream consumers, empty or not.
+                                let mut session = output.session(&capabilities.elements()[index]);
+                                // Extract updates not in advance of `upper`.
+                                let output =
+                                    batcher.seal::<ConsolidateBuilder<_, _, _, _>>(upper.clone());
+                                for mut batch in output {
+                                    session.give_container(&mut batch);
+                                }
+                            }
+                        }
+
+                        // Having extracted and sent batches between each capability and the input frontier,
+                        // we should downgrade all capabilities to match the batcher's lower update frontier.
+                        // This may involve discarding capabilities, which is fine as any new updates arrive
+                        // in messages with new capabilities.
+
+                        let mut new_capabilities = Antichain::new();
+                        for time in batcher.frontier().iter() {
+                            if let Some(capability) = capabilities
+                                .elements()
+                                .iter()
+                                .find(|c| c.time().less_equal(time))
+                            {
+                                new_capabilities.insert(capability.delayed(time));
+                            } else {
+                                panic!("failed to find capability");
+                            }
+                        }
+
+                        capabilities = new_capabilities;
+                    }
+
+                    prev_frontier.clear();
+                    prev_frontier.extend(input.frontier().frontier().iter().cloned());
+                }
+            }
+        })
+        .as_collection()
+}
+
+/// A builder that wraps a session for direct output to a stream.
+struct ConsolidateBuilder<K: Data, V: Data, T: Timestamp, R: Data> {
+    // Session<'a, T, Vec<((K, V), T, R)>, Counter<T, ((K, V), T, R), Tee<T, ((K, V), T, R)>>>,
+    buffer: Vec<Vec<((K, V), T, R)>>,
+}
+
+impl<K: Data, V: Data, T: Timestamp, R: Data> Builder for ConsolidateBuilder<K, V, T, R> {
+    type Item = ((K, V), T, R);
+    type Time = T;
+    type Output = Vec<Vec<Self::Item>>;
+
+    fn new() -> Self {
+        Self {
+            buffer: Vec::default(),
+        }
+    }
+
+    fn with_capacity(_keys: usize, _vals: usize, _upds: usize) -> Self {
+        Self::new()
+    }
+
+    fn push(&mut self, element: Self::Item) {
+        if let Some(last) = self.buffer.last_mut() {
+            if last.len() < last.capacity() {
+                last.push(element);
+                return;
+            }
+        }
+        let mut new =
+            Vec::with_capacity(timely::container::buffer::default_capacity::<Self::Item>());
+        new.push(element);
+        self.buffer.push(new);
+    }
+
+    fn copy(&mut self, element: &Self::Item) {
+        self.push(element.clone())
+    }
+
+    fn done(
+        self,
+        _lower: Antichain<Self::Time>,
+        _upper: Antichain<Self::Time>,
+        _since: Antichain<Self::Time>,
+    ) -> Self::Output {
+        self.buffer
+    }
 }


### PR DESCRIPTION
This changes consolidation to stream output without building intermediate batches. Ideally, it avoids a memory spike that's caused by keeping around two representations of the same data.

The implementation buffers the output in appropriately-sized batches as expected by Timely, but it only surfaces them after the whole batch's data is ready. An alternative implementation could directly surface the data, which could allow some downstream operators to see the data earlier. This is currently not possible due to limitations in the types used by the builder.

This is a re-implementation of https://github.com/TimelyDataflow/differential-dataflow/pull/446.

### Tips for reviewer

The capability tracking logic is directly borrowed from arrange.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
