### PR TITLE
compute: remove mz_dataflow_delayed_time_seconds_total metric

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -423,10 +423,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             panic!("dataflow server has already initialized logging");
         }
 
-        let worker_id = self.timely_worker.index();
-        let metrics = self.compute_state.metrics.for_logging(worker_id);
-
-        let (logger, traces) = logging::initialize(self.timely_worker, config, metrics);
+        let (logger, traces) = logging::initialize(self.timely_worker, config);
 
         // Install traces as maintained indexes
         for (log, trace) in traces {

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -25,7 +25,6 @@ use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::logging::compute::ComputeEvent;
 use crate::logging::reachability::ReachabilityEvent;
 use crate::logging::{BatchLogger, EventQueue, SharedLoggingState};
-use crate::metrics::LoggingMetrics;
 
 /// Initialize logging dataflows.
 ///
@@ -34,7 +33,6 @@ use crate::metrics::LoggingMetrics;
 pub fn initialize<A: Allocate + 'static>(
     worker: &mut timely::worker::Worker<A>,
     config: &LoggingConfig,
-    metrics: LoggingMetrics,
 ) -> (super::compute::Logger, BTreeMap<LogVariant, TraceBundle>) {
     let interval_ms = std::cmp::max(1, config.interval.as_millis())
         .try_into()
@@ -51,7 +49,6 @@ pub fn initialize<A: Allocate + 'static>(
     let mut context = LoggingContext {
         worker,
         config,
-        metrics,
         interval_ms,
         now,
         start_offset,
@@ -80,7 +77,6 @@ pub fn initialize<A: Allocate + 'static>(
 struct LoggingContext<'a, A: Allocate> {
     worker: &'a mut timely::worker::Worker<A>,
     config: &'a LoggingConfig,
-    metrics: LoggingMetrics,
     interval_ms: u64,
     now: Instant,
     start_offset: Duration,
@@ -114,7 +110,6 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
         traces.extend(super::compute::construct(
             self.worker,
             self.config,
-            self.metrics.clone(),
             self.c_event_queue.clone(),
             Rc::clone(&self.shared_state),
         ));

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2361,8 +2361,6 @@ def workflow_test_replica_metrics(c: Composition) -> None:
 
     maintenance = metrics.get_value("mz_arrangement_maintenance_seconds_total")
     assert maintenance > 0, f"unexpected arrangement maintanence time: {maintenance}"
-    delayed_time = metrics.get_value("mz_dataflow_delayed_time_seconds_total")
-    assert delayed_time < 1, f"unexpected delayed time: {delayed_time}"
 
     mv_correction_insertions = metrics.get_value(
         "mz_persist_sink_correction_insertions_total"


### PR DESCRIPTION
This metric was added in search for an alternative to CPU utilization, but with CPU utilization usable now there is no need for it at the moment. Removing it in the spirit of not keeping around unused code.

This is a revert of https://github.com/MaterializeInc/materialize/pull/22584.

### Motivation

   * This PR refactors existing code.

Closes #22659 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
