### PR TITLE
balancerd: fix flakey test

### DIFF
--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -150,7 +150,7 @@ async fn test_balancer() {
             .await
             .unwrap();
         task::spawn(|| "balancer-pg_client", async move {
-            conn.await.expect("balancer-pg_client")
+            let _ = conn.await;
         });
 
         let res: i32 = pg_client.query_one("SELECT 2", &[]).await.unwrap().get(0);
@@ -162,7 +162,7 @@ async fn test_balancer() {
             .copy_out("copy (subscribe (select * from mz_kafka_sinks)) to stdout")
             .await
             .unwrap();
-        cancel.cancel_query(tls).await.unwrap();
+        let _ = cancel.cancel_query(tls).await;
         let e = pin!(copy).next().await.unwrap().unwrap_err();
         assert_contains!(e.to_string(), "canceling statement due to user request");
 


### PR DESCRIPTION
Errors during cancellation attempts can occur but are not fatal.

Fixes #24647

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a