### PR TITLE
debezium-postgres tests: Fix flake

### DIFF
--- a/test/debezium/postgres/90-decimal-handling-mode.td
+++ b/test/debezium/postgres/90-decimal-handling-mode.td
@@ -64,6 +64,8 @@ INSERT INTO decimal_handling_mode_double VALUES (2234567.890);
 
 $ schema-registry-wait subject=postgres.public.decimal_handling_mode_double-value
 
+$ kafka-wait-topic topic=postgres.public.decimal_handling_mode_double
+
 > CREATE SOURCE decimal_handling_mode_double
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.decimal_handling_mode_double')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/tests/builds/73707#018d32c7-bd24-49eb-9f2a-f12a2464c2b4

Previously also in data-ingest: https://github.com/MaterializeInc/materialize/pull/24575

@guswynn Is this expected and do we need it all over the testdrive-based tests now? I missed what product change caused this.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
