### PR TITLE
webhook: Refactor errors

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -55,7 +55,7 @@ use crate::session::{EndTransactionAction, PreparedStatement, Session, Transacti
 use crate::statement_logging::StatementEndedExecutionReason;
 use crate::telemetry::{self, SegmentClientExt, StatementFailureType};
 use crate::webhook::AppendWebhookResponse;
-use crate::{AdapterNotice, PeekResponseUnary, StartupResponse};
+use crate::{AdapterNotice, AppendWebhookError, PeekResponseUnary, StartupResponse};
 
 /// A handle to a running coordinator.
 ///
@@ -325,7 +325,7 @@ Issue a SQL query to get started. Need help?
         database: String,
         schema: String,
         name: String,
-    ) -> Result<AppendWebhookResponse, AdapterError> {
+    ) -> Result<AppendWebhookResponse, AppendWebhookError> {
         let (tx, rx) = oneshot::channel();
 
         // Send our request.
@@ -338,7 +338,7 @@ Issue a SQL query to get started. Need help?
 
         // Using our one shot channel to get the result, returning an error if the sender dropped.
         let response = rx.await.map_err(|_| {
-            AdapterError::Internal("failed to receive webhook response".to_string())
+            AppendWebhookError::InternalError(anyhow::anyhow!("failed to receive webhook response"))
         })?;
 
         response

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -337,9 +337,9 @@ Issue a SQL query to get started. Need help?
         });
 
         // Using our one shot channel to get the result, returning an error if the sender dropped.
-        let response = rx.await.map_err(|_| {
-            AppendWebhookError::InternalError(anyhow::anyhow!("failed to receive webhook response"))
-        })?;
+        let response = rx
+            .await
+            .map_err(|_| anyhow::anyhow!("failed to receive webhook response"))?;
 
         response
     }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -40,7 +40,7 @@ use crate::session::{EndTransactionAction, RowBatchStream, Session};
 use crate::statement_logging::StatementEndedExecutionReason;
 use crate::util::Transmittable;
 use crate::webhook::AppendWebhookResponse;
