### PR TITLE
ci: reenable checks-backup-rollback

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -484,7 +484,6 @@ steps:
 
       - id: checks-backup-rollback
         label: "Checks + backup + rollback to previous"
-        skip: "Requires #18628 to be fixed"
         timeout_in_minutes: 60
         artifact_paths: junit_*.xml
         agents:


### PR DESCRIPTION
Nightly: https://buildkite.com/materialize/nightlies/builds/5956

✅ Nightly is green, can be re-enabled.

This fixes https://buildkite.com/materialize/nightlies/builds/5952#018cfb14-6348-4f37-a396-f56c482c5577 (closed issue warning).