### PR TITLE
scalability framework: separate build for connection workload

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -124,7 +124,7 @@ steps:
               - --exponent-base
               - "2.5"
               - --max-concurrency
-              - "4096"
+              - "2048"
 
   - group: Kafka
     key: kafka

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -122,7 +122,7 @@ steps:
               - --workload-group-marker
               - "ConnectionWorkload"
               - --exponent-base
-              - "4"
+              - "2.5"
               - --max-concurrency
               - "4096"
 

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -83,8 +83,8 @@ steps:
                - --other-tag
                # common-ancestor will default to latest if not in a PR
                - common-ancestor
-    - id: scalability-benchmark
-      label: "Scalability benchmark against merge base or 'latest'"
+    - id: scalability-benchmark-dml-dql
+      label: "Scalability benchmark (read & write) against merge base or 'latest'"
       timeout_in_minutes: 180
       agents:
         queue: linux-aarch64
@@ -99,8 +99,32 @@ steps:
               - common-ancestor
               - --regression-against
               - common-ancestor
+              - --workload-group-marker
+              - "DmlDqlWorkload"
               - --max-concurrency
               - "256"
+    - id: scalability-benchmark-connection
+      label: "Scalability benchmark (connection) against merge base or 'latest'"
+      timeout_in_minutes: 180
+      agents:
+        queue: linux-aarch64-large
+      artifact_paths: junit_*.xml
+      plugins:
+        - ./ci/plugins/mzcompose:
+            composition: scalability
+            args:
+              - --target
+              - HEAD
+              - --target
+              - common-ancestor
+              - --regression-against
+              - common-ancestor
+              - --workload-group-marker
+              - "ConnectionWorkload"
+              - --exponent-base
+              - "4"
+              - --max-concurrency
+              - "4096"
 
   - group: Kafka
     key: kafka

--- a/misc/python/materialize/scalability/benchmark_executor.py
+++ b/misc/python/materialize/scalability/benchmark_executor.py
@@ -292,8 +292,9 @@ class BenchmarkExecutor:
         lock.release()
 
     def _get_concurrencies(self) -> list[int]:
