### PR TITLE
persist-txn: fix optimizer cardinality estimates for "lazy"

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4844,13 +4844,6 @@ impl CachedStatisticsOracle {
 
             match stats {
                 Ok(stats) => {
-                    if timely::PartialOrder::less_than(&stats.as_of, as_of) {
-                        ::tracing::warn!(
-                            "stale statistics: statistics from {:?} are earlier than query at {as_of:?}",
-                            stats.as_of
-                        );
-                    }
-
                     cache.insert(*id, stats.num_updates);
                 }
                 Err(StorageError::IdentifierMissing(id)) => {

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -307,22 +307,25 @@ where
     ///
     /// This command returns the contents of this shard as of `as_of` once they
     /// are known. This may "block" (in an async-friendly way) if `as_of` is
-    /// greater or equal to the current `upper` of the shard.
+    /// greater or equal to the current `upper` of the shard. If `None` is given
+    /// for `as_of`, then the latest stats known by this process are used.
     ///
     /// The `Since` error indicates that the requested `as_of` cannot be served
     /// (the caller has out of date information) and includes the smallest
     /// `as_of` that would have been accepted.
     pub fn snapshot_stats(
         &self,
-        as_of: Antichain<T>,
-    ) -> impl Future<Output = Result<SnapshotStats<T>, Since<T>>> + Send + 'static {
+        as_of: Option<Antichain<T>>,
+    ) -> impl Future<Output = Result<SnapshotStats, Since<T>>> + Send + 'static {
         let mut machine = self.machine.clone();
         async move {
-            let batches = machine.snapshot(&as_of).await?;
+            let batches = match as_of {
+                Some(as_of) => machine.snapshot(&as_of).await?,
+                None => machine.applier.all_batches(),
+            };
             let num_updates = batches.iter().map(|b| b.len).sum();
             Ok(SnapshotStats {
                 shard_id: machine.shard_id(),
-                as_of,
                 num_updates,
             })
         }

--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -252,6 +252,20 @@ where
             })
     }
 
+    pub fn all_batches(&self) -> Vec<HollowBatch<T>> {
+        self.state
+            .read_lock(&self.metrics.locks.applier_read_noncacheable, |state| {
+                state
+                    .state
+                    .collections
+                    .trace
+                    .batches()
+                    .into_iter()
+                    .cloned()
+                    .collect()
+            })
+    }
+
     pub fn verify_listen(&self, as_of: &Antichain<T>) -> Result<Result<(), Upper<T>>, Since<T>> {
         self.state
             .read_lock(&self.metrics.locks.applier_read_noncacheable, |state| {

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -17,7 +17,6 @@ use mz_persist_types::part::{Part, PartBuilder};
 use mz_persist_types::stats::StructStats;
 use mz_persist_types::Codec;
 use proptest_derive::Arbitrary;
-use timely::progress::Antichain;
 
 use crate::batch::UntrimmableColumns;
 use crate::dyn_cfg::{Config, ConfigSet};
@@ -169,11 +168,9 @@ impl PartStats {
 ///
 /// TODO: Add more stats here as they become necessary.
 #[derive(Debug)]
-pub struct SnapshotStats<T> {
+pub struct SnapshotStats {
     /// The shard these statistics are for.
     pub shard_id: ShardId,
-    /// The frontier at which these statistics are valid.
-    pub as_of: Antichain<T>,
     /// An estimate of the count of updates in the shard.
     ///
     /// This is an upper bound on the number of updates that persist_source

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1085,8 +1085,7 @@ impl<'a> RunnerInner<'a> {
             deploy_generation: None,
             http_host_name: Some(host_name),
             internal_console_redirect_url: None,
-            // TODO(txn-lazy): Get "lazy" flipped on before turning "lazy" on in prod.
-            persist_txn_tables_cli: Some(PersistTxnTablesImpl::Eager),
+            persist_txn_tables_cli: Some(PersistTxnTablesImpl::Lazy),
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -409,7 +409,7 @@ pub trait StorageController: Debug {
         &self,
         id: GlobalId,
         as_of: Antichain<Self::Timestamp>,
-    ) -> Result<SnapshotStats<Self::Timestamp>, StorageError>;
+    ) -> Result<SnapshotStats, StorageError>;
 
     /// Assigns a read policy to specific identifiers.
     ///

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1241,7 +1241,7 @@ where
         &self,
         id: GlobalId,
         as_of: Antichain<Self::Timestamp>,
-    ) -> Result<SnapshotStats<Self::Timestamp>, StorageError> {
+    ) -> Result<SnapshotStats, StorageError> {
         let metadata = &self.collection(id)?.collection_metadata;
         // See the comments in Self::snapshot for what's going on here.
         let as_of = match metadata.txns_shard.as_ref() {


### PR DESCRIPTION
When `latest_write` on `DataSnapshot` is `None`, it means persist-txn knows that the latest write has been applied, but it has compacted away information about specifically what timestamp that was. This makes it hard to do the "as_of translation" for the `snapshot_stats` call. Work around this by adding the ability to `snapshot_stats` to get whatever the current stats are.

This makes the final remaining sqllogictest pass for lazy (cardinality.slt), so turn that one.

Touches #22173

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
