### PR TITLE
postgres consistency: add ignore for cast to default decimal type (inconsistency #24678)

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -225,6 +225,15 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("Consequence of #23571")
 
+        if db_operation.pattern == "CAST ($ AS $)":
+            casting_target = expression.args[1]
+            assert isinstance(casting_target, EnumConstant)
+
+            if casting_target.value == "DECIMAL(39)":
+                return YesIgnore(
+                    "#24678: different specification of default DECIMAL type"
+                )
+
         return NoIgnore()
 
 


### PR DESCRIPTION
This addresses the failure in https://buildkite.com/materialize/nightlies/builds/6142#018d3cbf-50aa-41d2-9a55-12d08e0b0edb.

Newly identified inconsistency: https://github.com/MaterializeInc/materialize/issues/24678

Nightly: https://buildkite.com/materialize/nightlies/builds/6148