### PR TITLE
rqg: Properly handle --duration=0

### DIFF
--- a/test/rqg/mzcompose.py
+++ b/test/rqg/mzcompose.py
@@ -223,7 +223,7 @@ def run_workload(c: Composition, args: argparse.Namespace, workload: Workload) -
         else []
     )
 
-    duration = args.duration or workload.duration
+    duration = args.duration if args.duration is not None else workload.duration
     grammar = args.grammar or workload.grammar
     threads = args.threads or workload.threads
 


### PR DESCRIPTION
0 is False, so --duration=0 was disregarded. Check for `None` instead.

### Motivation

--duration=0 did not work as advertized