### PR TITLE
Add `EXPLAIN WITH (redacted)` support for LIR plans

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -35,7 +35,7 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use timely::container::columnation::{Columnation, CopyRegion};
 
-use crate::explain::{HumanizedExplain, HumanizedExpr, HumanizerMode};
+use crate::explain::{HumanizedExpr, HumanizerMode};
 use crate::relation::func::{AggregateFunc, LagLeadType, TableFunc};
 use crate::visit::{Visit, VisitChildren};
 use crate::Id::Local;
@@ -2294,13 +2294,6 @@ impl RustType<ProtoColumnOrder> for ColumnOrder {
     }
 }
 
-impl fmt::Display for ColumnOrder {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mode = HumanizedExplain::default();
-        mode.expr(self, None).fmt(f)
-    }
-}
-
 impl<'a, M> fmt::Display for HumanizedExpr<'a, ColumnOrder, M>
 where
     M: HumanizerMode,
@@ -3456,6 +3449,8 @@ mod tests {
     use mz_proto::protobuf_roundtrip;
     use mz_repr::explain::text::text_string_at;
     use proptest::prelude::*;
+
+    use crate::explain::HumanizedExplain;
 
     use super::*;
 

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -14,6 +14,7 @@ use std::fmt::Write;
 use std::sync::{Arc, Mutex};
 
 use itertools::Itertools;
+use mz_expr::explain::{HumanizedExplain, HumanizerMode};
 use mz_expr::{
     non_nullable_columns, AggregateExpr, ColumnOrder, Id, JoinImplementation, LocalId,
     MirRelationExpr, MirScalarExpr, RECURSION_LIMIT,
@@ -1510,6 +1511,10 @@ impl<'a> TypeError<'a> {
                 let are = if num_cols == 1 { "is" } else { "are" };
                 let s = if num_cols == 1 { "" } else { "s" };
                 let input_type = columns_pretty(input_type, humanizer);
+
+                // TODO(cloud#8196)
+                let mode = HumanizedExplain::new(false);
+                let order = mode.expr(order, None);
 
                 writeln!(
                     f,

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -539,7 +539,7 @@ Explained Query:
   Project (#2)
     Map (record_get[0](#1))
       FlatMap unnest_list(#0)
-        Reduce aggregates=[lag[ignore_nulls=true, order_by=[#0 asc nulls_last]](row(row(row(#0{x}), row(#0{x}, █, █)), (#0{x} || #0{x})))]
+        Reduce aggregates=[lag[ignore_nulls=true, order_by=[#0{x} asc nulls_last]](row(row(row(#0{x}), row(#0{x}, █, █)), (#0{x} || #0{x})))]
           ReadStorage materialize.public.t1
 
 EOF
@@ -553,7 +553,7 @@ Explained Query:
   Project (#2)
     Map (record_get[0](#1))
       FlatMap unnest_list(#0)
-        Reduce aggregates=[first_value[order_by=[#0 asc nulls_last] rows between 5 preceding and current row](row(row(row(#0{x}), #0{x}), (#0{x} || #0{x})))]
+        Reduce aggregates=[first_value[order_by=[#0{x} asc nulls_last] rows between 5 preceding and current row](row(row(row(#0{x}), #0{x}), (#0{x} || #0{x})))]
           ReadStorage materialize.public.t1
 
 EOF

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -1,0 +1,1300 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+statement ok
+CREATE TABLE t (
+  a int,
+  b int
+)
+
+statement ok
+CREATE TABLE u (
+  c int,
+  d int
+)
+
+statement ok
+CREATE TABLE v (
+  e int,
+  f int
+)
+
+statement ok
+CREATE INDEX t_a_idx ON T(a);
+
+statement ok
+CREATE INDEX t_b_idx ON T(b);
+
+statement ok
+CREATE VIEW ov AS SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
+
+statement ok
+CREATE INDEX ov_a_idx ON ov(a);
+
+statement ok
+CREATE INDEX ov_b_idx ON ov(b);
+
+statement ok
+CREATE MATERIALIZED VIEW mv AS
+SELECT * FROM t WHERE a IS NOT NULL
+
+statement ok
+CREATE VIEW hierarchical_group_by AS
+SELECT
+  a,
+  MIN(b),
+  MAX(DISTINCT b)
+FROM t
+GROUP BY a
+
+statement ok
+CREATE MATERIALIZED VIEW hierarchical_group_by_mv AS
+SELECT * FROM hierarchical_group_by
+
+statement ok
+CREATE VIEW hierarchical_global AS
+SELECT
+  MIN(b),
+  MAX(DISTINCT b)
+FROM t
+
+statement ok
+CREATE MATERIALIZED VIEW hierarchical_global_mv AS
+SELECT * FROM hierarchical_global
+
+statement ok
+CREATE VIEW collated_group_by AS
+SELECT
+  a,
+  COUNT(DISTINCT b),
+  STRING_AGG(b::text || '1',  ',') AS b1,
+  MIN(b),
+  MAX(DISTINCT b),
+  SUM(b),
+  STRING_AGG(b::text || '2',  ',') AS b2
+FROM t
+GROUP BY a
+
+statement ok
+CREATE MATERIALIZED VIEW collated_group_by_mv AS
+SELECT * FROM collated_group_by
+
+statement ok
+CREATE VIEW collated_global AS
+SELECT
+  COUNT(DISTINCT b),
+  STRING_AGG(b::text || '1',  ',') AS b1,
+  MIN(b),
+  MAX(DISTINCT b),
+  SUM(b),
+  STRING_AGG(b::text || '2',  ',') AS b2
+FROM t
+
+statement ok
+CREATE MATERIALIZED VIEW collated_global_mv AS
+SELECT * FROM collated_global
+
+mode cockroach
+
+# Test constant error.
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(no_fast_path, redacted) AS TEXT FOR
+SELECT 1 / 0
+----
+Explained Query:
+  Error █
+
+EOF
+
+# Test constant with two elements.
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(no_fast_path, redacted) AS TEXT FOR
+(SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
+----
+Explained Query:
+  Constant
+    - ((█, █) x 2)
+    - (█, █)
+
+EOF
+
+
+# Test basic linear chains.
+
+# PassArrangements plan (identity transform on an arranged input).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(no_fast_path, redacted) AS TEXT FOR
+SELECT * FROM t
+----
+Explained Query:
+  Get::PassArrangements materialize.public.t
+    raw=false
+    arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# PassArrangements plan (identity transform on a raw input).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(no_fast_path, redacted) AS TEXT FOR
+SELECT * FROM u
+----
+Explained Query:
+  Get::PassArrangements materialize.public.u
+    raw=true
+
+EOF
+
+# GetArrangement plan (linear transform of an arranged input).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(no_fast_path, redacted) AS TEXT FOR
+SELECT a + b, 1 FROM t
+----
+Explained Query:
+  Get::Arrangement materialize.public.t
+    project=(#2, #3)
+    map=((#0 + #1), █)
+    key=#0
+    raw=false
+    arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# GetCollection plan (linear transform of a raw input).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(no_fast_path, redacted) AS TEXT FOR
+SELECT c + d, 1 FROM u
+----
+Explained Query:
+  Get::Collection materialize.public.u
+    raw=true
+
+Source materialize.public.u
+  project=(#2, #3)
+  map=((#0 + #1), █)
+
+EOF
+
+# TopKBasic plan.
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(no_fast_path, redacted) AS TEXT FOR
+INDEX ov_a_idx
+----
+materialize.public.ov_a_idx:
+  ArrangeBy
+    raw=true
+    arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    types=[integer?, integer?]
+    Get::PassArrangements materialize.public.ov
+      raw=true
+
+materialize.public.ov:
+  TopK::Basic order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=█
+    ArrangeBy
+      input_key=[#0]
+      raw=true
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# MonotonicTopK plan.
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(no_fast_path, redacted) AS TEXT FOR
+SELECT * FROM (SELECT * FROM t ORDER BY b asc, a desc LIMIT 5)
+----
+Explained Query:
+  TopK::MonotonicTopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=█ must_consolidate
+    ArrangeBy
+      input_key=[#0]
+      raw=true
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Threshold, Union, Distinct, Negate.
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT a FROM t EXCEPT ALL SELECT b FROM mv
+----
+Explained Query:
+  Threshold::Basic ensure_arrangement={ key=[#0], permutation=id, thinning=() }
+    ArrangeBy
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=() }
+      types=[integer?]
+      Union consolidate_output=true
+        Get::Arrangement materialize.public.t
+          project=(#0)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          types=[integer?, integer?]
+        Negate
+          Get::Collection materialize.public.mv
+            raw=true
+
+Source materialize.public.mv
+  project=(#1)
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test CTEs.
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
+(SELECT x + 1 FROM cte UNION ALL SELECT x - 1 FROM cte)
+----
+Explained Query:
+  Return
+    Union
+      Get::Arrangement l0
+        project=(#1)
+        map=((#0 + █))
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=() }
+        types=[integer?]
+      Get::Arrangement l0
+        project=(#1)
+        map=((#0 - █))
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=() }
+        types=[integer?]
+  With
+    cte l0 =
+      Threshold::Basic ensure_arrangement={ key=[#0], permutation=id, thinning=() }
+        ArrangeBy
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=() }
+          types=[integer?]
+          Union consolidate_output=true
+            Get::Arrangement materialize.public.t
+              project=(#0)
+              key=#0
+              raw=false
+              arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+              types=[integer?, integer?]
+            Negate
+              Get::Collection materialize.public.mv
+                raw=true
+
+Source materialize.public.mv
+  project=(#1)
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Mfp.
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
+SELECT x * 5 FROM cte WHERE x = 5
+----
+Explained Query:
+  Mfp
+    project=(#1)
+    map=(█)
+    input_key=#0
+    Threshold::Basic ensure_arrangement={ key=[#0], permutation=id, thinning=() }
+      ArrangeBy
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=() }
+        types=[integer]
+        Union consolidate_output=true
+          Join::Linear
+            linear_stage[0]
+              closure
+                project=(#0)
+              lookup={ relation=0, key=[#0] }
+              stream={ key=[#0], thinning=() }
+            source={ relation=1, key=[#0] }
+            Get::PassArrangements materialize.public.t
+              raw=false
+              arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+              types=[integer?, integer?]
+            ArrangeBy
+              raw=true
+              arrangements[0]={ key=[#0], permutation=id, thinning=() }
+              types=[integer]
+              Constant
+                - (█)
+          Negate
+            Get::Collection materialize.public.mv
+              raw=true
+
+Source materialize.public.mv
+  project=(#1)
+  filter=((#1 = █))
+
+Used Indexes:
+  - materialize.public.t_a_idx (lookup)
+
+EOF
+
+# Test FlatMap.
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT generate_series(a, b) from t
+----
+Explained Query:
+  FlatMap generate_series(#0, #1, █)
+    mfp_after
+      project=(#2)
+    input_key=#0
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Distinct.
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT DISTINCT a, b FROM t
+----
+Explained Query:
+  Reduce::Distinct
+    val_plan
+      project=()
+    key_plan=id
+    input_key=#0
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Accumulable (with GROUP BY).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT
+  a,
+  SUM(b),
+  COUNT(DISTINCT b)
+FROM t
+GROUP BY a
+----
+Explained Query:
+  Reduce::Accumulable
+    simple_aggrs[0]=(0, 0, sum(#1))
+    distinct_aggrs[0]=(1, 1, count(distinct #1))
+    val_plan
+      project=(#1, #1)
+    key_plan
+      project=(#0)
+    input_key=#0
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Accumulable (global aggregate).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT
+  SUM(b),
+  COUNT(DISTINCT b)
+FROM t
+----
+Explained Query:
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+      Mfp
+        project=(#0, #1)
+        map=(█, █)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+          Constant
+            - ()
+  With
+    cte l0 =
+      Reduce::Accumulable
+        simple_aggrs[0]=(0, 0, sum(#0))
+        distinct_aggrs[0]=(1, 1, count(distinct #0))
+        val_plan
+          project=(#0, #0)
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Hierarchical (with GROUP BY).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+MATERIALIZED VIEW hierarchical_group_by_mv
+----
+materialize.public.hierarchical_group_by_mv:
+  Reduce::Hierarchical
+    aggr_funcs=[min, max]
+    skips=[0, 0]
+    buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
+    val_plan
+      project=(#1, #1)
+    key_plan
+      project=(#0)
+    input_key=#0
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Hierarchical (with GROUP BY, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT * FROM hierarchical_group_by
+----
+Explained Query:
+  Reduce::Hierarchical
+    aggr_funcs=[min, max]
+    skips=[0, 0]
+    monotonic
+    must_consolidate
+    val_plan
+      project=(#1, #1)
+    key_plan
+      project=(#0)
+    input_key=#0
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Hierarchical (global aggregate).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+MATERIALIZED VIEW hierarchical_global_mv
+----
+materialize.public.hierarchical_global_mv:
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+      Mfp
+        project=(#0, #1)
+        map=(█, █)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+          Constant
+            - ()
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[min, max]
+        skips=[0, 0]
+        buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
+        val_plan
+          project=(#0, #0)
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Hierarchical (global aggregate, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT * FROM hierarchical_global
+----
+Explained Query:
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+      Mfp
+        project=(#0, #1)
+        map=(█, █)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+          Constant
+            - ()
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[min, max]
+        skips=[0, 0]
+        monotonic
+        must_consolidate
+        val_plan
+          project=(#0, #0)
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Basic (with GROUP BY).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT
+  a,
+  STRING_AGG(b::text || '1',  ','),
+  STRING_AGG(b::text || '2',  ',')
+FROM t
+GROUP BY a
+----
+Explained Query:
+  Reduce::Basic
+    aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+    aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+    val_plan
+      project=(#3, #4)
+      map=(integer_to_text(#1), row(row((#2 || █), █)), row(row((#2 || █), █)))
+    key_plan
+      project=(#0)
+    input_key=#0
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Basic (global aggregate).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT
+  STRING_AGG(b::text || '1',  ','),
+  STRING_AGG(b::text || '2',  ',')
+FROM t
+----
+Explained Query:
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+      Mfp
+        project=(#0, #1)
+        map=(█, █)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+          Constant
+            - ()
+  With
+    cte l0 =
+      Reduce::Basic
+        aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+        aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+        val_plan
+          project=(#2, #3)
+          map=(integer_to_text(#0), row(row((#1 || █), █)), row(row((#1 || █), █)))
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Collated (with GROUP BY).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+MATERIALIZED VIEW collated_group_by_mv
+----
+materialize.public.collated_group_by_mv:
+  Reduce::Collation
+    aggregate_types=[a, b, h, h, a, b]
+    accumulable
+      simple_aggrs[0]=(1, 4, sum(#1))
+      distinct_aggrs[0]=(0, 0, count(distinct #1))
+    hierarchical
+      aggr_funcs=[min, max]
+      skips=[2, 0]
+      buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
+    basic
+      aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+      aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+    val_plan
+      project=(#1, #3, #1, #1, #1, #4)
+      map=(integer_to_text(#1), row(row((#2 || █), █)), row(row((#2 || █), █)))
+    key_plan
+      project=(#0)
+    input_key=#0
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Collated (with GROUP BY, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT * FROM collated_group_by
+----
+Explained Query:
+  Reduce::Collation
+    aggregate_types=[a, b, h, h, a, b]
+    accumulable
+      simple_aggrs[0]=(1, 4, sum(#1))
+      distinct_aggrs[0]=(0, 0, count(distinct #1))
+    hierarchical
+      aggr_funcs=[min, max]
+      skips=[2, 0]
+      monotonic
+      must_consolidate
+    basic
+      aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+      aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+    val_plan
+      project=(#1, #3, #1, #1, #1, #4)
+      map=(integer_to_text(#1), row(row((#2 || █), █)), row(row((#2 || █), █)))
+    key_plan
+      project=(#0)
+    input_key=#0
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Collated (global aggregate).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+MATERIALIZED VIEW collated_global_mv
+----
+materialize.public.collated_global_mv:
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+      Mfp
+        project=(#0..=#5)
+        map=(█, █, █, █, █, █)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+          Constant
+            - ()
+  With
+    cte l0 =
+      Reduce::Collation
+        aggregate_types=[a, b, h, h, a, b]
+        accumulable
+          simple_aggrs[0]=(1, 4, sum(#0))
+          distinct_aggrs[0]=(0, 0, count(distinct #0))
+        hierarchical
+          aggr_funcs=[min, max]
+          skips=[2, 0]
+          buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
+        basic
+          aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+          aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+        val_plan
+          project=(#0, #2, #0, #0, #0, #3)
+          map=(integer_to_text(#0), row(row((#1 || █), █)), row(row((#1 || █), █)))
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test Reduce::Collated (global aggregate, one-shot).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT * FROM collated_global
+----
+Explained Query:
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+      Mfp
+        project=(#0..=#5)
+        map=(█, █, █, █, █, █)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+          Constant
+            - ()
+  With
+    cte l0 =
+      Reduce::Collation
+        aggregate_types=[a, b, h, h, a, b]
+        accumulable
+          simple_aggrs[0]=(1, 4, sum(#0))
+          distinct_aggrs[0]=(0, 0, count(distinct #0))
+        hierarchical
+          aggr_funcs=[min, max]
+          skips=[2, 0]
+          monotonic
+          must_consolidate
+        basic
+          aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+          aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+        val_plan
+          project=(#0, #2, #0, #0, #0, #3)
+          map=(integer_to_text(#0), row(row((#1 || █), █)), row(row((#1 || █), █)))
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+
+
+# Test EXPLAIN INDEX for an indexed source
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+INDEX t_a_idx
+----
+materialize.public.t_a_idx:
+  ArrangeBy
+    raw=true
+    arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    types=[integer?, integer?]
+    Get::PassArrangements materialize.public.t
+      raw=true
+
+EOF
+
+# Test EXPLAIN INDEX for an indexed view (first index)
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+INDEX ov_a_idx;
+----
+materialize.public.ov_a_idx:
+  ArrangeBy
+    raw=true
+    arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    types=[integer?, integer?]
+    Get::PassArrangements materialize.public.ov
+      raw=true
+
+materialize.public.ov:
+  TopK::Basic order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=█
+    ArrangeBy
+      input_key=[#0]
+      raw=true
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test EXPLAIN INDEX for an indexed view (based on a prior index)
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+INDEX ov_b_idx;
+----
+materialize.public.ov_b_idx:
+  ArrangeBy
+    input_key=[#0]
+    raw=false
+    arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    arrangements[1]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
+    types=[integer?, integer?]
+    Get::PassArrangements materialize.public.ov
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.ov_a_idx (*** full scan ***, index export)
+
+EOF
+
+
+# Test Join::Differential (acyclic).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(non_negative) AS TEXT FOR
+SELECT b + d, c + e, a + e
+FROM t, u, v
+WHERE a = c AND d = e AND b + d > 42
+----
+Explained Query:
+  Join::Linear
+    final_closure
+      project=(#0, #1, #1)
+    linear_stage[1]
+      closure
+        project=(#1, #2)
+      lookup={ relation=2, key=[#0] }
+      stream={ key=[#0], thinning=(#1, #2) }
+    linear_stage[0]
+      closure
+        project=(#2..=#4)
+        filter=((#0) IS NOT NULL AND (#3 > 42))
+        map=((#1 + #2), (#0 + #2))
+      lookup={ relation=1, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    source={ relation=0, key=[#0] }
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+    ArrangeBy
+      raw=true
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer, integer]
+      Get::Collection materialize.public.u
+        raw=true
+    ArrangeBy
+      raw=true
+      arrangements[0]={ key=[#0], permutation=id, thinning=() }
+      types=[integer]
+      Get::Collection materialize.public.v
+        raw=true
+
+Source materialize.public.u
+  filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+Source materialize.public.v
+  project=(#0)
+  filter=((#0) IS NOT NULL)
+
+Used Indexes:
+  - materialize.public.t_a_idx (differential join)
+
+EOF
+
+# Create indexes required for differential join tests
+
+statement ok
+CREATE INDEX u_c_idx ON U(c);
+
+statement ok
+CREATE INDEX u_d_idx ON U(d);
+
+statement ok
+CREATE INDEX v_e_idx ON V(e);
+
+# Test Join::Differential (cyclic).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(non_negative) AS TEXT FOR
+SELECT a, b, c, d, e, f
+FROM t, u, v
+WHERE a = c AND d = e AND f = a
+----
+Explained Query:
+  Join::Linear
+    final_closure
+      project=(#0, #1, #0, #2, #2, #0)
+    linear_stage[1]
+      closure
+        project=(#0, #2, #1)
+        filter=((#0) IS NOT NULL)
+      lookup={ relation=0, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    linear_stage[0]
+      closure
+        project=(#1, #0)
+      lookup={ relation=2, key=[#0, #1] }
+      stream={ key=[#1, #0], thinning=() }
+    source={ relation=1, key=[#1, #0] }
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+    ArrangeBy
+      raw=true
+      arrangements[0]={ key=[#1, #0], permutation={#0: #1, #1: #0}, thinning=() }
+      types=[integer, integer]
+      Get::Arrangement materialize.public.u
+        filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    ArrangeBy
+      raw=true
+      arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
+      types=[integer, integer]
+      Get::Arrangement materialize.public.v
+        filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (differential join)
+  - materialize.public.u_c_idx (*** full scan ***)
+  - materialize.public.v_e_idx (*** full scan ***)
+
+EOF
+
+# Test Join::Delta (star).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(non_negative) AS TEXT FOR
+SELECT a, b, c, d, e, f
+FROM t, u, v
+WHERE a = c and a = e
+----
+Explained Query:
+  Join::Delta
+    plan_path[0]
+      final_closure
+        project=(#0, #1, #0, #2, #0, #3)
+      delta_stage[1]
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      delta_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      initial_closure
+        filter=((#0) IS NOT NULL)
+      source={ relation=0, key=[#0] }
+    plan_path[1]
+      final_closure
+        project=(#0, #1, #0, #2, #0, #3)
+      delta_stage[1]
+        closure
+          project=(#1..=#4)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#2], thinning=(#0, #1, #3) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #0, #1)
+          filter=((#0) IS NOT NULL)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=1, key=[#0] }
+    plan_path[2]
+      final_closure
+        project=(#0, #1, #0, #2, #0, #3)
+      delta_stage[1]
+        closure
+          project=(#1, #2, #4, #3)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#2], thinning=(#0, #1, #3) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #0, #1)
+          filter=((#0) IS NOT NULL)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=2, key=[#0] }
+    Get::PassArrangements materialize.public.t
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+    Get::PassArrangements materialize.public.u
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+    Get::PassArrangements materialize.public.v
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (delta join 1st input (full scan))
+  - materialize.public.u_c_idx (delta join lookup)
+  - materialize.public.v_e_idx (delta join lookup)
+
+EOF
+
+# Test #17348.
+
+statement ok
+CREATE TABLE r(f0 INT, f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT, f9 INT, f10 INT, f11 INT, f12 INT, f13 INT, f14 INT, f15 INT, f16 INT);
+
+query T multiline
+EXPLAIN SELECT *
+FROM r AS r0, r AS r1
+WHERE
+  r0.f0=r1.f0 AND
+  r0.f2=r1.f2 AND
+  r0.f3=r1.f3 AND
+  r0.f4=r1.f4 AND
+  r0.f6=r1.f6 AND
+  r0.f8=r1.f8 AND
+  r0.f9=r1.f9 AND
+  r0.f11=r1.f11 AND
+  r0.f12=r1.f12 AND
+  r0.f13=r1.f13 AND
+  r0.f15=r1.f15 AND
+  r0.f16=r1.f16;
+----
+Explained Query:
+  Return
+    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
+      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
+        Get l0
+        Get l0
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0, #2..=#4, #6, #8, #9, #11..=#13, #15, #16]]
+        Filter (#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL
+          ReadStorage materialize.public.r
+
+Source materialize.public.r
+  filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)
+
+EOF
+
+# Test `LetRec` printing, with and without RECURSION LIMIT
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT * FROM (
+    WITH MUTUALLY RECURSIVE (RECURSION LIMIT 5)
+        foo (a int8) AS (SELECT DISTINCT a FROM foo)
+    SELECT * FROM foo
+)
+UNION ALL
+SELECT * FROM (
+    WITH MUTUALLY RECURSIVE
+        bar (a int8) AS (SELECT DISTINCT a - 2 FROM bar)
+    SELECT * FROM bar
+);
+----
+Explained Query:
+  Return
+    Union
+      Get::PassArrangements l0
+        raw=true
+      Get::PassArrangements l1
+        raw=true
+  With Mutually Recursive
+    cte l1 =
+      ArrangeBy
+        input_key=[#0]
+        raw=true
+        Reduce::Distinct
+          val_plan
+            project=()
+          key_plan
+            project=(#1)
+            map=((#0 - █))
+          Get::PassArrangements l1
+            raw=true
+    cte [recursion_limit=5] l0 =
+      ArrangeBy
+        input_key=[#0]
+        raw=true
+        Reduce::Distinct
+          val_plan
+            project=()
+          key_plan=id
+          Get::PassArrangements l0
+            raw=true
+
+EOF
+
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT lead(b, 3, -5) IGNORE NULLS OVER () as l
+FROM t;
+----
+Explained Query:
+  FlatMap unnest_list(#0)
+    mfp_after
+      project=(#2)
+      map=(record_get[0](#1))
+    input_key=
+    Reduce::Basic
+      aggr=(0, lag[ignore_nulls=true, order_by=[]](row(row(row(#0, #1), row(#1, █, █)))))
+      val_plan
+        project=(#2)
+        map=(row(row(row(#0, #1), row(#1, █, █))))
+      key_plan
+        project=()
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
+SELECT lag(b, 3, -5) IGNORE NULLS OVER (PARTITION BY b, a ORDER BY b+8, a-7) as l
+FROM t;
+----
+Explained Query:
+  FlatMap unnest_list(#0)
+    mfp_after
+      project=(#2)
+      map=(record_get[0](#1))
+    Mfp
+      project=(#2)
+      input_key=#0, #1
+      Reduce::Basic
+        aggr=(0, lag[ignore_nulls=true, order_by=[#0 asc nulls_last, #1 asc nulls_last]](row(row(row(#0, #1), row(#1, █, █)), (#1 + █), (#0 - █))))
+        val_plan
+          project=(#2)
+          map=(row(row(row(#0, #1), row(#1, █, █)), (#1 + █), (#0 - █)))
+        key_plan
+          project=(#1, #0)
+        input_key=#0
+        Get::PassArrangements materialize.public.t
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF


### PR DESCRIPTION
Add support for `EXPLAIN WITH(redacted)` output which replaces literals with █ and fixes an issue in `staging` and `production` where at the moment people would see redacted literals even if they are not requested with a `WITH` flag.


### Motivation

  * This PR adds a known-desirable feature.

Part of MaterializeInc/cloud#8196.

### Tips for reviewer

This is similar to MaterializeInc/materialize#23861.

I don't particularly like how now we have different mechanisms for rendering a structure paired with a context (`HumanizedExpr` and `HumanizedExplain + HumanizedNotice` on the one side and `DisplayText` on the other). Both have some benefits and drawbacks, but most notably I think it is confusing to have an implementation that uses both and asks of others to understand what to use when. Once I'm done with the HIR plans, I'll take a look at the code again and propose a unification, so moving forward we will use only one.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
