### PR TITLE
adapter: Fix timestamp selection of constant materialized views

### DIFF
--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -45,7 +45,8 @@ use crate::coord::timestamp_selection::TimestampProvider;
 use crate::coord::Coordinator;
 use crate::AdapterError;
 
-/// An enum describing the timeline context of a query.
+/// An enum describing whether or not a query belongs to a timeline and whether the query can be
+/// affected by the timestamp at which it executes.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub enum TimelineContext {
     /// Can only ever belong to a single specific timeline. The answer will depend on a timestamp
@@ -427,7 +428,7 @@ impl Coordinator {
         id_bundle
     }
 
-    /// Return an error if the ids are from incompatible timeline contexts. This should
+    /// Return an error if the ids are from incompatible [`TimelineContext`]s. This should
     /// be used to prevent users from doing things that are either meaningless
     /// (joining data from timelines that have similar numbers with different
     /// meanings like two separate debezium topics) or will never complete (joining
@@ -478,13 +479,13 @@ impl Coordinator {
         }
     }
 
-    /// Return the timeline context belonging to a GlobalId, if one exists.
+    /// Return the [`TimelineContext`] belonging to a GlobalId, if one exists.
     pub(crate) fn get_timeline_context(&self, id: GlobalId) -> TimelineContext {
         self.validate_timeline_context(vec![id])
             .expect("impossible for a single object to belong to incompatible timeline contexts")
     }
 
-    /// Return the timeline contexts belonging to a list of GlobalIds, if any exist.
+    /// Return the [`TimelineContext`]s belonging to a list of GlobalIds, if any exist.
     fn get_timeline_contexts<I>(&self, ids: I) -> BTreeSet<TimelineContext>
     where
         I: IntoIterator<Item = GlobalId>,
@@ -550,7 +551,8 @@ impl Coordinator {
         timelines
     }
 
-    /// Returns an iterator that partitions an id bundle by the timeline context that each id belongs to.
+    /// Returns an iterator that partitions an id bundle by the [`TimelineContext`] that each id
+    /// belongs to.
     pub fn partition_ids_by_timeline_context(
         &self,
         id_bundle: &CollectionIdBundle,

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -524,7 +524,7 @@ impl Coordinator {
                         // In some cases the timestamp selected may not affect the answer to a
                         // query, but it may affect our ability to query the materialized view.
                         // Materialized views must durably materialize the result of a query, even
-                        // for constant queries. If we choose a timestamps larger than the upper,
+                        // for constant queries. If we choose a timestamp larger than the upper,
                         // which represents the current progress of the view, then the query will
                         // need to block and wait for the materialized view to advance.
                         timelines.insert(TimelineContext::TimestampDependent);

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -955,16 +955,24 @@ SELECT * FROM const_mv
 ----
 1
 
-## We should be able to immediately query a constant MV even if the first refresh is in the future
+## We should be able to immediately query a constant MV under serializable isolation even if the
+## first refresh is in the future. The since will be advanced to [3000-01-01 23:59] and the upper
+## will be advanced to [].
 statement ok
 CREATE MATERIALIZED VIEW const_mv2
 WITH (REFRESH AT '3000-01-01 23:59')
 AS SELECT 2;
 
+statement ok
+SET transaction_isolation = 'serializable'
+
 query I
 SELECT * FROM const_mv2
 ----
 2
+
+statement ok
+SET transaction_isolation = 'strict serializable'
 
 ## MV that has refreshes only in the past
 query error db error: ERROR: all the specified refreshes of the materialized view would be too far in the past, and thus they would never happen


### PR DESCRIPTION
Previously, a materialized view with a constant query without temporal filters was considered timestamp independent, as in the adapter would be free to choose any timestamp for the query. While it's true that the timestamp selected would not affect the answer to the query, it would affect our ability to query the materialized view. Materialized views must durably materialize the results of their definition at a given timestamp before we can query this timestamp. This commit updates the timeline context logic to accurately reflect this.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes timestamp selection for constant materialized views.
