### PR TITLE
sql: functions to build maps

### DIFF
--- a/doc/user/content/sql/functions/map_agg.md
+++ b/doc/user/content/sql/functions/map_agg.md
@@ -1,0 +1,97 @@
+---
+title: "map_agg function"
+description: "Aggregate keys and values (excluding null keys) into a map"
+menu:
+    main:
+        parent: "sql-functions"
+---
+
+The `map_agg(keys, values)` aggregate function zips together `keys`
+and `values` into a [`map`](/sql/types/map).
+
+The input values to the aggregate can be [filtered](../filters).
+
+## Syntax
+
+{{< diagram "func-map-agg.svg" >}}
+
+## Signatures
+
+| Parameter | Type                       | Description              |
+| --------- | -------------------------- | ------------------------ |
+| _keys_    | [`text`](/sql/types/text/) | The keys to aggregate.   |
+| _values_  | any                        | The values to aggregate. |
+
+### Return value
+
+`map_agg` returns the aggregated key–value pairs as a map.
+
+-   Each row in the input corresponds to one key–value pair in the output,
+    unless the `key` is null, in which case the pair is ignored. (`map` keys
+    must be non-`NULL` strings.)
+-   If multiple rows have the same key, we retain only the value sorted in the
+    greatest/last position. You can determine this order using `ORDER BY` within
+    the aggregate function itself; otherwise, incoming rows are not guaranteed
+    to be handled in any order.
+
+### Usage in dataflows
+
+While `map_agg` is available in Materialize, materializing
+`map_agg(expression)` is considered an incremental view maintenance
+anti-pattern. Any change to the data underlying the function call will require
+the function to be recomputed entirely, discarding the benefits of maintaining
+incremental updates.
+
+Instead, we recommend that you materialize all components required for the
+`map_agg` function call and create a non-materialized view using
+`map_agg` on top of that. That pattern is illustrated in the following
+statements:
+
+```sql
+CREATE MATERIALIZED VIEW foo_view AS SELECT key_col, val_col FROM foo;
+CREATE VIEW bar AS SELECT map_agg(key_col, val_col) FROM foo_view;
+```
+
+## Examples
+
+Consider this query:
+
+```sql
+SELECT
+  map_agg(
+    t.k,
+    t.v
+    ORDER BY t.ts ASC, t.v DESC
+  ) FILTER (WHERE t.v != -8) AS my_agg
+FROM (
+  VALUES
+    -- k1
+    ('k1', 3, now()),
+    ('k1', 2, now() + INTERVAL '1s'),
+    ('k1', 1, now() + INTERVAL '1s'),
+    -- k2
+    ('k2', -9, now() - INTERVAL '1s'),
+    ('k2', -8, now()),
+    ('k2', NULL, now() + INTERVAL '1s'),
+    -- null
+    (NULL, 99, now()),
+    (NULL, 100, now())
+  ) AS t(k, v, ts);
+```
+
+```nofmt
+      my_agg
+------------------
+ {k1=>1,k2=>-9}
+```
+
+In this example:
+
+-   We order values by their timestamp (`t.ts ASC`) and then break ties using the
+    smallest values (`t.v DESC`).
+-   We filter out any values equal to exactly `-8`.
+-   All keys with a `NULL` value get excluded automatically.
+-   `k1` has two values tied with the same `t.ts` value; because we've also
+    ordered `t.v DESC`, the last value we see will be `1`.
+-   `k2` has its value for `-8` filtered out `FILTER (WHERE t.v != -8)`;
+    however, this `FILTER` also removes the `NULL` value at `now() + INTERVAL '1s'` because `WHERE null != -8` evaluates to `false`.

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -120,6 +120,13 @@
   functions:
     - signature: 'map_length(m: mapany) -> int'
       description: Return the number of elements in `m`.
