### PR TITLE
persist-txn: change default from "off" to "eager"

### DIFF
--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -555,7 +555,7 @@ impl Listeners {
             })
             .transpose()?;
         let mut persist_txn_tables =
-            persist_txn_tables_default.unwrap_or(PersistTxnTablesImpl::Off);
+            persist_txn_tables_default.unwrap_or(PersistTxnTablesImpl::Eager);
         if let Some(value) = persist_txn_tables_stash_ld {
             persist_txn_tables = value;
         }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -694,7 +694,7 @@ const PERSIST_FAST_PATH_LIMIT: ServerVar<usize> = ServerVar {
 
 pub const PERSIST_TXN_TABLES: ServerVar<PersistTxnTablesImpl> = ServerVar {
     name: UncasedStr::new("persist_txn_tables"),
-    value: PersistTxnTablesImpl::Off,
+    value: PersistTxnTablesImpl::Eager,
     description: "\
         Whether to use the new persist-txn tables implementation or the legacy \
         one.


### PR DESCRIPTION
Make the default reflect what we're running in production.

Touches #22173

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

I've intentionally left the CI overrides (currently also set to "eager") around so this doesn't create a merge conflict with the PR to flip them to "lazy".

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
