### PR TITLE
tests: introduce run_testdrive

### DIFF
--- a/doc/developer/mzcompose.md
+++ b/doc/developer/mzcompose.md
@@ -67,7 +67,7 @@ SERVICES = [
 def workflow_test(c: Composition):
     c.up("zookeeper", "kafka", "schema-registry", "materialized")
 
-    c.run_testdrive("*.td")
+    c.run_testdrive_files("*.td")
 ```
 
 Additional examples can be found here:
@@ -187,6 +187,6 @@ To run a Testdrive test or tests:
 ```python
 def workflow_simple_test(c: Composition):
    ...
-   c.run_testdrive("*.td")
+   c.run_testdrive_files("*.td")
    ...
 ```

--- a/doc/developer/mzcompose.md
+++ b/doc/developer/mzcompose.md
@@ -67,7 +67,7 @@ SERVICES = [
 def workflow_test(c: Composition):
     c.up("zookeeper", "kafka", "schema-registry", "materialized")
 
-    c.run("testdrive", "*.td")
+    c.run_testdrive("*.td")
 ```
 
 Additional examples can be found here:
@@ -187,6 +187,6 @@ To run a Testdrive test or tests:
 ```python
 def workflow_simple_test(c: Composition):
    ...
-   w.run("testdrive", "*.td")
+   c.run_testdrive("*.td")
    ...
 ```

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -480,7 +480,7 @@ class Composition:
             def workflow_default(c: Composition):
                 for tc in test_cases:
                     with c.test_case(tc.name):
-                        c.run_testdrive(*tc.files)
+                        c.run_testdrive_files(*tc.files)
             ```
 
         Args:
@@ -645,7 +645,7 @@ class Composition:
             check=check,
         )
 
-    def run_testdrive(
+    def run_testdrive_files(
         self,
         *args: str,
         rm: bool = False,

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -480,7 +480,7 @@ class Composition:
             def workflow_default(c: Composition):
                 for tc in test_cases:
                     with c.test_case(tc.name):
-                        c.run("testdrive", *tc.files)
+                        c.run_testdrive(*tc.files)
             ```
 
         Args:
@@ -643,6 +643,17 @@ class Composition:
             capture_stderr=capture_stderr,
             stdin=stdin,
             check=check,
+        )
+
+    def run_testdrive(
+        self,
+        *args: str,
+        rm: bool = False,
+    ) -> subprocess.CompletedProcess:
+        return self.run(
+            "testdrive",
+            *args,
+            rm=rm,
         )
 
     def exec(

--- a/test/aws-localstack/mzcompose.py
+++ b/test/aws-localstack/mzcompose.py
@@ -207,9 +207,9 @@ def workflow_secrets_manager(c: Composition) -> None:
 
 def workflow_aws_connection(c: Composition) -> None:
     c.up("localstack", "materialized")
-    c.run("testdrive", "aws-connection/aws-connection.td")
+    c.run_testdrive("aws-connection/aws-connection.td")
 
 
 def workflow_copy_to_s3(c: Composition) -> None:
     c.up("localstack", "materialized")
-    c.run("testdrive", "copy-to-s3/copy-to-s3.td")
+    c.run_testdrive("copy-to-s3/copy-to-s3.td")

--- a/test/aws-localstack/mzcompose.py
+++ b/test/aws-localstack/mzcompose.py
@@ -207,9 +207,9 @@ def workflow_secrets_manager(c: Composition) -> None:
 
 def workflow_aws_connection(c: Composition) -> None:
     c.up("localstack", "materialized")
-    c.run_testdrive("aws-connection/aws-connection.td")
+    c.run_testdrive_files("aws-connection/aws-connection.td")
 
 
 def workflow_copy_to_s3(c: Composition) -> None:
     c.up("localstack", "materialized")
-    c.run_testdrive("copy-to-s3/copy-to-s3.td")
+    c.run_testdrive_files("copy-to-s3/copy-to-s3.td")

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -198,7 +198,7 @@ def td(c: Composition, *args: str) -> None:
             ],
         )
     ):
-        c.run_testdrive(
+        c.run_testdrive_files(
             *args,
             rm=True,
         )

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -198,8 +198,7 @@ def td(c: Composition, *args: str) -> None:
             ],
         )
     ):
-        c.run(
-            "testdrive",
+        c.run_testdrive(
             *args,
             rm=True,
         )

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -130,7 +130,7 @@ def workflow_test_smoke(c: Composition, parser: WorkflowArgumentParser) -> None:
         user="mz_system",
     )
 
-    c.run_testdrive(*args.glob)
+    c.run_testdrive_files(*args.glob)
 
     # Add a replica to that cluster and verify that tests still pass.
     c.up("clusterd3")
@@ -150,16 +150,16 @@ def workflow_test_smoke(c: Composition, parser: WorkflowArgumentParser) -> None:
         port=6877,
         user="mz_system",
     )
-    c.run_testdrive(*args.glob)
+    c.run_testdrive_files(*args.glob)
 
     # Kill one of the nodes in the first replica of the compute cluster and
     # verify that tests still pass.
     c.kill("clusterd1")
-    c.run_testdrive(*args.glob)
+    c.run_testdrive_files(*args.glob)
 
     # Leave only replica 2 up and verify that tests still pass.
     c.sql("DROP CLUSTER REPLICA cluster1.replica1", port=6877, user="mz_system")
-    c.run_testdrive(*args.glob)
+    c.run_testdrive_files(*args.glob)
 
     c.sql("DROP CLUSTER cluster1 CASCADE", port=6877, user="mz_system")
 
@@ -1342,7 +1342,7 @@ def workflow_test_upsert(c: Composition) -> None:
         c.down(destroy_volumes=True)
         c.up("materialized", "zookeeper", "kafka", "schema-registry")
 
-        c.run_testdrive("upsert/01-create-sources.td")
+        c.run_testdrive_files("upsert/01-create-sources.td")
         # Sleep to make sure the errors have made it to persist.
         # This isn't necessary for correctness,
         # as we should be able to crash at any point and re-start.
@@ -1352,7 +1352,7 @@ def workflow_test_upsert(c: Composition) -> None:
         print("Sleeping for ten seconds")
         time.sleep(10)
         c.exec("materialized", "bash", "-c", "kill -9 `pidof clusterd`")
-        c.run_testdrive("upsert/02-after-clusterd-restart.td")
+        c.run_testdrive_files("upsert/02-after-clusterd-restart.td")
 
 
 def workflow_test_remote_storage(c: Composition) -> None:
@@ -1373,24 +1373,24 @@ def workflow_test_remote_storage(c: Composition) -> None:
             "schema-registry",
         )
 
-        c.run_testdrive("storage/01-create-sources.td")
+        c.run_testdrive_files("storage/01-create-sources.td")
 
         c.kill("materialized")
         c.up("materialized")
         c.kill("clusterd1")
         c.up("clusterd1")
         c.up("clusterd2")
-        c.run_testdrive("storage/02-after-environmentd-restart.td")
+        c.run_testdrive_files("storage/02-after-environmentd-restart.td")
 
         # just kill one of the clusterd's and make sure we can recover.
         # `clusterd2` will die on its own.
         c.kill("clusterd1")
-        c.run_testdrive("storage/03-while-clusterd-down.td")
+        c.run_testdrive_files("storage/03-while-clusterd-down.td")
 
         # Bring back both clusterd's
         c.up("clusterd1")
         c.up("clusterd2")
-        c.run_testdrive("storage/04-after-clusterd-restart.td")
+        c.run_testdrive_files("storage/04-after-clusterd-restart.td")
 
 
 def workflow_test_drop_quickstart_cluster(c: Composition) -> None:
@@ -1419,7 +1419,7 @@ def workflow_test_resource_limits(c: Composition) -> None:
     ):
         c.up("materialized", "postgres")
 
-        c.run_testdrive("resources/resource-limits.td")
+        c.run_testdrive_files("resources/resource-limits.td")
 
 
 def workflow_pg_snapshot_resumption(c: Composition) -> None:
@@ -1437,21 +1437,21 @@ def workflow_pg_snapshot_resumption(c: Composition) -> None:
     ):
         c.up("materialized", "postgres", "storage")
 
-        c.run_testdrive("pg-snapshot-resumption/01-configure-postgres.td")
-        c.run_testdrive("pg-snapshot-resumption/02-create-sources.td")
-        c.run_testdrive("pg-snapshot-resumption/03-ensure-source-down.td")
+        c.run_testdrive_files("pg-snapshot-resumption/01-configure-postgres.td")
+        c.run_testdrive_files("pg-snapshot-resumption/02-create-sources.td")
+        c.run_testdrive_files("pg-snapshot-resumption/03-ensure-source-down.td")
 
         # Temporarily disabled because it is timing out.
         # https://github.com/MaterializeInc/materialize/issues/14533
         # # clusterd should crash
-        # c.run_testdrive("pg-snapshot-resumption/04-while-clusterd-down.td")
+        # c.run_testdrive_files("pg-snapshot-resumption/04-while-clusterd-down.td")
 
         with c.override(
             # turn off the failpoint
             Clusterd(name="storage")
         ):
             c.up("storage")
-            c.run_testdrive("pg-snapshot-resumption/05-verify-data.td")
+            c.run_testdrive_files("pg-snapshot-resumption/05-verify-data.td")
 
 
 def workflow_sink_failure(c: Composition) -> None:
@@ -1469,15 +1469,15 @@ def workflow_sink_failure(c: Composition) -> None:
     ):
         c.up("materialized", "zookeeper", "kafka", "schema-registry", "storage")
 
-        c.run_testdrive("sink-failure/01-configure-sinks.td")
-        c.run_testdrive("sink-failure/02-ensure-sink-down.td")
+        c.run_testdrive_files("sink-failure/01-configure-sinks.td")
+        c.run_testdrive_files("sink-failure/02-ensure-sink-down.td")
 
         with c.override(
             # turn off the failpoint
             Clusterd(name="storage")
         ):
             c.up("storage")
-            c.run_testdrive("sink-failure/03-verify-data.td")
+            c.run_testdrive_files("sink-failure/03-verify-data.td")
 
 
 def workflow_test_bootstrap_vars(c: Composition) -> None:
@@ -1495,7 +1495,7 @@ def workflow_test_bootstrap_vars(c: Composition) -> None:
     ):
         c.up("materialized")
 
-        c.run_testdrive("resources/bootstrapped-system-vars.td")
+        c.run_testdrive_files("resources/bootstrapped-system-vars.td")
 
     with c.override(
         Testdrive(no_reset=True),
@@ -1506,7 +1506,7 @@ def workflow_test_bootstrap_vars(c: Composition) -> None:
         ),
     ):
         c.up("materialized")
-        c.run_testdrive("resources/bootstrapped-system-vars.td")
+        c.run_testdrive_files("resources/bootstrapped-system-vars.td")
 
 
 def workflow_test_system_table_indexes(c: Composition) -> None:
@@ -1750,10 +1750,12 @@ def workflow_pg_snapshot_partial_failure(c: Composition) -> None:
     ):
         c.up("materialized", "postgres", "storage")
 
