### PR TITLE
CODEOWNERS: remove DevEx ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,10 +16,10 @@
 /bin/lint-versions                  @MaterializeInc/testing
 /ci                                 @MaterializeInc/testing
 /ci/test/lint-deps.toml             @danhhz @benesch
-/doc/user                           @MaterializeInc/docs
+/doc/user                           @morsapaes
 /doc/developer/reference/compute    @MaterializeInc/compute
 /doc/developer/reference/storage    @MaterializeInc/storage
-/misc/dbt-materialize               @MaterializeInc/devex
+/misc/dbt-materialize               @morsapaes
 /src/adapter                        @MaterializeInc/adapter
 /src/adapter-types                  @MaterializeInc/adapter
 /src/adapter/src/optimizer          @MaterializeInc/compute
@@ -55,7 +55,6 @@
 /src/lowertest                      @MaterializeInc/compute
 /src/lowertest-derive               @MaterializeInc/compute
 /src/metabase                       @benesch
-/src/mz                             @MaterializeInc/devex
 /src/npm                            @benesch
 /src/orchestrator                   @benesch
 /src/orchestrator-kubernetes        @benesch
@@ -92,10 +91,7 @@
 # layer, despite being located in the `sql` crate.
 /src/sql/src/plan/lowering.rs       @MaterializeInc/compute
 /src/sql-lexer                      @MaterializeInc/adapter
-# DevEx is added as an owner of /src/sql-parser to increase awareness of
-# cross-team dependencies via notifications. The code is solely owned by the
-# Adapter team.
-/src/sql-parser                     @MaterializeInc/adapter @MaterializeInc/devex
+/src/sql-parser                     @MaterializeInc/adapter
 /src/sqllogictest                   @MaterializeInc/adapter
 /src/ssh-util                       @MaterializeInc/storage
 /src/stash                          @MaterializeInc/adapter

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,6 +55,7 @@
 /src/lowertest                      @MaterializeInc/compute
 /src/lowertest-derive               @MaterializeInc/compute
 /src/metabase                       @benesch
+/src/mz                             @MaterializeInc/integrations
 /src/npm                            @benesch
 /src/orchestrator                   @benesch
 /src/orchestrator-kubernetes        @benesch


### PR DESCRIPTION
Cleaning up `CODEOWNERS` as work previously owned by DevEx moves under Engineering. Also, making it explicit that the user documentation code path is owned by an individual, since `MaterializeInc/docs` does not map to an actual team (which has caused confusion before).

@benesch, could you remove the DevEx team from the Materialize organization?