### PR TITLE
adapter: correct some auto routing bugs

### DIFF
--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -189,11 +189,11 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
 /// Checks if we're currently running on the [`MZ_INTROSPECTION_CLUSTER`], and if so, do
 /// we depend on any objects that we're not allowed to query from the cluster.
 pub fn check_cluster_restrictions(
+    cluster: &str,
     catalog: &impl SessionCatalog,
     plan: &Plan,
 ) -> Result<(), AdapterError> {
     // We only impose restrictions if the current cluster is the introspection cluster.
-    let cluster = catalog.active_cluster();
     if cluster != MZ_INTROSPECTION_CLUSTER.name {
         return Ok(());
     }

--- a/test/sqllogictest/timedomain.slt
+++ b/test/sqllogictest/timedomain.slt
@@ -63,7 +63,7 @@ COMPLETE 1
 2
 COMPLETE 1
 
-query error Transactions can only reference objects in the same timedomain.
+query error db error: ERROR: querying the following items "materialize\.public\.t" is not allowed from the "mz_introspection" cluster
 SELECT * FROM t;
 
 statement ok

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -277,10 +277,8 @@ simple
 SELECT 1;
 SELECT * FROM t;
 ----
-1
-COMPLETE 1
-1
-COMPLETE 1
+db error: ERROR: querying the following items "materialize.public.t" is not allowed from the "mz_introspection" cluster
+HINT: Use `SET CLUSTER = <cluster-name>` to change your cluster and re-run the query.
 
 statement ok
 CREATE SCHEMA other

--- a/test/sqllogictest/updates.slt
+++ b/test/sqllogictest/updates.slt
@@ -104,3 +104,12 @@ SELECT * FROM t1
 
 statement error db error: ERROR: column "t1\.x" does not exist
 UPDATE t1 AS m SET x = 5 WHERE t1.x < 10
+
+# Regression for #24612
+simple
+BEGIN;
+SELECT 1;
+INSERT INTO t VALUES (1) RETURNING 0;
+COMMIT;
+----
+db error: ERROR: INSERT INTO t VALUES (1) RETURNING 0 cannot be run inside a transaction block

--- a/test/testdrive/correctness-property-2.td
+++ b/test/testdrive/correctness-property-2.td
@@ -52,6 +52,9 @@ $ kafka-ingest format=avro topic=correctness-data key-format=avro key-schema=${k
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
 
+# Prime tokio-postgres with the missing OIDs.
+> SELECT mz_now(), * FROM correctness_data WHERE false AS OF AT LEAST 0
+
 # Grab a cursor at timestamp 0
 > BEGIN
 


### PR DESCRIPTION
We have various features that interact in unanticipated ways:
- transaction timedomains
- cluster auto routing
- non-timeline queries (`SELECT 1`) upgradeable to timeline transactions
- constant, non-query INSERTs allowed in read transactions

Here are some commits that fix a few of these interactions.

Presumably:
Fixes #24341

### Motivation

  * This PR fixes a recognized bug.
  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix some rare cases where queries or `INSERT .. RETURNING` were erroneously allowed to execute.