### PR TITLE
sql: migrate some `~Plan` types from `Mir~` to `HirRelationExpr`

### DIFF
--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -57,11 +57,11 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
             },
         ),
         Plan::ExplainPlan(ExplainPlanPlan {
-            explainee: Explainee::Statement(ExplaineeStatement::Select { raw_plan, .. }),
+            explainee: Explainee::Statement(ExplaineeStatement::Select { plan, .. }),
             ..
         }) => (
-            raw_plan.depends_on(),
-            raw_plan.could_run_expensive_function(),
+            plan.source.depends_on(),
+            plan.source.could_run_expensive_function(),
         ),
         Plan::ExplainTimestamp(ExplainTimestampPlan { raw_plan, .. }) => (
             raw_plan.depends_on(),

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2009,23 +2009,17 @@ impl Coordinator {
         let root_dispatch = tracing::dispatcher::get_default(|d| d.clone());
 
         let pipeline_result = match stmt {
-            plan::ExplaineeStatement::Select {
-                raw_plan,
-                row_set_finishing,
-                desc,
-                when,
-                broken,
-            } => {
+            plan::ExplaineeStatement::Select { broken, plan, desc } => {
                 // Please see the doc comment on `explain_query_optimizer_pipeline` for more
                 // information regarding its subtleties.
                 self.explain_query_optimizer_pipeline(
-                    raw_plan,
+                    plan.source,
                     broken,
                     target_cluster,
                     ctx.session_mut(),
-                    row_set_finishing,
+                    plan.finishing,
                     desc,
-                    when,
+                    plan.when,
                     &config,
                     root_dispatch,
                 )

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2817,10 +2817,26 @@ impl Coordinator {
         mut ctx: ExecuteContext,
         plan: plan::InsertPlan,
     ) {
+        // The structure of this code originates from a time where
+        // `ReadThenWritePlan` was carrying an `MirRelationExpr` instead of an
+        // optimized `MirRelationExpr`.
+        //
+        // Ideally, we would like to make the `selection.as_const().is_some()`
+        // check on `plan.values` instead. However, `VALUES (1), (3)` statements
+        // are planned as a Wrap($n, $vals) call, so until we can reduce
+        // HirRelationExpr this will always returns false.
+        //
+        // Unfortunately, hitting the default path of the match below also
+        // causes a lot of tests to fail, so we opted to go with the extra
+        // `plan.values.clone()` statements when producing the `optimized_mir`
+        // and re-optimize the values in the `sequence_read_then_write` call.
         let optimized_mir = if let Some(..) = &plan.values.as_const() {
             // We don't perform any optimizations on an expression that is already
             // a constant for writes, as we want to maximize bulk-insert throughput.
-            let expr = return_if_err!(plan.values.lower(self.catalog().system_config()), ctx);
+            let expr = return_if_err!(
+                plan.values.clone().lower(self.catalog().system_config()),
+                ctx
+            );
             OptimizedMirRelationExpr(expr)
         } else {
             // Collect optimizer parameters.
@@ -2830,7 +2846,7 @@ impl Coordinator {
             let mut optimizer = optimize::view::Optimizer::new(optimizer_config);
 
             // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
-            return_if_err!(optimizer.optimize(plan.values), ctx)
+            return_if_err!(optimizer.optimize(plan.values.clone()), ctx)
         };
 
         match optimized_mir.into_inner() {
@@ -2843,7 +2859,7 @@ impl Coordinator {
                 });
             }
             // All non-constant values must be planned as read-then-writes.
-            selection => {
+            _ => {
                 let desc_arity = match self.catalog().try_get_entry(&plan.id) {
                     Some(table) => table
                         .desc(
@@ -2865,7 +2881,7 @@ impl Coordinator {
                     }
                 };
 
-                if selection.contains_temporal() {
+                if plan.values.contains_temporal() {
                     ctx.retire(Err(AdapterError::Unsupported(
                         "calls to mz_now in write statements",
                     )));
@@ -2881,7 +2897,7 @@ impl Coordinator {
 
                 let read_then_write_plan = plan::ReadThenWritePlan {
                     id: plan.id,
-                    selection,
+                    selection: plan.values,
                     finishing,
                     assignments: BTreeMap::new(),
                     kind: MutationKind::Insert,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -712,7 +712,7 @@ pub struct SetTransactionPlan {
 
 #[derive(Clone, Debug)]
 pub struct SelectPlan {
-    pub source: MirRelationExpr,
+    pub source: HirRelationExpr,
     pub when: QueryWhen,
     pub finishing: RowSetFinishing,
     pub copy_to: Option<CopyFormat>,
@@ -972,7 +972,7 @@ pub struct InsertPlan {
 #[derive(Debug)]
 pub struct ReadThenWritePlan {
     pub id: GlobalId,
-    pub selection: mz_expr::MirRelationExpr,
+    pub selection: HirRelationExpr,
     pub finishing: RowSetFinishing,
     pub assignments: BTreeMap<usize, mz_expr::MirScalarExpr>,
     pub kind: MutationKind,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -845,12 +845,10 @@ pub enum Explainee {
 pub enum ExplaineeStatement {
     /// The object to be explained is a SELECT statement.
     Select {
-        raw_plan: HirRelationExpr,
-        row_set_finishing: RowSetFinishing,
-        desc: RelationDesc,
-        when: QueryWhen,
         /// Broken flag (see [`ExplaineeStatement::broken()`]).
         broken: bool,
+        plan: plan::SelectPlan,
+        desc: RelationDesc,
     },
     /// The object to be explained is a CREATE MATERIALIZED VIEW.
     CreateMaterializedView {
@@ -869,7 +867,7 @@ pub enum ExplaineeStatement {
 impl ExplaineeStatement {
     pub fn depends_on(&self) -> BTreeSet<GlobalId> {
         match self {
-            Self::Select { raw_plan, .. } => raw_plan.depends_on(),
+            Self::Select { plan, .. } => plan.source.depends_on(),
             Self::CreateMaterializedView { plan, .. } => plan.materialized_view.expr.depends_on(),
             Self::CreateIndex { plan, .. } => btreeset! {plan.index.on},
         }
@@ -895,14 +893,10 @@ impl ExplaineeStatement {
 
     pub fn row_set_finishing(&self) -> Option<RowSetFinishing> {
         match self {
-            Self::Select {
-                row_set_finishing,
-                desc,
-                ..
-            } => {
-                if !row_set_finishing.is_trivial(desc.arity()) {
+            Self::Select { plan, desc, .. } => {
+                if !plan.finishing.is_trivial(desc.arity()) {
                     // Use the optional finishing extracted in the plan_query call.
-                    Some(row_set_finishing.clone())
+                    Some(plan.finishing.clone())
                 } else {
                     None
                 }

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -484,8 +484,9 @@ pub fn plan_explain_timestamp(
     }))
 }
 
-/// Plans and decorrelates a `Query`. Like `query::plan_root_query`, but returns
-/// an `mz_expr::MirRelationExpr`, which cannot include correlated expressions.
+/// Plans and decorrelates a [`Query`]. Like [`query::plan_root_query`], but
+/// returns an [`MirRelationExpr`], which cannot include correlated expressions.
+#[deprecated = "Use `query::plan_root_query` and use `HirRelationExpr` in `~Plan` structs."]
 pub fn plan_query(
     scx: &StatementContext,
     query: Query<Aug>,
@@ -615,6 +616,7 @@ pub fn plan_subscribe(
             (SubscribeFrom::Id(entry.id()), desc.into_owned(), scope)
         }
         SubscribeRelation::Query(query) => {
+            #[allow(deprecated)] // TODO(aalexandrov): Use HirRelationExpr in Subscribe
             let query = plan_query(scx, query, params, QueryLifetime::Subscribe)?;
             // There's no way to apply finishing operations to a `SUBSCRIBE` directly, so the
             // finishing should have already been turned into a `TopK` by
@@ -962,6 +964,7 @@ pub fn plan_copy(
                     if !stmt.query.order_by.is_empty() {
                         sql_bail!("ORDER BY is not supported in SELECT query for COPY statements")
                     }
+                    #[allow(deprecated)] // TODO(aalexandrov): Use HirRelationExpr in CopyToFrom
                     let PlannedRootQuery {
                         expr,
                         finishing,


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

The main motivation for this change is that we want the compute team to own HIR ⇒ MIR lowering and nowadays also consider it part of the optimization process. My current mental model (which I'm happy to change) is as follows:

* Planning should do `AST ⇒ HIR` and possibly some syntactic normalization that is best expressed as `HIR ⇒ HIR` transforms. IIRC HIR was first introduced to facilitate name resolution, so it should be a sufficient representation to complete the planning process (but I might be missing something here).
* Optimization should start with HIR plan and finish with an LIR plan that can be rendered. For example, some optimization work is realized as alternative HIR ⇒ MIR lowering paths (#22560, #24345).
 
Because of this, we want to extend various concerns that apply to all other parts of the optimizer extend to HIR. Examples are:

- `EXPLAIN`ing plans before and after HIR ⇒ MIR lowering,
- protecting the main thread against panics in the HIR ⇒ MIR lowering code,
- threading through other cross cutting concerns (metrics collection, notice collection, feature flags) in a unified manner.

All of the above are much easier to handle and maintain if we consider `HirRelationExpr` to be the entry point of the `Optimize` pipeline (so part of `sequence_~` where the `Optimize` instances are created).

I already changed [the representation for `View` and `MaterializedView` plan structs](https://github.com/MaterializeInc/materialize/pull/21973/files#diff-1f1679d8d239da84a9ffbf2f13bd615849ae62d4f93fdf4e945b43bcd1e56606L1251-L1265) some months ago in #21973 and I don't think we observed any regressions because of that, but maybe there is something unique to `SELECT` that warrants more careful consideration.

`EXPLAIN SELECT` already does decorrelation in the `sequence_~` code, but uses a different `~Plan` representation.
Since this we want to to unify the `EXPLAIN SELECT` and `SELECT` paths, I wanted to change `ExplaineeStatement::Select` to carry an `HirRelationExpr` similar to what was done in #21973 in order to pass the same struct in `peek_stage_`.

```rust
// In main
Select {
    raw_plan: HirRelationExpr,
    row_set_finishing: RowSetFinishing,
    desc: RelationDesc,
    when: QueryWhen,
    /// Broken flag (see [`ExplaineeStatement::broken()`]).
    broken: bool,
},

// In this PR, in order to be able pass the same `plan::SelectPlan` struct to
// `peek_stage_~` both when explaining and executing a SELECT statement.
Select {
    /// Broken flag (see [`ExplaineeStatement::broken()`]).
    broken: bool,
    plan: plan::SelectPlan,
    desc: RelationDesc,
},
```

AFAICT the only interface that is needed before the `sequence_` methods start optimizing the plan is 

- `CollectionPlan` (which is already implemented by `HirRelationExpr`), and
- the methods re-defined on top of `HirRelationExpr` in this PR.


### Tips for reviewer

* This was split off from #24569 so we can discuss and test only these changes in isolation.
* I deprecated `dml::plan_query` and instead removed its use from `plan_select`.
* There are multiple tests failing if I comment out the optimization path
   ```rust
   if selection.as_const().is_some() && plan.returning.is_empty() {
   ```
   in `sequence_insert` (even without any of the other changes in this PR). I'll open a follow-up issue and assign this to @MaterializeInc/adapter for further investigation.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
