### PR TITLE
compute-client: aggressively downgrade read holds for sink dataflows

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2644,20 +2644,22 @@ impl Coordinator {
     }
 
     /// Call into the compute controller to install a finalized dataflow, and
-    /// initialize the read policies for its exported objects.
+    /// initialize the read policies for its exported readable objects.
     pub(crate) async fn ship_dataflow(
         &mut self,
         dataflow: DataflowDescription<Plan>,
         instance: ComputeInstanceId,
     ) {
-        let export_ids = dataflow.export_ids().collect();
+        // We must only install read policies for indexes, not for sinks.
+        // Sinks are write-only compute collections that don't have read policies.
+        let index_ids = dataflow.exported_index_ids().collect();
 
         self.controller
             .active_compute()
             .create_dataflow(instance, dataflow)
             .unwrap_or_terminate("dataflow creation cannot fail");
 
-        self.initialize_compute_read_policies(export_ids, instance, CompactionWindow::Default)
+        self.initialize_compute_read_policies(index_ids, instance, CompactionWindow::Default)
             .await;
     }
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1389,6 +1389,7 @@ impl Coordinator {
         let scheduling_config = flags::orchestrator_scheduling_config(system_config);
         let merge_effort = system_config.default_idle_arrangement_merge_effort();
         let exert_prop = system_config.default_arrangement_exert_proportionality();
+        let aggressive_downgrades = system_config.enable_compute_aggressive_readhold_downgrades();
         self.controller.compute.update_configuration(compute_config);
         self.controller.storage.update_parameters(storage_config);
         self.controller
@@ -1397,6 +1398,8 @@ impl Coordinator {
             .set_default_idle_arrangement_merge_effort(merge_effort);
         self.controller
             .set_default_arrangement_exert_proportionality(exert_prop);
+        self.controller
+            .set_enable_compute_aggressive_readhold_downgrades(aggressive_downgrades);
 
         let mut policies_to_set: BTreeMap<CompactionWindow, CollectionIdBundle> =
             Default::default();

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -758,18 +758,14 @@ impl Coordinator {
                 continue;
             }
 
-            if self.drop_compute_read_policy(&sink.global_id) {
-                by_cluster
-                    .entry(sink.cluster_id)
-                    .or_default()
-                    .push(sink.global_id);
+            by_cluster
+                .entry(sink.cluster_id)
+                .or_default()
+                .push(sink.global_id);
 
-                // Mark the sink as dropped so we don't try to drop it again.
-                if let Some(sink) = self.active_subscribes.get_mut(&sink.global_id) {
-                    sink.dropping = true;
-                }
-            } else {
-                tracing::error!("Instructed to drop a compute sink that isn't one");
+            // Mark the sink as dropped so we don't try to drop it again.
+            if let Some(sink) = self.active_subscribes.get_mut(&sink.global_id) {
+                sink.dropping = true;
             }
         }
         let mut compute = self.controller.active_compute();
@@ -817,12 +813,8 @@ impl Coordinator {
         let mut by_cluster: BTreeMap<_, Vec<_>> = BTreeMap::new();
         let mut source_ids = Vec::new();
         for (cluster_id, id) in mviews {
-            if self.drop_compute_read_policy(&id) {
-                by_cluster.entry(cluster_id).or_default().push(id);
-                source_ids.push(id);
-            } else {
-                tracing::error!("Instructed to drop a materialized view that isn't one");
-            }
+            by_cluster.entry(cluster_id).or_default().push(id);
+            source_ids.push(id);
         }
 
         // Drop compute sinks.

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -10,7 +10,8 @@
 use std::fmt::Debug;
 
 use mz_compute_client::controller::error::{
-    CollectionUpdateError, DataflowCreationError, InstanceMissing, PeekError, SubscribeTargetError,
+    CollectionUpdateError, DataflowCreationError, InstanceMissing, PeekError, ReadPolicyError,
+    SubscribeTargetError,
 };
 use mz_controller_types::ClusterId;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -374,6 +375,16 @@ impl ShouldHalt for PeekError {
             | PeekError::InstanceMissing(_)
             | PeekError::CollectionMissing(_)
             | PeekError::ReplicaMissing(_) => false,
+        }
+    }
+}
+
+impl ShouldHalt for ReadPolicyError {
+    fn should_halt(&self) -> bool {
+        match self {
+            ReadPolicyError::InstanceMissing(_)
+            | ReadPolicyError::CollectionMissing(_)
+            | ReadPolicyError::WriteOnlyCollection(_) => false,
         }
     }
 }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -54,8 +54,8 @@ use uuid::Uuid;
 
 use crate::controller::error::{
     CollectionLookupError, CollectionMissing, CollectionUpdateError, DataflowCreationError,
-    InstanceExists, InstanceMissing, PeekError, ReplicaCreationError, ReplicaDropError,
-    SubscribeTargetError,
+    InstanceExists, InstanceMissing, PeekError, ReadPolicyError, ReplicaCreationError,
+    ReplicaDropError, SubscribeTargetError,
 };
 use crate::controller::instance::{ActiveInstance, Instance};
 use crate::controller::replica::ReplicaConfig;
@@ -566,11 +566,14 @@ where
     /// capability is already ahead of it.
     ///
     /// Identifiers not present in `policies` retain their existing read policies.
+    ///
+    /// It is an error to attempt to set a read policy for a collection that is not readable in the
+    /// context of compute. At this time, only indexes are readable compute collections.
     pub fn set_read_policy(
         &mut self,
         instance_id: ComputeInstanceId,
         policies: Vec<(GlobalId, ReadPolicy<T>)>,
-    ) -> Result<(), CollectionUpdateError> {
+    ) -> Result<(), ReadPolicyError> {
         self.instance(instance_id)?.set_read_policy(policies)?;
         Ok(())
     }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -674,7 +674,11 @@ pub struct CollectionState<T> {
     /// The implicit capability associated with collection creation.
     implied_capability: Antichain<T>,
     /// The policy to use to downgrade `self.implied_capability`.
-    read_policy: ReadPolicy<T>,
+    ///
+    /// If `None`, the collection is a write-only collection (i.e. a sink). For write-only
+    /// collections, the `implied_capability` is only required for maintaining read holds on the
+    /// inputs, so we can immediately downgrade it to the `write_frontier`.
+    read_policy: Option<ReadPolicy<T>>,
 
     /// Storage identifiers on which this collection depends.
     storage_dependencies: Vec<GlobalId>,
@@ -731,7 +735,7 @@ impl<T: Timestamp> CollectionState<T> {
             dropped: false,
             read_capabilities,
             implied_capability: since.clone(),
-            read_policy: ReadPolicy::ValidFrom(since),
+            read_policy: Some(ReadPolicy::ValidFrom(since)),
             storage_dependencies,
             compute_dependencies,
             write_frontier: upper,

--- a/src/compute-client/src/controller/error.rs
+++ b/src/compute-client/src/controller/error.rs
@@ -190,6 +190,33 @@ impl From<CollectionMissing> for CollectionUpdateError {
     }
 }
 
+/// Errors arising during collection read policy assignment.
+#[derive(Error, Debug)]
+pub enum ReadPolicyError {
+    #[error("instance does not exist: {0}")]
+    InstanceMissing(ComputeInstanceId),
+    #[error("collection does not exist: {0}")]
+    CollectionMissing(GlobalId),
+    #[error("collection is write-only: {0}")]
+    WriteOnlyCollection(GlobalId),
+}
+
+impl From<InstanceMissing> for ReadPolicyError {
+    fn from(error: InstanceMissing) -> Self {
+        Self::InstanceMissing(error.0)
+    }
+}
+
+impl From<instance::ReadPolicyError> for ReadPolicyError {
+    fn from(error: instance::ReadPolicyError) -> Self {
+        use instance::ReadPolicyError::*;
+        match error {
+            CollectionMissing(id) => Self::CollectionMissing(id),
+            WriteOnlyCollection(id) => Self::WriteOnlyCollection(id),
+        }
+    }
+}
+
 // Errors arising during subscribe target assignment.
 #[derive(Error, Debug)]
 pub enum SubscribeTargetError {

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -278,10 +278,17 @@ where
 
     /// Identifiers of exported objects (indexes and sinks).
     pub fn export_ids(&self) -> impl Iterator<Item = GlobalId> + Clone + '_ {
-        self.index_exports
-            .keys()
-            .chain(self.sink_exports.keys())
-            .copied()
+        self.exported_index_ids().chain(self.exported_sink_ids())
+    }
+
+    /// Identifiers of exported indexes.
+    pub fn exported_index_ids(&self) -> impl Iterator<Item = GlobalId> + Clone + '_ {
+        self.index_exports.keys().copied()
+    }
+
+    /// Identifiers of exported sinks.
+    pub fn exported_sink_ids(&self) -> impl Iterator<Item = GlobalId> + Clone + '_ {
+        self.sink_exports.keys().copied()
     }
 
     /// Identifiers of exported subscribe sinks.

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -184,6 +184,11 @@ impl<T: Timestamp> Controller<T> {
             .set_default_arrangement_exert_proportionality(value);
     }
 