-        c.run_testdrive("pg-snapshot-partial-failure/01-configure-postgres.td")
-        c.run_testdrive("pg-snapshot-partial-failure/02-create-sources.td")
+        c.run_testdrive_files("pg-snapshot-partial-failure/01-configure-postgres.td")
+        c.run_testdrive_files("pg-snapshot-partial-failure/02-create-sources.td")
 
-        c.run_testdrive("pg-snapshot-partial-failure/03-verify-good-sub-source.td")
+        c.run_testdrive_files(
+            "pg-snapshot-partial-failure/03-verify-good-sub-source.td"
+        )
 
         c.kill("storage")
         # Restart the storage instance with the failpoint off...
@@ -1761,9 +1763,9 @@ def workflow_pg_snapshot_partial_failure(c: Composition) -> None:
             # turn off the failpoint
             Clusterd(name="storage")
         ):
-            c.run_testdrive("pg-snapshot-partial-failure/04-add-more-data.td")
+            c.run_testdrive_files("pg-snapshot-partial-failure/04-add-more-data.td")
             c.up("storage")
-            c.run_testdrive("pg-snapshot-partial-failure/05-verify-data.td")
+            c.run_testdrive_files("pg-snapshot-partial-failure/05-verify-data.td")
 
 
 def workflow_test_compute_reconciliation_reuse(c: Composition) -> None:
@@ -2103,7 +2105,7 @@ def workflow_test_query_without_default_cluster(c: Composition) -> None:
     ):
         c.up("materialized", "postgres")
 
-        c.run_testdrive(
+        c.run_testdrive_files(
             "query-without-default-cluster/query-without-default-cluster.td",
         )
 
@@ -2870,7 +2872,7 @@ def workflow_test_index_source_stuck(
         c.up("materialized")
         c.up("clusterd1")
         c.up("clusterd2")
-        c.run_testdrive("index-source-stuck/run.td")
+        c.run_testdrive_files("index-source-stuck/run.td")
 
 
 def workflow_test_github_cloud_7998(
@@ -2888,21 +2890,21 @@ def workflow_test_github_cloud_7998(
         c.up("materialized")
         c.up("clusterd1")
 
-        c.run_testdrive("github-cloud-7998/setup.td")
+        c.run_testdrive_files("github-cloud-7998/setup.td")
 
         # Make the compute cluster unavailable.
         c.kill("clusterd1")
-        c.run_testdrive("github-cloud-7998/check.td")
+        c.run_testdrive_files("github-cloud-7998/check.td")
 
         # Trigger an environment bootstrap.
         c.kill("materialized")
         c.up("materialized")
-        c.run_testdrive("github-cloud-7998/check.td")
+        c.run_testdrive_files("github-cloud-7998/check.td")
 
         # Run a second bootstrap check, just to be sure.
         c.kill("materialized")
         c.up("materialized")
-        c.run_testdrive("github-cloud-7998/check.td")
+        c.run_testdrive_files("github-cloud-7998/check.td")
 
 
 def workflow_test_github_23246(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -2972,7 +2974,7 @@ def workflow_statement_logging(c: Composition, parser: WorkflowArgumentParser) -
             user="mz_system",
         )
 
-        c.run_testdrive("statement-logging/statement-logging.td")
+        c.run_testdrive_files("statement-logging/statement-logging.td")
 
 
 class PropagatingThread(Thread):
@@ -3059,14 +3061,14 @@ def workflow_blue_green_deployment(
         c.up("clusterd1")
         c.up("clusterd2")
         c.up("clusterd3")
-        c.run_testdrive("blue-green-deployment/setup.td")
+        c.run_testdrive_files("blue-green-deployment/setup.td")
 
         threads = [PropagatingThread(target=fn) for fn in (selects, subscribe)]
         for thread in threads:
             thread.start()
         time.sleep(10)  # some time to make sure the queries run fine
         try:
-            c.run_testdrive("blue-green-deployment/deploy.td")
+            c.run_testdrive_files("blue-green-deployment/deploy.td")
         finally:
             running = False
             for thread in threads:

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -130,7 +130,7 @@ def workflow_test_smoke(c: Composition, parser: WorkflowArgumentParser) -> None:
         user="mz_system",
     )
 
-    c.run("testdrive", *args.glob)
+    c.run_testdrive(*args.glob)
 
     # Add a replica to that cluster and verify that tests still pass.
     c.up("clusterd3")
@@ -150,16 +150,16 @@ def workflow_test_smoke(c: Composition, parser: WorkflowArgumentParser) -> None:
         port=6877,
         user="mz_system",
     )
-    c.run("testdrive", *args.glob)
+    c.run_testdrive(*args.glob)
 
     # Kill one of the nodes in the first replica of the compute cluster and
     # verify that tests still pass.
     c.kill("clusterd1")
-    c.run("testdrive", *args.glob)
+    c.run_testdrive(*args.glob)
 
     # Leave only replica 2 up and verify that tests still pass.
     c.sql("DROP CLUSTER REPLICA cluster1.replica1", port=6877, user="mz_system")
-    c.run("testdrive", *args.glob)
+    c.run_testdrive(*args.glob)
 
     c.sql("DROP CLUSTER cluster1 CASCADE", port=6877, user="mz_system")
 
@@ -1342,7 +1342,7 @@ def workflow_test_upsert(c: Composition) -> None:
         c.down(destroy_volumes=True)
         c.up("materialized", "zookeeper", "kafka", "schema-registry")
 
-        c.run("testdrive", "upsert/01-create-sources.td")
+        c.run_testdrive("upsert/01-create-sources.td")
         # Sleep to make sure the errors have made it to persist.
         # This isn't necessary for correctness,
         # as we should be able to crash at any point and re-start.
@@ -1352,7 +1352,7 @@ def workflow_test_upsert(c: Composition) -> None:
         print("Sleeping for ten seconds")
         time.sleep(10)
         c.exec("materialized", "bash", "-c", "kill -9 `pidof clusterd`")
-        c.run("testdrive", "upsert/02-after-clusterd-restart.td")
+        c.run_testdrive("upsert/02-after-clusterd-restart.td")
 
 
 def workflow_test_remote_storage(c: Composition) -> None:
@@ -1373,24 +1373,24 @@ def workflow_test_remote_storage(c: Composition) -> None:
             "schema-registry",
         )
 
-        c.run("testdrive", "storage/01-create-sources.td")
+        c.run_testdrive("storage/01-create-sources.td")
 
         c.kill("materialized")
         c.up("materialized")
         c.kill("clusterd1")
         c.up("clusterd1")
         c.up("clusterd2")
-        c.run("testdrive", "storage/02-after-environmentd-restart.td")
+        c.run_testdrive("storage/02-after-environmentd-restart.td")
 
         # just kill one of the clusterd's and make sure we can recover.
         # `clusterd2` will die on its own.
         c.kill("clusterd1")
-        c.run("testdrive", "storage/03-while-clusterd-down.td")
+        c.run_testdrive("storage/03-while-clusterd-down.td")
 
         # Bring back both clusterd's
         c.up("clusterd1")
         c.up("clusterd2")
-        c.run("testdrive", "storage/04-after-clusterd-restart.td")
+        c.run_testdrive("storage/04-after-clusterd-restart.td")
 
 
 def workflow_test_drop_quickstart_cluster(c: Composition) -> None:
@@ -1419,7 +1419,7 @@ def workflow_test_resource_limits(c: Composition) -> None:
     ):
         c.up("materialized", "postgres")
 
-        c.run("testdrive", "resources/resource-limits.td")
+        c.run_testdrive("resources/resource-limits.td")
 
 
 def workflow_pg_snapshot_resumption(c: Composition) -> None:
@@ -1437,21 +1437,21 @@ def workflow_pg_snapshot_resumption(c: Composition) -> None:
     ):
         c.up("materialized", "postgres", "storage")
 
-        c.run("testdrive", "pg-snapshot-resumption/01-configure-postgres.td")
-        c.run("testdrive", "pg-snapshot-resumption/02-create-sources.td")
-        c.run("testdrive", "pg-snapshot-resumption/03-ensure-source-down.td")
+        c.run_testdrive("pg-snapshot-resumption/01-configure-postgres.td")
+        c.run_testdrive("pg-snapshot-resumption/02-create-sources.td")
+        c.run_testdrive("pg-snapshot-resumption/03-ensure-source-down.td")
 
         # Temporarily disabled because it is timing out.
         # https://github.com/MaterializeInc/materialize/issues/14533
         # # clusterd should crash
-        # c.run("testdrive", "pg-snapshot-resumption/04-while-clusterd-down.td")
+        # c.run_testdrive("pg-snapshot-resumption/04-while-clusterd-down.td")
 
         with c.override(
             # turn off the failpoint
             Clusterd(name="storage")
         ):
             c.up("storage")
-            c.run("testdrive", "pg-snapshot-resumption/05-verify-data.td")
+            c.run_testdrive("pg-snapshot-resumption/05-verify-data.td")
 
 
 def workflow_sink_failure(c: Composition) -> None:
@@ -1469,15 +1469,15 @@ def workflow_sink_failure(c: Composition) -> None:
     ):
         c.up("materialized", "zookeeper", "kafka", "schema-registry", "storage")
 
-        c.run("testdrive", "sink-failure/01-configure-sinks.td")
-        c.run("testdrive", "sink-failure/02-ensure-sink-down.td")
+        c.run_testdrive("sink-failure/01-configure-sinks.td")
+        c.run_testdrive("sink-failure/02-ensure-sink-down.td")
 
         with c.override(
             # turn off the failpoint
             Clusterd(name="storage")
         ):
             c.up("storage")
-            c.run("testdrive", "sink-failure/03-verify-data.td")
+            c.run_testdrive("sink-failure/03-verify-data.td")
 
 
 def workflow_test_bootstrap_vars(c: Composition) -> None:
@@ -1495,7 +1495,7 @@ def workflow_test_bootstrap_vars(c: Composition) -> None:
     ):
         c.up("materialized")
 
-        c.run("testdrive", "resources/bootstrapped-system-vars.td")
+        c.run_testdrive("resources/bootstrapped-system-vars.td")
 
     with c.override(
         Testdrive(no_reset=True),
@@ -1506,7 +1506,7 @@ def workflow_test_bootstrap_vars(c: Composition) -> None:
         ),
     ):
         c.up("materialized")
-        c.run("testdrive", "resources/bootstrapped-system-vars.td")
+        c.run_testdrive("resources/bootstrapped-system-vars.td")
 
 
 def workflow_test_system_table_indexes(c: Composition) -> None:
@@ -1750,10 +1750,10 @@ def workflow_pg_snapshot_partial_failure(c: Composition) -> None:
     ):
         c.up("materialized", "postgres", "storage")
 
-        c.run("testdrive", "pg-snapshot-partial-failure/01-configure-postgres.td")
-        c.run("testdrive", "pg-snapshot-partial-failure/02-create-sources.td")
+        c.run_testdrive("pg-snapshot-partial-failure/01-configure-postgres.td")
+        c.run_testdrive("pg-snapshot-partial-failure/02-create-sources.td")
 
