### PR TITLE
Remove some unsafe code from the avro library

### DIFF
--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -353,7 +353,6 @@ pub use crate::encode::encode as encode_unchecked;
 pub use crate::reader::{from_avro_datum, Block, BlockIter, Reader};
 pub use crate::schema::{ParseSchemaError, Schema};
 pub use crate::types::SchemaResolutionError;
-pub use crate::util::max_allocation_bytes;
 pub use crate::writer::{to_avro_datum, write_avro_datum, ValidationError, Writer};
 
 #[cfg(test)]


### PR DESCRIPTION
This code seems sound, so I don't think it was causing any problems, but we weren't relying on being able to change this value, so let's just hardcode a constant.

### Motivation

   * This PR refactors existing code.

Removes non-essential unsafe code. This was the only remaining bit of unsafe code in `mz_avro`.
