### PR TITLE
storage: collect postgres table row size during snapshotting

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -180,7 +180,6 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             collect_strict_count: config.pg_source_snapshot_collect_strict_count(),
             fallback_to_strict_count: config.pg_source_snapshot_fallback_to_strict_count(),
             wait_for_count: config.pg_source_snapshot_wait_for_count(),
-            collect_count_per_worker: config.pg_source_snapshot_collect_count_per_worker(),
         },
     }
 }

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -18,7 +18,7 @@ use mz_persist_client::cfg::{PersistParameters, RetryParameters};
 use mz_service::params::GrpcClientParameters;
 use mz_sql::session::vars::{SystemVars, DEFAULT_LINEAR_JOIN_YIELDING};
 use mz_storage_types::parameters::{
-    StorageMaxInflightBytesConfig, StorageParameters, UpsertAutoSpillConfig,
+    PgSourceSnapshotConfig, StorageMaxInflightBytesConfig, StorageParameters, UpsertAutoSpillConfig,
 };
 use mz_tracing::params::TracingParameters;
 
@@ -176,6 +176,12 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
         ),
         statistics_interval: config.storage_statistics_interval(),
         statistics_collection_interval: config.storage_statistics_collection_interval(),
+        pg_snapshot_config: PgSourceSnapshotConfig {
+            collect_strict_count: config.pg_source_snapshot_collect_strict_count(),
+            fallback_to_strict_count: config.pg_source_snapshot_fallback_to_strict_count(),
+            wait_for_count: config.pg_source_snapshot_wait_for_count(),
+            collect_count_per_worker: config.pg_source_snapshot_collect_count_per_worker(),
+        },
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1113,6 +1113,43 @@ const PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
+/// Please see `PgSourceSnapshotConfig`.
+const PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("pg_source_snapshot_collect_strict_count"),
+    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().collect_strict_count,
+    description: "Please see <https://dev.materialize.com/api/rust-private\
+        /mz_storage_types/parameters\
+        /struct.PgSourceSnapshotConfig.html#structfield.collect_strict_count>",
+    internal: true,
+};
+/// Please see `PgSourceSnapshotConfig`.
+const PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("pg_source_snapshot_fallback_to_strict_count"),
+    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().fallback_to_strict_count,
+    description: "Please see <https://dev.materialize.com/api/rust-private\
+        /mz_storage_types/parameters\
+        /struct.PgSourceSnapshotConfig.html#structfield.fallback_to_strict_count>",
+    internal: true,
+};
+/// Please see `PgSourceSnapshotConfig`.
+const PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("pg_source_snapshot_wait_for_count"),
+    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().wait_for_count,
+    description: "Please see <https://dev.materialize.com/api/rust-private\
+        /mz_storage_types/parameters\
+        /struct.PgSourceSnapshotConfig.html#structfield.wait_for_count>",
+    internal: true,
+};
+/// Please see `PgSourceSnapshotConfig`.
+const PG_SOURCE_SNAPSHOT_COLLECT_COUNT_PER_WORKER: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("pg_source_snapshot_collect_count_per_worker"),
+    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().collect_count_per_worker,
+    description: "Please see <https://dev.materialize.com/api/rust-private\
+        /mz_storage_types/parameters\
+        /struct.PgSourceSnapshotConfig.html#structfield.collect_count_per_worker>",
+    internal: true,
+};
+
 /// Controls the check interval for connections to SSH bastions via `mz_ssh_util`.
 const SSH_CHECK_INTERVAL: ServerVar<Duration> = ServerVar {
     name: UncasedStr::new("ssh_check_interval"),
@@ -3092,6 +3129,10 @@ impl SystemVars {
             .with_var(&PG_SOURCE_KEEPALIVES_RETRIES)
             .with_var(&PG_SOURCE_TCP_USER_TIMEOUT)
             .with_var(&PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT)
+            .with_var(&PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT)
+            .with_var(&PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT)
+            .with_var(&PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT)
+            .with_var(&PG_SOURCE_SNAPSHOT_COLLECT_COUNT_PER_WORKER)
             .with_var(&SSH_CHECK_INTERVAL)
             .with_var(&SSH_CONNECT_TIMEOUT)
             .with_var(&SSH_KEEPALIVES_IDLE)
@@ -3702,6 +3743,23 @@ impl SystemVars {
     /// Returns the `pg_source_snapshot_statement_timeout` configuration parameter.
     pub fn pg_source_snapshot_statement_timeout(&self) -> Duration {
         *self.expect_value(&PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT)
+    }
+
+    /// Returns the `pg_source_snapshot_collect_strict_count` configuration parameter.
+    pub fn pg_source_snapshot_collect_strict_count(&self) -> bool {
+        *self.expect_value(&PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT)
+    }
+    /// Returns the `pg_source_snapshot_fallback_to_strict_count` configuration parameter.
+    pub fn pg_source_snapshot_fallback_to_strict_count(&self) -> bool {
+        *self.expect_value(&PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT)
+    }
+    /// Returns the `pg_source_snapshot_collect_strict_count` configuration parameter.
+    pub fn pg_source_snapshot_wait_for_count(&self) -> bool {
+        *self.expect_value(&PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT)
+    }
+    /// Returns the `pg_source_snapshot_collect_count_per_worker` configuration parameter.
+    pub fn pg_source_snapshot_collect_count_per_worker(&self) -> bool {
+        *self.expect_value(&PG_SOURCE_SNAPSHOT_COLLECT_COUNT_PER_WORKER)
     }
 
     /// Returns the `ssh_check_interval` configuration parameter.
@@ -5731,6 +5789,10 @@ impl SystemVars {
             || name == PG_SOURCE_KEEPALIVES_RETRIES.name()
             || name == PG_SOURCE_TCP_USER_TIMEOUT.name()
             || name == PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT.name()
+            || name == PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT.name()
+            || name == PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT.name()
+            || name == PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT.name()
+            || name == PG_SOURCE_SNAPSHOT_COLLECT_COUNT_PER_WORKER.name()
             || name == ENABLE_STORAGE_SHARD_FINALIZATION.name()
             || name == SSH_CHECK_INTERVAL.name()
             || name == SSH_CONNECT_TIMEOUT.name()

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1140,15 +1140,6 @@ const PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT: ServerVar<bool> = ServerVar {
         /struct.PgSourceSnapshotConfig.html#structfield.wait_for_count>",
     internal: true,
 };
-/// Please see `PgSourceSnapshotConfig`.
-const PG_SOURCE_SNAPSHOT_COLLECT_COUNT_PER_WORKER: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("pg_source_snapshot_collect_count_per_worker"),
-    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().collect_count_per_worker,
-    description: "Please see <https://dev.materialize.com/api/rust-private\
-        /mz_storage_types/parameters\
-        /struct.PgSourceSnapshotConfig.html#structfield.collect_count_per_worker>",
-    internal: true,
-};
 
 /// Controls the check interval for connections to SSH bastions via `mz_ssh_util`.
 const SSH_CHECK_INTERVAL: ServerVar<Duration> = ServerVar {
@@ -3132,7 +3123,6 @@ impl SystemVars {
             .with_var(&PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT)
             .with_var(&PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT)
             .with_var(&PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT)
-            .with_var(&PG_SOURCE_SNAPSHOT_COLLECT_COUNT_PER_WORKER)
             .with_var(&SSH_CHECK_INTERVAL)
             .with_var(&SSH_CONNECT_TIMEOUT)
             .with_var(&SSH_KEEPALIVES_IDLE)
@@ -3756,10 +3746,6 @@ impl SystemVars {
     /// Returns the `pg_source_snapshot_collect_strict_count` configuration parameter.
     pub fn pg_source_snapshot_wait_for_count(&self) -> bool {
         *self.expect_value(&PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT)
-    }
-    /// Returns the `pg_source_snapshot_collect_count_per_worker` configuration parameter.
-    pub fn pg_source_snapshot_collect_count_per_worker(&self) -> bool {
-        *self.expect_value(&PG_SOURCE_SNAPSHOT_COLLECT_COUNT_PER_WORKER)
     }
 
     /// Returns the `ssh_check_interval` configuration parameter.
@@ -5792,7 +5778,6 @@ impl SystemVars {
             || name == PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT.name()
             || name == PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT.name()
             || name == PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT.name()
-            || name == PG_SOURCE_SNAPSHOT_COLLECT_COUNT_PER_WORKER.name()
             || name == ENABLE_STORAGE_SHARD_FINALIZATION.name()
             || name == SSH_CHECK_INTERVAL.name()
             || name == SSH_CONNECT_TIMEOUT.name()

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -55,7 +55,6 @@ message ProtoPgSourceSnapshotConfig {
     bool collect_strict_count = 1;
     bool fallback_to_strict_count = 2;
     bool wait_for_count = 3;
-    bool collect_count_per_worker = 4;
 }
 
 message ProtoKafkaTimeouts {

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -39,6 +39,7 @@ message ProtoStorageParameters {
     ProtoKafkaTimeouts kafka_timeout_config = 21;
     mz_proto.ProtoDuration statistics_interval = 22;
     mz_proto.ProtoDuration statistics_collection_interval = 23;
+    ProtoPgSourceSnapshotConfig pg_snapshot_config = 24;
 }
 
 
@@ -48,6 +49,13 @@ message ProtoPgSourceTcpTimeouts {
     optional mz_proto.ProtoDuration keepalives_idle = 3;
     optional mz_proto.ProtoDuration keepalives_interval = 4;
     optional mz_proto.ProtoDuration tcp_user_timeout = 5;
+}
+
+message ProtoPgSourceSnapshotConfig {
+    bool collect_strict_count = 1;
+    bool fallback_to_strict_count = 2;
+    bool wait_for_count = 3;
+    bool collect_count_per_worker = 4;
 }
 
 message ProtoKafkaTimeouts {

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -71,6 +71,7 @@ pub struct StorageParameters {
     // defined by this interval. This is known to be somewhat inaccurate,
     // but people mostly care about either rates, or the values to within 1 minute.
     pub statistics_collection_interval: Duration,
+    pub pg_snapshot_config: PgSourceSnapshotConfig,
 }
 
 pub const STATISTICS_INTERVAL_DEFAULT: Duration = Duration::from_secs(60);
@@ -100,6 +101,7 @@ impl Default for StorageParameters {
             kafka_timeout_config: Default::default(),
             statistics_interval: STATISTICS_INTERVAL_DEFAULT,
             statistics_collection_interval: STATISTICS_COLLECTION_INTERVAL_DEFAULT,
+            pg_snapshot_config: Default::default(),
         }
     }
 }
@@ -195,6 +197,7 @@ impl StorageParameters {
             kafka_timeout_config,
             statistics_interval,
             statistics_collection_interval,
+            pg_snapshot_config,
         }: StorageParameters,
     ) {
         self.persist.update(persist);
@@ -219,6 +222,7 @@ impl StorageParameters {
         // We set this in the statistics scraper tasks only once at startup.
         self.statistics_interval = statistics_interval;
         self.statistics_collection_interval = statistics_collection_interval;
+        self.pg_snapshot_config = pg_snapshot_config;
     }
 }
 
@@ -256,6 +260,7 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             kafka_timeout_config: Some(self.kafka_timeout_config.into_proto()),
             statistics_interval: Some(self.statistics_interval.into_proto()),
             statistics_collection_interval: Some(self.statistics_collection_interval.into_proto()),
+            pg_snapshot_config: Some(self.pg_snapshot_config.into_proto()),
         }
     }
 
@@ -316,6 +321,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             statistics_collection_interval: proto
                 .statistics_collection_interval
                 .into_rust_if_some("ProtoStorageParameters::statistics_collection_interval")?,
+            pg_snapshot_config: proto
+                .pg_snapshot_config
+                .into_rust_if_some("ProtoStorageParameters::pg_snapshot_config")?,
         })
     }
 }
