### PR TITLE
Revert "adapter: inline optimize_peek in peek_stage_optimize_mir"

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -34,7 +34,7 @@ use crate::command::Command;
 use crate::coord::appends::Deferred;
 use crate::coord::statement_logging::StatementLoggingId;
 use crate::coord::{
-    Coordinator, CreateConnectionValidationReady, Message, PeekStage, PeekStageOptimizeLir,
+    Coordinator, CreateConnectionValidationReady, Message, PeekStage, PeekStageFinish,
     PendingReadTxn, PlanValidity, PurifiedStatementReady, RealTimeRecencyContext,
 };
 use crate::session::Session;
@@ -861,7 +861,7 @@ impl Coordinator {
                 self.sequence_peek_stage(
                     ctx,
                     root_otel_ctx,
-                    PeekStage::OptimizeLir(PeekStageOptimizeLir {
+                    PeekStage::Finish(PeekStageFinish {
                         validity,
                         plan,
                         id_bundle: None,

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -175,7 +175,6 @@ pub struct ResolvedGlobal<'s> {
 
 /// The (final) result after MIR ⇒ LIR lowering and optimizing the resulting
 /// `DataflowDescription` with `LIR` plans.
-#[derive(Debug)]
 pub struct GlobalLirPlan {
     plan: PeekPlan,
     df_meta: DataflowMetainfo,


### PR DESCRIPTION
Reverting the last 2 commits from #24526 in order to fix the broken Nightlies test until I find the root cause for these issues.

### Motivation

  * This PR fixes a recognized bug.

Fixes broken Nightlies CI tests.

### Tips for reviewer

The issue must come from "adapter: move all peek optimization stages off thread", but I wasn't able to revert this cleanly without undoing the following inlining commit first.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([Nightlies runs](https://buildkite.com/materialize/nightlies/builds?branch=aalexandrov%3Asequence_peek_stages_revert))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
