### PR TITLE
docs: Update access privilege function docs

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -903,7 +903,7 @@
 - type: Access privilege inquiry
   description: |
     Functions that allow querying object access privileges. None of the following functions consider
-    whether the provided role is a superuser or not.
+    whether the provided role is a _superuser_ or not.
   functions:
     - signature: 'has_cluster_privilege([role: text or oid,] cluster: text, privilege: text) -> bool'
       description: >-

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -924,10 +924,11 @@
       description: >-
         Reports whether the role with the specified role name or OID has the privilege on
         the schema with the specified schema name or OID. If the role is omitted then
-        the `current_role` is assumed. This function has limitations involved in resolving the
-        schema names passed in. None of the schema names can have database qualifiers. For example,
-        `has_schema_privilege('materialize.public', 'SELECT')` will not work properly. Additionally,
-        the name lookup does not consider the active database.
+        the `current_role` is assumed. This function has the following
+        limitations around schema resolution: 1) none of the schema names can have
+        database qualifiers (e.g., `has_schema_privilege('materialize.public', 'SELECT')`
+        will not work properly); 2) the name lookup does not consider the
+        active database.
     - signature: 'has_role([user: name or oid,] role: text or oid, privilege: text) -> bool'
       description: >-
         Reports whether the `user` has the privilege for `role`. `privilege` can either be `MEMBER`

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -902,11 +902,8 @@
 
 - type: Access privilege inquiry
   description: |
-    Functions that allow querying object access privileges. All of the following functions have
-    limitations involved in resolving the text names passed in. None of the object names can have
-    any schema or database qualifiers. For example, `has_table_privilege('public.t', 'SELECT')`
-    will not work properly. Additionally, the name lookup does not consider the current search path
-    or active database.
+    Functions that allow querying object access privileges. None of the following functions consider
+    whether the provided role is a superuser or not.
   functions:
     - signature: 'has_cluster_privilege([role: text or oid,] cluster: text, privilege: text) -> bool'
       description: >-
@@ -927,7 +924,10 @@
       description: >-
         Reports whether the role with the specified role name or OID has the privilege on
         the schema with the specified schema name or OID. If the role is omitted then
-        the `current_role` is assumed.
+        the `current_role` is assumed. This function has limitations involved in resolving the
+        schema names passed in. None of the schema names can have database qualifiers. For example,
+        `has_schema_privilege('materialize.public', 'SELECT')` will not work properly. Additionally,
+        the name lookup does not consider the active database.
     - signature: 'has_role([user: name or oid,] role: text or oid, privilege: text) -> bool'
       description: >-
         Reports whether the `user` has the privilege for `role`. `privilege` can either be `MEMBER`


### PR DESCRIPTION
c7544ec372ccee534b227b2b0740948c5a56f17c fixed name resolution when casting a string to a regclass, regproc, or regtype. This indirectly fixed name resolution in the access privilege inquiry functions, since they are implemented using those casts. This commit updates the docs to remove the limitation warning around name resolution. `has_schema_privilege` still has limitations around name resolution because it is implemented differently, so a warning was kept for that function only.

Also, this commit adds a note about whether superuser status is considered in access privilege inquiry functions. It is not.

### Motivation
Updates docs.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
