### PR TITLE
Use console.materialize.com instead of cloud.materialize.com

### DIFF
--- a/bin/cloud-push
+++ b/bin/cloud-push
@@ -33,6 +33,6 @@ done
 
 echo "Deploy this build to staging by running:"
 echo
-echo "    $ bin/mz profile init --endpoint=https://staging.cloud.materialize.com --profile=staging"
+echo "    $ bin/mz profile init --endpoint=https://staging.console.materialize.com --profile=staging"
 echo "    $ bin/mz region enable --version $username:$tag --region=aws/us-east-1 --profile=staging"
 echo

--- a/doc/developer/platform/ux.md
+++ b/doc/developer/platform/ux.md
@@ -209,7 +209,7 @@ either.
 
 ### Global API
 
-The global API is a REST API hosted at <https://cloud.materialize.com/api>. It
+The global API is a REST API hosted at <https://api.cloud.materialize.com>. It
 handles operations that apply globally to an account rather than to a single
 region within an account.
 

--- a/misc/python/materialize/cloudtest/util/jwt_key.py
+++ b/misc/python/materialize/cloudtest/util/jwt_key.py
@@ -59,7 +59,7 @@ def make_jwt(tenant_id: str) -> str:
             "materialize.environment.write",
         ],
         "tenantId": tenant_id,
-        "iss": "https://cloud.materialize.com",
+        "iss": "https://admin.cloud.materialize.com",
         "iat": now,
         "exp": now + 3600,
     }


### PR DESCRIPTION
See discussion in https://materializeinc.slack.com/archives/CM7ATT65S/p1706100390895369

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
