### PR TITLE
Notice when creating an index that is identical to an already existing one

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4967,6 +4967,9 @@ impl Coordinator {
         for notice in notices {
             let kind = OptimizerNoticeKind::from(notice);
             let notice_enabled = match kind {
+                OptimizerNoticeKind::IndexAlreadyExists => {
+                    system_vars.enable_notices_for_index_already_exists()
+                }
                 OptimizerNoticeKind::IndexTooWideForLiteralConstraints => {
                     system_vars.enable_notices_for_index_too_wide_for_literal_constraints()
                 }

--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -150,6 +150,7 @@ impl<'a> DataflowBuilder<'a> {
         }
     }
 
+    #[allow(dead_code)] // We will need this for `EXPLAIN REPLAN <item>` statements.
     pub fn ignore_indexes(&mut self, indexes: impl Iterator<Item = GlobalId>) {
         self.ignored_indexes.extend(indexes);
     }

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -41,8 +41,7 @@ use crate::optimize::dataflows::{
     prep_relation_expr, prep_scalar_expr, ComputeInstanceSnapshot, DataflowBuilder, ExprPrepStyle,
 };
 use crate::optimize::{
-    LirDataflowDescription, MirDataflowDescription, Optimize, OptimizeMode, OptimizerConfig,
-    OptimizerError,
+    LirDataflowDescription, MirDataflowDescription, Optimize, OptimizerConfig, OptimizerError,
 };
 
 pub struct Optimizer {
@@ -148,24 +147,6 @@ impl Optimize<Index> for Optimizer {
 
         let mut df_builder = DataflowBuilder::new(state, self.compute_instance.clone());
         let mut df_desc = MirDataflowDescription::new(full_name.to_string());
-
-        // In EXPLAIN mode we should configure the dataflow builder to
-        // not consider existing indexes that are identical to the one that
-        // we are currently trying to explain.
-        if self.config.mode == OptimizeMode::Explain {
-            let ignored_indexes = state
-                .get_indexes_on(index.on, self.compute_instance.instance_id())
-                .filter_map(|(idx_id, idx)| {
-                    // Ignore `idx` if it is idential to the `index` we are
-                    // currently trying to optimize.
-                    if idx.on == index.on && idx.keys == index.keys {
-                        Some(idx_id)
-                    } else {
-                        None
-                    }
-                });
-            df_builder.ignore_indexes(ignored_indexes);
-        }
 
         df_builder.import_into_dataflow(&index.on, &mut df_desc)?;
         df_builder.reoptimize_imported_views(&mut df_desc, &self.config)?;

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1978,6 +1978,13 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
+        name: enable_notices_for_index_already_exists,
+        desc: "emitting notices for IndexAlreadyExists (doesn't affect EXPLAIN)",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
         name: enable_notices_for_index_too_wide_for_literal_constraints,
         desc: "emitting notices for IndexTooWideForLiteralConstraints (doesn't affect EXPLAIN)",
         default: false,

--- a/src/transform/src/notice/index_already_exists.rs
+++ b/src/transform/src/notice/index_already_exists.rs
@@ -1,0 +1,98 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Hosts [`IndexAlreadyExists`].
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+use mz_expr::explain::{HumanizedNotice, HumanizerMode};
+use mz_expr::MirScalarExpr;
+use mz_ore::str::separated;
+use mz_repr::explain::ExprHumanizer;
+use mz_repr::GlobalId;
+
+use crate::notice::{ActionKind, OptimizerNoticeApi};
+
+/// Trying to re-create an index that already exists.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IndexAlreadyExists {
+    /// The id of the identical index.
+    pub index_id: GlobalId,
+    /// The key of the index.
+    pub index_key: Vec<MirScalarExpr>,
+    /// The id of the object that the index is on.
+    pub index_on_id: GlobalId,
+}
+
+impl OptimizerNoticeApi for IndexAlreadyExists {
+    fn dependencies(&self) -> BTreeSet<GlobalId> {
+        BTreeSet::from([self.index_id, self.index_on_id])
+    }
+
+    fn fmt_message(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        humanizer: &dyn ExprHumanizer,
+        redacted: bool,
+    ) -> fmt::Result {
+        let index_name = humanizer
+            .humanize_id(self.index_id)
+            .unwrap_or_else(|| self.index_id.to_string());
+        let index_on_id_name = humanizer
+            .humanize_id_unqualified(self.index_on_id)
+            .unwrap_or_else(|| self.index_on_id.to_string());
+
+        let mode = HumanizedNotice::new(redacted);
+        let col_names = humanizer.column_names_for_id(self.index_on_id);
+        let col_names = col_names.as_ref();
+        let index_key = separated(", ", mode.seq(&self.index_key, col_names));
+
+        write!(
+            f,
+            "The current index is identical to {index_name}, which \
+             is also defined on {index_on_id_name}({index_key})."
+        )
+    }
+
+    fn fmt_hint(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        humanizer: &dyn ExprHumanizer,
+        redacted: bool,
+    ) -> fmt::Result {
+        let index_on_id_name = humanizer
+            .humanize_id_unqualified(self.index_on_id)
+            .unwrap_or_else(|| self.index_on_id.to_string());
+
+        let mode = HumanizedNotice::new(redacted);
+        let col_names = humanizer.column_names_for_id(self.index_on_id);
+        let col_names = col_names.as_ref();
+        let index_key = separated(", ", mode.seq(&self.index_key, col_names));
+
+        write!(
+            f,
+            "Please drop all indexes except the first index created on \
+             {index_on_id_name}({index_key}) and recreate all dependent objects."
+        )
+    }
+
+    fn fmt_action(
+        &self,
+        _f: &mut fmt::Formatter<'_>,
+        _humanizer: &dyn ExprHumanizer,
+        _redacted: bool,
+    ) -> fmt::Result {
+        Ok(())
+    }
+
+    fn action_kind(&self, _humanizer: &dyn ExprHumanizer) -> ActionKind {
+        ActionKind::None
+    }
+}

--- a/src/transform/src/notice/mod.rs
+++ b/src/transform/src/notice/mod.rs
@@ -28,9 +28,11 @@
 //!    the [`RawOptimizerNotice`] enum and other boilerplate code.
 
 // Modules (one for each notice type).
+mod index_already_exists;
 mod index_key_empty;
 mod index_too_wide_for_literal_constraints;
 
+pub use index_already_exists::IndexAlreadyExists;
 pub use index_key_empty::IndexKeyEmpty;
 pub use index_too_wide_for_literal_constraints::IndexTooWideForLiteralConstraints;
 
@@ -350,6 +352,7 @@ macro_rules! raw_optimizer_notices {
 }
 
 raw_optimizer_notices![
+    IndexAlreadyExists => "An identical index already exists",
     IndexTooWideForLiteralConstraints => "Index too wide for literal constraints",
     IndexKeyEmpty => "Empty index key",
 ];

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -491,6 +491,10 @@ materialize.public.iv_b_idx_2:
 Used Indexes:
   - materialize.public.iv_b_idx (plan root (no new arrangement), index export)
 
+Notices:
+  - Notice: The current index is identical to materialize.public.iv_b_idx, which is also defined on iv(b).
+    Hint: Please drop all indexes except the first index created on iv(b) and recreate all dependent objects.
+
 EOF
 
 # Test multiple CTEs: a case where we cannot pull the let statement up through

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -187,12 +187,6 @@ ORDER BY
 	l_returnflag,
 	l_linestatus;
 
-# Create a default index on Q01 in order to ensure that the EXPLAIN CREATE INDEX
-# output does not produce a plan that just reads from the explained index if it
-# already exists.
-statement ok
-CREATE DEFAULT INDEX ON Q01;
-
 query T multiline
 -- Explain index on Q01
 EXPLAIN WITH(humanized_exprs, arity, join_impls)
@@ -214,6 +208,12 @@ Used Indexes:
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
 
 EOF
+
+# Create a default index on Q01 in order to ensure that the EXPLAIN CREATE INDEX
+# output does not produce a plan that just reads from the explained index if it
+# already exists.
+statement ok
+CREATE DEFAULT INDEX ON Q01;
 
 
 statement ok

--- a/test/sqllogictest/transform/notice/index_already_exists.slt
+++ b/test/sqllogictest/transform/notice/index_already_exists.slt
@@ -1,0 +1,177 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_table_keys TO true
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_mz_notices TO true
+----
+COMPLETE 0
+
+# Disable rbac checks in order to select from mz_notices.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_rbac_checks TO false
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE t (
+  a int,
+  b int
+);
+
+# Create an index on t(a + 7).
+statement ok
+CREATE INDEX t_idx1 ON t(a + 7);
+
+# EXPLAIN CREATE INDEX for an identical index that emits the optimizer notice.
+query T multiline
+EXPLAIN WITH(humanized_exprs) CREATE INDEX t_idx2 ON t(a + 7);
+----
+materialize.public.t_idx2:
+  ArrangeBy keys=[[(#0{a} + 7)]]
+    ReadIndex on=t t_idx1=[plan root (no new arrangement)]
+
+Used Indexes:
+  - materialize.public.t_idx1 (plan root (no new arrangement), index export)
+
+Notices:
+  - Notice: The current index is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+    Hint: Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
+
+EOF
+
+# CREATE INDEX for an identical index that emits the optimizer notice.
+statement ok
+CREATE INDEX t_idx2 ON t(a + 7);
+
+# Verify that the notice is shown in EXPLAIN.
+query T multiline
+EXPLAIN WITH(humanized_exprs) INDEX t_idx2;
+----
+materialize.public.t_idx2:
+  ArrangeBy keys=[[(#0{a} + 7)]]
+    ReadIndex on=t t_idx1=[plan root (no new arrangement)]
+
+Used Indexes:
+  - materialize.public.t_idx1 (plan root (no new arrangement), index export)
+
+Notices:
+  - Notice: The current index is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+    Hint: Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
+
+EOF
+
+# Verify that the same notice can be found in the catalog.
+query TTTTTTTT
+SELECT
+  n.notice_type, n.message, n.redacted_message, n.hint, n.redacted_hint, n.action, n.redacted_action, n.action_type
+FROM
+  mz_internal.mz_notices n JOIN
+  mz_catalog.mz_indexes idx ON(n.object_id = idx.id)
+WHERE
+  idx.name LIKE 't_idx%'
+----
+An identical index already exists
+The current index is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+The current index is identical to materialize.public.t_idx1, which is also defined on t((a + █)).
+Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
+Please drop all indexes except the first index created on t((a + █)) and recreate all dependent objects.
+NULL
+NULL
+NULL
+
+
+# Drop the catalog item associated with the notice.
+statement ok
+DROP INDEX t_idx2;
+
+# Verify that the notice is no longer in the catalog.
+query TTTTTTTT
+SELECT
+  n.notice_type, n.message, n.redacted_message, n.hint, n.redacted_hint, n.action, n.redacted_action, n.action_type
+FROM
+  mz_internal.mz_notices n JOIN
+  mz_catalog.mz_indexes idx ON(n.object_id = idx.id)
+----
+
+
+# CREATE INDEX for an identical index that emits the optimizer notice.
+statement ok
+CREATE INDEX t_idx3 ON t(a + 7);
+
+# Verify that the notice is shown in EXPLAIN.
+query T multiline
+EXPLAIN WITH(humanized_exprs) INDEX t_idx3;
+----
+materialize.public.t_idx3:
+  ArrangeBy keys=[[(#0{a} + 7)]]
+    ReadIndex on=t t_idx1=[plan root (no new arrangement)]
+
+Used Indexes:
+  - materialize.public.t_idx1 (plan root (no new arrangement), index export)
+
+Notices:
+  - Notice: The current index is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+    Hint: Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
+
+EOF
+
+# Verify that the same notice can be found in the catalog.
+query TTTTTTTT
+SELECT
+  n.notice_type, n.message, n.redacted_message, n.hint, n.redacted_hint, n.action, n.redacted_action, n.action_type
+FROM
+  mz_internal.mz_notices n JOIN
+  mz_catalog.mz_indexes idx ON(n.object_id = idx.id)
+WHERE
+  idx.name = 't_idx3'
+----
+An identical index already exists
+The current index is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+The current index is identical to materialize.public.t_idx1, which is also defined on t((a + █)).
+Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
+Please drop all indexes except the first index created on t((a + █)) and recreate all dependent objects.
+NULL
+NULL
+NULL
+
+
+# Drop the catalog item associated with the notice.
+statement ok
+DROP INDEX t_idx1;
+
+
+# Verify that the notice is no longer shown in EXPLAIN.
+query T multiline
+EXPLAIN WITH(humanized_exprs) INDEX t_idx3;
+----
+materialize.public.t_idx3:
+  ArrangeBy keys=[[(#0{a} + 7)]]
+    ReadIndex on=t [DELETED INDEX]=[plan root (no new arrangement)]
+
+Used Indexes:
+  - [DELETED INDEX] (plan root (no new arrangement), index export)
+
+EOF
+
+
+# Verify that the notice is no longer in the catalog.
+query TTTTTTTT
+SELECT
+  n.notice_type, n.message, n.redacted_message, n.hint, n.redacted_hint, n.action, n.redacted_action, n.action_type
+FROM
+  mz_internal.mz_notices n JOIN
+  mz_catalog.mz_indexes idx ON(n.object_id = idx.id)
+WHERE
+  idx.name = 't_idx3'
+----


### PR DESCRIPTION
Fixes #23299.

### Motivation

  * This PR adds a known-desirable feature.


### Tips for reviewer

* The first commit removes some code that currently causes `EXPLAIN CREATE INDEX` to produce unfaithful plans.
* The second commit adds the new notice type. There is nothing unexpected there, so this should be easy to review.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
