### PR TITLE
catalog: Include more details in debug tool msgs

### DIFF
--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use clap::Parser;
 use mz_adapter::catalog::Catalog;
 use mz_build_info::{build_info, BuildInfo};
@@ -135,7 +135,11 @@ async fn main() {
         enable_version_flag: true,
     });
     if let Err(err) = run(args).await {
-        eprintln!("catalog: fatal: {:?}", err.display_with_causes());
+        eprintln!(
+            "catalog-debug: fatal: {}\nbacktrace: {}",
+            err.display_with_causes(),
+            err.backtrace()
+        );
         process::exit(1);
     }
 }

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use clap::Parser;
 use mz_adapter::catalog::Catalog;
 use mz_build_info::{build_info, BuildInfo};

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -135,7 +135,7 @@ async fn main() {
         enable_version_flag: true,
     });
     if let Err(err) = run(args).await {
-        eprintln!("catalog: fatal: {}", err.display_with_causes());
+        eprintln!("catalog: fatal: {:?}", err.display_with_causes());
         process::exit(1);
     }
 }


### PR DESCRIPTION
This commit adds more details to the catalog-debug tool's error messages.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
