### PR TITLE
storage: avoid buffering entire upsert snapshot in memory

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -440,6 +440,14 @@ SCENARIOS = [
             ]
         )
         + KafkaScenario.END_MARKER
+        # Ensure this config works.
+        + dedent(
+            """
+            $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+            $ postgres-execute connection=mz_system
+            ALTER SYSTEM SET storage_upsert_max_snapshot_batch_buffering = 2;
+            """
+        )
         + KafkaScenario.SOURCE
         + dedent(
             """

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -196,6 +196,9 @@ class KafkaScenario(Scenario):
         $ kafka-ingest format=avro key-format=avro topic=topic1 schema=${{value-schema}} key-schema=${{key-schema}} repeat={REPEAT}
         "${{kafka-ingest.iteration}}"
 
+        $ kafka-ingest format=avro key-format=avro topic=topic1 schema=${{value-schema}} key-schema=${{key-schema}} repeat={REPEAT}
+        "MMM"
+
         # Expect that only markers are left
         > SELECT * FROM v1;
         2
@@ -430,7 +433,7 @@ SCENARIOS = [
                 dedent(
                     f"""
                     $ kafka-ingest format=avro key-format=avro topic=topic1 schema=${{value-schema}} key-schema=${{key-schema}} repeat={REPEAT}
-                    "${{kafka-ingest.iteration}}" {{"f1": "{i}{STRING_PAD}"}}
+                    "MMM" {{"f1": "{i}{STRING_PAD}"}}
                     """
                 )
                 for i in range(0, ITERATIONS)
@@ -439,14 +442,14 @@ SCENARIOS = [
         + KafkaScenario.END_MARKER
         + KafkaScenario.SOURCE
         + dedent(
-            f"""
+            """
             # Expect all ingested data + two MARKERs
             > SELECT * FROM v1;
-            {REPEAT + 2}
+            3
             """
         ),
         post_restart=KafkaScenario.SCHEMAS + KafkaScenario.POST_RESTART,
-        materialized_memory="4.5Gb",
+        materialized_memory="2Gb",
         clusterd_memory="3.5Gb",
     ),
     # Perform updates while the source is ingesting

