### PR TITLE
explain: refine error handling for `EXPLAIN BROKEN`

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -284,11 +284,19 @@ impl Coordinator {
                             })
                         }
                     }
-                    // Pipeline errors are handled fifferently depending on the caller.
+                    // Internal optimizer errors errors are handled differently
+                    // depending on the caller.
                     Err(err) => {
-                        if let Some(explain_ctx) = explain_ctx {
-                            // In `explain_~` contexts, just move to the next
-                            // stage with default parameters.
+                        let Some(explain_ctx) = explain_ctx else {
+                            // In `sequence_~` contexts, immediately retire the
+                            // execution with the error.
+                            return ctx.retire(Err(err.into()));
+                        };
+
+                        if explain_ctx.broken {
+                            // In `EXPLAIN BROKEN` contexts, just log the error
+                            // and move to the next stage with default
+                            // parameters.
                             tracing::error!("error while handling EXPLAIN statement: {}", err);
                             CreateIndexStage::Explain(CreateIndexExplain {
                                 validity,
@@ -299,9 +307,9 @@ impl Coordinator {
                                 explain_ctx,
                             })
                         } else {
-                            // In `sequence_~` contexts, immediately retire the
-                            // execution with the error.
-                            return ctx.retire(Err(err));
+                            // In regular `EXPLAIN` contexts, immediately retire
+                            // the execution with the error.
+                            return ctx.retire(Err(err.into()));
                         }
                     }
                 };

--- a/test/sqllogictest/explain/broken_statements.slt
+++ b/test/sqllogictest/explain/broken_statements.slt
@@ -95,6 +95,17 @@ EXPLAIN OPTIMIZER TRACE FOR BROKEN
 CREATE MATERIALIZED VIEW mv AS
 SELECT mz_unsafe.mz_panic('forced optimizer panic');
 
+# Regression test for #24398
+statement error internal error: stage `optimize/global` not present
+EXPLAIN OPTIMIZED PLAN FOR BROKEN
+CREATE MATERIALIZED VIEW mv AS
+SELECT pg_catalog.now();
+
+statement error cannot materialize call to current_timestamp
+EXPLAIN PHYSICAL PLAN FOR
+CREATE MATERIALIZED VIEW mv AS
+SELECT pg_catalog.now();
+
 
 # EXPLAIN ... BROKEN CREATE INDEX
 # -------------------------------


### PR DESCRIPTION
Errors returned by optimizer calls in `EXPLAIN CREATE` should not be directly reported to the client. We should only supress the error and try to render a result when the caller uses the `EXPLAIN BROKEN` syntax.

Fixes #24398.

### Motivation

  * This PR fixes a recognized bug.

Fixes a regression in the error handling logic which causes user-friendly errors returned by `<statement>` to be replaced by `internal error` when running an `EXPLAIN <statement>`.

### Tips for reviewer

I just refined the error handling logic towards the end of `create_materialized_view_optimize` and `create_index_optimize` a bit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
