### PR TITLE
catalog: Cache large collections during startup

### DIFF
--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -683,13 +683,10 @@ impl<T> LargeCollectionStartupCache<T> {
     /// If the cache is open, then return all the cached values and close the cache, otherwise
     /// return `None`.
     fn take(&mut self) -> Option<Vec<T>> {
-        match self {
-            LargeCollectionStartupCache::Open(cache) => {
-                let cache = Some(std::mem::take(cache));
-                *self = LargeCollectionStartupCache::Closed;
-                cache
-            }
-            LargeCollectionStartupCache::Closed => None,
+        if let Self::Open(cache) = std::mem::replace(self, Self::Closed) {
+            Some(cache)
+        } else {
+            None
         }
     }
 }

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -1007,7 +1007,7 @@ impl ReadOnlyDurableCatalogState for PersistCatalogState {
         let audit_logs = match self.audit_logs.take() {
             Some(audit_logs) => audit_logs,
             None => {
-                error!("audit logs were not found in cache, so they were retrieved from persist, this unexpected and bad for performance");
+                error!("audit logs were not found in cache, so they were retrieved from persist, this is unexpected and bad for performance");
                 self.persist_snapshot()
                     .await
                     .filter_map(

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -1213,7 +1213,7 @@ impl DurableCatalogState for PersistCatalogState {
         let storage_usage = match self.storage_usage_events.take() {
             Some(storage_usage) => storage_usage,
             None => {
-                error!("storage usage events were not found in cache, so they were retrieved from persist, this unexpected and bad for performance");
+                error!("storage usage events were not found in cache, so they were retrieved from persist, this is unexpected and bad for performance");
                 self.persist_snapshot()
                     .await
                     .filter_map(


### PR DESCRIPTION
This commit caches the audit log and storage usages collections in
memory for the persist catalog. The cache is only populated during
startup and then kept empty once startup is complete. We only ever
need these collections once during startup to populate certain builtin
tables, so keeping them in memory after would be wasteful. Previously,
we would fetch an entire persist snapshot whenever we needed these
collections which resulted in two redundant persist snapshots.

Works towards resolving #24218

### Motivation

Perf improvement.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
