### PR TITLE
compute: apply source backpressure also within persist_sink

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -107,7 +107,7 @@ where
         SnapshotMode::Include,
         Antichain::new(), // we want all updates
         None,             // no MFP
-        None,             // no flow control
+        compute_state.dataflow_max_inflight_bytes,
     );
     let persist_collection = ok_stream
         .as_collection()


### PR DESCRIPTION
This PR changes the construction of the `persist_source` within Compute's `persist_sink` to also use the configured backpressure value.

Previously this value was only used for dataflow input sources and `persist_source`s within `persist_sink`s were unregulated, [leading to hydration memory spikes](https://www.notion.so/materialize/Analysis-of-persist_sink-correction-Memory-Spikes-in-Production-98ae0fcb68eb4eff909d1c4ca9796881). There is no reason to not treat sink sources the same way as input sources in this regard.

### Motivation

  * This PR fixes a previously unreported bug.
 
Decoding within `persist_source`s that get instantiated as part of Compute `persist_sink`s can cause hydration memory spikes and OOMs. Setting `compute_max_inflight_bytes` to counteract this is not effective.

### Tips for reviewer

I said that there is no reason to not do this, but that only means that _I_ can't think of a reason. I assume leaving these sources un-backpressured was an oversight when the `persist_source`-internal backpressure was introduced, but I might be wrong!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A