### PR TITLE
stash: disable Consolidator in tests by default

### DIFF
--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -583,7 +583,7 @@ async fn test_stash_batch_large_number_updates() {
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
 async fn test_stash_readonly() {
     let factory = DebugStashFactory::try_new().await.expect("must succeed");
-    let mut stash_rw = factory.open().await;
+    let mut stash_rw = factory.open_with_consolidation().await;
     let col_rw = collection::<i64, i64>(&mut stash_rw, "c1").await.unwrap();
     let mut batch = make_batch(&col_rw, &mut stash_rw).await.unwrap();
     col_rw.append_to_batch(&mut batch, &1, &2, 1);
@@ -612,7 +612,7 @@ async fn test_stash_readonly() {
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
 async fn test_stash_savepoint() {
     let factory = DebugStashFactory::try_new().await.expect("must succeed");
-    let mut stash_rw = factory.open().await;
+    let mut stash_rw = factory.open_with_consolidation().await;
     // Data still present from previous test.
 
     // Now make a savepoint stash. We should be allowed to create anything
@@ -683,8 +683,8 @@ async fn test_stash_fence() {
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
 async fn test_stash_append() {
     let factory = DebugStashFactory::try_new().await.expect("must succeed");
-    test_append(|| async { factory.open().await }).await;
-    factory.open().await.verify().await.unwrap();
+    test_append(|| async { factory.open_with_consolidation().await }).await;
+    factory.open_with_consolidation().await.verify().await.unwrap();
     factory.drop().await;
 }
 
@@ -692,8 +692,8 @@ async fn test_stash_append() {
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
 async fn test_stash_stash() {
     let factory = DebugStashFactory::try_new().await.expect("must succeed");
-    test_stash(|| async { factory.open().await }).await;
-    factory.open().await.verify().await.unwrap();
+    test_stash(|| async { factory.open_with_consolidation().await }).await;
+    factory.open_with_consolidation().await.verify().await.unwrap();
     factory.drop().await;
 }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
