### PR TITLE
repr: fix some `PlanTrace` bugs

### DIFF
--- a/src/repr/src/explain/tracing.rs
+++ b/src/repr/src/explain/tracing.rs
@@ -28,6 +28,8 @@ pub struct PlanTrace<T> {
     /// A path of segments identifying the spans in the current ancestor-or-self
     /// chain. The current path is used when accumulating new `entries`.
     path: Mutex<String>,
+    /// The the first time when entering a span (None no span was entered yet).
+    start: Mutex<Option<std::time::Instant>>,
     /// A path of times at which the spans in the current ancestor-or-self chain
     /// were started. The duration since the last time is used when accumulating
     /// new `entries`.
@@ -185,9 +187,13 @@ where
     }
 
     fn on_enter(&self, _id: &span::Id, _ctx: layer::Context<'_, S>) {
+        let now = std::time::Instant::now();
+        // set start value on first ever on_enter
+        let mut start = self.start.lock().expect("start shouldn't be poisoned");
+        start.get_or_insert(now);
         // push to time stack
         let mut times = self.times.lock().expect("times shouldn't be poisoned");
-        times.push(std::time::Instant::now());
+        times.push(now);
     }
 
     fn on_exit(&self, _id: &span::Id, _ctx: layer::Context<'_, S>) {
@@ -226,8 +232,9 @@ impl<T: 'static> PlanTrace<T> {
         Self {
             find: path,
             path: Mutex::new(String::with_capacity(256)),
-            times: Mutex::new(vec![]),
-            entries: Mutex::new(vec![]),
+            start: Mutex::new(None),
+            times: Mutex::new(Default::default()),
+            entries: Mutex::new(Default::default()),
         }
     }
 
@@ -261,7 +268,8 @@ impl<T: 'static> PlanTrace<T> {
     {
         if let Some(current_path) = self.current_path() {
             let times = self.times.lock().expect("times shouldn't be poisoned");
-            if let (Some(full_start), Some(span_start)) = (times.first(), times.last()) {
+            let start = self.start.lock().expect("start shouldn't is poisoned");
+            if let (Some(full_start), Some(span_start)) = (start.as_ref(), times.last()) {
                 let mut entries = self.entries.lock().expect("entries shouldn't be poisoned");
                 let time = std::time::Instant::now();
                 entries.push(TraceEntry {


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug.

A separate PR with `PlanTrace` fixes / improvements found while working on unifying the `EXPLAIN SELECT` with `SELECT` paths in the `Coordinator` code.

### Tips for reviewer

Review only the `repr: *` commits (the rest is part of #24581 and will be merged shortly).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
