### PR TITLE
Make sure new builtin roles get persisted to the catalog.

### DIFF
--- a/misc/python/materialize/checks/all_checks/roles.py
+++ b/misc/python/materialize/checks/all_checks/roles.py
@@ -130,3 +130,25 @@ class DropRole(CreateRole):
                 )
             )
         )
+
+
+class BuiltinRoles(CreateRole):
+    def manipulate(self) -> list[Testdrive]:
+        return [Testdrive(TESTDRIVE_NOP), Testdrive(TESTDRIVE_NOP)]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+            $ skip-if
+            SELECT mz_version_num() < 8300
+
+            > SELECT name FROM mz_roles
+            mz_system
+            mz_support
+            mz_monitor
+            materialize
+            mz_monitor_redacted
+            """
+            )
+        )

--- a/misc/python/materialize/checks/all_checks/roles.py
+++ b/misc/python/materialize/checks/all_checks/roles.py
@@ -143,12 +143,12 @@ class BuiltinRoles(CreateRole):
             $ skip-if
             SELECT mz_version_num() < 8300
 
-            > SELECT name FROM mz_roles
-            mz_system
-            mz_support
-            mz_monitor
+            > SELECT name FROM mz_roles ORDER BY name
             materialize
+            mz_monitor
             mz_monitor_redacted
+            mz_support
+            mz_system
             """
             )
         )

--- a/misc/python/materialize/checks/all_checks/roles.py
+++ b/misc/python/materialize/checks/all_checks/roles.py
@@ -143,12 +143,9 @@ class BuiltinRoles(CreateRole):
             $ skip-if
             SELECT mz_version_num() < 8300
 
-            > SELECT name FROM mz_roles ORDER BY name
-            materialize
+            > SELECT name FROM mz_roles WHERE name IN ('mz_monitor', 'mz_monitor_redacted') ORDER BY name
             mz_monitor
             mz_monitor_redacted
-            mz_support
-            mz_system
             """
             )
         )

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -52,7 +52,7 @@ use mz_repr::role_id::RoleId;
 use mz_repr::GlobalId;
 use mz_sql::catalog::{
     CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem, CatalogItemType, CatalogSchema,
-    CatalogType,
+    CatalogType, RoleMembership, RoleVars,
 };
 use mz_sql::func::OP_IMPLS;
 use mz_sql::names::{
@@ -382,6 +382,35 @@ impl Catalog {
                 schemas_by_name.insert(name.clone(), id);
             }
 
+            let default_privileges = txn.get_default_privileges();
+            for mz_catalog::durable::DefaultPrivilege { object, acl_item } in default_privileges {
+                state.default_privileges.grant(object, acl_item);
+            }
+
+            let system_privileges = txn.get_system_privileges();
+            state.system_privileges.grant_all(system_privileges);
+
+            Catalog::load_system_configuration(
+                &mut state,
+                &mut txn,
+                &config.system_parameter_defaults,
+                config.remote_system_parameters.as_ref(),
+            )?;
+
+            // Now that LD is loaded, set the intended catalog timeout.
+            // TODO: Move this into the catalog constructor.
+            txn.set_connection_timeout(state.system_config().crdb_connect_timeout());
+
+            // Add any new builtin Clusters, Cluster Replicas, or Roles that may be newly defined.
+            if !is_read_only {
+                add_new_builtin_clusters_migration(&mut txn)?;
+                add_new_builtin_cluster_replicas_migration(
+                    &mut txn,
+                    config.builtin_cluster_replica_size,
+                )?;
+                add_new_builtin_roles_migration(&mut txn)?;
+            }
+
             let roles = txn.get_roles();
             for mz_catalog::durable::Role {
                 id,
@@ -404,34 +433,6 @@ impl Catalog {
                         vars,
                     },
                 );
-            }
-
-            let default_privileges = txn.get_default_privileges();
-            for mz_catalog::durable::DefaultPrivilege { object, acl_item } in default_privileges {
-                state.default_privileges.grant(object, acl_item);
-            }
-
-            let system_privileges = txn.get_system_privileges();
-            state.system_privileges.grant_all(system_privileges);
-
-            Catalog::load_system_configuration(
-                &mut state,
-                &mut txn,
-                &config.system_parameter_defaults,
-                config.remote_system_parameters.as_ref(),
-            )?;
-
-            // Now that LD is loaded, set the intended catalog timeout.
-            // TODO: Move this into the catalog constructor.
-            txn.set_connection_timeout(state.system_config().crdb_connect_timeout());
-
-            // Add any new builtin Clusters or Cluster Replicas that may be newly defined.
-            if !is_read_only {
-                add_new_builtin_clusters_migration(&mut txn)?;
-                add_new_builtin_cluster_replicas_migration(
-                    &mut txn,
-                    config.builtin_cluster_replica_size,
-                )?;
             }
 
             let comments = txn.get_comments();
@@ -1740,6 +1741,24 @@ fn add_new_builtin_clusters_migration(
                     // TODO: Should builtin clusters be managed or unmanaged?
                     variant: mz_catalog::durable::ClusterVariant::Unmanaged,
                 },
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn add_new_builtin_roles_migration(
+    txn: &mut mz_catalog::durable::Transaction<'_>,
+) -> Result<(), mz_catalog::durable::CatalogError> {
+    let role_names: BTreeSet<_> = txn.get_roles().map(|role| role.name).collect();
+    for builtin_role in BUILTIN_ROLES {
+        if !role_names.contains(builtin_role.name) {
+            txn.insert_role(
+                builtin_role.id,
+                builtin_role.name.to_string(),
+                builtin_role.attributes.clone(),
+                RoleMembership::new(),
+                RoleVars::default(),
             )?;
         }
     }

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -277,7 +277,7 @@ impl<'a> Transaction<'a> {
         Ok(id)
     }
 
-    pub(crate) fn insert_role(
+    pub fn insert_role(
         &mut self,
         id: RoleId,
         name: String,


### PR DESCRIPTION
We were not persisting builtin roles in the catalog, causing them not to show up in `mz_roles` and various other issues.

### Motivation

  * This PR fixes a recognized bug.

    Reported to me by @SangJunBak in person.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixed a bug causing `mz_monitor` and `mz_monitor_redacted` to not show up in `mz_roles`.
