### PR TITLE
storage/pg: set PG source to running on render

### DIFF
--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -316,6 +316,9 @@ types_table           subsource <null>  <null>
 utf8_table            subsource <null>  <null>
 таблица               subsource <null>  <null>
 
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
+running
+
 > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source_progress';
 running
 


### PR DESCRIPTION
many users are confused that PG sources' primary sources state that they're starting instead of running, even while the ingestion is running. we can patch over this by just seeding the state of the primary source with a Running update.

Note that it is expected behavior that restarting the source will lose definite errors in the status collection. #23950

### Motivation

This PR fixes a recognized bug. Fixes #24044

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
