### PR TITLE
sql: fully prevent item name references in INSERT

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -24,7 +24,7 @@ use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::role_id::RoleId;
 use mz_repr::Timestamp;
 use mz_sql::ast::{
-    CopyRelation, CopyStatement, ObjectReferences, Raw, Statement, SubscribeStatement,
+    ConstantVisitor, CopyRelation, CopyStatement, Raw, Statement, SubscribeStatement,
 };
 use mz_sql::catalog::RoleAttributes;
 use mz_sql::names::{Aug, PartialItemName, ResolvedIds};
@@ -521,7 +521,7 @@ impl Coordinator {
 
                     Statement::Insert(InsertStatement {
                         source, returning, ..
-                    }) if returning.is_empty() && !ObjectReferences::insert_source(source) => {
+                    }) if returning.is_empty() && ConstantVisitor::insert_source(source) => {
                         // Inserting from constant values statements that do not need to execute on
                         // any cluster (no RETURNING) is always safe.
                     }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -24,7 +24,7 @@ use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::role_id::RoleId;
 use mz_repr::Timestamp;
 use mz_sql::ast::{
-    CopyRelation, CopyStatement, InsertSource, Query, Raw, SetExpr, Statement, SubscribeStatement,
+    CopyRelation, CopyStatement, ObjectReferences, Raw, Statement, SubscribeStatement,
 };
 use mz_sql::catalog::RoleAttributes;
 use mz_sql::names::{Aug, PartialItemName, ResolvedIds};
@@ -520,15 +520,8 @@ impl Coordinator {
                     }
 
                     Statement::Insert(InsertStatement {
-                        source:
-                            InsertSource::Query(Query {
-                                body: SetExpr::Values(..),
-                                ..
-                            })
-                            | InsertSource::DefaultValues,
-                        returning,
-                        ..
-                    }) if returning.is_empty() => {
+                        source, returning, ..
+                    }) if returning.is_empty() && !ObjectReferences::insert_source(source) => {
                         // Inserting from constant values statements that do not need to execute on
                         // any cluster (no RETURNING) is always safe.
                     }

--- a/src/sql/src/ast/mod.rs
+++ b/src/sql/src/ast/mod.rs
@@ -9,5 +9,39 @@
 
 //! SQL abstract syntax tree.
 
+use mz_sql_parser::ast::visit::Visit;
 pub use mz_sql_parser::ast::*;
 pub mod transform;
+
+/// A visitor that determines if object references are present.
+#[derive(Debug)]
+pub struct ObjectReferences {
+    pub references: bool,
+}
+
+impl ObjectReferences {
+    /// Returns the referenced objects.
+    pub fn insert_source<T: AstInfo>(node: &InsertSource<T>) -> bool {
+        let mut visitor = Self { references: false };
+        visitor.visit_insert_source(node);
+        visitor.references
+    }
+}
+
+impl<'ast, T: AstInfo> Visit<'ast, T> for ObjectReferences {
+    fn visit_set_expr(&mut self, node: &'ast SetExpr<T>) {
+        if matches!(node, SetExpr::Show(_) | SetExpr::Table(_)) {
+            self.references = true;
+        }
+        visit::visit_set_expr(self, node);
+    }
+
+    fn visit_table_factor(&mut self, node: &'ast TableFactor<T>) {
+        // It's possible a table reference is referencing some constant table defined within the
+        // query, but we don't want the AST to have to figure that out yet. If that's required, the
+        // statement must be planned instead.
+        if matches!(node, TableFactor::Table { .. }) {
+            self.references = true;
+        }
+    }
+}

--- a/test/sqllogictest/updates.slt
+++ b/test/sqllogictest/updates.slt
@@ -113,3 +113,33 @@ INSERT INTO t VALUES (1) RETURNING 0;
 COMMIT;
 ----
 db error: ERROR: INSERT INTO t VALUES (1) RETURNING 0 cannot be run inside a transaction block
+
+# Regression for non-constant VALUES
+# VALUES cannot contain a query that references a table.
+simple
+ROLLBACK;
+BEGIN;
+INSERT INTO t1 VALUES((SELECT x FROM t1 LIMIT 1));
+COMMIT;
+----
+db error: ERROR: INSERT INTO t1 VALUES ((SELECT x FROM t1 LIMIT 1)) cannot be run inside a transaction block
+
+# VALUES can contain a subselect with no table references.
+simple
+ROLLBACK;
+BEGIN;
+INSERT INTO t1 VALUES((SELECT 1));
+COMMIT;
+----
+COMPLETE 0
+COMPLETE 0
+COMPLETE 1
+COMPLETE 0
+
+# Make sure we can't trick the constant checker with things like an ORDER BY.
+simple
+BEGIN;
+INSERT INTO t1 VALUES((SELECT 1 ORDER BY (SELECT x FROM t1 LIMIT 1)));
+COMMIT;
+----
+db error: ERROR: INSERT INTO t1 VALUES ((SELECT 1 ORDER BY (SELECT x FROM t1 LIMIT 1))) cannot be run inside a transaction block

--- a/test/testdrive/insert-select.td
+++ b/test/testdrive/insert-select.td
@@ -42,9 +42,7 @@ contains:column "i" is of type integer but expression is of type text
 
 > INSERT INTO t VALUES (11, 12, 'f')
 
-! INSERT INTO t SELECT * FROM (
-    VALUES (13, 14, 'g')
-  );
+! INSERT INTO t SELECT * FROM t;
 contains:cannot be run inside a transaction block
 
 > COMMIT
@@ -58,10 +56,9 @@ contains:cannot be run inside a transaction block
 
 > BEGIN
 
-! INSERT INTO t SELECT * FROM (
-    VALUES (11, 12, 'f')
+> INSERT INTO t SELECT * FROM (
+    VALUES (17, 18, 'i')
   );
-contains:cannot be run inside a transaction block
 
 > COMMIT
 
@@ -114,6 +111,7 @@ contains:invalid selection
 9 10 e
 11 12 f
 13 14 g
+17 18 i
 
 # Multiple connections
 


### PR DESCRIPTION
Previously we had assumed that VALUES never referenced relations, but subselects was an escape hatch.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Prevent `INSERT`s with table references in `VALUES` in transactions.