### PR TITLE
platform-checks: Capture additional logs

### DIFF
--- a/misc/python/materialize/checks/scenarios_persist_txn.py
+++ b/misc/python/materialize/checks/scenarios_persist_txn.py
@@ -22,25 +22,25 @@ class PersistTxnToggle(Scenario):
                 self, additional_system_parameter_defaults={"persist_txn_tables": "off"}
             ),
             Initialize(self),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"persist_txn_tables": "eager"},
             ),
             Manipulate(self, phase=1),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"persist_txn_tables": "lazy"},
             ),
             Manipulate(self, phase=2),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"persist_txn_tables": "eager"},
             ),
             Validate(self),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self, additional_system_parameter_defaults={"persist_txn_tables": "off"}
             ),
@@ -76,7 +76,10 @@ class PersistTxnFencing(Scenario):
             ),
             Validate(self, mz_service="mz_txn_tables_lazy"),
             # Since we are creating Mz instances with a non-default name,
-            # we need to perform explicit cleanup here
+            # we need to perform explicit cleanup here. Some instances are
+            # dead by now, but we still need to capture their logs
+            KillMz(mz_service="mz_txn_tables_default"),
+            KillMz(mz_service="mz_txn_tables_eager"),
             KillMz(mz_service="mz_txn_tables_lazy"),
             Down(),
         ]

--- a/misc/python/materialize/checks/scenarios_platform_v2.py
+++ b/misc/python/materialize/checks/scenarios_platform_v2.py
@@ -22,24 +22,24 @@ class PersistTxnToggle(Scenario):
                 self, additional_system_parameter_defaults={"persist_txn_tables": "off"}
             ),
             Initialize(self),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"persist_txn_tables": "eager"},
             ),
             Manipulate(self, phase=1),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self, additional_system_parameter_defaults={"persist_txn_tables": "off"}
             ),
             Manipulate(self, phase=2),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"persist_txn_tables": "eager"},
             ),
             Validate(self),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self, additional_system_parameter_defaults={"persist_txn_tables": "off"}
             ),
@@ -71,8 +71,11 @@ class PersistTxnFencing(Scenario):
             StartMz(self, mz_service="mz_txn_tables_default"),
             Validate(self, mz_service="mz_txn_tables_default"),
             # Since we are creating Mz instances with a non-default name,
-            # we need to perform explicit cleanup here
-            KillMz(mz_service="mz_txn_tables_default"),
+            # we need to perform explicit cleanup here. Some Mz instances
+            # are dead by now, but we still need to capture their logs.
+            KillMz(mz_service="mz_txn_tables_eager", capture_logs=True),
+            KillMz(mz_service="mz_txn_tables_off", capture_logs=True),
+            KillMz(mz_service="mz_txn_tables_default", capture_logs=True),
             Down(),
         ]
 
@@ -84,16 +87,16 @@ class PersistCatalogToggle(Scenario):
         return [
             StartMz(self, catalog_store="stash"),
             Initialize(self),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, catalog_store="persist"),
             Manipulate(self, phase=1),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, catalog_store="stash"),
             Manipulate(self, phase=2),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, catalog_store="persist"),
             Validate(self),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, catalog_store="stash"),
             Validate(self),
         ]
@@ -109,25 +112,25 @@ class TimestampOracleToggle(Scenario):
                 additional_system_parameter_defaults={"timestamp_oracle": "catalog"},
             ),
             Initialize(self),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"timestamp_oracle": "postgres"},
             ),
             Manipulate(self, phase=1),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"timestamp_oracle": "catalog"},
             ),
             Manipulate(self, phase=2),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"timestamp_oracle": "postgres"},
             ),
             Validate(self),
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"timestamp_oracle": "catalog"},

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -96,9 +96,10 @@ IGNORE_RE = re.compile(
     | larger\ sizes\ prevent\ running\ out\ of\ memory
     # Old versions won't support new parameters
     | (platform-checks|legacy-upgrade|upgrade-matrix|feature-benchmark)-materialized-.* \| .*cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
-    # Fencing warnings are OK in fencing test
+    # Fencing warnings are OK in fencing tests
     | persist-txn-fencing-mz_first-.* \| .*unexpected\ fence\ epoch
     | persist-txn-fencing-mz_first-.* \| .*fenced\ by\ new\ catalog\ upper
+    | platform-checks-mz_txn_tables.* \| .*unexpected\ fence\ epoch
     # For platform-checks upgrade tests
     | platform-checks-clusterd.* \| .* received\ persist\ state\ from\ the\ future
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage(\ to\ set\ (default|configured)\ parameter)?


### PR DESCRIPTION
Due to a docker-compose change, now every service that is restarted using a new definition gets is logs wiped out. Therefore they need to be explicitly preserved whenever possible.

### Motivation

A lot of the fancier platform checks had no materialize log lines whatsoever in services.txt