### PR TITLE
persist-txn: remove code for persist_txn_tables=off

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -601,38 +601,6 @@ impl Coordinator {
                 coord
                     .initialize_storage_read_policies(vec![table_id], CompactionWindow::Default)
                     .await;
-
-                // Advance the new table to a timestamp higher than the current
-                // read timestamp so that the table is immediately readable.
-                // Since we're applying the register ts, do this through group
-                // commit so all the other tables are immediately readable
-                // again, too.
-                //
-                // TODO: It's a little odd to use a second timestamp here, but
-                // create tables should be rare and at most one of them will
-                // actually need to communicate with CRDB since we still
-                // allocate ranges of timestamps. This whole advancement and
-                // group_commit can be removed once we've finished the migration
-                // to the persist-txn tables.
-                let initial_read_ts = coord.get_local_write_ts().await;
-                let appends = vec![(table_id, Vec::new())];
-                coord
-                    .controller
-                    .storage
-                    .append_table(
-                        initial_read_ts.timestamp,
-                        initial_read_ts.advance_to,
-                        appends,
-                    )
-                    .expect("invalid table upper initialization")
-                    .await
-                    .expect("One-shot dropped while waiting synchronously")
-                    .unwrap_or_terminate("cannot fail to append");
-                coord.apply_local_write(initial_read_ts.timestamp).await;
-
-                // Kick off a group commit so the new rest of the tables catch up to the new oracle read
-                // ts.
-                coord.trigger_group_commit();
             })
             .await;
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -95,17 +95,12 @@ pub static ALL_COLLECTIONS: &[&str] = &[
 
 #[derive(Debug)]
 enum PersistTxns<T> {
-    NeverEnabled,
     EnabledEager {
         txns_id: ShardId,
         txns_client: PersistClient,
     },
     EnabledLazy {
         txns_read: TxnsRead<T>,
-        txns_client: PersistClient,
-    },
-    DisabledPreviouslyEnabled {
-        txns_id: ShardId,
         txns_client: PersistClient,
     },
 }
@@ -117,9 +112,7 @@ impl<T: Timestamp + Lattice + Codec64> PersistTxns<T> {
                 assert_eq!(txns_id, txns_read.txns_id());
                 txns_read
             }
-            PersistTxns::NeverEnabled
-            | PersistTxns::EnabledEager { .. }
-            | PersistTxns::DisabledPreviouslyEnabled { .. } => {
+            PersistTxns::EnabledEager { .. } => {
                 panic!("set if txns are enabled and lazy")
             }
         }
@@ -451,8 +444,6 @@ where
                         // normally.
                         PersistTxns::EnabledEager { .. } => None,
                         PersistTxns::EnabledLazy { txns_read, .. } => Some(*txns_read.txns_id()),
-                        PersistTxns::NeverEnabled
-                        | PersistTxns::DisabledPreviouslyEnabled { .. } => None,
                     },
                     DataSource::Ingestion(_)
                     | DataSource::Introspection(_)
@@ -1886,11 +1877,6 @@ where
     async fn init_txns(&mut self, init_ts: T) -> Result<(), StorageError> {
         assert_eq!(self.txns_init_run, false);
         let (txns_id, txns_client) = match &self.txns {
-            PersistTxns::NeverEnabled => {
-                info!("init_txns at {:?}: disabled", init_ts);
-                self.txns_init_run = true;
-                return Ok(());
-            }
             PersistTxns::EnabledEager {
                 txns_id,
                 txns_client,
@@ -1911,13 +1897,6 @@ where
                     txns_read.txns_id()
                 );
                 (txns_read.txns_id(), txns_client)
-            }
-            PersistTxns::DisabledPreviouslyEnabled {
-                txns_id,
-                txns_client,
-            } => {
-                info!("init_txns at {:?}: disabled txns_id={}", init_ts, txns_id);
-                (txns_id, txns_client)
             }
         };
 
@@ -2091,61 +2070,39 @@ where
             .open(persist_location.clone())
             .await
             .expect("location should be valid");
-        let (persist_txn_tables, lazy_persist_txn_tables) = match persist_txn_tables {
-            PersistTxnTablesImpl::Off => (false, false),
-            PersistTxnTablesImpl::Eager => (true, false),
-            PersistTxnTablesImpl::Lazy => (true, true),
-        };
         let txns_metrics = Arc::new(TxnMetrics::new(&metrics_registry));
