### PR TITLE
ci: Tag aarch64 images as devel- too

### DIFF
--- a/ci/test/dev_tag.py
+++ b/ci/test/dev_tag.py
@@ -18,8 +18,7 @@ from materialize.xcompile import Arch
 def main() -> None:
     repos = [
         mzbuild.Repository(Path("."), Arch.X86_64, coverage=False),
-        # NOTE: aarch64 images are excluded from development tags to save on CI
-        # time. We can reenable if we get serious about supporting aarch64.
+        mzbuild.Repository(Path("."), Arch.AARCH64, coverage=False),
     ]
     print("--- Tagging development Docker images")
     deps = [


### PR DESCRIPTION
Currently causes failures in RQG WMR, see https://buildkite.com/materialize/nightlies/builds/6135#018d3b86-95a5-417a-ae7f-baad16ba130a

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
