### PR TITLE
adapter: run all peek optimization stages off thread

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -98,7 +98,7 @@ use mz_compute_types::ComputeInstanceId;
 use mz_controller::clusters::{ClusterConfig, ClusterEvent, CreateReplicaConfig};
 use mz_controller::ControllerConfig;
 use mz_controller_types::{ClusterId, ReplicaId};
-use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
+use mz_expr::OptimizedMirRelationExpr;
 use mz_orchestrator::ServiceProcessMetrics;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
@@ -115,7 +115,7 @@ use mz_secrets::{SecretsController, SecretsReader};
 use mz_sql::ast::{CreateSubsourceStatement, Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
 use mz_sql::names::{Aug, ResolvedIds};
-use mz_sql::plan::{self, CopyFormat, CreateConnectionPlan, Params, QueryWhen};
+use mz_sql::plan::{self, CreateConnectionPlan, Params, QueryWhen};
 use mz_sql::rbac::UnauthorizedError;
 use mz_sql::session::user::{RoleMetadata, User};
 use mz_sql::session::vars::{self, ConnectionCounter, OwnedVarInput, SystemVars};
@@ -359,9 +359,8 @@ pub enum RealTimeRecencyContext {
     },
     Peek {
         ctx: ExecuteContext,
+        plan: mz_sql::plan::SelectPlan,
         root_otel_ctx: OpenTelemetryContext,
-        copy_to: Option<CopyFormat>,
-        when: QueryWhen,
         target_replica: Option<ReplicaId>,
         timeline_context: TimelineContext,
         oracle_read_ts: Option<Timestamp>,
@@ -411,10 +410,8 @@ pub struct PeekStageValidate {
 #[derive(Debug)]
 pub struct PeekStageTimestamp {
     validity: PlanValidity,
-    source: MirRelationExpr,
-    copy_to: Option<CopyFormat>,
+    plan: mz_sql::plan::SelectPlan,
     source_ids: BTreeSet<GlobalId>,
-    when: QueryWhen,
     target_replica: Option<ReplicaId>,
     timeline_context: TimelineContext,
     in_immediate_multi_stmt_txn: bool,
@@ -424,10 +421,8 @@ pub struct PeekStageTimestamp {
 #[derive(Debug)]
 pub struct PeekStageOptimize {
     validity: PlanValidity,
-    source: MirRelationExpr,
-    copy_to: Option<CopyFormat>,
+    plan: mz_sql::plan::SelectPlan,
     source_ids: BTreeSet<GlobalId>,
-    when: QueryWhen,
     target_replica: Option<ReplicaId>,
     timeline_context: TimelineContext,
     oracle_read_ts: Option<Timestamp>,
@@ -438,10 +433,9 @@ pub struct PeekStageOptimize {
 #[derive(Debug)]
 pub struct PeekStageRealTimeRecency {
     validity: PlanValidity,
-    copy_to: Option<CopyFormat>,
+    plan: mz_sql::plan::SelectPlan,
     source_ids: BTreeSet<GlobalId>,
     id_bundle: CollectionIdBundle,
-    when: QueryWhen,
     target_replica: Option<ReplicaId>,
     timeline_context: TimelineContext,
     oracle_read_ts: Option<Timestamp>,
@@ -453,9 +447,8 @@ pub struct PeekStageRealTimeRecency {
 #[derive(Debug)]
 pub struct PeekStageFinish {
     validity: PlanValidity,
-    copy_to: Option<CopyFormat>,
+    plan: mz_sql::plan::SelectPlan,
     id_bundle: Option<CollectionIdBundle>,
-    when: QueryWhen,
     target_replica: Option<ReplicaId>,
     timeline_context: TimelineContext,
     oracle_read_ts: Option<Timestamp>,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -34,7 +34,7 @@ use crate::command::Command;
 use crate::coord::appends::Deferred;
 use crate::coord::statement_logging::StatementLoggingId;
 use crate::coord::{
-    Coordinator, CreateConnectionValidationReady, Message, PeekStage, PeekStageFinish,
+    Coordinator, CreateConnectionValidationReady, Message, PeekStage, PeekStageOptimizeLir,
     PendingReadTxn, PlanValidity, PurifiedStatementReady, RealTimeRecencyContext,
 };
 use crate::session::Session;
@@ -861,7 +861,7 @@ impl Coordinator {
                 self.sequence_peek_stage(
                     ctx,
                     root_otel_ctx,
-                    PeekStage::Finish(PeekStageFinish {
+                    PeekStage::OptimizeLir(PeekStageOptimizeLir {
                         validity,
                         plan,
                         id_bundle: None,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -849,8 +849,7 @@ impl Coordinator {
             RealTimeRecencyContext::Peek {
                 ctx,
                 root_otel_ctx,
-                copy_to,
-                when,
+                plan,
                 target_replica,
                 timeline_context,
                 oracle_read_ts,
@@ -864,9 +863,8 @@ impl Coordinator {
                     root_otel_ctx,
                     PeekStage::Finish(PeekStageFinish {
                         validity,
-                        copy_to,
+                        plan,
                         id_bundle: None,
-                        when,
                         target_replica,
                         timeline_context,
                         oracle_read_ts,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -20,7 +20,7 @@ use mz_sql::catalog::CatalogCluster;
 use mz_catalog::memory::objects::CatalogItem;
 use mz_sql::plan;
 use mz_sql::plan::QueryWhen;
-use mz_transform::{EmptyStatisticsOracle, StatisticsOracle};
+use mz_transform::EmptyStatisticsOracle;
 use tracing::Instrument;
 use tracing::{event, warn, Level};
 
@@ -309,77 +309,8 @@ impl Coordinator {
         &mut self,
         ctx: ExecuteContext,
         root_otel_ctx: OpenTelemetryContext,
-        mut stage: PeekStageOptimizeMir,
-    ) {
-        // Generate data structures that can be moved to another task where we will perform possibly
-        // expensive optimizations.
-        let internal_cmd_tx = self.internal_cmd_tx.clone();
-
-        // TODO: Is there a way to avoid making two dataflow_builders (the second is in
-        // optimize_peek)?
-        let id_bundle = self
-            .dataflow_builder(stage.optimizer.cluster_id())
-            .sufficient_collections(&stage.source_ids);
-        // Although we have added `sources.depends_on()` to the validity already, also add the
-        // sufficient collections for safety.
-        stage.validity.dependency_ids.extend(id_bundle.iter());
-
-        let stats = {
-            match self
-                .determine_timestamp(
-                    ctx.session(),
-                    &id_bundle,
-                    &stage.plan.when,
-                    stage.optimizer.cluster_id(),
-                    &stage.timeline_context,
-                    stage.oracle_read_ts.clone(),
-                    None,
-                )
-                .await
-            {
-                Err(_) => Box::new(EmptyStatisticsOracle),
-                Ok(query_as_of) => self
-                    .statistics_oracle(
-                        ctx.session(),
-                        &stage.source_ids,
-                        query_as_of.timestamp_context.antichain(),
-                        true,
-                    )
-                    .await
-                    .unwrap_or_else(|_| Box::new(EmptyStatisticsOracle)),
-            }
-        };
-
-        let span = tracing::debug_span!("optimize peek task");
-
-        mz_ore::task::spawn_blocking(
-            || "optimize peek",
-            move || {
-                let _guard = span.enter();
-
-                match Self::optimize_peek(ctx.session(), stats, id_bundle, stage) {
-                    Ok(stage) => {
-                        let stage = PeekStage::RealTimeRecency(stage);
-                        // Ignore errors if the coordinator has shut down.
-                        let _ = internal_cmd_tx.send(Message::PeekStageReady {
-                            ctx,
-                            otel_ctx: root_otel_ctx,
-                            stage,
-                        });
-                    }
-                    Err(err) => ctx.retire(Err(err)),
-                }
-            },
-        );
-    }
-
-    #[tracing::instrument(level = "debug", skip_all)]
-    fn optimize_peek(
-        session: &Session,
-        stats: Box<dyn StatisticsOracle>,
-        id_bundle: CollectionIdBundle,
         PeekStageOptimizeMir {
-            validity,
+            mut validity,
             plan,
             source_ids,
             target_replica,
@@ -388,23 +319,85 @@ impl Coordinator {
             in_immediate_multi_stmt_txn,
             mut optimizer,
         }: PeekStageOptimizeMir,
-    ) -> Result<PeekStageRealTimeRecency, AdapterError> {
-        let local_mir_plan = optimizer.catch_unwind_optimize(plan.source.clone())?;
-        let local_mir_plan = local_mir_plan.resolve(session, stats);
-        let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
+    ) {
+        // Generate data structures that can be moved to another task where we will perform possibly
+        // expensive optimizations.
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
 
-        Ok(PeekStageRealTimeRecency {
-            validity,
-            plan,
-            source_ids,
-            id_bundle,
-            target_replica,
-            timeline_context,
-            oracle_read_ts,
-            in_immediate_multi_stmt_txn,
-            optimizer,
-            global_mir_plan,
-        })
+        // TODO: Is there a way to avoid making two dataflow_builders (the second is in
+        // optimize_peek)?
+        let id_bundle = self
+            .dataflow_builder(optimizer.cluster_id())
+            .sufficient_collections(&source_ids);
+        // Although we have added `sources.depends_on()` to the validity already, also add the
+        // sufficient collections for safety.
+        validity.dependency_ids.extend(id_bundle.iter());
+
+        let stats = {
+            match self
+                .determine_timestamp(
+                    ctx.session(),
+                    &id_bundle,
+                    &plan.when,
+                    optimizer.cluster_id(),
+                    &timeline_context,
+                    oracle_read_ts.clone(),
+                    None,
+                )
+                .await
+            {
+                Err(_) => Box::new(EmptyStatisticsOracle),
+                Ok(query_as_of) => self
+                    .statistics_oracle(
+                        ctx.session(),
+                        &source_ids,
+                        query_as_of.timestamp_context.antichain(),
+                        true,
+                    )
+                    .await
+                    .unwrap_or_else(|_| Box::new(EmptyStatisticsOracle)),
+            }
+        };
+
+        let span = tracing::debug_span!("optimize peek task (mir)");
+
+        mz_ore::task::spawn_blocking(
+            || "optimize peek (MIR)",
+            move || {
+                let pipeline = || -> Result<optimize::peek::GlobalMirPlan, AdapterError> {
+                    let local_mir_plan = optimizer.catch_unwind_optimize(plan.source.clone())?;
+                    let local_mir_plan = local_mir_plan.resolve(ctx.session(), stats);
+                    let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
+
+                    Ok(global_mir_plan)
+                };
+                let _guard = span.enter();
+
+                let stage = match pipeline() {
+                    Ok(global_mir_plan) => PeekStage::RealTimeRecency(PeekStageRealTimeRecency {
+                        validity,
+                        plan,
+                        source_ids,
+                        id_bundle,
+                        target_replica,
+                        timeline_context,
+                        oracle_read_ts,
+                        in_immediate_multi_stmt_txn,
+                        optimizer,
+                        global_mir_plan,
+                    }),
+                    Err(err) => {
+                        return ctx.retire(Err(err.into()));
+                    }
+                };
+
+                let _ = internal_cmd_tx.send(Message::PeekStageReady {
+                    ctx,
+                    otel_ctx: root_otel_ctx,
+                    stage,
+                });
+            },
+        );
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
@@ -519,12 +512,10 @@ impl Coordinator {
 
         let timestamp_context = determination.clone().timestamp_context;
 
-        let span = tracing::debug_span!("optimize peek task (lir)");
-
         mz_ore::task::spawn_blocking(
             || "optimize peek (lir)",
             move || {
-                let _guard = span.enter();
+                let _span_guard = tracing::debug_span!(target: "optimizer", "optimize").entered();
 
                 let global_mir_plan =
                     global_mir_plan.resolve(timestamp_context.clone(), ctx.session_mut());

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -175,6 +175,7 @@ pub struct ResolvedGlobal<'s> {
 
 /// The (final) result after MIR ⇒ LIR lowering and optimizing the resulting
 /// `DataflowDescription` with `LIR` plans.
+#[derive(Debug)]
 pub struct GlobalLirPlan {
     plan: PeekPlan,
     df_meta: DataflowMetainfo,


### PR DESCRIPTION
This is the final prerequisite before I can integrate `EXPLAIN SELECT` into the `sequence_peek` code.

### Motivation

  * This PR adds a known-desirable feature.

As requested in #16217 we want to run all query optimization stages off thread. Currently, for `SELECT` statements the `MIR ⇒ LIR` lowering stage and any `LIR ⇒ LIR` rewrites were running on the coordinator thread. This PR moves them into a separate thread.

### Tips for reviewer

* Start by inspecting the changes in the `PeekStage` enum.
* The first part of the `fn peek_stage_finish` code has been moved to a new `fn peek_stage_optimize_lir`.
* Optimizer pipeline advancements are executed in a spawned thread in `peek_stage_optimize_lir`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. Relying on existing `SELECT` coverage to catch possible regressions.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