-        let (persist_table_worker, txns) = if persist_txn_tables {
-            let txns_id = PERSIST_TXNS_SHARD
-                .insert_key_without_overwrite(&mut stash, (), ShardId::new().into_proto())
-                .await
-                .expect("could not get txns shard id")
-                .parse::<ShardId>()
-                .expect("should be valid shard id");
-            let txns = TxnsHandle::open(
-                T::minimum(),
-                txns_client.clone(),
-                Arc::clone(&txns_metrics),
-                txns_id,
-                Arc::new(RelationDesc::empty()),
-                Arc::new(UnitSchema),
-            )
-            .await;
-            let worker = persist_handles::PersistTableWriteWorker::new_txns(
-                tx.clone(),
-                txns,
-                lazy_persist_txn_tables,
-            );
-            let txns = if lazy_persist_txn_tables {
+        let txns_id = PERSIST_TXNS_SHARD
+            .insert_key_without_overwrite(&mut stash, (), ShardId::new().into_proto())
+            .await
+            .expect("could not get txns shard id")
+            .parse::<ShardId>()
+            .expect("should be valid shard id");
+        let txns = TxnsHandle::open(
+            T::minimum(),
+            txns_client.clone(),
+            Arc::clone(&txns_metrics),
+            txns_id,
+            Arc::new(RelationDesc::empty()),
+            Arc::new(UnitSchema),
+        )
+        .await;
+        let persist_table_worker = persist_handles::PersistTableWriteWorker::new_txns(
+            tx.clone(),
+            txns,
+            persist_txn_tables,
+        );
+        let txns = match persist_txn_tables {
+            PersistTxnTablesImpl::Lazy => {
                 let txns_read = TxnsRead::start::<TxnsCodecRow>(txns_client.clone(), txns_id).await;
                 PersistTxns::EnabledLazy {
                     txns_read,
                     txns_client,
                 }
-            } else {
-                PersistTxns::EnabledEager {
-                    txns_id,
-                    txns_client,
-                }
-            };
-            (worker, txns)
-        } else {
-            let worker = persist_handles::PersistTableWriteWorker::new_legacy(tx.clone());
-            let txns_id = PERSIST_TXNS_SHARD
-                .peek_key_one(&mut stash, ())
-                .await
-                .expect("could not get txns shard id")
-                .map(|x| x.parse::<ShardId>().expect("should be valid shard id"));
-            let txns = match txns_id {
-                Some(txns_id) => PersistTxns::DisabledPreviouslyEnabled {
-                    txns_id,
-                    txns_client,
-                },
-                None => PersistTxns::NeverEnabled,
-            };
-            (worker, txns)
+            }
+            PersistTxnTablesImpl::Eager => PersistTxns::EnabledEager {
+                txns_id,
+                txns_client,
+            },
         };
         let persist_monotonic_worker =
             persist_handles::PersistMonotonicWriteWorker::new(tx.clone());

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -304,10 +304,9 @@ impl From<DataflowError> for StorageError {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
+#[derive(Clone, Copy, Debug, PartialEq, num_enum::IntoPrimitive)]
 #[repr(u64)]
 pub enum PersistTxnTablesImpl {
-    Off = 0,
     Eager = 1,
     Lazy = 2,
 }
@@ -315,7 +314,6 @@ pub enum PersistTxnTablesImpl {
 impl std::fmt::Display for PersistTxnTablesImpl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            PersistTxnTablesImpl::Off => f.write_str("off"),
             PersistTxnTablesImpl::Eager => f.write_str("eager"),
             PersistTxnTablesImpl::Lazy => f.write_str("lazy"),
         }
@@ -327,10 +325,21 @@ impl std::str::FromStr for PersistTxnTablesImpl {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "off" => Ok(PersistTxnTablesImpl::Off),
-            "eager" => Ok(PersistTxnTablesImpl::Eager),
+            "off" | "eager" => Ok(PersistTxnTablesImpl::Eager),
             "lazy" => Ok(PersistTxnTablesImpl::Lazy),
             _ => Err(s.into()),
+        }
+    }
+}
+
+impl TryFrom<u64> for PersistTxnTablesImpl {
+    type Error = u64;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 | 1 => Ok(PersistTxnTablesImpl::Eager),
+            2 => Ok(PersistTxnTablesImpl::Lazy),
+            _ => Err(value),
         }
     }
 }


### PR DESCRIPTION
Eager is now deployed to all of prod, most of it for the past week. We're pretty committed to rolling forward at this point, so go ahead and remove the legacy codepath.

Touches #22173

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