--- a/test/testdrive/pr-24663-regression.td
+++ b/test/testdrive/pr-24663-regression.td
@@ -1,0 +1,163 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This is a test that was used to ensure a specific ordering of updates
+# in `upsert` continued to be processed properly in pr #24663. Its short,
+# so its copied here.
+
+$ set-arg-default default-storage-size=1
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET kafka_default_metadata_fetch_interval = 1000
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
+
+# must be a subset of the keys in the rows
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "id", "type": "long"}
+    ]
+  }
+
+$ set schema={
+    "type" : "record",
+    "name" : "envelope",
+    "fields" : [
+      { "name": "op", "type": "string" },
+      {
+        "name": "after",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {
+                  "name": "id",
+                  "type": "long"
+              },
+              {
+                "name": "creature",
+                "type": "string"
+              }]
+           },
+           "null"
+         ]
+      },
+      {
+        "name": "source",
+        "type": {
+          "type": "record",
+          "name": "Source",
+          "namespace": "io.debezium.connector.mysql",
+          "fields": [
+            {
+              "name": "file",
+              "type": "string"
+            },
+            {
+              "name": "pos",
+              "type": "long"
+            },
+            {
+              "name": "row",
+              "type": "int"
+            },
+            {
+              "name": "snapshot",
+              "type": [
+                {
+                  "type": "boolean",
+                  "connect.default": false
+                },
+                "null"
+              ],
+              "default": false
+            }
+          ],
+          "connect.name": "io.debezium.connector.mysql.Source"
+        }
+      }
+    ]
+  }
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+$ kafka-create-topic topic=dbz-no-before partitions=1
+
+# Note: we ignore the `op` field, so can be "u" or "c"
+
+$ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
+{"id": 1} {"after": {"row": {"id": 1, "creature": "mudskipper"}}, "op": "c", "source": {"file": "binlog1", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+{"id": 1} {"after": {"row": {"id": 1, "creature": "salamander"}}, "op": "c", "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+{"id": 1} {"after": null, "op": "c", "source": {"file": "binlog3", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+
+> CREATE CLUSTER dbz_no_before_cluster SIZE '${arg.default-storage-size}';
+> CREATE SOURCE dbz_no_before
+  IN CLUSTER dbz_no_before_cluster
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbz-no-before-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+> SELECT count(*) FROM dbz_no_before
+0
+
+> SELECT
+    bool_and(u.snapshot_committed),
+    SUM(u.bytes_indexed) > 0,
+    SUM(u.records_indexed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('dbz_no_before')
+  GROUP BY s.name
+  ORDER BY s.name
+true true 0
+
+$ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
+{"id": 1} {"after": {"row": {"id": 1, "creature": "mudskipper"}}, "op": "c", "source": {"file": "binlog1", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+
+> SELECT * FROM dbz_no_before
+id creature
+-------------
+1  mudskipper
+
+> SELECT
+    bool_and(u.snapshot_committed),
+    SUM(u.bytes_indexed) > 0,
+    SUM(u.records_indexed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('dbz_no_before')
+  GROUP BY s.name
+  ORDER BY s.name
+true true 1
+
+$ kafka-ingest format=avro topic=dbz-no-before key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
+{"id": 1} {"after": null, "op": "c", "source": {"file": "binlog3", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+
+> SELECT count(*) FROM dbz_no_before
+0
+
+# A tombstone is left behind
+> SELECT
+    bool_and(u.snapshot_committed),
+    SUM(u.bytes_indexed) > 0,
+    SUM(u.records_indexed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('dbz_no_before')
+  GROUP BY s.name
+  ORDER BY s.name
+true true 0

--- a/test/testdrive/source-statistics-view.td
+++ b/test/testdrive/source-statistics-view.td
@@ -9,6 +9,10 @@
 
 $ set-arg-default single-replica-cluster=quickstart
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
+
 > CREATE SOURCE counter
   IN CLUSTER ${arg.single-replica-cluster}
   FROM LOAD GENERATOR COUNTER;

--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -9,6 +9,11 @@
 
 $ set-arg-default single-replica-cluster=quickstart
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET kafka_default_metadata_fetch_interval = 1000
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
+
 $ set keyschema={
     "type": "record",
     "name": "Key",
@@ -28,6 +33,8 @@ $ set schema={
 
 $ kafka-create-topic topic=upsert partitions=1
 
+# The length of `moosemooose` must be longer than `moose` to ensure a tombstone doesn't HAPPEN
+# to have the same size.
 $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
 {"key": "fish"} {"f1": "fish", "f2": 1000}
 {"key": "bird1"} {"f1":"goose", "f2": 1}
@@ -37,7 +44,7 @@ $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} 
 {"key": "birdmore"} {"f1":"geese", "f2": 56}
 {"key": "mammalmore"} {"f1": "moose", "f2": 42}
 {"key": "mammal1"}
-{"key": "mammalmore"} {"f1":"moose", "f2": 2}
+{"key": "mammalmore"} {"f1":"moosemoose", "f2": 2}
 
 $ kafka-create-topic topic=metrics-test partitions=1
 $ kafka-ingest topic=metrics-test format=bytes
@@ -73,7 +80,7 @@ key           f1      f2
 ------------------------
 fish          fish    1000
 birdmore      geese   56
-mammalmore    moose   2
+mammalmore    moosemoose   2
 
 # statistics are only populated every minute by default
 $ set-sql-timeout duration=2minutes


### PR DESCRIPTION
Closes: https://github.com/MaterializeInc/materialize/issues/23998


This turned out to be a significant change, with several tradeoffs, so I will discuss the intrinsic complexity and decisions on tradeoffs here.

## The core change

The core change is in the 4th commit. Fundamentally, solving this problem requires that _we are able to record batches of records in the upsert state backend before a frontier covering them has appeared_. This is a significant change to the `UpsertState` contract, and requires that we record an _order key_ alongside the data inside the upsert state. This order key allows us to ensure we correctly record that _final_ value in the output state.

This _order key_ is the `FromTime` of the data, that we were previously only using to order values in-memory before committing them to the upsert state. Actually, in practice, the _order key_ is an `Option<FromTime>`, so that during rehydration we are not required to recover and order key for an operation that is fundamentally guaranteed to happen before (in the literal sense of frontiers) any other values arrive.

## Tombstoning

Records within a timestamp can arrive out of order within timely operators (this is not an academic reality, it happens all the time as we exchange values by value (not key) during decoding to get even cpu usage). This means that _deletes_ can also appear before older value. This requires us to ALSO support tombstones, recording the _order key_ at which they appeared within the collection.

## Additional cost during steady-state

In practice, recording the _order key_ takes up about 30-40 additional bytes-per-value. Pre-compression, for some canonical workloads, this is 15-20% overhead. I don't expect this to cause a meaningful regression in latencies, only a <20% increase (because of compression) in disk usage. For in-memory workloads, its probably more like 20%. 

Note that because values are slightly bigger, we may autospill from memory to disk slightly earlier.

## Additional cost during hydration

In steady-state, tombstones do not occur, but during _hydration_, any values that are deleted in the fullness of time take up additional space to store the tombstone. This pr does not implement a side-channel to cleanup these tombstones after hydration is finished mostly because:

- During hydration, disk usage will scale with the _total cardinality of all keys that ever existed within the snapshot_. This is unavoidable as we process the snapshot out of order.
- Implementing this is probably fairly difficult (requires using a rocksdb iterator)

Note that I did add a metric that counts the outstanding tombstones. We can expose this to users if it becomes a problem.

## Additional cost during rehydration

Rehydration doesn't reason about _order keys_ or tombstones, and therefore should have no regression whatsoever.

## Statistics

tombstones greatly expand the state-space of cases when recording statistics to record to users. The code here was refactored to share complex logic between implementations.

Note that it is now possible to have an `envelope_state_bytes` that is non-zero when `envelope_state_records` is 0. This is because we expose the size of tombstones in the state space. Exposing the outstanding tombstones count to users can be done later if need be.


## Tips for review

I **highly** recommend reviewing this pr as separate commits. The first few are pure code movement, then there is a commit that adds support for _order keys_ within the upsert state. After that there is the actual fix for the original issue, plus additional commits with tests and adjustments/improvements.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):