### PR TITLE
output consistency: add OtherReturnTypeSpec

### DIFF
--- a/misc/python/materialize/output_consistency/data_type/data_type_category.py
+++ b/misc/python/materialize/output_consistency/data_type/data_type_category.py
@@ -28,3 +28,5 @@ class DataTypeCategory(Enum):
     ENUM = 200
 
     ARRAY = 300
+
+    OTHER_UNSUPPORTED = 400

--- a/misc/python/materialize/output_consistency/input_data/return_specs/other_return_spec.py
+++ b/misc/python/materialize/output_consistency/input_data/return_specs/other_return_spec.py
@@ -1,0 +1,23 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.operation.return_type_spec import ReturnTypeSpec
+
+
+class OtherReturnTypeSpec(ReturnTypeSpec):
+    """
+    Return type spec for other, yet unsupported types.
+    An expression with an operation specifying this return type cannot be used as input for other operations.
+    """
+
+    def __init__(
+        self,
+    ) -> None:
+        super().__init__(DataTypeCategory.OTHER_UNSUPPORTED)


### PR DESCRIPTION
>     Return type spec for other, yet unsupported types.
>     An expression with an operation specifying this return type cannot be used as input for other operations.