### PR TITLE
test: disable known-flaky test in test/pg-cdc/pg-cdc.td

### DIFF
--- a/src/postgres-util/src/replication.rs
+++ b/src/postgres-util/src/replication.rs
@@ -124,7 +124,10 @@ pub async fn drop_replication_slots(
         match rows.len() {
             0 => {
                 // DROP_REPLICATION_SLOT will error if the slot does not exist
-                // todo@jldlaughlin: don't let invalid Postgres sources ship!
+                tracing::info!(
+                    "drop_replication_slots called on non-existent slot {}",
+                    slot
+                );
                 continue;
             }
             1 => {

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -322,6 +322,7 @@ async fn ensure_replication_slot(client: &Client, slot: &str) -> Result<(), Tran
         Ok(_) => Ok(()),
         // If the slot already exists that's still ok
         Err(PostgresError::Postgres(err)) if err.code() == Some(&SqlState::DUPLICATE_OBJECT) => {
+            tracing::trace!("replication slot {slot} already existed");
             Ok(())
         }
         Err(err) => Err(TransientError::PostgresError(err)),

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -202,7 +202,6 @@ impl SourceRender for PostgresSourceConnection {
             let update = HealthStatusUpdate::halting(err_string.clone(), None);
 
             let namespace = match err {
-                // Is there a better way to reach into an Rc?
                 ReplicationError::Transient(err)
                     if matches!(
                         &*err,

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -188,6 +188,8 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             let replication_client = connection_config.connect_replication(
                 &config.config.connection_context.ssh_tunnel_manager,
             ).await?;
+
+            tracing::info!(%id, "ensuring replication slot {slot} exists");
             super::ensure_replication_slot(&replication_client, slot).await?;
             let slot_lsn = super::fetch_slot_resume_lsn(&replication_client, slot).await?;
 

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -148,7 +148,8 @@ CREATE PUBLICATION another_publication FOR TABLE another_schema.another_table;
 
 #
 # Test that slots created for replication sources are deleted on DROP
-$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=materialize_% active=false
+# TODO: enable once we land #24586
+# $ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=materialize_% active=false
 
 # Sneak in a test for pg_source_snapshot_statement_timeout
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
@@ -168,7 +169,8 @@ test_slot_source_progress progress
 
 > DROP SOURCE test_slot_source
 
-$ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=materialize_% active=false
+# TODO: enable once we land #24586
+# $ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=materialize_% active=false
 
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET pg_source_snapshot_statement_timeout = 0


### PR DESCRIPTION
We can't yet fix #24357, so disable the test for the time being.

### Motivation

This PR mitigates the CI impact of a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
