### PR TITLE
rqg: Add a lateral-joins workload

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -981,6 +981,17 @@ steps:
             composition: rqg
             args: ["dbt3-joins", "--seed=$BUILDKITE_JOB_ID"]
 
+    - id: rqg-lateral-joins
+      label: "RQG lateral-joins workload"
+      artifact_paths: junit_*.xml
+      timeout_in_minutes: 45
+      agents:
+        queue: linux-x86_64
+      plugins:
+        - ./ci/plugins/mzcompose:
+            composition: rqg
+            args: ["lateral-joins", "--seed=$BUILDKITE_JOB_ID"]
+
     - id: rqg-banking
       label: "RQG banking workload"
       artifact_paths: junit_*.xml

--- a/test/rqg/Dockerfile
+++ b/test/rqg/Dockerfile
@@ -28,7 +28,7 @@ ADD https://api.github.com/repos/MaterializeInc/RQG/git/refs/heads/main version.
 
 RUN git clone --single-branch https://github.com/MaterializeInc/RQG.git \
     && cd RQG \
-    && git checkout 7ad0e1cd8529d247aac59e7cd410f95ac1da3c65
+    && git checkout ffd96b0e2bca4f15e7fac3ab0cb4c6a615849114
 
 ENTRYPOINT ["/usr/bin/perl"]
 

--- a/test/rqg/mzcompose.py
+++ b/test/rqg/mzcompose.py
@@ -54,6 +54,9 @@ class ReferenceImplementation(Enum):
 @dataclass
 class Workload:
     name: str
+    # All paths are relative to the CWD of the rqg container, which is /RQG and contains
+    # a checked-out copy of the MaterializeInc/RQG repository
+    # Use /workdir/file-name-goes-here.yy for files located in test/rqg
     grammar: str
     reference_implementation: ReferenceImplementation | None
     dataset: Dataset | None = None
@@ -68,6 +71,13 @@ WORKLOADS = [
         name="simple-aggregates",
         dataset=Dataset.SIMPLE,
         grammar="conf/mz/simple-aggregates.yy",
+        reference_implementation=ReferenceImplementation.POSTGRES,
+        validator="ResultsetComparatorSimplify",
+    ),
+    Workload(
+        name="lateral-joins",
+        dataset=Dataset.SIMPLE,
+        grammar="conf/mz/lateral-joins.yy",
         reference_implementation=ReferenceImplementation.POSTGRES,
         validator="ResultsetComparatorSimplify",
     ),


### PR DESCRIPTION
### Motivation

The lateral-joins RQG grammar is able to run error-free, so it suitable for CI.