### PR TITLE
build(deps): Update shlex 1.1.0 -> 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8199,9 +8199,9 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -1395,7 +1395,7 @@ version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.shlex]]
-version = "1.1.0"
+version = "1.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.signature]]


### PR DESCRIPTION
Following security advisory https://rustsec.org/advisories/RUSTSEC-2024-0006

via https://buildkite.com/materialize/security/builds/1127#018d31b2-e6ad-4b5c-86d8-eba6c51626e8

Test run is green: https://buildkite.com/materialize/security/builds/1128

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
