### PR TITLE
postgres consistency: add ignore for cast from boolean to bigint/int8

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -299,6 +299,9 @@ class PgPostExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("Not supported by pg")
 
+        if "cannot cast type boolean to bigint" in pg_error_msg:
+            return YesIgnore("Not supported by pg")
+
         return NoIgnore()
 
     def _shall_ignore_mz_failure_where_pg_succeeds(


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/6151#018d409c-ee64-4318-9a77-1fd2ee08ea36.

I have not created an issue since I think that this deviation is ok. Let me know if you disagree.

### Postgres

```
postgres=# select cast('true'::boolean as int);
 int4 
------
    1
(1 row)

postgres=# select cast('true'::boolean as int8);
ERROR:  cannot cast type boolean to bigint
LINE 1: select cast('true'::boolean as int8);
               ^
```

### Materialize

```
materialize=> select cast('true'::boolean as int);
 int4 
------
    1
(1 row)

materialize=> select cast('true'::boolean as int8);
 int8 
------
    1
(1 row)
```