### PR TITLE
environmentd: use part of envid in connid

### DIFF
--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -103,7 +103,7 @@ pub struct TestHarness {
     system_parameter_defaults: BTreeMap<String, String>,
     internal_console_redirect_url: Option<String>,
     metrics_registry: Option<MetricsRegistry>,
-    environment_id: EnvironmentId,
+    pub environment_id: EnvironmentId,
 }
 
 impl Default for TestHarness {

--- a/src/ore/benches/id_gen.rs
+++ b/src/ore/benches/id_gen.rs
@@ -31,7 +31,7 @@ fn bench_id_allocator<A: IdAllocatorInner>(
 ) {
     let name = format!("id_allocator_{}_{initial_conns}_{bench_conns}", A::NAME);
     c.bench_function(&name, |b| {
-        let allocator = IdAllocator::<A>::new(1, 1 << 20);
+        let allocator = IdAllocator::<A>::new(1, 1 << 20, 0);
         let permanent = (0..initial_conns)
             .map(|_| allocator.alloc().unwrap())
             .collect::<Vec<_>>();


### PR DESCRIPTION
Use the lower 12 bits of the environment id as the upper 12 bits of the connection id.

See https://github.com/MaterializeInc/materialize/issues/24081#issuecomment-1874880062

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a