### PR TITLE
dbt-materialize: stub support for scheduled refreshes

### DIFF
--- a/misc/dbt-materialize/dbt/adapters/materialize/exceptions.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/exceptions.py
@@ -1,0 +1,43 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+from dbt.exceptions import CompilationError
+
+
+class RefreshIntervalConfigNotDictError(CompilationError):
+    def __init__(self, raw_refresh_interval: Any):
+        self.raw_refresh_interval = raw_refresh_interval
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        msg = (
+            f"Invalid refresh_interval config:\n"
+            f"  Got: {self.raw_refresh_interval}\n"
+            f'  Expected a dictionary with at minimum a "at", "at_creation", or "every" key'
+        )
+        return msg
+
+
+class RefreshIntervalConfigError(CompilationError):
+    def __init__(self, exc: TypeError):
+        self.exc = exc
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        validator_msg = self.validator_error_message(self.exc)
+        msg = f"Could not parse refresh interval config: {validator_msg}"
+        return msg

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -70,7 +70,7 @@ class MaterializeIndexConfig(dbtClassMixin):
 
 # NOTE(morsapaes): Materialize allows configuring a refresh interval for the
 # materialized view materialization. If no config option is specified, the
-# default is REFRESH ON COMMIT. We add an explicity attribute for the special
+# default is REFRESH ON COMMIT. We add an explicitly attribute for the special
 # case of parametrizing the configuration option e.g. in macros.
 @dataclass
 class MaterializeRefreshIntervalConfig(dbtClassMixin):

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -27,7 +27,10 @@ from dbt.adapters.capability import (
     Support,
 )
 from dbt.adapters.materialize.connections import MaterializeConnectionManager
-from dbt.adapters.materialize.exceptions import RefreshIntervalConfigError, RefreshIntervalConfigNotDictError
+from dbt.adapters.materialize.exceptions import (
+    RefreshIntervalConfigError,
+    RefreshIntervalConfigNotDictError,
+)
 from dbt.adapters.materialize.relation import MaterializeRelation
 from dbt.adapters.postgres import PostgresAdapter
 from dbt.adapters.postgres.column import PostgresColumn
@@ -64,6 +67,7 @@ class MaterializeIndexConfig(dbtClassMixin):
                 '  Expected a dictionary with at minimum a "columns" key'
             )
 
+
 # NOTE(morsapaes): Materialize allows configuring a refresh interval for the
 # materialized view materialization. If no config option is specified, the
 # default is REFRESH ON COMMIT. We add an explicity attribute for the special
@@ -77,7 +81,9 @@ class MaterializeRefreshIntervalConfig(dbtClassMixin):
     on_commit: Optional[bool] = False
 
     @classmethod
-    def parse(cls, raw_refresh_interval) -> Optional["MaterializeRefreshIntervalConfig"]:
+    def parse(
+        cls, raw_refresh_interval
+    ) -> Optional["MaterializeRefreshIntervalConfig"]:
         if raw_refresh_interval is None:
             return None
         try:
@@ -145,7 +151,9 @@ class MaterializeAdapter(PostgresAdapter):
         return MaterializeIndexConfig.parse(raw_index)
 
     @available
-    def parse_refresh_interval(self, raw_refresh_interval: Any) -> Optional[MaterializeRefreshIntervalConfig]:
+    def parse_refresh_interval(
+        self, raw_refresh_interval: Any
+    ) -> Optional[MaterializeRefreshIntervalConfig]:
         return MaterializeRefreshIntervalConfig.parse(raw_refresh_interval)
 
     def list_relations_without_caching(

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -37,19 +37,27 @@
     in cluster {{ cluster }}
   {% endif %}
 
-  -- Contracts and constraints
+  {# Scheduled refreshes #}
+  {%- set refresh_interval = config.get('refresh_interval') -%}
+  {%- if refresh_interval -%}
+    with (
+      {{ materialize__get_refresh_interval_sql(relation, refresh_interval) }}
+    )
+  {%- endif %}
+
+  {# Contracts and constraints #}
   {% set contract_config = config.get('contract') %}
   {% if contract_config.enforced %}
     {{ get_assert_columns_equivalent(sql) }}
 
     {% set ns = namespace(c_constraints=False, m_constraints=False) %}
-    -- Column-level constraints
+    {# Column-level constraints #}
     {% set raw_columns = model['columns'] %}
     {% for c_id, c_details in raw_columns.items() if c_details['constraints'] != [] %}
       {% set ns.c_constraints = True %}
     {%- endfor %}
 
-    -- Model-level constraints
+    {# Model-level contraints #}
 
     -- NOTE(morsapaes): not_null constraints are not originally supported in
     -- dbt-core at model-level, since model-level constraints are intended for
@@ -150,6 +158,25 @@
     {% endfor %}
   {% endif %}
 {% endmacro %}
+
+{% macro materialize__get_refresh_interval_sql(relation, refresh_interval_dict) -%}
+  {%- set refresh_interval = adapter.parse_refresh_interval(refresh_interval_dict) -%}
+    {% if refresh_interval.at -%}
+      refresh at '{{ refresh_interval.at }}'
+    {%- endif %}
+    {% if refresh_interval.at_creation -%}
+      refresh at creation
+    {%- endif %}
+    {% if refresh_interval.every -%}
+      {% if refresh_interval.at or refresh_interval.at_creation -%}
+        ,
+      {%- endif %}
+      refresh every '{{ refresh_interval.every }}'
+      {% if refresh_interval.aligned_to -%}
+        aligned to '{{ refresh_interval.aligned_to }}'
+      {%- endif %}
+    {%- endif %}
+{%- endmacro %}
 
 {% macro materialize__alter_column_comment_single(relation, column_name, quote, comment) %}
   {% set escaped_comment = postgres_escape_comment(comment) %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -57,7 +57,7 @@
       {% set ns.c_constraints = True %}
     {%- endfor %}
 
-    {# Model-level contraints #}
+    {# Model-level constraints #}
 
     -- NOTE(morsapaes): not_null constraints are not originally supported in
     -- dbt-core at model-level, since model-level constraints are intended for
@@ -175,6 +175,9 @@
       {% if refresh_interval.aligned_to -%}
         aligned to '{{ refresh_interval.aligned_to }}'
       {%- endif %}
+    {%- endif %}
+    {% if refresh_interval.on_commit -%}
+      refresh on commit
     {%- endif %}
 {%- endmacro %}
 


### PR DESCRIPTION
Minimum viable implementation for #23035 to unblock a user. Known limitations (that will be covered as a follow-up PR):

* We don't reject mutually exclusive options. We're doing the same for the index config, which is wrong (_e.g._ it's possible to specify `default` + other options, which is an unsupported combination). As a follow-up, we should explicitly raise compilation errors that reflect the accepted configurations:
  * `on_commit` is exclusive with all other options;
  * ~`at` and `at_creation` are exclusive;~
  * `aligned_to` isn't silently ignored if `every` isn't specified.
* `aligned_to` doesn't support `mz_now()` as a configuration value.
* `at` and `every` can be specified multiple times, so the configuration options should be supported as `list`.
* We don't support specifying [constraints](https://materialize.com/docs/manage/dbt/#constraints) **and** scheduled refreshes.

None of these limitations are particularly hard to solve, but I'd rather not block releasing the base functionality on iterating on the solutions.