### PR TITLE
compute-client: move hydration status tracking to `Instance`

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -140,7 +140,7 @@ pub struct ComputeController<T> {
     response_tx: crossbeam_channel::Sender<ComputeControllerResponse<T>>,
 }
 
-impl<T> ComputeController<T> {
+impl<T: Timestamp> ComputeController<T> {
     /// Construct a new [`ComputeController`].
     pub fn new(
         build_info: &'static BuildInfo,
@@ -240,12 +240,7 @@ impl<T> ComputeController<T> {
     pub fn set_default_arrangement_exert_proportionality(&mut self, value: u32) {
         self.default_arrangement_exert_proportionality = value;
     }
-}
 
-impl<T> ComputeController<T>
-where
-    T: Clone,
-{
     /// Returns the read and write frontiers for each collection.
     pub fn collection_frontiers(&self) -> BTreeMap<GlobalId, (Antichain<T>, Antichain<T>)> {
         let collections = self.instances.values().flat_map(|i| i.collections_iter());
@@ -415,7 +410,7 @@ pub struct ActiveComputeController<'a, T> {
     storage: &'a mut dyn StorageController<Timestamp = T>,
 }
 
-impl<T> ActiveComputeController<'_, T> {
+impl<T: Timestamp> ActiveComputeController<'_, T> {
     pub fn instance_exists(&self, id: ComputeInstanceId) -> bool {
         self.compute.instance_exists(id)
     }
@@ -637,7 +632,7 @@ pub struct ComputeInstanceRef<'a, T> {
     instance: &'a Instance<T>,
 }
 
-impl<T> ComputeInstanceRef<'_, T> {
+impl<T: Timestamp> ComputeInstanceRef<'_, T> {
     /// Return the ID of this compute instance.
     pub fn instance_id(&self) -> ComputeInstanceId {
         self.instance_id

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -39,8 +39,8 @@ use crate::controller::{
     CollectionState, ComputeControllerResponse, IntrospectionUpdates, ReplicaId,
 };
 use crate::logging::LogVariant;
-use crate::metrics::InstanceMetrics;
-use crate::metrics::UIntGauge;
+use crate::metrics::{InstanceMetrics, ReplicaMetrics};
+use crate::metrics::{ReplicaCollectionMetrics, UIntGauge};
 use crate::protocol::command::{
     ComputeCommand, ComputeParameters, InstanceConfig, Peek, PeekTarget,
 };
@@ -154,7 +154,7 @@ pub(super) struct Instance<T> {
     metrics: InstanceMetrics,
 }
 
-impl<T> Instance<T> {
+impl<T: Timestamp> Instance<T> {
     /// Acquire a handle to the collection state associated with `id`.
     pub fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, CollectionMissing> {
         self.collections.get(&id).ok_or(CollectionMissing(id))
@@ -172,14 +172,76 @@ impl<T> Instance<T> {
         self.collections.iter()
     }
 
-    fn add_collection(&mut self, id: GlobalId, state: CollectionState<T>) {
+    /// Add a collection to the instance state.
+    fn add_collection(
+        &mut self,
+        id: GlobalId,
+        as_of: Antichain<T>,
+        storage_dependencies: Vec<GlobalId>,
+        compute_dependencies: Vec<GlobalId>,
+    ) {
+        // Add global collection state.
+        let state = CollectionState::new(as_of.clone(), storage_dependencies, compute_dependencies);
         self.collections.insert(id, state);
+
+        // Add per-replica collection state.
+        for replica in self.replicas.values_mut() {
+            replica.add_collection(id, as_of.clone());
+        }
+
+        // Update introspection.
         self.report_dependency_updates(id, 1);
     }
 
     fn remove_collection(&mut self, id: GlobalId) {
+        // Update introspection.
         self.report_dependency_updates(id, -1);
+
+        // Remove per-replica collection state.
+        for replica in self.replicas.values_mut() {
+            replica.remove_collection(id);
+        }
+
+        // Remove global collection state.
         self.collections.remove(&id);
+    }
+
+    fn add_replica_state(
+        &mut self,
+        id: ReplicaId,
+        client: ReplicaClient<T>,
+        config: ReplicaConfig,
+    ) {
+        let metrics = self.metrics.for_replica(id);
+        let mut replica =
+            ReplicaState::new(id, client, config, metrics, self.introspection_tx.clone());
+
+        // Add per-replica collection state.
+        for (collection_id, collection) in &self.collections {
+            let as_of = collection.read_frontier().to_owned();
+            replica.add_collection(*collection_id, as_of);
+        }
+
+        self.replicas.insert(id, replica);
+    }
+
+    fn remove_replica_state(&mut self, id: ReplicaId) -> Option<ReplicaState<T>> {
+        let Some(replica) = self.replicas.remove(&id) else {
+            return None;
+        };
+
+        if let Some(time) = replica.last_heartbeat {
+            let row = Row::pack_slice(&[
+                Datum::String(&id.to_string()),
+                Datum::TimestampTz(time.try_into().expect("must fit")),
+            ]);
+            self.deliver_introspection_updates(
+                IntrospectionType::ComputeReplicaHeartbeats,
+                vec![(row, -1)],
+            );
+        }
+
+        Some(replica)
     }
 
     /// Enqueue the given response for delivery to the controller clients.
@@ -292,6 +354,51 @@ impl<T> Instance<T> {
             .collect();
 
         self.deliver_introspection_updates(IntrospectionType::ComputeDependencies, updates);
+    }
+
+    /// Update the tracked hydration status for the given collection and replica according to an
+    /// observed frontier update.
+    fn update_hydration_status(
+        &mut self,
+        id: GlobalId,
+        replica_id: ReplicaId,
+        frontier: &Antichain<T>,
+    ) {
+        let Some(replica) = self.replicas.get_mut(&replica_id) else {
+            tracing::error!(
+                %id, %replica_id, frontier = ?frontier.elements(),
+                "frontier update for an unknown replica"
+            );
+            return;
+        };
+        let Some(collection) = replica.collections.get_mut(&id) else {
+            tracing::error!(
+                %id, %replica_id, frontier = ?frontier.elements(),
+                "frontier update for an unknown collection"
+            );
+            return;
+        };
+
+        // We may have already reported successful hydration before, in which case we have nothing
+        // left to do.
+        if collection.hydrated() {
+            return;
+        }
+
+        // If the observed frontier is not greater than the collection's as-of, the collection has
+        // not yet produced any output and is therefore not hydrated yet.
+        if !PartialOrder::less_than(&collection.as_of, frontier) {
+            return;
+        }
+
+        // Update metrics if we are maintaining them for this collection.
+        if let Some(metrics) = &collection.metrics {
+            let duration = collection.created_at.elapsed().as_secs_f64();
+            metrics.initial_output_duration_seconds.set(duration);
+        }
+
+        // Set the hydration flag.
+        collection.hydration_flag.set();
     }
 
     /// Clean up collection state that is not needed anymore.
@@ -587,22 +694,21 @@ where
 
         let replica_epoch = self.compute.replica_epochs.entry(id).or_default();
         *replica_epoch += 1;
+        let metrics = self.compute.metrics.for_replica(id);
         let client = ReplicaClient::spawn(
             id,
             self.compute.build_info,
             config.clone(),
             ClusterStartupEpoch::new(self.compute.envd_epoch, *replica_epoch),
-            self.compute.metrics.for_replica(id),
-            self.compute.introspection_tx.clone(),
+            metrics.clone(),
         );
-        let replica = ReplicaState::new(client, config);
 
         // Take this opportunity to clean up the history we should present.
         self.compute.history.reduce();
 
         // Replay the commands at the client, creating new dataflow identifiers.
         for command in self.compute.history.iter() {
-            if replica.client.send(command.clone()).is_err() {
+            if client.send(command.clone()).is_err() {
                 // We swallow the error here. On the next send, we will fail again, and
                 // restart the connection as well as this rehydration.
                 tracing::warn!("Replica {:?} connection terminated during hydration", id);
@@ -611,33 +717,19 @@ where
         }
 
         // Add replica to tracked state.
-        self.compute.replicas.insert(id, replica);
+        self.compute.add_replica_state(id, client, config);
 
         Ok(())
     }
 
     /// Remove an existing instance replica, by ID.
     pub fn remove_replica(&mut self, id: ReplicaId) -> Result<(), ReplicaMissing> {
-        let replica = self
-            .compute
-            .replicas
-            .remove(&id)
+        self.compute
+            .remove_replica_state(id)
             .ok_or(ReplicaMissing(id))?;
 
         // Remove frontier tracking for this replica.
         self.remove_write_frontiers(id);
-
-        // Remove introspection for this replica.
-        if let Some(time) = replica.last_heartbeat {
-            let row = Row::pack_slice(&[
-                Datum::String(&id.to_string()),
-                Datum::TimestampTz(time.try_into().expect("must fit")),
-            ]);
-            self.compute.deliver_introspection_updates(
-                IntrospectionType::ComputeReplicaHeartbeats,
-                vec![(row, -1)],
-            );
-        }
 
         // Subscribes targeting this replica either won't be served anymore (if the replica is
         // dropped) or might produce inconsistent output (if the target collection is an
@@ -793,11 +885,9 @@ where
         for export_id in dataflow.export_ids() {
             self.compute.add_collection(
                 export_id,
-                CollectionState::new(
-                    as_of.clone(),
-                    storage_dependencies.clone(),
-                    compute_dependencies.clone(),
-                ),
+                as_of.clone(),
+                storage_dependencies.clone(),
+                compute_dependencies.clone(),
             );
             updates.push((export_id, replica_write_frontier.clone()));
         }
@@ -1321,6 +1411,8 @@ where
             }
         }
 
+        self.compute
+            .update_hydration_status(id, replica_id, &new_frontier);
         self.update_write_frontiers(replica_id, &[(id, new_frontier)]);
     }
 
@@ -1374,6 +1466,9 @@ where
             SubscribeResponse::Batch(batch) => batch.upper.clone(),
             SubscribeResponse::DroppedAt(_) => Antichain::new(),
         };
+
+        self.compute
+            .update_hydration_status(subscribe_id, replica_id, &write_frontier);
         self.update_write_frontiers(replica_id, &[(subscribe_id, write_frontier)]);
 
         // If the subscribe is not tracked, or targets a different replica, there is nothing to do.
@@ -1480,10 +1575,18 @@ impl<T: Timestamp> ActiveSubscribe<T> {
 /// State maintained about individual replicas.
 #[derive(Debug)]
 pub struct ReplicaState<T> {
+    /// The ID of the replica.
+    id: ReplicaId,
     /// Client for the running replica task.
     client: ReplicaClient<T>,
     /// The replica configuration.
     config: ReplicaConfig,
+    /// Replica metrics.
+    metrics: ReplicaMetrics,
+    /// A channel through which introspection updates are delivered.
+    introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
+    /// Per-replica collection state.
+    collections: BTreeMap<GlobalId, ReplicaCollectionState<T>>,
     /// Whether the replica has failed and requires rehydration.
     failed: bool,
     /// The time of the last reported heartbeat.
@@ -1491,12 +1594,135 @@ pub struct ReplicaState<T> {
 }
 
 impl<T> ReplicaState<T> {
-    fn new(client: ReplicaClient<T>, config: ReplicaConfig) -> Self {
+    fn new(
+        id: ReplicaId,
+        client: ReplicaClient<T>,
+        config: ReplicaConfig,
+        metrics: ReplicaMetrics,
+        introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
+    ) -> Self {
         Self {
+            id,
             client,
             config,
+            metrics,
+            introspection_tx,
+            collections: Default::default(),
             failed: false,
             last_heartbeat: None,
         }
+    }
+
+    /// Add a collection to the replica state.
+    fn add_collection(&mut self, id: GlobalId, as_of: Antichain<T>) {
+        let metrics = self.metrics.for_collection(id);
+        let hydration_flag = HydrationFlag::new(self.id, id, self.introspection_tx.clone());
+        let state = ReplicaCollectionState {
+            metrics,
+            created_at: Instant::now(),
+            as_of,
+            hydration_flag,
+        };
+        self.collections.insert(id, state);
+    }
+
+    /// Remove state for a collection.
+    fn remove_collection(&mut self, id: GlobalId) -> Option<ReplicaCollectionState<T>> {
+        self.collections.remove(&id)
+    }
+}
+
+#[derive(Debug)]
+struct ReplicaCollectionState<T> {
+    /// Metrics tracked for this collection.
+    ///
+    /// If this is `None`, no metrics are collected.
+    metrics: Option<ReplicaCollectionMetrics>,
+    /// Time at which this collection was installed.
+    created_at: Instant,
+    /// As-of frontier with which this collection was installed on the replica.
+    as_of: Antichain<T>,
+    /// Tracks whether this collection is hydrated, i.e., it has produced some initial output.
+    hydration_flag: HydrationFlag,
+}
+
+impl<T> ReplicaCollectionState<T> {
+    /// Returns whether this collection is hydrated.
+    fn hydrated(&self) -> bool {
+        self.hydration_flag.hydrated
+    }
+}
+
+/// A wrapper type that maintains hydration introspection for a given replica and collection, and
+/// ensures that reported introspection data is retracted when the flag is dropped.
+#[derive(Debug)]
+struct HydrationFlag {
+    replica_id: ReplicaId,
+    collection_id: GlobalId,
+    hydrated: bool,
+    introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
+}
+
+impl HydrationFlag {
+    /// Create a new unset `HydrationFlag` and update introspection.
+    fn new(
+        replica_id: ReplicaId,
+        collection_id: GlobalId,
+        introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
+    ) -> Self {
+        let self_ = Self {
+            replica_id,
+            collection_id,
+            hydrated: false,
+            introspection_tx,
+        };
+
+        let insertion = self_.row();
+        self_.send(vec![(insertion, 1)]);
+
+        self_
+    }
+
+    /// Mark the collection as hydrated and update introspection.
+    fn set(&mut self) {
+        if self.hydrated {
+            return; // nothing to do
+        }
+
+        let retraction = self.row();
+        self.hydrated = true;
+        let insertion = self.row();
+
+        self.send(vec![(retraction, -1), (insertion, 1)]);
+    }
+
+    fn row(&self) -> Row {
+        Row::pack_slice(&[
+            Datum::String(&self.collection_id.to_string()),
+            Datum::String(&self.replica_id.to_string()),
+            Datum::from(self.hydrated),
+        ])
+    }
+
+    fn send(&self, updates: Vec<(Row, Diff)>) {
+        let result = self
+            .introspection_tx
+            .send((IntrospectionType::ComputeHydrationStatus, updates));
+
+        if result.is_err() {
+            // The global controller holds on to the `introspection_rx`. So when we get here that
+            // probably means that the controller was dropped and the process is shutting down, in
+            // which case we don't care about introspection updates anymore.
+            tracing::info!(
+                "discarding `ComputeHydrationStatus` update because the receiver disconnected"
+            );
+        }
+    }
+}
+
+impl Drop for HydrationFlag {
+    fn drop(&mut self) {
+        let retraction = self.row();
+        self.send(vec![(retraction, -1)]);
     }
 }

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -9,8 +9,7 @@
 
 //! A client for replicas of a compute instance.
 
-use std::collections::BTreeMap;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use anyhow::bail;
 use differential_dataflow::lattice::Lattice;
@@ -18,22 +17,19 @@ use mz_build_info::BuildInfo;
 use mz_cluster_client::client::{ClusterReplicaLocation, ClusterStartupEpoch, TimelyConfig};
 use mz_ore::retry::Retry;
 use mz_ore::task::AbortOnDropHandle;
-use mz_repr::{Datum, Diff, GlobalId, Row};
 use mz_service::client::{GenericClient, Partitioned};
 use mz_service::params::GrpcClientParameters;
-use mz_storage_client::controller::IntrospectionType;
-use timely::progress::{Antichain, Timestamp};
-use timely::PartialOrder;
+use timely::progress::Timestamp;
 use tokio::select;
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tracing::{debug, info, trace, warn};
 
-use crate::controller::{IntrospectionUpdates, ReplicaId};
+use crate::controller::ReplicaId;
 use crate::logging::LoggingConfig;
-use crate::metrics::{ReplicaCollectionMetrics, ReplicaMetrics};
+use crate::metrics::ReplicaMetrics;
 use crate::protocol::command::{ComputeCommand, InstanceConfig};
-use crate::protocol::response::{ComputeResponse, SubscribeResponse};
+use crate::protocol::response::ComputeResponse;
 use crate::service::{ComputeClient, ComputeGrpcClient};
 
 type Client<T> = Partitioned<ComputeGrpcClient, ComputeCommand<T>, ComputeResponse<T>>;
@@ -78,7 +74,6 @@ where
         config: ReplicaConfig,
         epoch: ClusterStartupEpoch,
         metrics: ReplicaMetrics,
-        introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
     ) -> Self {
         // Launch a task to handle communication with the replica
         // asynchronously. This isolates the main controller thread from
@@ -94,10 +89,8 @@ where
                 config: config.clone(),
                 command_rx,
                 response_tx,
-                introspection_tx,
                 epoch,
                 metrics: metrics.clone(),
-                collections: Default::default(),
             }
             .run(),
         );
@@ -144,15 +137,11 @@ struct ReplicaTask<T> {
     command_rx: UnboundedReceiver<ComputeCommand<T>>,
     /// A channel upon which responses from the replica are delivered.
     response_tx: UnboundedSender<ComputeResponse<T>>,
-    /// A channel upon which the replica task delivers introspection updates.
-    introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
     /// A number (technically, pair of numbers) identifying this incarnation of the replica.
     /// The semantics of this don't matter, except that it must strictly increase.
     epoch: ClusterStartupEpoch,
     /// Replica metrics.
     metrics: ReplicaMetrics,
-    /// Tracked collection state.
-    collections: BTreeMap<GlobalId, CollectionState<T>>,
 }
 
 impl<T> ReplicaTask<T>
@@ -279,24 +268,6 @@ where
         }
     }
 
-    /// Start tracking the given collection.
-    fn add_collection(&mut self, id: GlobalId, as_of: Antichain<T>) {
-        let metrics = self.metrics.for_collection(id);
-        let hydration_flag = HydrationFlag::new(self.replica_id, id, self.introspection_tx.clone());
-        let state = CollectionState {
-            metrics,
-            hydration_flag,
-            created_at: Instant::now(),
-            as_of,
-        };
-        self.collections.insert(id, state);
-    }
-
-    /// Stop tracking the given collection.
-    fn remove_collection(&mut self, id: GlobalId) {
-        self.collections.remove(&id);
-    }
-
     /// Update task state according to an observed command.
     fn observe_command(&mut self, command: &ComputeCommand<T>) {
         trace!(
@@ -306,26 +277,6 @@ where
         );
 
         self.metrics.inner.command_queue_size.dec();
-
-        // Initialize or drop per-collection state.
-        match command {
-            ComputeCommand::CreateInstance(config) => {
-                for &id in config.logging.index_logs.values() {
-                    let as_of = Antichain::from_elem(T::minimum());
-                    self.add_collection(id, as_of);
-                }
-            }
-            ComputeCommand::CreateDataflow(dataflow) => {
-                for id in dataflow.export_ids() {
-                    let as_of = dataflow.as_of.clone().unwrap();
-                    self.add_collection(id, as_of);
-                }
-            }
-            ComputeCommand::AllowCompaction { id, frontier } if frontier.is_empty() => {
-                self.remove_collection(*id);
-            }
-            _ => (),
-        }
     }
 
     /// Update task state according to an observed response.
@@ -337,137 +288,5 @@ where
         );
 
         self.metrics.inner.response_queue_size.inc();
-
-        // Apply changes to the `initial_output_duration_seconds` metric.
-        let collection_frontier = match response {
-            ComputeResponse::FrontierUpper { id, upper } => Some((id, upper.clone())),
-            ComputeResponse::SubscribeResponse(id, resp) => match resp {
-                SubscribeResponse::Batch(batch) => Some((id, batch.upper.clone())),
-                SubscribeResponse::DroppedAt(_) => Some((id, Antichain::new())),
-            },
-            _ => None,
-        };
-        if let Some((id, frontier)) = collection_frontier {
-            self.observe_collection_frontier_update(*id, &frontier)
-        }
-    }
-
-    /// Update task state according to an observed collection frontier update.
-    fn observe_collection_frontier_update(&mut self, id: GlobalId, frontier: &Antichain<T>) {
-        let Some(collection) = self.collections.get_mut(&id) else {
-            return;
-        };
-
-        // We currently only report on completed hydration. If the collection is already hydrated
-        // we have nothing to do.
-        if collection.hydrated() {
-            return;
-        }
-
-        // If the observed frontier is not greater than the collection's as-of, the collection has
-        // not yet produced any output and is therefore not hydrated yet.
-        if !PartialOrder::less_than(&collection.as_of, frontier) {
-            return;
-        }
-
-        // Update metrics if we are maintaining them for this collection.
-        if let Some(metrics) = &collection.metrics {
-            let duration = collection.created_at.elapsed().as_secs_f64();
-            metrics.initial_output_duration_seconds.set(duration);
-        }
-
-        // Set the hydration flag.
-        collection.hydration_flag.set();
-    }
-}
-
-/// State tracked for a compute collection.
-struct CollectionState<T> {
-    /// Metrics tracked for this collection.
-    ///
-    /// If this is `None`, no metrics are collected.
-    metrics: Option<ReplicaCollectionMetrics>,
-    /// Tracks whether this collection is hydrated, i.e., it has produced some initial output.
-    hydration_flag: HydrationFlag,
-    /// Time at which this collection was installed.
-    created_at: Instant,
-    /// Original as_of of this collection.
-    as_of: Antichain<T>,
-}
-
-impl<T: Timestamp> CollectionState<T> {
-    fn hydrated(&self) -> bool {
-        self.hydration_flag.hydrated
-    }
-}
-
-/// A wrapper type that maintains hydration introspection for a given replica and collection, and
-/// ensures that reported introspection data is retracted when the flag is dropped.
-struct HydrationFlag {
-    replica_id: ReplicaId,
-    collection_id: GlobalId,
-    hydrated: bool,
-    introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
-}
-
-impl HydrationFlag {
-    /// Create a new unset `HydrationFlag` and update introspection.
-    fn new(
-        replica_id: ReplicaId,
-        collection_id: GlobalId,
-        introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
-    ) -> Self {
-        let self_ = Self {
-            replica_id,
-            collection_id,
-            hydrated: false,
-            introspection_tx,
-        };
-
-        let insertion = self_.row();
-        self_.send(vec![(insertion, 1)]);
-
-        self_
-    }
-
-    /// Mark the collection as hydrated and update introspection.
-    fn set(&mut self) {
-        if self.hydrated {
-            return; // nothing to do
-        }
-
-        let retraction = self.row();
-        self.hydrated = true;
-        let insertion = self.row();
-
-        self.send(vec![(retraction, -1), (insertion, 1)]);
-    }
-
-    fn row(&self) -> Row {
-        Row::pack_slice(&[
-            Datum::String(&self.collection_id.to_string()),
-            Datum::String(&self.replica_id.to_string()),
-            Datum::from(self.hydrated),
-        ])
-    }
-
-    fn send(&self, updates: Vec<(Row, Diff)>) {
-        let result = self
-            .introspection_tx
-            .send((IntrospectionType::ComputeHydrationStatus, updates));
-
-        if result.is_err() {
-            // The global controller holds on to the `introspection_rx`. So when we get here that
-            // probably means that the controller was dropped and the process is shutting down, in
-            // which case we don't care about introspection updates anymore.
-            info!("discarding `ComputeHydrationStatus` update because the receiver disconnected");
-        }
-    }
-}
-
-impl Drop for HydrationFlag {
-    fn drop(&mut self) {
-        let retraction = self.row();
-        self.send(vec![(retraction, -1)]);
     }
 }

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -169,7 +169,7 @@ pub struct Controller<T = mz_repr::Timestamp> {
     immediate_watch_sets: Vec<Box<dyn Any>>,
 }
 
-impl<T> Controller<T> {
+impl<T: Timestamp> Controller<T> {
     pub fn active_compute(&mut self) -> ActiveComputeController<T> {
         self.compute.activate(&mut *self.storage)
     }

--- a/test/testdrive/hydration-status.td
+++ b/test/testdrive/hydration-status.td
@@ -44,6 +44,7 @@ s true
 > CREATE TABLE t (a int)
 > CREATE INDEX idx ON t (a)
 > CREATE MATERIALIZED VIEW mv AS SELECT * FROM t
+> CREATE MATERIALIZED VIEW mv_const AS SELECT 1
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
@@ -52,8 +53,9 @@ s true
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
-idx hydrated_test_1 true
-mv  hydrated_test_1 true
+idx      hydrated_test_1 true
+mv       hydrated_test_1 true
+mv_const hydrated_test_1 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
@@ -62,8 +64,9 @@ mv  hydrated_test_1 true
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
-idx hydrated_test_1 true
-mv  hydrated_test_1 true
+idx      hydrated_test_1 true
+mv       hydrated_test_1 true
+mv_const hydrated_test_1 true
 
 # Test adding new replicas.
 
@@ -76,10 +79,12 @@ mv  hydrated_test_1 true
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
-idx hydrated_test_1 true
-idx hydrated_test_2 true
-mv  hydrated_test_1 true
-mv  hydrated_test_2 true
+idx      hydrated_test_1 true
+idx      hydrated_test_2 true
+mv       hydrated_test_1 true
+mv       hydrated_test_2 true
+mv_const hydrated_test_1 true
+mv_const hydrated_test_2 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
@@ -88,10 +93,12 @@ mv  hydrated_test_2 true
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
-idx hydrated_test_1 true
-idx hydrated_test_2 true
-mv  hydrated_test_1 true
-mv  hydrated_test_2 true
+idx      hydrated_test_1 true
+idx      hydrated_test_2 true
+mv       hydrated_test_1 true
+mv       hydrated_test_2 true
+mv_const hydrated_test_1 true
+mv_const hydrated_test_2 true
 
 # Test dropping replicas.
 
@@ -104,8 +111,9 @@ mv  hydrated_test_2 true
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
-idx hydrated_test_2 true
-mv  hydrated_test_2 true
+idx      hydrated_test_2 true
+mv       hydrated_test_2 true
+mv_const hydrated_test_2 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
@@ -114,8 +122,9 @@ mv  hydrated_test_2 true
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
-idx hydrated_test_2 true
-mv  hydrated_test_2 true
+idx      hydrated_test_2 true
+mv       hydrated_test_2 true
+mv_const hydrated_test_2 true
 
 > DROP CLUSTER REPLICA test.hydrated_test_2
 
@@ -146,8 +155,9 @@ mv  hydrated_test_2 true
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
-idx hydrated_test_3 true
-mv  hydrated_test_3 true
+idx      hydrated_test_3 true
+mv       hydrated_test_3 true
+mv_const hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
@@ -156,10 +166,12 @@ mv  hydrated_test_3 true
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
-idx hydrated_test_3 true
-mv  hydrated_test_3 true
+idx      hydrated_test_3 true
+mv       hydrated_test_3 true
+mv_const hydrated_test_3 true
 
 > DROP INDEX idx;
+> DROP MATERIALIZED VIEW mv_const;
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h


### PR DESCRIPTION
This PR moves the hydration status tracking for compute collections based on their frontiers from the `ReplicaTask` to the `Instance` controller.

This prepares us for a world in which the compute controller allows replicas to drop their compute resources for collections that are still considered alive by the controller. In this world the controller might send an `AllowCompaction([])` command for a collection even though that collection has not yet been dropped, so we would like to keep around the introspection data about its hydration status. However, the `ReplicaTask` does not know about the drop status of collections since it only observes compute commands, so it might drop the hydration status data too soon. Moving the hydration status tracking to the `Instance` solves this issue.

### Motivation

  * This PR fixes a recognized bug.

This unblocks https://github.com/MaterializeInc/materialize/pull/24487, which is a fix for https://github.com/MaterializeInc/materialize/issues/24469.

### Tips for reviewer

Commits can be reviewed separately.

The last commit is not strictly related to this change, but plugs a whole in our hydration status tests that occurred to me while working on it.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
