### PR TITLE
sql: Change DISCARD ALL to reset SessionVars instead of creating a new one

### DIFF
--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -171,7 +171,7 @@ impl<T: TimestampManipulation> Session<T> {
     ) -> Session<T> {
         let (notices_tx, notices_rx) = mpsc::unbounded_channel();
         let default_cluster = INTERNAL_USER_NAME_TO_DEFAULT_CLUSTER.get(&user.name);
-        let mut vars = SessionVars::new(build_info, user);
+        let mut vars = SessionVars::new_unchecked(build_info, user);
         if let Some(default_cluster) = default_cluster {
             vars.set_cluster(default_cluster.clone());
         }
@@ -659,7 +659,7 @@ impl<T: TimestampManipulation> Session<T> {
     pub fn reset(&mut self) {
         let _ = self.clear_transaction();
         self.prepared_statements.clear();
-        self.vars = SessionVars::new(self.vars.build_info(), self.vars.user().clone());
+        self.vars.reset_all();
     }
 
     /// Returns the user who owns this session.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2396,7 +2396,8 @@ pub struct SessionVars {
 }
 
 impl SessionVars {
-    pub fn new(build_info: &'static BuildInfo, user: User) -> SessionVars {
+    /// Creates a new [`SessionVars`] without considering the System or Role defaults.
+    pub fn new_unchecked(build_info: &'static BuildInfo, user: User) -> SessionVars {
         let s = SessionVars {
             vars: BTreeMap::new(),
             build_info,
@@ -2540,6 +2541,13 @@ impl SessionVars {
         // has an analogous extension [0].
         // [0]: https://github.com/cockroachdb/cockroach/blob/369c4057a/pkg/sql/pgwire/conn.go#L1840
         .chain(std::iter::once(self.build_info as &dyn Var))
+    }
+
+    /// Resets all variables to their default value.
+    pub fn reset_all(&mut self) {
+        for (_name, var) in &mut self.vars {
+            var.reset(false);
+        }
     }
 
     /// Returns a [`Var`] representing the configuration parameter with the

--- a/test/sqllogictest/discard.slt
+++ b/test/sqllogictest/discard.slt
@@ -1,0 +1,90 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+# Start from a pristine server
+reset-server
+
+query T
+SHOW cluster
+----
+quickstart
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET cluster TO foo;
+----
+COMPLETE 0
+
+statement ok
+CREATE ROLE parker;
+
+simple conn=parker_1,user=parker
+SHOW cluster;
+----
+foo
+COMPLETE 1
+
+simple conn=parker_1,user=parker
+SET cluster TO bar;
+----
+COMPLETE 0
+
+simple conn=parker_1,user=parker
+SHOW cluster;
+----
+bar
+COMPLETE 1
+
+simple conn=parker_1,user=parker
+DISCARD ALL;
+----
+COMPLETE 0
+
+# After DISCARD ALL we should still respect the system default.
+simple conn=parker_1,user=parker
+SHOW cluster;
+----
+foo
+COMPLETE 1
+
+simple conn=parker_1,user=parker
+ALTER ROLE parker SET cluster TO baz;
+----
+COMPLETE 0
+
+# Use a new connection.
+simple conn=parker_2,user=parker
+SHOW cluster
+----
+baz
+COMPLETE 1
+
+simple conn=parker_2,user=parker
+SET cluster TO other_other;
+----
+COMPLETE 0
+
+simple conn=parker_2,user=parker
+SHOW cluster
+----
+other_other
+COMPLETE 1
+
+simple conn=parker_2,user=parker
+DISCARD ALL;
+----
+COMPLETE 0
+
+# After DISCARD ALL we should still respect the Role default.
+simple conn=parker_2,user=parker
+SHOW cluster
+----
+baz
+COMPLETE 1


### PR DESCRIPTION
This PR updates the behavior for `DISCARD ALL` to reset all of the session variables instead of creating a new `SessionVars` struct that didn't consider system or role defaults. Recently a user ran into this behavior where their queries started failing with "unknown cluster 'quickstart'" because their session was getting restarted without respecting their system value for `cluster`.

Note: I confirmed that the tests added in `discard.slt` fail without this fix.

### Motivation

Fixes https://github.com/MaterializeInc/accounts/issues/33

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes `DISCARD ALL` with respect to session variables.
