### PR TITLE
rqg: Add a WMR workload

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1025,6 +1025,19 @@ steps:
             composition: rqg
             args: ["window-functions", "--seed=$BUILDKITE_JOB_ID"]
 
+    - id: rqg-wmr
+      label: "RQG WMR workload"
+      artifact_paths: junit_*.xml
+      timeout_in_minutes: 45
+      agents:
+        queue: linux-x86_64
+      plugins:
+        - ./ci/plugins/mzcompose:
+            composition: rqg
+            # Postgres does not support WMR, so our only hope for a comparison
+            # test is to use a previous Mz version via --other-tag=...
+            args: ["wmr", "--seed=$BUILDKITE_JOB_ID", "--other-tag=common-ancestor"]
+
     - id: rqg-banking
       label: "RQG banking workload"
       artifact_paths: junit_*.xml

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -73,6 +73,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_sink_doc_on_option": "true",
     "enable_specialized_arrangements": "true",
     "enable_statement_lifecycle_logging": "true",
+    "enable_table_keys": "true",
     "enable_try_parse_monotonic_iso8601_timestamp": "true",
     "persist_batch_delete_enabled": "true",
     "persist_fast_path_limit": "1000",

--- a/test/rqg/Dockerfile
+++ b/test/rqg/Dockerfile
@@ -28,7 +28,7 @@ ADD https://api.github.com/repos/MaterializeInc/RQG/git/refs/heads/main version.
 
 RUN git clone --single-branch https://github.com/MaterializeInc/RQG.git \
     && cd RQG \
-    && git checkout 68f56378a83e8928da68b21efb5db2806bb28e1b
+    && git checkout 69a0e7b910d2d0ee22e7f25edd16648d7ea4fcb4
 
 ENTRYPOINT ["/usr/bin/perl"]
 


### PR DESCRIPTION
As Postgres does not support WMR, in this workload we compare against another Mz instance. The --other-tag is chosen the same way as we choose the tag for the other frameworks that perform comparisons across Mz versions.

### Motivation

A subset of the WMR grammar runs even in the presence of:

- https://github.com/MaterializeInc/materialize/issues/24451

So I am adding it to the CI and will post instructions in #24451 on how to re-enable the affected parts.