@@ -338,6 +346,66 @@ impl RustType<ProtoPgSourceTcpTimeouts> for mz_postgres_util::TcpTimeoutConfig {
             keepalives_idle: proto.keepalives_idle.into_rust()?,
             keepalives_interval: proto.keepalives_interval.into_rust()?,
             tcp_user_timeout: proto.tcp_user_timeout.into_rust()?,
+        })
+    }
+}
+
+/// Configuration for how storage performs Postgres snapshots.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PgSourceSnapshotConfig {
+    /// Whether or not to collect a strict `count(*)` for each table during snapshotting.
+    /// This is more accurate but way more expensive compared to an estimate in `pg_class`.
+    pub collect_strict_count: bool,
+    /// If a table is not vacuumed or analyzed (usually if it has a low number of writes, or low
+    /// number of rows in general) in postgres, the estimate count in `pg_class` is just `-1.
+    /// This config controls whether we should fallback to `count(*)` in that case. It does
+    /// nothing if `collect_strict_count=true`.
+    pub fallback_to_strict_count: bool,
+    /// Whether or not we wait for `count(*)` to finish before beginning to read the snapshot for
+    /// the given table.
+    pub wait_for_count: bool,
+    /// Whether to query `count(*)` metrics per-worker, or only within the snapshot leader.
+    /// If true, each worker will use an additional connection, as opposed to a singular extra
+    /// connection.
+    pub collect_count_per_worker: bool,
+}
+
+impl PgSourceSnapshotConfig {
+    pub const fn new() -> Self {
+        PgSourceSnapshotConfig {
+            // We want accurate values, if its not too expensive.
+            collect_strict_count: true,
+            fallback_to_strict_count: true,
+            // For now, wait to start snapshotting until after we have the count.
+            wait_for_count: true,
+            // This is faster, at the cost of extra connections if `wait_for_count` is false.
+            collect_count_per_worker: true,
+        }
+    }
+}
+
+impl Default for PgSourceSnapshotConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RustType<ProtoPgSourceSnapshotConfig> for PgSourceSnapshotConfig {
+    fn into_proto(&self) -> ProtoPgSourceSnapshotConfig {
+        ProtoPgSourceSnapshotConfig {
+            collect_strict_count: self.collect_strict_count,
+            fallback_to_strict_count: self.fallback_to_strict_count,
+            wait_for_count: self.wait_for_count,
+            collect_count_per_worker: self.collect_count_per_worker,
+        }
+    }
+
+    fn from_proto(proto: ProtoPgSourceSnapshotConfig) -> Result<Self, TryFromProtoError> {
+        Ok(PgSourceSnapshotConfig {
+            collect_strict_count: proto.collect_strict_count,
+            fallback_to_strict_count: proto.fallback_to_strict_count,
+            wait_for_count: proto.wait_for_count,
+            collect_count_per_worker: proto.collect_count_per_worker,
         })
     }
 }

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -364,10 +364,6 @@ pub struct PgSourceSnapshotConfig {
     /// Whether or not we wait for `count(*)` to finish before beginning to read the snapshot for
     /// the given table.
     pub wait_for_count: bool,
-    /// Whether to query `count(*)` metrics per-worker, or only within the snapshot leader.
-    /// If true, each worker will use an additional connection, as opposed to a singular extra
-    /// connection.
-    pub collect_count_per_worker: bool,
 }
 
 impl PgSourceSnapshotConfig {
@@ -378,8 +374,6 @@ impl PgSourceSnapshotConfig {
             fallback_to_strict_count: true,
             // For now, wait to start snapshotting until after we have the count.
             wait_for_count: true,
-            // This is faster, at the cost of extra connections if `wait_for_count` is false.
-            collect_count_per_worker: true,
         }
     }
 }
