### PR TITLE
ci: Fix some nightly timeouts

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -118,7 +118,7 @@ steps:
 
     - id: kafka-multi-broker
       label: Kafka multi-broker test
-      timeout_in_minutes: 10
+      timeout_in_minutes: 30
       agents:
         queue: linux-aarch64-small
       artifact_paths: junit_*.xml
@@ -206,7 +206,7 @@ steps:
         label: Full Testdrive in Cloudtest (K8s)
         timeout_in_minutes: 300
         agents:
-          queue: linux-aarch64-small
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
@@ -622,7 +622,7 @@ steps:
 
       - id: checks-upgrade-entire-mz-four-versions
         label: "Checks upgrade across four versions"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: linux-aarch64-large
         artifact_paths: junit_*.xml
@@ -770,7 +770,7 @@ steps:
     steps:
       - id: persist-maelstrom
         label: Maelstrom coverage of persist
-        timeout_in_minutes: 10
+        timeout_in_minutes: 30
         artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
         plugins:
           - ./ci/plugins/mzcompose:
@@ -803,7 +803,7 @@ steps:
 
       - id: persist-txn-maelstrom
         label: Maelstrom coverage of persist-txn
-        timeout_in_minutes: 10
+        timeout_in_minutes: 30
         agents:
           queue: linux-aarch64-small
         artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
@@ -854,7 +854,8 @@ steps:
     concurrency: 1
     concurrency_group: 'cloud-canary'
     agents:
-      queue: linux-aarch64-small
+      # no matching manifest for linux/arm64/v8 in the manifest list entries
+      queue: linux-x86-64-small
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cloud-canary


### PR DESCRIPTION
In some cases docker pull was so slow it didn't even finish within 10 min

Seen in https://buildkite.com/materialize/nightlies/builds/6134

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
