### PR TITLE
testdrive: Fortify certain tests to run with --replicas=4

### DIFF
--- a/test/testdrive/github-24173.td
+++ b/test/testdrive/github-24173.td
@@ -21,12 +21,15 @@
     URL '${testdrive.schema-registry-url}'
   );
 
-> CREATE SINK sink FROM supplier
+> CREATE SINK sink
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM supplier
   INTO KAFKA CONNECTION kafka_fixed (TOPIC 'testdrive-supplier-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
 
 > CREATE SOURCE progress_check
+  IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_fixed (TOPIC 'testdrive-progress-fixed-${testdrive.seed}')
   FORMAT JSON ENVELOPE NONE
 

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -332,6 +332,7 @@ $ kafka-verify-data headers=materialize-timestamp format=avro sink=materialize.p
 1	{"before": null, "after": {"row": {"a": 2, "b": 2}}}
 
 > CREATE SOURCE compaction_test_sink_check
+  IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_fixed (TOPIC 'testdrive-progress-fixed-${testdrive.seed}')
   FORMAT JSON ENVELOPE NONE
 


### PR DESCRIPTION
When testdrive is run with --replicas=4, CREATE SOURCE and CREATE SINK statements need to be directed to a dedicated single-replica cluster.

### Motivation

Nightly CI was failing.