### PR TITLE
Surface source errors in `mz_source_statistics`

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -838,6 +838,7 @@ the system are restarted.
 | `updates_committed`      | [`uint8`]    | The number of updates (insertions plus deletions) the worker has committed to the storage layer.                                                                                                                                                                                    |
 | `envelope_state_bytes`   | [`uint8`]    | The number of bytes stored in the source envelope state.                                                                       |
 | `envelope_state_records` | [`uint8`]    | The number of individual records stored in the source envelope state.                                                                                                                                                                                                               |
+| `errors`                 | [`uint8`]    | The number of errors in the source.                                                                                                                                                                                                                                                 |
 | `rehydration_latency`    | [`interval`] | The amount of time it took for the worker to rehydrate the source envelope state. |
 
 ### `mz_source_statistics`
@@ -865,6 +866,7 @@ Note that:
 | `updates_committed`      | [`uint8`]    | The number of updates (insertions plus deletions) the source has committed to the storage layer.                                                                                                                                                                                    |
 | `envelope_state_bytes`   | [`uint8`]    | The number of bytes stored in the source envelope state.                                                                       |
 | `envelope_state_records` | [`uint8`]    | The number of individual records stored in the source envelope state.                                                                                                                                                                                                               |
+| `errors`                 | [`uint8`]    | The number of errors in the source.                                                                                                                                                                                                                                                 |
 | `rehydration_latency`    | [`interval`] | The amount of time it took for the worker to rehydrate the source envelope state. |
 
 ### `mz_source_statuses`

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2931,6 +2931,7 @@ pub static MZ_SOURCE_STATISTICS_PER_WORKER: Lazy<BuiltinSource> = Lazy::new(|| B
         .with_column("updates_committed", ScalarType::UInt64.nullable(false))
         .with_column("envelope_state_bytes", ScalarType::UInt64.nullable(false))
         .with_column("envelope_state_records", ScalarType::UInt64.nullable(false))
+        .with_column("errors", ScalarType::UInt64.nullable(false))
         .with_column("rehydration_latency", ScalarType::Interval.nullable(true)),
     is_retained_metrics_object: true,
     access: vec![PUBLIC_SELECT],
@@ -6164,6 +6165,7 @@ SELECT
     SUM(updates_committed)::uint8 AS updates_committed,
     SUM(envelope_state_bytes)::uint8 AS envelope_state_bytes,
     SUM(envelope_state_records)::uint8 AS envelope_state_records,
+    SUM(errors)::uint8 AS errors,
     -- Ensure we aggregate to NULL when not all workers are done rehydrating.
     CASE
         WHEN bool_or(rehydration_latency IS NULL) THEN NULL

--- a/src/storage-client/src/client.proto
+++ b/src/storage-client/src/client.proto
@@ -98,6 +98,7 @@ message ProtoStorageResponse {
         uint64 envelope_state_bytes = 8;
         uint64 envelope_state_records = 9;
         optional int64 rehydration_latency_ms = 10;
+        uint64 errors = 11;
     }
     message ProtoSinkStatisticsUpdate {
         mz_repr.global_id.ProtoGlobalId id = 1;

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -305,6 +305,7 @@ pub struct SourceStatisticsUpdate {
     pub updates_committed: u64,
     pub envelope_state_bytes: u64,
     pub envelope_state_records: u64,
+    pub errors: u64,
     pub rehydration_latency_ms: Option<i64>,
 }
 
@@ -336,6 +337,7 @@ impl PackableStats for SourceStatisticsUpdate {
         packer.push(Datum::from(self.updates_committed));
         packer.push(Datum::from(self.envelope_state_bytes));
         packer.push(Datum::from(self.envelope_state_records));
+        packer.push(Datum::from(self.errors));
         packer.push(Datum::from(
             self.rehydration_latency_ms
                 .map(chrono::Duration::milliseconds),
@@ -442,6 +444,7 @@ impl RustType<ProtoStorageResponse> for StorageResponse<mz_repr::Timestamp> {
                                 updates_committed: update.updates_committed,
                                 envelope_state_bytes: update.envelope_state_bytes,
                                 envelope_state_records: update.envelope_state_records,
+                                errors: update.errors,
                                 rehydration_latency_ms: update.rehydration_latency_ms,
                             })
                             .collect(),
@@ -492,6 +495,7 @@ impl RustType<ProtoStorageResponse> for StorageResponse<mz_repr::Timestamp> {
                             bytes_received: update.bytes_received,
                             envelope_state_bytes: update.envelope_state_bytes,
                             envelope_state_records: update.envelope_state_records,
+                            errors: update.errors,
                             rehydration_latency_ms: update.rehydration_latency_ms,
                         })
                     })

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -506,6 +506,10 @@ where
         _ => collection::concatenate(scope, error_collections),
     };
 
+    // Maintain error count for the source statistics.
+    let stats = base_source_config.source_statistics.clone();
+    let err_collection = err_collection.inspect(move |(_, _, diff)| stats.update_errors_by(*diff));
+
     // Return the collections and any needed tokens.
     (collection, err_collection, needed_tokens, health)
 }

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -473,7 +473,8 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 7  updates_committed  uint8
 8  envelope_state_bytes  uint8
 9  envelope_state_records  uint8
-10  rehydration_latency  interval
+10  errors  uint8
+11  rehydration_latency  interval
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_source_statistics' ORDER BY position
@@ -486,7 +487,8 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 6  updates_committed  uint8
 7  envelope_state_bytes  uint8
 8  envelope_state_records  uint8
