### PR TITLE
sqllogictest: construct PersistClient with all necessary dyn configs

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -68,6 +68,7 @@ use mz_repr::ColumnName;
 use mz_secrets::SecretsController;
 use mz_sql::ast::{Expr, Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
+use mz_sql::session::vars::all_dyn_configs;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
     CreateIndexStatement, CreateViewStatement, CteBlock, Distinct, DropObjectsStatement, Ident,
@@ -971,7 +972,11 @@ impl<'a> RunnerInner<'a> {
         let now = SYSTEM_TIME.clone();
         let metrics_registry = MetricsRegistry::new();
 
-        let persist_config = PersistConfig::new(&mz_environmentd::BUILD_INFO, now.clone());
+        let persist_config = PersistConfig::new_with_configs(
+            &mz_environmentd::BUILD_INFO,
+            now.clone(),
+            all_dyn_configs(),
+        );
         let persist_pubsub_server =
             PersistGrpcPubSubServer::new(&persist_config, &metrics_registry);
         let persist_pubsub_client = persist_pubsub_server.new_same_process_connection();


### PR DESCRIPTION
This needs the same PersistConfig construction logic as environmentd's main, but that (also) got missed in #24597.

Was causing `ERROR` logs when running sqllogictest.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
