### PR TITLE
adapter: Fix timeline determination for temporals

### DIFF
--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -489,79 +489,55 @@ impl Coordinator {
     where
         I: IntoIterator<Item = GlobalId>,
     {
-        let mut timelines: BTreeMap<GlobalId, TimelineContext> = BTreeMap::new();
-        let mut contains_temporal = false;
+        let mut seen: BTreeSet<GlobalId> = BTreeSet::new();
+        let mut timelines: BTreeSet<TimelineContext> = BTreeSet::new();
 
         // Recurse through IDs to find all sources and tables, adding new ones to
         // the set until we reach the bottom.
         let mut ids: Vec<_> = ids.into_iter().collect();
         // Helper function for both materialized views and views.
         fn visit_view_expr(
-            id: GlobalId,
             optimized_expr: &OptimizedMirRelationExpr,
             ids: &mut Vec<GlobalId>,
-            timelines: &mut BTreeMap<GlobalId, TimelineContext>,
-            contains_temporal: &mut bool,
+            timelines: &mut BTreeSet<TimelineContext>,
         ) {
-            if !*contains_temporal && optimized_expr.contains_temporal() {
-                *contains_temporal = true;
-            }
-            let depends_on = optimized_expr.depends_on();
-            if depends_on.is_empty() {
-                // If the definition contains a temporal function, the timeline must
-                // be timestamp dependent.
-                if *contains_temporal {
-                    timelines.insert(id, TimelineContext::TimestampDependent);
-                } else {
-                    timelines.insert(id, TimelineContext::TimestampIndependent);
-                }
+            // If the definition contains a temporal function, the timeline must
+            // be timestamp dependent.
+            if optimized_expr.contains_temporal() {
+                timelines.insert(TimelineContext::TimestampDependent);
             } else {
-                ids.extend(depends_on);
+                timelines.insert(TimelineContext::TimestampIndependent);
             }
+            ids.extend(optimized_expr.depends_on());
         }
         while let Some(id) = ids.pop() {
             // Protect against possible infinite recursion. Not sure if it's possible, but
             // a cheap prevention for the future.
-            if timelines.contains_key(&id) {
+            if !seen.insert(id) {
                 continue;
             }
             if let Some(entry) = self.catalog().try_get_entry(&id) {
                 match entry.item() {
                     CatalogItem::Source(source) => {
-                        timelines.insert(
-                            id,
-                            TimelineContext::TimelineDependent(source.timeline.clone()),
-                        );
+                        timelines
+                            .insert(TimelineContext::TimelineDependent(source.timeline.clone()));
                     }
                     CatalogItem::Index(index) => {
                         ids.push(index.on);
                     }
                     CatalogItem::View(view) => {
-                        visit_view_expr(
-                            id,
-                            &view.optimized_expr,
-                            &mut ids,
-                            &mut timelines,
-                            &mut contains_temporal,
-                        );
+                        visit_view_expr(&view.optimized_expr, &mut ids, &mut timelines);
                     }
                     CatalogItem::MaterializedView(mview) => {
-                        visit_view_expr(
-                            id,
-                            &mview.optimized_expr,
-                            &mut ids,
-                            &mut timelines,
-                            &mut contains_temporal,
-                        );
+                        visit_view_expr(&mview.optimized_expr, &mut ids, &mut timelines);
                     }
                     CatalogItem::Table(table) => {
-                        timelines.insert(id, TimelineContext::TimelineDependent(table.timeline()));
+                        timelines.insert(TimelineContext::TimelineDependent(table.timeline()));
                     }
                     CatalogItem::Log(_) => {
-                        timelines.insert(
-                            id,
-                            TimelineContext::TimelineDependent(Timeline::EpochMilliseconds),
-                        );
+                        timelines.insert(TimelineContext::TimelineDependent(
+                            Timeline::EpochMilliseconds,
+                        ));
                     }
                     CatalogItem::Sink(_)
                     | CatalogItem::Type(_)
@@ -573,9 +549,6 @@ impl Coordinator {
         }
 
         timelines
-            .into_iter()
-            .map(|(_, timeline)| timeline)
-            .collect()
     }
 
     /// Returns an iterator that partitions an id bundle by the timeline context that each id belongs to.

--- a/test/sqllogictest/temporal.slt
+++ b/test/sqllogictest/temporal.slt
@@ -96,3 +96,119 @@ select * from valid_events;
 
 statement error mz_logical_timestamp\(\) has been renamed to mz_now\(\)
 CREATE VIEW mlt AS SELECT 1 WHERE mz_logical_timestamp() = 0;
+
+# Regression test for view visitation order.
+
+statement ok
+CREATE SCHEMA dev_fy2023;
+
+statement ok
+CREATE SCHEMA dev_warm;
+
+statement ok
+CREATE SCHEMA dev;
+
+statement ok
+CREATE VIEW dev.mock_data_days AS
+    WITH
+        days AS (
+            SELECT generate_series(
+                CAST('2023-12-01 11:00:00' AS timestamp),
+                CAST('2024-01-06' AS timestamp),
+                CAST('1 day' AS interval)
+            ) AS "day"
+            UNION ALL
+            SELECT generate_series(
+                CAST('10000-12-01 11:00:00' AS timestamp),
+                CAST('10001-01-01' AS timestamp),
+                CAST('1 day' AS interval)
+            ) AS "day"
+        )
+    SELECT
+        "day" AS ts,
+        datediff('hour', CAST('2020-01-01' AS timestamp), "day") AS id
+    FROM days;
+
+statement ok
+CREATE VIEW dev_warm.stg_data_days AS
+    SELECT *
+    FROM dev.mock_data_days
+    WHERE
+        mz_now() <= date_trunc('year', ts + CAST('1 year' AS interval)) AND
+        ts + CAST('7 days' AS interval) - CAST('1 month' AS interval) < mz_now();
+
+statement ok
+CREATE VIEW dev_warm.count_by_day AS
+    SELECT
+        date_trunc('day', ts) AS "day",
+        count(*) AS cnt
+    FROM dev_warm.stg_data_days
+    GROUP BY 1
+    HAVING
+        NOT (mz_now() <= date_trunc('day', ts) + CAST('7 days' AS interval)) AND
+        mz_now() <= date_trunc('year', date_trunc('day', ts) + CAST('1 year' AS interval));
+
+statement ok
+CREATE VIEW dev_fy2023.stg_data_days AS
+    SELECT *
+    FROM dev.mock_data_days
+    WHERE
+        CAST('2023-01-01' AS timestamp) <= ts AND
+        ts - CAST('1 month' AS interval) < CAST('2024-01-01' AS timestamp) AND
+        ts - CAST('0 month' AS interval) < CAST('2025-01-01' AS timestamp);
+
+statement ok
+CREATE VIEW dev_fy2023.count_by_day AS
+    SELECT
+        date_trunc('day', ts) AS "day",
+        count(*) AS cnt
+    FROM dev_fy2023.stg_data_days
+    GROUP BY 1
+    HAVING
+        NOT (CAST('2024-01-01' AS timestamp) <= date_trunc('day', ts)) AND
+        CAST('2023-01-01' AS timestamp) <= date_trunc('day', ts);
+
+# This test will break in the year 10000. If you've survived that far then congratulations. Please
+# update the years 10000 and 10001 in the view dev.mock_data_days to a much larger year.
+query TIT
+SELECT *, 'fy2023' AS origin FROM dev_fy2023.count_by_day
+UNION ALL
+SELECT *, 'warm' AS origin FROM dev_warm.count_by_day
+ORDER BY day DESC;
+----
+2024-01-05␠00:00:00  1  warm
+2024-01-04␠00:00:00  1  warm
+2024-01-03␠00:00:00  1  warm
+2024-01-02␠00:00:00  1  warm
+2024-01-01␠00:00:00  1  warm
+2023-12-31␠00:00:00  1  fy2023
+2023-12-30␠00:00:00  1  fy2023
+2023-12-29␠00:00:00  1  fy2023
+2023-12-28␠00:00:00  1  fy2023
+2023-12-27␠00:00:00  1  fy2023
+2023-12-26␠00:00:00  1  fy2023
+2023-12-25␠00:00:00  1  fy2023
+2023-12-24␠00:00:00  1  fy2023
+2023-12-23␠00:00:00  1  fy2023
+2023-12-22␠00:00:00  1  fy2023
+2023-12-21␠00:00:00  1  fy2023
+2023-12-20␠00:00:00  1  fy2023
+2023-12-19␠00:00:00  1  fy2023
+2023-12-18␠00:00:00  1  fy2023
+2023-12-17␠00:00:00  1  fy2023
+2023-12-16␠00:00:00  1  fy2023
+2023-12-15␠00:00:00  1  fy2023
+2023-12-14␠00:00:00  1  fy2023
+2023-12-13␠00:00:00  1  fy2023
+2023-12-12␠00:00:00  1  fy2023
+2023-12-11␠00:00:00  1  fy2023
+2023-12-10␠00:00:00  1  fy2023
+2023-12-09␠00:00:00  1  fy2023
+2023-12-08␠00:00:00  1  fy2023
+2023-12-07␠00:00:00  1  fy2023
+2023-12-06␠00:00:00  1  fy2023
+2023-12-05␠00:00:00  1  fy2023
+2023-12-04␠00:00:00  1  fy2023
+2023-12-03␠00:00:00  1  fy2023
+2023-12-02␠00:00:00  1  fy2023
+2023-12-01␠00:00:00  1  fy2023


### PR DESCRIPTION
Previously we would determine the timeline context of a query by performing BFS over all the objects in the query and their dependencies. At each dependency we would add a timeline using the following logic:

  - If the current object is a leaf view, and we HAVE previously seen a view with a temporal function then add the `TimestampDependent` timeline context.
  - If the current object is a leaf view, and we HAVE NOT previously seen a view with a temporal function then add the `TimestampIndependent` timeline context.
  - All other objects directly add their timeline.

The final timeline contexts from this process is dependent on the traversal order of each node. Specifically if a view with a temporal function is visited after all leaf views have been visited, then we will incorrectly not add any `TimestampDependent` contexts.

This commit fixes this issue by changing the logic to the following:

  - If the current view contains a temporal function then add the `TimestampDependent` timeline context.
  - If the current view does not contain a temporal function then add the `TimestampIndependent` timeline context.
  - All other objects directly add their timeline.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix query results that rely on static views with temporal filters.
