### PR TITLE
peek: move LIR optimization back on the main thread

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -627,28 +627,23 @@ impl Coordinator {
         let determination = return_if_err!(determination, ctx);
         let timestamp_context = determination.clone().timestamp_context;
 
-        mz_ore::task::spawn_blocking(
-            || "optimize peek (LIR)",
-            move || {
-                let pipeline =
-                    || -> Result<(optimize::peek::GlobalLirPlan, UsedIndexes), AdapterError> {
-                        // In `explain_~` contexts, set the trace-derived dispatch
-                        // as default while optimizing.
-                        let _dispatch_guard = if let Some(explain_ctx) = explain_ctx.as_ref() {
-                            let dispatch = tracing::Dispatch::from(&explain_ctx.optimizer_trace);
-                            Some(tracing::dispatcher::set_default(&dispatch))
-                        } else {
-                            None
-                        };
+        let pipeline = || -> Result<(optimize::peek::GlobalLirPlan, UsedIndexes), AdapterError> {
+            // In `explain_~` contexts, set the trace-derived dispatch
+            // as default while optimizing.
+            let _dispatch_guard = if let Some(explain_ctx) = explain_ctx.as_ref() {
+                let dispatch = tracing::Dispatch::from(&explain_ctx.optimizer_trace);
+                Some(tracing::dispatcher::set_default(&dispatch))
+            } else {
+                None
+            };
 
-                        let _span_guard =
-                            tracing::debug_span!(target: "optimizer", "optimize").entered();
+            let _span_guard = tracing::debug_span!(target: "optimizer", "optimize").entered();
 
-                        // Collect the list of indexes used by the dataflow at this point
-                        let mut used_indexes = {
-                            let df_desc = global_mir_plan.df_desc();
-                            let df_meta = global_mir_plan.df_meta();
-                            UsedIndexes::new(
+            // Collect the list of indexes used by the dataflow at this point
+            let mut used_indexes = {
+                let df_desc = global_mir_plan.df_desc();
+                let df_meta = global_mir_plan.df_meta();
+                UsedIndexes::new(
                                 df_desc
                                     .index_imports
                                     .iter()
@@ -657,104 +652,102 @@ impl Coordinator {
                                     })
                                     .collect(),
                             )
-                        };
+            };
 
-                        // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                        let global_mir_plan =
-                            global_mir_plan.resolve(timestamp_context.clone(), ctx.session_mut());
-                        let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan)?;
+            // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
+            let global_mir_plan =
+                global_mir_plan.resolve(timestamp_context.clone(), ctx.session_mut());
+            let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan)?;
 
-                        // Trace the resulting plan for the top-level `optimize` path.
-                        match global_lir_plan.peek_plan() {
-                            peek::PeekPlan::FastPath(plan) => {
-                                let arity = global_lir_plan.typ().arity();
-                                let finishing = if !optimizer.finishing().is_trivial(arity) {
-                                    Some(optimizer.finishing().clone())
-                                } else {
-                                    None
-                                };
-                                used_indexes = plan.used_indexes(&finishing);
-
-                                // TODO(aalexandrov): rework `OptimizerTrace` with support
-                                // for diverging plan types towards the end and add a
-                                // `PlanTrace` for the `FastPathPlan` type.
-                                trace_plan(&"fast_path_plan (missing)".to_string());
-                            }
-                            peek::PeekPlan::SlowPath(plan) => trace_plan(&plan.desc),
-                        }
-
-                        Ok((global_lir_plan, used_indexes))
+            // Trace the resulting plan for the top-level `optimize` path.
+            match global_lir_plan.peek_plan() {
+                peek::PeekPlan::FastPath(plan) => {
+                    let arity = global_lir_plan.typ().arity();
+                    let finishing = if !optimizer.finishing().is_trivial(arity) {
+                        Some(optimizer.finishing().clone())
+                    } else {
+                        None
                     };
+                    used_indexes = plan.used_indexes(&finishing);
 
-                let stage = match pipeline() {
-                    Ok((global_lir_plan, used_indexes)) => {
-                        if let Some(explain_ctx) = explain_ctx {
-                            let (peek_plan, df_meta) = global_lir_plan.unapply();
-                            PeekStage::Explain(PeekStageExplain {
-                                validity,
-                                select_id: optimizer.select_id(),
-                                finishing: optimizer.finishing().clone(),
-                                fast_path_plan: match peek_plan {
-                                    peek::PeekPlan::FastPath(plan) => Some(plan),
-                                    peek::PeekPlan::SlowPath(_) => None,
-                                },
-                                df_meta,
-                                used_indexes,
-                                explain_ctx,
-                            })
-                        } else {
-                            PeekStage::Finish(PeekStageFinish {
-                                validity,
-                                plan,
-                                id_bundle,
-                                target_replica,
-                                source_ids,
-                                determination,
-                                timestamp_context,
-                                optimizer,
-                                global_lir_plan,
-                            })
-                        }
-                    }
-                    // Internal optimizer errors are handled differently
-                    // depending on the caller.
-                    Err(err) => {
-                        let Some(explain_ctx) = explain_ctx else {
-                            // In `sequence_~` contexts, immediately retire the
-                            // execution with the error.
-                            return ctx.retire(Err(err.into()));
-                        };
+                    // TODO(aalexandrov): rework `OptimizerTrace` with support
+                    // for diverging plan types towards the end and add a
+                    // `PlanTrace` for the `FastPathPlan` type.
+                    trace_plan(&"fast_path_plan (missing)".to_string());
+                }
+                peek::PeekPlan::SlowPath(plan) => trace_plan(&plan.desc),
+            }
 
-                        if explain_ctx.broken {
-                            // In `EXPLAIN BROKEN` contexts, just log the error
-                            // and move to the next stage with default
-                            // parameters.
-                            tracing::error!("error while handling EXPLAIN statement: {}", err);
-                            PeekStage::Explain(PeekStageExplain {
-                                validity,
-                                select_id: optimizer.select_id(),
-                                finishing: optimizer.finishing().clone(),
-                                fast_path_plan: Default::default(),
-                                df_meta: Default::default(),
-                                used_indexes: Default::default(),
-                                explain_ctx,
-                            })
-                        } else {
-                            // In regular `EXPLAIN` contexts, immediately retire
-                            // the execution with the error.
-                            return ctx.retire(Err(err.into()));
-                        }
-                    }
+            Ok((global_lir_plan, used_indexes))
+        };
+
+        let stage = match pipeline() {
+            Ok((global_lir_plan, used_indexes)) => {
+                if let Some(explain_ctx) = explain_ctx {
+                    let (peek_plan, df_meta) = global_lir_plan.unapply();
+                    PeekStage::Explain(PeekStageExplain {
+                        validity,
+                        select_id: optimizer.select_id(),
+                        finishing: optimizer.finishing().clone(),
+                        fast_path_plan: match peek_plan {
+                            peek::PeekPlan::FastPath(plan) => Some(plan),
+                            peek::PeekPlan::SlowPath(_) => None,
+                        },
+                        df_meta,
+                        used_indexes,
+                        explain_ctx,
+                    })
+                } else {
+                    PeekStage::Finish(PeekStageFinish {
+                        validity,
+                        plan,
+                        id_bundle,
+                        target_replica,
+                        source_ids,
+                        determination,
+                        timestamp_context,
+                        optimizer,
+                        global_lir_plan,
+                    })
+                }
+            }
+            // Internal optimizer errors are handled differently
+            // depending on the caller.
+            Err(err) => {
+                let Some(explain_ctx) = explain_ctx else {
+                    // In `sequence_~` contexts, immediately retire the
+                    // execution with the error.
+                    return ctx.retire(Err(err.into()));
                 };
 
-                // Ignore errors if the coordinator has shut down.
-                let _ = internal_cmd_tx.send(Message::PeekStageReady {
-                    ctx,
-                    otel_ctx: root_otel_ctx,
-                    stage,
-                });
-            },
-        );
+                if explain_ctx.broken {
+                    // In `EXPLAIN BROKEN` contexts, just log the error
+                    // and move to the next stage with default
+                    // parameters.
+                    tracing::error!("error while handling EXPLAIN statement: {}", err);
+                    PeekStage::Explain(PeekStageExplain {
+                        validity,
+                        select_id: optimizer.select_id(),
+                        finishing: optimizer.finishing().clone(),
+                        fast_path_plan: Default::default(),
+                        df_meta: Default::default(),
+                        used_indexes: Default::default(),
+                        explain_ctx,
+                    })
+                } else {
+                    // In regular `EXPLAIN` contexts, immediately retire
+                    // the execution with the error.
+                    return ctx.retire(Err(err.into()));
+                }
+            }
+        };
+
+        // Ignore errors if the coordinator has shut down.
+        let _ = internal_cmd_tx.send(Message::PeekStageReady {
+            ctx,
+            otel_ctx: root_otel_ctx,
+            stage,
+        });
     }
 
     #[tracing::instrument(level = "debug", skip_all)]


### PR DESCRIPTION
We have to do this because #24130 started happening again after we moved LIR optimizatio back on a separate thread in #24569.

### Motivation

  * This PR fixes a previously unreported bug.

See [this comment](https://github.com/MaterializeInc/materialize/issues/24130#issuecomment-1909672173).

### Tips for reviewers

@def-: It's strange that the nightly run for #24569 didn't catch this. Maybe some repeated runs of the problematic stages that manifest this is needed before we merge the revert in order to ensure that this is actually solving the issue.
@teskje: please stamp this so we can merge later today if everything looks good.
@mjibson: we might need some assistance from the @MaterializeInc/adapter team in order to figure out what is going wrong here.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
