### PR TITLE
scalability framework: add DDL operations

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -103,6 +103,30 @@ steps:
               - "DmlDqlWorkload"
               - --max-concurrency
               - "256"
+    - id: scalability-benchmark-ddl
+      label: "Scalability benchmark (DDL) against merge base or 'latest'"
+      timeout_in_minutes: 1200
+      agents:
+        queue: linux-aarch64
+      artifact_paths: junit_*.xml
+      plugins:
+        - ./ci/plugins/mzcompose:
+            composition: scalability
+            args:
+              - --target
+              - HEAD
+              - --target
+              - common-ancestor
+              - --regression-against
+              - common-ancestor
+              - --workload-group-marker
+              - "DdlWorkload"
+              - --count
+              - "128"
+              - --exponent-base
+              - "4"
+              - --max-concurrency
+              - "64"
     - id: scalability-benchmark-connection
       label: "Scalability benchmark (connection) against merge base or 'latest'"
       timeout_in_minutes: 180

--- a/misc/python/materialize/scalability/benchmark_executor.py
+++ b/misc/python/materialize/scalability/benchmark_executor.py
@@ -182,6 +182,9 @@ class BenchmarkExecutor:
             print(init_sql)
             init_cursor.execute(init_sql.encode("utf8"))
 
+        for init_operation in workload.init_operations():
+            workload.execute_operation(init_operation, init_cursor, -1)
+
         print(
             f"Creating a cursor pool with {concurrency} entries against endpoint: {endpoint.url()}"
         )

--- a/misc/python/materialize/scalability/benchmark_executor.py
+++ b/misc/python/materialize/scalability/benchmark_executor.py
@@ -255,13 +255,14 @@ class BenchmarkExecutor:
         self, args: tuple[Workload, int, threading.local, list[Cursor], Operation, int]
     ) -> dict[str, Any]:
         workload, concurrency, local, cursor_pool, operation, transaction_index = args
+        worker_id = local.worker_id
         assert (
-            len(cursor_pool) >= local.worker_id + 1
-        ), f"len(cursor_pool) is {len(cursor_pool)} but local.worker_id is {local.worker_id}"
-        cursor = cursor_pool[local.worker_id]
+            len(cursor_pool) >= worker_id + 1
+        ), f"len(cursor_pool) is {len(cursor_pool)} but local.worker_id is {worker_id}"
+        cursor = cursor_pool[worker_id]
 
         start = time.time()
