### PR TITLE
ci: Only one miri test job again

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -209,11 +209,10 @@ steps:
           queue: builder-linux-x86_64
 
       - id: miri-test
-        label: Miri test (fast) %N
+        label: Miri test (fast)
         inputs: [src]
         depends_on: []
-        parallelism: 2
-        timeout_in_minutes: 30
+        timeout_in_minutes: 45
         artifact_paths: [junit_*.xml, target/nextest/ci/junit_cargo-test.xml]
         plugins:
           - ./ci/plugins/scratch-aws-access: ~


### PR DESCRIPTION
Seems to have gotten faster recently, we probably excluded more slow tests too

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
