### PR TITLE
storage/testing: wait for topic creation in schema-registry-wait as well

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -852,10 +852,10 @@ The required `schema-type` argument indicates the type of the schema. At
 present, only Avro schemas are supported. Feel free to adjust the action to
 support additional schema types.
 
-#### `$ schema-registry-wait subject=...`
+#### `$ schema-registry-wait topic=...`
 
-Block the test until schema with the specified subject has been defined at the
-schema registry.
+Block the test until schema with the specified subject (both value and key) has been
+defined at the schema registry. Also waits for the kafka topic to exist.
 
 This action is useful to fortify tests that expect an external party, e.g.
 Debezium, to upload a particular schema.

--- a/misc/python/materialize/checks/all_checks/debezium.py
+++ b/misc/python/materialize/checks/all_checks/debezium.py
@@ -48,7 +48,7 @@ class DebeziumPostgres(Check):
                   }
                 }
 
-                $ schema-registry-wait subject=postgres.public.debezium_table-value
+                $ schema-registry-wait topic=postgres.public.debezium_table
 
                 $ kafka-wait-topic topic=postgres.public.debezium_table
 

--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -123,7 +123,7 @@ class CreateDebeziumSource(Action):
                       }}
                     }}
 
-                    $ schema-registry-wait subject=postgres.public.{self.postgres_table.name}-value
+                    $ schema-registry-wait topic=postgres.public.{self.postgres_table.name}
 
                     > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL PLAINTEXT);
 

--- a/src/testdrive/src/action/kafka.rs
+++ b/src/testdrive/src/action/kafka.rs
@@ -24,3 +24,5 @@ pub use verify_commit::run_verify_commit;
 pub use verify_data::run_verify_data;
 pub use verify_topic::run_verify_topic;
 pub use wait_topic::run_wait_topic;
+
+pub(crate) use wait_topic::check_topic_exists;

--- a/test/debezium/mysql/40-check-smoke.td
+++ b/test/debezium/mysql/40-check-smoke.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ schema-registry-wait subject=mysql.test.t1-value
+$ schema-registry-wait topic=mysql.test.t1
 
 $ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
 
@@ -16,7 +16,7 @@ USE test;
 INSERT INTO t1 VALUES (345, 345, 345);
 COMMIT;
 
-$ schema-registry-wait subject=mysql.transaction-value
+$ schema-registry-wait topic=mysql.transaction
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 

--- a/test/debezium/postgres/03-drop-not-null-column.td
+++ b/test/debezium/postgres/03-drop-not-null-column.td
@@ -16,7 +16,7 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 CREATE TABLE alter_drop_column_not_null (f1 INTEGER PRIMARY KEY, col_not_null INTEGER NOT NULL);
 INSERT INTO alter_drop_column_not_null VALUES (123, 234);
 
-$ schema-registry-wait subject=postgres.public.alter_drop_column_not_null-value
+$ schema-registry-wait topic=postgres.public.alter_drop_column_not_null
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/04-drop-column-nullable.td
+++ b/test/debezium/postgres/04-drop-column-nullable.td
@@ -15,7 +15,7 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 CREATE TABLE alter_drop_column (f1 INTEGER PRIMARY KEy, col_null_no_default INTEGER, col_null_default INTEGER DEFAULT 999);
 INSERT INTO alter_drop_column VALUES (123, 234, 345);
 
-$ schema-registry-wait subject=postgres.public.alter_drop_column-value
+$ schema-registry-wait topic=postgres.public.alter_drop_column
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/06-add-column-with-update.td
+++ b/test/debezium/postgres/06-add-column-with-update.td
@@ -18,7 +18,7 @@ CREATE TABLE alter_add_column (f1 INTEGER PRIMARY KEY);
 ALTER TABLE alter_add_column REPLICA IDENTITY FULL;
 INSERT INTO alter_add_column VALUES (123);
 
-$ schema-registry-wait subject=postgres.public.alter_add_column-value
+$ schema-registry-wait topic=postgres.public.alter_add_column
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/07-add-column-with-delete.td
+++ b/test/debezium/postgres/07-add-column-with-delete.td
@@ -18,7 +18,7 @@ CREATE TABLE alter_add_column_with_delete (f1 INTEGER, f2 INTEGER PRIMARY KEY);
 ALTER TABLE alter_add_column_with_delete REPLICA IDENTITY FULL;
 INSERT INTO alter_add_column_with_delete VALUES (123, 0),(123, 1),(123, 2),(123, 3);
 
