### PR TITLE
Adding retries for VersionNotFound errors from Confluent Schema Registry

### DIFF
--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1712,7 +1712,8 @@ async fn get_schema_with_strategy(
         ReaderSchemaSelectionStrategy::Latest => {
             match client.get_schema_by_subject(subject).await {
                 Ok(CcsrSchema { raw, .. }) => Ok(Some(raw)),
-                Err(GetBySubjectError::SubjectNotFound) => Ok(None),
+                Err(GetBySubjectError::SubjectNotFound)
+                | Err(GetBySubjectError::VersionNotFound(_)) => Ok(None),
                 Err(e) => Err(PlanError::FetchingCsrSchemaFailed {
                     schema_lookup: format!("subject {}", subject.quoted()),
                     cause: Arc::new(e),

--- a/src/testdrive/src/action/schema_registry.rs
+++ b/src/testdrive/src/action/schema_registry.rs
@@ -94,9 +94,10 @@ pub async fn run_verify(
         .retry_async(|_| async {
             match state.ccsr_client.get_schema_by_subject(&subject).await {
                 Ok(s) => mz_ore::retry::RetryResult::Ok(s.raw),
-                Err(e @ mz_ccsr::GetBySubjectError::SubjectNotFound) => {
-                    mz_ore::retry::RetryResult::RetryableErr(e)
-                }
+                Err(
+                    e @ mz_ccsr::GetBySubjectError::SubjectNotFound
+                    | e @ mz_ccsr::GetBySubjectError::VersionNotFound(_),
+                ) => mz_ore::retry::RetryResult::RetryableErr(e),
                 Err(e) => mz_ore::retry::RetryResult::FatalErr(e),
             }
         })


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->
From [Confluent's api docs](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--subjects-(string-%20subject)-versions-(versionId-%20version)), there can be two NotFound statuses, 40401 (subject not found) and 40402 (version not found). We were special casing the former to retry again, but not the latter. This PR adds a case for 40402 as well and makes fetching schema retry-able for it.

In the issue https://github.com/MaterializeInc/materialize/issues/23539, there are errors like "server error 40402: Version -1 not found." which we get when trying to fetch the schema just after creating a sink where [-1 means it's the latest schema](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--subjects-(string-%20subject)-versions-(versionId-%20version)). 

### Motivation
Fixes https://github.com/MaterializeInc/materialize/issues/23539

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
