### PR TITLE
catalog: remove vestigial Option from BuiltinSource's data_source

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -594,11 +594,6 @@ impl Catalog {
                         }
 
                         Builtin::Source(coll) => {
-                            let introspection_type = match &coll.data_source {
-                                Some(i) => i.clone(),
-                                None => continue,
-                            };
-
                             let oid = state.allocate_oid()?;
                             let mut acl_items = vec![rbac::owner_privilege(
                                 mz_sql::catalog::ObjectType::Source,
@@ -612,7 +607,7 @@ impl Catalog {
                                 name.clone(),
                                 CatalogItem::Source(Source {
                                     create_sql: None,
-                                    data_source: DataSourceDesc::Introspection(introspection_type),
+                                    data_source: DataSourceDesc::Introspection(coll.data_source),
                                     desc: coll.desc.clone(),
                                     timeline: Timeline::EpochMilliseconds,
                                     resolved_ids: ResolvedIds(BTreeSet::new()),

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -132,7 +132,7 @@ pub struct BuiltinSource {
     pub name: &'static str,
     pub schema: &'static str,
     pub desc: RelationDesc,
-    pub data_source: Option<IntrospectionType>,
+    pub data_source: IntrospectionType,
     /// Whether the source's retention policy is controlled by
     /// the system variable `METRICS_RETENTION`
     pub is_retained_metrics_object: bool,
@@ -1927,7 +1927,7 @@ pub static MZ_OBJECT_DEPENDENCIES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTabl
 pub static MZ_COMPUTE_DEPENDENCIES: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_compute_dependencies",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::ComputeDependencies),
+    data_source: IntrospectionType::ComputeDependencies,
     desc: RelationDesc::empty()
         .with_column("object_id", ScalarType::String.nullable(false))
         .with_column("dependency_id", ScalarType::String.nullable(false)),
@@ -1937,7 +1937,7 @@ pub static MZ_COMPUTE_DEPENDENCIES: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSo
 pub static MZ_COMPUTE_HYDRATION_STATUSES: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_compute_hydration_statuses",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::ComputeHydrationStatus),
+    data_source: IntrospectionType::ComputeHydrationStatus,
     desc: RelationDesc::empty()
         .with_column("object_id", ScalarType::String.nullable(false))
         .with_column("replica_id", ScalarType::String.nullable(false))
@@ -2431,7 +2431,7 @@ pub static MZ_CLUSTER_REPLICA_SIZES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTa
 pub static MZ_CLUSTER_REPLICA_HEARTBEATS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_cluster_replica_heartbeats",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::ComputeReplicaHeartbeats),
+    data_source: IntrospectionType::ComputeReplicaHeartbeats,
     desc: RelationDesc::empty()
         .with_column("replica_id", ScalarType::String.nullable(false))
         .with_column(
@@ -2462,7 +2462,7 @@ pub static MZ_AUDIT_EVENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_source_status_history",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::SourceStatusHistory),
+    data_source: IntrospectionType::SourceStatusHistory,
     desc: MZ_SOURCE_STATUS_HISTORY_DESC.clone(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
@@ -2472,7 +2472,7 @@ pub static MZ_AWS_PRIVATELINK_CONNECTION_STATUS_HISTORY: Lazy<BuiltinSource> =
     Lazy::new(|| BuiltinSource {
         name: "mz_aws_privatelink_connection_status_history",
         schema: MZ_INTERNAL_SCHEMA,
-        data_source: Some(IntrospectionType::PrivatelinkConnectionStatusHistory),
+        data_source: IntrospectionType::PrivatelinkConnectionStatusHistory,
         desc: MZ_AWS_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC.clone(),
         is_retained_metrics_object: false,
         access: vec![PUBLIC_SELECT],
@@ -2513,7 +2513,7 @@ pub static MZ_AWS_PRIVATELINK_CONNECTION_STATUSES: Lazy<BuiltinView> = Lazy::new
 pub static MZ_STATEMENT_EXECUTION_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_statement_execution_history",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::StatementExecutionHistory),
+    data_source: IntrospectionType::StatementExecutionHistory,
     desc: MZ_STATEMENT_EXECUTION_HISTORY_DESC.clone(),
     is_retained_metrics_object: false,
     access: vec![MONITOR_SELECT],
@@ -2536,7 +2536,7 @@ FROM mz_internal.mz_statement_execution_history",
 pub static MZ_PREPARED_STATEMENT_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_prepared_statement_history",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::PreparedStatementHistory),
+    data_source: IntrospectionType::PreparedStatementHistory,
     desc: MZ_PREPARED_STATEMENT_HISTORY_DESC.clone(),
     is_retained_metrics_object: false,
     access: vec![MONITOR_SELECT],
@@ -2556,7 +2556,7 @@ FROM mz_internal.mz_prepared_statement_history",
 pub static MZ_SESSION_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_session_history",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::SessionHistory),
+    data_source: IntrospectionType::SessionHistory,
     desc: MZ_SESSION_HISTORY_DESC.clone(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
@@ -2604,7 +2604,7 @@ pub static MZ_STATEMENT_LIFECYCLE_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| Bu
             "occurred_at",
             ScalarType::TimestampTz { precision: None }.nullable(false),
         ),
-    data_source: Some(IntrospectionType::StatementLifecycleHistory),
+    data_source: IntrospectionType::StatementLifecycleHistory,
     is_retained_metrics_object: false,
     // TODO[btv]: Maybe this should be public instead of
     // `MONITOR_REDACTED`, but since that would be a backwards-compatible
@@ -2690,7 +2690,7 @@ WHERE mz_sources.id NOT LIKE 's%';",
 pub static MZ_SINK_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_sink_status_history",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::SinkStatusHistory),
+    data_source: IntrospectionType::SinkStatusHistory,
     desc: MZ_SINK_STATUS_HISTORY_DESC.clone(),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
@@ -2800,7 +2800,7 @@ pub static MZ_CLUSTER_REPLICA_METRICS: Lazy<BuiltinTable> = Lazy::new(|| Builtin
 pub static MZ_CLUSTER_REPLICA_FRONTIERS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_cluster_replica_frontiers",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::ReplicaFrontiers),
+    data_source: IntrospectionType::ReplicaFrontiers,
     desc: RelationDesc::empty()
         .with_column("object_id", ScalarType::String.nullable(false))
         .with_column("replica_id", ScalarType::String.nullable(false))
@@ -2812,7 +2812,7 @@ pub static MZ_CLUSTER_REPLICA_FRONTIERS: Lazy<BuiltinSource> = Lazy::new(|| Buil
 pub static MZ_FRONTIERS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_frontiers",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::Frontiers),
+    data_source: IntrospectionType::Frontiers,
     desc: RelationDesc::empty()
         .with_column("object_id", ScalarType::String.nullable(false))
         .with_column("read_frontier", ScalarType::MzTimestamp.nullable(true))
@@ -2920,7 +2920,7 @@ pub static MZ_WEBHOOKS_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_SOURCE_STATISTICS_PER_WORKER: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_source_statistics_per_worker",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::StorageSourceStatistics),
+    data_source: IntrospectionType::StorageSourceStatistics,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("worker_id", ScalarType::UInt64.nullable(false))
@@ -2938,7 +2938,7 @@ pub static MZ_SOURCE_STATISTICS_PER_WORKER: Lazy<BuiltinSource> = Lazy::new(|| B
 pub static MZ_SINK_STATISTICS_PER_WORKER: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_sink_statistics_per_worker",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::StorageSinkStatistics),
+    data_source: IntrospectionType::StorageSinkStatistics,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("worker_id", ScalarType::UInt64.nullable(false))
@@ -2953,7 +2953,7 @@ pub static MZ_SINK_STATISTICS_PER_WORKER: Lazy<BuiltinSource> = Lazy::new(|| Bui
 pub static MZ_STORAGE_SHARDS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_storage_shards",
     schema: MZ_INTERNAL_SCHEMA,
-    data_source: Some(IntrospectionType::ShardMapping),
+    data_source: IntrospectionType::ShardMapping,
     desc: RelationDesc::empty()
         .with_column("object_id", ScalarType::String.nullable(false))
         .with_column("shard_id", ScalarType::String.nullable(false)),


### PR DESCRIPTION
This field no longer needs to be an option.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
