### PR TITLE
persist-txn: fix optimizer cost statistics for lazy

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1079,8 +1079,7 @@ impl<'a> RunnerInner<'a> {
             deploy_generation: None,
             http_host_name: Some(host_name),
             internal_console_redirect_url: None,
-            // TODO(txn-lazy): Get "lazy" flipped on before turning "lazy" on in prod.
-            persist_txn_tables_cli: Some(PersistTxnTablesImpl::Eager),
+            persist_txn_tables_cli: Some(PersistTxnTablesImpl::Lazy),
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned


### PR DESCRIPTION
This is yet another example of a read path needing to learn how to go through persist-txn for shards that it manages because the physical upper may be lagging behind the logical upper. The other ones all use the `unblock_read` trick but we don't want to do this here because it's too slow (this happens as part of planning). Instead, use the "translate as_of" trick that we invented previously but didn't end up using.

Since this is (finally) enough to get sqllogictests to pass with lazy, go ahead and flip them over to it in CI.

Touches #22173

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
