### PR TITLE
storage: remove compat timestamps from `SourceTimestamp`

### DIFF
--- a/src/expr/src/id.proto
+++ b/src/expr/src/id.proto
@@ -24,10 +24,3 @@ message ProtoId {
 message ProtoLocalId {
     uint64 value = 1;
 }
-
-message ProtoPartitionId {
-    oneof kind {
-        int32 kafka = 1;
-        google.protobuf.Empty none = 2;
-    }
-}

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -28,7 +28,7 @@ pub mod refresh_schedule;
 pub mod virtual_syntax;
 pub mod visit;
 
-pub use id::{Id, LocalId, PartitionId, ProtoId, ProtoLocalId, ProtoPartitionId, SourceInstanceId};
+pub use id::{Id, LocalId, ProtoId, ProtoLocalId, SourceInstanceId};
 pub use interpret::{ColumnSpec, ColumnSpecs, Interpreter, ResultSpec, Trace, TraceSummary};
 pub use linear::plan::{MfpPlan, SafeMfpPlan};
 pub use linear::util::{join_permutations, permutation_for_arrangement};

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -20,7 +20,6 @@ use bytes::BufMut;
 
 use itertools::EitherOrBoth::Both;
 use itertools::Itertools;
-use mz_expr::PartitionId;
 
 use mz_persist_types::columnar::{
     ColumnFormat, ColumnGet, ColumnPush, Data, DataType, PartDecoder, PartEncoder, Schema,
@@ -356,26 +355,11 @@ where
 }
 
 pub trait SourceTimestamp: timely::progress::Timestamp + Refines<()> + std::fmt::Display {
-    fn from_compat_ts(pid: PartitionId, offset: MzOffset) -> Self;
-    fn try_into_compat_ts(&self) -> Option<(PartitionId, MzOffset)>;
     fn encode_row(&self) -> Row;
     fn decode_row(row: &Row) -> Self;
 }
 
 impl SourceTimestamp for MzOffset {
-    fn from_compat_ts(pid: PartitionId, offset: MzOffset) -> Self {
-        assert_eq!(
-            pid,
-            PartitionId::None,
-            "invalid non-partitioned partition {pid}"
-        );
-        offset
-    }
-
-    fn try_into_compat_ts(&self) -> Option<(PartitionId, MzOffset)> {
-        Some((PartitionId::None, *self))
-    }
-
     fn encode_row(&self) -> Row {
         Row::pack([Datum::UInt64(self.offset)])
     }

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -14,7 +14,6 @@ use std::fmt;
 use std::time::Duration;
 
 use dec::OrderedDecimal;
-use mz_expr::PartitionId;
 use mz_proto::{IntoRustIfSome, RustType, TryFromProtoError};
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::{ColumnType, Datum, GlobalId, RelationDesc, Row, ScalarType};
@@ -384,18 +383,6 @@ impl<P> Extrema for RangeBound<P> {
 }
 
 impl SourceTimestamp for Partitioned<RangeBound<i32>, MzOffset> {
-    fn from_compat_ts(pid: PartitionId, offset: MzOffset) -> Self {
-        match pid {
-            PartitionId::Kafka(pid) => Partitioned::new_singleton(RangeBound::exact(pid), offset),
-            PartitionId::None => panic!("invalid partitioned partition {pid}"),
-        }
-    }
-
-    fn try_into_compat_ts(&self) -> Option<(PartitionId, MzOffset)> {
-        let pid = self.interval().singleton()?.unwrap_exact();
-        Some((PartitionId::Kafka(*pid), *self.timestamp()))
-    }
-
     fn encode_row(&self) -> Row {
         use mz_repr::adt::range;
         let mut row = Row::with_capacity(2);

--- a/src/storage/src/metrics/source.rs
+++ b/src/storage/src/metrics/source.rs
@@ -14,131 +14,28 @@
 //! vectors to the registry once, and then generate concrete instantiations of them for the
 //! appropriate source.
 
-use std::collections::BTreeMap;
-
-use mz_expr::PartitionId;
 use mz_ore::metric;
 use mz_ore::metrics::{
     CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt, IntCounter, IntCounterVec,
     IntGaugeVec, MetricsRegistry, UIntGaugeVec,
 };
 use mz_repr::GlobalId;
-use mz_storage_types::sources::MzOffset;
-use prometheus::core::{AtomicI64, AtomicU64, GenericCounterVec};
+use prometheus::core::{AtomicI64, AtomicU64};
 
 use super::kafka::KafkaPartitionMetricDefs;
 use super::postgres::PgSourceMetricDefs;
 use super::upsert::{UpsertBackpressureMetricDefs, UpsertMetricDefs};
 
-/// Definitions for per-partition metrics.
-#[derive(Clone, Debug)]
-pub(crate) struct PartitionMetricDefs {
-    pub(crate) offset_ingested: UIntGaugeVec,
-    pub(crate) offset_received: UIntGaugeVec,
-    pub(crate) closed_ts: UIntGaugeVec,
-    pub(crate) messages_ingested: GenericCounterVec<AtomicI64>,
-}
-
-impl PartitionMetricDefs {
-    fn register_with(registry: &MetricsRegistry) -> Self {
-        Self {
-            offset_ingested: registry.register(metric!(
-                name: "mz_partition_offset_ingested",
-                help: "The most recent offset that we have ingested into a dataflow. This correspond to \
-                 data that we have 1)ingested 2) assigned a timestamp",
-                var_labels: ["topic", "source_id", "partition_id"],
-            )),
-            offset_received: registry.register(metric!(
-                name: "mz_partition_offset_received",
-                help: "The most recent offset that we have been received by this source.",
-                var_labels: ["topic", "source_id", "partition_id"],
-            )),
-            closed_ts: registry.register(metric!(
-                name: "mz_partition_closed_ts",
-                help: "The highest closed timestamp for each partition in this dataflow",
-                var_labels: ["topic", "source_id", "partition_id"],
-            )),
-            messages_ingested: registry.register(metric!(
-                name: "mz_messages_ingested",
-                help: "The number of messages ingested per partition.",
-                var_labels: ["topic", "source_id", "partition_id"],
-            )),
-        }
-    }
-}
-
-/// Partition-specific metrics.
-pub(crate) struct PartitionMetrics {
-    /// Highest offset that has been received by the source and timestamped
-    pub(crate) offset_ingested: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    /// Highest offset that has been received by the source
-    pub(crate) offset_received: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    /// Value of the highest timestamp that is closed (for which all messages have been ingested)
-    pub(crate) closed_ts: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    /// Total number of messages that have been received by the source and timestamped
-    pub(crate) messages_ingested: DeleteOnDropCounter<'static, AtomicI64, Vec<String>>,
-    pub(crate) last_offset: u64,
-    pub(crate) last_timestamp: i64,
-}
-
-impl PartitionMetrics {
-    /// Record the latest offset ingested high-water mark
-    fn record_offset(
-        &mut self,
-        _source_name: &str,
-        _source_id: GlobalId,
-        _partition_id: &PartitionId,
-        offset: u64,
-        timestamp: i64,
-    ) {
-        self.offset_received.set(offset);
-        self.offset_ingested.set(offset);
-        self.last_offset = offset;
-        self.last_timestamp = timestamp;
-    }
-
-    /// Initializes partition metrics for a given (source_id, partition_id)
-    pub(crate) fn new(
-        defs: &PartitionMetricDefs,
-        source_name: &str,
-        source_id: GlobalId,
-        partition_id: &PartitionId,
-    ) -> PartitionMetrics {
-        let labels = &[
-            source_name.to_string(),
-            source_id.to_string(),
-            partition_id.to_string(),
-        ];
-        PartitionMetrics {
-            offset_ingested: defs
-                .offset_ingested
-                .get_delete_on_drop_gauge(labels.to_vec()),
-            offset_received: defs
-                .offset_received
-                .get_delete_on_drop_gauge(labels.to_vec()),
-            closed_ts: defs.closed_ts.get_delete_on_drop_gauge(labels.to_vec()),
-            messages_ingested: defs
-                .messages_ingested
-                .get_delete_on_drop_counter(labels.to_vec()),
-            last_offset: 0,
-            last_timestamp: 0,
-        }
-    }
-}
-
 /// Definitions for general metrics about sources that are not specific to the source type.
 ///
 /// Registers metrics for
-/// `SourceMetrics`, `PartitionMetrics`, `OffsetCommitMetrics`, and `SourcePersistSinkMetrics`.
+/// `SourceMetrics`, `OffsetCommitMetrics`, and `SourcePersistSinkMetrics`.
 #[derive(Clone, Debug)]
 pub(crate) struct GeneralSourceMetricDefs {
     // Source metrics
     pub(crate) capability: UIntGaugeVec,
     pub(crate) resume_upper: IntGaugeVec,
     pub(crate) inmemory_remap_bindings: UIntGaugeVec,
-
-    // Per-partition metrics
-    pub(crate) partition_defs: PartitionMetricDefs,
 
     // OffsetCommitMetrics
     pub(crate) offset_commit_failures: IntCounterVec,
@@ -161,7 +58,7 @@ impl GeneralSourceMetricDefs {
             // should be fixed
             capability: registry.register(metric!(
                 name: "mz_capability",
-                help: "The current capability for this dataflow. This corresponds to min(mz_partition_closed_ts)",
+                help: "The current capability for this dataflow.",
                 var_labels: ["topic", "source_id", "worker_id"],
             )),
             resume_upper: registry.register(metric!(
@@ -180,7 +77,6 @@ impl GeneralSourceMetricDefs {
                 help: "A counter representing how many times we have failed to commit offsets for a source",
                 var_labels: ["source_id"],
             )),
-            partition_defs: PartitionMetricDefs::register_with(registry),
             progress: registry.register(metric!(
                 name: "mz_source_progress",
                 help: "A timestamp gauge representing forward progess in the data shard",
@@ -216,22 +112,14 @@ impl GeneralSourceMetricDefs {
     }
 }
 
-/// General metrics about sources that are not specific to the source type, including partitions
-/// metrics.
+/// General metrics about sources that are not specific to the source type
 pub(crate) struct SourceMetrics {
     /// Value of the capability associated with this source
     pub(crate) capability: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     /// The resume_upper for a source.
     pub(crate) resume_upper: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
-    /// Per-partition Prometheus metrics.
-    pub(crate) partition_metrics: BTreeMap<PartitionId, PartitionMetrics>,
     /// The number of in-memory remap bindings that reclocking a time needs to iterate over.
     pub(crate) inmemory_remap_bindings: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-
-    // Used for creation `partition_metrics` on-the-fly.
-    partition_defs: PartitionMetricDefs,
-    source_id: GlobalId,
-    source_name: String,
 }
 
 impl SourceMetrics {
@@ -255,40 +143,6 @@ impl SourceMetrics {
             inmemory_remap_bindings: defs
                 .inmemory_remap_bindings
                 .get_delete_on_drop_gauge(vec![source_id.to_string(), worker_id.to_string()]),
-            partition_metrics: Default::default(),
-            partition_defs: defs.partition_defs.clone(),
-            source_id,
-            source_name: source_name.to_string(),
-        }
-    }
-
-    /// Log updates to which offsets / timestamps read up to.
-    pub(crate) fn record_partition_offsets(
-        &mut self,
-        offsets: BTreeMap<PartitionId, (MzOffset, mz_repr::Timestamp, i64)>,
-    ) {
-        for (partition, (offset, timestamp, count)) in offsets {
-            let metric = self
-                .partition_metrics
-                .entry(partition.clone())
-                .or_insert_with(|| {
-                    PartitionMetrics::new(
-                        &self.partition_defs,
-                        &self.source_name,
-                        self.source_id,
-                        &partition,
-                    )
-                });
-
-            metric.messages_ingested.inc_by(count);
-
-            metric.record_offset(
-                &self.source_name,
-                self.source_id,
-                &partition,
-                offset.offset,
-                i64::try_from(timestamp).expect("materialize exists after 250M AD"),
-            );
         }
     }
 }

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -68,8 +68,6 @@ pub fn as_generator(g: &LoadGenerator, tick_micros: Option<u64>) -> Box<dyn Gene
 }
 
 impl SourceRender for LoadGeneratorSourceConnection {
-    type Key = ();
-    type Value = Row;
     type Time = MzOffset;
 
     const STATUS_NAMESPACE: StatusNamespace = StatusNamespace::Generator;
@@ -81,14 +79,7 @@ impl SourceRender for LoadGeneratorSourceConnection {
         _resume_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
-        Collection<
-            G,
-            (
-                usize,
-                Result<SourceMessage<Self::Key, Self::Value>, SourceReaderError>,
-            ),
-            Diff,
-        >,
+        Collection<G, (usize, Result<SourceMessage, SourceReaderError>), Diff>,
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
         Vec<PressOnDropButton>,
@@ -128,7 +119,7 @@ impl SourceRender for LoadGeneratorSourceConnection {
                         let message = (
                             output,
                             Ok(SourceMessage {
-                                key: (),
+                                key: Row::default(),
                                 value,
                                 metadata: Row::default(),
                             }),

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -46,8 +46,6 @@ mod timestamp;
 use timestamp::TransactionId;
 
 impl SourceRender for MySqlSourceConnection {
-    type Key = ();
-    type Value = Row;
     // TODO: Eventually replace with a Partitioned<Uuid, TransactionId> timestamp
     type Time = TransactionId;
 
@@ -62,7 +60,7 @@ impl SourceRender for MySqlSourceConnection {
         resume_uppers: impl futures::Stream<Item = Antichain<TransactionId>> + 'static,
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
-        Collection<G, (usize, Result<SourceMessage<(), Row>, SourceReaderError>), Diff>,
+        Collection<G, (usize, Result<SourceMessage, SourceReaderError>), Diff>,
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
         Vec<PressOnDropButton>,
@@ -117,7 +115,7 @@ impl SourceRender for MySqlSourceConnection {
 
         let updates = snapshot_updates.concat(&repl_updates).map(|(output, res)| {
             let res = res.map(|row| SourceMessage {
-                key: (),
+                key: Row::default(),
                 value: row,
                 metadata: Row::default(),
             });

--- a/src/storage/src/source/mysql/timestamp.rs
+++ b/src/storage/src/source/mysql/timestamp.rs
@@ -10,9 +10,8 @@
 use core::ops::Add;
 use std::fmt;
 
-use mz_expr::PartitionId;
 use mz_repr::{Datum, Row};
-use mz_storage_types::sources::{MzOffset, SourceTimestamp};
+use mz_storage_types::sources::SourceTimestamp;
 use serde::{Deserialize, Serialize};
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::timestamp::{PathSummary, Refines, Timestamp};
@@ -90,21 +89,6 @@ impl Refines<()> for TransactionId {
 }
 
 impl SourceTimestamp for TransactionId {
-    fn from_compat_ts(pid: PartitionId, offset: MzOffset) -> Self {
-        assert_eq!(
-            pid,
-            PartitionId::None,
-            "invalid non-partitioned partition {pid}"
-        );
-        let id: u64 = offset.offset;
-        Self::new(id)
-    }
-
-    fn try_into_compat_ts(&self) -> Option<(PartitionId, MzOffset)> {
-        let id: u64 = self.0;
-        Some((PartitionId::None, MzOffset::from(id)))
-    }
-
     fn encode_row(&self) -> Row {
         Row::pack([Datum::UInt64(self.0)])
     }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -110,8 +110,6 @@ mod replication;
 mod snapshot;
 
 impl SourceRender for PostgresSourceConnection {
-    type Key = ();
-    type Value = Row;
     type Time = MzOffset;
 
     const STATUS_NAMESPACE: StatusNamespace = StatusNamespace::Postgres;
@@ -125,7 +123,7 @@ impl SourceRender for PostgresSourceConnection {
         resume_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
-        Collection<G, (usize, Result<SourceMessage<(), Row>, SourceReaderError>), Diff>,
+        Collection<G, (usize, Result<SourceMessage, SourceReaderError>), Diff>,
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
         Vec<PressOnDropButton>,
@@ -181,7 +179,7 @@ impl SourceRender for PostgresSourceConnection {
 
         let updates = snapshot_updates.concat(&repl_updates).map(|(output, res)| {
             let res = res.map(|row| SourceMessage {
-                key: (),
+                key: Row::default(),
                 value: row,
                 metadata: Row::default(),
             });

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -24,7 +24,6 @@
 #![allow(clippy::needless_borrow)]
 
 use std::cell::RefCell;
-use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::fmt::Display;
@@ -41,7 +40,6 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use futures::stream::StreamExt;
 use itertools::Itertools;
-use mz_expr::PartitionId;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::error::ErrorExt;
@@ -53,16 +51,14 @@ use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::SourceError;
 use mz_storage_types::sources::encoding::SourceDataEncoding;
-use mz_storage_types::sources::{MzOffset, SourceConnection, SourceExport, SourceTimestamp};
+use mz_storage_types::sources::{SourceConnection, SourceExport, SourceTimestamp};
 use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{
-    AsyncOutputHandle, Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder,
-    PressOnDropButton,
+    Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
 use mz_timely_util::capture::UnboundedTokioCapture;
 use mz_timely_util::operator::StreamExt as _;
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::capture::capture::Capture;
 use timely::dataflow::operators::capture::Event;
 use timely::dataflow::operators::{Broadcast, CapabilitySet, Concat, Leave, Partition};
@@ -585,7 +581,7 @@ where
         // The capability of the output after reclocking the source frontier
         let mut cap_set = CapabilitySet::from_elem(capabilities.into_element());
 
-        let mut source_metrics = metrics.get_source_metrics(&name, id, worker_id);
+        let source_metrics = metrics.get_source_metrics(&name, id, worker_id);
 
         // Compute the overall resume upper to report for the ingestion
         let resume_upper = Antichain::from_iter(resume_uppers.values().flat_map(|f| f.iter().cloned()));
@@ -684,23 +680,32 @@ where
 
                     // Accumulate updates to bytes_read for Prometheus metrics collection
                     let mut bytes_read = 0;
-                    // Accumulate updates to offsets for Prometheus and system table metrics collection
-                    let mut metric_updates = BTreeMap::new();
 
                     let mut total_processed = 0;
-                    for ((message, from_ts, diff), into_ts) in timestamper.reclock(msgs) {
+                    for (((idx, msg), from_ts, diff), into_ts) in timestamper.reclock(msgs) {
                         let into_ts = into_ts.expect("reclock for update not beyond upper failed");
-                        handle_message(
-                            message,
-                            from_ts,
-                            diff,
-                            &mut bytes_read,
-                            &cap_set,
-                            &mut reclocked_output,
-                            &mut metric_updates,
-                            into_ts,
-                            id,
-                        ).await;
+                        let output = match msg {
+                            Ok(message) => {
+                                bytes_read += message.key.byte_len() + message.value.byte_len();
+                                let ok = SourceOutput {
+                                    key: message.key,
+                                    value: message.value,
+                                    metadata: message.metadata,
+                                    from_time: from_ts,
+                                };
+                                (idx, Ok(ok))
+                            }
+                            Err(SourceReaderError { inner }) => {
+                                let err = SourceError {
+                                    source_id: id,
+                                    error: inner,
+                                };
+                                (idx, Err(err))
+                            }
+                        };
+
+                        let ts_cap = cap_set.delayed(&into_ts);
+                        reclocked_output.give(&ts_cap, (output, into_ts, diff)).await;
                         total_processed += 1;
                     }
                     // The loop above might have completely emptied batches. We can now remove them
@@ -714,7 +719,6 @@ where
                     );
 
                     bytes_read_counter.inc_by(u64::cast_from(bytes_read));
-                    source_metrics.record_partition_offsets(metric_updates);
 
                     // This is correct for totally ordered times because there can be at
                     // most one entry in the `CapabilitySet`. If this ever changes we
@@ -749,12 +753,6 @@ where
                         "timely-{worker_id} reclock({id}) downgrading timestamper: since={}",
                         into_ready_upper.pretty()
                     );
-
-                    // TODO(aljoscha&guswynn): will these be overwritten with multi-worker
-                    let ts = into_ready_upper.as_option().cloned().unwrap_or(mz_repr::Timestamp::MAX);
-                    for partition_metrics in source_metrics.partition_metrics.values_mut() {
-                        partition_metrics.closed_ts.set(ts.into());
-                    }
 
                     cap_set.downgrade(into_ready_upper.elements());
                     timestamper.compact(into_ready_upper.clone());
@@ -862,78 +860,4 @@ where
             }
         }
     })
-}
-
-/// Take `message` and assign it the appropriate timestamps and push it into the
-/// dataflow layer, if possible.
-///
-/// TODO: This function is a bit of a mess rn but hopefully this function makes
-/// the existing mess more obvious and points towards ways to improve it.
-async fn handle_message<FromTime: Timestamp, D>(
-    (output_index, message): (usize, Result<SourceMessage, SourceReaderError>),
-    from_time: FromTime,
-    diff: D,
-    bytes_read: &mut usize,
-    cap_set: &CapabilitySet<mz_repr::Timestamp>,
-    output_handle: &mut AsyncOutputHandle<
-        mz_repr::Timestamp,
-        Vec<(
-            (usize, Result<SourceOutput<FromTime>, SourceError>),
-            mz_repr::Timestamp,
-            D,
-        )>,
-        Tee<
-            mz_repr::Timestamp,
-            (
-                (usize, Result<SourceOutput<FromTime>, SourceError>),
-                mz_repr::Timestamp,
-                D,
-            ),
-        >,
-    >,
-    metric_updates: &mut BTreeMap<PartitionId, (MzOffset, mz_repr::Timestamp, Diff)>,
-    ts: mz_repr::Timestamp,
-    source_id: GlobalId,
-) where
-    FromTime: SourceTimestamp,
-    D: Semigroup,
-{
-    let output = match message {
-        Ok(message) => {
-            let (partition, offset) = from_time
-                .try_into_compat_ts()
-                .expect("data at invalid timestamp");
-
-            *bytes_read += message.key.byte_len() + message.value.byte_len();
-
-            match metric_updates.entry(partition) {
-                Entry::Occupied(mut entry) => {
-                    entry.insert((offset, ts, entry.get().2 + 1));
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert((offset, ts, 1));
-                }
-            }
-
-            (
-                output_index,
-                Ok(SourceOutput {
-                    key: message.key,
-                    value: message.value,
-                    metadata: message.metadata,
-                    from_time,
-                }),
-            )
-        }
-        Err(SourceReaderError { inner }) => {
-            let err = SourceError {
-                source_id,
-                error: inner,
-            };
-            (output_index, Err(err))
-        }
-    };
-
-    let ts_cap = cap_set.delayed(&ts);
-    output_handle.give(&ts_cap, (output, ts, diff)).await;
 }

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 use differential_dataflow::Collection;
 use mz_repr::{Diff, Row};
 use mz_storage_types::errors::{DecodeError, SourceErrorDetails};
-use mz_storage_types::sources::{MzOffset, SourceTimestamp};
+use mz_storage_types::sources::SourceTimestamp;
 use mz_timely_util::builder_async::PressOnDropButton;
 use serde::{Deserialize, Serialize};
 use timely::dataflow::{Scope, Stream};
@@ -85,22 +85,20 @@ pub struct SourceMessage {
 
 /// A record produced by a source
 #[derive(Clone, Serialize, Debug, Deserialize)]
-pub struct SourceOutput {
+pub struct SourceOutput<FromTime> {
     /// The record's key (or some empty/default value for sources without the concept of key)
     pub key: Row,
     /// The record's value
     pub value: Row,
     /// Additional metadata columns requested by the user
     pub metadata: Row,
-    /// The offset position in the partition of a kafka source. This is field is on its way out and
-    /// its only valid use is in the upsert operator. Do NOT use it in any new place!
-    // TODO(petrosagg): remove this field
-    pub position_for_upsert: MzOffset,
+    /// The original timestamp of this message
+    pub from_time: FromTime,
 }
 
 /// The output of the decoding operator
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
-pub struct DecodeResult {
+pub struct DecodeResult<FromTime> {
     /// The decoded key
     pub key: Option<Result<Row, DecodeError>>,
     /// The decoded value, as well as the the
@@ -109,10 +107,8 @@ pub struct DecodeResult {
     pub value: Option<Result<Row, DecodeError>>,
     /// Additional metadata requested by the user
     pub metadata: Row,
-    /// The offset position in the partition of a kafka source. This is field is on its way out and
-    /// its only valid use is in the upsert operator. Do NOT use it in any new place!
-    // TODO(petrosagg): remove this field
-    pub position_for_upsert: MzOffset,
+    /// The original timestamp of this message
+    pub from_time: FromTime,
 }
 
 /// A structured error for `SourceReader::get_next_message` implementors.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

We have been sitting on some legacy code for a while now so this PR finally removes it. The code in question is related to the source timestamps we had before the `SourceRender` trait made them generic. The source timestamp in these old days had to be `(PartitionId, MzOffset)` for *all* sources, regardless of whether the source had the notion of a partition or not. This assumption had been removed from most places except two:
1. Per-partition metrics that are instantiated for all sources unconditionally
2. Post-reclocking ordering of updates using `MzOffset`

This PR addresses both of these in the following ways:
1. The metrics are removed. The kafka source, which is the only one that has partitions, already has kafka specific metrics that we can track.
2. The relevant types (`SourceOutput` and `DecodeResult`) now carry a generic `FromTime` type which records the original source timestamp of this update throughout the ingestion pipeline. The upsert operator then uses that to order updates that happen at the same mz-timestamp.

A stepping stone to do the above was to make the pipeline generic over the source connection type, so that the `FromTime` generic could be carried all the way to the upsert operator. This task was made significantly easier by removing the associated types for custom key and value types from `SourceRender`. I argue that this is a better choice regardless since these associated types were not actually free variables and one could only set them to very specific values (i.e either `Row` or `Option<Vec<u8>>`).

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

It's a small PR so reviewing the full diff should be easy but I broke it up in semantic commits anyway in case it helps.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
