### PR TITLE
adapter: attempt for longer to drop replication slots

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -606,7 +606,7 @@ impl Coordinator {
                     for (config, slot_name) in replication_slots_to_drop {
                         // Try to drop the replication slots, but give up after a while.
                         let _ = Retry::default()
-                            .max_duration(Duration::from_secs(30))
+                            .max_duration(Duration::from_secs(60))
                             .retry_async(|_state| async {
                                 mz_postgres_util::drop_replication_slots(
                                     &ssh_tunnel_manager,


### PR DESCRIPTION
we occasionally give up dropping a replication slot on a long- running cluster too soon, leaking the replication slot. this commit extends the timeout to 60 seconds to see if this can fix the issue before we emark on a more invasive refactor to clean up external state.

I tried running this change locally myself but `bin/scratch` and I were having a hard time getting along.

Fixes #24357

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
