### PR TITLE
ci: junit.xml content: include error details (other testdrive-based checks)

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -38,6 +38,7 @@ from semver.version import Version
 
 from materialize import MZ_ROOT, ci_util, mzbuild, spawn, ui
 from materialize.mzcompose.composition import Composition, UnknownCompositionError
+from materialize.mzcompose.test_result import TestResult
 from materialize.ui import UIError
 
 RECOMMENDED_MIN_MEM = 7 * 1024**3  # 7GiB
@@ -647,7 +648,7 @@ To see the available workflows, run:
         junit_suite: junit_xml.TestSuite,
         test_class_name: str,
         test_case_key: str,
-        result: Composition.TestResult,
+        result: TestResult,
     ):
         if result.is_successful():
             test_case_name = test_case_key

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -660,7 +660,7 @@ To see the available workflows, run:
             junit_suite.test_cases.append(test_case)
         else:
             for error in result.errors:
-                test_case_name = error.get_error_file() or test_case_key
+                test_case_name = error.location_as_file_name() or test_case_key
                 test_case = junit_xml.TestCase(
                     test_case_name,
                     test_class_name,

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -492,7 +492,7 @@ class Composition:
             if isinstance(e, CommandFailureCausedUIError):
                 if e.stderr is not None:
                     # This is to avoid that captured stderr is missing in the logs.
-                    print(e.stderr, file=sys.stderr)
+                    print(e.stderr, file=sys.stderr, flush=True)
 
                 try:
                     extracted_errors = self.try_determine_errors_from_cmd_execution(e)

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -477,8 +477,10 @@ class Composition:
         start_time = time.time()
         try:
             yield
+            end_time = time.time()
             ui.header(f"mzcompose: test case {name} succeeded")
         except Exception as e:
+            end_time = time.time()
             error_message = f"{str(type(e))}: {e}"
             error_details = None
             error_location = None
@@ -496,7 +498,7 @@ class Composition:
 
             errors = [TestFailureDetails(error_message, error_details, error_location)]
 
-        duration = time.time() - start_time
+        duration = end_time - start_time
         self.test_results[name] = TestResult(duration, errors)
 
     def try_determine_error_location_from_cmd(self, cmd: list[str]) -> str | None:

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -659,6 +659,8 @@ class Composition:
             "testdrive",
             *args,
             rm=rm,
+            # needed for sufficient error information in the junit.xml
+            capture_stderr=True,
         )
 
     def exec(

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -490,6 +490,10 @@ class Composition:
             ]
 
             if isinstance(e, CommandFailureCausedUIError):
+                if e.stderr is not None:
+                    # This is to avoid that captured stderr is missing in the logs.
+                    print(e.stderr, file=sys.stderr)
+
                 try:
                     extracted_errors = self.try_determine_errors_from_cmd_execution(e)
                 except:

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -330,7 +330,8 @@ class Composition:
                     raise CommandFailureCausedUIError(
                         f"running docker compose failed (exit status {e.returncode})",
                         cmd=e.cmd,
-                        stderr=e.stderr if capture_stderr == True else None,
+                        stdout=e.stdout,
+                        stderr=e.stderr,
                     )
             break
 

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -279,6 +279,10 @@ class Composition:
         stdout = None
         if capture:
             stdout = subprocess.PIPE if capture == True else capture
+        elif capture_stderr:
+            # this is necessary for the stderr to work
+            stdout = subprocess.PIPE
+
         stderr = None
         if capture_stderr:
             stderr = subprocess.PIPE if capture_stderr == True else capture_stderr

--- a/misc/python/materialize/mzcompose/test_result.py
+++ b/misc/python/materialize/mzcompose/test_result.py
@@ -9,7 +9,6 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 
 
@@ -26,16 +25,15 @@ class TestResult:
 class TestFailureDetails:
     message: str
     details: str | None
+    # depending on the check, this may either be a file name or a path
     location: str | None
+    line_number: int | None
 
-    def get_error_file(self) -> str | None:
+    def location_as_file_name(self) -> str | None:
         if self.location is None:
             return None
 
-        file_name = self.location
-        file_name = re.sub(r":\d+", "", file_name)
+        if "/" in self.location:
+            return self.location[self.location.rindex("/") + 1 :]
 
-        if "/" in file_name:
-            file_name = file_name[file_name.rindex("/") + 1 :]
-
-        return file_name
+        return self.location

--- a/misc/python/materialize/mzcompose/test_result.py
+++ b/misc/python/materialize/mzcompose/test_result.py
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass
+class TestResult:
+    duration: float
+    errors: list[TestFailureDetails]
+
+    def is_successful(self) -> bool:
+        return len(self.errors) == 0
+
+
+@dataclass
+class TestFailureDetails:
+    message: str
+    details: str | None
+    location: str | None
+
+    def get_error_file(self) -> str | None:
+        if self.location is None:
+            return None
+
+        file_name = self.location
+        file_name = re.sub(r":\d+", "", file_name)
+
+        if "/" in file_name:
+            file_name = file_name[file_name.rindex("/") + 1 :]
+
+        return file_name

--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -189,11 +189,13 @@ class CommandFailureCausedUIError(UIError):
         self,
         message: str,
         cmd: list[str],
+        stdout: str | None = None,
         stderr: str | None = None,
         hint: str | None = None,
     ):
         super().__init__(message, hint)
         self.cmd = cmd
+        self.stdout = stdout
         self.stderr = stderr
 
 


### PR DESCRIPTION
This is a follow-up to https://github.com/MaterializeInc/materialize/pull/24505 and addresses further checks. Note that it splits test cases if multiple errors (in different files) are detected. Tested with "Postgres CDC".

### Commits
8cc537ace4 tests: capture stdout as well
f93b04ee3c tests: make sure that stderr can be captured
8187a65edd tests: always capture stderr when running testdrive
df2e87efb8 tests: extract junit generation to methods
77bdb8f76d tests: allow collecting multiple errors per test
2f8601b69c tests: extract TestResult to separate file
fb0c5893ef tests: test duration measurement
298445390c tests: extract error information from stderr
2cce85ee9a tests: avoid that stderr gets lost

### Demo

#### Postgres CDC
Build: https://buildkite.com/materialize/tests/builds/73499

<img width="1151" alt="Bildschirmfoto 2024-01-19 um 16 43 17" src="https://github.com/MaterializeInc/materialize/assets/129728240/96be7c64-20a9-4b1d-9ebd-7b87645741a3">

#### Other build jobs
* Before: https://buildkite.com/materialize/tests/builds/73541 (https://buildkite.com/materialize/tests/builds?branch=ci%2Fjunitxml-demo-before)
* After: https://buildkite.com/materialize/tests/builds/73521 (https://buildkite.com/materialize/tests/builds?branch=ci%2Fjunitxml-demo)
