### PR TITLE
Revert "mzcompose: Make output buildkite-compatible"

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -274,7 +274,7 @@ class Composition:
         """
 
         if not self.silent and not silent:
-            print(f"--- docker compose {' '.join(args)}", file=sys.stderr)
+            print(f"$ docker compose {' '.join(args)}", file=sys.stderr)
 
         stdout = None
         if capture:

--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -58,7 +58,7 @@ def speaker(prefix: str) -> Callable[..., None]:
     return say
 
 
-header = speaker("--- ")
+header = speaker("==> ")
 say = speaker("")
 
 


### PR DESCRIPTION
I couldn't find a good way to make this work with other output. Any small `docker compose exec` would spam the output with groups, making the remaining output hard to find. Buildkite doesn't allow closing a header again, except by having a new one. Developers also complained about this and tried to fix it.

Pathological example: https://buildkite.com/materialize/nightlies/builds/6034#018d1be6-c555-49f2-a9cf-bd30cb122b47

This reverts commit 2985ac9c3ef2482f1ac1f2693fac51285cabe1e0.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
