### PR TITLE
persist-txn-fencing: Increase test timeout

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1255,7 +1255,7 @@ steps:
 
   - id: persist-txn-fencing
     label: Persist-txn fencing
-    timeout_in_minutes: 90
+    timeout_in_minutes: 120
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
The test is already legitimately taking 1h 28m, so a 1h 30min timeout makes it flaky. Increase to 2h.

### Motivation

Nightly CI is failing.