### PR TITLE
cargo test: Unflake test_retry_fail_max_duration

### DIFF
--- a/src/ore/src/retry.rs
+++ b/src/ore/src/retry.rs
@@ -712,29 +712,29 @@ mod tests {
     fn test_retry_fail_max_duration() {
         let mut states = vec![];
         let res = Retry::default()
-            .initial_backoff(Duration::from_millis(5))
-            .max_duration(Duration::from_millis(10))
+            .initial_backoff(Duration::from_millis(10))
+            .max_duration(Duration::from_millis(20))
             .retry(|state| {
                 states.push(state);
                 Err::<(), _>("injected")
             });
         assert_eq!(res, Err("injected"));
 
-        // The first try should indicate a next backoff of exactly 5ms.
+        // The first try should indicate a next backoff of exactly 10ms.
         assert_eq!(
             states[0],
             RetryState {
                 i: 0,
-                next_backoff: Some(Duration::from_millis(5))
+                next_backoff: Some(Duration::from_millis(10))
             },
         );
 
-        // The next try should indicate a next backoff of between 0 and 5ms. The
+        // The next try should indicate a next backoff of between 0 and 10ms. The
         // exact value depends on how long it took for the first try itself to
         // execute.
         assert_eq!(states[1].i, 1);
         let backoff = states[1].next_backoff.unwrap();
-        assert!(backoff > Duration::from_millis(0) && backoff < Duration::from_millis(5));
+        assert!(backoff > Duration::from_millis(0) && backoff < Duration::from_millis(10));
 
         // The final try should indicate that the operation is complete with
         // a next backoff of None.


### PR DESCRIPTION
My idea is that the machine is sometimes too overloaded to finish in 5ms, so give 10ms instead

Fixes: #20529

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
