### PR TITLE
feature-benchmark: Speed up

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -70,9 +70,12 @@ class Benchmark:
             f"Running scenario {name}, scale = {scenario.scale()}, N = {scenario.n()}"
         )
 
+        # Reset state
+        self._executor.Td("$ nop", no_reset=False)
+
         # Run the shared() section once for both Mzs under measurement
         shared = scenario.shared()
-        if self._mz_id == 0 and shared is not None:
+        if shared is not None:
             print(f"Running the shared() section for {name} ...")
 
             for shared_item in shared if isinstance(shared, list) else [shared]:

--- a/misc/python/materialize/feature_benchmark/scenario.py
+++ b/misc/python/materialize/feature_benchmark/scenario.py
@@ -77,7 +77,7 @@ class RootScenario:
     def view_ten(self) -> TdAction:
         return TdAction(
             """
-> CREATE VIEW ten (f1) AS (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9));
+> CREATE VIEW IF NOT EXISTS ten (f1) AS (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9));
 """
         )
 
@@ -87,9 +87,9 @@ class RootScenario:
             f"(a{i+1}.f1 * {10**i})" for i in range(0, ceil(self.scale()))
         )
 
-    def join(self) -> str:
+    def join(self, ten: str = "ten") -> str:
         """Returns a string of the form 'ten AS a1 , ten AS a2 , ten AS a3 ...'"""
