### PR TITLE
scalability framework: test connection establishment (with balancerd)

### DIFF
--- a/misc/python/materialize/scalability/benchmark_executor.py
+++ b/misc/python/materialize/scalability/benchmark_executor.py
@@ -257,7 +257,7 @@ class BenchmarkExecutor:
         cursor = cursor_pool[local.worker_id]
 
         start = time.time()
-        operation.execute(cursor)
+        workload.execute_operation(operation, cursor)
         wallclock = time.time() - start
 
         return {

--- a/misc/python/materialize/scalability/benchmark_executor.py
+++ b/misc/python/materialize/scalability/benchmark_executor.py
@@ -279,6 +279,7 @@ class BenchmarkExecutor:
 
         if isinstance(workload, WorkloadWithContext):
             workload.set_endpoint(endpoint)
+            workload.set_schema(self.schema)
 
         return workload
 

--- a/misc/python/materialize/scalability/endpoint.py
+++ b/misc/python/materialize/scalability/endpoint.py
@@ -19,8 +19,12 @@ class Endpoint:
     def __init__(self, specified_target: str):
         self._specified_target = specified_target
 
-    def sql_connection(self) -> psycopg.connection.Connection[tuple[Any, ...]]:
-        print(f"Connecting to URL: {self.url()}")
+    def sql_connection(
+        self, quiet: bool = False
+    ) -> psycopg.connection.Connection[tuple[Any, ...]]:
+        if not quiet:
+            print(f"Connecting to URL: {self.url()}")
+
         conn = psycopg.connect(self.url())
         conn.autocommit = True
         return conn

--- a/misc/python/materialize/scalability/operation.py
+++ b/misc/python/materialize/scalability/operation.py
@@ -12,6 +12,11 @@ from psycopg import Cursor, ProgrammingError
 
 class Operation:
     def execute(self, cursor: Cursor) -> None:
+        raise NotImplementedError
+
+
+class SqlOperation(Operation):
+    def execute(self, cursor: Cursor) -> None:
         try:
             cursor.execute(self.sql_statement().encode("utf8"))
             cursor.fetchall()

--- a/misc/python/materialize/scalability/operation.py
+++ b/misc/python/materialize/scalability/operation.py
@@ -51,3 +51,21 @@ class SqlOperation(Operation):
 
     def sql_statement(self) -> str:
         raise NotImplementedError
+
+
+class OperationChainWithDataExchange(Operation):
+    def __init__(self, operations: list[Operation]):
+        assert len(operations) > 0, "requires at least one operation"
+        self.ops = operations
+
+    def required_keys(self) -> set[str]:
+        return self.operations()[0].required_keys()
+
+    def operations(self) -> list[Operation]:
+        return self.ops
+
+    def _execute(self, data: OperationData) -> OperationData:
+        for operation in self.operations():
+            data = operation.execute(data)
+
+        return data

--- a/misc/python/materialize/scalability/operation_data.py
+++ b/misc/python/materialize/scalability/operation_data.py
@@ -1,0 +1,39 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import Any
+
+from psycopg import Cursor
+
+
+class OperationData:
+    def __init__(self, cursor: Cursor):
+        self._data: dict[str, Any] = dict()
+        self._data["cursor"] = cursor
+
+    def cursor(self) -> Cursor:
+        return self._data["cursor"]
+
+    def push(self, key: str, value: Any) -> None:
+        self._data[key] = value
+
+    def get(self, key: str) -> Any:
+        if key not in self._data.keys():
+            raise RuntimeError(f"Key does not exist: {key}")
+
+        return self._data[key]
+
+    def validate_requirements(
+        self, expected_keys: set[str], required_by: type[Any], requirement: str
+    ) -> None:
+        for key in expected_keys:
+            if key not in self._data.keys():
+                raise RuntimeError(
+                    f"{required_by.__name__} {requirement} '{key}' but got only: {self._data.keys()}"
+                )

--- a/misc/python/materialize/scalability/operation_data.py
+++ b/misc/python/materialize/scalability/operation_data.py
@@ -23,6 +23,9 @@ class OperationData:
     def push(self, key: str, value: Any) -> None:
         self._data[key] = value
 
+    def remove(self, key: str) -> None:
+        self._data.pop(key, None)
+
     def get(self, key: str) -> Any:
         if key not in self._data.keys():
             raise RuntimeError(f"Key does not exist: {key}")

--- a/misc/python/materialize/scalability/operations.py
+++ b/misc/python/materialize/scalability/operations.py
@@ -8,44 +8,44 @@
 # by the Apache License, Version 2.0.
 
 
-from materialize.scalability.operation import Operation
+from materialize.scalability.operation import SqlOperation
 
 
-class InsertDefaultValues(Operation):
+class InsertDefaultValues(SqlOperation):
     def sql_statement(self) -> str:
         return "INSERT INTO t1 DEFAULT VALUES;"
 
 
-class SelectOne(Operation):
+class SelectOne(SqlOperation):
     def sql_statement(self) -> str:
         return "SELECT 1;"
 
 
-class SelectStar(Operation):
+class SelectStar(SqlOperation):
     def sql_statement(self) -> str:
         return "SELECT * FROM t1;"
 
 
-class SelectLimit(Operation):
+class SelectLimit(SqlOperation):
     def sql_statement(self) -> str:
         return "SELECT * FROM t1 LIMIT 1;"
 
 
-class SelectCount(Operation):
+class SelectCount(SqlOperation):
     def sql_statement(self) -> str:
         return "SELECT COUNT(*) FROM t1;"
 
 
-class SelectCountInMv(Operation):
+class SelectCountInMv(SqlOperation):
     def sql_statement(self) -> str:
         return "SELECT count FROM mv1;"
 
 
-class SelectUnionAll(Operation):
+class SelectUnionAll(SqlOperation):
     def sql_statement(self) -> str:
         return "SELECT * FROM t1 UNION ALL SELECT * FROM t1;"
 
 
-class Update(Operation):
+class Update(SqlOperation):
     def sql_statement(self) -> str:
         return "UPDATE t1 SET f1 = f1 + 1;"

--- a/misc/python/materialize/scalability/workload.py
+++ b/misc/python/materialize/scalability/workload.py
@@ -12,6 +12,7 @@ from psycopg import Cursor
 from materialize.scalability.endpoint import Endpoint
 from materialize.scalability.operation import Operation
 from materialize.scalability.operation_data import OperationData
+from materialize.scalability.schema import Schema
 
 
 class Workload:
@@ -28,9 +29,13 @@ class Workload:
 
 class WorkloadWithContext(Workload):
     endpoint: Endpoint
+    schema: Schema
 
     def set_endpoint(self, endpoint: Endpoint) -> None:
         self.endpoint = endpoint
+
+    def set_schema(self, schema: Schema) -> None:
+        self.schema = schema
 
 
 class WorkloadSelfTest(Workload):

--- a/misc/python/materialize/scalability/workload.py
+++ b/misc/python/materialize/scalability/workload.py
@@ -21,7 +21,11 @@ class Workload:
 
     def execute_operation(self, operation: Operation, cursor: Cursor) -> None:
         data = OperationData(cursor)
+        self.amend_data_before_execution(data)
         operation.execute(data)
+
+    def amend_data_before_execution(self, data: OperationData) -> None:
+        pass
 
     def name(self) -> str:
         return self.__class__.__name__

--- a/misc/python/materialize/scalability/workload.py
+++ b/misc/python/materialize/scalability/workload.py
@@ -9,6 +9,7 @@
 
 from psycopg import Cursor
 
+from materialize.scalability.endpoint import Endpoint
 from materialize.scalability.operation import Operation
 
 
@@ -21,6 +22,13 @@ class Workload:
 
     def name(self) -> str:
         return self.__class__.__name__
+
+
+class WorkloadWithContext(Workload):
+    endpoint: Endpoint
+
+    def set_endpoint(self, endpoint: Endpoint) -> None:
+        self.endpoint = endpoint
 
 
 class WorkloadSelfTest(Workload):

--- a/misc/python/materialize/scalability/workload.py
+++ b/misc/python/materialize/scalability/workload.py
@@ -7,12 +7,17 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+from psycopg import Cursor
+
 from materialize.scalability.operation import Operation
 
 
 class Workload:
     def operations(self) -> list[Operation]:
         raise NotImplementedError
+
+    def execute_operation(self, operation: Operation, cursor: Cursor) -> None:
+        operation.execute(cursor)
 
     def name(self) -> str:
         return self.__class__.__name__

--- a/misc/python/materialize/scalability/workload.py
+++ b/misc/python/materialize/scalability/workload.py
@@ -11,6 +11,7 @@ from psycopg import Cursor
 
 from materialize.scalability.endpoint import Endpoint
 from materialize.scalability.operation import Operation
+from materialize.scalability.operation_data import OperationData
 
 
 class Workload:
@@ -18,7 +19,8 @@ class Workload:
         raise NotImplementedError
 
     def execute_operation(self, operation: Operation, cursor: Cursor) -> None:
-        operation.execute(cursor)
+        data = OperationData(cursor)
+        operation.execute(data)
 
     def name(self) -> str:
         return self.__class__.__name__

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -47,7 +47,11 @@ from materialize.scalability.regression_assessment import RegressionAssessment
 from materialize.scalability.result_analyzer import ResultAnalyzer
 from materialize.scalability.result_analyzers import DefaultResultAnalyzer
 from materialize.scalability.schema import Schema, TransactionIsolation
-from materialize.scalability.workload import Workload, WorkloadSelfTest
+from materialize.scalability.workload import (
+    Workload,
+    WorkloadSelfTest,
+    WorkloadWithContext,
+)
 from materialize.scalability.workloads import *  # noqa: F401 F403
 from materialize.scalability.workloads_test import *  # noqa: F401 F403
 from materialize.util import YesNoOnce, all_subclasses
@@ -299,6 +303,8 @@ def get_workload_classes(args: argparse.Namespace) -> list[type[Workload]]:
             workload_cls
             for workload_cls in all_subclasses(Workload)
             if not issubclass(workload_cls, WorkloadSelfTest)
+            # abstract base class
+            and not workload_cls == WorkloadWithContext
         ]
     )
 


### PR DESCRIPTION
This PR introduces a workload that tests the establishment of a connection (including using the connection for a select and disconnecting) and contains the necessary refactorings for that. The refactorings introduce the possibility to exchange data between operations that are chained and executed by the same worker.

This builds upon https://github.com/MaterializeInc/materialize/pull/24458, supports https://github.com/MaterializeInc/materialize/issues/21843, and closes https://github.com/MaterializeInc/materialize/issues/23801.

### Commits
4e09f41ccb scalability framework: introduce SqlOperation
0863d3d27a scalability framework: refactoring: delegate execution of operation to workload
9a5021e69a scalability framework: introduce WorkloadWithContext
d653651488 scalability framework: input and output for operations
e308c1d114 scalability framework: introduce OperationChainWithDataExchange
**21ddc87cb1 scalability framework: add Connect and Disconnect operations
f65ea37762 scalability framework: introduce EstablishConnectionWorkload**
34517e3cef scalability framework: do not run base class


### Nightlies
https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Ascalability%2Fconnections-workload

### Future Work
Experimenting with higher concurrencies through a separate build step in https://github.com/MaterializeInc/materialize/pull/24632.