### PR TITLE
fivetran-destination: Add a logging layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4391,6 +4391,7 @@ dependencies = [
  "clap",
  "csv-async",
  "futures",
+ "insta",
  "itertools",
  "mz-ore",
  "mz-pgrepr",
@@ -4401,10 +4402,15 @@ dependencies = [
  "prost-build",
  "prost-types",
  "protobuf-src",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-postgres",
  "tonic",
  "tonic-build",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
  "workspace-hack",
 ]
 

--- a/src/fivetran-destination/Cargo.toml
+++ b/src/fivetran-destination/Cargo.toml
@@ -16,17 +16,25 @@ clap = { version = "3.2.24", features = ["derive", "env"] }
 csv-async = { version = "1.2.6", default-features = false, features = ["tokio"] }
 futures = "0.3.25"
 itertools = "0.10.5"
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", features = ["cli"] }
 mz-pgrepr = { path = "../pgrepr" }
 openssl = { version = "0.10.48", features = ["vendored"] }
 postgres-openssl = "0.5.0"
 postgres-protocol = { version = "0.6.5" }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 prost-types = { version = "0.11.9" }
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.89"
 tonic = "0.9.2"
 tokio = { version = "1.32.0", features = ["rt"] }
 tokio-postgres = { version = "0.7.8" }
+tracing = "0.1.37"
+tracing-core = "0.1.30"
+tracing-subscriber = "0.3.16"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+
+[dev-dependencies]
+insta = "1.32"
 
 [build-dependencies]
 prost-build = "0.11.2"

--- a/src/fivetran-destination/src/bin/mz-fivetran-destination.rs
+++ b/src/fivetran-destination/src/bin/mz-fivetran-destination.rs
@@ -9,6 +9,7 @@
 
 //! Fivetran destination for Materialize.
 
+use mz_fivetran_destination::logging::FivetranLoggingFormat;
 use mz_fivetran_destination::{DestinationServer, MaterializeDestination};
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::error::ErrorExt;
@@ -27,6 +28,13 @@ struct Args {
 
 #[tokio::main]
 async fn main() {
+    // Start our tracing as early as possible so we can capture any issues with startup.
+    tracing_subscriber::fmt()
+        .with_ansi(false)
+        .with_max_level(tracing_core::Level::TRACE)
+        .event_format(FivetranLoggingFormat::destination())
+        .init();
+
     let args = cli::parse_args(CliConfig {
         env_prefix: Some("MZ_FIVETRAN_DESTINATION_"),
         enable_version_flag: false,

--- a/src/fivetran-destination/src/lib.rs
+++ b/src/fivetran-destination/src/lib.rs
@@ -11,5 +11,7 @@ mod crypto;
 mod destination;
 mod fivetran_sdk;
 
+pub mod logging;
+
 pub use destination::MaterializeDestination;
 pub use fivetran_sdk::destination_server::DestinationServer;

--- a/src/fivetran-destination/src/logging.rs
+++ b/src/fivetran-destination/src/logging.rs
@@ -1,0 +1,219 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use serde::Serialize;
+use tracing_core::{Event, Level, Subscriber};
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::{format, FmtContext, FormatEvent, FormatFields};
+use tracing_subscriber::registry::LookupSpan;
+
+use std::io;
+
+/// Implements [`tracing_subscriber::fmt::FormatEvent`] according to the Fivetran SDK logging
+/// format.
+///
+/// See: <https://github.com/fivetran/fivetran_sdk/blob/main/development-guide.md#logging>
+pub struct FivetranLoggingFormat {
+    origin: FivetranEventOrigin,
+}
+
+impl FivetranLoggingFormat {
+    /// Returns a type that implements [`FormatEvent`] and is configured to log for a Fivetran
+    /// Destination.
+    pub fn destination() -> Self {
+        FivetranLoggingFormat {
+            origin: FivetranEventOrigin::SdkDestination,
+        }
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for FivetranLoggingFormat
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: format::Writer<'_>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        let mut message = String::new();
+        ctx.format_fields(Writer::new(&mut message), event)?;
+
+        let level = match *event.metadata().level() {
+            // Mapping TRACE and DEBUG isn't the best, but Fivetran has no other severity level.
+            Level::TRACE | Level::DEBUG => FivetranEventLevel::Notice,
+            Level::INFO => FivetranEventLevel::Info,
+            Level::WARN => FivetranEventLevel::Warning,
+            Level::ERROR => FivetranEventLevel::Severe,
+        };
+
+        let event = FivetranEvent {
+            message,
+            level,
+            message_origin: self.origin,
+        };
+        let write_adapter = WriteAdapter::new(&mut writer);
+
+        match serde_json::to_writer(write_adapter, &event) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // Last ditch effort to figure out why we failed to serialize, it's not guaranteed
+                // we'll be able to see this.
+                eprintln!("Failed to serialize logging event! err: {e}");
+                Err(std::fmt::Error)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct FivetranEvent {
+    level: FivetranEventLevel,
+    message: String,
+    message_origin: FivetranEventOrigin,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+enum FivetranEventLevel {
+    // TODO(parkmycar): Check with Emrah to make sure NOTICE is a supported level.
+    Notice,
+    Info,
+    Warning,
+    Severe,
+}
+
+#[derive(Copy, Clone, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum FivetranEventOrigin {
+    SdkDestination,
+    // TODO(parkmycar): One day we'll support this.
+    // SdkConnector,
+}
+
+/// [`tracing_subscriber::fmt::format::Writer`] implements [`std::fmt::Write`] but
+/// [`serde_json::to_writer`] requires a type that implements [`std::io::Write`] so this struct
+/// acts as an adapter between the two `Write` traits.
+struct WriteAdapter<'a> {
+    writer: &'a mut dyn std::fmt::Write,
+}
+
+impl<'a> WriteAdapter<'a> {
+    pub fn new(writer: &'a mut dyn std::fmt::Write) -> Self {
+        WriteAdapter { writer }
+    }
+}
+
+impl<'a> io::Write for WriteAdapter<'a> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let s =
+            std::str::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        self.writer
+            .write_str(s)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        Ok(s.as_bytes().len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FivetranLoggingFormat;
+
+    use std::sync::{Arc, Mutex};
+
+    use tracing_subscriber::fmt::MakeWriter;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    #[derive(Debug, Default, Clone)]
+    struct TestWriter {
+        writer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl TestWriter {
+        fn drain(&self) -> Vec<u8> {
+            let mut guard = self.writer.lock().unwrap();
+            guard.drain(..).collect()
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for TestWriter {
+        type Writer = TestWriter;
+
+        fn make_writer(&self) -> Self::Writer {
+            TestWriter {
+                writer: Arc::clone(&self.writer),
+            }
+        }
+    }
+
+    impl std::io::Write for TestWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let mut guard = self.writer.lock().unwrap();
+            guard.write(buf)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[mz_ore::test]
+    fn smoketest_tracing_format() {
+        let writer = TestWriter::default();
+
+        let subscriber = tracing_subscriber::fmt::fmt()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .with_max_level(tracing_core::Level::TRACE)
+            .event_format(FivetranLoggingFormat::destination())
+            .finish();
+
+        let _guard = subscriber.set_default();
+
+        tracing::trace!("this is a low priority trace");
+        let msg = String::from_utf8(writer.drain()).unwrap();
+        insta::assert_snapshot!(msg, @r###"{"level":"NOTICE","message":"this is a low priority trace","message-origin":"sdk_destination"}"###);
+
+        tracing::debug!(alert_count = 42, "good level for debug printing");
+        let msg = String::from_utf8(writer.drain()).unwrap();
+        insta::assert_snapshot!(msg, @r###"{"level":"NOTICE","message":"good level for debug printing alert_count=42","message-origin":"sdk_destination"}"###);
+
+        #[derive(Debug)]
+        #[allow(unused)]
+        struct ComplexData {
+            level: usize,
+            msg: &'static str,
+        }
+        let data = ComplexData {
+            level: 101,
+            msg: "this is a nested message",
+        };
+
+        tracing::info!(?data, "hello world!");
+        let msg = String::from_utf8(writer.drain()).unwrap();
+        insta::assert_snapshot!(msg, @r###"{"level":"INFO","message":"hello world! data=ComplexData { level: 101, msg: \"this is a nested message\" }","message-origin":"sdk_destination"}"###);
+
+        tracing::warn!("oh no something went wrong but we can try to recover");
+        let msg = String::from_utf8(writer.drain()).unwrap();
+        insta::assert_snapshot!(msg, @r###"{"level":"WARNING","message":"oh no something went wrong but we can try to recover","message-origin":"sdk_destination"}"###);
+
+        tracing::error!("EEK! hopefully we never hit this");
+        let msg = String::from_utf8(writer.drain()).unwrap();
+        insta::assert_snapshot!(msg, @r###"{"level":"SEVERE","message":"EEK! hopefully we never hit this","message-origin":"sdk_destination"}"###);
+    }
+}

--- a/src/fivetran-destination/src/logging.rs
+++ b/src/fivetran-destination/src/logging.rs
@@ -48,10 +48,12 @@ where
         ctx.format_fields(Writer::new(&mut message), event)?;
 
         let level = match *event.metadata().level() {
-            // Mapping TRACE and DEBUG to the same level isn't the best, but Fivetran has no other
-            // severity level.
-            Level::TRACE | Level::DEBUG => FivetranEventLevel::Notice,
-            Level::INFO => FivetranEventLevel::Info,
+            // Mapping TRACE and DEBUG to "Info" isn't great, but Fivetran doesn't support any
+            // other logging level.
+            //
+            // TODO(parkmycar): When we support pushing traces to our own logging infra, we should
+            // filter out `TRACE` and `DEBUG` at this level.
+            Level::TRACE | Level::DEBUG | Level::INFO => FivetranEventLevel::Info,
             Level::WARN => FivetranEventLevel::Warning,
             Level::ERROR => FivetranEventLevel::Severe,
         };
@@ -86,7 +88,6 @@ struct FivetranEvent {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "UPPERCASE")]
 enum FivetranEventLevel {
-    Notice,
     Info,
     Warning,
     Severe,

--- a/src/fivetran-destination/src/logging.rs
+++ b/src/fivetran-destination/src/logging.rs
@@ -212,14 +212,14 @@ mod tests {
         let msg = String::from_utf8(writer.drain()).unwrap();
         insta::assert_snapshot!(
             msg,
-            @r###"{"level":"NOTICE","message":"this is a low priority trace","message-origin":"sdk_destination"}"###
+            @r###"{"level":"INFO","message":"this is a low priority trace","message-origin":"sdk_destination"}"###
         );
 
         tracing::debug!(alert_count = 42, "good level for debug printing");
         let msg = String::from_utf8(writer.drain()).unwrap();
         insta::assert_snapshot!(
             msg,
-            @r###"{"level":"NOTICE","message":"good level for debug printing alert_count=42","message-origin":"sdk_destination"}"###
+            @r###"{"level":"INFO","message":"good level for debug printing alert_count=42","message-origin":"sdk_destination"}"###
         );
 
         #[derive(Debug)]


### PR DESCRIPTION
This PR adds a type that implements [`FormatEvent`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.FormatEvent.html) that conforms to the [Fivetran SDK logging format](https://github.com/fivetran/fivetran_sdk/blob/main/development-guide.md#logging)

Note: this doesn't add any additional logging yet, just implements the format and enables it for the destination.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/24445

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
