### PR TITLE
parallel-workload: Handle new errors

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -91,6 +91,7 @@ class Action:
                     "was concurrently dropped",  # role was dropped
                     "unknown cluster",  # cluster was dropped
                     "the transaction's active cluster has been dropped",  # cluster was dropped
+                    "was removed",  # dependency was removed, started with moving optimization off main thread, see #24367
                 ]
             )
         if exe.db.scenario == Scenario.Cancel:
@@ -111,6 +112,9 @@ class Action:
                     "Connection refused",
                 ]
             )
+        if exe.db.scenario in (Scenario.Kill, Scenario.TogglePersistTxn):
+            # Expected, see #20465
+            result.extend(["unknown catalog item", "unknown schema"])
         if exe.db.scenario == Scenario.Rename:
             result.extend(["unknown schema", "ambiguous reference to schema name"])
         if materialize.parallel_workload.database.NAUGHTY_IDENTIFIERS:
@@ -460,18 +464,7 @@ class DropIndexAction(Action):
                 return False
 
             query = f"DROP INDEX {index}"
-            try:
-                exe.execute(query)
-            except QueryError as e:
-                # expected, see #20465
-                if exe.db.scenario not in (
-                    Scenario.Kill,
-                    Scenario.TogglePersistTxn,
-                ) or (
-                    "unknown catalog item" not in e.msg
-                    and "unknown schema" not in e.msg
-                ):
-                    raise e
+            exe.execute(query)
             exe.db.indexes.remove(index)
             return True
 
@@ -509,18 +502,7 @@ class DropTableAction(Action):
                 return False
 
             query = f"DROP TABLE {table}"
-            try:
-                exe.execute(query)
-            except QueryError as e:
-                # expected, see #20465
-                if exe.db.scenario not in (
-                    Scenario.Kill,
-                    Scenario.TogglePersistTxn,
-                ) or (
-                    "unknown catalog item" not in e.msg
-                    and "unknown schema" not in e.msg
-                ):
-                    raise e
+            exe.execute(query)
             exe.db.tables.remove(table)
         return True
 
@@ -659,15 +641,7 @@ class DropSchemaAction(Action):
                 return False
 
             query = f"DROP SCHEMA {schema}"
-            try:
-                exe.execute(query)
-            except QueryError as e:
-                # expected, see #20465
-                if (
-                    exe.db.scenario not in (Scenario.Kill, Scenario.TogglePersistTxn)
-                    or "unknown schema" not in e.msg
-                ):
-                    raise e
+            exe.execute(query)
             exe.db.schemas.remove(schema)
         return True
 
@@ -813,18 +787,7 @@ class DropViewAction(Action):
                 query = f"DROP MATERIALIZED VIEW {view}"
             else:
                 query = f"DROP VIEW {view}"
-            try:
-                exe.execute(query)
-            except QueryError as e:
-                # expected, see #20465
-                if exe.db.scenario not in (
-                    Scenario.Kill,
-                    Scenario.TogglePersistTxn,
-                ) or (
-                    "unknown catalog item" not in e.msg
-                    and "unknown schema" not in e.msg
-                ):
-                    raise e
+            exe.execute(query)
             exe.db.views.remove(view)
         return True
 
@@ -1333,18 +1296,7 @@ class DropWebhookSourceAction(Action):
                 return False
 
             query = f"DROP SOURCE {source}"
-            try:
-                exe.execute(query)
-            except QueryError as e:
-                # expected, see #20465
-                if exe.db.scenario not in (
-                    Scenario.Kill,
-                    Scenario.TogglePersistTxn,
-                ) or (
-                    "unknown catalog item" not in e.msg
-                    and "unknown schema" not in e.msg
-                ):
-                    raise e
+            exe.execute(query)
             exe.db.webhook_sources.remove(source)
         return True
 
@@ -1406,18 +1358,7 @@ class DropKafkaSourceAction(Action):
                 return False
 
             query = f"DROP SOURCE {source}"
-            try:
-                exe.execute(query)
-            except QueryError as e:
-                # expected, see #20465
-                if exe.db.scenario not in (
-                    Scenario.Kill,
-                    Scenario.TogglePersistTxn,
-                ) or (
-                    "unknown catalog item" not in e.msg
-                    and "unknown schema" not in e.msg
-                ):
-                    raise e
+            exe.execute(query)
             exe.db.kafka_sources.remove(source)
         return True
 
@@ -1483,18 +1424,7 @@ class DropPostgresSourceAction(Action):
                 return False
 
             query = f"DROP SOURCE {source.executor.source}"
-            try:
-                exe.execute(query)
-            except QueryError as e:
-                # expected, see #20465
-                if exe.db.scenario not in (
-                    Scenario.Kill,
-                    Scenario.TogglePersistTxn,
-                ) or (
-                    "unknown catalog item" not in e.msg
-                    and "unknown schema" not in e.msg
-                ):
-                    raise e
+            exe.execute(query)
             exe.db.postgres_sources.remove(source)
         return True
 
@@ -1550,18 +1480,7 @@ class DropKafkaSinkAction(Action):
                 return False
 
             query = f"DROP SINK {sink}"
-            try:
-                exe.execute(query)
-            except QueryError as e:
-                # expected, see #20465
-                if exe.db.scenario not in (
-                    Scenario.Kill,
-                    Scenario.TogglePersistTxn,
-                ) or (
-                    "unknown catalog item" not in e.msg
-                    and "unknown schema" not in e.msg
-                ):
-                    raise e
+            exe.execute(query)
             exe.db.kafka_sinks.remove(sink)
         return True
 


### PR DESCRIPTION
Seem to be happening because we moved optimization off the main thread

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
