### PR TITLE
adapter: add `id: GlobalId` to `OptimizerNotice`

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -430,6 +430,7 @@ system. The view can be accessed by Materialize superusers.
 <!-- RELATION_SPEC mz_internal.mz_notices -->
 | Field                   | Type                         | Meaning                                                                                                                                           |
 | ----------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                    | [`text`]                     | Materialize's unique ID for this notice.                                                                                                          |
 | `notice_type`           | [`text`]                     | The notice type.                                                                                                                                  |
 | `message`               | [`text`]                     | A brief description of the issue highlighted by this notice.                                                                                      |
 | `hint`                  | [`text`]                     | A high-level hint that tells the user what can be improved.                                                                                       |
@@ -454,10 +455,11 @@ superusers and Materialize support.
 <!-- RELATION_SPEC mz_internal.mz_notices_redacted -->
 | Field                   | Type                         | Meaning                                                                                                                                           |
 | ----------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                    | [`text`]                     | Materialize's unique ID for this notice.                                                                                                          |
 | `notice_type`           | [`text`]                     | The notice type.                                                                                                                                  |
-| `message`               | [`text`]                     | A redacted brief description of the issue highlighted by this notice.                                                                                      |
-| `hint`                  | [`text`]                     | A redacted high-level hint that tells the user what can be improved.                                                                                       |
-| `action`                | [`text`]                     | A redacted concrete action that will resolve the notice.                                                                                                   |
+| `message`               | [`text`]                     | A redacted brief description of the issue highlighted by this notice.                                                                             |
+| `hint`                  | [`text`]                     | A redacted high-level hint that tells the user what can be improved.                                                                              |
+| `action`                | [`text`]                     | A redacted concrete action that will resolve the notice.                                                                                          |
 | `action_type`           | [`text`]                     | The type of the `action` string (`sql_statements` for a valid SQL string or `plain_text` for plain text).                                         |
 | `object_id`             | [`text`]                     | The ID of the materialized view or index. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects). For global notices, this column is `NULL`. |
 | `created_at`            | [`timestamp with time zone`] | The time at which the notice was created. Note that some notices are re-created on `environmentd` restart.                                        |

