### PR TITLE
ci: Parallelize feature-benchmark

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -71,8 +71,9 @@ steps:
     key: benchmark
     steps:
     - id: feature-benchmark
-      label: "Feature benchmark against merge base or 'latest'"
+      label: "Feature benchmark against merge base or 'latest' %N"
       timeout_in_minutes: 720
+      parallelism: 8
       agents:
         queue: linux-aarch64-large
       artifact_paths: junit_*.xml

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -127,8 +127,9 @@ steps:
             args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=100000, --max-execution-time=8h]
 
   - id: feature-benchmark-scale-plus-one
-    label: "Feature benchmark against 'latest' with --scale=+1"
+    label: "Feature benchmark against 'latest' with --scale=+1 %N"
     timeout_in_minutes: 2880
+    parallelism: 8
     agents:
       queue: linux-aarch64-large
     plugins:


### PR DESCRIPTION
To prevent feature benchmark from blocking a release when it has to be rerun (seems to happen more often than we'd wish)

Test runs: https://buildkite.com/materialize/nightlies/builds/6190#018d47ff-45a1-44f4-b0b9-c71db5cae678
https://buildkite.com/materialize/release-qualification/builds/415

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
