### PR TITLE
Move `EXPLAIN SELECT` optimization off the coordinator thread

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -368,6 +368,7 @@ pub enum RealTimeRecencyContext {
         in_immediate_multi_stmt_txn: bool,
         optimizer: optimize::peek::Optimizer,
         global_mir_plan: optimize::peek::GlobalMirPlan,
+        explain_ctx: Option<ExplainContext>,
     },
 }
 
@@ -407,6 +408,9 @@ impl PeekStage {
 pub struct PeekStageValidate {
     plan: mz_sql::plan::SelectPlan,
     target_cluster: TargetCluster,
+    /// An optional context set iff the state machine is initiated from
+    /// sequencing an EXPALIN for this statement.
+    explain_ctx: Option<ExplainContext>,
 }
 
 #[derive(Debug)]
@@ -418,6 +422,9 @@ pub struct PeekStageTimestamp {
     timeline_context: TimelineContext,
     in_immediate_multi_stmt_txn: bool,
     optimizer: optimize::peek::Optimizer,
+    /// An optional context set iff the state machine is initiated from
+    /// sequencing an EXPALIN for this statement.
+    explain_ctx: Option<ExplainContext>,
 }
 
 #[derive(Debug)]
@@ -430,6 +437,9 @@ pub struct PeekStageOptimizeMir {
     oracle_read_ts: Option<Timestamp>,
     in_immediate_multi_stmt_txn: bool,
     optimizer: optimize::peek::Optimizer,
+    /// An optional context set iff the state machine is initiated from
+    /// sequencing an EXPALIN for this statement.
+    explain_ctx: Option<ExplainContext>,
 }
 
 #[derive(Debug)]
@@ -444,6 +454,9 @@ pub struct PeekStageRealTimeRecency {
     in_immediate_multi_stmt_txn: bool,
     optimizer: optimize::peek::Optimizer,
     global_mir_plan: optimize::peek::GlobalMirPlan,
+    /// An optional context set iff the state machine is initiated from
+    /// sequencing an EXPALIN for this statement.
+    explain_ctx: Option<ExplainContext>,
 }
 
 #[derive(Debug)]
@@ -458,6 +471,9 @@ pub struct PeekStageOptimizeLir {
     real_time_recency_ts: Option<mz_repr::Timestamp>,
     optimizer: optimize::peek::Optimizer,
     global_mir_plan: optimize::peek::GlobalMirPlan,
+    /// An optional context set iff the state machine is initiated from
+    /// sequencing an EXPALIN for this statement.
+    explain_ctx: Option<ExplainContext>,
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -34,7 +34,7 @@ use crate::command::Command;
 use crate::coord::appends::Deferred;
 use crate::coord::statement_logging::StatementLoggingId;
 use crate::coord::{
-    Coordinator, CreateConnectionValidationReady, Message, PeekStage, PeekStageFinish,
+    Coordinator, CreateConnectionValidationReady, Message, PeekStage, PeekStageOptimizeLir,
     PendingReadTxn, PlanValidity, PurifiedStatementReady, RealTimeRecencyContext,
 };
 use crate::session::Session;
@@ -861,7 +861,7 @@ impl Coordinator {
                 self.sequence_peek_stage(
                     ctx,
                     root_otel_ctx,
-                    PeekStage::Finish(PeekStageFinish {
+                    PeekStage::OptimizeLir(PeekStageOptimizeLir {
                         validity,
                         plan,
                         id_bundle: None,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -857,6 +857,7 @@ impl Coordinator {
                 in_immediate_multi_stmt_txn: _,
                 optimizer,
                 global_mir_plan,
+                explain_ctx,
             } => {
                 self.sequence_peek_stage(
                     ctx,
@@ -872,6 +873,7 @@ impl Coordinator {
                         real_time_recency_ts: Some(real_time_recency_ts),
                         optimizer,
                         global_mir_plan,
+                        explain_ctx,
                     }),
                 )
                 .await;

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -155,7 +155,7 @@ impl Coordinator {
                     stage,
                 } => {
                     otel_ctx.attach_as_parent();
-                    self.sequence_peek_stage(ctx, otel_ctx, stage).await;
+                    self.execute_peek_stage(ctx, otel_ctx, stage).await;
                 }
                 Message::CreateIndexStageReady {
                     ctx,
@@ -859,7 +859,7 @@ impl Coordinator {
                 global_mir_plan,
                 explain_ctx,
             } => {
-                self.sequence_peek_stage(
+                self.execute_peek_stage(
                     ctx,
                     root_otel_ctx,
                     PeekStage::OptimizeLir(PeekStageOptimizeLir {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1818,10 +1818,8 @@ impl Coordinator {
                         plan::ExplaineeStatement::CreateIndex { .. } => {
                             self.explain_create_index(ctx, plan).await;
                         }
-                        _ => {
-                            let result =
-                                self.explain_statement(&mut ctx, plan, target_cluster).await;
-                            ctx.retire(result);
+                        plan::ExplaineeStatement::Select { .. } => {
+                            self.explain_peek(ctx, plan, target_cluster).await;
                         }
                     }
                 } else {

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -90,6 +90,7 @@ impl Coordinator {
                     config,
                     format,
                     stage,
+                    desc: None,
                     optimizer_trace,
                 }),
             }),
@@ -284,7 +285,7 @@ impl Coordinator {
                             })
                         }
                     }
-                    // Internal optimizer errors errors are handled differently
+                    // Internal optimizer errors are handled differently
                     // depending on the caller.
                     Err(err) => {
                         let Some(explain_ctx) = explain_ctx else {
@@ -459,6 +460,7 @@ impl Coordinator {
                     format,
                     stage,
                     optimizer_trace,
+                    ..
                 },
             ..
         }: CreateIndexExplain,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -96,6 +96,7 @@ impl Coordinator {
                     config,
                     format,
                     stage,
+                    desc: None,
                     optimizer_trace,
                 }),
             }),
@@ -351,7 +352,7 @@ impl Coordinator {
                             })
                         }
                     }
-                    // Internal optimizer errors errors are handled differently
+                    // Internal optimizer errors are handled differently
                     // depending on the caller.
                     Err(err) => {
                         let Some(explain_ctx) = explain_ctx else {
@@ -600,6 +601,7 @@ impl Coordinator {
                     format,
                     stage,
                     optimizer_trace,
+                    ..
                 },
             ..
         }: CreateMaterializedViewExplain,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -20,7 +20,7 @@ use mz_sql::catalog::CatalogCluster;
 use mz_catalog::memory::objects::CatalogItem;
 use mz_sql::plan;
 use mz_sql::plan::QueryWhen;
-use mz_transform::{EmptyStatisticsOracle, StatisticsOracle};
+use mz_transform::EmptyStatisticsOracle;
 use tracing::Instrument;
 use tracing::{event, warn, Level};
 
@@ -310,77 +310,8 @@ impl Coordinator {
         &mut self,
         ctx: ExecuteContext,
         root_otel_ctx: OpenTelemetryContext,
-        mut stage: PeekStageOptimizeMir,
-    ) {
-        // Generate data structures that can be moved to another task where we will perform possibly
-        // expensive optimizations.
-        let internal_cmd_tx = self.internal_cmd_tx.clone();
-
-        // TODO: Is there a way to avoid making two dataflow_builders (the second is in
-        // optimize_peek)?
-        let id_bundle = self
-            .dataflow_builder(stage.optimizer.cluster_id())
-            .sufficient_collections(&stage.source_ids);
-        // Although we have added `sources.depends_on()` to the validity already, also add the
-        // sufficient collections for safety.
-        stage.validity.dependency_ids.extend(id_bundle.iter());
-
-        let stats = {
-            match self
-                .determine_timestamp(
-                    ctx.session(),
-                    &id_bundle,
-                    &stage.plan.when,
-                    stage.optimizer.cluster_id(),
-                    &stage.timeline_context,
-                    stage.oracle_read_ts.clone(),
-                    None,
-                )
-                .await
-            {
-                Err(_) => Box::new(EmptyStatisticsOracle),
-                Ok(query_as_of) => self
-                    .statistics_oracle(
-                        ctx.session(),
-                        &stage.source_ids,
-                        query_as_of.timestamp_context.antichain(),
-                        true,
-                    )
-                    .await
-                    .unwrap_or_else(|_| Box::new(EmptyStatisticsOracle)),
-            }
-        };
-
-        let span = tracing::debug_span!("optimize peek task");
-
-        mz_ore::task::spawn_blocking(
-            || "optimize peek",
-            move || {
-                let _guard = span.enter();
-
-                match Self::optimize_peek(ctx.session(), stats, id_bundle, stage) {
-                    Ok(stage) => {
-                        let stage = PeekStage::RealTimeRecency(stage);
-                        // Ignore errors if the coordinator has shut down.
-                        let _ = internal_cmd_tx.send(Message::PeekStageReady {
-                            ctx,
-                            otel_ctx: root_otel_ctx,
-                            stage,
-                        });
-                    }
-                    Err(err) => ctx.retire(Err(err)),
-                }
-            },
-        );
-    }
-
-    #[tracing::instrument(level = "debug", skip_all)]
-    fn optimize_peek(
-        session: &Session,
-        stats: Box<dyn StatisticsOracle>,
-        id_bundle: CollectionIdBundle,
         PeekStageOptimizeMir {
-            validity,
+            mut validity,
             plan,
             source_ids,
             target_replica,
@@ -389,23 +320,85 @@ impl Coordinator {
             in_immediate_multi_stmt_txn,
             mut optimizer,
         }: PeekStageOptimizeMir,
-    ) -> Result<PeekStageRealTimeRecency, AdapterError> {
-        let local_mir_plan = optimizer.catch_unwind_optimize(plan.source.clone())?;
-        let local_mir_plan = local_mir_plan.resolve(session, stats);
-        let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
+    ) {
+        // Generate data structures that can be moved to another task where we will perform possibly
+        // expensive optimizations.
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
 
-        Ok(PeekStageRealTimeRecency {
-            validity,
-            plan,
-            source_ids,
-            id_bundle,
-            target_replica,
-            timeline_context,
-            oracle_read_ts,
-            in_immediate_multi_stmt_txn,
-            optimizer,
-            global_mir_plan,
-        })
+        // TODO: Is there a way to avoid making two dataflow_builders (the second is in
+        // optimize_peek)?
+        let id_bundle = self
+            .dataflow_builder(optimizer.cluster_id())
+            .sufficient_collections(&source_ids);
+        // Although we have added `sources.depends_on()` to the validity already, also add the
+        // sufficient collections for safety.
+        validity.dependency_ids.extend(id_bundle.iter());
+
+        let stats = {
+            match self
+                .determine_timestamp(
+                    ctx.session(),
+                    &id_bundle,
+                    &plan.when,
+                    optimizer.cluster_id(),
+                    &timeline_context,
+                    oracle_read_ts.clone(),
+                    None,
+                )
+                .await
+            {
+                Err(_) => Box::new(EmptyStatisticsOracle),
+                Ok(query_as_of) => self
+                    .statistics_oracle(
+                        ctx.session(),
+                        &source_ids,
+                        query_as_of.timestamp_context.antichain(),
+                        true,
+                    )
+                    .await
+                    .unwrap_or_else(|_| Box::new(EmptyStatisticsOracle)),
+            }
+        };
+
+        let span = tracing::debug_span!("optimize peek task (mir)");
+
+        mz_ore::task::spawn_blocking(
+            || "optimize peek (MIR)",
+            move || {
+                let pipeline = || -> Result<optimize::peek::GlobalMirPlan, AdapterError> {
+                    let local_mir_plan = optimizer.catch_unwind_optimize(plan.source.clone())?;
+                    let local_mir_plan = local_mir_plan.resolve(ctx.session(), stats);
+                    let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
+
+                    Ok(global_mir_plan)
+                };
+                let _guard = span.enter();
+
+                let stage = match pipeline() {
+                    Ok(global_mir_plan) => PeekStage::RealTimeRecency(PeekStageRealTimeRecency {
+                        validity,
+                        plan,
+                        source_ids,
+                        id_bundle,
+                        target_replica,
+                        timeline_context,
+                        oracle_read_ts,
+                        in_immediate_multi_stmt_txn,
+                        optimizer,
+                        global_mir_plan,
+                    }),
+                    Err(err) => {
+                        return ctx.retire(Err(err.into()));
+                    }
+                };
+
+                let _ = internal_cmd_tx.send(Message::PeekStageReady {
+                    ctx,
+                    otel_ctx: root_otel_ctx,
+                    stage,
+                });
+            },
+        );
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
@@ -520,12 +513,10 @@ impl Coordinator {
 
         let timestamp_context = determination.clone().timestamp_context;
 
-        let span = tracing::debug_span!("optimize peek task (lir)");
-
         mz_ore::task::spawn_blocking(
             || "optimize peek (lir)",
             move || {
-                let _guard = span.enter();
+                let _span_guard = tracing::debug_span!(target: "optimizer", "optimize").entered();
 
                 let global_mir_plan =
                     global_mir_plan.resolve(timestamp_context.clone(), ctx.session_mut());

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -34,9 +34,9 @@ use crate::coord::timestamp_selection::{
     TimestampContext, TimestampDetermination, TimestampProvider,
 };
 use crate::coord::{
-    Coordinator, ExecuteContext, Message, PeekStage, PeekStageFinish, PeekStageOptimize,
-    PeekStageRealTimeRecency, PeekStageTimestamp, PeekStageValidate, PlanValidity,
-    RealTimeRecencyContext, TargetCluster,
+    Coordinator, ExecuteContext, Message, PeekStage, PeekStageFinish, PeekStageOptimizeLir,
+    PeekStageOptimizeMir, PeekStageRealTimeRecency, PeekStageTimestamp, PeekStageValidate,
+    PlanValidity, RealTimeRecencyContext, TargetCluster,
 };
 use crate::error::AdapterError;
 use crate::notice::AdapterNotice;
@@ -104,16 +104,21 @@ impl Coordinator {
                         .await;
                     return;
                 }
-                PeekStage::Optimize(stage) => {
-                    self.peek_stage_optimize(ctx, root_otel_ctx.clone(), stage)
+                PeekStage::OptimizeMir(stage) => {
+                    self.peek_stage_optimize_mir(ctx, root_otel_ctx.clone(), stage)
                         .await;
                     return;
                 }
                 PeekStage::RealTimeRecency(stage) => {
                     match self.peek_stage_real_time_recency(ctx, root_otel_ctx.clone(), stage) {
-                        Some((ctx, next)) => (ctx, PeekStage::Finish(next)),
+                        Some((ctx, next)) => (ctx, PeekStage::OptimizeLir(next)),
                         None => return,
                     }
+                }
+                PeekStage::OptimizeLir(stage) => {
+                    self.peek_stage_optimize_lir(ctx, root_otel_ctx.clone(), stage)
+                        .await;
+                    return;
                 }
                 PeekStage::Finish(stage) => {
                     let res = self.peek_stage_finish(&mut ctx, stage).await;
@@ -236,18 +241,19 @@ impl Coordinator {
 
         let internal_cmd_tx = self.internal_cmd_tx.clone();
 
-        let build_optimize_stage = move |oracle_read_ts: Option<Timestamp>| -> PeekStageOptimize {
-            PeekStageOptimize {
-                validity,
-                plan,
-                source_ids,
-                target_replica,
-                timeline_context,
-                oracle_read_ts,
-                in_immediate_multi_stmt_txn,
-                optimizer,
-            }
-        };
+        let build_optimize_stage =
+            move |oracle_read_ts: Option<Timestamp>| -> PeekStageOptimizeMir {
+                PeekStageOptimizeMir {
+                    validity,
+                    plan,
+                    source_ids,
+                    target_replica,
+                    timeline_context,
+                    oracle_read_ts,
+                    in_immediate_multi_stmt_txn,
+                    optimizer,
+                }
+            };
 
         match linearized_timeline {
             Some(timeline) => {
@@ -262,7 +268,7 @@ impl Coordinator {
                         let oracle_read_ts = shared_oracle.read_ts().instrument(span).await;
                         let stage = build_optimize_stage(Some(oracle_read_ts));
 
-                        let stage = PeekStage::Optimize(stage);
+                        let stage = PeekStage::OptimizeMir(stage);
                         // Ignore errors if the coordinator has shut down.
                         let _ = internal_cmd_tx.send(Message::PeekStageReady {
                             ctx,
@@ -277,7 +283,7 @@ impl Coordinator {
                     let oracle_read_ts = oracle.read_ts().await;
                     let stage = build_optimize_stage(Some(oracle_read_ts));
 
-                    let stage = PeekStage::Optimize(stage);
+                    let stage = PeekStage::OptimizeMir(stage);
                     // Ignore errors if the coordinator has shut down.
                     let _ = internal_cmd_tx.send(Message::PeekStageReady {
                         ctx,
@@ -288,7 +294,7 @@ impl Coordinator {
             }
             None => {
                 let stage = build_optimize_stage(None);
-                let stage = PeekStage::Optimize(stage);
+                let stage = PeekStage::OptimizeMir(stage);
                 // Ignore errors if the coordinator has shut down.
                 let _ = internal_cmd_tx.send(Message::PeekStageReady {
                     ctx,
@@ -300,11 +306,11 @@ impl Coordinator {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn peek_stage_optimize(
+    async fn peek_stage_optimize_mir(
         &mut self,
         ctx: ExecuteContext,
         root_otel_ctx: OpenTelemetryContext,
-        mut stage: PeekStageOptimize,
+        mut stage: PeekStageOptimizeMir,
     ) {
         // Generate data structures that can be moved to another task where we will perform possibly
         // expensive optimizations.
@@ -373,7 +379,7 @@ impl Coordinator {
         session: &Session,
         stats: Box<dyn StatisticsOracle>,
         id_bundle: CollectionIdBundle,
-        PeekStageOptimize {
+        PeekStageOptimizeMir {
             validity,
             plan,
             source_ids,
@@ -382,7 +388,7 @@ impl Coordinator {
             oracle_read_ts,
             in_immediate_multi_stmt_txn,
             mut optimizer,
-        }: PeekStageOptimize,
+        }: PeekStageOptimizeMir,
     ) -> Result<PeekStageRealTimeRecency, AdapterError> {
         let local_mir_plan = optimizer.catch_unwind_optimize(plan.source.clone())?;
         let local_mir_plan = local_mir_plan.resolve(session, stats);
@@ -419,7 +425,7 @@ impl Coordinator {
             optimizer,
             global_mir_plan,
         }: PeekStageRealTimeRecency,
-    ) -> Option<(ExecuteContext, PeekStageFinish)> {
+    ) -> Option<(ExecuteContext, PeekStageOptimizeLir)> {
         match self.recent_timestamp(ctx.session(), source_ids.iter().cloned()) {
             Some(fut) => {
                 let internal_cmd_tx = self.internal_cmd_tx.clone();
@@ -455,7 +461,7 @@ impl Coordinator {
             }
             None => Some((
                 ctx,
-                PeekStageFinish {
+                PeekStageOptimizeLir {
                     validity,
                     plan,
                     id_bundle: Some(id_bundle),
@@ -472,11 +478,12 @@ impl Coordinator {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn peek_stage_finish(
+    async fn peek_stage_optimize_lir(
         &mut self,
-        ctx: &mut ExecuteContext,
-        PeekStageFinish {
-            validity: _,
+        mut ctx: ExecuteContext,
+        root_otel_ctx: OpenTelemetryContext,
+        PeekStageOptimizeLir {
+            validity,
             plan,
             id_bundle,
             target_replica,
@@ -486,18 +493,20 @@ impl Coordinator {
             real_time_recency_ts,
             mut optimizer,
             global_mir_plan,
-        }: PeekStageFinish,
-    ) -> Result<ExecuteResponse, AdapterError> {
+        }: PeekStageOptimizeLir,
+    ) {
+        // Generate data structures that can be moved to another task where we will perform possibly
+        // expensive optimizations.
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
+
         let id_bundle = id_bundle.unwrap_or_else(|| {
             self.index_oracle(optimizer.cluster_id())
                 .sufficient_collections(&source_ids)
         });
 
-        let session = ctx.session_mut();
-        let conn_id = session.conn_id().clone();
         let determination = self
             .sequence_peek_timestamp(
-                session,
+                ctx.session_mut(),
                 &plan.when,
                 optimizer.cluster_id(),
                 timeline_context,
@@ -506,13 +515,63 @@ impl Coordinator {
                 &source_ids,
                 real_time_recency_ts,
             )
-            .await?;
+            .await;
+        let determination = return_if_err!(determination, ctx);
 
         let timestamp_context = determination.clone().timestamp_context;
-        let ts = timestamp_context.clone().timestamp_or_default();
 
-        let global_mir_plan = global_mir_plan.resolve(timestamp_context, session);
-        let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan)?;
+        let span = tracing::debug_span!("optimize peek task (lir)");
+
+        mz_ore::task::spawn_blocking(
+            || "optimize peek (lir)",
+            move || {
+                let _guard = span.enter();
+
+                let global_mir_plan =
+                    global_mir_plan.resolve(timestamp_context.clone(), ctx.session_mut());
+                let global_lir_plan =
+                    return_if_err!(optimizer.catch_unwind_optimize(global_mir_plan), ctx);
+
+                let stage = PeekStage::Finish(PeekStageFinish {
+                    validity,
+                    plan,
+                    id_bundle,
+                    target_replica,
+                    source_ids,
+                    determination,
+                    timestamp_context,
+                    optimizer,
+                    global_lir_plan,
+                });
+
+                // Ignore errors if the coordinator has shut down.
+                let _ = internal_cmd_tx.send(Message::PeekStageReady {
+                    ctx,
+                    otel_ctx: root_otel_ctx,
+                    stage,
+                });
+            },
+        );
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn peek_stage_finish(
+        &mut self,
+        ctx: &mut ExecuteContext,
+        PeekStageFinish {
+            validity: _,
+            plan,
+            id_bundle,
+            target_replica,
+            source_ids,
+            determination,
+            timestamp_context,
+            optimizer,
+            global_lir_plan,
+        }: PeekStageFinish,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        let session = ctx.session_mut();
+        let conn_id = session.conn_id().clone();
 
         let source_arity = global_lir_plan.typ().arity();
         let (peek_plan, df_meta) = global_lir_plan.unapply();
@@ -537,6 +596,7 @@ impl Coordinator {
         }
 
         if let Some(uuid) = ctx.extra().contents() {
+            let ts = timestamp_context.timestamp_or_default();
             let mut transitive_storage_deps = BTreeSet::new();
             let mut transitive_compute_deps = BTreeSet::new();
             for id in id_bundle

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -86,6 +86,10 @@ impl Optimizer {
         &self.finishing
     }
 
+    pub fn select_id(&self) -> GlobalId {
+        self.select_id
+    }
+
     pub fn index_id(&self) -> GlobalId {
         self.index_id
     }

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -175,6 +175,7 @@ pub struct ResolvedGlobal<'s> {
 
 /// The (final) result after MIR ⇒ LIR lowering and optimizing the resulting
 /// `DataflowDescription` with `LIR` plans.
+#[derive(Debug)]
 pub struct GlobalLirPlan {
     plan: PeekPlan,
     df_meta: DataflowMetainfo,

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -177,12 +177,16 @@ pub struct ResolvedGlobal<'s> {
 /// `DataflowDescription` with `LIR` plans.
 #[derive(Debug)]
 pub struct GlobalLirPlan {
-    plan: PeekPlan,
+    peek_plan: PeekPlan,
     df_meta: DataflowMetainfo,
     typ: RelationType,
 }
 
 impl GlobalLirPlan {
+    pub fn peek_plan(&self) -> &PeekPlan {
+        &self.peek_plan
+    }
+
     /// Return the output type for this [`GlobalLirPlan`].
     pub fn typ(&self) -> &RelationType {
         &self.typ
@@ -399,7 +403,7 @@ impl<'s> Optimize<GlobalMirPlan<ResolvedGlobal<'s>>> for Optimizer {
         //     .map(|(_key, (_desc, typ))| typ.clone())
         //     .expect("GlobalMirPlan type");
 
-        let plan = match create_fast_path_plan(
+        let peek_plan = match create_fast_path_plan(
             &mut df_desc,
             self.select_id,
             Some(&self.finishing),
@@ -467,13 +471,17 @@ impl<'s> Optimize<GlobalMirPlan<ResolvedGlobal<'s>>> for Optimizer {
             }
         };
 
-        Ok(GlobalLirPlan { plan, df_meta, typ })
+        Ok(GlobalLirPlan {
+            peek_plan,
+            df_meta,
+            typ,
+        })
     }
 }
 
 impl GlobalLirPlan {
     /// Unwraps the parts of the final result of the optimization pipeline.
     pub fn unapply(self) -> (PeekPlan, DataflowMetainfo) {
-        (self.plan, self.df_meta)
+        (self.peek_plan, self.df_meta)
     }
 }


### PR DESCRIPTION
This is the final part of the main tasks tracked in #24260.

### Motivation

  * This PR adds a feature that has not yet been specified.

Moved `EXPLAIN SELECT` off the coordinator thread.

### Tips for reviewer

Review individual commits with hidden whitespace changes.

* adapter: move all peek optimization stages off thread (re-apply)
  * repapply a commit reverted in #24579
* adapter: inline `optimize_peek` in `peek_stage_optimize_mir` (re-apply)
  * repapply a commit reverted in #24579
* adapter: prepare `peek_stage_optimize_~` stages for `EXPLAIN` path unification
  * Bring the `pipeline()` methods closer to what is needed in order to run `EXPLAIN` on the same threads.
* adapter: wire `ExplainContext` through most `PeekStage` variants
  * Add an `ExplainContext` parameter (similar to `create_materialized_view.rs` and `create_index.rs`)
* adapter: add `PeekStageExplain` stage
  * Add a new terminal `PeekStageExplain` stage (similar to `create_materialized_view.rs` and `create_index.rs`)


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. Relying on existing tests for that.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
