### PR TITLE
zippy: Use redpanda instead of kafka

### DIFF
--- a/misc/python/materialize/zippy/kafka_actions.py
+++ b/misc/python/materialize/zippy/kafka_actions.py
@@ -46,7 +46,7 @@ class KafkaStart(Action):
         return [KafkaRunning()]
 
     def run(self, c: Composition) -> None:
-        c.up("kafka")
+        c.up("redpanda")
 
 
 class KafkaStop(Action):
@@ -60,7 +60,7 @@ class KafkaStop(Action):
         return {KafkaRunning}
 
     def run(self, c: Composition) -> None:
-        c.kill("kafka")
+        c.kill("redpanda")
 
 
 class CreateTopicParameterized(ActionFactory):

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -20,13 +20,12 @@ from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.debezium import Debezium
 from materialize.mzcompose.services.grafana import Grafana
-from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc, Minio
 from materialize.mzcompose.services.persistcli import Persistcli
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.prometheus import Prometheus
-from materialize.mzcompose.services.schema_registry import SchemaRegistry
+from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.ssh_bastion_host import (
     SshBastionHost,
     setup_default_ssh_test_connection,
@@ -40,9 +39,8 @@ from materialize.zippy.scenarios import UserTables
 
 SERVICES = [
     Zookeeper(),
-    Kafka(auto_create_topics=True),
-    SchemaRegistry(),
-    Debezium(),
+    Redpanda(auto_create_topics=True),
+    Debezium(redpanda=True),
     Postgres(),
     Cockroach(),
     Minio(setup_materialize=True),
@@ -134,7 +132,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = parser.parse_args()
     scenario_class = globals()[args.scenario]
 
-    c.up("zookeeper", "kafka", "schema-registry", "ssh-bastion-host")
+    c.up("zookeeper", "redpanda", "ssh-bastion-host")
     c.enable_minio_versioning()
 
     if args.observability:


### PR DESCRIPTION
For reduced memory consumption

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