@@ -396,7 +390,6 @@ impl RustType<ProtoPgSourceSnapshotConfig> for PgSourceSnapshotConfig {
             collect_strict_count: self.collect_strict_count,
             fallback_to_strict_count: self.fallback_to_strict_count,
             wait_for_count: self.wait_for_count,
-            collect_count_per_worker: self.collect_count_per_worker,
         }
     }
 
@@ -405,7 +398,6 @@ impl RustType<ProtoPgSourceSnapshotConfig> for PgSourceSnapshotConfig {
             collect_strict_count: proto.collect_strict_count,
             fallback_to_strict_count: proto.fallback_to_strict_count,
             wait_for_count: proto.wait_for_count,
-            collect_count_per_worker: proto.collect_count_per_worker,
         })
     }
 }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -46,7 +46,7 @@ mz-cluster = { path = "../cluster" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
 mz-mysql-util = { path = "../mysql-util" }
-mz-ore = { path = "../ore", features = ["async", "tracing_", "chrono"] }
+mz-ore = { path = "../ore", features = ["async", "tracing_", "chrono", "metrics"] }
 mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }

--- a/src/storage/src/metrics/postgres.rs
+++ b/src/storage/src/metrics/postgres.rs
@@ -11,11 +11,13 @@
 
 use mz_ore::metric;
 use mz_ore::metrics::{
-    CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt, IntCounterVec,
-    MetricsRegistry, UIntGaugeVec,
+    CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVec, GaugeVecExt, IntCounterVec,
+    IntGaugeVec, MetricsRegistry, UIntGaugeVec,
 };
 use mz_repr::GlobalId;
