### PR TITLE
adapter: cancel subscribes on cluster drop

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -213,6 +213,7 @@ impl Coordinator {
         let mut vpc_endpoints_to_drop = vec![];
         let mut clusters_to_drop = vec![];
         let mut cluster_replicas_to_drop = vec![];
+        let mut subscribe_sinks_to_drop = vec![];
         let mut peeks_to_drop = vec![];
         let mut update_tracing_config = false;
         let mut update_compute_config = false;
@@ -383,35 +384,43 @@ impl Coordinator {
             .chain(views_to_drop.iter())
             .collect();
 
-        // Clean up any active subscribes that rely on dropped relations.
-        let subscribe_sinks_to_drop: Vec<_> = self
-            .active_subscribes
-            .iter()
-            .filter(|(_id, sub)| !sub.dropping)
-            .filter_map(|(sink_id, sub)| {
-                sub.depends_on
-                    .iter()
-                    .find(|id| relations_to_drop.contains(id))
-                    .map(|dependent_id| (dependent_id, sink_id, sub))
-            })
-            .map(|(dependent_id, sink_id, active_subscribe)| {
-                let conn_id = &active_subscribe.conn_id;
-                let entry = self.catalog().get_entry(dependent_id);
+        // Clean up any active subscribes that rely on dropped relations or clusters.
+        for (&global_id, subscribe) in &self.active_subscribes {
+            if subscribe.dropping {
+                continue; // don't drop subscribes twice
+            }
+            let cluster_id = subscribe.cluster_id;
+            let sink_id = ComputeSinkId {
+                cluster_id,
+                global_id,
+            };
+            let conn_id = &subscribe.conn_id;
+            if let Some(id) = subscribe
+                .depends_on
+                .iter()
+                .find(|id| relations_to_drop.contains(id))
+            {
+                let entry = self.catalog().get_entry(id);
                 let name = self
                     .catalog()
-                    .resolve_full_name(entry.name(), Some(conn_id));
+                    .resolve_full_name(entry.name(), Some(conn_id))
+                    .to_string();
+                subscribe_sinks_to_drop.push((
+                    conn_id.clone(),
+                    format!("relation {}", name.quoted()),
+                    sink_id,
+                ));
+            } else if clusters_to_drop.contains(&cluster_id) {
+                let name = self.catalog().get_cluster(cluster_id).name();
+                subscribe_sinks_to_drop.push((
+                    conn_id.clone(),
+                    format!("cluster {}", name.quoted()),
+                    sink_id,
+                ));
+            }
+        }
 
-                (
-                    (conn_id.clone(), name.to_string()),
-                    ComputeSinkId {
-                        cluster_id: active_subscribe.cluster_id,
-                        global_id: *sink_id,
-                    },
-                )
-            })
-            .collect();
-
-        // Clean up any pending peeks that rely on dropped relations.
+        // Clean up any pending peeks that rely on dropped relations or clusters.
         for (uuid, pending_peek) in &self.pending_peeks {
             if let Some(id) = pending_peek
                 .depends_on
@@ -532,20 +541,18 @@ impl Coordinator {
                 self.drop_storage_sinks(storage_sinks_to_drop);
             }
             if !subscribe_sinks_to_drop.is_empty() {
-                let (dropped_metadata, subscribe_sinks_to_drop): (Vec<_>, BTreeSet<_>) =
-                    subscribe_sinks_to_drop.into_iter().unzip();
-                for (conn_id, dropped_name) in dropped_metadata {
+                let mut sink_ids = Vec::new();
+                for (conn_id, dropped_name, sink_id) in subscribe_sinks_to_drop {
                     if let Some(conn_meta) = self.active_conns.get_mut(&conn_id) {
-                        conn_meta
-                            .drop_sinks
-                            .retain(|sink| !subscribe_sinks_to_drop.contains(sink));
+                        conn_meta.drop_sinks.retain(|id| *id != sink_id);
                         // Send notice on a best effort basis.
                         let _ = conn_meta
                             .notice_tx
                             .send(AdapterNotice::DroppedSubscribe { dropped_name });
                     }
+                    sink_ids.push(sink_id);
                 }
-                self.drop_compute_sinks(subscribe_sinks_to_drop);
+                self.drop_compute_sinks(sink_ids);
             }
             if !peeks_to_drop.is_empty() {
                 for (dropped_name, uuid) in peeks_to_drop {

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -366,7 +366,7 @@ impl fmt::Display for AdapterNotice {
             AdapterNotice::DroppedSubscribe { dropped_name } => {
                 write!(
                     f,
-                "subscribe has been terminated because underlying relation {dropped_name} was dropped"
+                    "subscribe has been terminated because underlying {dropped_name} was dropped"
                 )
             }
             AdapterNotice::BadStartupSetting { name, reason } => {

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -389,10 +389,15 @@ where
     /// # Panics
     ///
     /// Panics if the compute instance still has active replicas.
+    /// Panics if the compute instance still has collections installed.
     pub fn drop(self) {
         assert!(
             self.replicas.is_empty(),
             "cannot drop instances with provisioned replicas"
+        );
+        assert!(
+            self.collections.values().all(|c| c.log_collection),
+            "cannot drop instances with installed collections"
         );
     }
 


### PR DESCRIPTION
This PR makes adapter cancel subscribes when their target cluster is dropped. This has two benefits:

* The subscribe issuer receives a NOTICE informing them about the cluster drop, which removes some confusion about why the subscribe stops responding.
* In the compute controller we can add an assert to ensure that all collections have been dropped when a compute instance is dropped, ensuring a bit more sanity.

Note that this commit does not ensure that subscribes are actually aborted on the pgwire connection. While this would be desirable, it looks to be a more involved change.

### Motivation

  * This PR fixes a recognized bug.

Touches https://github.com/MaterializeInc/materialize/issues/16121.

My private motivation for this change was that I wanted to add that assert to the compute controller and couldn't because it made CI fail.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A