### PR TITLE
platform-checks: Bump statement_timeout for slow test

### DIFF
--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -285,6 +285,8 @@ class SinkTables(Check):
                   )
                   GROUP BY f2
 
+                > SET statement_timeout = '120s'
+
                 > SELECT * FROM sink_large_transaction_view2
                 500000 200000 100000 0 99999
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/6135#018d3b86-952b-441b-88cd-15108539045d

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
