### PR TITLE
feature-benchmark: Undo accidental change

### DIFF
--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -653,7 +653,7 @@ class Retraction(Dataflow):
     def before(self) -> Action:
         return TdAction(
             f"""
-> DROP TABLE IF EXISTS ten;
+> DROP TABLE IF EXISTS ten CASCADE;
 
 > CREATE TABLE ten (f1 INTEGER);
 
@@ -821,7 +821,7 @@ class FullOuterJoin(Dataflow):
 
 > DROP MATERIALIZED VIEW IF EXISTS v1 CASCADE;
 
-> DROP TABLE IF EXISTS ten CASCADE;
+> DROP TABLE IF EXISTS ten;
 
 > CREATE TABLE ten (f1 INTEGER);
 


### PR DESCRIPTION
Happened in https://github.com/MaterializeInc/materialize/pull/24501/files#diff-0323c9ed034f8755d0c049904d3e1dd7ffabc097c8121b4b8da9a4275fee031c

Didn't belong in this PR

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
