### PR TITLE
Correct PointStamp `step_back`

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -983,7 +983,7 @@ impl RenderTimestamp for mz_repr::Timestamp {
     }
 }
 
-impl<T: Timestamp + Lattice + Columnation> RenderTimestamp for Product<mz_repr::Timestamp, T> {
+impl RenderTimestamp for Product<mz_repr::Timestamp, PointStamp<u64>> {
     fn system_time(&mut self) -> &mut mz_repr::Timestamp {
         &mut self.outer
     }
@@ -997,7 +997,17 @@ impl<T: Timestamp + Lattice + Columnation> RenderTimestamp for Product<mz_repr::
         Product::new(delay, Default::default())
     }
     fn step_back(&self) -> Self {
-        Product::new(self.outer.saturating_sub(1), self.inner.clone())
+        // It is necessary to step back both coordinates of a product, 
+        // and when one is a `PointStamp` that also means all coordinates
+        // of the pointstamp.
+        let mut inner = self.inner.clone();
+        for item in inner.vector.iter_mut() {
+            *item = item.saturating_sub(1);
+        }
+        while inner.vector.last() == Some(&0) {
+            inner.vector.pop();
+        }
+        Product::new(self.outer.saturating_sub(1), inner)
     }
 }
 

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -997,7 +997,7 @@ impl RenderTimestamp for Product<mz_repr::Timestamp, PointStamp<u64>> {
         Product::new(delay, Default::default())
     }
     fn step_back(&self) -> Self {
-        // It is necessary to step back both coordinates of a product, 
+        // It is necessary to step back both coordinates of a product,
         // and when one is a `PointStamp` that also means all coordinates
         // of the pointstamp.
         let mut inner = self.inner.clone();


### PR DESCRIPTION
The implementation of `RenderTimestamp::step_back` was incorrect for `Product`, only stepping back the first coordinate. In fact, one needs to step back all coordinates (as in the dogs3 example) if one wants to avoid compaction correctness issues. 

This PR fixes the stepping back by subtracting (with saturation) one from each pointstamp coordinate as well.

cc: @mgree @nrainer-materialize 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