+    - signature: 'map_build(kvs: list record(text, T)) -> map[text=>T]'
+      description: >-
+        Builds a map from a list of records whose fields are two elements, the
+        first of which is `text`. This function's current implementation is
+        purpose-built to process [Kafka headers](/sql/create-source/kafka/#headers).
+    - signature: 'map_agg(keys: text, values: T) -> map[text=>T]'
+      description: Aggregate keys and values (including nulls) as a map. ([docs](/sql/functions/map_agg))
 
 - type: Numbers
   description: Number functions take number-like arguments, e.g. [`int`](../types/int),

--- a/doc/user/layouts/partials/sql-grammar/func-map-agg.svg
+++ b/doc/user/layouts/partials/sql-grammar/func-map-agg.svg
@@ -1,0 +1,140 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="627" height="337">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="82" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">map_agg</text>
+   <rect x="133" y="3" width="26" height="32" rx="10"/>
+   <rect x="131"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="141" y="21">(</text>
+   <rect x="179" y="3" width="50" height="32"/>
+   <rect x="177" y="1" width="50" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="187" y="21">keys</text>
+   <rect x="249" y="3" width="24" height="32" rx="10"/>
+   <rect x="247"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="21">,</text>
+   <rect x="293" y="3" width="62" height="32"/>
+   <rect x="291" y="1" width="62" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="301" y="21">values</text>
+   <rect x="45" y="113" width="68" height="32" rx="10"/>
+   <rect x="43"
+         y="111"
+         width="68"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="131">ORDER</text>
+   <rect x="133" y="113" width="40" height="32" rx="10"/>
+   <rect x="131"
+         y="111"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="141" y="131">BY</text>
+   <rect x="213" y="113" width="64" height="32"/>
+   <rect x="211" y="111" width="64" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="221" y="131">col_ref</text>
+   <rect x="317" y="145" width="50" height="32" rx="10"/>
+   <rect x="315"
+         y="143"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="325" y="163">ASC</text>
+   <rect x="317" y="189" width="58" height="32" rx="10"/>
+   <rect x="315"
+         y="187"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="325" y="207">DESC</text>
+   <rect x="435" y="145" width="106" height="32" rx="10"/>
+   <rect x="433"
+         y="143"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="443" y="163">NULLS LAST</text>
+   <rect x="435" y="189" width="110" height="32" rx="10"/>
+   <rect x="433"
+         y="187"
+         width="110"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="443" y="207">NULLS FIRST</text>
+   <rect x="213" y="69" width="24" height="32" rx="10"/>
+   <rect x="211"
+         y="67"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="221" y="87">,</text>
+   <rect x="147" y="271" width="26" height="32" rx="10"/>
+   <rect x="145"
+         y="269"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="155" y="289">)</text>
+   <rect x="213" y="303" width="66" height="32" rx="10"/>
+   <rect x="211"
+         y="301"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="221" y="321">FILTER</text>
+   <rect x="299" y="303" width="26" height="32" rx="10"/>
+   <rect x="297"
+         y="301"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="307" y="321">(</text>
+   <rect x="345" y="303" width="70" height="32" rx="10"/>
+   <rect x="343"
+         y="301"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="353" y="321">WHERE</text>
+   <rect x="435" y="303" width="98" height="32"/>
+   <rect x="433" y="301" width="98" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="443" y="321">filter_clause</text>
+   <rect x="553" y="303" width="26" height="32" rx="10"/>
+   <rect x="551"
+         y="301"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="561" y="321">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m62 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-374 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m68 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m64 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m50 0 h10 m0 0 h8 m-88 -10 v20 m98 0 v-20 m-98 20 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m40 -76 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m106 0 h10 m0 0 h4 m-140 -10 v20 m150 0 v-20 m-150 20 v24 m150 0 v-24 m-150 24 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m-372 -76 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m372 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-372 0 h10 m24 0 h10 m0 0 h328 m-560 44 h20 m560 0 h20 m-600 0 q10 0 10 10 m580 0 q0 -10 10 -10 m-590 10 v90 m580 0 v-90 m-580 90 q0 10 10 10 m560 0 q10 0 10 -10 m-570 10 h10 m0 0 h550 m22 -110 l2 0 m2 0 l2 0 m2 0 l2 0 m-502 158 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m26 0 h10 m20 0 h10 m0 0 h376 m-406 0 h20 m386 0 h20 m-426 0 q10 0 10 10 m406 0 q0 -10 10 -10 m-416 10 v12 m406 0 v-12 m-406 12 q0 10 10 10 m386 0 q10 0 10 -10 m-396 10 h10 m66 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m70 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m26 0 h10 m23 -32 h-3"/>
+   <polygon points="617 285 625 281 625 289"/>
+   <polygon points="617 285 609 281 609 289"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -347,6 +347,8 @@ func_date_part ::=
   'date_part' '(' "'" ( 'epoch' | 'millennium' | 'century' | 'decade' | 'year' | 'quarter' | 'month' | 'week' | 'dat' | 'hour' | 'minute' | 'second' | 'microsecond' | 'millisecond' | 'dow' | 'isodow' | 'doy' ) "'" ',' val ')'
 func_length ::=
   'length' '(' str (',' encoding_name)? ')'
+func_map_agg ::=
+  'map_agg' '(' keys ',' values ( 'ORDER' 'BY' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? ( ',' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? )* )? ')' ('FILTER' '(' 'WHERE' filter_clause ')')?
 func_substring ::=
   'substring' '(' str ',' start_pos (',' len)? ')'
 func_timezone ::=

--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -985,6 +985,7 @@ pub fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::MinTimestampTz => ReductionType::Hierarchical,
         AggregateFunc::JsonbAgg { .. }
         | AggregateFunc::JsonbObjectAgg { .. }
+        | AggregateFunc::MapAgg { .. }
         | AggregateFunc::ArrayConcat { .. }
         | AggregateFunc::ListConcat { .. }
         | AggregateFunc::StringAgg { .. }

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -2435,6 +2435,7 @@ mod monoids {
             | AggregateFunc::Dummy
             | AggregateFunc::JsonbAgg { .. }
             | AggregateFunc::JsonbObjectAgg { .. }
+            | AggregateFunc::MapAgg { .. }
             | AggregateFunc::ArrayConcat { .. }
             | AggregateFunc::ListConcat { .. }
             | AggregateFunc::StringAgg { .. }

--- a/src/expr/src/relation.proto
+++ b/src/expr/src/relation.proto
@@ -84,6 +84,11 @@ message ProtoAggregateFunc {
         mz_expr.relation.ProtoWindowFrame window_frame = 3;
     }
 
+    message ProtoMapAgg {
+        ProtoColumnOrders order_by = 1;
+        mz_repr.relation_and_scalar.ProtoScalarType value_type = 2;
+    }
+
     oneof kind {
         google.protobuf.Empty max_numeric = 1;
         google.protobuf.Empty max_int16 = 2;
@@ -142,6 +147,7 @@ message ProtoAggregateFunc {
         google.protobuf.Empty sum_uint64 = 51;
         google.protobuf.Empty max_mz_timestamp = 52;
         google.protobuf.Empty min_mz_timestamp = 53;
+        ProtoMapAgg map_agg = 56;
     }
 }
 

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -237,11 +237,7 @@ where
     })
 }
 
