### PR TITLE
postgres consistency: also ignore "cannot cast type bigint to boolean"

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -299,7 +299,10 @@ class PgPostExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("Not supported by pg")
 
-        if "cannot cast type boolean to bigint" in pg_error_msg:
+        if (
+            "cannot cast type boolean to bigint" in pg_error_msg
+            or "cannot cast type bigint to boolean" in pg_error_msg
+        ):
             return YesIgnore("Not supported by pg")
 
         return NoIgnore()


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/24686.

Seen in https://buildkite.com/materialize/nightlies/builds/6168#018d4332-df4b-424f-8c5d-8e60cdb74399.