### PR TITLE
catalog: Consolidate transactions in memory

### DIFF
--- a/src/catalog/tests/snapshots/debug__persist_opened_trace.snap
+++ b/src/catalog/tests/snapshots/debug__persist_opened_trace.snap
@@ -1228,121 +1228,6 @@ Trace {
                         id: Some(
                             SchemaId {
                                 value: Some(
-                                    User(
-                                        3,
-                                    ),
-                                ),
-                            },
-                        ),
-                    },
-                    SchemaValue {
-                        database_id: Some(
-                            DatabaseId {
-                                value: Some(
-                                    User(
-                                        1,
-                                    ),
-                                ),
-                            },
-                        ),
-                        name: "public",
-                        owner_id: Some(
-                            RoleId {
-                                value: Some(
-                                    System(
-                                        1,
-                                    ),
-                                ),
-                            },
-                        ),
-                        privileges: [
-                            MzAclItem {
-                                grantee: Some(
-                                    RoleId {
-                                        value: Some(
-                                            Public(
-                                                Empty,
-                                            ),
-                                        ),
-                                    },
-                                ),
-                                grantor: Some(
-                                    RoleId {
-                                        value: Some(
-                                            System(
-                                                1,
-                                            ),
-                                        ),
-                                    },
-                                ),
-                                acl_mode: Some(
-                                    AclMode {
-                                        bitflags: 256,
-                                    },
-                                ),
-                            },
-                            MzAclItem {
-                                grantee: Some(
-                                    RoleId {
-                                        value: Some(
-                                            System(
-                                                2,
-                                            ),
-                                        ),
-                                    },
-                                ),
-                                grantor: Some(
-                                    RoleId {
-                                        value: Some(
-                                            System(
-                                                1,
-                                            ),
-                                        ),
-                                    },
-                                ),
-                                acl_mode: Some(
-                                    AclMode {
-                                        bitflags: 256,
-                                    },
-                                ),
-                            },
-                            MzAclItem {
-                                grantee: Some(
-                                    RoleId {
-                                        value: Some(
-                                            System(
-                                                1,
-                                            ),
-                                        ),
-                                    },
-                                ),
-                                grantor: Some(
-                                    RoleId {
-                                        value: Some(
-                                            System(
-                                                1,
-                                            ),
-                                        ),
-                                    },
-                                ),
-                                acl_mode: Some(
-                                    AclMode {
-                                        bitflags: 768,
-                                    },
-                                ),
-                            },
-                        ],
-                    },
-                ),
-                "1",
-                1,
-            ),
-            (
-                (
-                    SchemaKey {
-                        id: Some(
-                            SchemaId {
-                                value: Some(
                                     System(
                                         1,
                                     ),
@@ -1781,6 +1666,121 @@ Trace {
                     SchemaValue {
                         database_id: None,
                         name: "mz_unsafe",
+                        owner_id: Some(
+                            RoleId {
+                                value: Some(
+                                    System(
+                                        1,
+                                    ),
+                                ),
+                            },
+                        ),
+                        privileges: [
+                            MzAclItem {
+                                grantee: Some(
+                                    RoleId {
+                                        value: Some(
+                                            Public(
+                                                Empty,
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                grantor: Some(
+                                    RoleId {
+                                        value: Some(
+                                            System(
+                                                1,
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                acl_mode: Some(
+                                    AclMode {
+                                        bitflags: 256,
+                                    },
+                                ),
+                            },
+                            MzAclItem {
+                                grantee: Some(
+                                    RoleId {
+                                        value: Some(
+                                            System(
+                                                2,
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                grantor: Some(
+                                    RoleId {
+                                        value: Some(
+                                            System(
+                                                1,
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                acl_mode: Some(
+                                    AclMode {
+                                        bitflags: 256,
+                                    },
+                                ),
+                            },
+                            MzAclItem {
+                                grantee: Some(
+                                    RoleId {
+                                        value: Some(
+                                            System(
+                                                1,
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                grantor: Some(
+                                    RoleId {
+                                        value: Some(
+                                            System(
+                                                1,
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                acl_mode: Some(
+                                    AclMode {
+                                        bitflags: 768,
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+                "1",
+                1,
+            ),
+            (
+                (
+                    SchemaKey {
+                        id: Some(
+                            SchemaId {
+                                value: Some(
+                                    User(
+                                        3,
+                                    ),
+                                ),
+                            },
+                        ),
+                    },
+                    SchemaValue {
+                        database_id: Some(
+                            DatabaseId {
+                                value: Some(
+                                    User(
+                                        1,
+                                    ),
+                                ),
+                            },
+                        ),
+                        name: "public",
                         owner_id: Some(
                             RoleId {
                                 value: Some(


### PR DESCRIPTION
This commit will consolidate durable catalog transactions in memory before committing them durably. Consolidating in-memory is usually much faster than consolidating on disk, so we optimistically do so. This is especially true of the stash which can fall over if too many retractions are written. This is even more true during catalog rollbacks form persist to the stash which may write an extremely large number of retractions that can all be consolidated in memory.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
