### PR TITLE
Acquire read holds after the timestamp selection of a REFRESH MV

### DIFF
--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -296,8 +296,7 @@ class View(DBObject):
                     "ON COMMIT",
                     f"EVERY '{rng.randint(1, 60)} seconds {rng.randint(0, 60)} minutes'",
                     f"EVERY '{rng.randint(1, 60)} seconds {rng.randint(0, 60)} minutes' ALIGNED TO (mz_now())",
-                    # TODO(def-): Allow AT again when #24288 is fixed
-                    # f"AT mz_now()::string::int8 + {rng.randint(0, 3600000)}",
+                    f"AT mz_now()::string::int8 + {rng.randint(0, 3600000)}",
                 ]
             )
             if self.materialized

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1239,7 +1239,7 @@ pub struct Coordinator {
     ///
     /// Upon completing a transaction, this timestamp should be removed from the holds
     /// in `self.read_capability[id]`, using the `release_read_holds` method.
-    txn_reads: BTreeMap<ConnectionId, crate::coord::read_policy::ReadHolds<mz_repr::Timestamp>>,
+    txn_read_holds: BTreeMap<ConnectionId, read_policy::ReadHolds<Timestamp>>,
 
     /// Access to the peek fields should be restricted to methods in the [`peek`] API.
     /// A map from pending peek ids to the queue into which responses are sent, and
@@ -2848,7 +2848,7 @@ pub fn serve(
                     active_conns: BTreeMap::new(),
                     storage_read_capabilities: Default::default(),
                     compute_read_capabilities: Default::default(),
-                    txn_reads: Default::default(),
+                    txn_read_holds: Default::default(),
                     pending_peeks: BTreeMap::new(),
                     client_pending_peeks: BTreeMap::new(),
                     pending_real_time_recency_timestamp: BTreeMap::new(),

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -33,6 +33,7 @@ use timely::progress::Antichain;
 
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::timeline::{TimelineContext, TimelineState};
+use crate::session::Session;
 use crate::util::ResultExt;
 
 /// Relevant information for acquiring or releasing a bundle of read holds.
@@ -417,6 +418,25 @@ impl crate::coord::Coordinator {
         }
 
         read_holds
+    }
+
+    /// Attempt to acquire read holds on the indicated collections at the indicated `time`.
+    /// This is similar to [Self::acquire_read_holds], but instead of returning the read holds,
+    /// it arranges for them to be automatically released at the end of the transaction.
+    ///
+    /// If we are unable to acquire a read hold at the provided `time` for a specific id, then we
+    /// will acquire a read hold at the lowest possible time for that id.
+    pub(crate) fn acquire_read_holds_auto_cleanup(
+        &mut self,
+        session: &mut Session,
+        time: Timestamp,
+        id_bundle: &CollectionIdBundle,
+    ) {
+        let read_holds = self.acquire_read_holds(time, id_bundle);
+        self.txn_read_holds
+            .entry(session.conn_id().clone())
+            .or_insert_with(ReadHolds::new)
+            .extend(read_holds);
     }
 
     /// Attempt to update the timestamp of the read holds on the indicated collections from the

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -208,7 +208,7 @@ impl Coordinator {
         self.drop_compute_sinks(drop_sinks);
 
         // Release this transaction's compaction hold on collections.
-        if let Some(txn_reads) = self.txn_reads.remove(conn_id) {
+        if let Some(txn_reads) = self.txn_read_holds.remove(conn_id) {
             self.release_read_hold(&txn_reads);
         }
     }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -95,7 +95,10 @@ pub use query::{ExprContext, QueryContext, QueryLifetime};
 pub use scope::Scope;
 pub use side_effecting_func::SideEffectingFunc;
 pub use statement::ddl::{PlannedAlterRoleOption, PlannedRoleVariable};
-pub use statement::{describe, plan, plan_copy_from, StatementContext, StatementDesc};
+pub use statement::{
+    describe, plan, plan_copy_from, resolve_cluster_for_materialized_view, StatementContext,
+    StatementDesc,
+};
 
 /// Instructions for executing a SQL query.
 #[derive(Debug, EnumKind)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2137,10 +2137,8 @@ pub fn plan_create_materialized_view(
     mut stmt: CreateMaterializedViewStatement<Aug>,
     params: &Params,
 ) -> Result<Plan, PlanError> {
-    let cluster_id = match &stmt.in_cluster {
-        None => scx.resolve_cluster(None)?.id(),
-        Some(in_cluster) => in_cluster.id,
-    };
+    let cluster_id =
+        crate::plan::statement::resolve_cluster_for_materialized_view(scx.catalog, &stmt)?;
     stmt.in_cluster = Some(ResolvedClusterName {
         id: cluster_id,
         print_name: None,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1804,13 +1804,7 @@ const MZ_NOW_SCHEMA: &str = "mz_catalog";
 /// references to ids appear or disappear during the purification.
 ///
 /// Note that in contrast with [`purify_statement`], this doesn't need to be async, because
-/// this function is not making any network calls. Furthermore, there is a good reason for it
-/// to be sync: if this were async, then the `mz_now` that our caller selected could become
-/// invalid by the time the async result message is handled by the coordinator main loop, in
-/// the sense that we might no longer be able to read our inputs at the selected timestamp.
-/// If it is sync, then there is no gap between observing the oracle read timestamp and
-/// installing the materialized view in the catalog, at which point it will install its own
-/// read holds for the refresh at `mz_now`.
+/// this function is not making any network calls.
 pub fn purify_create_materialized_view_options(
     catalog: impl SessionCatalog,
     mz_now: Option<Timestamp>,

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1017,3 +1017,12 @@ NULL  -1  -2
 10  11  12
 30  30  30
 100  100  100
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/24288
+# The sleep makes _optimization_ take a few seconds, so we need to grab read holds in purification right away after
+# choosing a timestamp for mz_now.
+statement ok
+create materialized view mv4 with (refresh at creation) as
+select * from
+  (select mz_unsafe.mz_sleep(3)),
+  (select * from t2);

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -812,10 +812,10 @@ SELECT * FROM mv_assertion_plus_refresh_every ORDER BY x;
 
 # Sleep for the refresh interval, so that we get a refresh.
 # Actually, we sleep one more second than the refresh interval, because we don't have real-time recency guarantees:
-# When we query the MV at a particular wall clock time time `t`, there is not guarantee that we see a refresh that
+# When we query the MV at a particular wall clock time time `t`, there is no guarantee that we see a refresh that
 # happened at, say, `t - 1ms`. Note that the test was actually failing sometimes when it was sleeping for only 8s.
-# A proper solution might be to add `AS OF now()` to this SELECT, but calling `now()` seems to not be currently allowed
-# in `AS OF`.
+# A proper solution might be to add `AS OF now()` to the following SELECT, but calling `now()` seems to not be currently
+# allowed in `AS OF`.
 statement ok
 SELECT mz_unsafe.mz_sleep(8+1);
 
@@ -990,17 +990,10 @@ NULL  -1  -2
 30  30  30
 100  100  100
 
-# Wait until the second refresh, which is the last one
-query III
-SELECT * FROM mv3;
-----
-NULL  -1  -2
-4  NULL  6
-7  8  NULL
-1  2  3
-10  11  12
-30  30  30
-100  100  100
+# Wait until we are past the second refresh, which is the last one.
+# (See the explanation for the `+1` above at a similar `mz_sleep`.)
+statement ok
+SELECT mz_unsafe.mz_sleep(2+1);
 
 # This insert will happen after the last refresh.
 statement ok


### PR DESCRIPTION
This fixes https://github.com/MaterializeInc/materialize/issues/24288 as discussed with @mjibson [here](https://materializeinc.slack.com/archives/C02FWJ94HME/p1704989974860729?thread_ts=1704982981.659269&cid=C02FWJ94HME).

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/24288

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