-        return ", ".join(f"ten AS a{i+1}" for i in range(0, ceil(self.scale())))
+        return ", ".join(f"{ten} AS a{i+1}" for i in range(0, ceil(self.scale())))
 
     def keyschema(self) -> str:
         return (

--- a/misc/python/materialize/optbench/schema/tpch.sql
+++ b/misc/python/materialize/optbench/schema/tpch.sql
@@ -9,26 +9,26 @@
 
 -- Table definitions for the schema of the `TPCH` benchmarking scenario.
 
-CREATE TABLE nation (
+CREATE TABLE IF NOT EXISTS nation (
     n_nationkey  integer ,
     n_name       char(25) NOT NULL,
     n_regionkey  integer NOT NULL,
     n_comment    varchar(152)
 );
 
-CREATE INDEX pk_nation_nationkey ON nation (n_nationkey ASC);
+CREATE INDEX IF NOT EXISTS pk_nation_nationkey ON nation (n_nationkey ASC);
 
-CREATE INDEX fk_nation_regionkey ON nation (n_regionkey ASC);
+CREATE INDEX IF NOT EXISTS fk_nation_regionkey ON nation (n_regionkey ASC);
 
-CREATE TABLE region  (
+CREATE TABLE IF NOT EXISTS region  (
     r_regionkey  integer ,
     r_name       char(25) NOT NULL,
     r_comment    varchar(152)
 );
 
-CREATE INDEX pk_region_regionkey ON region (r_regionkey ASC);
+CREATE INDEX IF NOT EXISTS pk_region_regionkey ON region (r_regionkey ASC);
 
-CREATE TABLE part (
+CREATE TABLE IF NOT EXISTS part (
     p_partkey     integer ,
     p_name        varchar(55) NOT NULL,
     p_mfgr        char(25) NOT NULL,
@@ -40,9 +40,9 @@ CREATE TABLE part (
     p_comment     varchar(23) NOT NULL
 );
 
-CREATE INDEX pk_part_partkey ON part (p_partkey ASC);
+CREATE INDEX IF NOT EXISTS pk_part_partkey ON part (p_partkey ASC);
 
-CREATE TABLE supplier (
+CREATE TABLE IF NOT EXISTS supplier (
     s_suppkey     integer ,
     s_name        char(25) NOT NULL,
     s_address     varchar(40) NOT NULL,
@@ -52,11 +52,11 @@ CREATE TABLE supplier (
     s_comment     varchar(101) NOT NULL
 );
 
-CREATE INDEX pk_supplier_suppkey ON supplier (s_suppkey ASC);
+CREATE INDEX IF NOT EXISTS pk_supplier_suppkey ON supplier (s_suppkey ASC);
 
-CREATE INDEX fk_supplier_nationkey ON supplier (s_nationkey ASC);
+CREATE INDEX IF NOT EXISTS fk_supplier_nationkey ON supplier (s_nationkey ASC);
 
-CREATE TABLE partsupp (
+CREATE TABLE IF NOT EXISTS partsupp (
     ps_partkey     integer NOT NULL,
     ps_suppkey     integer NOT NULL,
     ps_availqty    integer NOT NULL,
@@ -64,13 +64,13 @@ CREATE TABLE partsupp (
     ps_comment     varchar(199) NOT NULL
 );
 
-CREATE INDEX pk_partsupp_partkey_suppkey ON partsupp (ps_partkey ASC, ps_suppkey ASC);
+CREATE INDEX IF NOT EXISTS pk_partsupp_partkey_suppkey ON partsupp (ps_partkey ASC, ps_suppkey ASC);
 
-CREATE INDEX fk_partsupp_partkey ON partsupp (ps_partkey ASC);
+CREATE INDEX IF NOT EXISTS fk_partsupp_partkey ON partsupp (ps_partkey ASC);
 
-CREATE INDEX fk_partsupp_suppkey ON partsupp (ps_suppkey ASC);
+CREATE INDEX IF NOT EXISTS fk_partsupp_suppkey ON partsupp (ps_suppkey ASC);
 
-CREATE TABLE customer (
+CREATE TABLE IF NOT EXISTS customer (
     c_custkey     integer ,
     c_name        varchar(25) NOT NULL,
     c_address     varchar(40) NOT NULL,
@@ -81,11 +81,11 @@ CREATE TABLE customer (
     c_comment     varchar(117) NOT NULL
 );
 
-CREATE INDEX pk_customer_custkey ON customer (c_custkey ASC);
+CREATE INDEX IF NOT EXISTS pk_customer_custkey ON customer (c_custkey ASC);
 
-CREATE INDEX fk_customer_nationkey ON customer (c_nationkey ASC);
+CREATE INDEX IF NOT EXISTS fk_customer_nationkey ON customer (c_nationkey ASC);
 
-CREATE TABLE orders (
+CREATE TABLE IF NOT EXISTS orders (
     o_orderkey       integer ,
     o_custkey        integer NOT NULL,
     o_orderstatus    char(1) NOT NULL,
@@ -97,11 +97,11 @@ CREATE TABLE orders (
     o_comment        varchar(79) NOT NULL
 );
 
-CREATE INDEX pk_orders_orderkey ON orders (o_orderkey ASC);
+CREATE INDEX IF NOT EXISTS pk_orders_orderkey ON orders (o_orderkey ASC);
 
-CREATE INDEX fk_orders_custkey ON orders (o_custkey ASC);
+CREATE INDEX IF NOT EXISTS fk_orders_custkey ON orders (o_custkey ASC);
 
-CREATE TABLE lineitem (
+CREATE TABLE IF NOT EXISTS lineitem (
     l_orderkey       integer NOT NULL,
     l_partkey        integer NOT NULL,
     l_suppkey        integer NOT NULL,
@@ -120,17 +120,17 @@ CREATE TABLE lineitem (
     l_comment        varchar(44) NOT NULL
 );
 
-CREATE INDEX pk_lineitem_orderkey_linenumber ON lineitem (l_orderkey ASC, l_linenumber ASC);
+CREATE INDEX IF NOT EXISTS pk_lineitem_orderkey_linenumber ON lineitem (l_orderkey ASC, l_linenumber ASC);
 
-CREATE INDEX fk_lineitem_orderkey ON lineitem (l_orderkey ASC);
+CREATE INDEX IF NOT EXISTS fk_lineitem_orderkey ON lineitem (l_orderkey ASC);
 
-CREATE INDEX fk_lineitem_partkey ON lineitem (l_partkey ASC);
+CREATE INDEX IF NOT EXISTS fk_lineitem_partkey ON lineitem (l_partkey ASC);
 
-CREATE INDEX fk_lineitem_suppkey ON lineitem (l_suppkey ASC);
+CREATE INDEX IF NOT EXISTS fk_lineitem_suppkey ON lineitem (l_suppkey ASC);
 
-CREATE INDEX fk_lineitem_partsuppkey ON lineitem (l_partkey ASC, l_suppkey ASC);
+CREATE INDEX IF NOT EXISTS fk_lineitem_partsuppkey ON lineitem (l_partkey ASC, l_suppkey ASC);
 
-CREATE VIEW revenue (supplier_no, total_revenue) AS
+CREATE VIEW IF NOT EXISTS revenue (supplier_no, total_revenue) AS
 SELECT
     l_suppkey,
     sum(l_extendedprice * (1 - l_discount))


### PR DESCRIPTION
by restarting less often (once per cycle and per this/other instead of once per scenario)

Maybe I'm missing something obvious about why we didn't do this before? Still waiting for nightly result: https://buildkite.com/materialize/nightlies/builds/6060

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
