### PR TITLE
catalog: Fix LargeCollectionStartupCache

### DIFF
--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -639,6 +639,7 @@ async fn test_large_collection_retractions(openable_state: impl OpenableDurableC
         .unwrap();
     let (mut txn, old_audit_logs, old_storage_usages) =
         state.whole_migration_transaction().await.unwrap();
+    // This will issue retractions for everything in the catalog.
     txn.set_catalog(
         Snapshot::empty(),
         old_audit_logs,

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -594,3 +594,69 @@ async fn test_set_catalog(openable_state: impl OpenableDurableCatalogState) {
 
     Box::new(state).expire().await;
 }
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_stash_large_collection_retractions() {
+    let debug_factory = DebugStashFactory::new().await;
+    let openable_state = test_stash_backed_catalog_state(&debug_factory);
+    test_large_collection_retractions(openable_state).await;
+    debug_factory.drop().await;
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_persist_large_collection_retractions() {
+    let persist_client = PersistClient::new_for_tests().await;
+    let organization_id = Uuid::new_v4();
+    let openable_state =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    test_large_collection_retractions(openable_state).await;
+}
+
+async fn test_large_collection_retractions(openable_state: impl OpenableDurableCatalogState) {
+    let new_audit_logs = vec![VersionedEvent::V1(EventV1 {
+        id: 2,
+        event_type: EventType::Create,
+        object_type: mz_audit_log::ObjectType::Cluster,
+        details: EventDetails::IdNameV1(IdNameV1 {
+            id: "c".to_string(),
+            name: "d".to_string(),
+        }),
+        user: None,
+        occurred_at: 0,
+    })];
+    let new_storage_usages = vec![VersionedStorageUsage::V1(StorageUsageV1 {
+        id: 4,
+        shard_id: None,
+        size_bytes: 5,
+        collection_timestamp: 6,
+    })];
+
+    let mut state = Box::new(openable_state)
+        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
+        .await
+        .unwrap();
+    let (mut txn, old_audit_logs, old_storage_usages) =
+        state.whole_migration_transaction().await.unwrap();
+    txn.set_catalog(
+        Snapshot::empty(),
+        old_audit_logs,
+        old_storage_usages,
+        new_audit_logs.clone(),
+        new_storage_usages.clone(),
+    )
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    let audit_logs = state.get_audit_logs().await.unwrap();
+    let storage_usages = state
+        .get_and_prune_storage_usage(None, mz_repr::Timestamp::new(0), false)
+        .await
+        .unwrap();
+
+    assert_eq!(audit_logs, new_audit_logs);
+    assert_eq!(storage_usages, new_storage_usages);
+
+    Box::new(state).expire().await;
+}


### PR DESCRIPTION
Previously, the LargeCollectionStartupCache assumed that the cache was append only and therefore when inserting new values ignored the diff. For the most part this was true because audit events and storage usage events are append only. However, during a catalog store migration or rollback, we can actually retract audit events and storage usage events. This commit teaches the LargeCollectionStartupCache how to deal with retractions.

Works towards resolving #24218

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
