### PR TITLE
ci: junit.xml content: include error details (part 1)

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -595,15 +595,17 @@ To see the available workflows, run:
             with composition.test_case(f"workflow-{args.workflow}"):
                 composition.workflow(args.workflow, *args.unknown_subargs[1:])
 
-            test_suite_name = composition.name
-            test_class_name = os.getenv("BUILDKITE_LABEL") or test_suite_name
+            buildkite_step_name = os.getenv("BUILDKITE_LABEL")
+            test_suite_name = buildkite_step_name or composition.name
+            test_class_name = test_suite_name
 
             # Upload test report to Buildkite Test Analytics.
             junit_suite = junit_xml.TestSuite(test_suite_name)
 
-            for test_case_name, result in composition.test_results.items():
+            for test_case_key, result in composition.test_results.items():
+                test_case_name = result.get_error_file() or test_case_key
                 test_case = junit_xml.TestCase(
-                    result.get_error_file() or test_case_name,
+                    test_case_name,
                     test_class_name,
                     result.duration,
                 )

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -595,11 +595,16 @@ To see the available workflows, run:
             with composition.test_case(f"workflow-{args.workflow}"):
                 composition.workflow(args.workflow, *args.unknown_subargs[1:])
 
-            # Upload test report to Buildkite Test Analytics.
-            junit_suite = junit_xml.TestSuite(composition.name)
+            test_suite_name = composition.name
+            test_class_name = os.getenv("BUILDKITE_LABEL") or test_suite_name
 
-            for name, result in composition.test_results.items():
-                test_case = junit_xml.TestCase(name, composition.name, result.duration)
+            # Upload test report to Buildkite Test Analytics.
+            junit_suite = junit_xml.TestSuite(test_suite_name)
+
+            for test_case_name, result in composition.test_results.items():
+                test_case = junit_xml.TestCase(
+                    test_case_name, test_class_name, result.duration
+                )
                 if result.is_failure():
                     assert result.error is not None
                     test_case.add_error_info(

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -601,7 +601,9 @@ To see the available workflows, run:
             for name, result in composition.test_results.items():
                 test_case = junit_xml.TestCase(name, composition.name, result.duration)
                 if result.error:
-                    test_case.add_error_info(message=result.error)
+                    test_case.add_error_info(
+                        message=result.error, output=result.error_details
+                    )
                 junit_suite.test_cases.append(test_case)
             junit_report = ci_util.junit_report_filename("mzcompose")
             with junit_report.open("w") as f:

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -600,7 +600,8 @@ To see the available workflows, run:
 
             for name, result in composition.test_results.items():
                 test_case = junit_xml.TestCase(name, composition.name, result.duration)
-                if result.error:
+                if result.is_failure():
+                    assert result.error is not None
                     test_case.add_error_info(
                         message=result.error, output=result.error_details
                     )

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -603,7 +603,9 @@ To see the available workflows, run:
 
             for test_case_name, result in composition.test_results.items():
                 test_case = junit_xml.TestCase(
-                    test_case_name, test_class_name, result.duration
+                    result.get_error_file() or test_case_name,
+                    test_class_name,
+                    result.duration,
                 )
                 if result.is_failure():
                     assert result.error is not None

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -89,6 +89,10 @@ class Composition:
         error_details: str | None
         error_location: str | None
 
+        def is_failure(self) -> bool:
+            return self.error is not None
+
+
     def __init__(
         self,
         repo: mzbuild.Repository,

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -46,7 +46,7 @@ from materialize import MZ_ROOT, mzbuild, spawn, ui
 from materialize.mzcompose import loader
 from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.minio import minio_blob_uri
-from materialize.ui import UIError
+from materialize.ui import CommandFailureCausedUIError, UIError
 
 
 class UnknownCompositionError(UIError):
@@ -309,8 +309,9 @@ class Composition:
                     time.sleep(1)
                     continue
                 else:
-                    raise UIError(
-                        f"running docker compose failed (exit status {e.returncode})"
+                    raise CommandFailureCausedUIError(
+                        f"running docker compose failed (exit status {e.returncode})",
+                        cmd=e.cmd,
                     )
             break
 

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -92,6 +92,18 @@ class Composition:
         def is_failure(self) -> bool:
             return self.error is not None
 
+        def get_error_file(self) -> str | None:
+            if self.error_location is None:
+                return None
+
+            file_name = self.error_location
+            file_name = re.sub(r":\d+", "", file_name)
+
+            if "/" in file_name:
+                file_name = file_name[file_name.rindex("/") + 1 :]
+
+            return file_name
+
     def __init__(
         self,
         repo: mzbuild.Repository,

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -312,6 +312,7 @@ class Composition:
                     raise CommandFailureCausedUIError(
                         f"running docker compose failed (exit status {e.returncode})",
                         cmd=e.cmd,
+                        stderr=e.stderr if capture_stderr == True else None,
                     )
             break
 
@@ -1045,12 +1046,12 @@ class Composition:
             ]
 
         if persistent:
-            self.exec(service, *args, stdin=input)
+            self.exec(service, *args, stdin=input, capture_stderr=True)
         else:
             assert (
                 mz_service is None
             ), "testdrive(mz_service = ...) can only be used with persistent Testdrive containers."
-            self.run(service, *args, stdin=input)
+            self.run(service, *args, stdin=input, capture_stderr=True)
 
     def enable_minio_versioning(self) -> None:
         self.up("minio")

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -92,7 +92,6 @@ class Composition:
         def is_failure(self) -> bool:
             return self.error is not None
 
-
     def __init__(
         self,
         repo: mzbuild.Repository,
@@ -505,9 +504,12 @@ class Composition:
         )
 
     def try_determine_error_location_from_cmd(self, cmd: list[str]) -> str | None:
+        root_path_as_string = f"{MZ_ROOT}/"
         for cmd_part in cmd:
             if type(cmd_part) == str and cmd_part.startswith("--source="):
-                return cmd_part.removeprefix("--source=")
+                return cmd_part.removeprefix("--source=").replace(
+                    root_path_as_string, ""
+                )
 
         return None
 

--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -180,6 +180,23 @@ class UIError(Exception):
         self.hint = hint
 
 
+class CommandFailureCausedUIError(UIError):
+    """
+    An UIError that is caused by executing a command.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        cmd: list[str],
+        stderr: str | None = None,
+        hint: str | None = None,
+    ):
+        super().__init__(message, hint)
+        self.cmd = cmd
+        self.stderr = stderr
+
+
 @contextmanager
 def error_handler(prog: str) -> Any:
     """Catches and pretty-prints any raised `UIError`s.


### PR DESCRIPTION
This is work towards https://github.com/MaterializeInc/materialize/issues/22690.

junit.xml of platform checks are the changes **(updated):**
```
		<testcase name="comment.py" time="40.914175" classname="Checks + restart of environmentd & storage clusterd (5)">
			<error type="error" message="Executing misc/python/materialize/checks/all_checks/comment.py:24 failed">^^^ +++
2:1: error: preparing query failed: db error: ERROR: type &quot;into&quot; does not exist: ERROR: type &quot;into&quot; does not exist
     |
   1 | 
   2 | &gt; CREATE TYPE comment_type AS (x text, y int, z into)
     | ^
+++ !!! Error Report
1 errors were encountered during execution
source: /Users/nrainer/Workspaces/mz-repo/misc/python/materialize/checks/all_checks/comment.py:24
</error>
		</testcase>

```

Build with a failure to check how it looks in Buildkite: https://buildkite.com/materialize/tests/builds/73337

The changes might need to be extended for further patterns / jobs (as follow-up when observed).