### PR TITLE
doc/user: add warning about using Aurora reader endpoints

### DIFF
--- a/doc/user/content/ingest-data/postgres-amazon-aurora.md
+++ b/doc/user/content/ingest-data/postgres-amazon-aurora.md
@@ -188,7 +188,12 @@ Now that you've configured your database network and created an ingestion cluste
       );
     ```
 
-    - Replace `<host>` with your RDS endpoint. To find your RDS endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+    - Replace `<host>` with the **Writer** endpoint for your Aurora database. To find your endpoint, select your database in the RDS Console, select the **Connectivity & security** tab, and look for the endpoint with type **Writer**.
+
+        <div class="warning">
+            <strong class="gutter">WARNING!</strong>
+            You must use the <strong>Writer</strong> endpoint for the database. Using a <strong>Reader</strong> endpoint will not work.
+        </div>
 
     - Replace `<database>` with the name of the database containing the tables you want to replicate to Materialize.
 

--- a/doc/user/content/ingest-data/postgres-amazon-aurora.md
+++ b/doc/user/content/ingest-data/postgres-amazon-aurora.md
@@ -188,7 +188,7 @@ Now that you've configured your database network and created an ingestion cluste
       );
     ```
 
-    - Replace `<host>` with the **Writer** endpoint for your Aurora database. To find your endpoint, select your database in the RDS Console, select the **Connectivity & security** tab, and look for the endpoint with type **Writer**.
+    - Replace `<host>` with the **Writer** endpoint for your Aurora database. To find the endpoint, select your database in the RDS Console, then click the **Connectivity & security** tab and look for the endpoint with type **Writer**.
 
         <div class="warning">
             <strong class="gutter">WARNING!</strong>


### PR DESCRIPTION
Fix #24745.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR improves documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
