### PR TITLE
balancerd: cancelation broadcasting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3619,6 +3619,7 @@ dependencies = [
  "mz-storage-types",
  "serde",
  "timely",
+ "uuid",
  "workspace-hack",
 ]
 
@@ -3726,6 +3727,7 @@ dependencies = [
  "hyper",
  "hyper-openssl",
  "jsonwebtoken",
+ "mz-adapter-types",
  "mz-build-info",
  "mz-environmentd",
  "mz-frontegg-auth",

--- a/src/adapter-types/Cargo.toml
+++ b/src/adapter-types/Cargo.toml
@@ -15,6 +15,7 @@ mz-repr = { path = "../repr" }
 mz-storage-types = { path = "../storage-types" }
 serde = "1.0.152"
 timely = { version = "0.12.0", default-features = false }
+uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/adapter-types/src/connection.rs
+++ b/src/adapter-types/src/connection.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use mz_ore::id_gen::{IdAllocatorInnerBitSet, IdHandle};
+use uuid::Uuid;
 
 /// Inner type of a [`ConnectionId`], `u32` for postgres compatibility.
 ///
@@ -16,3 +17,45 @@ pub type ConnectionIdType = u32;
 
 /// An abstraction allowing us to name different connections.
 pub type ConnectionId = IdHandle<ConnectionIdType, IdAllocatorInnerBitSet>;
+
+/// Number of bits the org id is offset into a connection id.
+pub const ORG_ID_OFFSET: usize = 19;
+
+/// Extracts the lower 12 bits from an org id
+pub fn org_id_conn_bits(uuid: &Uuid) -> ConnectionIdType {
+    let lower = uuid.as_u128();
+    let lower = (lower & 0xFFF) << ORG_ID_OFFSET;
+    let lower: u32 = lower.try_into().expect("must fit");
+    lower
+}
+
+/// Returns the org's UUID from the connection id.
+pub fn conn_id_org_uuid(conn_id: u32) -> String {
+    const UPPER: [char; 16] = [
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+    ];
+
+    // Extract UUID from conn_id: upper 12 bits excluding the first.
+    let orgid = usize::try_from((conn_id >> ORG_ID_OFFSET) & 0xFFF).expect("must cast");
+    // Convert the bits into a 3 char string and inject into the resolver template.
+    let mut dst = String::with_capacity(3);
+    dst.push(UPPER[(orgid >> 8) & 0xf]);
+    dst.push(UPPER[(orgid >> 4) & 0xf]);
+    dst.push(UPPER[orgid & 0xf]);
+    dst
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use crate::connection::{conn_id_org_uuid, org_id_conn_bits};
+
+    #[mz_ore::test]
+    fn test_conn_org() {
+        let uuid = Uuid::parse_str("9e37ec59-56f4-450a-acbd-18ff14f10ca8").unwrap();
+        let lower = org_id_conn_bits(&uuid);
+        let org_lower_uuid = conn_id_org_uuid(lower);
+        assert_eq!(org_lower_uuid, "CA8");
+    }
+}

--- a/src/adapter-types/src/connection.rs
+++ b/src/adapter-types/src/connection.rs
@@ -21,7 +21,8 @@ pub type ConnectionId = IdHandle<ConnectionIdType, IdAllocatorInnerBitSet>;
 /// Number of bits the org id is offset into a connection id.
 pub const ORG_ID_OFFSET: usize = 19;
 
-/// Extracts the lower 12 bits from an org id
+/// Extracts the lower 12 bits from an org id. These are later used as the [31, 20] bits of a
+/// connection id to help route cancellation requests.
 pub fn org_id_conn_bits(uuid: &Uuid) -> ConnectionIdType {
     let lower = uuid.as_u128();
     let lower = (lower & 0xFFF) << ORG_ID_OFFSET;
@@ -29,7 +30,7 @@ pub fn org_id_conn_bits(uuid: &Uuid) -> ConnectionIdType {
     lower
 }
 
-/// Returns the org's UUID from the connection id.
+/// Returns the portion of the org's UUID present in connection id.
 pub fn conn_id_org_uuid(conn_id: u32) -> String {
     const UPPER: [char; 16] = [
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3.25"
 hyper = { version = "0.14.23", features = ["http1", "server"] }
 hyper-openssl = "0.9.2"
 jsonwebtoken = "9.2.0"
+mz-adapter-types = { path = "../adapter-types" }
 mz-build-info = { path = "../build-info" }
 mz-frontegg-auth = { path = "../frontegg-auth" }
 mz-http-util = { path = "../http-util" }

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -29,11 +29,12 @@ use axum::{routing, Router};
 use bytes::BytesMut;
 use futures::TryFutureExt;
 use hyper::StatusCode;
+use mz_adapter_types::connection::conn_id_org_uuid;
 use mz_build_info::{build_info, BuildInfo};
 use mz_frontegg_auth::Authentication as FronteggAuthentication;
 use mz_ore::metrics::{ComputedGauge, IntCounter, IntGauge, MetricsRegistry};
 use mz_ore::netio::AsyncReady;
-use mz_ore::task::JoinSetExt;
+use mz_ore::task::{spawn, JoinSetExt};
 use mz_ore::{metric, netio};
 use mz_pgwire_common::{
     decode_startup, Conn, ErrorResponse, FrontendMessage, FrontendStartupMessage,
@@ -65,6 +66,8 @@ pub struct BalancerConfig {
     pgwire_listen_addr: SocketAddr,
     /// Listen address for HTTPS connections.
     https_listen_addr: SocketAddr,
+    /// Cancellation DNS resolver.
+    cancellation_resolver_template: Option<String>,
     /// DNS resolver.
     resolver: Resolver,
     https_addr_template: String,
@@ -79,6 +82,7 @@ impl BalancerConfig {
         internal_http_listen_addr: SocketAddr,
         pgwire_listen_addr: SocketAddr,
         https_listen_addr: SocketAddr,
+        cancellation_resolver_template: Option<String>,
         resolver: Resolver,
         https_addr_template: String,
         tls: Option<TlsCertConfig>,
@@ -90,6 +94,7 @@ impl BalancerConfig {
             internal_http_listen_addr,
             pgwire_listen_addr,
             https_listen_addr,
+            cancellation_resolver_template,
             resolver,
             https_addr_template,
             tls,
@@ -171,6 +176,7 @@ impl BalancerService {
         {
             let pgwire = PgwireBalancer {
                 resolver: Arc::new(self.cfg.resolver),
+                cancellation_resolver: self.cfg.cancellation_resolver_template.map(Arc::new),
                 tls: pgwire_tls,
                 metrics: ServerMetrics::new(metrics.clone(), "pgwire"),
             };
@@ -353,6 +359,7 @@ impl ServerMetrics {
 
 struct PgwireBalancer {
     tls: Option<TlsConfig>,
+    cancellation_resolver: Option<Arc<String>>,
     resolver: Arc<Resolver>,
     metrics: ServerMetrics,
 }
@@ -479,6 +486,7 @@ impl mz_server_core::Server for PgwireBalancer {
         let tls = self.tls.clone();
         let resolver = Arc::clone(&self.resolver);
         let metrics = self.metrics.clone();
+        let cancellation_resolver = self.cancellation_resolver.clone();
         Box::pin(async move {
             // TODO: Try to merge this with pgwire/server.rs to avoid the duplication. May not be
             // worth it.
@@ -508,11 +516,17 @@ impl mz_server_core::Server for PgwireBalancer {
                             return Ok(());
                         }
 
-                        Some(FrontendStartupMessage::CancelRequest { .. }) => {
-                            // Balancer ignores cancel requests.
-                            //
-                            // TODO: Can/should we return some error here so users are informed
-                            // this won't ever work?
+                        Some(FrontendStartupMessage::CancelRequest {
+                            conn_id,
+                            secret_key,
+                        }) => {
+                            if let Some(resolver) = cancellation_resolver {
+                                spawn(|| "cancel request", async move {
+                                    cancel_request(conn_id, secret_key, &resolver).await;
+                                });
+                            }
+                            // Do not wait on cancel requests to return because cancellation is best
+                            // effort.
                             return Ok(());
                         }
 
@@ -544,6 +558,41 @@ impl mz_server_core::Server for PgwireBalancer {
             metrics.connection_status(result.is_ok()).inc();
             Ok(())
         })
+    }
+}
+
+async fn cancel_request(conn_id: u32, secret_key: u32, cancellation_resolver: &str) {
+    let addr = cancellation_resolver.replace("{}", &conn_id_org_uuid(conn_id));
+    let ips = match tokio::net::lookup_host(&addr).await {
+        Ok(ips) => ips,
+        Err(err) => {
+            error!("{addr} failed resolution: {err}");
+            return;
+        }
+    };
+    let mut buf = BytesMut::with_capacity(16);
+    let msg = FrontendStartupMessage::CancelRequest {
+        conn_id,
+        secret_key,
+    };
+    msg.encode(&mut buf).expect("must encode");
+    // TODO: Is there a way to not use an Arc here by convincing rust that buf will outlive the
+    // spawn? Will awaiting the JoinHandle work?
+    let buf = Arc::new(buf);
+    for ip in ips {
+        debug!("resolved {addr} to {ip}");
+        let buf = Arc::clone(&buf);
+        spawn(|| "cancel request for ip", async move {
+            let send = async {
+                let mut stream = TcpStream::connect(&ip).await?;
+                stream.write_all(&buf).await?;
+                stream.shutdown().await?;
+                Ok::<_, io::Error>(())
+            };
+            if let Err(err) = send.await {
+                error!("error mirroring cancel to {ip}: {err}");
+            }
+        });
     }
 }
 

--- a/src/balancerd/src/service.rs
+++ b/src/balancerd/src/service.rs
@@ -50,6 +50,11 @@ pub struct Args {
     /// destinaiton.
     #[clap(long, value_name = "HOST.{}.NAME:PORT")]
     https_resolver_template: String,
+    /// Cancellation DNS resolver address. `{}` is replaced with the org id part of the incoming
+    /// connection id (the 12 bits after (and excluding) the first bit) converted to a 3-char UUID
+    /// string. The cancellation request will be mirrored to all IPs this address resolves to.
+    #[clap(long, value_name = "HOST.{}.NAME:PORT")]
+    cancellation_resolver_template: Option<String>,
 
     /// JWK used to validate JWTs during Frontegg authentication as a PEM public
     /// key. Can optionally be base64 encoded with the URL-safe alphabet.
@@ -133,6 +138,7 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         args.internal_http_listen_addr,
         args.pgwire_listen_addr,
         args.https_listen_addr,
+        args.cancellation_resolver_template,
         resolver,
         args.https_resolver_template,
         args.tls.into_config()?,

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -11,9 +11,11 @@
 
 use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::StreamExt;
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use mz_balancerd::{BalancerConfig, BalancerService, FronteggResolver, Resolver, BUILD_INFO};
 use mz_environmentd::test_util::{self, make_pg_tls, Ca};
@@ -25,7 +27,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::retry::Retry;
-use mz_ore::task;
+use mz_ore::{assert_contains, task};
 use mz_server_core::TlsCertConfig;
 use openssl::ssl::{SslConnectorBuilder, SslVerifyMode};
 use uuid::Uuid;
@@ -122,6 +124,7 @@ async fn test_balancer() {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            Some(envd_server.inner.balancer_sql_local_addr().to_string()),
             resolver,
             envd_server.inner.http_local_addr().to_string(),
             cert_config.clone(),
@@ -139,20 +142,29 @@ async fn test_balancer() {
             balancer_pgwire_listen.port()
         ));
 
-        let (pg_client, conn) = tokio_postgres::connect(
-            &conn_str,
-            make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
-                Ok(b.set_verify(SslVerifyMode::NONE))
-            })),
-        )
-        .await
-        .unwrap();
+        let tls = make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
+            Ok(b.set_verify(SslVerifyMode::NONE))
+        }));
+
+        let (pg_client, conn) = tokio_postgres::connect(&conn_str, tls.clone())
+            .await
+            .unwrap();
         task::spawn(|| "balancer-pg_client", async move {
             conn.await.expect("balancer-pg_client")
         });
 
         let res: i32 = pg_client.query_one("SELECT 2", &[]).await.unwrap().get(0);
         assert_eq!(res, 2);
+
+        // Assert cancellation is propagated.
+        let cancel = pg_client.cancel_token();
+        let copy = pg_client
+            .copy_out("copy (subscribe (select * from mz_kafka_sinks)) to stdout")
+            .await
+            .unwrap();
+        cancel.cancel_query(tls).await.unwrap();
+        let e = pin!(copy).next().await.unwrap().unwrap_err();
+        assert_contains!(e.to_string(), "canceling statement due to user request");
 
         if !is_frontegg_resolver {
             continue;

--- a/src/ore/src/id_gen.rs
+++ b/src/ore/src/id_gen.rs
@@ -49,17 +49,7 @@ pub type IdGen = Gen<u64>;
 
 /// IdAllocator common traits.
 pub trait IdGenerator:
-    From<u8>
-    + AddAssign
-    + Sub
-    + PartialOrd
-    + Copy
-    + Eq
-    + Hash
-    + Ord
-   // + rand::distributions::uniform::SampleUniform
-    + serde::Serialize
-    + fmt::Display
+    From<u8> + AddAssign + Sub + PartialOrd + Copy + Eq + Hash + Ord + serde::Serialize + fmt::Display
 {
 }
 
@@ -72,7 +62,6 @@ impl<T> IdGenerator for T where
         + Eq
         + Hash
         + Ord
-        //  + rand::distributions::uniform::SampleUniform
         + serde::Serialize
         + fmt::Display
 {

--- a/src/pgwire-common/src/codec.rs
+++ b/src/pgwire-common/src/codec.rs
@@ -140,6 +140,14 @@ impl FrontendStartupMessage {
                 }
                 dst.put_i8(0);
             }
+            FrontendStartupMessage::CancelRequest {
+                conn_id,
+                secret_key,
+            } => {
+                dst.put_i32(VERSION_CANCEL);
+                dst.put_u32(*conn_id);
+                dst.put_u32(*secret_key);
+            }
             _ => panic!("unsupported"),
         }
 


### PR DESCRIPTION
When balancer receives a cancel request, broadcast it to all envds with matching ids.

See https://github.com/MaterializeInc/materialize/issues/24081#issuecomment-1874880062

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a