### PR TITLE
rqg: Pass --duration=0 to the RQG as well

### DIFF
--- a/test/rqg/mzcompose.py
+++ b/test/rqg/mzcompose.py
@@ -221,25 +221,24 @@ def run_workload(c: Composition, args: argparse.Namespace, workload: Workload) -
                     print(f"--- Populating {psql_url} with {file} ...")
                     c.exec("rqg", "bash", "-c", f"psql -f conf/mz/{file} {psql_url}")
 
-            if duration > 0:
-                c.exec(
-                    "rqg",
-                    "perl",
-                    "gentest.pl",
-                    "--dsn1=dbi:Pg:dbname=materialize;host=mz_this;user=materialize;port=6875",
-                    *dsn2,
-                    f"--grammar={grammar}",
-                    f"--validator={workload.validator}"
-                    if workload.validator is not None
-                    else "",
-                    f"--starting-rule={args.starting_rule}"
-                    if args.starting_rule is not None
-                    else "",
-                    "--queries=100000000",
-                    f"--threads={threads}",
-                    f"--duration={duration}",
-                    f"--seed={args.seed}",
-                    env_extra=env_extra,
-                )
+            c.exec(
+                "rqg",
+                "perl",
+                "gentest.pl",
+                "--dsn1=dbi:Pg:dbname=materialize;host=mz_this;user=materialize;port=6875",
+                *dsn2,
+                f"--grammar={grammar}",
+                f"--validator={workload.validator}"
+                if workload.validator is not None
+                else "",
+                f"--starting-rule={args.starting_rule}"
+                if args.starting_rule is not None
+                else "",
+                "--queries=100000000",
+                f"--threads={threads}",
+                f"--duration={duration}",
+                f"--seed={args.seed}",
+                env_extra=env_extra,
+            )
         finally:
             c.capture_logs()


### PR DESCRIPTION
Previously, the RQG was not even run if the mzcompose was called with --duration=0. This means that any initialization steps that are in the grammar will not get run.

Remove the special-case for --duration=0, so that the RQG is called, It will have the opportunity to run the grammar initialization and will then terminate immediately.

### Motivation

A user should be able to run an RQG workload with `--duration=0` and get a database pre-populated with any DDLs from the grammar initialization rules.

### Tips for reviewer

Review with whitespace off, it is a 1-liner.