### PR TITLE
storage: buy us some walltime headroom on storage_command_protobuf_roundtrip

### DIFF
--- a/src/mysql-util/src/desc.rs
+++ b/src/mysql-util/src/desc.rs
@@ -70,8 +70,8 @@ impl Arbitrary for MySqlTableDesc {
         (
             any::<String>(),
             any::<String>(),
-            any::<Vec<MySqlColumnDesc>>(),
-            any::<BTreeSet<MySqlKeyDesc>>(),
+            proptest::collection::vec(any::<MySqlColumnDesc>(), 1..4),
+            proptest::collection::btree_set(any::<MySqlKeyDesc>(), 1..4),
         )
             .prop_map(|(schema_name, name, columns, keys)| Self {
                 schema_name,

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -137,8 +137,8 @@ impl Arbitrary for PostgresTableDesc {
             any::<String>(),
             any::<String>(),
             any::<u32>(),
-            any::<Vec<PostgresColumnDesc>>(),
-            any::<BTreeSet<PostgresKeyDesc>>(),
+            proptest::collection::vec(any::<PostgresColumnDesc>(), 1..4),
+            proptest::collection::btree_set(any::<PostgresKeyDesc>(), 1..4),
         )
             .prop_map(|(name, namespace, oid, columns, keys)| PostgresTableDesc {
                 name,

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -13,7 +13,6 @@ use mz_proto::{IntoRustIfSome, RustType, TryFromProtoError};
 use mz_repr::{ColumnType, GlobalId, RelationDesc, ScalarType};
 use once_cell::sync::Lazy;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
-use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use crate::connections::inline::{
@@ -127,9 +126,20 @@ impl RustType<ProtoMySqlSourceConnection> for MySqlSourceConnection {
     }
 }
 
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MySqlSourceDetails {
     pub tables: Vec<mz_mysql_util::MySqlTableDesc>,
+}
+
+impl Arbitrary for MySqlSourceDetails {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        proptest::collection::vec(any::<mz_mysql_util::MySqlTableDesc>(), 1..4)
+            .prop_map(|tables| Self { tables })
+            .boxed()
+    }
 }
 
 impl RustType<ProtoMySqlSourceDetails> for MySqlSourceDetails {


### PR DESCRIPTION
locally this got this test from 60s to 6 seconds

fixes https://github.com/MaterializeInc/materialize/issues/24381

### Motivation


  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
