### PR TITLE
doc/user: fix ingestion status query for snapshot committed

### DIFF
--- a/doc/user/layouts/shortcodes/postgres-direct/check-the-ingestion-status.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/check-the-ingestion-status.html
@@ -31,7 +31,7 @@ In this step, you'll first verify that the source is running and then check the 
     WITH
       source_ids AS
       (SELECT id FROM mz_sources WHERE name = 'mz_source')
-    SELECT sources.object_id, snapshot_committed
+    SELECT sources.referenced_object_id AS id, mz_sources.name, snapshot_committed
     FROM
       mz_internal.mz_source_statistics
         JOIN
@@ -44,7 +44,7 @@ In this step, you'll first verify that the source is running and then check the 
           )
           AS sources
         ON mz_source_statistics.id = sources.referenced_object_id
-      GROUP BY sources.object_id;
+        JOIN mz_sources ON mz_sources.id = sources.referenced_object_id;
     ```
     <p></p>
 


### PR DESCRIPTION
@chuck-alt-delete noticed that this query had rotted, since mz_source_statistics is no longer broken out by worker.

Fixes #24746.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR fixes documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
