### PR TITLE
deps: upgrade to rust-rdkafka with non-blocking drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7438,7 +7438,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#8ea07c4d2b96636ff093e670bc921892aee0d56a"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#c729f89b70935fb2ad8a4f377cff2845acc197b0"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "4.3.0+1.9.2"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#8ea07c4d2b96636ff093e670bc921892aee0d56a"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#c729f89b70935fb2ad8a4f377cff2845acc197b0"
 dependencies = [
  "cmake",
  "libc",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -140,6 +140,16 @@ who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
 version = "10.7.0"
 
+[[audits.rdkafka]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.29.0@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
+
+[[audits.rdkafka-sys]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "4.3.0+1.9.2@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
+
 [[audits.redox_syscall]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -1194,14 +1194,6 @@ criteria = "safe-to-deploy"
 version = "0.3.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.rdkafka]]
-version = "0.29.0@git:8ea07c4d2b96636ff093e670bc921892aee0d56a"
-criteria = "safe-to-deploy"
-
-[[exemptions.rdkafka-sys]]
-version = "4.3.0+1.9.2@git:8ea07c4d2b96636ff093e670bc921892aee0d56a"
-criteria = "safe-to-deploy"
-
 [[exemptions.redox_syscall]]
 version = "0.2.10"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
@guswynn discovered that dropping a Kafka consumer or producer blocks until the consumer/producer is fully shut down (i.e., outstanding messages flushed, offsets committed, rebalance assignment released). This can cause deadlocks if the Kafka consumer or producer is dropped from an async task that is scheduled on the same Tokio core thread as an async task that is handling a librdkafka callback (e.g., establishing an SSH tunnel).

This is particularly bad when dropping a Kafka consumer or producer from `environmentd`, as we do during connection validation, as there are 50-50 odds that we deadlock on the thread handling the main coordinator loop, thus stalling out the entire system.

The updated version of rust-rdkafka includes a patch to always drop Kafka consumers/producers from a dedicated thread. Since this thread is guaranteed not to be a Tokio thread, the drop will not deadlock.

This fixes the root cause of incident 92.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

Alternative approach to https://github.com/MaterializeInc/materialize/pull/24537. See that PR for a lot of context/discussion.

Please also review the underlying rdkafka patch, as it only exists on our fork: https://github.com/MaterializeInc/rust-rdkafka/commit/c729f89b70935fb2ad8a4f377cff2845acc197b0

If we don't end up merging this, I'll remove the above commit from our fork.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Prevent the system from stalling when validating a Kafka connection that uses SSH tunnels.
