### PR TITLE
tests: Adapt tests to auto routing of introspection queries

### DIFF
--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -65,6 +65,7 @@ class Worker:
         cur = self.conn.cursor()
         self.exe = Executor(self.rng, cur, database)
         self.exe.set_isolation("SERIALIZABLE")
+        cur.execute("SET auto_route_introspection_queries TO false")
         cur.execute("SELECT pg_backend_pid()")
         self.exe.pg_pid = cur.fetchall()[0][0]
 

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -123,6 +123,8 @@ true
 
         return Td(
             f"""
+> SET auto_route_introspection_queries TO false
+
 > BEGIN
 
 > SELECT 1;
@@ -238,6 +240,8 @@ class InsertBatch(DML):
 
 > CREATE TABLE t1 (f1 INTEGER)
   /* A */
+
+> SET auto_route_introspection_queries TO false
 
 > BEGIN
 
@@ -1433,6 +1437,8 @@ class QueryLatency(Coordinator):
 
         return Td(
             f"""
+> SET auto_route_introspection_queries TO false
+
 > BEGIN
 
 > SELECT 1;
@@ -1464,6 +1470,8 @@ SELECT 1;
 
         return Td(
             f"""
+> SET auto_route_introspection_queries TO false
+
 > BEGIN
 
 > SELECT 1;


### PR DESCRIPTION
See https://github.com/MaterializeInc/materialize/issues/24718

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
