### PR TITLE
storage: actually ensure the topic exists when purifying kafka sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4260,6 +4260,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "rand",
+ "rdkafka",
  "rdkafka-sys",
  "regex",
  "reqwest",

--- a/misc/dbt-materialize/tests/adapter/fixtures.py
+++ b/misc/dbt-materialize/tests/adapter/fixtures.py
@@ -70,7 +70,7 @@ test_source = """
 }}
 
 CREATE SOURCE {{ this }}
-FROM KAFKA CONNECTION kafka_connection (TOPIC 'test-source')
+FROM KAFKA CONNECTION kafka_connection (TOPIC 'testdrive-test-source-1')
 FORMAT BYTES
 """
 
@@ -81,7 +81,7 @@ test_source_index = """
 ) }}
 
 CREATE SOURCE {{ this }}
-FROM KAFKA CONNECTION kafka_connection (TOPIC 'test-source')
+FROM KAFKA CONNECTION kafka_connection (TOPIC 'testdrive-test-source-1')
 FORMAT BYTES
 """
 

--- a/misc/python/materialize/checks/all_checks/debezium.py
+++ b/misc/python/materialize/checks/all_checks/debezium.py
@@ -50,6 +50,8 @@ class DebeziumPostgres(Check):
 
                 $ schema-registry-wait subject=postgres.public.debezium_table-value
 
+                $ kafka-wait-topic topic=postgres.public.debezium_table
+
                 # UPSERT is requred due to https://github.com/MaterializeInc/materialize/issues/14211
                 > CREATE SOURCE debezium_source1
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.debezium_table')

