### PR TITLE
canary-load test: Support downing without environment variables

### DIFF
--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -21,19 +21,18 @@ from materialize.mzcompose.composition import Composition, WorkflowArgumentParse
 from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.testdrive import Testdrive
 
-REGION = "aws/us-east-1"
-ENVIRONMENT = os.getenv("ENVIRONMENT", "production")
-USERNAME = os.getenv("PRODUCTION_SANDBOX_USERNAME", "infra+bot@materialize.com")
-APP_PASSWORD = os.environ["PRODUCTION_SANDBOX_APP_PASSWORD"]
-
-
 SERVICES = [
     Testdrive(),  # Overriden below
-    Mz(region=REGION, environment=ENVIRONMENT, app_password=APP_PASSWORD),
+    Mz(app_password=""),  # Overridden below
 ]
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    REGION = "aws/us-east-1"
+    ENVIRONMENT = os.getenv("ENVIRONMENT", "production")
+    USERNAME = os.getenv("PRODUCTION_SANDBOX_USERNAME", "infra+bot@materialize.com")
+    APP_PASSWORD = os.environ["PRODUCTION_SANDBOX_APP_PASSWORD"]
+
     parser.add_argument("--runtime", default=600, type=int, help="Runtime in seconds")
     args = parser.parse_args()
 
@@ -45,7 +44,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         Testdrive(
             no_reset=True,
             materialize_url=f"postgres://{urllib.parse.quote(USERNAME)}:{urllib.parse.quote(APP_PASSWORD)}@{host}:6875/materialize",
-        )
+        ),
+        Mz(region=REGION, environment=ENVIRONMENT, app_password=APP_PASSWORD),
     ):
         c.up("testdrive", persistent=True)
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
