### PR TITLE
Fix Demand's Threshold case interacting with the Union case

### DIFF
--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -340,9 +340,10 @@ impl Demand {
                     self.action(input, (0..arity).collect(), gets)
                 }
                 MirRelationExpr::Union { base, inputs } => {
-                    self.action(base, columns.clone(), gets)?;
+                    let all_columns: BTreeSet<_> = (0..base.arity()).collect();
+                    self.action(base, all_columns.clone(), gets)?;
                     for input in inputs {
-                        self.action(input, columns.clone(), gets)?;
+                        self.action(input, all_columns.clone(), gets)?;
                     }
                     Ok(())
                 }

--- a/test/sqllogictest/transform/demand.slt
+++ b/test/sqllogictest/transform/demand.slt
@@ -26,6 +26,43 @@ select x from (select x, 1/a from (select 2 as x), t);
 2
 2
 
+statement ok
+CREATE TABLE t1 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+query RR
+SELECT
+  COUNT (a1.f2) AS agg1,
+  MIN (a1.f2) AS agg2
+FROM
+  (
+    SELECT
+      MIN (f1) AS f1,
+      MIN (f2) AS f2
+    FROM
+      t1 AS a2
+    WHERE
+      a2.f2 IS NULL
+  ) AS a1
+  LEFT JOIN (
+    SELECT * FROM (VALUES (1, 2)) t1 (f1, f2)
+  ) AS a2 ON (TRUE)
+INTERSECT
+SELECT
+  MIN (a1.f2) AS agg1,
+  AVG (a1.f1) AS agg2
+FROM
+   (
+    SELECT
+      a1.f2 AS f1,
+      a1.f1 AS f2
+    FROM
+      t1 AS a1
+    LIMIT
+      0
+  ) AS a1;
+----
+
+
 ## -------------------- Tests for WITH MUTUALLY RECURSIVE --------------------
 
 # Demand creates the `#0 + #0` from `#0 + #2`.


### PR DESCRIPTION
Draft to run CI

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
