### PR TITLE
test: allow waiting longer when verifying slot

### DIFF
--- a/src/testdrive/src/action/postgres/verify_slot.rs
+++ b/src/testdrive/src/action/postgres/verify_slot.rs
@@ -30,7 +30,7 @@ pub async fn run_verify_slot(
 
     Retry::default()
         .initial_backoff(Duration::from_millis(50))
-        .max_duration(cmp::max(state.default_timeout, Duration::from_secs(10)))
+        .max_duration(cmp::max(state.default_timeout, Duration::from_secs(60)))
         .retry_async_canceling(|_| async {
             println!(">> checking for postgres replication slot {}", &slot);
             let rows = client

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -148,9 +148,7 @@ CREATE PUBLICATION another_publication FOR TABLE another_schema.another_table;
 
 #
 # Test that slots created for replication sources are deleted on DROP
-#
-# TODO(def-) Reenable when #24357 is fixed
-#$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=materialize_% active=false
+$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=materialize_% active=false
 
 # Sneak in a test for pg_source_snapshot_statement_timeout
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}


### PR DESCRIPTION
when verifying the state of a slot, we could hit some unfortunate timing when dropping the slot on a persistent cluster (i.e. one that will continue running after the source is dropped). namely, when dropping a source, we very quickly spawn a task to drop the replication slot, while communicating with the cluster that the dataflow needs to be dropped takes slightly longer. if the task dropping the replication slot is unfortunate, it's possible that its retry loop backs off too quickly to effectively be retried after we know that the dataflow has stopped being rendered.

these kinds of race conditions between the adapter and storaged are well known and are actively being worked on. However, until we make the ordering of commands deterministic, the easiest thing to do is just wait longer for the dataflow to stop being rendered and let us drop the replication slot.

### Motivation

This PR fixes a recognized bug. Fixes #24357

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
