### PR TITLE
testdrive: Increase materialization-lag.td intervals further

### DIFF
--- a/test/testdrive/materialization-lag.td
+++ b/test/testdrive/materialization-lag.td
@@ -69,8 +69,8 @@ true
   FROM mz_internal.mz_materialization_lag
   JOIN mz_objects ON (id = object_id)
   WHERE
-    local_lag > INTERVAL '3s' OR
-    global_lag > INTERVAL '3s'
+    local_lag > INTERVAL '5s' OR
+    global_lag > INTERVAL '5s'
 
 # When the source is down, there should be no visible lag either, as lag is
 # relative to the source frontiers.
@@ -81,8 +81,8 @@ true
   FROM mz_internal.mz_materialization_lag
   JOIN mz_objects ON (id = object_id)
   WHERE
-    local_lag > INTERVAL '3s' OR
-    global_lag > INTERVAL '3s'
+    local_lag > INTERVAL '5s' OR
+    global_lag > INTERVAL '5s'
 
 > ALTER CLUSTER source SET (REPLICATION FACTOR 1)
 
@@ -93,13 +93,13 @@ true
 > SELECT name
   FROM mz_internal.mz_materialization_lag
   JOIN mz_objects o ON (id = object_id)
-  WHERE local_lag > INTERVAL '3s'
+  WHERE local_lag > INTERVAL '5s'
 idx
 
 > SELECT name
   FROM mz_internal.mz_materialization_lag
   JOIN mz_objects ON (id = object_id)
-  WHERE global_lag > INTERVAL '3s'
+  WHERE global_lag > INTERVAL '5s'
 idx
 mv
 snk
@@ -112,8 +112,8 @@ snk
   FROM mz_internal.mz_materialization_lag
   JOIN mz_objects ON (id = object_id)
   WHERE
-    local_lag > INTERVAL '3s' OR
-    global_lag > INTERVAL '3s'
+    local_lag > INTERVAL '5s' OR
+    global_lag > INTERVAL '5s'
 
 # Bring down the sink cluster and observe resulting lag.
 
@@ -122,13 +122,13 @@ snk
 > SELECT name
   FROM mz_internal.mz_materialization_lag
   JOIN mz_objects ON (id = object_id)
-  WHERE local_lag > INTERVAL '3s'
+  WHERE local_lag > INTERVAL '5s'
 snk
 
 > SELECT name
   FROM mz_internal.mz_materialization_lag
   JOIN mz_objects ON (id = object_id)
-  WHERE global_lag > INTERVAL '3s'
+  WHERE global_lag > INTERVAL '5s'
 snk
 
 # Bringing up the sink cluster again should remove the lag.
@@ -139,8 +139,8 @@ snk
   FROM mz_internal.mz_materialization_lag
   JOIN mz_objects ON (id = object_id)
   WHERE
-    local_lag > INTERVAL '3s' OR
-    global_lag > INTERVAL '3s'
+    local_lag > INTERVAL '5s' OR
+    global_lag > INTERVAL '5s'
 
 # If a source has an empty frontier we can't compute a lag value anymore, so
 # the lag of dependant collections shows up as NULL instead.


### PR DESCRIPTION
Another too low limit seen in https://buildkite.com/materialize/nightlies/builds/6119#018d3797-1a1e-42ab-b199-1a5b64e2e234
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