-use prometheus::core::AtomicU64;
+use prometheus::core::{AtomicF64, AtomicI64, AtomicU64};
+use std::sync::Arc;
+use std::sync::Mutex;
 
 /// Definitions for Postgres source metrics.
 #[derive(Clone, Debug)]
@@ -28,6 +30,10 @@ pub(crate) struct PgSourceMetricDefs {
     pub(crate) delete_messages: IntCounterVec,
     pub(crate) tables_in_publication: UIntGaugeVec,
     pub(crate) wal_lsn: UIntGaugeVec,
+    pub(crate) table_count: IntGaugeVec,
+    pub(crate) table_count_latency: GaugeVec,
+    pub(crate) table_estimate: IntGaugeVec,
+    pub(crate) table_estimate_latency: GaugeVec,
 }
 
 impl PgSourceMetricDefs {
@@ -72,8 +78,80 @@ impl PgSourceMetricDefs {
                 name: "mz_postgres_per_source_wal_lsn",
                 help: "LSN of the latest transaction committed for this source, see Postgres Replication docs for more details on LSN",
                 var_labels: ["source_id"],
-            ))
+            )),
+            table_count: registry.register(metric!(
+                name: "mz_postgres_snapshot_count",
+                help: "The count(*) of tables in the sources snapshot.",
+                var_labels: ["source_id", "table_name"],
+            )),
+            table_count_latency: registry.register(metric!(
+                name: "mz_postgres_snapshot_count_latency",
+                help: "The wall time used to obtain `mz_postgres_snapshot_count`.",
+                var_labels: ["source_id", "table_name"],
+            )),
+            table_estimate: registry.register(metric!(
+                name: "mz_postgres_snapshot_estimate",
+                help: "An estimate of the size of tables in the sources snapshot.",
+                var_labels: ["source_id", "table_name"],
+            )),
+            table_estimate_latency: registry.register(metric!(
+                name: "mz_postgres_snapshot_estimate_latency",
+                help: "The wall time used to obtain `mz_postgres_snapshot_estimate`.",
+                var_labels: ["source_id", "table_name"],
+            )),
         }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PgSnapshotMetrics {
+    source_id: GlobalId,
+    // This has to be shared between tokio tasks and the replication operator, as the collection
+    // of these metrics happens once in those tasks, which do not live long enough to keep them
+    // alive.
+    gauges: Arc<
+        Mutex<
+            Vec<(
+                DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
+                DeleteOnDropGauge<'static, AtomicF64, Vec<String>>,
+            )>,
+        >,
+    >,
+    defs: PgSourceMetricDefs,
+}
+
+impl PgSnapshotMetrics {
+    pub(crate) fn record_table_count(&self, table_name: String, count: i64, latency: f64) {
+        let gauge = self
+            .defs
+            .table_count
+            .get_delete_on_drop_gauge(vec![self.source_id.to_string(), table_name.clone()]);
+        let latency_gauge = self
+            .defs
+            .table_count_latency
+            .get_delete_on_drop_gauge(vec![self.source_id.to_string(), table_name]);
+        gauge.set(count);
+        latency_gauge.set(latency);
+        self.gauges
+            .lock()
+            .expect("poisoned")
+            .push((gauge, latency_gauge))
+    }
+    pub(crate) fn record_table_estimate(&self, table_name: String, estimate: i64, latency: f64) {
+        let gauge = self
+            .defs
+            .table_estimate
+            .get_delete_on_drop_gauge(vec![self.source_id.to_string(), table_name.clone()]);
+        let latency_gauge = self
+            .defs
+            .table_estimate_latency
+            .get_delete_on_drop_gauge(vec![self.source_id.to_string(), table_name]);
+        gauge.set(estimate);
+        latency_gauge.set(latency);
+        self.gauges
+            .lock()
+            .expect("poisoned")
+            .push((gauge, latency_gauge))
     }
 }
 
