### PR TITLE
cluster tests: Reenable blue-green-deployment

### DIFF
--- a/test/cluster/blue-green-deployment/deploy.td
+++ b/test/cluster/blue-green-deployment/deploy.td
@@ -61,7 +61,7 @@
         LEFT JOIN mz_internal.mz_materialization_lag l ON (l.object_id = d.id)
         WHERE
             h.hydrated AND
-            (l.local_lag < '1s' OR l.local_lag IS NULL)
+            (l.local_lag <= '1s' OR l.local_lag IS NULL)
     ),
     -- Collect dataflows that are not yet ready.
     pending_dataflows AS (

--- a/test/cluster/blue-green-deployment/setup.td
+++ b/test/cluster/blue-green-deployment/setup.td
@@ -89,7 +89,7 @@ ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
         LEFT JOIN mz_internal.mz_materialization_lag l ON (l.object_id = d.id)
         WHERE
             h.hydrated AND
-            (l.local_lag < '1s' OR l.local_lag IS NULL)
+            (l.local_lag <= '1s' OR l.local_lag IS NULL)
     ),
     -- Collect dataflows that are not yet ready.
     pending_dataflows AS (

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -76,12 +76,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     for i, name in enumerate(c.workflows):
         # incident-70 requires more memory, runs in separate CI step
         # concurrent-connections is too flaky
-        # blue-green-deployment is too flaky (again)
         if name in (
             "default",
             "test-incident-70",
             "test-concurrent-connections",
-            "blue-green-deployment",
         ):
             continue
         if shard is None or shard_count is None or i % int(shard_count) == shard:


### PR DESCRIPTION
With new <= 1s local_lag, as suggested by Jan

I'll run this in an endless loop on my dev server to verify.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