-fn jsonb_object_agg<'a, I>(
-    datums: I,
-    temp_storage: &'a RowArena,
-    order_by: &[ColumnOrder],
-) -> Datum<'a>
+fn dict_agg<'a, I>(datums: I, temp_storage: &'a RowArena, order_by: &[ColumnOrder]) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -1276,6 +1272,13 @@ pub enum AggregateFunc {
     JsonbObjectAgg {
         order_by: Vec<ColumnOrder>,
     },
+    /// Zips a `Datum::List` whose first element is a `Datum::List` guaranteed
+    /// to be non-empty and whose len % 2 == 0 into a `Datum::Map`. The other
+    /// elements are columns used by `order_by`.
+    MapAgg {
+        order_by: Vec<ColumnOrder>,
+        value_type: ScalarType,
+    },
     /// Accumulates `Datum::Array`s of `ScalarType::Record` whose first element is a `Datum::Array`
     /// into a single `Datum::Array` (the remaining fields are used by `order_by`).
     ArrayConcat {
@@ -1387,6 +1390,15 @@ impl Arbitrary for AggregateFunc {
                 .boxed(),
             vec(proptest_any::<ColumnOrder>(), 1..4)
                 .prop_map(|order_by| AggregateFunc::JsonbObjectAgg { order_by })
+                .boxed(),
+            (
+                vec(proptest_any::<ColumnOrder>(), 1..4),
+                proptest_any::<ScalarType>(),
+            )
+                .prop_map(|(order_by, value_type)| AggregateFunc::MapAgg {
+                    order_by,
+                    value_type,
+                })
                 .boxed(),
             vec(proptest_any::<ColumnOrder>(), 1..4)
                 .prop_map(|order_by| AggregateFunc::ArrayConcat { order_by })
@@ -1504,6 +1516,13 @@ impl RustType<ProtoAggregateFunc> for AggregateFunc {
                 AggregateFunc::JsonbObjectAgg { order_by } => {
                     Kind::JsonbObjectAgg(order_by.into_proto())
                 }
+                AggregateFunc::MapAgg {
+                    order_by,
+                    value_type,
+                } => Kind::MapAgg(proto_aggregate_func::ProtoMapAgg {
+                    order_by: Some(order_by.into_proto()),
+                    value_type: Some(value_type.into_proto()),
+                }),
                 AggregateFunc::ArrayConcat { order_by } => Kind::ArrayConcat(order_by.into_proto()),
                 AggregateFunc::ListConcat { order_by } => Kind::ListConcat(order_by.into_proto()),
                 AggregateFunc::StringAgg { order_by } => Kind::StringAgg(order_by.into_proto()),
@@ -1607,6 +1626,12 @@ impl RustType<ProtoAggregateFunc> for AggregateFunc {
             },
             Kind::JsonbObjectAgg(order_by) => AggregateFunc::JsonbObjectAgg {
                 order_by: order_by.into_rust()?,
+            },
+            Kind::MapAgg(pma) => AggregateFunc::MapAgg {
+                order_by: pma.order_by.into_rust_if_some("ProtoMapAgg::order_by")?,
+                value_type: pma
+                    .value_type
+                    .into_rust_if_some("ProtoMapAgg::value_type")?,
             },
             Kind::ArrayConcat(order_by) => AggregateFunc::ArrayConcat {
                 order_by: order_by.into_rust()?,
@@ -1738,8 +1763,8 @@ impl AggregateFunc {
             AggregateFunc::Any => any(datums),
             AggregateFunc::All => all(datums),
             AggregateFunc::JsonbAgg { order_by } => jsonb_agg(datums, temp_storage, order_by),
-            AggregateFunc::JsonbObjectAgg { order_by } => {
-                jsonb_object_agg(datums, temp_storage, order_by)
+            AggregateFunc::MapAgg { order_by, .. } | AggregateFunc::JsonbObjectAgg { order_by } => {
+                dict_agg(datums, temp_storage, order_by)
             }
             AggregateFunc::ArrayConcat { order_by } => array_concat(datums, temp_storage, order_by),
             AggregateFunc::ListConcat { order_by } => list_concat(datums, temp_storage, order_by),
@@ -1852,6 +1877,10 @@ impl AggregateFunc {
             AggregateFunc::SumUInt32 => ScalarType::UInt64,
             AggregateFunc::SumUInt64 => ScalarType::Numeric {
                 max_scale: Some(NumericMaxScale::ZERO),
+            },
+            AggregateFunc::MapAgg { value_type, .. } => ScalarType::Map {
+                value_type: Box::new(value_type.clone()),
+                custom_id: None,
             },
             AggregateFunc::ArrayConcat { .. } | AggregateFunc::ListConcat { .. } => {
                 match input_type.scalar_type {
@@ -2308,6 +2337,10 @@ where
                     "jsonb_object_agg[order_by=[{}]]",
                     separated(", ", order_by)
                 )
+            }
+            AggregateFunc::MapAgg { order_by, .. } => {
+                let order_by = order_by.iter().map(|col| self.child(col));
+                write!(f, "map_agg[order_by=[{}]]", separated(", ", order_by))
             }
             AggregateFunc::ArrayConcat { order_by } => {
                 let order_by = order_by.iter().map(|col| self.child(col));

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2742,7 +2742,9 @@ impl AggregateExpr {
             | AggregateFunc::SumNumeric
             | AggregateFunc::Any
             | AggregateFunc::All
-            | AggregateFunc::Dummy => self.expr.clone(),
+            | AggregateFunc::Dummy
+            // TODO: this could be rewritten if we had `MAP[foo=>bar]`.
+            | AggregateFunc::MapAgg { .. } => self.expr.clone(),
         }
     }
 

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -128,7 +128,7 @@ message ProtoUnaryFunc {
         repeated ProtoMirScalarExpr cast_exprs = 2;
     }
     reserved 5, 6, 15, 104, 111, 115, 212, 306, 313;
-    // next field number 317
+    // next field number 318
     oneof kind {
         google.protobuf.Empty not = 1;
         google.protobuf.Empty is_null = 2;
@@ -438,6 +438,7 @@ message ProtoUnaryFunc {
         google.protobuf.Empty acl_item_grantee = 303;
         google.protobuf.Empty acl_item_privileges = 304;
         mz_repr.adt.regex.ProtoRegex regexp_split_to_array = 305;
+        mz_repr.relation_and_scalar.ProtoScalarType map_build_from_record_list = 317;
     }
 }
 

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -686,6 +686,7 @@ message ProtoVariadicFunc {
         google.protobuf.Empty make_acl_item = 38;
         google.protobuf.Empty regexp_split_to_array = 39;
         google.protobuf.Empty regexp_replace = 40;
+        mz_repr.relation_and_scalar.ProtoScalarType map_build = 41;
     }
 }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4669,6 +4669,7 @@ derive_unary!(
     RecordGet,
     ListLength,
     MapLength,
+    MapBuildFromRecordList,
     Upper,
     Lower,
     Cos,
@@ -5074,6 +5075,11 @@ impl Arbitrary for UnaryFunc {
             TrimTrailingWhitespace::arbitrary().prop_map_into().boxed(),
             RecordGet::arbitrary().prop_map_into().boxed(),
             ListLength::arbitrary().prop_map_into().boxed(),
+            (any::<ScalarType>())
+                .prop_map(|value_type| {
+                    UnaryFunc::MapBuildFromRecordList(MapBuildFromRecordList { value_type })
+                })
+                .boxed(),
             MapLength::arbitrary().prop_map_into().boxed(),
             Upper::arbitrary().prop_map_into().boxed(),
             Lower::arbitrary().prop_map_into().boxed(),
@@ -5449,6 +5455,9 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
             UnaryFunc::TrimTrailingWhitespace(_) => TrimTrailingWhitespace(()),
             UnaryFunc::RecordGet(func) => RecordGet(func.0.into_proto()),
             UnaryFunc::ListLength(_) => ListLength(()),
+            UnaryFunc::MapBuildFromRecordList(inner) => {
+                MapBuildFromRecordList(inner.value_type.into_proto())
+            }
             UnaryFunc::MapLength(_) => MapLength(()),
             UnaryFunc::Upper(_) => Upper(()),
             UnaryFunc::Lower(_) => Lower(()),
@@ -5906,6 +5915,10 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                 TrimTrailingWhitespace(()) => Ok(impls::TrimTrailingWhitespace.into()),
                 RecordGet(field) => Ok(impls::RecordGet(field.into_rust()?).into()),
                 ListLength(()) => Ok(impls::ListLength.into()),
+                MapBuildFromRecordList(value_type) => Ok(impls::MapBuildFromRecordList {
+                    value_type: value_type.into_rust()?,
+                }
+                .into()),
                 MapLength(()) => Ok(impls::MapLength.into()),
                 Upper(()) => Ok(impls::Upper.into()),
                 Lower(()) => Ok(impls::Lower.into()),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -6443,6 +6443,23 @@ fn jsonb_build_object<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> D
     }
 }
 
+fn map_build<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a> {
+    // Collect into a `BTreeMap` to provide the same semantics as it.
+    let map: std::collections::BTreeMap<&str, _> = datums
+        .into_iter()
+        .tuples()
+        .filter_map(|(k, v)| {
+            if k.is_null() {
+                None
+            } else {
+                Some((k.unwrap_str(), v))
+            }
+        })
+        .collect();
+
+    temp_storage.make_datum(|packer| packer.push_dict(map.into_iter()))
+}
+
 /// Constructs a new multidimensional array out of an arbitrary number of
 /// lower-dimensional arrays.
 ///
@@ -7430,6 +7447,9 @@ pub enum VariadicFunc {
     Replace,
     JsonbBuildArray,
     JsonbBuildObject,
+    MapBuild {
+        value_type: ScalarType,
+    },
     ArrayCreate {
         // We need to know the element type to type empty arrays.
         elem_type: ScalarType,
@@ -7524,6 +7544,7 @@ impl VariadicFunc {
             VariadicFunc::Translate => Ok(translate(&ds, temp_storage)),
             VariadicFunc::JsonbBuildArray => Ok(jsonb_build_array(&ds, temp_storage)),
             VariadicFunc::JsonbBuildObject => Ok(jsonb_build_object(&ds, temp_storage)),
+            VariadicFunc::MapBuild { .. } => Ok(map_build(&ds, temp_storage)),
             VariadicFunc::ArrayCreate {
                 elem_type: ScalarType::Array(_),
             } => array_create_multidim(&ds, temp_storage),
@@ -7606,6 +7627,7 @@ impl VariadicFunc {
             | VariadicFunc::Translate
             | VariadicFunc::JsonbBuildArray
             | VariadicFunc::JsonbBuildObject
+            | VariadicFunc::MapBuild { value_type: _ }
             | VariadicFunc::ArrayCreate { elem_type: _ }
             | VariadicFunc::ArrayToString { elem_type: _ }
             | VariadicFunc::ArrayIndex { offset: _ }
@@ -7661,6 +7683,11 @@ impl VariadicFunc {
             Replace => ScalarType::String.nullable(in_nullable),
             Translate => ScalarType::String.nullable(in_nullable),
             JsonbBuildArray | JsonbBuildObject => ScalarType::Jsonb.nullable(true),
+            MapBuild { value_type } => ScalarType::Map {
+                value_type: Box::new(value_type.clone()),
+                custom_id: None,
+            }
+            .nullable(true),
             ArrayCreate { elem_type } => {
                 debug_assert!(
                     input_types.iter().all(|t| t.scalar_type.base_eq(elem_type)),
@@ -7749,6 +7776,7 @@ impl VariadicFunc {
                 | VariadicFunc::ConcatWs
                 | VariadicFunc::JsonbBuildArray
                 | VariadicFunc::JsonbBuildObject
+                | VariadicFunc::MapBuild { .. }
                 | VariadicFunc::ListCreate { .. }
                 | VariadicFunc::RecordCreate { .. }
                 | VariadicFunc::ArrayCreate { .. }
@@ -7776,6 +7804,7 @@ impl VariadicFunc {
             | Translate
             | JsonbBuildArray
             | JsonbBuildObject
+            | MapBuild { .. }
             | ArrayCreate { .. }
             | ArrayToString { .. }
             | ListCreate { .. }
@@ -7879,6 +7908,7 @@ impl VariadicFunc {
             | VariadicFunc::Replace
             | VariadicFunc::JsonbBuildArray
             | VariadicFunc::JsonbBuildObject
+            | VariadicFunc::MapBuild { .. }
             | VariadicFunc::ArrayCreate { .. }
             | VariadicFunc::ArrayToString { .. }
             | VariadicFunc::ArrayIndex { .. }
@@ -7925,6 +7955,7 @@ impl fmt::Display for VariadicFunc {
             VariadicFunc::Translate => f.write_str("translate"),
             VariadicFunc::JsonbBuildArray => f.write_str("jsonb_build_array"),
             VariadicFunc::JsonbBuildObject => f.write_str("jsonb_build_object"),
+            VariadicFunc::MapBuild { .. } => f.write_str("map_build"),
             VariadicFunc::ArrayCreate { .. } => f.write_str("array_create"),
             VariadicFunc::ArrayToString { .. } => f.write_str("array_to_string"),
             VariadicFunc::ArrayIndex { .. } => f.write_str("array_index"),
@@ -7990,6 +8021,9 @@ impl Arbitrary for VariadicFunc {
             Just(VariadicFunc::Replace).boxed(),
             Just(VariadicFunc::JsonbBuildArray).boxed(),
             Just(VariadicFunc::JsonbBuildObject).boxed(),
+            ScalarType::arbitrary()
+                .prop_map(|value_type| VariadicFunc::MapBuild { value_type })
+                .boxed(),
             Just(VariadicFunc::MakeAclItem).boxed(),
             Just(VariadicFunc::MakeMzAclItem).boxed(),
             ScalarType::arbitrary()
@@ -8050,6 +8084,7 @@ impl RustType<ProtoVariadicFunc> for VariadicFunc {
             VariadicFunc::Translate => Translate(()),
             VariadicFunc::JsonbBuildArray => JsonbBuildArray(()),
             VariadicFunc::JsonbBuildObject => JsonbBuildObject(()),
+            VariadicFunc::MapBuild { value_type } => MapBuild(value_type.into_proto()),
             VariadicFunc::ArrayCreate { elem_type } => ArrayCreate(elem_type.into_proto()),
             VariadicFunc::ArrayToString { elem_type } => ArrayToString(elem_type.into_proto()),
             VariadicFunc::ArrayIndex { offset } => ArrayIndex(offset.into_proto()),
@@ -8101,6 +8136,9 @@ impl RustType<ProtoVariadicFunc> for VariadicFunc {
                 Translate(()) => Ok(VariadicFunc::Translate),
                 JsonbBuildArray(()) => Ok(VariadicFunc::JsonbBuildArray),
                 JsonbBuildObject(()) => Ok(VariadicFunc::JsonbBuildObject),
+                MapBuild(value_type) => Ok(VariadicFunc::MapBuild {
+                    value_type: value_type.into_rust()?,
+                }),
                 ArrayCreate(elem_type) => Ok(VariadicFunc::ArrayCreate {
                     elem_type: elem_type.into_rust()?,
                 }),

--- a/src/pgrepr-consts/src/oid.rs
+++ b/src/pgrepr-consts/src/oid.rs
@@ -371,3 +371,4 @@ pub const FUNC_PRETTY_SQL_NOWIDTH: u32 = 16_648;
 pub const FUNC_MZ_NAME_RANK: u32 = 16_649;
 pub const FUNC_CONNECTION_OID_OID: u32 = 16_650;
 pub const FUNC_SECRET_OID_OID: u32 = 16_651;
+pub const FUNC_MAP_BUILD: u32 = 16_652;

--- a/src/pgrepr-consts/src/oid.rs
+++ b/src/pgrepr-consts/src/oid.rs
@@ -372,3 +372,4 @@ pub const FUNC_MZ_NAME_RANK: u32 = 16_649;
 pub const FUNC_CONNECTION_OID_OID: u32 = 16_650;
 pub const FUNC_SECRET_OID_OID: u32 = 16_651;
 pub const FUNC_MAP_BUILD: u32 = 16_652;
+pub const FUNC_MAP_AGG: u32 = 16_653;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3665,6 +3665,16 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
             }) => MapAny, oid::FUNC_MAP_AGG;
         },
         "map_build" => Scalar {
+            // TODO: support a function to construct maps that looks like...
+            //
+            // params!([String], Any...) => Operation::variadic(|ecx, exprs| {
+            //
+            // ...the challenge here is that we don't support constructing other
+            // complex types from varidaic functions and instead use a SQL
+            // keyword; however that doesn't work very well for map because the
+            // intuitive syntax would be something akin to `MAP[key=>value]`,
+            // but that doesn't work out of the box because `key=>value` looks
+            // like an expression.
             params!(ListAny) => Operation::unary(|ecx, expr| {
                 let ty = ecx.scalar_type(&expr);
 

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -156,7 +156,7 @@ impl<C: ConnectionAccess> SourceConnection for KafkaSourceConnection<C> {
                                 (
                                     "value".into(),
                                     ColumnType {
-                                        nullable: false,
+                                        nullable: true,
                                         scalar_type: ScalarType::Bytes,
                                     },
                                 ),

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -694,5 +694,97 @@ CREATE TYPE missing_value AS (f1 TEXT);
 query error db error: ERROR: function map_build\(missing_value list\) does not exist
 SELECT map_build(LIST[ROW('a'), ROW('a')]::missing_value list)::TEXT;
 
-query error function map_build(integer) does not exist
-SELECT map_build(1);
+query error db error: ERROR: function map_build\(integer\) does not exist
+SELECT map_build(1)::TEXT;
+
+query error db error: ERROR: function map_build\(integer list\) does not exist
+SELECT map_build(LIST[1])::TEXT;
+
+# map_agg
+
+statement ok
+CREATE TABLE t1 (a int)
+
+statement ok
+INSERT INTO t1 VALUES (1), (2), (3), (NULL)
+
+query error db error: ERROR: function map_agg\(integer, integer\) does not exist
+SELECT map_agg(k, v)::TEXT FROM (SELECT 1 AS k, 2 AS V WHERE false)
+
+query T
+SELECT map_agg(k, v)::TEXT FROM (SELECT 1::TEXT AS k, 2 AS V WHERE false)
+----
+NULL
+
+query T
+SELECT map_agg('one', 2)::TEXT
+----
+{one=>2}
+
+query error db error: ERROR: function map_agg\(integer, integer\) does not exist
+SELECT map_agg(1, 2)
+
+query T
+SELECT map_agg(k, v)::TEXT FROM (SELECT (a - 1)::TEXT AS k, a AS v FROM t1 WHERE a IS NOT NULL)
+----
+{0=>1,1=>2,2=>3}
+
+query T
+SELECT map_agg(column1, column2)::TEXT FROM (VALUES ('a', null), ('b', 1))
+----
+{a=>NULL,b=>1}
+
+query T
+SELECT map_agg(column1, column2)::TEXT FROM (VALUES ('b', 2), ('a', 1))
+----
+{a=>1,b=>2}
+
+query T
+SELECT map_agg(column1, column2)::TEXT FROM (VALUES ('a', 1), ('a', 2))
+----
+{a=>2}
+
+query T
+SELECT map_agg(column1, column2)::TEXT FROM (VALUES ('a', 2), ('a', 1))
+----
+{a=>2}
+
+query T
+SELECT map_agg(a, b ORDER BY b DESC)::TEXT FROM (VALUES ('a', 2), ('a', 1)) AS t (a, b);
+----
+{a=>1}
+
+query T
+SELECT map_agg(a, b ORDER BY b ASC)::TEXT FROM (VALUES ('a', 2), ('a', 1)) AS t (a, b);
+----
+{a=>2}
+
+query T
+SELECT map_agg(null, null)::TEXT
+----
+{}
+
+query T
+SELECT map_agg(null, null)::TEXT
+----
+{}
+
+query T
+SELECT map_agg(null, 1)::TEXT
+----
+{}
+
+query T
+SELECT (map_agg(a::TEXT, a) FILTER (WHERE a IS NOT NULL))::TEXT FROM t1
+----
+{1=>1,2=>2,3=>3}
+
+query T
+SELECT map_agg(a::TEXT, a)::TEXT FROM t1
+----
+{1=>1,2=>2,3=>3}
+
+query T
+SELECT (map_agg(a::TEXT, a) FILTER (WHERE a = 1))::TEXT FROM t1
+----
+{1=>1}

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -611,3 +611,88 @@ query T
 SELECT map_length(NULL::map[text=>int])
 ----
 NULL
+
+# map_build
+
+statement ok
+CREATE TYPE r AS (f1 TEXT, f2 INT);
+
+query T
+SELECT map_build(LIST[ROW('a', 1), ROW('b', 2)]::r list)::TEXT;
+----
+{a=>1,b=>2}
+
+query T
+SELECT map_build(LIST[ROW('a', 1), ROW('a', 2)]::r list)::TEXT;
+----
+{a=>2}
+
+query T
+SELECT map_build(LIST[ROW('a', 2), ROW('a', 1)]::r list)::TEXT;
+----
+{a=>1}
+
+# skip null keys
+query T
+SELECT map_build(LIST[ROW('a', 1), ROW(NULL, 2)]::r list)::TEXT;
+----
+{a=>1}
+
+query T
+SELECT map_build(LIST[NULL]::r list)::TEXT;
+----
+{}
+
+query T
+SELECT map_build(LIST[ROW('a', 1), NULL]::r list)::TEXT;
+----
+{a=>1}
+
+query T
+SELECT map_build(LIST[NULL, ROW('a', 1)]::r list)::TEXT;
+----
+{a=>1}
+
+query T
+SELECT map_build(LIST[ROW('a', 9), NULL, ROW('a', 1)]::r list)::TEXT;
+----
+{a=>1}
+
+query error could not determine polymorphic type because input has type unknown
+SELECT map_build(NULL)::TEXT;
+
+query T
+SELECT map_build(NULL::r list)::TEXT;
+----
+NULL
+
+statement ok
+CREATE TYPE int_list AS LIST (ELEMENT TYPE = int4);
+
+statement ok
+CREATE TYPE l AS (f1 TEXT, f2 int_list);
+
+query T
+SELECT map_build(LIST[ROW('a', LIST[1]), ROW('a', LIST[2])]::l list)::TEXT;
+----
+{a=>{2}}
+
+query T
+SELECT map_build(LIST[ROW('a', LIST[2]), ROW('a', LIST[1])]::l list)::TEXT;
+----
+{a=>{1}}
+
+statement ok
+CREATE TYPE int_key AS (f1 INT, f2 INT);
+
+query error db error: ERROR: function map_build\(int_key list\) does not exist
+SELECT map_build(LIST[ROW(1, 1), ROW(1, 2)]::int_key list)::TEXT;
+
+statement ok
+CREATE TYPE missing_value AS (f1 TEXT);
+
+query error db error: ERROR: function map_build\(missing_value list\) does not exist
+SELECT map_build(LIST[ROW('a'), ROW('a')]::missing_value list)::TEXT;
+
+query error function map_build(integer) does not exist
+SELECT map_build(1);

--- a/test/sqllogictest/regclass.slt
+++ b/test/sqllogictest/regclass.slt
@@ -35,12 +35,12 @@ CREATE MATERIALIZED VIEW s.m AS SELECT * FROM s.t;
 query T
 SELECT 't'::regclass::oid::int
 ----
-20696
+20698
 
 query T
 SELECT 's.t'::regclass::oid::int
 ----
-20697
+20699
 
 query T
 SELECT 't'::regclass = 's.t'::regclass
@@ -73,7 +73,7 @@ t
 query T
 SELECT 't'::regclass::oid::int
 ----
-20697
+20699
 
 query T
 SELECT 'public.t'::regclass::text;
@@ -101,12 +101,12 @@ d.public.t
 query T
 SELECT 'm'::regclass::oid::int
 ----
-20701
+20703
 
 query T
 SELECT 's.m'::regclass::oid::int
 ----
-20702
+20704
 
 query T
 SELECT 'm'::regclass = 's.m'::regclass

--- a/test/sqllogictest/regtype.slt
+++ b/test/sqllogictest/regtype.slt
@@ -142,12 +142,12 @@ CREATE TYPE d.public.t AS LIST (ELEMENT TYPE = int4);
 query T
 SELECT 't'::regtype::oid::int
 ----
-20697
+20699
 
 query T
 SELECT 's.t'::regtype::oid::int
 ----
-20698
+20700
 
 query T
 SELECT 't'::regtype = 's.t'::regtype

--- a/test/testdrive/kafka-headers.td
+++ b/test/testdrive/kafka-headers.td
@@ -59,6 +59,13 @@ key     f1       f2     gus
 fish    fishval  1000   gusfive
 fish2   fishval  1000   <null>
 
+# map_build lets you get the headers as a map
+> SELECT key, f1, f2, map_build(headers)->'gus' as gus, map_build(headers)->'gus2' AS gus2 from headers_src;
+key     f1       f2     gus       gus2
+-------------------------------------------
+fish    fishval  1000   gusfive   gus3
+fish2   fishval  1000   <null>    <null>
+
 # selecting by key works
 > SELECT key, f1, f2, thekey, value FROM (SELECT i.key, i.f1, i.f2, unnest(headers).key as thekey, unnest(headers).value as value from headers_src as I) i WHERE thekey = 'gus'
 key     f1       f2     thekey  value

--- a/test/testdrive/kafka-headers.td
+++ b/test/testdrive/kafka-headers.td
@@ -245,6 +245,33 @@ key          duplicates                 headers
 -------------------------------------------------
 message_3    message_3_header_3_third   "{\"(duplicates,\\\\x6d6573736167655f335f6865616465725f335f6669727374)\",\"(duplicates,\\\\x6d6573736167655f335f6865616465725f335f7365636f6e64)\",\"(duplicates,\\\\x6d6573736167655f335f6865616465725f335f7468697264)\"}"
 
+# We can control the header map more granularly with `map_agg`.
+> SELECT
+    key,
+    map_agg((headers).key, convert_from((headers).value, 'utf-8') ORDER BY (headers).value ASC)::TEXT AS headers_map
+  FROM (
+    SELECT
+      key, unnest(headers) AS headers
+    FROM duplicate_individual_headers
+  )
+  GROUP BY key;
+key       headers_map
+---------------------
+message_3 "{duplicates=>message_3_header_3_third}"
+
+# Reverse order of aggregating values.
+> SELECT
+    key,
+    map_agg((headers).key, convert_from((headers).value, 'utf-8') ORDER BY (headers).value DESC)::TEXT AS headers_map
+  FROM (
+    SELECT
+      key, unnest(headers) AS headers
+    FROM duplicate_individual_headers
+  )
+  GROUP BY key;
+key       headers_map
+---------------------
+message_3 "{duplicates=>message_3_header_3_first}"
 
 # Verify that the source is bricked when there are headers that cannot be parsed as utf-8
 $ kafka-create-topic topic=ill_formed_header


### PR DESCRIPTION
Mentioned in #20958, it would be nice to have functions that can construct maps en masse. Implemented the function mentioned there, tailored to process Kafka headers, as well as another more general (and less efficient) approach.

Will make some doc amends in a bit.

### Motivation

This PR adds a feature that has not yet been specified.
- `map_build` detailed in #20958
- `map_agg`  is essentially the same function as `jsonb_object_agg` requires the first argument to be typed as a string. 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support `map_build`, which can extract Kafka headers into a `map[text=>text]`.
  - Support `map_agg`, which is an aggregate function to build maps. To control which value gets returned when multiple tuples have the same key, it is an optionally ordered aggregate function akin to `jsonb_object_agg`.