-$ schema-registry-wait subject=postgres.public.alter_add_column_with_delete-value
+$ schema-registry-wait topic=postgres.public.alter_add_column_with_delete
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/09-add-nullability.td
+++ b/test/debezium/postgres/09-add-nullability.td
@@ -16,7 +16,7 @@ CREATE TABLE alter_allow_nullability (f1 INTEGER NOT NULL, f2 INTEGER PRIMARY KE
 ALTER TABLE alter_allow_nullability REPLICA IDENTITY FULL;
 INSERT INTO alter_allow_nullability VALUES (123, 0),(234, 1);
 
-$ schema-registry-wait subject=postgres.public.alter_allow_nullability-value
+$ schema-registry-wait topic=postgres.public.alter_allow_nullability
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/11-change-date-timestamp.td
+++ b/test/debezium/postgres/11-change-date-timestamp.td
@@ -16,7 +16,7 @@ CREATE TABLE alter_change_date_timestamp (f1 DATE, f2 INTEGER PRIMARY KEY);
 ALTER TABLE alter_change_date_timestamp REPLICA IDENTITY FULL;
 INSERT INTO alter_change_date_timestamp VALUES ('2011-11-11', 0),('2012-12-12', 1);
 
-$ schema-registry-wait subject=postgres.public.alter_change_date_timestamp-value
+$ schema-registry-wait topic=postgres.public.alter_change_date_timestamp
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/12-change-decimal.td
+++ b/test/debezium/postgres/12-change-decimal.td
@@ -17,7 +17,7 @@ CREATE TABLE alter_change_decimal (f1 DECIMAL(5,3), f2 INTEGER PRIMARY KEY);
 ALTER TABLE alter_change_decimal REPLICA IDENTITY FULL;
 INSERT INTO alter_change_decimal VALUES (0, 0),(NULL, 1),(12.345, 2);
 
-$ schema-registry-wait subject=postgres.public.alter_change_decimal-value
+$ schema-registry-wait topic=postgres.public.alter_change_decimal
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/21-types-boolean.td
+++ b/test/debezium/postgres/21-types-boolean.td
@@ -17,7 +17,7 @@ ALTER TABLE boolean_type REPLICA IDENTITY FULL;
 INSERT INTO boolean_type VALUES (TRUE, TRUE);
 INSERT INTO boolean_type VALUES (FALSE, FALSE);
 
-$ schema-registry-wait subject=postgres.public.boolean_type-value
+$ schema-registry-wait topic=postgres.public.boolean_type
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/22-types-double.td
+++ b/test/debezium/postgres/22-types-double.td
@@ -16,7 +16,7 @@ CREATE TABLE double_type (f1 DOUBLE PRECISION, f2 INTEGER PRIMARY KEY);
 ALTER TABLE double_type REPLICA IDENTITY FULL;
 INSERT INTO double_type VALUES (NULL, 0), ('Infinity', 1),('-Infinity', 2), ('NaN', 3);
 
-$ schema-registry-wait subject=postgres.public.double_type-value
+$ schema-registry-wait topic=postgres.public.double_type
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/23-types-decimal.td
+++ b/test/debezium/postgres/23-types-decimal.td
@@ -16,7 +16,7 @@ CREATE TABLE decimal_type (f1 DECIMAL(5,3), f2 INTEGER PRIMARY KEY);
 ALTER TABLE decimal_type REPLICA IDENTITY FULL;
 INSERT INTO decimal_type VALUES (NULL, 0), (NULL, 1), (12.345, 2), ('NaN', 3);
 
-$ schema-registry-wait subject=postgres.public.decimal_type-value
+$ schema-registry-wait topic=postgres.public.decimal_type
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/24-types-enum.td
+++ b/test/debezium/postgres/24-types-enum.td
@@ -16,7 +16,7 @@ CREATE TYPE enum1 AS ENUM ('val1', 'val2');
 CREATE TABLE enum_type ( f1 enum1, f2 INTEGER PRIMARY KEY);
 INSERT INTO enum_type VALUES ('val1', 0), ('val2', 1);
 
-$ schema-registry-wait subject=postgres.public.enum_type-value
+$ schema-registry-wait topic=postgres.public.enum_type
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/25-types-array.td
+++ b/test/debezium/postgres/25-types-array.td
@@ -15,7 +15,7 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 CREATE TABLE array_type (f1 text[], f2 INTEGER PRIMARY KEY);
 INSERT INTO array_type VALUES ('{foo, null}', 0);
 
-$ schema-registry-wait subject=postgres.public.array_type-value
+$ schema-registry-wait topic=postgres.public.array_type
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/26-types-bytea.td
+++ b/test/debezium/postgres/26-types-bytea.td
@@ -16,7 +16,7 @@ CREATE TABLE bytea_type (f1 BYTEA, f2 INTEGER PRIMARY KEY);
 ALTER TABLE bytea_type REPLICA IDENTITY FULL;
 INSERT INTO bytea_type VALUES (NULL, 0), ('', 1), (E'\\x00', 2), (E'\\xABCDEF1234', 3);
 
-$ schema-registry-wait subject=postgres.public.bytea_type-value
+$ schema-registry-wait topic=postgres.public.bytea_type
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/27-types-hstore.td
+++ b/test/debezium/postgres/27-types-hstore.td
@@ -17,7 +17,7 @@ CREATE TABLE hstore_type (f1 hstore, f2 INTEGER PRIMARY KEY);
 ALTER TABLE hstore_type REPLICA IDENTITY FULL;
 INSERT INTO hstore_type VALUES (NULL, 0), ('a=>1'::hstore, 1);
 
-$ schema-registry-wait subject=postgres.public.hstore_type-value
+$ schema-registry-wait topic=postgres.public.hstore_type
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/28-types-uuid.td
+++ b/test/debezium/postgres/28-types-uuid.td
@@ -16,7 +16,7 @@ CREATE TABLE uuid_type (pk_col UUID PRIMARY KEY, nopk_col UUID);
 ALTER TABLE uuid_type REPLICA IDENTITY FULL;
 INSERT INTO uuid_type VALUES ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
 
-$ schema-registry-wait subject=postgres.public.uuid_type-value
+$ schema-registry-wait topic=postgres.public.uuid_type
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/29-types-char-varchar.td
+++ b/test/debezium/postgres/29-types-char-varchar.td
@@ -16,7 +16,7 @@ CREATE TABLE char_varchar_type (char_col CHAR(5), varchar_col VARCHAR(5), f3 INT
 ALTER TABLE char_varchar_type REPLICA IDENTITY FULL;
 INSERT INTO char_varchar_type VALUES ('a ', 'a ', 0);
 
-$ schema-registry-wait subject=postgres.public.char_varchar_type-value
+$ schema-registry-wait topic=postgres.public.char_varchar_type
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/33-toasted-values.td
+++ b/test/debezium/postgres/33-toasted-values.td
@@ -11,7 +11,7 @@
 # Make sure that TOAST-ed values are handled correctly.
 #
 # TOAST-ed values are values larger than around 8Kb
-# see https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-toasted-values
+# see https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-toasteds
 # and https://www.postgresql.org/docs/current/storage-toast.html
 #
 
@@ -20,7 +20,7 @@ CREATE TABLE toasted_full (f1 text, f2 INTEGER PRIMARY KEY);
 ALTER TABLE toasted_full REPLICA IDENTITY FULL;
 INSERT INTO toasted_full VALUES (NULL, 0), (REPEAT('a', 32 * 1024) || 'b', 1);
 
-$ schema-registry-wait subject=postgres.public.toasted_full-value
+$ schema-registry-wait topic=postgres.public.toasted_full
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/34-replica-identity-default.td
+++ b/test/debezium/postgres/34-replica-identity-default.td
@@ -17,7 +17,7 @@ CREATE TABLE replica_identity_default (f1 INTEGER, f2 INTEGER, f3 INTEGER, PRIMA
 ALTER TABLE replica_identity_default REPLICA IDENTITY DEFAULT;
 INSERT INTO replica_identity_default VALUES (1,1,1), (2,2,2), (3,3,3), (4,4,4);
 
-$ schema-registry-wait subject=postgres.public.replica_identity_default-value
+$ schema-registry-wait topic=postgres.public.replica_identity_default
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/60-concurrent-insert-same.td
+++ b/test/debezium/postgres/60-concurrent-insert-same.td
@@ -16,7 +16,7 @@ CREATE TABLE insert_same_table (f1 INTEGER, PRIMARY KEY (f1));
 ALTER TABLE insert_same_table REPLICA IDENTITY FULL;
 INSERT INTO insert_same_table VALUES (0);
 
-$ schema-registry-wait subject=postgres.public.insert_same_table-value
+$ schema-registry-wait topic=postgres.public.insert_same_table
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/60-update-pk-values.td
+++ b/test/debezium/postgres/60-update-pk-values.td
@@ -17,7 +17,7 @@ ALTER TABLE update_pk_values REPLICA IDENTITY FULL;
 INSERT INTO update_pk_values VALUES (1, 10);
 INSERT INTO update_pk_values VALUES (2, 20);
 
-$ schema-registry-wait subject=postgres.public.update_pk_values-value
+$ schema-registry-wait topic=postgres.public.update_pk_values
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/61-concurrent-insert-multi.td
+++ b/test/debezium/postgres/61-concurrent-insert-multi.td
@@ -21,9 +21,9 @@ CREATE TABLE insert_multi_table2 (f1 INTEGER, PRIMARY KEY (f1));
 ALTER TABLE insert_multi_table2 REPLICA IDENTITY FULL;
 INSERT INTO insert_multi_table2 VALUES (0);
 
-$ schema-registry-wait subject=postgres.public.insert_multi_table1-value
+$ schema-registry-wait topic=postgres.public.insert_multi_table1
 
-$ schema-registry-wait subject=postgres.public.insert_multi_table2-value
+$ schema-registry-wait topic=postgres.public.insert_multi_table2
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/62-concurrent-update-nopk.td
+++ b/test/debezium/postgres/62-concurrent-update-nopk.td
@@ -17,7 +17,7 @@ ALTER TABLE concurrent_update REPLICA IDENTITY FULL;
 INSERT INTO concurrent_update VALUES (1, 'r1', 0);
 INSERT INTO concurrent_update VALUES (11, 'r2', 1);
 
-$ schema-registry-wait subject=postgres.public.concurrent_update-value
+$ schema-registry-wait topic=postgres.public.concurrent_update
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/63-concurrent-update-pk.td
+++ b/test/debezium/postgres/63-concurrent-update-pk.td
@@ -17,7 +17,7 @@ ALTER TABLE concurrent_update_pk REPLICA IDENTITY FULL;
 INSERT INTO concurrent_update_pk VALUES (1, 10);
 INSERT INTO concurrent_update_pk VALUES (2, 20);
 
-$ schema-registry-wait subject=postgres.public.concurrent_update_pk-value
+$ schema-registry-wait topic=postgres.public.concurrent_update_pk
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/64-concurrent-delete-same.td
+++ b/test/debezium/postgres/64-concurrent-delete-same.td
@@ -21,7 +21,7 @@ INSERT INTO concurrent_delete VALUES (4);
 INSERT INTO concurrent_delete VALUES (5);
 INSERT INTO concurrent_delete VALUES (6);
 
-$ schema-registry-wait subject=postgres.public.concurrent_delete-value
+$ schema-registry-wait topic=postgres.public.concurrent_delete
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/65-concurrent-delete-multi.td
+++ b/test/debezium/postgres/65-concurrent-delete-multi.td
@@ -28,9 +28,9 @@ INSERT INTO concurrent_delete2 VALUES (3);
 INSERT INTO concurrent_delete2 VALUES (4);
 INSERT INTO concurrent_delete2 VALUES (5);
 
-$ schema-registry-wait subject=postgres.public.concurrent_delete1-value
+$ schema-registry-wait topic=postgres.public.concurrent_delete1
 
-$ schema-registry-wait subject=postgres.public.concurrent_delete2-value
+$ schema-registry-wait topic=postgres.public.concurrent_delete2
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/70-insert-delete.td
+++ b/test/debezium/postgres/70-insert-delete.td
@@ -16,7 +16,7 @@ CREATE TABLE insert_delete (f1 INTEGER, PRIMARY KEY (f1));
 ALTER TABLE insert_delete REPLICA IDENTITY FULL;
 INSERT INTO insert_delete VALUES (1);
 
-$ schema-registry-wait subject=postgres.public.insert_delete-value
+$ schema-registry-wait topic=postgres.public.insert_delete
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/71-update-update.td
+++ b/test/debezium/postgres/71-update-update.td
@@ -18,7 +18,7 @@ ALTER TABLE update_update REPLICA IDENTITY FULL;
 INSERT INTO update_update VALUES (1);
 INSERT INTO update_update VALUES (10);
 
-$ schema-registry-wait subject=postgres.public.update_update-value
+$ schema-registry-wait topic=postgres.public.update_update
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/postgres/90-decimal-handling-mode.td
+++ b/test/debezium/postgres/90-decimal-handling-mode.td
@@ -15,7 +15,7 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 CREATE TABLE decimal_handling_mode_precise (f1 DECIMAL(10,3) PRIMARY KEY);
 INSERT INTO decimal_handling_mode_precise VALUES (1234567.890);
 
-$ schema-registry-wait subject=postgres.public.decimal_handling_mode_precise-value
+$ schema-registry-wait topic=postgres.public.decimal_handling_mode_precise
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
@@ -62,9 +62,7 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 CREATE TABLE decimal_handling_mode_double (f1 DECIMAL(10,3) PRIMARY KEY);
 INSERT INTO decimal_handling_mode_double VALUES (2234567.890);
 
-$ schema-registry-wait subject=postgres.public.decimal_handling_mode_double-value
-
-$ kafka-wait-topic topic=postgres.public.decimal_handling_mode_double
+$ schema-registry-wait topic=postgres.public.decimal_handling_mode_double
 
 > CREATE SOURCE decimal_handling_mode_double
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.decimal_handling_mode_double')
@@ -104,7 +102,7 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 CREATE TABLE decimal_handling_mode_string (f1 DECIMAL(10,3) PRIMARY KEY);
 INSERT INTO decimal_handling_mode_string VALUES (3234567.890);
 
-$ schema-registry-wait subject=postgres.public.decimal_handling_mode_string-value
+$ schema-registry-wait topic=postgres.public.decimal_handling_mode_string
 
 > CREATE SOURCE decimal_handling_mode_string
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.decimal_handling_mode_string')

--- a/test/debezium/postgres/92-large-transaction.td.gh13629
+++ b/test/debezium/postgres/92-large-transaction.td.gh13629
@@ -50,9 +50,9 @@ INSERT INTO large_distinct_rows SELECT nextval('large_transaction_sequence') FRO
 INSERT INTO large_same_rows SELECT 1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4;
 COMMIT;
 
-$ schema-registry-wait subject=postgres.public.large_distinct_rows-value
+$ schema-registry-wait topic=postgres.public.large_distinct_rows
 
-$ schema-registry-wait subject=postgres.public.large_same_rows-value
+$ schema-registry-wait topic=postgres.public.large_same_rows
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/sql-server/40-check-delete.td
+++ b/test/debezium/sql-server/40-check-delete.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ schema-registry-wait subject=sql-server.test.dbo.delete_table_pk-value
+$ schema-registry-wait topic=sql-server.test.dbo.delete_table_pk
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
@@ -21,7 +21,7 @@ $ schema-registry-wait subject=sql-server.test.dbo.delete_table_pk-value
   ENVELOPE DEBEZIUM;
 
 # [btv] uncomment if we bring back classic debezium mode
-# $ schema-registry-wait subject=sql-server.dbo.delete_table_nopk-value
+# $ schema-registry-wait topic=sql-server.dbo.delete_table_nopk
 
 # > CREATE SOURCE delete_table_nopk
 #   FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.dbo.delete_table_nopk')

--- a/test/debezium/sql-server/40-check-smoke.td
+++ b/test/debezium/sql-server/40-check-smoke.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ schema-registry-wait subject=sql-server.test.dbo.t1-value
+$ schema-registry-wait topic=sql-server.test.dbo.t1
 
 $ sql-server-connect name=sql-server
 server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
@@ -16,7 +16,7 @@ $ sql-server-execute name=sql-server
 USE test;
 INSERT INTO t1 VALUES (345);
 
-$ schema-registry-wait subject=sql-server.transaction-value
+$ schema-registry-wait topic=sql-server.transaction
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/sql-server/40-check-transactions.td
+++ b/test/debezium/sql-server/40-check-transactions.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ schema-registry-wait subject=sql-server.test.dbo.transaction_table1-value
+$ schema-registry-wait topic=sql-server.test.dbo.transaction_table1
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
@@ -16,7 +16,7 @@ $ schema-registry-wait subject=sql-server.test.dbo.transaction_table1-value
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM;
 
-$ schema-registry-wait subject=sql-server.test.dbo.transaction_table2-value
+$ schema-registry-wait topic=sql-server.test.dbo.transaction_table2
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/sql-server/40-check-types.td
+++ b/test/debezium/sql-server/40-check-types.td
@@ -10,7 +10,7 @@
 $ sql-server-connect name=sql-server
 server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
-$ schema-registry-wait subject=sql-server.test.dbo.types_table-value
+$ schema-registry-wait topic=sql-server.test.dbo.types_table
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'

--- a/test/debezium/sql-server/40-check-update.td
+++ b/test/debezium/sql-server/40-check-update.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ schema-registry-wait subject=sql-server.test.dbo.update_table_pk-value
+$ schema-registry-wait topic=sql-server.test.dbo.update_table_pk
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
@@ -16,7 +16,7 @@ $ schema-registry-wait subject=sql-server.test.dbo.update_table_pk-value
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM;
 
-# $ schema-registry-wait subject=sql-server.dbo.update_table_nopk-value
+# $ schema-registry-wait topic=sql-server.dbo.update_table_nopk
 
 # > CREATE CONNECTION IF NOT EXISTS csr_conn
 #   FOR CONFLUENT SCHEMA REGISTRY


### PR DESCRIPTION
draft to fix: https://github.com/MaterializeInc/materialize/pull/24600, waiting on ci before publishing

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
