### PR TITLE
storage: instrument sends and recvs into unbounded channels in source pipeline

### DIFF
--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -103,6 +103,7 @@ default = ["tokio-console", "workspace-hack"]
 async = [
   "async-trait",
   "futures",
+  "metrics",
   "openssl",
   "tokio-openssl",
   "tokio",

--- a/src/storage/src/metrics/channel.rs
+++ b/src/storage/src/metrics/channel.rs
@@ -1,0 +1,38 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Utilities for tracking metrics related to decoding.
+
+use mz_ore::metric;
+use mz_ore::metrics::raw::IntCounterVec;
+use mz_ore::metrics::MetricsRegistry;
+
+/// Metrics specific to a single worker.
+#[derive(Clone, Debug)]
+pub struct ChannelMetricDefs {
+    pub(crate) sends: IntCounterVec,
+    pub(crate) recvs: IntCounterVec,
+}
+
+impl ChannelMetricDefs {
+    pub(crate) fn register_with(registry: &MetricsRegistry) -> Self {
+        Self {
+            sends: registry.register(metric!(
+                name: "mz_storage_source_channel_sends",
+                help: "Sends to unbounded channels in the source pipeline.",
+                var_labels: ["source_id", "worker_id", "worker_count", "location"],
+            )),
+            recvs: registry.register(metric!(
+                name: "mz_storage_source_channel_recvs",
+                help: "Receives from unbounded channels in the source pipeline.",
+                var_labels: ["source_id", "worker_id", "worker_count", "location"],
+            )),
+        }
+    }
+}

--- a/src/storage/src/metrics/source.rs
+++ b/src/storage/src/metrics/source.rs
@@ -239,6 +239,9 @@ pub(crate) struct SourceMetricDefs {
     pub(crate) upsert_backpressure_defs: UpsertBackpressureMetricDefs,
     /// A cluster-wide counter shared across all sources.
     pub(crate) bytes_read: IntCounter,
+
+    // Additional metrics definitions;
+    pub(crate) channel_metric_defs: super::channel::ChannelMetricDefs,
 }
 
 impl SourceMetricDefs {
@@ -253,6 +256,7 @@ impl SourceMetricDefs {
                 name: "mz_bytes_read_total",
                 help: "Count of bytes read from sources",
             )),
+            channel_metric_defs: super::channel::ChannelMetricDefs::register_with(registry),
         }
     }
 }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -15,7 +15,7 @@ futures-util = "0.3.25"
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 serde = { version = "1.0.152", features = ["derive"] }
-mz-ore = { path = "../ore", features = ["tracing_", "test"] }
+mz-ore = { path = "../ore", features = ["async", "tracing_", "test"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "time"] }
 num-traits = "0.2"

--- a/src/timely-util/src/capture.rs
+++ b/src/timely-util/src/capture.rs
@@ -13,12 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use mz_ore::channel::{InstrumentedChannelMetric, InstrumentedUnboundedSender};
 use timely::dataflow::operators::capture::{EventCore, EventPusherCore};
-use tokio::sync::mpsc::UnboundedSender;
 
-pub struct UnboundedTokioCapture<T, D>(pub UnboundedSender<EventCore<T, D>>);
+pub struct UnboundedTokioCapture<T, D, M>(pub InstrumentedUnboundedSender<EventCore<T, D>, M>);
 
-impl<T, D> EventPusherCore<T, D> for UnboundedTokioCapture<T, D> {
+impl<T, D, M> EventPusherCore<T, D> for UnboundedTokioCapture<T, D, M>
+where
+    M: InstrumentedChannelMetric,
+{
     fn push(&mut self, event: EventCore<T, D>) {
         // NOTE: An Err(x) result just means "data not accepted" most likely
         //       because the receiver is gone. No need to panic.


### PR DESCRIPTION
We appear to have a small memory leak in at least 2 places in storage, see https://materializeinc.slack.com/archives/C01CFKM1QRF/p1705447561489359 for details.

The worse of these *appears* to be related to our use of tokio mpsc channels. However, its unclear WHICH sources and which workers are causing issues in practice in production. This pr adds counters to sending and recv-ing from these channels

I don't expect a measurable performance cost; For the resume upper channel, that cost is one atomic bump per second, and for the data channels, its 1 atomic bump per chunk of data.

### Motivation

  * This PR adds a known-desirable feature.
 
additional instrumentation


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