+    pub fn set_enable_compute_aggressive_readhold_downgrades(&mut self, value: bool) {
+        self.compute
+            .set_enable_aggressive_readhold_downgrades(value);
+    }
+
     /// Returns the connection context installed in the controller.
     ///
     /// This is purely a helper, and can be obtained from `self.storage`.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2153,6 +2153,13 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_compute_aggressive_readhold_downgrades,
+        desc: "let the compute controller aggressively downgrade read holds for sink dataflows",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 /// Returns a new ConfigSet containing every `Config` in Materialize.

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -517,16 +517,21 @@ mv_div_by_zero   2
   JOIN mz_objects o ON (c.export_id = o.id)
   ORDER BY name
 
-# Test logging of errors in things that advance to the empty frontier.
+# Test logging of errors in indexes that advance to the empty frontier.
+#
+# Note that the same is not expected to work for MVs that advance to the empty
+# frontier. There is no reason to keep completed MV dataflows around, so we
+# drop them immediately, removing all their associated logging in the process.
 
 > CREATE MATERIALIZED VIEW mv_zero AS SELECT 0 AS x
-> CREATE MATERIALIZED VIEW mv2_div_by_zero AS SELECT 1 / x FROM mv_zero
+> CREATE VIEW div_by_zero AS SELECT 1 / x FROM mv_zero
+> CREATE INDEX idx_div_by_zero ON div_by_zero ()
 
 > SELECT name, count
   FROM mz_internal.mz_compute_error_counts c
   JOIN mz_objects o ON (c.export_id = o.id)
   ORDER BY name