--- a/src/adapter/src/catalog/builtin_table_updates/notice.rs
+++ b/src/adapter/src/catalog/builtin_table_updates/notice.rs
@@ -136,6 +136,7 @@ impl CatalogState {
 
             // Pre-convert some fields into a type that can be wrapped into a
             // Datum.
+            let id = notice.id.to_string();
             let item_id = notice.item_id.as_ref().map(ToString::to_string);
             let deps = notice
                 .dependencies
@@ -146,6 +147,8 @@ impl CatalogState {
                 .try_into()
                 .expect("must fit");
 
+            // push `id` column
+            packer.push(Datum::String(id.as_str()));
             // push `notice_type` column (TODO(21513): encode as int?)
             packer.push(Datum::String(notice.kind.as_str()));
             // push `message` column

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1980,7 +1980,15 @@ impl Coordinator {
                     let global_lir_plan = optimizer.optimize(global_mir_plan)?;
 
                     let (physical_plan, metainfo) = global_lir_plan.unapply();
-                    let metainfo = self.catalog().render_notices(metainfo, Some(entry.id()));
+                    let metainfo = {
+                        // Pre-allocate a vector of transient GlobalIds for each notice.
+                        let notice_ids = std::iter::repeat_with(|| self.allocate_transient_id())
+                            .take(metainfo.optimizer_notices.len())
+                            .collect::<Result<Vec<_>, _>>()?;
+                        // Return a metainfo with rendered notices.
+                        self.catalog()
+                            .render_notices(metainfo, notice_ids, Some(entry.id()))
+                    };
 
                     let catalog = self.catalog_mut();
                     catalog.set_optimized_plan(id, optimized_plan);
@@ -2023,7 +2031,15 @@ impl Coordinator {
                     let global_lir_plan = optimizer.optimize(global_mir_plan)?;
 
                     let (physical_plan, metainfo) = global_lir_plan.unapply();
-                    let metainfo = self.catalog().render_notices(metainfo, Some(entry.id()));
+                    let metainfo = {
+                        // Pre-allocate a vector of transient GlobalIds for each notice.
+                        let notice_ids = std::iter::repeat_with(|| self.allocate_transient_id())
+                            .take(metainfo.optimizer_notices.len())
+                            .collect::<Result<Vec<_>, _>>()?;
+                        // Return a metainfo with rendered notices.
+                        self.catalog()
+                            .render_notices(metainfo, notice_ids, Some(entry.id()))
+                    };
 
                     let catalog = self.catalog_mut();
                     catalog.set_optimized_plan(id, optimized_plan);

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -129,6 +129,10 @@ impl GlobalLirPlan {
     pub fn df_desc(&self) -> &LirDataflowDescription {
         &self.df_desc
     }
+
+    pub fn df_meta(&self) -> &DataflowMetainfo {
+        &self.df_meta
+    }
 }
 
 impl Optimize<Index> for Optimizer {

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -142,6 +142,10 @@ impl GlobalLirPlan {
         &self.df_desc
     }
 
+    pub fn df_meta(&self) -> &DataflowMetainfo {
+        &self.df_meta
+    }
+
     pub fn desc(&self) -> &RelationDesc {
         let sink_exports = &self.df_desc.sink_exports;
         let sink = sink_exports.values().next().expect("valid sink");

--- a/src/catalog/src/builtin/notice.rs
+++ b/src/catalog/src/builtin/notice.rs
@@ -23,6 +23,7 @@ pub static MZ_OPTIMIZER_NOTICES: Lazy<BuiltinTable> = Lazy::new(|| {
         name: "mz_optimizer_notices",
         schema: MZ_INTERNAL_SCHEMA,
         desc: RelationDesc::empty()
+            .with_column("id", String.nullable(false))
             .with_column("notice_type", String.nullable(false))
             .with_column("message", String.nullable(false))
             .with_column("hint", String.nullable(false))
@@ -44,7 +45,7 @@ pub static MZ_OPTIMIZER_NOTICES: Lazy<BuiltinTable> = Lazy::new(|| {
                 "created_at",
                 TimestampTz { precision: None }.nullable(false),
             )
-            .without_keys(),
+            .with_key(vec![0]),
         is_retained_metrics_object: false,
         access: vec![MONITOR_SELECT],
     }
@@ -63,6 +64,7 @@ pub static MZ_NOTICES: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
     schema: MZ_INTERNAL_SCHEMA,
     column_defs: None,
     sql: "SELECT
+    n.id,
     n.notice_type,
     n.message,
     n.hint,
@@ -87,6 +89,7 @@ pub static MZ_NOTICES_REDACTED: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
     schema: MZ_INTERNAL_SCHEMA,
     column_defs: None,
     sql: "SELECT
+    id,
     notice_type,
     coalesce(redacted_message, message) as message,
     coalesce(redacted_hint, hint) as hint,
@@ -103,7 +106,7 @@ FROM
 pub const MZ_NOTICES_IND: BuiltinIndex = BuiltinIndex {
     name: "mz_notices_ind",
     schema: MZ_INTERNAL_SCHEMA,
-    sql: "IN CLUSTER mz_introspection ON mz_internal.mz_notices (object_id)",
+    sql: "IN CLUSTER mz_introspection ON mz_internal.mz_notices(id)",
     is_retained_metrics_object: false,
 };
 

--- a/src/transform/src/notice/mod.rs
+++ b/src/transform/src/notice/mod.rs
@@ -47,6 +47,8 @@ use mz_repr::GlobalId;
 /// An long lived in-memory representation of a [`RawOptimizerNotice`] that is
 /// meant to be kept as part of the hydrated catalog state.
 pub struct OptimizerNotice {
+    /// An `id` that uniquely identifies this notice in the `mz_notices` relation.
+    pub id: GlobalId,
     /// The notice kind.
     pub kind: OptimizerNoticeKind,
     /// The ID of the catalog item associated with this notice.

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -243,27 +243,29 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_notices' ORDER BY position
 ----
-1  notice_type  text
-2  message  text
-3  hint  text
-4  action  text
-5  redacted_message  text
-6  redacted_hint  text
-7  redacted_action  text
-8  action_type  text
-9  object_id  text
-10  created_at  timestamp␠with␠time␠zone
+1  id  text
+2  notice_type  text
+3  message  text
+4  hint  text
+5  action  text
+6  redacted_message  text
+7  redacted_hint  text
+8  redacted_action  text
+9  action_type  text
+10  object_id  text
+11  created_at  timestamp␠with␠time␠zone
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_notices_redacted' ORDER BY position
 ----
-1  notice_type  text
-2  message  text
-3  hint  text
-4  action  text
-5  action_type  text
-6  object_id  text
-7  created_at  timestamp␠with␠time␠zone
+1  id  text
+2  notice_type  text
+3  message  text
+4  hint  text
+5  action  text
+6  action_type  text
+7  object_id  text
+8  created_at  timestamp␠with␠time␠zone
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_postgres_sources' ORDER BY position

--- a/test/sqllogictest/mz_introspection_index_accounting.slt
+++ b/test/sqllogictest/mz_introspection_index_accounting.slt
@@ -63,7 +63,7 @@ mz_message_batch_counts_received_raw_s2_primary_idx  CREATE␠INDEX␠"mz_messag
 mz_message_batch_counts_sent_raw_s2_primary_idx  CREATE␠INDEX␠"mz_message_batch_counts_sent_raw_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_message_batch_counts_sent_raw"␠("channel_id",␠"from_worker_id",␠"to_worker_id")
 mz_message_counts_received_raw_s2_primary_idx  CREATE␠INDEX␠"mz_message_counts_received_raw_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_message_counts_received_raw"␠("channel_id",␠"from_worker_id",␠"to_worker_id")
 mz_message_counts_sent_raw_s2_primary_idx  CREATE␠INDEX␠"mz_message_counts_sent_raw_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_message_counts_sent_raw"␠("channel_id",␠"from_worker_id",␠"to_worker_id")
-mz_notices_ind  CREATE␠INDEX␠"mz_notices_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_notices"␠("object_id")
+mz_notices_ind  CREATE␠INDEX␠"mz_notices_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_notices"␠("id")
 mz_object_dependencies_ind  CREATE␠INDEX␠"mz_object_dependencies_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_object_dependencies"␠("object_id")
 mz_object_lifetimes_ind  CREATE␠INDEX␠"mz_object_lifetimes_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_object_lifetimes"␠("id")
 mz_object_transitive_dependencies_ind  CREATE␠INDEX␠"mz_object_transitive_dependencies_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_object_transitive_dependencies"␠("object_id")
@@ -296,6 +296,7 @@ mz_notices  action
 mz_notices  action_type
 mz_notices  created_at
 mz_notices  hint
+mz_notices  id
 mz_notices  message
 mz_notices  notice_type
 mz_notices  object_id
@@ -322,6 +323,7 @@ mz_optimizer_notices  action_type
 mz_optimizer_notices  created_at
 mz_optimizer_notices  dependency_ids
 mz_optimizer_notices  hint
+mz_optimizer_notices  id
 mz_optimizer_notices  message
 mz_optimizer_notices  notice_type
 mz_optimizer_notices  object_id

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -307,7 +307,7 @@ mz_message_counts_sent_raw_s2_primary_idx                   mz_message_counts_se
 mz_object_dependencies_ind                                  mz_object_dependencies                       mz_introspection    {object_id}
 mz_object_lifetimes_ind                                     mz_object_lifetimes                          mz_introspection    {id}
 mz_object_transitive_dependencies_ind                       mz_object_transitive_dependencies            mz_introspection    {object_id}
-mz_notices_ind                                              mz_notices                                   mz_introspection    {object_id}
+mz_notices_ind                                              mz_notices                                   mz_introspection    {id}
 mz_peek_durations_histogram_raw_s2_primary_idx              mz_peek_durations_histogram_raw              mz_introspection    {worker_id,type,duration_ns}
 mz_roles_ind                                                mz_roles                                     mz_introspection    {id}
 mz_scheduling_elapsed_raw_s2_primary_idx                    mz_scheduling_elapsed_raw                    mz_introspection    {id,worker_id}

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -707,8 +707,8 @@ ReduceMinsMaxes
 "ArrangeAccumulable [val: empty]"             3
 "ArrangeBy[[Column(0), Column(2)]]"           1
 "ArrangeBy[[Column(0)]] [val: empty]"         2
-"ArrangeBy[[Column(0)]]-errors"              20
-"ArrangeBy[[Column(0)]]"                     37
+"ArrangeBy[[Column(0)]]-errors"              21
+"ArrangeBy[[Column(0)]]"                     38
 "ArrangeBy[[Column(1), Column(3)]]"           2
 "ArrangeBy[[Column(1)]]-errors"               4
 "ArrangeBy[[Column(1)]]"                      9
@@ -719,8 +719,6 @@ ReduceMinsMaxes
 "ArrangeBy[[Column(4)]]"                      5
 "ArrangeBy[[Column(5)]]-errors"               2
 "ArrangeBy[[Column(5)]]"                      2
-"ArrangeBy[[Column(8)]]-errors"               1
-"ArrangeBy[[Column(8)]]"                      1
 "Arranged DistinctBy [val: empty]"            7
 "Arranged MinsMaxesHierarchical input"        7
 "Arranged ReduceInaccumulable"                1


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

The UX will benefit if the route when browsing to a specific notice can be identified by a unique ID. At the moment we are using a derived hash which is both CPU-heavy and possibly non-unique.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
