### PR TITLE
version consistency: add ignore

### DIFF
--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -71,6 +71,8 @@ _MIN_ANCESTOR_MZ_VERSION_PER_COMMIT_TO_ACCOUNT_FOR_CORRECTNESS_REGRESSIONS: dict
     str, MzVersion
 ] = {
     # insert newer commits at the top
+    # PR#24497 (Make sure variance never returns a negative number) changes DFR or CTF handling compared to v0.84.0
+    "82a5130a8466525c5b3bdb3eff845c7c34585774": MzVersion.parse_mz("v0.85.0"),
 }
 
 ANCESTOR_OVERRIDES_FOR_PERFORMANCE_REGRESSIONS = _MIN_ANCESTOR_MZ_VERSION_PER_COMMIT_TO_ACCOUNT_FOR_PERFORMANCE_AND_SCALABILITY_REGRESSIONS


### PR DESCRIPTION
This should fix https://buildkite.com/materialize/nightlies/builds/6066#018d21b5-f318-4fa3-9c69-b75cf866670f caused by https://github.com/MaterializeInc/materialize/pull/24497.

(Note that it is not possible to verify this in a PR because other versions will be compared. Therefore, I am not gonna trigger a build.)