### PR TITLE
Allow for timezone when parsing an `mz_timestamp`

### DIFF
--- a/doc/user/content/sql/types/mz_timestamp.md
+++ b/doc/user/content/sql/types/mz_timestamp.md
@@ -28,7 +28,7 @@ Detail | Info
 For details about casting, including contexts, see [Functions:
 Cast](../../functions/cast).
 
-Integer and numeric casts must be in the form of milliseconds since the Unix epoch. Casting from `text` can be either also in the form of milliseconds since the Unix epoch or in a human-readable form that is the same as for the [`timestamp`](../timestamp) type.
+Integer and numeric casts must be in the form of milliseconds since the Unix epoch. Casting from `text` can be either also in the form of milliseconds since the Unix epoch or in a human-readable form that is the same as for the [`timestamptz`](../timestamptz) type.
 
 From | To | Required context
 -----|----|--------

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -17,7 +17,7 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize, Serializer};
 
 use crate::adt::numeric::Numeric;
-use crate::strconv::parse_timestamp;
+use crate::strconv::parse_timestamptz;
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.timestamp.rs"));
 
@@ -358,7 +358,7 @@ impl std::str::FromStr for Timestamp {
                 .parse::<u64>()
                 .map_err(|_| "could not parse as number of milliseconds since epoch".to_string())
                 .or_else(|err_num_of_millis| {
-                    parse_timestamp(s)
+                    parse_timestamptz(s)
                         .map_err(|parse_error| {
                             format!(
                                 "{}; could not parse as date and time: {}",

--- a/test/sqllogictest/mztimestamp.slt
+++ b/test/sqllogictest/mztimestamp.slt
@@ -44,22 +44,24 @@ SELECT *
 FROM intervals
 WHERE mz_now() BETWEEN a AND b;
 
-query TTBBB
+query TTBBBB
 SELECT
   '1702129950259'::mz_timestamp::text,
   '1990-01-04 11:00'::mz_timestamp::text,
   greatest('1990-01-04 11:00', mz_now()) > '1990-01-04 11:00'::mz_timestamp,
      least('1990-01-04 11:00', mz_now()) > '1990-01-04 11:00'::mz_timestamp,
-  greatest(mz_now(), '1990-01-04 11:00') > '3000-01-04 11:00'::mz_timestamp
+  greatest(mz_now(), '1990-01-04 11:00') > '3000-01-04 11:00'::mz_timestamp,
+  '1990-01-04 11:00+08'::mz_timestamp < '1990-01-04 11:00+06'::mz_timestamp;
 ----
 1702129950259
 631450800000
 true
 false
 false
+true
 
 # Bad timestamp string
-query error invalid input syntax for type mz_timestamp: could not parse mz_timestamp: could not parse as number of milliseconds since epoch; could not parse as date and time: invalid input syntax for type timestamp: YEAR, MONTH, DAY are all required: "1990\-01": "1990\-01"
+query error invalid input syntax for type mz_timestamp: could not parse mz_timestamp: could not parse as number of milliseconds since epoch; could not parse as date and time: invalid input syntax for type timestamp with time zone: YEAR, MONTH, DAY are all required: "1990\-01": "1990\-01"
 SELECT '1990-01'::mz_timestamp;
 
 # This would be negative milliseconds since the Unix epoch


### PR DESCRIPTION
A user would like to use time zones in `ALIGNED TO`, which is planned as a cast to `mz_timestamp`. This PR modifies `Timestamp::from_str` (which is called for a text to mz_timestamp cast) to call `parse_timestamptz` instead of `parse_timestamp`.

### Motivation

  * This PR adds a known-desirable feature: #24591

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