-use crate::AdapterNotice;
+use crate::{AdapterNotice, AppendWebhookError};
 
 #[derive(Debug)]
 pub struct CatalogSnapshot {
@@ -90,7 +90,7 @@ pub enum Command {
         database: String,
         schema: String,
         name: String,
-        tx: oneshot::Sender<Result<AppendWebhookResponse, AdapterError>>,
+        tx: oneshot::Sender<Result<AppendWebhookResponse, AppendWebhookError>>,
     },
 
     GetSystemVars {

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -60,7 +60,7 @@ use crate::util::{ClientTransmitter, ResultExt};
 use crate::webhook::{
     AppendWebhookResponse, AppendWebhookValidator, WebhookAppender, WebhookAppenderInvalidator,
 };
-use crate::{catalog, metrics, ExecuteContext};
+use crate::{catalog, metrics, AppendWebhookError, ExecuteContext};
 
 use super::ExecuteContextExtra;
 
@@ -963,7 +963,7 @@ impl Coordinator {
         database: String,
         schema: String,
         name: String,
-        tx: oneshot::Sender<Result<AppendWebhookResponse, AdapterError>>,
+        tx: oneshot::Sender<Result<AppendWebhookResponse, AppendWebhookError>>,
     ) {
         /// Attempts to resolve a Webhook source from a provided `database.schema.name` path.
         ///
@@ -1048,7 +1048,7 @@ impl Coordinator {
         }
 
         let response = resolve(self, database, schema, name).map_err(|name| {
-            AdapterError::UnknownWebhookSource {
+            AppendWebhookError::UnknownWebhook {
                 database: name.database.expect("provided"),
                 schema: name.schema.expect("provided"),
                 name: name.item,

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -159,12 +159,6 @@ pub enum AdapterError {
         cluster_name: String,
         replica_name: String,
     },
-    /// The named webhook source does not exist.
-    UnknownWebhookSource {
-        database: String,
-        schema: String,
-        name: String,
-    },
     /// The named setting does not exist.
     UnrecognizedConfigurationParam(String),
     /// A generic error occurred.
@@ -462,7 +456,6 @@ impl AdapterError {
             AdapterError::UnknownPreparedStatement(_) => SqlState::UNDEFINED_PSTATEMENT,
             AdapterError::UnknownLoginRole(_) => SqlState::INVALID_AUTHORIZATION_SPECIFICATION,
             AdapterError::UnknownClusterReplica { .. } => SqlState::UNDEFINED_OBJECT,
-            AdapterError::UnknownWebhookSource { .. } => SqlState::UNDEFINED_OBJECT,
             AdapterError::UnrecognizedConfigurationParam(_) => SqlState::UNDEFINED_OBJECT,
             AdapterError::Unsupported(..) => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::Unstructured(_) => SqlState::INTERNAL_ERROR,
@@ -648,14 +641,6 @@ impl fmt::Display for AdapterError {
             } => write!(
                 f,
                 "cluster replica '{cluster_name}.{replica_name}' does not exist"
-            ),
-            AdapterError::UnknownWebhookSource {
-                database,
-                schema,
-                name,
-            } => write!(
-                f,
-                "webhook source '{database}.{schema}.{name}' does not exist"
             ),
             AdapterError::UnrecognizedConfigurationParam(setting_name) => write!(
                 f,

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -30,21 +30,30 @@ pub enum AppendWebhookError {
     // A secret that we need for validation has gone missing.
     #[error("could not read a required secret")]
     MissingSecret,
-    #[error("the provided request body is not UTF-8")]
-    NonUtf8Body,
+    #[error("the provided request body is not UTF-8: {msg}")]
+    InvalidUtf8Body { msg: String },
+    #[error("the provided request body is not valid JSON: {msg}")]
+    InvalidJsonBody { msg: String },
+    #[error("webhook source '{database}.{schema}.{name}' does not exist")]
+    UnknownWebhook {
+        database: String,
+        schema: String,
+        name: String,
+    },
+    #[error("failed to validate the request")]
+    ValidationFailed,
     // Note: we should _NEVER_ add more detail to this error, including the actual error we got
     // when running validation. This is because the error messages might contain info about the
     // arguments provided to the validation expression, we could contains user SECRETs. So by
     // including any more detail we might accidentally expose SECRETs.
-    #[error("validation failed")]
+    #[error("validation error")]
     ValidationError,
     #[error("internal channel closed")]
     ChannelClosed,
+    #[error("internal error: {0:?}")]
+    InternalError(#[from] anyhow::Error),
     #[error("internal storage failure! {0:?}")]
     StorageError(#[from] StorageError),
-    // Note: we should _NEVER_ add more detail to this error, see above as to why.
-    #[error("internal error when validating request")]
-    InternalError,
 }
 
 /// Contains all of the components necessary for running webhook validation.
@@ -108,7 +117,7 @@ impl AppendWebhookValidator {
         )
         .map_err(|err| {
             tracing::error!(?err, "failed to evaluate current time");
-            AppendWebhookError::InternalError
+            AppendWebhookError::ValidationError
         })?;
 
         // Create a closure to run our validation, this allows lifetimes and unwind boundaries to
@@ -130,7 +139,7 @@ impl AppendWebhookValidator {
                     Datum::Bytes(&body[..])
                 } else {
                     let s = std::str::from_utf8(&body[..])
-                        .map_err(|_| AppendWebhookError::NonUtf8Body)?;
+                        .map_err(|m| AppendWebhookError::InvalidUtf8Body { msg: m.to_string() })?;
                     Datum::String(s)
                 };
                 datums.push(datum);
@@ -203,7 +212,7 @@ impl AppendWebhookValidator {
                 // be extra careful and guard against issues taking down the entire process.
                 mz_ore::panic::catch_unwind(validate).map_err(|_| {
                     tracing::error!("panic while validating webhook request!");
-                    AppendWebhookError::InternalError
+                    AppendWebhookError::ValidationError
                 })
             },
         )
@@ -211,7 +220,7 @@ impl AppendWebhookValidator {
         .context("joining on validation")
         .map_err(|e| {
             tracing::error!("Failed to run validation for webhook, {e}");
-            AppendWebhookError::InternalError
+            AppendWebhookError::ValidationError
         })??;
 
         valid


### PR DESCRIPTION
This is a small change that removes the `ChannelClosed` error from our external facing `WebhookError` type and does some other general cleanup.

### Motivation

Follow-up from https://github.com/MaterializeInc/materialize/pull/23777

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
