### PR TITLE
rust: Specify build rules for x86_64-apple-darwin

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -21,6 +21,15 @@ rustflags = [
     "--cfg=tokio_unstable",
 ]
 
+[target."x86_64-apple-darwin"]
+# Duplicate the "rustflags" for x86 Linux for x86 macOS.
+rustflags = [
+    "-Csymbol-mangling-version=v0",
+    "-Ctarget-cpu=x86-64-v3",
+    "-Ctarget-feature=+aes",
+    "--cfg=tokio_unstable",
+]
+
 # As of Jan 2024 all of the Linux based aarch64 hardware we run on supports the Neoverse N1 micro
 # architecture.
 #


### PR DESCRIPTION
We have a couple folks internally that develop on x86_64 macOS machines, so we add `.cargo/config` options for that toolchain to match what we do on Linux.

### Motivation

@mgree was hitting some build issues that happen in CI but not locally, we want to make sure local builds are as close as possible to CI.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Internal only.
