### PR TITLE
dbt-materialize: release v1.7.3

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,11 @@
 # dbt-materialize Changelog
 
+## 1.7.3 - 2024-01-24
+
+* Support scheduled refreshes in the `materialized_view` materialization via the
+  new `refresh_interval` configuration. This is a private preview feature in
+  Materialize, so configuration details are likely to change in the future.
+
 ## 1.7.2 - 2023-12-18
 
 * Backport [dbt-core #8887](https://github.com/dbt-labs/dbt-core/pull/8887) to

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.7.2"
+version = "1.7.3"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,7 +26,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.7.2",
+    version="1.7.3",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Cut a bugfix release of `dbt-materialize` with an initial stub for scheduled refresh support. See #24611 for limitations and follow-up plans.