--- a/misc/python/materialize/checks/all_checks/ssh.py
+++ b/misc/python/materialize/checks/all_checks/ssh.py
@@ -137,6 +137,10 @@ class SshKafka(Check):
                 """
                 $ kafka-create-topic topic=ssh1
 
+                $ kafka-create-topic topic=ssh2
+
+                $ kafka-create-topic topic=ssh3
+
                 $ kafka-ingest topic=ssh1 format=bytes
                 one
 

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -135,6 +135,12 @@ postgres-protocol = { version = "0.6.5" }
 postgres_array = { version = "0.11.0" }
 predicates = "2.1.4"
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+rdkafka = { version = "0.29.0", features = [
+    "cmake-build",
+    "ssl-vendored",
+    "libz-static",
+    "zstd",
+] }
 reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.89"
 serde_urlencoded = "0.7.1"

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -51,6 +51,8 @@ use tracing::info;
 use tungstenite::error::ProtocolError;
 use tungstenite::{Error, Message};
 
+// Allow the use of banned rdkafka methods, because we are just in tests.
+#[allow(clippy::disallowed_methods)]
 #[mz_ore::test]
 fn test_persistence() {
     let data_dir = tempfile::tempdir().unwrap();
@@ -61,6 +63,17 @@ fn test_persistence() {
     {
         let server = harness.clone().start_blocking();
         let mut client = server.connect(postgres::NoTls).unwrap();
+
+        let new_topic = NewTopic::new("foo", 1, TopicReplication::Fixed(1));
+        let topic_results = admin
+            .create_topics([&new_topic], &AdminOptions::new())
+            .await
+            .expect("topic creation failed");
+        match topic_results[0] {
+            Ok(_) | Err((_, RDKafkaErrorCode::TopicAlreadyExists)) => {}
+            Err((ref err, _)) => panic!("failed to ensure topic: {err}"),
+        }
+
         client
             .batch_execute(&format!(
                 "CREATE CONNECTION kafka_conn TO KAFKA (BROKER '{}', SECURITY PROTOCOL PLAINTEXT)",
@@ -69,7 +82,7 @@ fn test_persistence() {
             .unwrap();
         client
             .batch_execute(
-                "CREATE SOURCE src FROM KAFKA CONNECTION kafka_conn (TOPIC 'ignored') FORMAT BYTES",
+                "CREATE SOURCE src FROM KAFKA CONNECTION kafka_conn (TOPIC 'foo') FORMAT BYTES",
             )
             .unwrap();
         client

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -589,7 +589,18 @@ async fn purify_create_source(
                 extracted_options.start_offset,
                 extracted_options.start_timestamp,
             ) {
-                (None, None) => (),
+                (None, None) => {
+                    // Validate that the topic at least exists.
+                    kafka_util::ensure_topic_exists(
+                        Arc::clone(&consumer),
+                        &topic,
+                        storage_configuration
+                            .parameters
+                            .kafka_timeout_config
+                            .fetch_metadata_timeout,
+                    )
+                    .await?;
+                }
                 (Some(_), Some(_)) => {
                     sql_bail!("cannot specify START TIMESTAMP and START OFFSET at same time")
                 }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -733,6 +733,7 @@ impl Run for PosCommand {
                     "http-request" => http::run_request(builtin, state).await,
                     "kafka-add-partitions" => kafka::run_add_partitions(builtin, state).await,
                     "kafka-create-topic" => kafka::run_create_topic(builtin, state).await,
+                    "kafka-wait-topic" => kafka::run_wait_topic(builtin, state).await,
                     "kafka-delete-topic-flaky" => kafka::run_delete_topic(builtin, state).await,
                     "kafka-ingest" => kafka::run_ingest(builtin, state).await,
                     "kafka-verify-data" => kafka::run_verify_data(builtin, state).await,

--- a/src/testdrive/src/action/kafka.rs
+++ b/src/testdrive/src/action/kafka.rs
@@ -14,6 +14,7 @@ mod ingest;
 mod verify_commit;
 mod verify_data;
 mod verify_topic;
+mod wait_topic;
 
 pub use add_partitions::run_add_partitions;
 pub use create_topic::run_create_topic;
@@ -22,3 +23,4 @@ pub use ingest::run_ingest;
 pub use verify_commit::run_verify_commit;
 pub use verify_data::run_verify_data;
 pub use verify_topic::run_verify_topic;
+pub use wait_topic::run_wait_topic;

--- a/src/testdrive/src/action/kafka/wait_topic.rs
+++ b/src/testdrive/src/action/kafka/wait_topic.rs
@@ -1,0 +1,48 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use mz_ore::retry::Retry;
+
+use crate::action::{ControlFlow, State};
+use crate::parser::BuiltinCommand;
+
+pub async fn run_wait_topic(
+    mut cmd: BuiltinCommand,
+    state: &mut State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let topic = cmd.args.string("topic")?;
+
+    println!("Waiting for Kafka topic {} to exist", topic);
+    Retry::default()
+        .initial_backoff(Duration::from_millis(50))
+        .factor(1.5)
+        .max_duration(state.timeout)
+        .retry_async_canceling(|_| async {
+            let metadata = state
+                .kafka_admin
+                .inner()
+                // N.B. It is extremely important not to ask specifically
+                // about the topic here, even though the API supports it!
+                // Asking about the topic will create it automatically...
+                // with the wrong number of partitions. Yes, this is
+                // unbelievably horrible.
+                .fetch_metadata(None, Some(Duration::from_secs(10)))?;
+
+            let topic_exists = metadata.topics().iter().any(|t| t.name() == topic);
+            if !topic_exists {
+                Err(anyhow::anyhow!("topic {} doesn't exist", topic))
+            } else {
+                Ok(())
+            }
+        })
+        .await?;
+    Ok(ControlFlow::Continue)
+}

--- a/test/cloudtest/test_compute_shared_fate.py
+++ b/test/cloudtest/test_compute_shared_fate.py
@@ -37,12 +37,12 @@ def populate(mz: MaterializeApplication, seed: int) -> None:
 
             > CREATE CONNECTION kafka TO KAFKA (BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL PLAINTEXT)
 
+            $ kafka-create-topic topic=shared-fate partitions={CLUSTER_SIZE}
+
             > CREATE SOURCE s1
               FROM KAFKA CONNECTION kafka (TOPIC 'testdrive-shared-fate-${{testdrive.seed}}')
               FORMAT BYTES
               ENVELOPE NONE;
-
-            $ kafka-create-topic topic=shared-fate partitions={CLUSTER_SIZE}
 
             $ kafka-ingest format=bytes topic=shared-fate repeat=1000
             CDE${{kafka-ingest.iteration}}

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -33,13 +33,13 @@ def populate(mz: MaterializeApplication, seed: int) -> None:
 
             > CREATE CONNECTION kafka TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
 
+            $ kafka-create-topic topic=crash
+
             > CREATE SOURCE s1
               FROM KAFKA CONNECTION kafka
               (TOPIC 'testdrive-crash-${testdrive.seed}')
               FORMAT BYTES
               ENVELOPE NONE;
-
-            $ kafka-create-topic topic=crash
 
             $ kafka-ingest format=bytes topic=crash
             CDE

--- a/test/kafka-auth/test-schema-registry-ssl-basic.td
+++ b/test/kafka-auth/test-schema-registry-ssl-basic.td
@@ -186,6 +186,8 @@ contains:Unauthorized
 
 > ALTER CONNECTION schema_registry DROP (SSL CERTIFICATE AUTHORITY) WITH (VALIDATE = false);
 
+$ kafka-create-topic topic=data partitions=1
+
 ! CREATE SOURCE kafka_broken_csr_connector_source_broken
   FROM KAFKA CONNECTION kafka (TOPIC 'testdrive-data-${testdrive.seed}')
     FORMAT AVRO

--- a/test/testdrive/avro-registry.td
+++ b/test/testdrive/avro-registry.td
@@ -19,6 +19,8 @@
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
+$ kafka-create-topic topic=noexist partitions=1
+
 ! CREATE SOURCE noexist
   IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-noexist-${testdrive.seed}')

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -12,6 +12,16 @@
 
 $ set-regex match=cluster1|quickstart replacement=<CLUSTER_NAME>
 
+$ kafka-create-topic topic=data partitions=1
+
+$ kafka-create-topic topic=data-blah partitions=1
+
+$ kafka-create-topic topic=v partitions=1
+
+$ kafka-create-topic topic=v2 partitions=1
+
+$ kafka-create-topic topic=v3 partitions=1
+
 $ set schema={
     "name": "row",
     "type": "record",

--- a/test/testdrive/github-24173.td
+++ b/test/testdrive/github-24173.td
@@ -11,9 +11,6 @@
   IN CLUSTER ${arg.single-replica-cluster}
   FROM LOAD GENERATOR TPCH (SCALE FACTOR 0.1) FOR ALL TABLES;
 
-# Pre-create the topic so we can create the source based on it
-$ kafka-create-topic topic=progress-fixed partitions=1
-
 > CREATE CONNECTION kafka_fixed TO KAFKA (
     BROKER '${testdrive.kafka-addr}',
     PROGRESS TOPIC 'testdrive-progress-fixed-${testdrive.seed}',
@@ -30,6 +27,9 @@ $ kafka-create-topic topic=progress-fixed partitions=1
   INTO KAFKA CONNECTION kafka_fixed (TOPIC 'testdrive-supplier-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
+
+# Wait for the sink to create the topic
+$ kafka-wait-topic topic=testdrive-supplier-${testdrive.seed} partitions=1
 
 > CREATE SOURCE progress_check
   IN CLUSTER ${arg.single-replica-cluster}

--- a/test/testdrive/github-24173.td
+++ b/test/testdrive/github-24173.td
@@ -11,6 +11,9 @@
   IN CLUSTER ${arg.single-replica-cluster}
   FROM LOAD GENERATOR TPCH (SCALE FACTOR 0.1) FOR ALL TABLES;
 
+# Pre-create the topic so we can create the source based on it
+$ kafka-create-topic topic=progress-fixed partitions=1
+
 > CREATE CONNECTION kafka_fixed TO KAFKA (
     BROKER '${testdrive.kafka-addr}',
     PROGRESS TOPIC 'testdrive-progress-fixed-${testdrive.seed}',

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -408,6 +408,8 @@ $ kafka-create-topic topic=new-dbz-data partitions=1
 # 2 3
 # -1 7
 
+$ kafka-create-topic topic=ignored partitions=1
+
 ! CREATE SOURCE recursive
   IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-ignored-${testdrive.seed}')

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -188,6 +188,8 @@ named_id named_geo a
 <null>   <null>    88
 1        nyc       99
 
+$ kafka-create-topic topic=avro-dbz partitions=1
+
 ! CREATE SOURCE avro_debezium
   IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-avro-dbz-${testdrive.seed}')

--- a/test/testdrive/kafka-source-errors.td
+++ b/test/testdrive/kafka-source-errors.td
@@ -9,6 +9,8 @@
 
 # Test that Kafka sources with no format are disallowed.
 
+$ kafka-create-topic topic=thetopic partitions=1
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_create_source_denylist_with_options = true
 
@@ -16,10 +18,10 @@ ALTER SYSTEM SET enable_create_source_denylist_with_options = true
 
 ! CREATE SOURCE s
   IN CLUSTER ${arg.single-replica-cluster}
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-thetopic-${testdrive.seed}')
 contains:Source format must be specified
 
-! CREATE CONNECTION no_topic TO KAFKA (BROKER '');
+! CREATE CONNECTION no_broker TO KAFKA (BROKER '');
 contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
 
 # Verify that incorrect/unreachable brokers throw up an error on source creation.
@@ -72,3 +74,10 @@ contains:cannot convert negative interval to duration
   FORMAT TEXT
   ENVELOPE NONE
 contains:TOPIC METADATA REFRESH INTERVAL cannot be greater than 1 hour
+
+! CREATE SOURCE bad_topic
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'whatever')
+  FORMAT TEXT
+  ENVELOPE NONE
+contains:Topic does not exist

--- a/test/testdrive/protobuf-map.td
+++ b/test/testdrive/protobuf-map.td
@@ -9,6 +9,8 @@
 
 # Test that Protobuf map fields are unsupported.
 
+$ kafka-create-topic topic=maps partitions=1
+
 $ file-append path=maps.proto
 syntax = "proto3";
 

--- a/test/testdrive/protobuf-recursive.td
+++ b/test/testdrive/protobuf-recursive.td
@@ -33,6 +33,8 @@ $ protobuf-compile-descriptors inputs=recursive.proto output=recursive.pb set-va
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
+$ kafka-create-topic topic=recursive partitions=1
+
 ! CREATE SOURCE recursive
   IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-recursive-${testdrive.seed}')

--- a/test/testdrive/protobuf-wrong-message-count.td
+++ b/test/testdrive/protobuf-wrong-message-count.td
@@ -10,6 +10,10 @@
 # Test that Protobuf files with too few or too many messages are handled
 # correctly.
 
+$ kafka-create-topic topic=too-few partitions=1
+
+$ kafka-create-topic topic=too-many partitions=1
+
 $ schema-registry-publish subject=testdrive-too-few-${testdrive.seed}-value schema-type=protobuf
 syntax = "proto3";
 


### PR DESCRIPTION
This must have been lost in a rebase somewhere. Im genuinely astounded by this, as if you dont specify start offsets, you get no validation on your kafka source working...

Note this would have made the race in incident-92 wayyy less likely

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
