### PR TITLE
tracing: include with_channel fix in opentelemetry-otlp using git patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6521,8 +6521,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+source = "git+https://github.com/MaterializeInc/opentelemetry-rust?rev=9d300167e728983f3d655cf20782fc832d31ceac#9d300167e728983f3d655cf20782fc832d31ceac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -6537,8 +6536,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-otlp"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
+source = "git+https://github.com/MaterializeInc/opentelemetry-rust?rev=9d300167e728983f3d655cf20782fc832d31ceac#9d300167e728983f3d655cf20782fc832d31ceac"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -6556,8 +6554,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
+source = "git+https://github.com/MaterializeInc/opentelemetry-rust?rev=9d300167e728983f3d655cf20782fc832d31ceac#9d300167e728983f3d655cf20782fc832d31ceac"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -6568,8 +6565,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
+source = "git+https://github.com/MaterializeInc/opentelemetry-rust?rev=9d300167e728983f3d655cf20782fc832d31ceac#9d300167e728983f3d655cf20782fc832d31ceac"
 dependencies = [
  "opentelemetry",
 ]
@@ -6577,8 +6573,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
+source = "git+https://github.com/MaterializeInc/opentelemetry-rust?rev=9d300167e728983f3d655cf20782fc832d31ceac#9d300167e728983f3d655cf20782fc832d31ceac"
 dependencies = [
  "async-trait",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,15 @@ tonic-build = { git = "https://github.com/MaterializeInc/tonic", rev = "0d86e360
 # upstream.
 tracing-opentelemetry = { git = "https://github.com/MaterializeInc/tracing-opentelemetry.git" }
 
+# Waiting on a patch release to `opentelemetry-otlp` to include
+# <https://github.com/open-telemetry/opentelemetry-rust/pull/1335#issuecomment-1907101992>
+# Cherry-picked on a known-good rev (the one for version 0.21.2 <https://github.com/open-telemetry/opentelemetry-rust/releases/tag/v0.21.2>
+#
+# Note that we can't just patch `opentelemetry-otlp`, or it will rely on traits/structs in conflicting versions of the other crates.
+opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust", rev = "9d300167e728983f3d655cf20782fc832d31ceac" }
+opentelemetry_sdk = { git = "https://github.com/MaterializeInc/opentelemetry-rust", rev = "9d300167e728983f3d655cf20782fc832d31ceac" }
+opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-rust", rev = "9d300167e728983f3d655cf20782fc832d31ceac" }
+
 # Waiting on https://github.com/launchdarkly/rust-server-sdk/pull/20 to make
 # it into a release.
 # Also bumps lru to 0.12.0


### PR DESCRIPTION
This includes the fix in upstream but not in the `opentelemetry-otlp` released version: https://github.com/open-telemetry/opentelemetry-rust/pull/1335#issuecomment-1907101992

I tested on staging and it resolves the known issues with tracing.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