-mv2_div_by_zero 1
+idx_div_by_zero 1
 
 > DROP MATERIALIZED VIEW mv_zero CASCADE
 

--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -173,6 +173,80 @@ ALTER SYSTEM SET enable_refresh_every_mvs = true
 2
 3
 
+# Test that MVs that advance to the empty frontier do not retain read holds on
+# their inputs. Regression test for #24469.
+
+> CREATE TABLE t4 (x int)
+> CREATE MATERIALIZED VIEW mv7 WITH (REFRESH AT CREATION) AS SELECT * FROM t4
+> SELECT * FROM mv7
+
+> SELECT f.write_frontier
+  FROM mz_internal.mz_frontiers f
+  JOIN mz_materialized_views m ON (m.id = f.object_id)
+  WHERE m.name = 'mv7'
+<null>
+
+# Verify that `t4`'s read frontier advances past the read frontier of `mv7`.
+> SELECT ft.read_frontier > fm.read_frontier
+  FROM mz_internal.mz_frontiers fm
+  JOIN mz_materialized_views m ON (m.id = fm.object_id)
+  JOIN mz_internal.mz_frontiers ft ON (true)
+  JOIN mz_tables t ON (t.id = ft.object_id)
+  WHERE m.name = 'mv7' AND t.name = 't4'
+true
+
+# Test the same thing with multiple replicas.
+
+> DROP MATERIALIZED VIEW mv7
+> ALTER CLUSTER refresh_cluster SET (REPLICATION FACTOR 2);
+
+> CREATE MATERIALIZED VIEW mv7
+  IN CLUSTER refresh_cluster
+  WITH (REFRESH AT CREATION)
+  AS SELECT * FROM t4
+> SELECT * FROM mv7
+
+> SELECT f.write_frontier
+  FROM mz_internal.mz_frontiers f
+  JOIN mz_materialized_views m ON (m.id = f.object_id)
+  WHERE m.name = 'mv7'
+<null>
+
+> SELECT ft.read_frontier > fm.read_frontier
+  FROM mz_internal.mz_frontiers fm
+  JOIN mz_materialized_views m ON (m.id = fm.object_id)
+  JOIN mz_internal.mz_frontiers ft ON (true)
+  JOIN mz_tables t ON (t.id = ft.object_id)
+  WHERE m.name = 'mv7' AND t.name = 't4'
+true
+
+# Test the same thing with initially zero replicas.
+
+> DROP MATERIALIZED VIEW mv7
+> ALTER CLUSTER refresh_cluster SET (REPLICATION FACTOR 0);
+
+> CREATE MATERIALIZED VIEW mv7
+  IN CLUSTER refresh_cluster
+  WITH (REFRESH AT CREATION)
+  AS SELECT * FROM t4
+
+> ALTER CLUSTER refresh_cluster SET (REPLICATION FACTOR 1);
+> SELECT * FROM mv7
+
+> SELECT f.write_frontier
+  FROM mz_internal.mz_frontiers f
+  JOIN mz_materialized_views m ON (m.id = f.object_id)
+  WHERE m.name = 'mv7'
+<null>
+
+> SELECT ft.read_frontier > fm.read_frontier
+  FROM mz_internal.mz_frontiers fm
+  JOIN mz_materialized_views m ON (m.id = fm.object_id)
+  JOIN mz_internal.mz_frontiers ft ON (true)
+  JOIN mz_tables t ON (t.id = ft.object_id)
+  WHERE m.name = 'mv7' AND t.name = 't4'
+true
+
 ######## Cleanup ########
 > DROP DATABASE materialized_view_refresh_options CASCADE;
 > DROP CLUSTER refresh_cluster CASCADE;


