### PR TITLE
Improve representation in top-k

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -115,7 +115,7 @@ use mz_compute_types::dataflows::{BuildDesc, DataflowDescription, IndexDesc};
 use mz_compute_types::plan::Plan;
 use mz_expr::{EvalError, Id};
 use mz_persist_client::operators::shard_source::SnapshotMode;
-use mz_repr::{Diff, GlobalId};
+use mz_repr::{Datum, Diff, GlobalId, Row, SharedRow};
 use mz_storage_operators::persist_source;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
@@ -1052,4 +1052,45 @@ where
             }
         }
     })
+}
+
+/// Helper to merge pairs of datum iterators into a row or split a datum iterator
+/// into two rows, given the arity of the first component.
+#[derive(Clone, Copy, Debug)]
+struct Pairer {
+    split_arity: usize,
+}
+
+impl Pairer {
+    /// Creates a pairer with knowledge of the arity of first component in the pair.
+    fn new(split_arity: usize) -> Self {
+        Self { split_arity }
+    }
+
+    /// Merges a pair of datum iterators creating a `Row` instance.
+    fn merge<'a, I1, I2>(&self, first: I1, second: I2) -> Row
+    where
+        I1: IntoIterator<Item = Datum<'a>>,
+        I2: IntoIterator<Item = Datum<'a>>,
+    {
+        let binding = SharedRow::get();
+        let mut row_builder = binding.borrow_mut();
+        let mut row_packer = row_builder.packer();
+        row_packer.extend(first);
+        row_packer.extend(second);
+        row_builder.clone()
+    }
+
+    /// Splits a datum iterator into a pair of `Row` instances.
+    fn split<'a>(&self, datum_iter: impl IntoIterator<Item = Datum<'a>>) -> (Row, Row) {
+        let mut datum_iter = datum_iter.into_iter();
+        let binding = SharedRow::get();
+        let mut row_builder = binding.borrow_mut();
+        let mut row_packer = row_builder.packer();
+        row_packer.extend(datum_iter.by_ref().take(self.split_arity));
+        let first = row_builder.clone();
+        row_packer = row_builder.packer();
+        row_packer.extend(datum_iter);
+        (first, row_builder.clone())
+    }
 }


### PR DESCRIPTION
This PR improves the representation of `(key, hash)` pairs used in top-k arrangement stacks to use `Row` instead of `(Row, u64)`. The latter allows us to use spine types that specialize the representation of rows by `DatumContainer`. Additionally, the PR also improves the type-based dispatch to form arrangement stacks in top-k, thereby allowing us to use a spine type relying on `DatumContainer` for values in addition to keys in all but the first level of the stack.

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/24337

### Tips for reviewer

The commits can be looked at individually. This is the final PR in the series of #24307, #24375, and #24388.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
