### PR TITLE
adapter: panic on more controller errors

### DIFF
--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -327,12 +327,12 @@ impl ShouldHalt for mz_catalog::durable::DurableCatalogError {
 impl ShouldHalt for StorageError {
     fn should_halt(&self) -> bool {
         match self {
+            StorageError::ResourceExhausted(_) => true,
             StorageError::UpdateBeyondUpper(_)
             | StorageError::ReadBeforeSince(_)
             | StorageError::InvalidUppers(_)
             | StorageError::InvalidUsage(_)
-            | StorageError::ResourceExhausted(_) => true,
-            StorageError::SourceIdReused(_)
+            | StorageError::SourceIdReused(_)
             | StorageError::SinkIdReused(_)
             | StorageError::IdentifierMissing(_)
             | StorageError::IdentifierInvalid(_)
@@ -350,8 +350,8 @@ impl ShouldHalt for StorageError {
 impl ShouldHalt for DataflowCreationError {
     fn should_halt(&self) -> bool {
         match self {
-            DataflowCreationError::SinceViolation(_) => true,
-            DataflowCreationError::InstanceMissing(_)
+            DataflowCreationError::SinceViolation(_)
+            | DataflowCreationError::InstanceMissing(_)
             | DataflowCreationError::CollectionMissing(_)
             | DataflowCreationError::MissingAsOf => false,
         }
@@ -370,8 +370,8 @@ impl ShouldHalt for CollectionUpdateError {
 impl ShouldHalt for PeekError {
     fn should_halt(&self) -> bool {
         match self {
-            PeekError::SinceViolation(_) => true,
-            PeekError::InstanceMissing(_)
+            PeekError::SinceViolation(_)
+            | PeekError::InstanceMissing(_)
             | PeekError::CollectionMissing(_)
             | PeekError::ReplicaMissing(_) => false,
         }


### PR DESCRIPTION
This PR adjusts the `ShouldHalt` implementations of controller errors to be less lenient. All of the errors that panic now are ones that we don't expect to see in the absence of bugs, so if they are returned we want to process to panic so we get notified in Sentry.

[Relevant Slack thread.](https://materializeinc.slack.com/archives/C02FWJ94HME/p1705582715690299)

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

I'm pretty sure that this is the correct thing to do for the compute controller errors, but only somewhat sure for the storage controller errors. Can someone from @MaterializeInc/storage check my work here?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A