-9  rehydration_latency  interval
+9  errors  uint8
+10  rehydration_latency  interval
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_source_statuses' ORDER BY position

--- a/test/sqllogictest/mz_introspection_index_accounting.slt
+++ b/test/sqllogictest/mz_introspection_index_accounting.slt
@@ -427,6 +427,7 @@ mz_sinks  type
 mz_source_statistics  bytes_received
 mz_source_statistics  envelope_state_bytes
 mz_source_statistics  envelope_state_records
+mz_source_statistics  errors
 mz_source_statistics  id
 mz_source_statistics  messages_received
 mz_source_statistics  rehydration_latency
@@ -436,6 +437,7 @@ mz_source_statistics  updates_staged
 mz_source_statistics_per_worker  bytes_received
 mz_source_statistics_per_worker  envelope_state_bytes
 mz_source_statistics_per_worker  envelope_state_records
+mz_source_statistics_per_worker  errors
 mz_source_statistics_per_worker  id
 mz_source_statistics_per_worker  messages_received
 mz_source_statistics_per_worker  rehydration_latency

--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -83,35 +83,47 @@ $ set-sql-timeout duration=2minutes
 
 # NOTE: These queries are slow to succeed because the default metrics scraping
 # interval is 30 seconds.
-> SELECT s.name,
-  bool_and(u.snapshot_committed),
-  SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
+> SELECT
+    s.name,
+    bool_and(u.snapshot_committed),
+    SUM(u.messages_received),
+    SUM(u.updates_staged),
+    SUM(u.updates_committed),
+    SUM(u.bytes_received) > 0,
+    SUM(u.errors),
+    bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_per_worker u ON s.id = u.id
   WHERE s.name IN ('metrics_test_source')
   GROUP BY s.name
   ORDER BY s.name
-metrics_test_source true 2 2 2 true true
+metrics_test_source true 2 2 2 true 0 true
 
 > DROP SOURCE metrics_test_source
 
 # Note that only the base-source has `messages_received`, but the sub-sources have `messages_committed`.
 # Committed will usually, for auction sources, add up to received, but we don't test this (right now) because of
 # jitter on when metrics are produced for each sub-source.
-> SELECT s.name,
-  bool_and(u.snapshot_committed),
-  SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
+> SELECT
+    s.name,
+    bool_and(u.snapshot_committed),
+    SUM(u.messages_received) > 0,
+    SUM(u.updates_staged) > 0,
+    SUM(u.updates_committed) > 0,
+    SUM(u.bytes_received) > 0,
+    SUM(u.errors)
+    bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_per_worker u ON s.id = u.id
   WHERE s.name IN ('accounts', 'auction_house', 'auctions', 'bids', 'organizations', 'users')
   GROUP BY s.name
   ORDER BY s.name
-accounts       true      false   true  true  false   true
-auction_house  true      true    false false true    true
-auctions       true      false   true  true  false   true
-bids           true      false   true  true  false   true
-organizations  true      false   true  true  false   true
-users          true      false   true  true  false   true
+accounts       true      false   true  true  false  0  true
+auction_house  true      true    false false true   0  true
+auctions       true      false   true  true  false  0  true
+bids           true      false   true  true  false  0  true
+organizations  true      false   true  true  false  0  true
+users          true      false   true  true  false  0  true
 
 > DROP SOURCE auction_house
 
@@ -131,13 +143,14 @@ users          true      false   true  true  false   true
     SUM(u.bytes_received) > 0,
     SUM(u.envelope_state_bytes) > 0,
     SUM(u.envelope_state_records),
+    SUM(u.errors),
     bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_per_worker u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
-upsert true 9 true true true true 3 true
+upsert true 9 true true true true 3 0 true
 
 # While we can't control how batching works above, we can ensure that this new, later update
 # causes 1 more messages to be received, which is 1 update, a delete.
@@ -160,23 +173,27 @@ SELECT
 $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
 {"key": "mammalmore"}
 
-> SELECT s.name,
+> SELECT
+    s.name,
     bool_and(u.snapshot_committed),
     SUM(u.messages_received),
     SUM(u.updates_staged),
     SUM(u.updates_committed),
     SUM(u.bytes_received) > 0,
     SUM(u.envelope_state_bytes) < ${state-bytes},
-    SUM(u.envelope_state_records)
+    SUM(u.envelope_state_records),
+    SUM(u.errors),
+    bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_per_worker u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
-upsert true 10 "${updates-committed}" "${updates-committed}" true true 2
+upsert true 10 "${updates-committed}" "${updates-committed}" true true 2 0 true
 
 # check pre-aggregated view
-> SELECT s.name,
+> SELECT
+    s.name,
     u.snapshot_committed,
     u.messages_received,
     u.updates_staged,
@@ -184,10 +201,11 @@ upsert true 10 "${updates-committed}" "${updates-committed}" true true 2
     u.bytes_received > 0,
     u.envelope_state_bytes < ${state-bytes},
     u.envelope_state_records,
+    u.errors,
     u.rehydration_latency IS NOT NULL
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
-upsert true 10 "${updates-committed}" "${updates-committed}" true true 2 true
+upsert true 10 "${updates-committed}" "${updates-committed}" true true 2 0 true
 
 > DROP SOURCE upsert


### PR DESCRIPTION
This PR makes the source ingestion pipeline keep track of errors written into sources and surfaces source error counts as source statistics. This makes the error counts visible in `mz_source_statistics`.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
