### PR TITLE
ci: Increase the timeout of the persist-txn-fencing CI step

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1193,7 +1193,7 @@ steps:
 
   - id: persist-txn-fencing
     label: Persist-txn fencing
-    timeout_in_minutes: 60
+    timeout_in_minutes: 90
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
The mzcompose workload runs 2 * 8 = 16 distinct workloads, each involving an Mz restart and a follow-up verification of data, so it can legitimately take 60+ minutes.

### Motivation

Nightly CI was failing.