+        range_end = 1024 if self.config.exponent_base < 2.0 else 32
         concurrencies: list[int] = [
-            round(self.config.exponent_base**c) for c in range(0, 1024)
+            round(self.config.exponent_base**c) for c in range(0, range_end)
         ]
         concurrencies = sorted(set(concurrencies))
         return [

--- a/misc/python/materialize/scalability/workload.py
+++ b/misc/python/materialize/scalability/workload.py
@@ -40,9 +40,3 @@ class WorkloadWithContext(Workload):
 
     def set_schema(self, schema: Schema) -> None:
         self.schema = schema
-
-
-class WorkloadSelfTest(Workload):
-    """Used to self-test the framework, so need to be excluded from regular benchmark runs."""
-
-    pass

--- a/misc/python/materialize/scalability/workload_markers.py
+++ b/misc/python/materialize/scalability/workload_markers.py
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.scalability.workload import Workload
+
+
+class WorkloadMarker(Workload):
+    """Workload marker to group workloads."""
+
+    pass
+
+
+class DmlDqlWorkload(WorkloadMarker):
+    """Workloads that only run DML & DQL statements."""
+
+    pass
+
+
+class ConnectionWorkload(WorkloadMarker):
+    """Workloads that perform connection operations."""
+
+    pass
+
+
+class SelfTestWorkload(WorkloadMarker):
+    """Used to self-test the framework, not relevant for regular benchmark runs."""
+
+    pass

--- a/misc/python/materialize/scalability/workloads.py
+++ b/misc/python/materialize/scalability/workloads.py
@@ -22,55 +22,61 @@ from materialize.scalability.operations import (
     SelectUnionAll,
     Update,
 )
-from materialize.scalability.workload import Workload, WorkloadWithContext
+from materialize.scalability.workload import (
+    WorkloadWithContext,
+)
+from materialize.scalability.workload_markers import (
+    ConnectionWorkload,
+    DmlDqlWorkload,
+)
 
 
-class InsertWorkload(Workload):
+class InsertWorkload(DmlDqlWorkload):
     def operations(self) -> list["Operation"]:
         return [InsertDefaultValues()]
 
 
-class SelectOneWorkload(Workload):
+class SelectOneWorkload(DmlDqlWorkload):
     def operations(self) -> list["Operation"]:
         return [SelectOne()]
 
 
-class SelectStarWorkload(Workload):
+class SelectStarWorkload(DmlDqlWorkload):
     def operations(self) -> list["Operation"]:
         return [SelectStar()]
 
 
-class SelectLimitWorkload(Workload):
+class SelectLimitWorkload(DmlDqlWorkload):
     def operations(self) -> list["Operation"]:
         return [SelectLimit()]
 
 
-class SelectCountWorkload(Workload):
+class SelectCountWorkload(DmlDqlWorkload):
     def operations(self) -> list["Operation"]:
         return [SelectCount()]
 
 
-class SelectUnionAllWorkload(Workload):
+class SelectUnionAllWorkload(DmlDqlWorkload):
     def operations(self) -> list["Operation"]:
         return [SelectUnionAll()]
 
 
-class InsertAndSelectCountInMvWorkload(Workload):
+class InsertAndSelectCountInMvWorkload(DmlDqlWorkload):
     def operations(self) -> list["Operation"]:
         return [InsertDefaultValues(), SelectCountInMv()]
 
 
-class InsertAndSelectLimitWorkload(Workload):
+class InsertAndSelectLimitWorkload(DmlDqlWorkload):
     def operations(self) -> list["Operation"]:
         return [InsertDefaultValues(), SelectLimit()]
 
 
-class UpdateWorkload(Workload):
+class UpdateWorkload(DmlDqlWorkload):
     def operations(self) -> list["Operation"]:
         return [Update()]
 
 
-class EstablishConnectionWorkload(WorkloadWithContext):
+class EstablishConnectionWorkload(WorkloadWithContext, ConnectionWorkload):
     def amend_data_before_execution(self, data: OperationData) -> None:
         data.push("endpoint", self.endpoint)
         data.push("schema", self.schema)

--- a/misc/python/materialize/scalability/workloads_test.py
+++ b/misc/python/materialize/scalability/workloads_test.py
@@ -15,29 +15,29 @@ from materialize.scalability.operations_test import (
     SleepInEnvironmentd,
     SleepInPython,
 )
-from materialize.scalability.workload import WorkloadSelfTest
+from materialize.scalability.workload_markers import SelfTestWorkload
 
 
-class EmptyOperatorWorkload(WorkloadSelfTest):
+class EmptyOperatorWorkload(SelfTestWorkload):
     def operations(self) -> list["Operation"]:
         return [EmptyOperation()]
 
 
-class EmptySqlStatementWorkload(WorkloadSelfTest):
+class EmptySqlStatementWorkload(SelfTestWorkload):
     def operations(self) -> list["Operation"]:
         return [EmptySqlStatement()]
 
 
-class Sleep10MsInEnvironmentdWorkload(WorkloadSelfTest):
+class Sleep10MsInEnvironmentdWorkload(SelfTestWorkload):
     def operations(self) -> list["Operation"]:
         return [SleepInEnvironmentd(duration_in_sec=0.01)]
 
 
-class Sleep10MsInClusterdWorkload(WorkloadSelfTest):
+class Sleep10MsInClusterdWorkload(SelfTestWorkload):
     def operations(self) -> list["Operation"]:
         return [SleepInClusterd(duration_in_sec=0.01)]
 
 
-class Sleep10MsInPythonWorkload(WorkloadSelfTest):
+class Sleep10MsInPythonWorkload(SelfTestWorkload):
     def operations(self) -> list["Operation"]:
         return [SleepInPython(duration_in_sec=0.01)]


### PR DESCRIPTION
Separate build with higher concurrencies.

Note that I am using a larger agent because the normal one got lost at concurrency 4096. Let me know if this is fine or if I should reduce the maximum concurrency.

### Nightlies
https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Ascalability%2Fseparate-connections-build