### PR TITLE
Shepherdly yml config

### DIFF
--- a/.config/shepherdly.yml
+++ b/.config/shepherdly.yml
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+
+# Docs: https://help.shepherdly.io/en/articles/8818618-shepherdly-repo-config
+configurations:
+  - name: scoring_comment_enabled
+    value: true
+  - name: scoring_comment_risk_score_threshold
+    value: 80
+  - name: scoring_comment_draft_mode
+    value: false
+  - name: qa_git_team_name
+    value: testing
+  - name: integration_test_path
+    value: test/,src/testdrive/,src/pgtest/
+  - name: file_path_exclusions
+    value: .github/,doc/,misc/,bin/,ci/,.devcontainer/,test/,tests/,testdrive/,sqllogictest/,pgtest/,lowertest/,lowertest-derive/
+mitigations:
+  - name: code_review
+    score_threshold: 0
+  - name: qa_review
+    score_threshold: 80
+  - name: feature_flag
+    score_threshold: 80
+  - name: integration_test
+    score_threshold: 80
+  - name: unit_test
+    # A value of 100 effectively makes this always optional
+    score_threshold: 100
+  - name: observability
+    score_threshold: 75
+  - name: run_nightly_tests
+    score_threshold: 80
+    custom: true
+    label: Run Nightly Tests
+    label_url: https://trigger-ci.dev.materialize.com/?pr={{pr_number}}
+default_system_mitigations: false


### PR DESCRIPTION
Shepherdly now supports `yml` config at the repo level as well as custom mitigations.

Another notable change is the support of custom mitigations. Per @def-'s [request](https://shepherdly.slack.com/archives/C051BG4BFL7/p1704815224163999), I've added a custom mitigation that links out to running nightly tests. 

Everything else in the file is a copy of how the repo settings were configured to date.

### Motivation
Shepherdly is moving towards injectable configuration and this change brings the `materialize` repo up to parity. 