### PR DESCRIPTION
This PR makes the compute controller more aggressive about downgrading the read holds on the inputs of some compute collections. The key observation is that for sink collections we don't need to hold inputs back further than the upper frontier. Once a subscribe or MV has produced data for some time, it will never have to produce data for the same time again.

In most cases the effect of this is that we can allow slightly faster compaction of some dataflow inputs, which doesn't seem very important. However, in the case of `REFRESH` MVs that can advance to the empty frontier, it is actually critical that we advance the read holds on their inputs to the empty frontier as well when they do. If we'd fail to do so, we'd end up disabling compaction of those inputs forever.

This change has two preconditions that previous PRs dealt with:

 * We need to be more explicit about dropping collections in the controller, to avoid forgetting about MVs when they advance to the empty frontier (#24541).
 * We need to move hydration status tracking out of the `ReplicaTask` into the `Instance` controller since the former doesn't have enough information to know whether a collection is still tracked by the controller (#24570).

This change also requires adapter to not attempt to install read holds on write-only collections anymore. If it did so, it would force the compute controller to hold back compaction of its inputs further than necessary. So this PR changes adapter to only install compute read holds for indexes. As a precaution, it also makes the compute controller API return an error when a caller tries to set a read policy for a write-only collection.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/24469.

### Tips for reviewer

Look at the commits and their descriptions separately!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
