### PR TITLE
ci: disable retain-history check for now

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1072,6 +1072,7 @@ steps:
 
   - id: retain-history
     label: "Check retain history"
+    skip: "#24479"
     timeout_in_minutes: 15
     artifact_paths: junit_*.xml
     agents:


### PR DESCRIPTION
It failed again in the most recent nightly; the feature is apparently not stable enough as of now.