-        c.run("testdrive", "pg-snapshot-partial-failure/03-verify-good-sub-source.td")
+        c.run_testdrive("pg-snapshot-partial-failure/03-verify-good-sub-source.td")
 
         c.kill("storage")
         # Restart the storage instance with the failpoint off...
@@ -1761,9 +1761,9 @@ def workflow_pg_snapshot_partial_failure(c: Composition) -> None:
             # turn off the failpoint
             Clusterd(name="storage")
         ):
-            c.run("testdrive", "pg-snapshot-partial-failure/04-add-more-data.td")
+            c.run_testdrive("pg-snapshot-partial-failure/04-add-more-data.td")
             c.up("storage")
-            c.run("testdrive", "pg-snapshot-partial-failure/05-verify-data.td")
+            c.run_testdrive("pg-snapshot-partial-failure/05-verify-data.td")
 
 
 def workflow_test_compute_reconciliation_reuse(c: Composition) -> None:
@@ -2103,8 +2103,7 @@ def workflow_test_query_without_default_cluster(c: Composition) -> None:
     ):
         c.up("materialized", "postgres")
 
-        c.run(
-            "testdrive",
+        c.run_testdrive(
             "query-without-default-cluster/query-without-default-cluster.td",
         )
 
@@ -2871,7 +2870,7 @@ def workflow_test_index_source_stuck(
         c.up("materialized")
         c.up("clusterd1")
         c.up("clusterd2")
-        c.run("testdrive", "index-source-stuck/run.td")
+        c.run_testdrive("index-source-stuck/run.td")
 
 
 def workflow_test_github_cloud_7998(
@@ -2889,21 +2888,21 @@ def workflow_test_github_cloud_7998(
         c.up("materialized")
         c.up("clusterd1")
 
-        c.run("testdrive", "github-cloud-7998/setup.td")
+        c.run_testdrive("github-cloud-7998/setup.td")
 
         # Make the compute cluster unavailable.
         c.kill("clusterd1")
-        c.run("testdrive", "github-cloud-7998/check.td")
+        c.run_testdrive("github-cloud-7998/check.td")
 
         # Trigger an environment bootstrap.
         c.kill("materialized")
         c.up("materialized")
-        c.run("testdrive", "github-cloud-7998/check.td")
+        c.run_testdrive("github-cloud-7998/check.td")
 
         # Run a second bootstrap check, just to be sure.
         c.kill("materialized")
         c.up("materialized")
-        c.run("testdrive", "github-cloud-7998/check.td")
+        c.run_testdrive("github-cloud-7998/check.td")
 
 
 def workflow_test_github_23246(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -2973,7 +2972,7 @@ def workflow_statement_logging(c: Composition, parser: WorkflowArgumentParser) -
             user="mz_system",
         )
 
-        c.run("testdrive", "statement-logging/statement-logging.td")
+        c.run_testdrive("statement-logging/statement-logging.td")
 
 
 class PropagatingThread(Thread):
@@ -3060,14 +3059,14 @@ def workflow_blue_green_deployment(
         c.up("clusterd1")
         c.up("clusterd2")
         c.up("clusterd3")
-        c.run("testdrive", "blue-green-deployment/setup.td")
+        c.run_testdrive("blue-green-deployment/setup.td")
 
         threads = [PropagatingThread(target=fn) for fn in (selects, subscribe)]
         for thread in threads:
             thread.start()
         time.sleep(10)  # some time to make sure the queries run fine
         try:
-            c.run("testdrive", "blue-green-deployment/deploy.td")
+            c.run_testdrive("blue-green-deployment/deploy.td")
         finally:
             running = False
             for thread in threads:

--- a/test/debezium/mzcompose.py
+++ b/test/debezium/mzcompose.py
@@ -36,15 +36,14 @@ SERVICES = [
 def workflow_postgres(c: Composition) -> None:
     c.up(*prerequisites, "postgres")
 
-    c.run("testdrive", "postgres/debezium-postgres.td.initialize")
-    c.run("testdrive", "postgres/*.td")
+    c.run_testdrive("postgres/debezium-postgres.td.initialize")
+    c.run_testdrive("postgres/*.td")
 
 
 def workflow_sql_server(c: Composition) -> None:
     c.up(*prerequisites, "sql-server")
 
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         f"--var=sa-password={SqlServer.DEFAULT_SA_PASSWORD}",
         "sql-server/*.td",
     )
@@ -53,8 +52,7 @@ def workflow_sql_server(c: Composition) -> None:
 def workflow_mysql(c: Composition) -> None:
     c.up(*prerequisites, "mysql")
 
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
         "mysql/*.td",
     )

--- a/test/debezium/mzcompose.py
+++ b/test/debezium/mzcompose.py
@@ -36,14 +36,14 @@ SERVICES = [
 def workflow_postgres(c: Composition) -> None:
     c.up(*prerequisites, "postgres")
 
-    c.run_testdrive("postgres/debezium-postgres.td.initialize")
-    c.run_testdrive("postgres/*.td")
+    c.run_testdrive_files("postgres/debezium-postgres.td.initialize")
+    c.run_testdrive_files("postgres/*.td")
 
 
 def workflow_sql_server(c: Composition) -> None:
     c.up(*prerequisites, "sql-server")
 
-    c.run_testdrive(
+    c.run_testdrive_files(
         f"--var=sa-password={SqlServer.DEFAULT_SA_PASSWORD}",
         "sql-server/*.td",
     )
@@ -52,7 +52,7 @@ def workflow_sql_server(c: Composition) -> None:
 def workflow_mysql(c: Composition) -> None:
     c.up(*prerequisites, "mysql")
 
-    c.run_testdrive(
+    c.run_testdrive_files(
         f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
         "mysql/*.td",
     )

--- a/test/fivetran-destination/mzcompose.py
+++ b/test/fivetran-destination/mzcompose.py
@@ -100,7 +100,7 @@ def _run_test_case(c: Composition, path: Path):
     for test_file in sorted(p for p in path.iterdir()):
         test_file = test_file.relative_to(ROOT)
         if test_file.suffix == ".td":
-            c.run("testdrive", str(test_file))
+            c.run_testdrive(str(test_file))
         elif test_file.suffix == ".json":
             _run_destination_tester(c, test_file)
         elif test_file.name != "00-README":

--- a/test/fivetran-destination/mzcompose.py
+++ b/test/fivetran-destination/mzcompose.py
@@ -100,7 +100,7 @@ def _run_test_case(c: Composition, path: Path):
     for test_file in sorted(p for p in path.iterdir()):
         test_file = test_file.relative_to(ROOT)
         if test_file.suffix == ".td":
-            c.run_testdrive(str(test_file))
+            c.run_testdrive_files(str(test_file))
         elif test_file.suffix == ".json":
             _run_destination_tester(c, test_file)
         elif test_file.name != "00-README":

--- a/test/incident-72/mzcompose.py
+++ b/test/incident-72/mzcompose.py
@@ -45,13 +45,13 @@ def workflow_default(c: Composition) -> None:
 
     with c.override(PRE_INCIDENT_MZ):
         c.up("materialized")
-        c.run_testdrive("produce-error.td")
+        c.run_testdrive_files("produce-error.td")
         c.kill("materialized")
 
     # Run the new version that will produce the legacy error retractions to
     # heal the shards.
     c.up("materialized")
-    c.run_testdrive("verify-heal-in-memory.td")
+    c.run_testdrive_files("verify-heal-in-memory.td")
     c.kill("materialized")
 
     # Now run a version of Materialize that panics if it ever encounters a
@@ -59,5 +59,5 @@ def workflow_default(c: Composition) -> None:
     # in-memory traces and the on-disk blobs.
     with c.override(REJECT_LEGACY_MZ):
         c.up("materialized")
-        c.run_testdrive("verify-heal-on-disk.td")
+        c.run_testdrive_files("verify-heal-on-disk.td")
         c.kill("materialized")

--- a/test/incident-72/mzcompose.py
+++ b/test/incident-72/mzcompose.py
@@ -45,13 +45,13 @@ def workflow_default(c: Composition) -> None:
 
     with c.override(PRE_INCIDENT_MZ):
         c.up("materialized")
-        c.run("testdrive", "produce-error.td")
+        c.run_testdrive("produce-error.td")
         c.kill("materialized")
 
     # Run the new version that will produce the legacy error retractions to
     # heal the shards.
     c.up("materialized")
-    c.run("testdrive", "verify-heal-in-memory.td")
+    c.run_testdrive("verify-heal-in-memory.td")
     c.kill("materialized")
 
     # Now run a version of Materialize that panics if it ever encounters a
@@ -59,5 +59,5 @@ def workflow_default(c: Composition) -> None:
     # in-memory traces and the on-disk blobs.
     with c.override(REJECT_LEGACY_MZ):
         c.up("materialized")
-        c.run("testdrive", "verify-heal-on-disk.td")
+        c.run_testdrive("verify-heal-on-disk.td")
         c.kill("materialized")

--- a/test/kafka-auth/mzcompose.py
+++ b/test/kafka-auth/mzcompose.py
@@ -258,7 +258,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         f"echo '{public_key}' >> /etc/authorized_keys/mz",
     )
 
-    c.run("testdrive", f"test-{args.filter}.td")
+    c.run_testdrive(f"test-{args.filter}.td")
 
 
 def add_acl(

--- a/test/kafka-auth/mzcompose.py
+++ b/test/kafka-auth/mzcompose.py
@@ -258,7 +258,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         f"echo '{public_key}' >> /etc/authorized_keys/mz",
     )
 
-    c.run_testdrive(f"test-{args.filter}.td")
+    c.run_testdrive_files(f"test-{args.filter}.td")
 
 
 def add_acl(

--- a/test/kafka-exactly-once/mzcompose.py
+++ b/test/kafka-exactly-once/mzcompose.py
@@ -33,7 +33,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = parser.parse_args()
 
     c.up("zookeeper", "kafka", "schema-registry", "materialized")
-    c.run_testdrive(
+    c.run_testdrive_files(
         f"--seed={args.seed}",
         "--kafka-option=group.id=group1",
         "--no-reset",
@@ -41,7 +41,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     c.kill("materialized")
     c.up("materialized")
-    c.run_testdrive(
+    c.run_testdrive_files(
         f"--seed={args.seed}",
         "--no-reset",
         "--kafka-option=group.id=group2",

--- a/test/kafka-exactly-once/mzcompose.py
+++ b/test/kafka-exactly-once/mzcompose.py
@@ -33,8 +33,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = parser.parse_args()
 
     c.up("zookeeper", "kafka", "schema-registry", "materialized")
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         f"--seed={args.seed}",
         "--kafka-option=group.id=group1",
         "--no-reset",
@@ -42,8 +41,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     c.kill("materialized")
     c.up("materialized")
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         f"--seed={args.seed}",
         "--no-reset",
         "--kafka-option=group.id=group2",

--- a/test/kafka-ingest-open-loop/mzcompose.py
+++ b/test/kafka-ingest-open-loop/mzcompose.py
@@ -129,8 +129,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     with c.override(*override):
         c.up(*prerequisites, "materialized")
 
-        c.run(
-            "testdrive",
+        c.run_testdrive(
             "setup.td",
         )
 

--- a/test/kafka-ingest-open-loop/mzcompose.py
+++ b/test/kafka-ingest-open-loop/mzcompose.py
@@ -129,7 +129,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     with c.override(*override):
         c.up(*prerequisites, "materialized")
 
-        c.run_testdrive(
+        c.run_testdrive_files(
             "setup.td",
         )
 

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -55,7 +55,7 @@ def workflow_default(c: Composition) -> None:
         with c.override(Redpanda(version=redpanda_version)):
             c.down(destroy_volumes=True)
             c.up("redpanda", "materialized")
-            c.run("testdrive", *TD_CMD)
+            c.run_testdrive(*TD_CMD)
 
     for confluent_version in CONFLUENT_PLATFORM_VERSIONS:
         print(f"--- Testing Confluent Platform {confluent_version}")
@@ -66,4 +66,4 @@ def workflow_default(c: Composition) -> None:
         ):
             c.down(destroy_volumes=True)
             c.up("zookeeper", "kafka", "schema-registry", "materialized")
-            c.run("testdrive", *TD_CMD)
+            c.run_testdrive(*TD_CMD)

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -55,7 +55,7 @@ def workflow_default(c: Composition) -> None:
         with c.override(Redpanda(version=redpanda_version)):
             c.down(destroy_volumes=True)
             c.up("redpanda", "materialized")
-            c.run_testdrive(*TD_CMD)
+            c.run_testdrive_files(*TD_CMD)
 
     for confluent_version in CONFLUENT_PLATFORM_VERSIONS:
         print(f"--- Testing Confluent Platform {confluent_version}")
@@ -66,4 +66,4 @@ def workflow_default(c: Composition) -> None:
         ):
             c.down(destroy_volumes=True)
             c.up("zookeeper", "kafka", "schema-registry", "materialized")
-            c.run_testdrive(*TD_CMD)
+            c.run_testdrive_files(*TD_CMD)

--- a/test/kafka-multi-broker/mzcompose.py
+++ b/test/kafka-multi-broker/mzcompose.py
@@ -36,11 +36,11 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     c.up("zookeeper", "kafka1", "kafka2", "kafka3", "schema-registry", "materialized")
-    c.run("testdrive", "--kafka-addr=kafka2", "01-init.td")
+    c.run_testdrive("--kafka-addr=kafka2", "01-init.td")
     time.sleep(10)
     c.kill("kafka1")
     time.sleep(10)
-    c.run("testdrive", "--kafka-addr=kafka2,kafka3", "--no-reset", "02-after-leave.td")
+    c.run_testdrive("--kafka-addr=kafka2,kafka3", "--no-reset", "02-after-leave.td")
     c.up("kafka1")
     time.sleep(10)
-    c.run("testdrive", "--kafka-addr=kafka1", "--no-reset", "03-after-join.td")
+    c.run_testdrive("--kafka-addr=kafka1", "--no-reset", "03-after-join.td")

--- a/test/kafka-multi-broker/mzcompose.py
+++ b/test/kafka-multi-broker/mzcompose.py
@@ -36,11 +36,13 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     c.up("zookeeper", "kafka1", "kafka2", "kafka3", "schema-registry", "materialized")
-    c.run_testdrive("--kafka-addr=kafka2", "01-init.td")
+    c.run_testdrive_files("--kafka-addr=kafka2", "01-init.td")
     time.sleep(10)
     c.kill("kafka1")
     time.sleep(10)
-    c.run_testdrive("--kafka-addr=kafka2,kafka3", "--no-reset", "02-after-leave.td")
+    c.run_testdrive_files(
+        "--kafka-addr=kafka2,kafka3", "--no-reset", "02-after-leave.td"
+    )
     c.up("kafka1")
     time.sleep(10)
-    c.run_testdrive("--kafka-addr=kafka1", "--no-reset", "03-after-join.td")
+    c.run_testdrive_files("--kafka-addr=kafka1", "--no-reset", "03-after-join.td")

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -53,8 +53,7 @@ def workflow_sink_networking(c: Composition) -> None:
         ]
     ):
         c.up("toxiproxy")
-        c.run(
-            "testdrive",
+        c.run_testdrive(
             "--no-reset",
             "--max-errors=1",
             f"--seed={seed}{i}",
@@ -78,8 +77,8 @@ def workflow_source_resumption(c: Composition) -> None:
     ):
         c.up("materialized", "zookeeper", "kafka", "clusterd")
 
-        c.run("testdrive", "source-resumption/setup.td")
-        c.run("testdrive", "source-resumption/verify.td")
+        c.run_testdrive("source-resumption/setup.td")
+        c.run_testdrive("source-resumption/verify.td")
 
         # Disabled due to https://github.com/MaterializeInc/materialize/issues/20819
         # assert (
@@ -95,8 +94,8 @@ def workflow_source_resumption(c: Composition) -> None:
         c.sleep(10)
 
         # Verify the same data is query-able, and that we can make forward progress
-        c.run("testdrive", "source-resumption/verify.td")
-        c.run("testdrive", "source-resumption/re-ingest-and-verify.td")
+        c.run_testdrive("source-resumption/verify.td")
+        c.run_testdrive("source-resumption/re-ingest-and-verify.td")
 
         # the first clusterd instance ingested 3 messages, so our
         # upper is at the 4th offset (0-indexed)

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -53,7 +53,7 @@ def workflow_sink_networking(c: Composition) -> None:
         ]
     ):
         c.up("toxiproxy")
-        c.run_testdrive(
+        c.run_testdrive_files(
             "--no-reset",
             "--max-errors=1",
             f"--seed={seed}{i}",
@@ -77,8 +77,8 @@ def workflow_source_resumption(c: Composition) -> None:
     ):
         c.up("materialized", "zookeeper", "kafka", "clusterd")
 
-        c.run_testdrive("source-resumption/setup.td")
-        c.run_testdrive("source-resumption/verify.td")
+        c.run_testdrive_files("source-resumption/setup.td")
+        c.run_testdrive_files("source-resumption/verify.td")
 
         # Disabled due to https://github.com/MaterializeInc/materialize/issues/20819
         # assert (
@@ -94,8 +94,8 @@ def workflow_source_resumption(c: Composition) -> None:
         c.sleep(10)
 
         # Verify the same data is query-able, and that we can make forward progress
-        c.run_testdrive("source-resumption/verify.td")
-        c.run_testdrive("source-resumption/re-ingest-and-verify.td")
+        c.run_testdrive_files("source-resumption/verify.td")
+        c.run_testdrive_files("source-resumption/re-ingest-and-verify.td")
 
         # the first clusterd instance ingested 3 messages, so our
         # upper is at the 4th offset (0-indexed)

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -156,8 +156,7 @@ def test_upgrade_from_version(
         created_cluster = "default"
     temp_dir = f"--temp-dir=/share/tmp/upgrade-from-{from_version}"
     seed = f"--seed={random.getrandbits(32)}"
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         "--no-reset",
         f"--var=upgrade-from-version={from_version}",
         f"--var=created-cluster={created_cluster}",
@@ -183,8 +182,7 @@ def test_upgrade_from_version(
             volumes_extra=["secrets:/share/secrets"],
         )
     ):
-        c.run(
-            "testdrive",
+        c.run_testdrive(
             "--no-reset",
             f"--var=upgrade-from-version={from_version}",
             f"--var=default-storage-size={Materialized.Size.DEFAULT_SIZE}-1",

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -156,7 +156,7 @@ def test_upgrade_from_version(
         created_cluster = "default"
     temp_dir = f"--temp-dir=/share/tmp/upgrade-from-{from_version}"
     seed = f"--seed={random.getrandbits(32)}"
-    c.run_testdrive(
+    c.run_testdrive_files(
         "--no-reset",
         f"--var=upgrade-from-version={from_version}",
         f"--var=created-cluster={created_cluster}",
@@ -182,7 +182,7 @@ def test_upgrade_from_version(
             volumes_extra=["secrets:/share/secrets"],
         )
     ):
-        c.run_testdrive(
+        c.run_testdrive_files(
             "--no-reset",
             f"--var=upgrade-from-version={from_version}",
             f"--var=default-storage-size={Materialized.Size.DEFAULT_SIZE}-1",

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -43,7 +43,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     c.up("materialized", "mysql")
 
-    c.run_testdrive(
+    c.run_testdrive_files(
         f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
         *args.filter,
     )

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -43,8 +43,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     c.up("materialized", "mysql")
 
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
         *args.filter,
     )

--- a/test/mzcompose_examples/mzcompose.py
+++ b/test/mzcompose_examples/mzcompose.py
@@ -59,7 +59,7 @@ def workflow_versioned_mz(c: Composition) -> None:
     for mz in versioned_mz:
         c.up(mz.name)
 
-        c.run("testdrive", "test*.td")
+        c.run_testdrive("test*.td")
 
         c.kill(mz.name)
 

--- a/test/mzcompose_examples/mzcompose.py
+++ b/test/mzcompose_examples/mzcompose.py
@@ -59,7 +59,7 @@ def workflow_versioned_mz(c: Composition) -> None:
     for mz in versioned_mz:
         c.up(mz.name)
 
-        c.run_testdrive("test*.td")
+        c.run_testdrive_files("test*.td")
 
         c.kill(mz.name)
 

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -63,7 +63,7 @@ def workflow_kafka_sources(
 
     c.up("materialized")
 
-    c.run_testdrive(f"--seed={seed}", f"kafka-sources/*{td_test}*-before.td")
+    c.run_testdrive_files(f"--seed={seed}", f"kafka-sources/*{td_test}*-before.td")
 
     c.kill("materialized")
     c.up("materialized")
@@ -72,7 +72,7 @@ def workflow_kafka_sources(
     c.kill("materialized")
     c.up("materialized")
 
-    c.run_testdrive(f"--seed={seed}", f"kafka-sources/*{td_test}*-after.td")
+    c.run_testdrive_files(f"--seed={seed}", f"kafka-sources/*{td_test}*-after.td")
 
     # Do one more restart, just in case and just confirm that Mz is able to come up
     c.kill("materialized")
@@ -92,7 +92,7 @@ def workflow_user_tables(
 
     c.up("materialized")
 
-    c.run_testdrive(
+    c.run_testdrive_files(
         f"--seed={seed}",
         f"user-tables/table-persistence-before-{td_test}.td",
     )
@@ -103,7 +103,7 @@ def workflow_user_tables(
     c.kill("materialized")
     c.up("materialized")
 
-    c.run_testdrive(
+    c.run_testdrive_files(
         f"--seed={seed}",
         f"user-tables/table-persistence-after-{td_test}.td",
     )
@@ -134,7 +134,7 @@ def run_one_failpoint(c: Composition, failpoint: str, action: str) -> None:
 
     c.up("materialized")
 
-    c.run_testdrive(
+    c.run_testdrive_files(
         f"--seed={seed}",
         f"--var=failpoint={failpoint}",
         f"--var=action={action}",
@@ -146,7 +146,7 @@ def run_one_failpoint(c: Composition, failpoint: str, action: str) -> None:
     c.kill("materialized")
     c.up("materialized")
 
-    c.run_testdrive(f"--seed={seed}", "failpoints/after.td")
+    c.run_testdrive_files(f"--seed={seed}", "failpoints/after.td")
 
     c.kill("materialized")
     c.rm("materialized", "testdrive", destroy_volumes=True)
@@ -159,7 +159,7 @@ def workflow_compaction(c: Composition) -> None:
     ):
         c.up("materialized")
 
-        c.run_testdrive("compaction/compaction.td")
+        c.run_testdrive_files("compaction/compaction.td")
 
         c.kill("materialized")
 

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -63,7 +63,7 @@ def workflow_kafka_sources(
 
     c.up("materialized")
 
-    c.run("testdrive", f"--seed={seed}", f"kafka-sources/*{td_test}*-before.td")
+    c.run_testdrive(f"--seed={seed}", f"kafka-sources/*{td_test}*-before.td")
 
     c.kill("materialized")
     c.up("materialized")
@@ -72,7 +72,7 @@ def workflow_kafka_sources(
     c.kill("materialized")
     c.up("materialized")
 
-    c.run("testdrive", f"--seed={seed}", f"kafka-sources/*{td_test}*-after.td")
+    c.run_testdrive(f"--seed={seed}", f"kafka-sources/*{td_test}*-after.td")
 
     # Do one more restart, just in case and just confirm that Mz is able to come up
     c.kill("materialized")
@@ -92,8 +92,7 @@ def workflow_user_tables(
 
     c.up("materialized")
 
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         f"--seed={seed}",
         f"user-tables/table-persistence-before-{td_test}.td",
     )
@@ -104,8 +103,7 @@ def workflow_user_tables(
     c.kill("materialized")
     c.up("materialized")
 
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         f"--seed={seed}",
         f"user-tables/table-persistence-after-{td_test}.td",
     )
@@ -136,8 +134,7 @@ def run_one_failpoint(c: Composition, failpoint: str, action: str) -> None:
 
     c.up("materialized")
 
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         f"--seed={seed}",
         f"--var=failpoint={failpoint}",
         f"--var=action={action}",
@@ -149,7 +146,7 @@ def run_one_failpoint(c: Composition, failpoint: str, action: str) -> None:
     c.kill("materialized")
     c.up("materialized")
 
-    c.run("testdrive", f"--seed={seed}", "failpoints/after.td")
+    c.run_testdrive(f"--seed={seed}", "failpoints/after.td")
 
     c.kill("materialized")
     c.rm("materialized", "testdrive", destroy_volumes=True)
@@ -162,7 +159,7 @@ def workflow_compaction(c: Composition) -> None:
     ):
         c.up("materialized")
 
-        c.run("testdrive", "compaction/compaction.td")
+        c.run_testdrive("compaction/compaction.td")
 
         c.kill("materialized")
 

--- a/test/pg-cdc-resumption/mzcompose.py
+++ b/test/pg-cdc-resumption/mzcompose.py
@@ -88,8 +88,7 @@ def initialize(c: Composition) -> None:
     c.down(destroy_volumes=True)
     c.up("materialized", "postgres", "toxiproxy")
 
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         "configure-toxiproxy.td",
         "populate-tables.td",
         "configure-postgres.td",
@@ -109,12 +108,11 @@ def restart_mz(c: Composition) -> None:
 
 def end(c: Composition) -> None:
     """Validate the data at the end."""
-    c.run("testdrive", "verify-data.td")
+    c.run_testdrive("verify-data.td")
 
 
 def disconnect_pg_during_snapshot(c: Composition) -> None:
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         "toxiproxy-close-connection.td",
         "toxiproxy-restore-connection.td",
         "delete-rows-t1.td",
@@ -127,8 +125,7 @@ def disconnect_pg_during_snapshot(c: Composition) -> None:
 def restart_pg_during_snapshot(c: Composition) -> None:
     restart_pg(c)
 
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
@@ -137,15 +134,14 @@ def restart_pg_during_snapshot(c: Composition) -> None:
 
 
 def restart_mz_during_snapshot(c: Composition) -> None:
-    c.run("testdrive", "alter-mz.td")
+    c.run_testdrive("alter-mz.td")
     restart_mz(c)
 
-    c.run("testdrive", "delete-rows-t1.td", "delete-rows-t2.td", "alter-table.td")
+    c.run_testdrive("delete-rows-t1.td", "delete-rows-t2.td", "alter-table.td")
 
 
 def disconnect_pg_during_replication(c: Composition) -> None:
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
         "delete-rows-t2.td",
@@ -157,8 +153,7 @@ def disconnect_pg_during_replication(c: Composition) -> None:
 
 
 def restart_pg_during_replication(c: Composition) -> None:
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
         "alter-table.td",
@@ -167,12 +162,11 @@ def restart_pg_during_replication(c: Composition) -> None:
 
     restart_pg(c)
 
-    c.run("testdrive", "delete-rows-t2.td")
+    c.run_testdrive("delete-rows-t2.td")
 
 
 def restart_mz_during_replication(c: Composition) -> None:
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
         "alter-table.td",
@@ -181,12 +175,11 @@ def restart_mz_during_replication(c: Composition) -> None:
 
     restart_mz(c)
 
-    c.run("testdrive", "delete-rows-t2.td")
+    c.run_testdrive("delete-rows-t2.td")
 
 
 def fix_pg_schema_while_mz_restarts(c: Composition) -> None:
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
@@ -201,12 +194,11 @@ def verify_no_snapshot_reingestion(c: Composition) -> None:
     """Confirm that Mz does not reingest the entire snapshot on restart by
     revoking its SELECT privileges
     """
-    c.run("testdrive", "wait-for-snapshot.td", "postgres-disable-select-permission.td")
+    c.run_testdrive("wait-for-snapshot.td", "postgres-disable-select-permission.td")
 
     restart_mz(c)
 
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
@@ -215,8 +207,7 @@ def verify_no_snapshot_reingestion(c: Composition) -> None:
 
 
 def pg_out_of_disk_space(c: Composition) -> None:
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
     )
@@ -232,7 +223,7 @@ def pg_out_of_disk_space(c: Composition) -> None:
     time.sleep(30)
     c.exec("postgres", "bash", "-c", f"rm {fill_file}")
 
-    c.run("testdrive", "delete-rows-t2.td", "alter-table.td", "alter-mz.td")
+    c.run_testdrive("delete-rows-t2.td", "alter-table.td", "alter-mz.td")
 
 
 def backup_restore_pg(c: Composition) -> None:
@@ -265,7 +256,7 @@ def backup_restore_pg(c: Composition) -> None:
         "-D",
         backup_dir,
     )
-    c.run("testdrive", "delete-rows-t1.td")
+    c.run_testdrive("delete-rows-t1.td")
 
     # Stop postgres service
     c.stop("postgres")
@@ -283,7 +274,7 @@ def backup_restore_pg(c: Composition) -> None:
 
     # Wait for postgres to become usable again
     c.up("postgres")
-    c.run("testdrive", "verify-postgres-select.td")
+    c.run_testdrive("verify-postgres-select.td")
 
     # Check state of the postgres source
-    c.run("testdrive", "verify-source-failed.td")
+    c.run_testdrive("verify-source-failed.td")

--- a/test/pg-cdc-resumption/mzcompose.py
+++ b/test/pg-cdc-resumption/mzcompose.py
@@ -88,7 +88,7 @@ def initialize(c: Composition) -> None:
     c.down(destroy_volumes=True)
     c.up("materialized", "postgres", "toxiproxy")
 
-    c.run_testdrive(
+    c.run_testdrive_files(
         "configure-toxiproxy.td",
         "populate-tables.td",
         "configure-postgres.td",
@@ -108,11 +108,11 @@ def restart_mz(c: Composition) -> None:
 
 def end(c: Composition) -> None:
     """Validate the data at the end."""
-    c.run_testdrive("verify-data.td")
+    c.run_testdrive_files("verify-data.td")
 
 
 def disconnect_pg_during_snapshot(c: Composition) -> None:
-    c.run_testdrive(
+    c.run_testdrive_files(
         "toxiproxy-close-connection.td",
         "toxiproxy-restore-connection.td",
         "delete-rows-t1.td",
@@ -125,7 +125,7 @@ def disconnect_pg_during_snapshot(c: Composition) -> None:
 def restart_pg_during_snapshot(c: Composition) -> None:
     restart_pg(c)
 
-    c.run_testdrive(
+    c.run_testdrive_files(
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
@@ -134,14 +134,14 @@ def restart_pg_during_snapshot(c: Composition) -> None:
 
 
 def restart_mz_during_snapshot(c: Composition) -> None:
-    c.run_testdrive("alter-mz.td")
+    c.run_testdrive_files("alter-mz.td")
     restart_mz(c)
 
-    c.run_testdrive("delete-rows-t1.td", "delete-rows-t2.td", "alter-table.td")
+    c.run_testdrive_files("delete-rows-t1.td", "delete-rows-t2.td", "alter-table.td")
 
 
 def disconnect_pg_during_replication(c: Composition) -> None:
-    c.run_testdrive(
+    c.run_testdrive_files(
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
         "delete-rows-t2.td",
@@ -153,7 +153,7 @@ def disconnect_pg_during_replication(c: Composition) -> None:
 
 
 def restart_pg_during_replication(c: Composition) -> None:
-    c.run_testdrive(
+    c.run_testdrive_files(
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
         "alter-table.td",
@@ -162,11 +162,11 @@ def restart_pg_during_replication(c: Composition) -> None:
 
     restart_pg(c)
 
-    c.run_testdrive("delete-rows-t2.td")
+    c.run_testdrive_files("delete-rows-t2.td")
 
 
 def restart_mz_during_replication(c: Composition) -> None:
-    c.run_testdrive(
+    c.run_testdrive_files(
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
         "alter-table.td",
@@ -175,11 +175,11 @@ def restart_mz_during_replication(c: Composition) -> None:
 
     restart_mz(c)
 
-    c.run_testdrive("delete-rows-t2.td")
+    c.run_testdrive_files("delete-rows-t2.td")
 
 
 def fix_pg_schema_while_mz_restarts(c: Composition) -> None:
-    c.run_testdrive(
+    c.run_testdrive_files(
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
@@ -194,11 +194,13 @@ def verify_no_snapshot_reingestion(c: Composition) -> None:
     """Confirm that Mz does not reingest the entire snapshot on restart by
     revoking its SELECT privileges
     """
-    c.run_testdrive("wait-for-snapshot.td", "postgres-disable-select-permission.td")
+    c.run_testdrive_files(
+        "wait-for-snapshot.td", "postgres-disable-select-permission.td"
+    )
 
     restart_mz(c)
 
-    c.run_testdrive(
+    c.run_testdrive_files(
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
@@ -207,7 +209,7 @@ def verify_no_snapshot_reingestion(c: Composition) -> None:
 
 
 def pg_out_of_disk_space(c: Composition) -> None:
-    c.run_testdrive(
+    c.run_testdrive_files(
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
     )
@@ -223,7 +225,7 @@ def pg_out_of_disk_space(c: Composition) -> None:
     time.sleep(30)
     c.exec("postgres", "bash", "-c", f"rm {fill_file}")
 
-    c.run_testdrive("delete-rows-t2.td", "alter-table.td", "alter-mz.td")
+    c.run_testdrive_files("delete-rows-t2.td", "alter-table.td", "alter-mz.td")
 
 
 def backup_restore_pg(c: Composition) -> None:
@@ -256,7 +258,7 @@ def backup_restore_pg(c: Composition) -> None:
         "-D",
         backup_dir,
     )
-    c.run_testdrive("delete-rows-t1.td")
+    c.run_testdrive_files("delete-rows-t1.td")
 
     # Stop postgres service
     c.stop("postgres")
@@ -274,7 +276,7 @@ def backup_restore_pg(c: Composition) -> None:
 
     # Wait for postgres to become usable again
     c.up("postgres")
-    c.run_testdrive("verify-postgres-select.td")
+    c.run_testdrive_files("verify-postgres-select.td")
 
     # Check state of the postgres source
-    c.run_testdrive("verify-source-failed.td")
+    c.run_testdrive_files("verify-source-failed.td")

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -25,7 +25,7 @@ SERVICES = [
 def workflow_replication_slots(c: Composition, parser: WorkflowArgumentParser) -> None:
     with c.override(Postgres(extra_command=["-c", "max_replication_slots=2"])):
         c.up("materialized", "postgres")
-        c.run("testdrive", "override/replication-slots.td")
+        c.run_testdrive("override/replication-slots.td")
 
 
 def workflow_wal_level(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -41,7 +41,7 @@ def workflow_wal_level(c: Composition, parser: WorkflowArgumentParser) -> None:
             )
         ):
             c.up("materialized", "postgres")
-            c.run("testdrive", "override/insufficient-wal-level.td")
+            c.run_testdrive("override/insufficient-wal-level.td")
 
 
 def workflow_replication_disabled(
@@ -49,7 +49,7 @@ def workflow_replication_disabled(
 ) -> None:
     with c.override(Postgres(extra_command=["-c", "max_wal_senders=0"])):
         c.up("materialized", "postgres")
-        c.run("testdrive", "override/replication-disabled.td")
+        c.run_testdrive("override/replication-disabled.td")
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -72,8 +72,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ).stdout
 
     c.up("materialized", "test-certs", "postgres")
-    c.run(
-        "testdrive",
+    c.run_testdrive(
         f"--var=ssl-ca={ssl_ca}",
         f"--var=ssl-cert={ssl_cert}",
         f"--var=ssl-key={ssl_key}",

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -25,7 +25,7 @@ SERVICES = [
 def workflow_replication_slots(c: Composition, parser: WorkflowArgumentParser) -> None:
     with c.override(Postgres(extra_command=["-c", "max_replication_slots=2"])):
         c.up("materialized", "postgres")
-        c.run_testdrive("override/replication-slots.td")
+        c.run_testdrive_files("override/replication-slots.td")
 
 
 def workflow_wal_level(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -41,7 +41,7 @@ def workflow_wal_level(c: Composition, parser: WorkflowArgumentParser) -> None:
             )
         ):
             c.up("materialized", "postgres")
-            c.run_testdrive("override/insufficient-wal-level.td")
+            c.run_testdrive_files("override/insufficient-wal-level.td")
 
 
 def workflow_replication_disabled(
@@ -49,7 +49,7 @@ def workflow_replication_disabled(
 ) -> None:
     with c.override(Postgres(extra_command=["-c", "max_wal_senders=0"])):
         c.up("materialized", "postgres")
-        c.run_testdrive("override/replication-disabled.td")
+        c.run_testdrive_files("override/replication-disabled.td")
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -72,7 +72,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ).stdout
 
     c.up("materialized", "test-certs", "postgres")
-    c.run_testdrive(
+    c.run_testdrive_files(
         f"--var=ssl-ca={ssl_ca}",
         f"--var=ssl-cert={ssl_cert}",
         f"--var=ssl-key={ssl_key}",

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -88,7 +88,7 @@ def workflow_retain_history(c: Composition) -> None:
 
 def workflow_github_8021(c: Composition) -> None:
     c.up("materialized")
-    c.run_testdrive("github-8021.td")
+    c.run_testdrive_files("github-8021.td")
 
     # Ensure MZ can boot
     c.kill("materialized")
@@ -181,7 +181,7 @@ def workflow_audit_log(c: Composition) -> None:
 def workflow_timelines(c: Composition) -> None:
     for _ in range(3):
         c.up("zookeeper", "kafka", "schema-registry", "materialized")
-        c.run_testdrive("timelines.td")
+        c.run_testdrive_files("timelines.td")
         c.rm(
             "zookeeper",
             "kafka",

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -88,7 +88,7 @@ def workflow_retain_history(c: Composition) -> None:
 
 def workflow_github_8021(c: Composition) -> None:
     c.up("materialized")
-    c.run("testdrive", "github-8021.td")
+    c.run_testdrive("github-8021.td")
 
     # Ensure MZ can boot
     c.kill("materialized")
@@ -181,7 +181,7 @@ def workflow_audit_log(c: Composition) -> None:
 def workflow_timelines(c: Composition) -> None:
     for _ in range(3):
         c.up("zookeeper", "kafka", "schema-registry", "materialized")
-        c.run("testdrive", "timelines.td")
+        c.run_testdrive("timelines.td")
         c.rm(
             "zookeeper",
             "kafka",

--- a/test/ssh-connection/mzcompose.py
+++ b/test/ssh-connection/mzcompose.py
@@ -53,7 +53,7 @@ def workflow_basic_ssh_features(c: Composition, redpanda: bool = False) -> None:
         dependencies += ["zookeeper", "kafka", "schema-registry"]
     c.up(*dependencies)
 
-    c.run_testdrive("ssh-connections.td")
+    c.run_testdrive_files("ssh-connections.td")
 
     # Check that objects can be restored correctly
     restart_mz(c)
@@ -62,7 +62,7 @@ def workflow_basic_ssh_features(c: Composition, redpanda: bool = False) -> None:
 def workflow_validate_connection(c: Composition) -> None:
     c.up("materialized", "ssh-bastion-host", "postgres")
 
-    c.run_testdrive("setup.td")
+    c.run_testdrive_files("setup.td")
 
     public_key = c.sql_query(
         """
@@ -72,7 +72,7 @@ def workflow_validate_connection(c: Composition) -> None:
         """
     )[0][0]
 
-    c.run_testdrive("--no-reset", "validate-failures.td")
+    c.run_testdrive_files("--no-reset", "validate-failures.td")
 
     c.exec(
         "ssh-bastion-host",
@@ -81,13 +81,13 @@ def workflow_validate_connection(c: Composition) -> None:
         f"echo '{public_key}' > /etc/authorized_keys/mz",
     )
 
-    c.run_testdrive("--no-reset", "validate-success.td")
+    c.run_testdrive_files("--no-reset", "validate-success.td")
 
 
 def workflow_pg(c: Composition) -> None:
     c.up("materialized", "ssh-bastion-host", "postgres")
 
-    c.run_testdrive("setup.td")
+    c.run_testdrive_files("setup.td")
 
     public_key = c.sql_query(
         """
@@ -104,11 +104,11 @@ def workflow_pg(c: Composition) -> None:
         f"echo '{public_key}' > /etc/authorized_keys/mz",
     )
 
-    c.run_testdrive("--no-reset", "pg-source.td")
+    c.run_testdrive_files("--no-reset", "pg-source.td")
     c.kill("ssh-bastion-host")
-    c.run_testdrive("--no-reset", "pg-source-after-ssh-failure.td")
+    c.run_testdrive_files("--no-reset", "pg-source-after-ssh-failure.td")
     c.up("ssh-bastion-host")
-    c.run_testdrive("--no-reset", "pg-source-after-ssh-restart.td")
+    c.run_testdrive_files("--no-reset", "pg-source-after-ssh-restart.td")
 
 
 def workflow_kafka(c: Composition, redpanda: bool = False) -> None:
@@ -128,7 +128,7 @@ def workflow_kafka(c: Composition, redpanda: bool = False) -> None:
             dependencies += ["zookeeper", "kafka", "schema-registry"]
         c.up(*dependencies)
 
-        c.run_testdrive("setup.td")
+        c.run_testdrive_files("setup.td")
 
         public_key = c.sql_query(
             """
@@ -145,12 +145,12 @@ def workflow_kafka(c: Composition, redpanda: bool = False) -> None:
             f"echo '{public_key}' > /etc/authorized_keys/mz",
         )
 
-        c.run_testdrive("--no-reset", "kafka-source.td")
+        c.run_testdrive_files("--no-reset", "kafka-source.td")
         c.kill("ssh-bastion-host")
-        c.run_testdrive("--no-reset", "kafka-source-after-ssh-failure.td")
+        c.run_testdrive_files("--no-reset", "kafka-source-after-ssh-failure.td")
 
         c.up("ssh-bastion-host")
-        c.run_testdrive("--no-reset", "kafka-source-after-ssh-restart.td")
+        c.run_testdrive_files("--no-reset", "kafka-source-after-ssh-restart.td")
 
 
 def workflow_kafka_restart_replica(c: Composition, redpanda: bool = False) -> None:
@@ -170,7 +170,7 @@ def workflow_kafka_restart_replica(c: Composition, redpanda: bool = False) -> No
             dependencies += ["zookeeper", "kafka", "schema-registry"]
         c.up(*dependencies)
 
-        c.run_testdrive("setup.td")
+        c.run_testdrive_files("setup.td")
 
         public_key = c.sql_query(
             """
@@ -187,15 +187,15 @@ def workflow_kafka_restart_replica(c: Composition, redpanda: bool = False) -> No
             f"echo '{public_key}' > /etc/authorized_keys/mz",
         )
 
-        c.run_testdrive("--no-reset", "kafka-source.td")
+        c.run_testdrive_files("--no-reset", "kafka-source.td")
         c.kill("ssh-bastion-host")
-        c.run_testdrive(
+        c.run_testdrive_files(
             "--no-reset",
             "kafka-source-after-ssh-failure-restart-replica.td",
         )
 
         c.up("ssh-bastion-host")
-        c.run_testdrive("--no-reset", "kafka-source-after-ssh-restart.td")
+        c.run_testdrive_files("--no-reset", "kafka-source-after-ssh-restart.td")
 
 
 def workflow_kafka_sink(c: Composition, redpanda: bool = False) -> None:
@@ -215,7 +215,7 @@ def workflow_kafka_sink(c: Composition, redpanda: bool = False) -> None:
             dependencies += ["zookeeper", "kafka", "schema-registry"]
         c.up(*dependencies)
 
-        c.run_testdrive("setup.td")
+        c.run_testdrive_files("setup.td")
 
         public_key = c.sql_query(
             """
@@ -232,12 +232,12 @@ def workflow_kafka_sink(c: Composition, redpanda: bool = False) -> None:
             f"echo '{public_key}' > /etc/authorized_keys/mz",
         )
 
-        c.run_testdrive("--no-reset", "kafka-sink.td")
+        c.run_testdrive_files("--no-reset", "kafka-sink.td")
         c.kill("ssh-bastion-host")
-        c.run_testdrive("--no-reset", "kafka-sink-after-ssh-failure.td")
+        c.run_testdrive_files("--no-reset", "kafka-sink-after-ssh-failure.td")
 
         c.up("ssh-bastion-host")
-        c.run_testdrive("--no-reset", "kafka-sink-after-ssh-restart.td")
+        c.run_testdrive_files("--no-reset", "kafka-sink-after-ssh-restart.td")
 
 
 def workflow_hidden_hosts(c: Composition, redpanda: bool = False) -> None:
@@ -249,7 +249,7 @@ def workflow_hidden_hosts(c: Composition, redpanda: bool = False) -> None:
         dependencies += ["zookeeper", "kafka", "schema-registry"]
     c.up(*dependencies)
 
-    c.run_testdrive("setup.td")
+    c.run_testdrive_files("setup.td")
 
     public_key = c.sql_query(
         """
@@ -280,7 +280,7 @@ def workflow_hidden_hosts(c: Composition, redpanda: bool = False) -> None:
     add_hidden_host("kafka")
     add_hidden_host("schema-registry")
 
-    c.run_testdrive("--no-reset", "hidden-hosts.td")
+    c.run_testdrive_files("--no-reset", "hidden-hosts.td")
 
 
 # Test that if we restart the bastion AND change its server keys(s), we can
@@ -288,7 +288,7 @@ def workflow_hidden_hosts(c: Composition, redpanda: bool = False) -> None:
 def workflow_pg_restart_bastion(c: Composition) -> None:
     c.up("materialized", "ssh-bastion-host", "postgres")
 
-    c.run_testdrive("setup.td")
+    c.run_testdrive_files("setup.td")
 
     public_key = c.sql_query(
         """
@@ -311,7 +311,7 @@ def workflow_pg_restart_bastion(c: Composition) -> None:
         capture=True,
     ).stdout.strip()
 
-    c.run_testdrive("--no-reset", "pg-source.td")
+    c.run_testdrive_files("--no-reset", "pg-source.td")
 
     restart_bastion(c)
     c.exec(
@@ -321,7 +321,7 @@ def workflow_pg_restart_bastion(c: Composition) -> None:
         f"echo '{public_key}' > /etc/authorized_keys/mz",
     )
 
-    c.run_testdrive("--no-reset", "pg-source-ingest-more.td")
+    c.run_testdrive_files("--no-reset", "pg-source-ingest-more.td")
 
     # we do this after we assert that we re-connnected
     # with the passing td file, to ensure that the
@@ -342,7 +342,7 @@ def workflow_pg_restart_bastion(c: Composition) -> None:
 def workflow_pg_restart_postgres(c: Composition) -> None:
     c.up("materialized", "ssh-bastion-host", "postgres")
 
-    c.run_testdrive("setup.td")
+    c.run_testdrive_files("setup.td")
 
     public_key = c.sql_query(
         """
@@ -358,18 +358,18 @@ def workflow_pg_restart_postgres(c: Composition) -> None:
         f"echo '{public_key}' > /etc/authorized_keys/mz",
     )
 
-    c.run_testdrive("--no-reset", "pg-source.td")
+    c.run_testdrive_files("--no-reset", "pg-source.td")
 
     c.kill("postgres")
     c.up("postgres")
 
-    c.run_testdrive("--no-reset", "pg-source-ingest-more.td")
+    c.run_testdrive_files("--no-reset", "pg-source-ingest-more.td")
 
 
 def workflow_pg_via_ssh_tunnel_with_ssl(c: Composition) -> None:
     c.up("materialized", "ssh-bastion-host", "postgres")
 
-    c.run_testdrive("setup.td")
+    c.run_testdrive_files("setup.td")
 
     public_key = c.sql_query(
         """
@@ -386,13 +386,13 @@ def workflow_pg_via_ssh_tunnel_with_ssl(c: Composition) -> None:
         f"echo '{public_key}' > /etc/authorized_keys/mz",
     )
 
-    c.run_testdrive("--no-reset", "pg-source-ssl.td")
+    c.run_testdrive_files("--no-reset", "pg-source-ssl.td")
 
 
 def workflow_ssh_key_after_restart(c: Composition) -> None:
     c.up("materialized")
 
-    c.run_testdrive("setup.td")
+    c.run_testdrive_files("setup.td")
 
     (primary, secondary) = c.sql_query(
         "SELECT public_key_1, public_key_2 FROM mz_ssh_tunnel_connections;"
@@ -424,7 +424,7 @@ def workflow_ssh_key_after_restart(c: Composition) -> None:
 def workflow_rotated_ssh_key_after_restart(c: Composition) -> None:
     c.up("materialized")
 
-    c.run_testdrive("setup.td")
+    c.run_testdrive_files("setup.td")
 
     secondary_public_key = c.sql_query(
         """
@@ -484,11 +484,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ]:
         workflow(c, redpanda=False)
         c.sanity_restart_mz()
-        c.run_testdrive("--no-reset", "validate-success.td")
+        c.run_testdrive_files("--no-reset", "validate-success.td")
         if args.extended:
             workflow(c, redpanda=True)
             c.sanity_restart_mz()
-            c.run_testdrive("--no-reset", "validate-success.td")
+            c.run_testdrive_files("--no-reset", "validate-success.td")
 
     # These tests core functionality related to pg with ssh and error reporting.
     workflow_basic_ssh_features(c)
@@ -500,7 +500,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ]:
         workflow(c)
         c.sanity_restart_mz()
-        c.run_testdrive("--no-reset", "validate-success.td")
+        c.run_testdrive_files("--no-reset", "validate-success.td")
 
     if args.extended:
         # Various special cases related to ssh
@@ -519,4 +519,4 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         ]:
             workflow(c)
             c.sanity_restart_mz()
-            c.run_testdrive("--no-reset", "validate-success.td")
+            c.run_testdrive_files("--no-reset", "validate-success.td")

--- a/test/ssh-connection/mzcompose.py
+++ b/test/ssh-connection/mzcompose.py
@@ -53,7 +53,7 @@ def workflow_basic_ssh_features(c: Composition, redpanda: bool = False) -> None:
         dependencies += ["zookeeper", "kafka", "schema-registry"]
     c.up(*dependencies)
 
-    c.run("testdrive", "ssh-connections.td")
+    c.run_testdrive("ssh-connections.td")
 
     # Check that objects can be restored correctly
     restart_mz(c)
@@ -62,7 +62,7 @@ def workflow_basic_ssh_features(c: Composition, redpanda: bool = False) -> None:
 def workflow_validate_connection(c: Composition) -> None:
     c.up("materialized", "ssh-bastion-host", "postgres")
 
-    c.run("testdrive", "setup.td")
+    c.run_testdrive("setup.td")
 
     public_key = c.sql_query(
         """
@@ -72,7 +72,7 @@ def workflow_validate_connection(c: Composition) -> None:
         """
     )[0][0]
 
-    c.run("testdrive", "--no-reset", "validate-failures.td")
+    c.run_testdrive("--no-reset", "validate-failures.td")
 
     c.exec(
         "ssh-bastion-host",
@@ -81,13 +81,13 @@ def workflow_validate_connection(c: Composition) -> None:
         f"echo '{public_key}' > /etc/authorized_keys/mz",
     )
 
-    c.run("testdrive", "--no-reset", "validate-success.td")
+    c.run_testdrive("--no-reset", "validate-success.td")
 
 
 def workflow_pg(c: Composition) -> None:
     c.up("materialized", "ssh-bastion-host", "postgres")
 
-    c.run("testdrive", "setup.td")
+    c.run_testdrive("setup.td")
 
     public_key = c.sql_query(
         """
@@ -104,11 +104,11 @@ def workflow_pg(c: Composition) -> None:
         f"echo '{public_key}' > /etc/authorized_keys/mz",
     )
 
-    c.run("testdrive", "--no-reset", "pg-source.td")
+    c.run_testdrive("--no-reset", "pg-source.td")
     c.kill("ssh-bastion-host")
-    c.run("testdrive", "--no-reset", "pg-source-after-ssh-failure.td")
+    c.run_testdrive("--no-reset", "pg-source-after-ssh-failure.td")
     c.up("ssh-bastion-host")
-    c.run("testdrive", "--no-reset", "pg-source-after-ssh-restart.td")
+    c.run_testdrive("--no-reset", "pg-source-after-ssh-restart.td")
 
 
 def workflow_kafka(c: Composition, redpanda: bool = False) -> None:
@@ -128,7 +128,7 @@ def workflow_kafka(c: Composition, redpanda: bool = False) -> None:
             dependencies += ["zookeeper", "kafka", "schema-registry"]
         c.up(*dependencies)
 
-        c.run("testdrive", "setup.td")
+        c.run_testdrive("setup.td")
 
         public_key = c.sql_query(
             """
@@ -145,12 +145,12 @@ def workflow_kafka(c: Composition, redpanda: bool = False) -> None:
             f"echo '{public_key}' > /etc/authorized_keys/mz",
         )
 
-        c.run("testdrive", "--no-reset", "kafka-source.td")
+        c.run_testdrive("--no-reset", "kafka-source.td")
         c.kill("ssh-bastion-host")
-        c.run("testdrive", "--no-reset", "kafka-source-after-ssh-failure.td")
+        c.run_testdrive("--no-reset", "kafka-source-after-ssh-failure.td")
 
         c.up("ssh-bastion-host")
-        c.run("testdrive", "--no-reset", "kafka-source-after-ssh-restart.td")
+        c.run_testdrive("--no-reset", "kafka-source-after-ssh-restart.td")
 
 
 def workflow_kafka_restart_replica(c: Composition, redpanda: bool = False) -> None:
@@ -170,7 +170,7 @@ def workflow_kafka_restart_replica(c: Composition, redpanda: bool = False) -> No
             dependencies += ["zookeeper", "kafka", "schema-registry"]
         c.up(*dependencies)
 
-        c.run("testdrive", "setup.td")
+        c.run_testdrive("setup.td")
 
         public_key = c.sql_query(
             """
@@ -187,16 +187,15 @@ def workflow_kafka_restart_replica(c: Composition, redpanda: bool = False) -> No
             f"echo '{public_key}' > /etc/authorized_keys/mz",
         )
 
-        c.run("testdrive", "--no-reset", "kafka-source.td")
+        c.run_testdrive("--no-reset", "kafka-source.td")
         c.kill("ssh-bastion-host")
-        c.run(
-            "testdrive",
+        c.run_testdrive(
             "--no-reset",
             "kafka-source-after-ssh-failure-restart-replica.td",
         )
 
         c.up("ssh-bastion-host")
-        c.run("testdrive", "--no-reset", "kafka-source-after-ssh-restart.td")
+        c.run_testdrive("--no-reset", "kafka-source-after-ssh-restart.td")
 
 
 def workflow_kafka_sink(c: Composition, redpanda: bool = False) -> None:
@@ -216,7 +215,7 @@ def workflow_kafka_sink(c: Composition, redpanda: bool = False) -> None:
             dependencies += ["zookeeper", "kafka", "schema-registry"]
         c.up(*dependencies)
 
-        c.run("testdrive", "setup.td")
+        c.run_testdrive("setup.td")
 
         public_key = c.sql_query(
             """
@@ -233,12 +232,12 @@ def workflow_kafka_sink(c: Composition, redpanda: bool = False) -> None:
             f"echo '{public_key}' > /etc/authorized_keys/mz",
         )
 
-        c.run("testdrive", "--no-reset", "kafka-sink.td")
+        c.run_testdrive("--no-reset", "kafka-sink.td")
         c.kill("ssh-bastion-host")
-        c.run("testdrive", "--no-reset", "kafka-sink-after-ssh-failure.td")
+        c.run_testdrive("--no-reset", "kafka-sink-after-ssh-failure.td")
 
         c.up("ssh-bastion-host")
-        c.run("testdrive", "--no-reset", "kafka-sink-after-ssh-restart.td")
+        c.run_testdrive("--no-reset", "kafka-sink-after-ssh-restart.td")
 
 
 def workflow_hidden_hosts(c: Composition, redpanda: bool = False) -> None:
@@ -250,7 +249,7 @@ def workflow_hidden_hosts(c: Composition, redpanda: bool = False) -> None:
         dependencies += ["zookeeper", "kafka", "schema-registry"]
     c.up(*dependencies)
 
-    c.run("testdrive", "setup.td")
+    c.run_testdrive("setup.td")
 
     public_key = c.sql_query(
         """
@@ -281,7 +280,7 @@ def workflow_hidden_hosts(c: Composition, redpanda: bool = False) -> None:
     add_hidden_host("kafka")
     add_hidden_host("schema-registry")
 
-    c.run("testdrive", "--no-reset", "hidden-hosts.td")
+    c.run_testdrive("--no-reset", "hidden-hosts.td")
 
 
 # Test that if we restart the bastion AND change its server keys(s), we can
@@ -289,7 +288,7 @@ def workflow_hidden_hosts(c: Composition, redpanda: bool = False) -> None:
 def workflow_pg_restart_bastion(c: Composition) -> None:
     c.up("materialized", "ssh-bastion-host", "postgres")
 
-    c.run("testdrive", "setup.td")
+    c.run_testdrive("setup.td")
 
     public_key = c.sql_query(
         """
@@ -312,7 +311,7 @@ def workflow_pg_restart_bastion(c: Composition) -> None:
         capture=True,
     ).stdout.strip()
 
-    c.run("testdrive", "--no-reset", "pg-source.td")
+    c.run_testdrive("--no-reset", "pg-source.td")
 
     restart_bastion(c)
     c.exec(
@@ -322,7 +321,7 @@ def workflow_pg_restart_bastion(c: Composition) -> None:
         f"echo '{public_key}' > /etc/authorized_keys/mz",
     )
 
-    c.run("testdrive", "--no-reset", "pg-source-ingest-more.td")
+    c.run_testdrive("--no-reset", "pg-source-ingest-more.td")
 
     # we do this after we assert that we re-connnected
     # with the passing td file, to ensure that the
@@ -343,7 +342,7 @@ def workflow_pg_restart_bastion(c: Composition) -> None:
 def workflow_pg_restart_postgres(c: Composition) -> None:
     c.up("materialized", "ssh-bastion-host", "postgres")
 
-    c.run("testdrive", "setup.td")
+    c.run_testdrive("setup.td")
 
     public_key = c.sql_query(
         """
@@ -359,18 +358,18 @@ def workflow_pg_restart_postgres(c: Composition) -> None:
         f"echo '{public_key}' > /etc/authorized_keys/mz",
     )
 
-    c.run("testdrive", "--no-reset", "pg-source.td")
+    c.run_testdrive("--no-reset", "pg-source.td")
 
     c.kill("postgres")
     c.up("postgres")
 
-    c.run("testdrive", "--no-reset", "pg-source-ingest-more.td")
+    c.run_testdrive("--no-reset", "pg-source-ingest-more.td")
 
 
 def workflow_pg_via_ssh_tunnel_with_ssl(c: Composition) -> None:
     c.up("materialized", "ssh-bastion-host", "postgres")
 
-    c.run("testdrive", "setup.td")
+    c.run_testdrive("setup.td")
 
     public_key = c.sql_query(
         """
@@ -387,13 +386,13 @@ def workflow_pg_via_ssh_tunnel_with_ssl(c: Composition) -> None:
         f"echo '{public_key}' > /etc/authorized_keys/mz",
     )
 
-    c.run("testdrive", "--no-reset", "pg-source-ssl.td")
+    c.run_testdrive("--no-reset", "pg-source-ssl.td")
 
 
 def workflow_ssh_key_after_restart(c: Composition) -> None:
     c.up("materialized")
 
-    c.run("testdrive", "setup.td")
+    c.run_testdrive("setup.td")
 
     (primary, secondary) = c.sql_query(
         "SELECT public_key_1, public_key_2 FROM mz_ssh_tunnel_connections;"
@@ -425,7 +424,7 @@ def workflow_ssh_key_after_restart(c: Composition) -> None:
 def workflow_rotated_ssh_key_after_restart(c: Composition) -> None:
     c.up("materialized")
 
-    c.run("testdrive", "setup.td")
+    c.run_testdrive("setup.td")
 
     secondary_public_key = c.sql_query(
         """
@@ -485,11 +484,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ]:
         workflow(c, redpanda=False)
         c.sanity_restart_mz()
-        c.run("testdrive", "--no-reset", "validate-success.td")
+        c.run_testdrive("--no-reset", "validate-success.td")
         if args.extended:
             workflow(c, redpanda=True)
             c.sanity_restart_mz()
-            c.run("testdrive", "--no-reset", "validate-success.td")
+            c.run_testdrive("--no-reset", "validate-success.td")
 
     # These tests core functionality related to pg with ssh and error reporting.
     workflow_basic_ssh_features(c)
@@ -501,7 +500,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ]:
         workflow(c)
         c.sanity_restart_mz()
-        c.run("testdrive", "--no-reset", "validate-success.td")
+        c.run_testdrive("--no-reset", "validate-success.td")
 
     if args.extended:
         # Various special cases related to ssh
@@ -520,4 +519,4 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         ]:
             workflow(c)
             c.sanity_restart_mz()
-            c.run("testdrive", "--no-reset", "validate-success.td")
+            c.run_testdrive("--no-reset", "validate-success.td")

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -142,7 +142,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             junit_report = ci_util.junit_report_filename(c.name)
             print("")
             for file in args.files:
-                c.run_testdrive(
+                c.run_testdrive_files(
                     f"--junit-report={junit_report}",
                     f"--var=replicas={args.replicas}",
                     f"--var=default-replica-size={materialized.default_replica_size}",

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -142,8 +142,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             junit_report = ci_util.junit_report_filename(c.name)
             print("")
             for file in args.files:
-                c.run(
-                    "testdrive",
+                c.run_testdrive(
                     f"--junit-report={junit_report}",
                     f"--var=replicas={args.replicas}",
                     f"--var=default-replica-size={materialized.default_replica_size}",

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -133,8 +133,7 @@ def workflow_testdrive(c: Composition, parser: WorkflowArgumentParser) -> None:
         try:
             junit_report = ci_util.junit_report_filename(c.name)
             for file in args.files:
-                c.run(
-                    "testdrive",
+                c.run_testdrive(
                     f"--junit-report={junit_report}",
                     f"--var=replicas={args.replicas}",
                     f"--var=default-replica-size={materialized.default_replica_size}",
@@ -219,17 +218,17 @@ def workflow_rehydration(c: Composition) -> None:
             c.down(destroy_volumes=True)
 
             c.up(*dependencies)
-            c.run("testdrive", "rehydration/01-setup.td")
-            c.run("testdrive", "rehydration/02-source-setup.td")
+            c.run_testdrive("rehydration/01-setup.td")
+            c.run_testdrive("rehydration/02-source-setup.td")
 
             c.kill("materialized")
             c.kill("clusterd1")
             c.up("materialized")
             c.up("clusterd1")
 
-            c.run("testdrive", "rehydration/03-after-rehydration.td")
+            c.run_testdrive("rehydration/03-after-rehydration.td")
 
-        c.run("testdrive", "rehydration/04-reset.td")
+        c.run_testdrive("rehydration/04-reset.td")
 
 
 def workflow_failpoint(c: Composition) -> None:
@@ -258,13 +257,13 @@ def run_one_failpoint(c: Composition, failpoint: str, error_message: str) -> Non
     dependencies = ["zookeeper", "kafka", "materialized"]
     c.kill("clusterd1")
     c.up(*dependencies)
-    c.run("testdrive", "failpoint/00-reset.td")
+    c.run_testdrive("failpoint/00-reset.td")
     with c.override(
         Testdrive(no_reset=True, consistent_seed=True),
     ):
-        c.run("testdrive", "failpoint/01-setup.td")
+        c.run_testdrive("failpoint/01-setup.td")
         c.up("clusterd1")
-        c.run("testdrive", "failpoint/02-source.td")
+        c.run_testdrive("failpoint/02-source.td")
         c.kill("clusterd1")
 
         with c.override(
@@ -275,14 +274,12 @@ def run_one_failpoint(c: Composition, failpoint: str, error_message: str) -> Non
             ),
         ):
             c.up("clusterd1")
-            c.run(
-                "testdrive", f"--var=error={error_message}", "failpoint/03-failpoint.td"
-            )
+            c.run_testdrive(f"--var=error={error_message}", "failpoint/03-failpoint.td")
             c.kill("clusterd1")
 
         # Running without set failpoint
         c.up("clusterd1")
-        c.run("testdrive", "failpoint/04-recover.td")
+        c.run_testdrive("failpoint/04-recover.td")
 
 
 def workflow_incident_49(c: Composition) -> None:
@@ -327,14 +324,14 @@ def workflow_incident_49(c: Composition) -> None:
             c.down(destroy_volumes=True)
             c.up(*dependencies)
 
-            c.run("testdrive", "incident-49/01-setup.td")
+            c.run_testdrive("incident-49/01-setup.td")
 
             c.kill("materialized")
             c.up("materialized")
 
-            c.run("testdrive", "incident-49/02-after-rehydration.td")
+            c.run_testdrive("incident-49/02-after-rehydration.td")
 
-        c.run("testdrive", "incident-49/03-reset.td")
+        c.run_testdrive("incident-49/03-reset.td")
 
 
 def workflow_rocksdb_cleanup(c: Composition) -> None:
@@ -463,12 +460,12 @@ def workflow_autospill(c: Composition) -> None:
             return value
 
         c.up(*dependencies)
-        c.run("testdrive", "autospill/01-setup.td")
+        c.run_testdrive("autospill/01-setup.td")
 
-        c.run("testdrive", "autospill/02-memory.td")
+        c.run_testdrive("autospill/02-memory.td")
         assert fetch_auto_spill_metric() == 0
 
-        c.run("testdrive", "autospill/03-rocksdb.td")
+        c.run_testdrive("autospill/03-rocksdb.td")
         assert fetch_auto_spill_metric() == 1
 
 


### PR DESCRIPTION
Rationale: In a follow-up PR, I want all testdrive invocations to be executed with `capture_stderr=True` to be able to extract appropriate error information.