### PR TITLE
parallel-workload-kill: Restore previous agent size

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1141,7 +1141,8 @@ steps:
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64-small
+          # OOMs with linux-x86_64-small
+          queue: linux-x86_64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload


### PR DESCRIPTION
The job is OOM-ing with a small agent, so use the default one as before.

### Motivation

Nighlty CI was failing.