@@ -87,6 +165,8 @@ pub(crate) struct PgSourceMetrics {
     pub(crate) transactions: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) tables: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     pub(crate) lsn: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+
+    pub(crate) snapshot_metrics: PgSnapshotMetrics,
 }
 
 impl PgSourceMetrics {
@@ -116,6 +196,11 @@ impl PgSourceMetrics {
                 .tables_in_publication
                 .get_delete_on_drop_gauge(labels.to_vec()),
             lsn: defs.wal_lsn.get_delete_on_drop_gauge(labels.to_vec()),
+            snapshot_metrics: PgSnapshotMetrics {
+                source_id,
+                gauges: Default::default(),
+                defs: defs.clone(),
+            },
         }
     }
 }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -159,12 +159,15 @@ impl SourceRender for PostgresSourceConnection {
             }
         }
 
+        let metrics = config.metrics.get_postgres_metrics(config.id);
+
         let (snapshot_updates, rewinds, snapshot_err, snapshot_token) = snapshot::render(
             scope.clone(),
             config.clone(),
             self.clone(),
             subsource_resume_uppers.clone(),
             table_info.clone(),
+            metrics.snapshot_metrics.clone(),
         );
 
         let (repl_updates, uppers, repl_err, repl_token) = replication::render(
@@ -175,6 +178,7 @@ impl SourceRender for PostgresSourceConnection {
             table_info,
             &rewinds,
             resume_uppers,
+            metrics,
         );
 
         let updates = snapshot_updates.concat(&repl_updates).map(|(output, res)| {

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -145,6 +145,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
     table_info: BTreeMap<u32, (usize, PostgresTableDesc, Vec<MirScalarExpr>)>,
     rewind_stream: &Stream<G, RewindRequest>,
     committed_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
+    metrics: PgSourceMetrics,
 ) -> (
     Collection<G, (usize, Result<Row, SourceReaderError>), Diff>,
     Stream<G, Infallible>,
@@ -164,7 +165,6 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
         [&data_output, &upper_output],
     );
 
-    let metrics = config.metrics.get_postgres_metrics(config.id);
     metrics.tables.set(u64::cast_from(table_info.len()));
 
     let reader_table_info = table_info.clone();

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -136,16 +136,22 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::pin::pin;
 use std::rc::Rc;
 use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
 
+use anyhow::{bail, Context};
 use differential_dataflow::{AsCollection, Collection};
 use futures::TryStreamExt;
 use mz_expr::MirScalarExpr;
 use mz_ore::result::ResultExt;
+use mz_ore::task::{AbortOnDropHandle, JoinHandleExt};
 use mz_postgres_util::desc::PostgresTableDesc;
 use mz_postgres_util::schemas::PublicationInfoError;
 use mz_postgres_util::simple_query_opt;
+use mz_postgres_util::tunnel::Config;
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
+use mz_storage_types::parameters::PgSourceSnapshotConfig;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
 use mz_timely_util::builder_async::{
     Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
@@ -155,10 +161,11 @@ use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::{Broadcast, CapabilitySet, Concat, ConnectLoop, Feedback, Map};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp};
-use tokio_postgres::types::PgLsn;
+use tokio_postgres::types::{Oid, PgLsn};
 use tokio_postgres::Client;
-use tracing::trace;
+use tracing::{trace, warn};
 
+use crate::metrics::postgres::PgSnapshotMetrics;
 use crate::source::postgres::replication::RewindRequest;
 use crate::source::postgres::{verify_schema, DefiniteError, ReplicationError, TransientError};
 use crate::source::types::SourceReaderError;
@@ -171,6 +178,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
     connection: PostgresSourceConnection,
     subsource_resume_uppers: BTreeMap<GlobalId, Antichain<MzOffset>>,
     table_info: BTreeMap<u32, (usize, PostgresTableDesc, Vec<MirScalarExpr>)>,
+    metrics: PgSnapshotMetrics,
 ) -> (
     Collection<G, (usize, Result<Row, SourceReaderError>), Diff>,
     Stream<G, RewindRequest>,
@@ -226,6 +234,19 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
         .map(|(k, v)| (*k, v.clone()))
         .collect();
 
+    let all_tables: Vec<_> = table_info
+        .iter()
+        .map(|(_, (_, desc, _))| {
+            (
+                format!(
+                    "{}.{}",
+                    Ident::new_unchecked(desc.namespace.clone()).to_ast_string(),
+                    Ident::new_unchecked(desc.name.clone()).to_ast_string()
+                ),
+                desc.oid.clone(),
+            )
+        })
+        .collect();
     let (button, transient_errors) = builder.build_fallible(move |caps| {
         Box::pin(async move {
             let id = config.id;
@@ -292,19 +313,14 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             // Configure statement_timeout based on param. We want to be able to
             // override the server value here in case it's set too low,
             // respective to the size of the data we need to copy.
-            //
-            // Value is known to accept milliseconds w/o units.
-            // https://www.postgresql.org/docs/current/runtime-config-client.html
-            client
-                .simple_query(&format!(
-                    "SET statement_timeout = {}",
-                    config
-                        .config
-                        .parameters
-                        .pg_source_snapshot_statement_timeout
-                        .as_millis()
-                ))
-                .await?;
+            set_statement_timeout(
+                &client,
+                config
+                    .config
+                    .parameters
+                    .pg_source_snapshot_statement_timeout,
+            )
+            .await?;
 
             mz_ore::soft_assert_no_log! {{
                 let row = simple_query_opt(&client, "SHOW statement_timeout;")
@@ -386,6 +402,33 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
 
             let upstream_info = upstream_info.into_iter().map(|t| (t.oid, t)).collect();
 
+            let worker_tables = reader_snapshot_table_info
+                .iter()
+                .map(|(_, (_, desc, _))| {
+                    (
+                        format!(
+                            "{}.{}",
+                            Ident::new_unchecked(desc.namespace.clone()).to_ast_string(),
+                            Ident::new_unchecked(desc.name.clone()).to_ast_string()
+                        ),
+                        desc.oid.clone(),
+                    )
+                })
+                .collect();
+
+            let client = Arc::new(client);
+            let _count_join_handle = record_table_sizes(
+                &config,
+                &connection_config,
+                &snapshot,
+                metrics,
+                worker_tables,
+                all_tables,
+                is_snapshot_leader,
+                Arc::clone(&client),
+            )
+            .await?;
+
             for (&oid, (_, expected_desc, _)) in reader_snapshot_table_info.iter() {
                 let desc = match verify_schema(oid, expected_desc, &upstream_info) {
                     Ok(()) => expected_desc,
@@ -402,6 +445,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                     "timely-{worker_id} snapshotting table {:?}({oid}) @ {snapshot_lsn}",
                     desc.name
                 );
+
                 // To handle quoted/keyword names, we can use `Ident`'s AST printing, which
                 // emulate's PG's rules for name formatting.
                 let query = format!(
@@ -506,6 +550,15 @@ async fn use_snapshot(client: &Client, snapshot: &str) -> Result<(), TransientEr
     Ok(())
 }
 
+async fn set_statement_timeout(client: &Client, timeout: Duration) -> Result<(), TransientError> {
+    // Value is known to accept milliseconds w/o units.
+    // https://www.postgresql.org/docs/current/runtime-config-client.html
+    client
+        .simple_query(&format!("SET statement_timeout = {}", timeout.as_millis()))
+        .await?;
+    Ok(())
+}
+
 /// Decodes a row of `col_len` columns obtained from a text encoded COPY query into `row`.
 fn decode_copy_row(data: &[u8], col_len: usize, row: &mut Row) -> Result<(), DefiniteError> {
     let mut packer = row.packer();
@@ -521,4 +574,156 @@ fn decode_copy_row(data: &[u8], col_len: usize, row: &mut Row) -> Result<(), Def
         packer.push(datum.unwrap_or(Datum::Null));
     }
     Ok(())
+}
+
+/// Record the sizes of the tables being snapshotted in `PgSnapshotMetrics`.
+async fn record_table_sizes(
+    config: &RawSourceCreationConfig,
+    connection_config: &Config,
+    snapshot: &str,
+    metrics: PgSnapshotMetrics,
+    // The table names and oids owned by this worker.
+    worker_tables: Vec<(String, Oid)>,
+    // All tables (names and oids) in the snapshot)
+    all_tables: Vec<(String, Oid)>,
+    // If this worker is the snapshot leader.
+    leader: bool,
+    // An optimization: when `wait_for_count` is true, we can use the client
+    // used for replication.
+    replication_client: Arc<Client>,
+) -> Result<Option<AbortOnDropHandle<Result<(), anyhow::Error>>>, anyhow::Error> {
+    let snapshot_config = config.config.parameters.pg_snapshot_config;
+    let statement_timeout = config
+        .config
+        .parameters
+        .pg_source_snapshot_statement_timeout;
+    let connection_context = &config.config.connection_context;
+
+    let source_id = config.id;
+    let worker_id = config.worker_id;
+
+    let tables = if !snapshot_config.collect_count_per_worker {
+        if leader {
+            all_tables
+        } else {
+            return Ok(None);
+        }
+    } else {
+        worker_tables
+    };
+
+    if tables.is_empty() {
+        return Ok(None);
+    }
+
+    let task_name = format!("timely-{worker_id} PG snapshot counter");
+
+    // We create a new connection here so that postgres can actually process this in parallel
+    // with the main snapshotting, unless we are waiting for the count.
+    let client = if snapshot_config.wait_for_count {
+        replication_client
+    } else {
+        let new_client = connection_config
+            .connect(&task_name, &connection_context.ssh_tunnel_manager)
+            .await?;
+
+        set_statement_timeout(&new_client, statement_timeout).await?;
+
+        // If we want a strict count, we want to count the rows in the snapshot
+        // determined in the operator.
+        if snapshot_config.collect_strict_count || snapshot_config.fallback_to_strict_count {
+            use_snapshot(&new_client, snapshot).await?
+        }
+        Arc::new(new_client)
+    };
+
+    let jh = mz_ore::task::spawn(|| format!("pg_source_count"), async move {
+        let metrics = &metrics;
+        let client = &client;
+
+        let mut result = Ok(());
+        for (table, oid) in tables {
+            match collect_table_statistics(client, snapshot_config, &table, oid).await {
+                Ok(stats) => {
+                    if let Some(count) = stats.estimate_count {
+                        metrics.record_table_estimate(table.clone(), count, stats.estimate_latency);
+                    }
+                    if let Some(count) = stats.count {
+                        metrics.record_table_count(table.clone(), count, stats.count_latency);
+                    }
+                }
+                Err(err) => {
+                    if !snapshot_config.wait_for_count {
+                        warn!(?err, "error when collecting pg count");
+                    }
+                    result = result.and(Err(err));
+                }
+            }
+        }
+        result.context(format!("{source_id}: "))?;
+
+        // If we want a strict count, we want to count the rows in the snapshot
+        // determined in the operator.
+        if !snapshot_config.wait_for_count
+            && (snapshot_config.collect_strict_count || snapshot_config.fallback_to_strict_count)
+        {
+            client.simple_query("COMMIT").await?;
+        }
+        Ok(())
+    });
+
+    if snapshot_config.wait_for_count {
+        jh.wait_and_assert_finished().await.map(|_| None)
+    } else {
+        // TODO(guswynn): should errors be communicated back to the health stream?
+        Ok(Some(jh.abort_on_drop()))
+    }
+}
+
+#[derive(Default)]
+struct TableStatistics {
+    count_latency: f64,
+    count: Option<i64>,
+    estimate_latency: f64,
+    estimate_count: Option<i64>,
+}
+
+async fn collect_table_statistics(
+    client: &Client,
+    config: PgSourceSnapshotConfig,
+    table: &str,
+    oid: u32,
+) -> Result<TableStatistics, anyhow::Error> {
+    use mz_ore::metrics::MetricsFutureExt;
+    let mut stats = TableStatistics::default();
+
+    let estimate_row = simple_query_opt(
+        client,
+        &format!("SELECT reltuples::bigint AS estimate_count FROM pg_class WHERE oid = '{oid}'"),
+    )
+    .wall_time()
+    .set_at(&mut stats.estimate_latency)
+    .await?;
+
+    match estimate_row {
+        Some(row) => match row.get("estimate_count").unwrap().parse().unwrap() {
+            -1 => stats.estimate_count = None,
+            n => stats.estimate_count = Some(n),
+        },
+        None => bail!("failed to get estimate count for {table}"),
+    }
+
+    // Postgres returns an estimate of -1 if the table doesn't have sufficient writes/analysis/vacuuming happening.
+    let should_fallback = config.fallback_to_strict_count && stats.estimate_count.is_none();
+    if config.collect_strict_count || should_fallback {
+        let count_row = simple_query_opt(client, &format!("SELECT count(*) as count from {table}"))
+            .wall_time()
+            .set_at(&mut stats.count_latency)
+            .await?;
+        match count_row {
+            Some(row) => stats.count = Some(row.get("count").unwrap().parse().unwrap()),
+            None => bail!("failed to get count for {table}"),
+        }
+    }
+    Ok(stats)
 }


### PR DESCRIPTION
As discussed here: https://github.com/MaterializeInc/materialize/pull/24318#discussion_r1446910714, the most risky change to the storage pipeline in service of user-facing progress metrics is _running count(*) on mysql/postgres sources as part of snapshotting_

This pr implements that behavior for postgres sources, emitting the data to prometheus only. This is because I want to be able to gauge the risk/latency cost of this change separately from the other work to get user-facing metrics out there. This means that in this pr, I instrument the latency of the count queries, as well as emit an estimate. In local testing, the estimate is useless, but in production we may see it be more useful.

This pr also implements the best possible case: concurrently collect the `count` while snapshotting, and do so in a new client in each worker. In the interest of safety, most choices like this are configurable with new LD parameters (at the cost of the actual implementation being some slightly more complex async code.


Personally I believe that we _must_ collect accurate statistics about the sizes of tables participating in snapshotting if we want users to be comfortable with the experience of using postgres sources, and that its worth adding a latency cost to do so (well, unfortunately neither pg nor mysql will ever give us useful stats about the progress of the processing _of the `count(*)` query itself_ :( ). Personally I don't think pg or mysql offer useful enough estimates to replace a real `count`, but its possible that we see in practice it being reasonable (at least for large, heavily-used tables)

### Motivation

  * This PR adds a known-desirable feature.


### Tips for reviewer
bottom commit is just rustfmt adjustments
the main commit also has some changes to the `WallTimeFuture` extension stuff to make collecting latencies easier

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
