### PR TITLE
persist: rename PersistConfig constructors to make usage more obvious

### DIFF
--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -164,7 +164,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         CatalogKind::Persist => {
             // It's important that the version in this `BUILD_INFO` is kept in sync with the build
             // info used to write data to the persist catalog.
-            let persist_config = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone());
+            let persist_config =
+                PersistConfig::new_default_configs(&BUILD_INFO, SYSTEM_TIME.clone());
             let persist_clients =
                 PersistClientCache::new(persist_config, &metrics_registry, |_, _| {
                     PubSubClientConnection::noop()

--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -262,8 +262,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         configs = mz_persist_txn::all_dyn_configs(configs);
         configs
     }
-    let persist_cfg =
-        PersistConfig::new_with_configs(&BUILD_INFO, SYSTEM_TIME.clone(), all_dyn_configs());
+    let persist_cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), all_dyn_configs());
     let persist_clients = Arc::new(PersistClientCache::new(
         persist_cfg,
         &metrics_registry,

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -788,7 +788,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     let secrets_reader = secrets_controller.reader();
     let now = SYSTEM_TIME.clone();
 
-    let persist_config = PersistConfig::new_with_configs(
+    let persist_config = PersistConfig::new(
         &mz_environmentd::BUILD_INFO,
         now.clone(),
         mz_sql::session::vars::all_dyn_configs(),

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -337,7 +337,7 @@ impl Listeners {
         // Messing with the clock causes persist to expire leases, causing hangs and
         // panics. Is it possible/desirable to put this back somehow?
         let persist_now = SYSTEM_TIME.clone();
-        let mut persist_cfg = PersistConfig::new(&crate::BUILD_INFO, persist_now);
+        let mut persist_cfg = PersistConfig::new_default_configs(&crate::BUILD_INFO, persist_now);
         // Tune down the number of connections to make this all work a little easier
         // with local postgres.
         persist_cfg.consensus_connection_pool_max_size = 1;

--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -386,7 +386,8 @@ impl Service for TransactorService {
         // should_timeout to for blobs, so use the same handle for both.
         let unreliable = UnreliableHandle::new(seed, should_happen, should_timeout);
 
-        let mut config = PersistConfig::new(&mz_persist_client::BUILD_INFO, SYSTEM_TIME.clone());
+        let mut config =
+            PersistConfig::new_default_configs(&mz_persist_client::BUILD_INFO, SYSTEM_TIME.clone());
         let metrics = Arc::new(PersistMetrics::new(&config, &MetricsRegistry::new()));
 
         // Construct requested Blob.

--- a/src/persist-cli/src/maelstrom/txn_list_append_single.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_single.rs
@@ -604,7 +604,8 @@ impl Service for TransactorService {
         // should_timeout to for blobs, so use the same handle for both.
         let unreliable = UnreliableHandle::new(seed, should_happen, should_timeout);
 
-        let mut config = PersistConfig::new(&mz_persist_client::BUILD_INFO, SYSTEM_TIME.clone());
+        let mut config =
+            PersistConfig::new_default_configs(&mz_persist_client::BUILD_INFO, SYSTEM_TIME.clone());
         let metrics = Arc::new(Metrics::new(&config, &MetricsRegistry::new()));
 
         // Construct requested Blob.

--- a/src/persist-cli/src/open_loop.rs
+++ b/src/persist-cli/src/open_loop.rs
@@ -129,7 +129,7 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         consensus_uri: args.consensus_uri.clone(),
     };
     let persist = PersistClientCache::new(
-        PersistConfig::new(&mz_persist_client::BUILD_INFO, SYSTEM_TIME.clone()),
+        PersistConfig::new_default_configs(&mz_persist_client::BUILD_INFO, SYSTEM_TIME.clone()),
         &metrics_registry,
         |_, _| PubSubClientConnection::noop(),
     )

--- a/src/persist-cli/src/service.rs
+++ b/src/persist-cli/src/service.rs
@@ -47,7 +47,8 @@ pub struct Args {
 
 pub async fn run(args: Args) -> Result<(), anyhow::Error> {
     let shard_id = ShardId::from_str("s00000000-0000-0000-0000-000000000000").expect("shard id");
-    let config = PersistConfig::new(&mz_persist_client::BUILD_INFO, SYSTEM_TIME.clone());
+    let config =
+        PersistConfig::new_default_configs(&mz_persist_client::BUILD_INFO, SYSTEM_TIME.clone());
     match args.role {
         Role::Server => {
             info!("listening on {}", args.listen_addr);

--- a/src/persist-cli/src/txns.rs
+++ b/src/persist-cli/src/txns.rs
@@ -56,7 +56,7 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         consensus_uri: args.consensus_uri.clone(),
     };
     let persist = PersistClientCache::new(
-        PersistConfig::new(&mz_persist_client::BUILD_INFO, SYSTEM_TIME.clone()),
+        PersistConfig::new_default_configs(&mz_persist_client::BUILD_INFO, SYSTEM_TIME.clone()),
         &metrics_registry,
         |_, _| PubSubClientConnection::noop(),
     )

--- a/src/persist-client/benches/benches.rs
+++ b/src/persist-client/benches/benches.rs
@@ -102,7 +102,7 @@ pub fn bench_persist(c: &mut Criterion) {
 }
 
 fn create_mem_mem_client() -> Result<PersistClient, ExternalError> {
-    let cfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+    let cfg = PersistConfig::new_default_configs(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
     let blob = Arc::new(MemBlob::open(MemBlobConfig::default()));
     let consensus = Arc::new(MemConsensus::default());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
@@ -133,7 +133,7 @@ async fn create_file_pg_client(
     let dir = tempfile::tempdir().map_err(anyhow::Error::new)?;
     let file = FileBlobConfig::from(dir.path());
 
-    let cfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+    let cfg = PersistConfig::new_default_configs(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
     let blob = Arc::new(FileBlob::open(file).await?);
     let postgres_consensus = Arc::new(PostgresConsensus::open(pg).await?);
     let consensus = Arc::clone(&postgres_consensus);
@@ -168,7 +168,7 @@ async fn create_s3_pg_client(
         None => return Ok(None),
     };
 
-    let cfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+    let cfg = PersistConfig::new_default_configs(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
     let blob = Arc::new(S3Blob::open(s3).await?);
     let postgres_consensus = Arc::new(PostgresConsensus::open(pg).await?);
     let consensus = Arc::clone(&postgres_consensus);

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -678,7 +678,6 @@ mod tests {
 
     use futures::stream::{FuturesUnordered, StreamExt};
     use mz_build_info::DUMMY_BUILD_INFO;
-    use mz_ore::now::SYSTEM_TIME;
     use mz_ore::task::spawn;
 
     use super::*;
@@ -687,7 +686,7 @@ mod tests {
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn client_cache() {
         let cache = PersistClientCache::new(
-            PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone()),
+            PersistConfig::new_for_tests(),
             &MetricsRegistry::new(),
             |_, _| PubSubClientConnection::noop(),
         );

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -152,14 +152,15 @@ impl std::ops::Deref for PersistConfig {
 }
 
 impl PersistConfig {
-    /// Returns a new instance of [PersistConfig] with default tuning.
-    pub fn new(build_info: &BuildInfo, now: NowFn) -> Self {
-        Self::new_with_configs(build_info, now, all_dyn_configs(ConfigSet::default()))
+    /// Returns a new instance of [PersistConfig] with default tuning and
+    /// default ConfigSet.
+    pub fn new_default_configs(build_info: &BuildInfo, now: NowFn) -> Self {
+        Self::new(build_info, now, all_dyn_configs(ConfigSet::default()))
     }
 
     /// Returns a new instance of [PersistConfig] with default tuning and the
     /// specified ConfigSet.
-    pub fn new_with_configs(build_info: &BuildInfo, now: NowFn, configs: ConfigSet) -> Self {
+    pub fn new(build_info: &BuildInfo, now: NowFn, configs: ConfigSet) -> Self {
         // Escape hatch in case we need to disable compaction.
         let compaction_disabled = mz_ore::env::is_var_truthy("MZ_PERSIST_COMPACTION_DISABLED");
         Self {
@@ -252,7 +253,7 @@ impl PersistConfig {
         use mz_build_info::DUMMY_BUILD_INFO;
         use mz_ore::now::SYSTEM_TIME;
 
-        let mut cfg = Self::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+        let mut cfg = Self::new_default_configs(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
         cfg.hostname = "tests".into();
         cfg.set_config(&STREAMING_COMPACTION_ENABLED, true);
         cfg.set_config(&STREAMING_SNAPSHOT_AND_FETCH_ENABLED, true);

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -30,7 +30,9 @@ use tracing::info;
 
 use crate::async_runtime::IsolatedRuntime;
 use crate::cache::StateCache;
+use crate::cfg::all_dyn_configs;
 use crate::cli::args::{make_blob, make_consensus, StateArgs, StoreArgs};
+use crate::dyn_cfg::ConfigSet;
 use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
 use crate::internal::encoding::Schemas;
 use crate::internal::gc::{GarbageCollector, GcReq};
@@ -99,7 +101,9 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
     match command.command {
         Command::ForceCompaction(args) => {
             let shard_id = ShardId::from_str(&args.state.shard_id).expect("invalid shard id");
-            let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone());
+            let configs = all_dyn_configs(ConfigSet::default());
+            // TODO: Fetch the latest values of these configs from Launch Darkly.
+            let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), configs);
             if args.compaction_memory_bound_bytes > 0 {
                 cfg.dynamic
                     .set_compaction_memory_bound_bytes(args.compaction_memory_bound_bytes);
@@ -120,7 +124,9 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
         }
         Command::ForceGc(args) => {
             let shard_id = ShardId::from_str(&args.state.shard_id).expect("invalid shard id");
-            let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone());
+            let configs = all_dyn_configs(ConfigSet::default());
+            // TODO: Fetch the latest values of these configs from Launch Darkly.
+            let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), configs);
             let metrics_registry = MetricsRegistry::new();
             // We don't actually care about the return value here, but we do need to prevent
             // the shard metrics from being dropped before they're reported below.
@@ -144,7 +150,9 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
             let shard_id = ShardId::from_str(&shard_id).expect("invalid shard id");
             let commit = command.commit;
 
-            let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone());
+            let configs = all_dyn_configs(ConfigSet::default());
+            // TODO: Fetch the latest values of these configs from Launch Darkly.
+            let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), configs);
             let metrics_registry = MetricsRegistry::new();
             let metrics = Arc::new(Metrics::new(&cfg, &metrics_registry));
             let consensus =
@@ -168,7 +176,9 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
                 concurrency,
             } = args;
             let commit = command.commit;
-            let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone());
+            let configs = all_dyn_configs(ConfigSet::default());
+            // TODO: Fetch the latest values of these configs from Launch Darkly.
+            let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), configs);
             let metrics_registry = MetricsRegistry::new();
             let metrics = Arc::new(Metrics::new(&cfg, &metrics_registry));
             let consensus =

--- a/src/persist-client/src/cli/args.rs
+++ b/src/persist-client/src/cli/args.rs
@@ -111,7 +111,7 @@ impl StateArgs {
     }
 
     pub(crate) async fn open(&self) -> Result<StateVersions, anyhow::Error> {
-        let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
+        let cfg = PersistConfig::new_default_configs(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
         let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
         let consensus =
             make_consensus(&cfg, &self.consensus_uri, NO_COMMIT, Arc::clone(&metrics)).await?;

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -327,7 +327,7 @@ pub async fn blob_batch_part(
     partial_key: String,
     limit: usize,
 ) -> Result<impl serde::Serialize, anyhow::Error> {
-    let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
+    let cfg = PersistConfig::new_default_configs(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let blob = make_blob(&cfg, blob_uri, NO_COMMIT, metrics).await?;
 
@@ -383,7 +383,7 @@ struct BlobCounts {
 
 /// Fetches the blob count for given path
 pub async fn blob_counts(blob_uri: &str) -> Result<impl serde::Serialize, anyhow::Error> {
-    let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
+    let cfg = PersistConfig::new_default_configs(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let blob = make_blob(&cfg, blob_uri, NO_COMMIT, metrics).await?;
 
@@ -413,7 +413,7 @@ pub async fn blob_counts(blob_uri: &str) -> Result<impl serde::Serialize, anyhow
 
 /// Rummages through S3 to find the latest rollup for each shard, then calculates summary stats.
 pub async fn shard_stats(blob_uri: &str) -> anyhow::Result<()> {
-    let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
+    let cfg = PersistConfig::new_default_configs(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let blob = make_blob(&cfg, blob_uri, NO_COMMIT, metrics).await?;
 
@@ -566,7 +566,7 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
     } else {
         Some(args.shard_id())
     };
-    let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
+    let cfg = PersistConfig::new_default_configs(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
     let metrics_registry = MetricsRegistry::new();
     let metrics = Arc::new(Metrics::new(&cfg, &metrics_registry));
     let consensus =

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -1182,9 +1182,7 @@ impl<'a> Iterator for ProtoStateFieldDiffsIter<'a> {
 mod tests {
     use std::ops::ControlFlow::Continue;
 
-    use mz_build_info::DUMMY_BUILD_INFO;
     use mz_ore::metrics::MetricsRegistry;
-    use mz_ore::now::SYSTEM_TIME;
 
     use crate::internal::state::TypedState;
     use crate::ShardId;
@@ -1276,10 +1274,7 @@ mod tests {
             _ => unreachable!(),
         };
 
-        let metrics = Metrics::new(
-            &PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone()),
-            &MetricsRegistry::new(),
-        );
+        let metrics = Metrics::new(&PersistConfig::new_for_tests(), &MetricsRegistry::new());
         assert_eq!(
             apply_diffs_spine(&metrics, diffs, &mut state.collections.trace),
             Ok(())
@@ -1319,10 +1314,7 @@ mod tests {
             let replacement = batch(&replacement);
             let batches = spine.iter().map(batch).collect::<Vec<_>>();
 
-            let metrics = Metrics::new(
-                &PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone()),
-                &MetricsRegistry::new(),
-            );
+            let metrics = Metrics::new(&PersistConfig::new_for_tests(), &MetricsRegistry::new());
             let actual = apply_compaction_lenient(&metrics, batches, &replacement);
             let expected = match expected {
                 Ok(batches) => Ok(batches.iter().map(batch).collect::<Vec<_>>()),

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1254,10 +1254,8 @@ mod tests {
     use std::pin;
     use std::str::FromStr;
 
-    use mz_build_info::DUMMY_BUILD_INFO;
     use mz_ore::cast::CastFrom;
     use mz_ore::metrics::MetricsRegistry;
-    use mz_ore::now::SYSTEM_TIME;
     use mz_persist::mem::{MemBlob, MemBlobConfig, MemConsensus};
     use mz_persist::unreliable::{UnreliableConsensus, UnreliableHandle};
     use serde::{Deserialize, Serialize};
@@ -1603,7 +1601,7 @@ mod tests {
             (("2".to_owned(), "two".to_owned()), 2, 1),
         ];
 
-        let cfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+        let cfg = PersistConfig::new_for_tests();
         let blob = Arc::new(MemBlob::open(MemBlobConfig::default()));
         let consensus = Arc::new(MemConsensus::default());
         let unreliable = UnreliableHandle::default();

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -972,11 +972,8 @@ impl<'a> RunnerInner<'a> {
         let now = SYSTEM_TIME.clone();
         let metrics_registry = MetricsRegistry::new();
 
-        let persist_config = PersistConfig::new_with_configs(
-            &mz_environmentd::BUILD_INFO,
-            now.clone(),
-            all_dyn_configs(),
-        );
+        let persist_config =
+            PersistConfig::new(&mz_environmentd::BUILD_INFO, now.clone(), all_dyn_configs());
         let persist_pubsub_server =
             PersistGrpcPubSubServer::new(&persist_config, &metrics_registry);
         let persist_pubsub_client = persist_pubsub_server.new_same_process_connection();

--- a/src/storage-controller/src/persist_handles.rs
+++ b/src/storage-controller/src/persist_handles.rs
@@ -1110,7 +1110,7 @@ mod tests {
     #[cfg_attr(miri, ignore)] // unsupported operation: integer-to-pointer casts and `ptr::from_exposed_addr`
     async fn snapshot_stats(&self) {
         let client = PersistClientCache::new(
-            PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone()),
+            PersistConfig::new_default_configs(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone()),
             &MetricsRegistry::new(),
             |_, _| PubSubClientConnection::noop(),
         )

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -646,7 +646,7 @@ mod tests {
     static PERSIST_READER_LEASE_TIMEOUT_MS: Duration = Duration::from_secs(60 * 15);
 
     static PERSIST_CACHE: Lazy<Arc<PersistClientCache>> = Lazy::new(|| {
-        let persistcfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+        let persistcfg = PersistConfig::new_default_configs(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
         persistcfg.set_reader_lease_duration(PERSIST_READER_LEASE_TIMEOUT_MS);
         Arc::new(PersistClientCache::new(
             persistcfg,

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -126,7 +126,8 @@ where
             let metrics_registry = MetricsRegistry::new();
             let metrics = StorageMetrics::register_with(&metrics_registry);
 
-            let mut persistcfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+            let mut persistcfg =
+                PersistConfig::new_default_configs(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
             persistcfg.set_reader_lease_duration(Duration::from_secs(60 * 15));
             persistcfg.now = SYSTEM_TIME.clone();
 

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -1056,7 +1056,7 @@ pub async fn create_state(
         persist_blob_url: config.persist_blob_url.clone(),
         build_info: config.build_info,
         persist_clients: PersistClientCache::new(
-            PersistConfig::new(config.build_info, SYSTEM_TIME.clone()),
+            PersistConfig::new_default_configs(config.build_info, SYSTEM_TIME.clone()),
             &MetricsRegistry::new(),
             |_, _| PubSubClientConnection::noop(),
         ),

--- a/src/testdrive/src/action/persist.rs
+++ b/src/testdrive/src/action/persist.rs
@@ -29,7 +29,7 @@ pub async fn run_force_compaction(
     cmd.args.done()?;
 
     let shard_id = ShardId::from_str(&shard_id).expect("invalid shard id");
-    let cfg = PersistConfig::new(state.build_info, SYSTEM_TIME.clone());
+    let cfg = PersistConfig::new_default_configs(state.build_info, SYSTEM_TIME.clone());
 
     let metrics_registry = MetricsRegistry::new();
 


### PR DESCRIPTION
It is expected that uses of persist outside of persist code itself will specify the dyn configs that are relevant, so make it a touch more obvious which to use by renaming `new` -> `new_default_configs` and `new_with_configs` to `new`.

Spun out of [a review comment](https://github.com/MaterializeInc/materialize/pull/24658#discussion_r1465487170).

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Looking at this diff, I almost want to just remove `new_default_configs` and inline the config stuff in the callers but there's just so many uses and I dislike how noisy it already is to construct persist. Initially marking as draft in case you think that's a better direction, or have suggestions for the name.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
