### PR TITLE
Clarify that frontier advancements past the `until` are not suppressed

### DIFF
--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -60,6 +60,9 @@ pub struct DataflowDescription<P, S: 'static = (), T = mz_repr::Timestamp> {
     /// Frontier beyond which the dataflow should not execute.
     /// Specifically, updates at times greater or equal to this frontier are suppressed.
     /// This is often set to `as_of + 1` to enable "batch" computations.
+    /// Note that frontier advancements might still happen to times that are after the `until`,
+    /// only data is suppressed. (This is consistent with how frontier advancements can also
+    /// happen before the `as_of`.)
     pub until: Antichain<T>,
     /// Human readable name
     pub debug_name: String,

--- a/src/compute/src/sink/refresh.rs
+++ b/src/compute/src/sink/refresh.rs
@@ -112,10 +112,9 @@ where
                             // We are past the last refresh. Drop the capability to signal that we
                             // are done.
                             capability = None;
-                            // We can only get here if we see the frontier advancing to a time after
-                            // the last refresh, but not empty, which would be a bug somewhere in
-                            // the `until` handling.
-                            soft_panic_or_log!("frontier advancements after the `until` should be suppressed");
+                            // We can only get here if we see the frontier advancing to a time after the last refresh,
+                            // but not empty. This is ok, because even though we set the `until` to the last refresh,
+                            // frontier advancements might still happen past the `until`.
                         }
                     }
                 }


### PR DESCRIPTION
[We decided](https://materializeinc.slack.com/archives/CMNT2QSBZ/p1705589936930539?thread_ts=1705509940.786839&cid=CMNT2QSBZ) that we shouldn't expect `until` to suppress frontier advancements. This PR clarifies this in the doc comment of `until`, and removes a `soft_assert` that was firing for frontier advancements past the `until`.

(I didn't add a test, because somehow I couldn't get the assert to fire on main now, maybe due to some Storage changes in the meantime. But in any case, Dan [says](https://github.com/MaterializeInc/materialize/issues/24481#issuecomment-1898832348) Storage still won't guarantee frontier advancements past the `until`.)

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/24481

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
