### PR TITLE
sql: force enable disk for new cc/C sizes

### DIFF
--- a/src/catalog/src/config.rs
+++ b/src/catalog/src/config.rs
@@ -222,6 +222,24 @@ impl Default for ClusterReplicaSizeMap {
                 selectors: BTreeMap::default(),
             },
         );
+
+        for size in ["1cc", "1C"] {
+            inner.insert(
+                size.to_string(),
+                ReplicaAllocation {
+                    memory_limit: None,
+                    cpu_limit: None,
+                    disk_limit: None,
+                    scale: 1,
+                    workers: 1,
+                    credits_per_hour: 1.into(),
+                    cpu_exclusive: false,
+                    disabled: false,
+                    selectors: BTreeMap::default(),
+                },
+            );
+        }
+
         Self(inner)
     }
 }

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1955,6 +1955,13 @@ impl mz_sql::catalog::CatalogCluster<'_> for Cluster {
     fn is_managed(&self) -> bool {
         self.is_managed()
     }
+
+    fn managed_size(&self) -> Option<&str> {
+        match &self.config.variant {
+            ClusterVariant::Managed(ClusterVariantManaged { size, .. }) => Some(size),
+            _ => None,
+        }
+    }
 }
 
 impl mz_sql::catalog::CatalogClusterReplica<'_> for ClusterReplica {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -537,6 +537,9 @@ pub trait CatalogCluster<'a> {
 
     /// Returns true if this cluster is a managed cluster.
     fn is_managed(&self) -> bool;
+
+    /// Returns the size of the cluster, if the cluster is a managed cluster.
+    fn managed_size(&self) -> Option<&str>;
 }
 
 /// A cluster replica in a [`SessionCatalog`]

--- a/test/testdrive/cc_cluster_sizes.td
+++ b/test/testdrive/cc_cluster_sizes.td
@@ -10,10 +10,6 @@
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_cc_cluster_sizes = false
 
-# Clean up cluster manually, since testdrive does not automatically clean up
-# clusters.
-> DROP CLUSTER IF EXISTS c;
-
 # Cannot create clusters with cc cluster size naming schemes
 ! CREATE CLUSTER c SIZE '1cc';
 contains:use of 'cc' cluster sizes is not supported
@@ -35,18 +31,71 @@ contains:use of 'cc' cluster sizes is not supported
 ! ALTER CLUSTER c SET (SIZE '1cc');
 contains:use of 'cc' cluster sizes is not supported
 
-> DROP CLUSTER IF EXISTS c;
+> DROP CLUSTER c
 
 # Now flip the flag and test that we can create clusters
-# with this naming scheme. Note that here the commands
-# still fail (haven't hooked up any of these size names
-# for testing), but crucially the error isn't due to the
-# feature flag gating
+# with this naming scheme.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_cc_cluster_sizes = true
 
-! CREATE CLUSTER c SIZE '1cc';
-contains:unknown cluster replica size 1cc
+> CREATE CLUSTER c SIZE '1cc';
+> DROP CLUSTER c
 
-! CREATE CLUSTER c SIZE '1C';
-contains:unknown cluster replica size 1C
+> CREATE CLUSTER c SIZE '1C';
+> DROP CLUSTER c
+
+# Create a cluster with a legacy size with disk enabled.
+> CREATE CLUSTER c SIZE '1', DISK = true
+
+# Altering to a cc size with disk explicitly toggled is not allowed.
+! ALTER CLUSTER c SET (SIZE = '1cc', DISK = true)
+contains:DISK option not supported for cluster sizes ending in cc or C
+! ALTER CLUSTER c SET (SIZE = '1cc', DISK = false)
+contains:DISK option not supported for cluster sizes ending in cc or C
+
+# But it's fine as long as the ALTER command doesn't mention disk explicitly,
+# even though the cluster's initial creation specified disk explicitly. The
+# DISK value is just forced to true.
+> ALTER CLUSTER c SET (SIZE = '1cc')
+> DROP CLUSTER c
+
+# Same test as before, except the legacy size cluster has disk explicitly
+# disabled.
+> CREATE CLUSTER c SIZE '1', DISK = false
+> ALTER CLUSTER c SET (SIZE = '1cc')
+> DROP CLUSTER c
+
+# Same test as before, except the legacy size cluster has no disk explicitly
+# configured.
+> CREATE CLUSTER c SIZE = '1'
+> ALTER CLUSTER c SET (SIZE = '1cc')
+
+# Cannot explicitly alter DISK option for new sizes.
+! ALTER CLUSTER c SET (DISK = false)
+contains:DISK option not supported for cluster sizes ending in cc or C
+! ALTER CLUSTER c SET (DISK = true)
+contains:DISK option not supported for cluster sizes ending in cc or C
+
+# But it's okay if you're going back to a legacy size.
+> ALTER CLUSTER c SET (DISK = true, SIZE = '1')
+> DROP CLUSTER c
+
+# Ensure that disk isn't configurable for the new sizes (as it's force enabled).
+
+! CREATE CLUSTER c SIZE '1cc', DISK = true;
+contains:DISK option not supported for cluster sizes ending in cc or C
+
+! CREATE CLUSTER c SIZE '1cc', DISK = false;
+contains:DISK option not supported for cluster sizes ending in cc or C
+
+> CREATE CLUSTER c REPLICAS (r1 (SIZE '1cc'))
+> CREATE CLUSTER REPLICA c.r2 SIZE '1cc';
+> CREATE CLUSTER REPLICA c.r3 SIZE '1C';
+
+! CREATE CLUSTER REPLICA c.r SIZE '1cc', DISK = true;
+contains:DISK option not supported for cluster sizes ending in cc or C
+
+! CREATE CLUSTER REPLICA c.r SIZE '1cc', DISK = false;
+contains:DISK option not supported for cluster sizes ending in cc or C
+
+> DROP CLUSTER c


### PR DESCRIPTION
In order to simplify cluster/replica configuration with the new "cc" and "C" sizes, we're force enabling local disk, and making it an error to explicitly configure the `DISK` option on such clusters/replicas.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
