### PR TITLE
compute: Check total size of peek response when aggregating rows

### DIFF
--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -340,8 +340,11 @@ where
                                     .fold(0u64, |total, x| total.saturating_add(x));
                                 match self.max_result_size {
                                     Some(max_size) if total_size > max_size => {
+                                        // Note: We match on this specific error message in tests
+                                        // so it's important that nothing else returns the same
+                                        // string.
                                         let err = format!(
-                                            "result exceeds max size of {}",
+                                            "total result exceeds max size of {}",
                                             ByteSize::b(max_size)
                                         );
                                         PeekResponse::Error(err)

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -15,10 +15,13 @@
 
 use std::collections::BTreeMap;
 use std::iter;
+use std::num::NonZeroUsize;
 
 use async_trait::async_trait;
+use bytesize::ByteSize;
 use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::lattice::Lattice;
+use mz_ore::cast::CastFrom;
 use mz_repr::{Diff, GlobalId, Row};
 use mz_service::client::{GenericClient, Partitionable, PartitionedState};
 use mz_service::grpc::{GrpcClient, GrpcServer, ProtoServiceTypes, ResponseStream};
@@ -108,6 +111,11 @@ where
 pub struct PartitionedComputeState<T> {
     /// Number of partitions the state machine represents.
     parts: usize,
+    /// The maximum result size this state machine can return.
+    ///
+    /// This isn't set when creating a [`PartitionedComputeState`], rather we listen for
+    /// [`ComputeCommand::UpdateConfiguration`] and update it then.
+    max_result_size: Option<u64>,
     /// Upper frontiers for indexes and sinks, both collected as a `MutableAntichain` across all
     /// partitions and individually listed for each partition.
     ///
@@ -168,6 +176,7 @@ where
     fn new(parts: usize) -> PartitionedComputeState<T> {
         PartitionedComputeState {
             parts,
+            max_result_size: None,
             uppers: BTreeMap::new(),
             peek_responses: BTreeMap::new(),
             pending_subscribes: BTreeMap::new(),
@@ -182,6 +191,7 @@ where
     fn reset(&mut self) {
         let PartitionedComputeState {
             parts: _,
+            max_result_size: _,
             uppers,
             peek_responses,
             pending_subscribes,
@@ -243,6 +253,10 @@ where
                     .collect()
             }
             command => {
+                if let ComputeCommand::UpdateConfiguration(config) = &command {
+                    self.max_result_size = config.max_result_size;
+                }
+
                 let mut r = vec![None; self.parts];
                 r[0] = Some(command);
                 r
@@ -311,7 +325,29 @@ where
                             (PeekResponse::Error(e), _) => PeekResponse::Error(e),
                             (PeekResponse::Rows(mut rows), PeekResponse::Rows(r)) => {
                                 rows.extend(r.into_iter());
-                                PeekResponse::Rows(rows)
+
+                                let total_size = rows
+                                    .iter()
+                                    // Note: if the type of count changes in the future to be a
+                                    // signed integer, then we'll need to consolidate rows before
+                                    // taking this summation.
+                                    .map(|(row, count): &(Row, NonZeroUsize)| {
+                                        let size = row
+                                            .byte_len()
+                                            .saturating_add(std::mem::size_of_val(count));
+                                        u64::cast_from(size)
+                                    })
+                                    .fold(0u64, |total, x| total.saturating_add(x));
+                                match self.max_result_size {
+                                    Some(max_size) if total_size > max_size => {
+                                        let err = format!(
+                                            "result exceeds max size of {}",
+                                            ByteSize::b(max_size)
+                                        );
+                                        PeekResponse::Error(err)
+                                    }
+                                    _ => PeekResponse::Rows(rows),
+                                }
                             }
                         };
                     }

--- a/test/sqllogictest/max_result_size.slt
+++ b/test/sqllogictest/max_result_size.slt
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET max_result_size TO 128;
+----
+COMPLETE 0
+
+statement ok
+CREATE CLUSTER c1 SIZE 'mem-2';
+
+query I
+SELECT workers FROM mz_internal.mz_cluster_replica_sizes JOIN mz_cluster_replicas USING (size);
+----
+2
+2
+2
+8
+
+statement ok
+CREATE TABLE t1 (a int);
+
+statement ok
+INSERT INTO t1 SELECT * FROM generate_series(1, 16);
+
+statement ok
+SET cluster TO 'c1';
+
+# Note: 'total' in the error message here is important because it indicates we failed when
+# aggregating the result from multiple workers, as opposed to on any single worker.
+query error db error: ERROR: total result exceeds max size of 128 B
+SELECT * FROM t1;


### PR DESCRIPTION
This PR adds a check for `max_result_size` when combining the results from multiple timely workers. A user recently hit an edge case where the result size per-worker was less then our limit, but the combined size required us to allocate 10GB which caused an OOM.

I added a test that checks for a specific error message, I'm open to removing it if folks have a better way to exercise this specific scenario.

### Motivation

Related to https://github.com/MaterializeInc/accounts/issues/33

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
