### PR TITLE
data-ingest: Put CREATE SOURCE behind a retry loop

### DIFF
--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -459,6 +459,7 @@ class KafkaRoundtripExecutor(Executor):
                 required_error_message_substrs=[
                     "No value schema found",
                     "Key schema is required for ENVELOPE DEBEZIUM",
+                    "Topic does not exist",
                 ],
             )
         self.mz_conn.autocommit = False

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -216,7 +216,7 @@ class KafkaExecutor(Executor):
 
         self.mz_conn.autocommit = True
         with self.mz_conn.cursor() as cur:
-            self.execute(
+            self.execute_with_retry_on_error(
                 cur,
                 f"""CREATE SOURCE {identifier(self.database)}.{identifier(self.schema)}.{identifier(self.table)}
                     {f"IN CLUSTER {identifier(self.cluster)}" if self.cluster else ""}
@@ -224,6 +224,9 @@ class KafkaExecutor(Executor):
                     FORMAT AVRO
                     USING CONFLUENT SCHEMA REGISTRY CONNECTION materialize.public.csr_conn
                     ENVELOPE UPSERT""",
+                required_error_message_substrs=[
+                    "Topic does not exist",
+                ],
             )
         self.mz_conn.autocommit = False
 


### PR DESCRIPTION
`CREATE SOURCE` was failing with `Topic does not exist.` . Without trying to reason if the topic is guaranteed to exist at that particular moment of time, just add a retry loop.


### Motivation

Nightly CI was failing:

```
	mzcompose: test case workflow-default failed: <class 'materialize.data_ingest.query_error.QueryError'>: ("{'S': 'ERROR', 'C': 'XX000', 'M': 'Topic does not exist'}", "CREATE SOURCE materialize.public.table_rt0\n \n FROM KAFKA CONNECTION kafka_conn (TOPIC 'data-ingest-rt-0')\n FORMAT AVRO\n USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn\n ENVELOPE DEBEZIUM")
```