### PR TITLE
Revert "rust: Specify build rules for x86_64-apple-darwin"

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -21,15 +21,6 @@ rustflags = [
     "--cfg=tokio_unstable",
 ]
 
-[target."x86_64-apple-darwin"]
-# Duplicate the "rustflags" for x86 Linux for x86 macOS.
-rustflags = [
-    "-Csymbol-mangling-version=v0",
-    "-Ctarget-cpu=x86-64-v3",
-    "-Ctarget-feature=+aes",
-    "--cfg=tokio_unstable",
-]
-
 # As of Jan 2024 all of the Linux based aarch64 hardware we run on supports the Neoverse N1 micro
 # architecture.
 #


### PR DESCRIPTION
Reverts MaterializeInc/materialize#24664

https://github.com/MaterializeInc/materialize/pull/24664 fails macOS Clippy on main: https://buildkite.com/materialize/tests/builds/73981#018d4118-f340-4f5d-a5ba-c29ca4550374
I'm guessing our mac builder is so old that it doesn't support the new target-cpu. I'm not sure if there is a better fix.