-        workload.execute_operation(operation, cursor)
+        workload.execute_operation(operation, cursor, worker_id)
         wallclock = time.time() - start
 
         return {

--- a/misc/python/materialize/scalability/endpoints.py
+++ b/misc/python/materialize/scalability/endpoints.py
@@ -99,6 +99,7 @@ class MaterializeNonRemote(Endpoint):
         priv_cursor = priv_conn.cursor()
         priv_cursor.execute("ALTER SYSTEM SET max_connections = 65535;")
         priv_cursor.execute("ALTER SYSTEM SET max_tables = 65535;")
+        priv_cursor.execute("ALTER SYSTEM SET max_materialized_views = 65535;")
 
 
 class MaterializeLocal(MaterializeNonRemote):

--- a/misc/python/materialize/scalability/operation.py
+++ b/misc/python/materialize/scalability/operation.py
@@ -35,19 +35,33 @@ class Operation:
         raise NotImplementedError
 
 
-class SqlOperation(Operation):
+class SqlOperationWithInput(Operation):
     def required_keys(self) -> set[str]:
-        return {"cursor"}
+        return {"cursor"}.union(self.required_input_keys())
+
+    def required_input_keys(self) -> set[str]:
+        raise NotImplementedError
 
     def _execute(self, data: OperationData) -> OperationData:
         try:
             cursor: Cursor = data.cursor()
-            cursor.execute(self.sql_statement().encode("utf8"))
+            cursor.execute(self.sql_statement_based_on_input(data).encode("utf8"))
             cursor.fetchall()
         except ProgrammingError as e:
             assert "the last operation didn't produce a result" in str(e)
 
         return data
+
+    def sql_statement_based_on_input(self, input: OperationData) -> str:
+        raise NotImplementedError
+
+
+class SimpleSqlOperation(SqlOperationWithInput):
+    def required_input_keys(self) -> set[str]:
+        return set()
+
+    def sql_statement_based_on_input(self, _input: OperationData) -> str:
+        return self.sql_statement()
 
     def sql_statement(self) -> str:
         raise NotImplementedError

--- a/misc/python/materialize/scalability/operation.py
+++ b/misc/python/materialize/scalability/operation.py
@@ -56,6 +56,37 @@ class SqlOperationWithInput(Operation):
         raise NotImplementedError
 
 
+class SqlOperationWithSeed(SqlOperationWithInput):
+    def __init__(self, seed_key: str):
+        self.seed_key = seed_key
+
+    def required_input_keys(self) -> set[str]:
+        return {self.seed_key}
+
+    def sql_statement_based_on_input(self, input: OperationData) -> str:
+        return self.sql_statement(str(input.get(self.seed_key)))
+
+    def sql_statement(self, seed: str) -> str:
+        raise NotImplementedError
+
+
+class SqlOperationWithTwoSeeds(SqlOperationWithInput):
+    def __init__(self, seed_key1: str, seed_key2: str):
+        self.seed_key1 = seed_key1
+        self.seed_key2 = seed_key2
+
+    def required_input_keys(self) -> set[str]:
+        return {self.seed_key1, self.seed_key2}
+
+    def sql_statement_based_on_input(self, input: OperationData) -> str:
+        return self.sql_statement(
+            str(input.get(self.seed_key1)), str(input.get(self.seed_key2))
+        )
+
+    def sql_statement(self, seed1: str, seed2: str) -> str:
+        raise NotImplementedError
+
+
 class SimpleSqlOperation(SqlOperationWithInput):
     def required_input_keys(self) -> set[str]:
         return set()

--- a/misc/python/materialize/scalability/operation_data.py
+++ b/misc/python/materialize/scalability/operation_data.py
@@ -13,12 +13,16 @@ from psycopg import Cursor
 
 
 class OperationData:
-    def __init__(self, cursor: Cursor):
+    def __init__(self, cursor: Cursor, worker_id: int):
         self._data: dict[str, Any] = dict()
         self._data["cursor"] = cursor
+        self._data["worker_id"] = worker_id
 
     def cursor(self) -> Cursor:
         return self._data["cursor"]
+
+    def worker_id(self) -> Cursor:
+        return self._data["worker_id"]
 
     def push(self, key: str, value: Any) -> None:
         self._data[key] = value

--- a/misc/python/materialize/scalability/operations.py
+++ b/misc/python/materialize/scalability/operations.py
@@ -9,47 +9,47 @@
 from psycopg import Connection
 
 from materialize.scalability.endpoint import Endpoint
-from materialize.scalability.operation import Operation, SqlOperation
+from materialize.scalability.operation import Operation, SimpleSqlOperation
 from materialize.scalability.operation_data import OperationData
 from materialize.scalability.schema import Schema
 
 
-class InsertDefaultValues(SqlOperation):
+class InsertDefaultValues(SimpleSqlOperation):
     def sql_statement(self) -> str:
         return "INSERT INTO t1 DEFAULT VALUES;"
 
 
-class SelectOne(SqlOperation):
+class SelectOne(SimpleSqlOperation):
     def sql_statement(self) -> str:
         return "SELECT 1;"
 
 
-class SelectStar(SqlOperation):
+class SelectStar(SimpleSqlOperation):
     def sql_statement(self) -> str:
         return "SELECT * FROM t1;"
 
 
-class SelectLimit(SqlOperation):
+class SelectLimit(SimpleSqlOperation):
     def sql_statement(self) -> str:
         return "SELECT * FROM t1 LIMIT 1;"
 
 
-class SelectCount(SqlOperation):
+class SelectCount(SimpleSqlOperation):
     def sql_statement(self) -> str:
         return "SELECT COUNT(*) FROM t1;"
 
 
-class SelectCountInMv(SqlOperation):
+class SelectCountInMv(SimpleSqlOperation):
     def sql_statement(self) -> str:
         return "SELECT count FROM mv1;"
 
 
-class SelectUnionAll(SqlOperation):
+class SelectUnionAll(SimpleSqlOperation):
     def sql_statement(self) -> str:
         return "SELECT * FROM t1 UNION ALL SELECT * FROM t1;"
 
 
-class Update(SqlOperation):
+class Update(SimpleSqlOperation):
     def sql_statement(self) -> str:
         return "UPDATE t1 SET f1 = f1 + 1;"
 

--- a/misc/python/materialize/scalability/operations.py
+++ b/misc/python/materialize/scalability/operations.py
@@ -91,22 +91,6 @@ class PopulateTableX(SqlOperationWithSeed):
         return f"INSERT INTO x_{table_seed} SELECT generate_series(1, 100), 200, 300, 400, 500;"
 
 
-class AddColumnToTableX(SqlOperationWithTwoSeeds):
-    def __init__(self, column_seed_key: str = "column_seed") -> None:
-        super().__init__("table_seed", column_seed_key)
-
-    def sql_statement(self, table_seed: str, column_seed: str) -> str:
-        return f"ALTER TABLE x_{table_seed} ADD COLUMN c_{column_seed} INT;"
-
-
-class DropColumnFromTableX(SqlOperationWithTwoSeeds):
-    def __init__(self, column_seed_key: str = "column_seed") -> None:
-        super().__init__("table_seed", column_seed_key)
-
-    def sql_statement(self, table_seed: str, column_seed: str) -> str:
-        return f"ALTER TABLE x_{table_seed} DROP COLUMN c_{column_seed};"
-
-
 class FillColumnInTableX(SqlOperationWithTwoSeeds):
     def __init__(self, column_seed_key: str = "column_seed") -> None:
         super().__init__("table_seed", column_seed_key)

--- a/misc/python/materialize/scalability/operations_test.py
+++ b/misc/python/materialize/scalability/operations_test.py
@@ -10,17 +10,16 @@
 
 import time
 
-from psycopg import Cursor
-
-from materialize.scalability.operation import Operation, SqlOperation
+from materialize.scalability.operation import Operation, SimpleSqlOperation
+from materialize.scalability.operation_data import OperationData
 
 
 class EmptyOperation(Operation):
-    def _execute(self, cursor: Cursor) -> None:
-        pass
+    def _execute(self, data: OperationData) -> OperationData:
+        return data
 
 
-class EmptySqlStatement(SqlOperation):
+class EmptySqlStatement(SimpleSqlOperation):
     def sql_statement(self) -> str:
         return ""
 
@@ -29,11 +28,12 @@ class SleepInPython(Operation):
     def __init__(self, duration_in_sec: float) -> None:
         self.duration_in_sec = duration_in_sec
 
-    def _execute(self, cursor: Cursor) -> None:
+    def _execute(self, data: OperationData) -> OperationData:
         time.sleep(self.duration_in_sec)
+        return data
 
 
-class SleepInEnvironmentd(SqlOperation):
+class SleepInEnvironmentd(SimpleSqlOperation):
     """Run mz_sleep() in a constant query so that the sleep actually happens in environmentd."""
 
     def __init__(self, duration_in_sec: float) -> None:
@@ -43,7 +43,7 @@ class SleepInEnvironmentd(SqlOperation):
         return f"SELECT mz_unsafe.mz_sleep({self.duration_in_sec});"
 
 
-class SleepInClusterd(SqlOperation):
+class SleepInClusterd(SimpleSqlOperation):
     """Run mz_sleep() in a manner that it will be run in clusterd.
     The first part of the UNION is what makes this query non-constant,
     but at the same time it matches no rows, so mz_sleep will only run once,

--- a/misc/python/materialize/scalability/workload.py
+++ b/misc/python/materialize/scalability/workload.py
@@ -19,8 +19,10 @@ class Workload:
     def operations(self) -> list[Operation]:
         raise NotImplementedError
 
-    def execute_operation(self, operation: Operation, cursor: Cursor) -> None:
-        data = OperationData(cursor)
+    def execute_operation(
+        self, operation: Operation, cursor: Cursor, worker_id: int
+    ) -> None:
+        data = OperationData(cursor, worker_id)
         self.amend_data_before_execution(data)
         operation.execute(data)
 

--- a/misc/python/materialize/scalability/workload.py
+++ b/misc/python/materialize/scalability/workload.py
@@ -16,6 +16,9 @@ from materialize.scalability.schema import Schema
 
 
 class Workload:
+    def init_operations(self) -> list[Operation]:
+        return []
+
     def operations(self) -> list[Operation]:
         raise NotImplementedError
 

--- a/misc/python/materialize/scalability/workload_markers.py
+++ b/misc/python/materialize/scalability/workload_markers.py
@@ -23,6 +23,12 @@ class DmlDqlWorkload(WorkloadMarker):
     pass
 
 
+class DdlWorkload(WorkloadMarker):
+    """Workloads that run DDL statements."""
+
+    pass
+
+
 class ConnectionWorkload(WorkloadMarker):
     """Workloads that perform connection operations."""
 

--- a/misc/python/materialize/scalability/workloads.py
+++ b/misc/python/materialize/scalability/workloads.py
@@ -33,6 +33,7 @@ from materialize.scalability.workload import (
 )
 from materialize.scalability.workload_markers import (
     ConnectionWorkload,
+    DdlWorkload,
     DmlDqlWorkload,
 )
 
@@ -92,7 +93,7 @@ class EstablishConnectionWorkload(WorkloadWithContext, ConnectionWorkload):
         return [OperationChainWithDataExchange([Connect(), SelectOne(), Disconnect()])]
 
 
-class CreateAndDropTableWorkload(WorkloadWithContext):
+class CreateAndDropTableWorkload(WorkloadWithContext, DdlWorkload):
     def amend_data_before_execution(self, data: OperationData) -> None:
         data.push("table_seed", data.get("worker_id"))
 
@@ -104,7 +105,7 @@ class CreateAndDropTableWorkload(WorkloadWithContext):
         ]
 
 
-class CreateAndDropTableWithMvWorkload(WorkloadWithContext):
+class CreateAndDropTableWithMvWorkload(WorkloadWithContext, DdlWorkload):
     def amend_data_before_execution(self, data: OperationData) -> None:
         data.push("table_seed", data.get("worker_id"))
 

--- a/misc/python/materialize/scalability/workloads.py
+++ b/misc/python/materialize/scalability/workloads.py
@@ -11,14 +11,11 @@
 from materialize.scalability.operation import Operation, OperationChainWithDataExchange
 from materialize.scalability.operation_data import OperationData
 from materialize.scalability.operations import (
-    AddColumnToTableX,
     Connect,
     CreateMvOnTableX,
     CreateTableX,
     Disconnect,
-    DropColumnFromTableX,
     DropTableX,
-    FillColumnInTableX,
     InsertDefaultValues,
     PopulateTableX,
     SelectCount,
@@ -120,34 +117,6 @@ class CreateAndDropTableWithMvWorkload(WorkloadWithContext):
                     CreateMvOnTableX(),
                     SelectStarFromMvOnTableX(),
                     DropTableX(),
-                ]
-            )
-        ]
-
-
-class AlterTableColumnsWorkload(WorkloadWithContext):
-    def init_operations(self) -> list["Operation"]:
-        return [CreateTableX(), PopulateTableX()]
-
-    def amend_data_before_execution(self, data: OperationData) -> None:
-        data.push("table_seed", "fixed")
-        data.push("column_seed_a", f"{data.get('worker_id')}_a")
-        data.push("column_seed_b", f"{data.get('worker_id')}_b")
-        data.push("column_seed_c", f"{data.get('worker_id')}_c")
-
-    def operations(self) -> list["Operation"]:
-        return [
-            OperationChainWithDataExchange(
-                [
-                    AddColumnToTableX(column_seed_key="column_seed_a"),
-                    FillColumnInTableX(column_seed_key="column_seed_a"),
-                    AddColumnToTableX(column_seed_key="column_seed_b"),
-                    FillColumnInTableX(column_seed_key="column_seed_b"),
-                    AddColumnToTableX(column_seed_key="column_seed_c"),
-                    FillColumnInTableX(column_seed_key="column_seed_c"),
-                    DropColumnFromTableX(column_seed_key="column_seed_a"),
-                    DropColumnFromTableX(column_seed_key="column_seed_b"),
-                    DropColumnFromTableX(column_seed_key="column_seed_c"),
                 ]
             )
         ]


### PR DESCRIPTION
This closes https://github.com/MaterializeInc/materialize/issues/23799.

### Commits
95b64eab25 scalability framework: introduce SqlOperationWithInput
d99f419521 scalability framework: introduce SqlOperationWithSeed
bb315f7ef1 scalability framework: provide worker_id as input data
79cd90dba0 scalability framework: allow workloads to have init operations
a373f47cd5 scalability framework: add DDL operations
35c1442c6c scalability framework: add DDL workloads
1792891fdf scalability framework: remove alter-column operations and workloads
1e523d45ba scalability framework: separate build step for DDL workloads

### Nightlies
https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Ascalability%2Fddl