### PR TITLE
webhooks: Support `BODY FORMAT JSON ARRAY`

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -913,9 +913,11 @@ impl CatalogState {
                     mz_sql::plan::DataSourceDesc::Source => DataSourceDesc::Source,
                     mz_sql::plan::DataSourceDesc::Webhook {
                         validate_using,
+                        body_format,
                         headers,
                     } => DataSourceDesc::Webhook {
                         validate_using,
+                        body_format,
                         headers,
                         cluster_id: in_cluster
                             .expect("webhook sources must use an existing cluster"),

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -22,7 +22,7 @@ use mz_compute_client::protocol::response::PeekResponse;
 use mz_ore::task;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::role_id::RoleId;
-use mz_repr::Timestamp;
+use mz_repr::{ScalarType, Timestamp};
 use mz_sql::ast::{
     CopyRelation, CopyStatement, InsertSource, Query, Raw, SetExpr, Statement, SubscribeStatement,
 };
@@ -1015,11 +1015,12 @@ impl Coordinator {
                 return Err(name);
             };
 
-            let (body_ty, header_tys, validator) = match entry.item() {
+            let (body_format, header_tys, validator) = match entry.item() {
                 CatalogItem::Source(Source {
                     data_source:
                         DataSourceDesc::Webhook {
                             validate_using,
+                            body_format,
                             headers,
                             ..
                         },
@@ -1036,10 +1037,14 @@ impl Coordinator {
                         desc.arity()
                     );
 
-                    let body = desc
+                    // Double check that the body column of the webhook source matches the type
+                    // we're about to deserialize as.
+                    let body_column = desc
                         .get_by_name(&"body".into())
                         .map(|(_idx, ty)| ty.clone())
                         .ok_or(name.clone())?;
+                    assert!(!body_column.nullable, "webhook body column is nullable!?");
+                    assert_eq!(body_column.scalar_type, ScalarType::from(*body_format));
 
                     // Create a validator that can be called to validate a webhook request.
                     let validator = validate_using.as_ref().map(|v| {
@@ -1049,7 +1054,7 @@ impl Coordinator {
                             coord.caching_secrets_reader.clone(),
                         )
                     });
-                    (body, headers.clone(), validator)
+                    (*body_format, headers.clone(), validator)
                 }
                 _ => return Err(name),
             };
@@ -1068,7 +1073,7 @@ impl Coordinator {
 
             Ok(AppendWebhookResponse {
                 tx,
-                body_ty,
+                body_format,
                 header_tys,
                 validator,
             })

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -14,10 +14,10 @@ use std::sync::Arc;
 use anyhow::Context;
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
-use mz_repr::{ColumnType, Datum, Diff, Row, RowArena};
+use mz_repr::{Datum, Diff, Row, RowArena};
 use mz_secrets::cache::CachingSecretsReader;
 use mz_secrets::SecretsReader;
-use mz_sql::plan::{WebhookHeaders, WebhookValidation, WebhookValidationSecret};
+use mz_sql::plan::{WebhookBodyFormat, WebhookHeaders, WebhookValidation, WebhookValidationSecret};
 use mz_storage_client::controller::MonotonicAppender;
 use mz_storage_types::controller::StorageError;
 use tokio::sync::Semaphore;
@@ -233,7 +233,7 @@ pub struct AppendWebhookResponse {
     /// Channel to monotonically append rows to a webhook source.
     pub tx: WebhookAppender,
     /// Column type for the `body` column.
-    pub body_ty: ColumnType,
+    pub body_format: WebhookBodyFormat,
     /// Types of the columns for the headers of a request.
     pub header_tys: WebhookHeaders,
     /// Expression used to validate a webhook request.

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -45,8 +45,8 @@ use mz_sql::names::{
     ResolvedDatabaseSpecifier, ResolvedIds, SchemaId, SchemaSpecifier,
 };
 use mz_sql::plan::{
-    CreateSourcePlan, HirRelationExpr, Ingestion as PlanIngestion, WebhookHeaders,
-    WebhookValidation,
+    CreateSourcePlan, HirRelationExpr, Ingestion as PlanIngestion, WebhookBodyFormat,
+    WebhookHeaders, WebhookValidation,
 };
 use mz_sql::rbac;
 use mz_sql::session::vars::OwnedVarInput;
@@ -394,6 +394,8 @@ pub enum DataSourceDesc {
     Webhook {
         /// Optional components used to validation a webhook request.
         validate_using: Option<WebhookValidation>,
+        /// Describes how we deserialize the body of a webhook request.
+        body_format: WebhookBodyFormat,
         /// Describes whether or not to include headers and how to map them.
         headers: WebhookHeaders,
         /// The cluster which this source is associated with.
@@ -494,9 +496,11 @@ impl Source {
                 }
                 mz_sql::plan::DataSourceDesc::Webhook {
                     validate_using,
+                    body_format,
                     headers,
                 } => DataSourceDesc::Webhook {
                     validate_using,
+                    body_format,
                     headers,
                     cluster_id: plan
                         .in_cluster

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -415,7 +415,9 @@ pub enum Format<T: AstInfo> {
         columns: CsvColumns,
         delimiter: char,
     },
-    Json,
+    Json {
+        array: bool,
+    },
     Text,
 }
 
@@ -621,7 +623,12 @@ impl<T: AstInfo> AstDisplay for Format<T> {
                     f.write_str("'");
                 }
             }
-            Self::Json => f.write_str("JSON"),
+            Self::Json { array } => {
+                f.write_str("JSON");
+                if *array {
+                    f.write_str(" ARRAY");
+                }
+            }
             Self::Text => f.write_str("TEXT"),
         }
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1908,7 +1908,7 @@ impl<'a> Parser<'a> {
             };
             Format::Csv { columns, delimiter }
         } else if self.parse_keyword(JSON) {
-            Format::Json
+            Format::Json { array: false }
         } else if self.parse_keyword(TEXT) {
             Format::Text
         } else if self.parse_keyword(BYTES) {
@@ -2768,7 +2768,10 @@ impl<'a> Parser<'a> {
         // Note: we don't use `parse_format()` here because we support fewer formats than other
         // sources, and the user gets better errors if we reject the formats here.
         let body_format = match self.expect_one_of_keywords(&[JSON, TEXT, BYTES])? {
-            JSON => Format::Json,
+            JSON => {
+                let array = self.parse_keyword(ARRAY);
+                Format::Json { array }
+            }
             TEXT => Format::Text,
             BYTES => Format::Bytes,
             _ => unreachable!(),

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -239,14 +239,21 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT J
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
+
+parse-statement
+CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON ARRAY INCLUDE HEADERS
+----
+CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON ARRAY INCLUDE HEADERS
+=>
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: true }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS ( 'x-signature' )
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS ('x-signature')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -255,7 +262,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS ('x-signature', 'event-timestamp')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: false, header_name: "event-timestamp" }]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: false, header_name: "event-timestamp" }]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -264,7 +271,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS ('x-signature', NOT 'event-timestamp', 'x-another-one')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: true, header_name: "event-timestamp" }, CreateWebhookSourceFilterHeader { block: false, header_name: "x-another-one" }]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: true, header_name: "event-timestamp" }, CreateWebhookSourceFilterHeader { block: false, header_name: "x-another-one" }]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -274,7 +281,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS ('x-signature', 'x-another-one', NOT 'x-auth', NOT 'x-authorization')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: false, header_name: "x-another-one" }, CreateWebhookSourceFilterHeader { block: true, header_name: "x-auth" }, CreateWebhookSourceFilterHeader { block: true, header_name: "x-authorization" }]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: Some([CreateWebhookSourceFilterHeader { block: false, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: false, header_name: "x-another-one" }, CreateWebhookSourceFilterHeader { block: true, header_name: "x-auth" }, CreateWebhookSourceFilterHeader { block: true, header_name: "x-authorization" }]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -285,7 +292,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADER 'x-timestamp' AS x_timestamp INCLUDE HEADER 'hash' AS hash BYTES INCLUDE HEADERS (NOT 'x-signature', 'x-another-one')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [CreateWebhookSourceMapHeader { header_name: "x-timestamp", column_name: Ident("x_timestamp"), use_bytes: false }, CreateWebhookSourceMapHeader { header_name: "hash", column_name: Ident("hash"), use_bytes: true }], column: Some([CreateWebhookSourceFilterHeader { block: true, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: false, header_name: "x-another-one" }]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [CreateWebhookSourceMapHeader { header_name: "x-timestamp", column_name: Ident("x_timestamp"), use_bytes: false }, CreateWebhookSourceMapHeader { header_name: "hash", column_name: Ident("hash"), use_bytes: true }], column: Some([CreateWebhookSourceFilterHeader { block: true, header_name: "x-signature" }, CreateWebhookSourceFilterHeader { block: false, header_name: "x-another-one" }]) }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -295,7 +302,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADER 'x-signature' AS x_signature INCLUDE HEADER 'x-bytes' AS bytes BYTES
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [CreateWebhookSourceMapHeader { header_name: "x-signature", column_name: Ident("x_signature"), use_bytes: false }, CreateWebhookSourceMapHeader { header_name: "x-bytes", column_name: Ident("bytes"), use_bytes: true }], column: None }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [CreateWebhookSourceMapHeader { header_name: "x-signature", column_name: Ident("x_signature"), use_bytes: false }, CreateWebhookSourceMapHeader { header_name: "x-bytes", column_name: Ident("bytes"), use_bytes: true }], column: None }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -304,7 +311,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADER 'x-case-sensitive' AS "caseSensitive" BYTES
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [CreateWebhookSourceMapHeader { header_name: "x-case-sensitive", column_name: Ident("caseSensitive"), use_bytes: true }], column: None }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [CreateWebhookSourceMapHeader { header_name: "x-case-sensitive", column_name: Ident("caseSensitive"), use_bytes: true }], column: None }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -327,7 +334,7 @@ CREATE SOURCE webhook_json_no_headers IN CLUSTER webhook_cluster FROM WEBHOOK BO
 ----
 CREATE SOURCE webhook_json_no_headers IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json_no_headers")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json_no_headers")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: None, in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_bytes IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT BYTES
@@ -355,14 +362,14 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT J
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: None, using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: None, using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK ( headers['signature'] = hmac(sha256, 'body=' || body) )
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (headers['signature'] = hmac(sha256, 'body=' || body))
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: None, using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("hmac")])), args: Args { args: [Identifier([Ident("sha256")]), Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("body=")), expr2: Some(Identifier([Ident("body")])) }], order_by: [] }, filter: None, over: None, distinct: false })) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: None, using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("hmac")])), args: Args { args: [Identifier([Ident("sha256")]), Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("body=")), expr2: Some(Identifier([Ident("body")])) }], order_by: [] }, filter: None, over: None, distinct: false })) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -374,7 +381,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET test_key) headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -389,7 +396,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET test_key, SECRET other_key) headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: None, use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: None, use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -404,7 +411,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET test_key AS foo, SECRET other_key) headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: Some(Ident("foo")), use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: Some(Ident("foo")), use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -434,7 +441,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET test_key AS bar, SECRET other_key) headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: Some(Ident("bar")), use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: Some(Ident("bar")), use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -446,7 +453,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET bytes_key BYTES) headers['signature'] = bytes_key)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: None, use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: None, use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -458,7 +465,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET bytes_key AS bytes) headers['signature'] = bytes_key)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: Some(Ident("bytes")), use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: Some(Ident("bytes")), use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -470,7 +477,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET bytes_key AS bytes BYTES) headers['signature'] = bytes_key)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: Some(Ident("bytes")), use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: Some(Ident("bytes")), use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -482,7 +489,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET secret_key, SECRET other_key AS foo BYTES) headers['signature'] = bytes_key)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("secret_key")])), alias: None, use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: Some(Ident("foo")), use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json { array: false }, include_headers: CreateWebhookSourceIncludeHeaders { mappings: [], column: None }, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("secret_key")])), alias: None, use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: Some(Ident("foo")), use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2870,14 +2870,14 @@ CREATE SOURCE header1 FROM KAFKA CONNECTION conn (TOPIC 'test') FORMAT JSON INCL
 ----
 CREATE SOURCE header1 FROM KAFKA CONNECTION conn (TOPIC = 'test') FORMAT JSON INCLUDE HEADERS, HEADER 'header3' AS h3, HEADER 'header5' AS h5 BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [Headers { alias: None }, Header { key: "header3", alias: Ident("h3"), use_bytes: false }, Header { key: "header5", alias: Ident("h5"), use_bytes: true }], format: Bare(Json), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [Headers { alias: None }, Header { key: "header3", alias: Ident("h3"), use_bytes: false }, Header { key: "header5", alias: Ident("h5"), use_bytes: true }], format: Bare(Json { array: false }), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE header2 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON INCLUDE HEADER 'header1' AS h1, HEADER 'header2' AS h2 BYTES ENVELOPE UPSERT
 ----
 CREATE SOURCE header2 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON INCLUDE HEADER 'header1' AS h1, HEADER 'header2' AS h2 BYTES ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header2")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [Header { key: "header1", alias: Ident("h1"), use_bytes: false }, Header { key: "header2", alias: Ident("h2"), use_bytes: true }], format: KeyValue { key: Text, value: Json }, envelope: Some(Upsert), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header2")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [Header { key: "header1", alias: Ident("h1"), use_bytes: false }, Header { key: "header2", alias: Ident("h2"), use_bytes: true }], format: KeyValue { key: Text, value: Json { array: false } }, envelope: Some(Upsert), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (RETAIN HISTORY FOR '1s');

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -126,7 +126,8 @@ use crate::plan::{
     CreateTablePlan, CreateTypePlan, CreateViewPlan, DataSourceDesc, DropObjectsPlan,
     DropOwnedPlan, FullItemName, HirScalarExpr, Index, Ingestion, MaterializedView, Params, Plan,
     PlanClusterOption, PlanContext, PlanNotice, QueryContext, ReplicaConfig, Secret, Sink, Source,
-    Table, Type, VariableValue, View, WebhookHeaderFilters, WebhookHeaders, WebhookValidation,
+    Table, Type, VariableValue, View, WebhookBodyFormat, WebhookHeaderFilters, WebhookHeaders,
+    WebhookValidation,
 };
 use crate::session::vars;
 use crate::session::vars::ENABLE_REFRESH_EVERY_MVS;
@@ -446,10 +447,10 @@ pub fn plan_create_webhook_source(
         }
     }
 
-    let body_scalar_type = match body_format {
-        Format::Bytes => ScalarType::Bytes,
-        Format::Json => ScalarType::Jsonb,
-        Format::Text => ScalarType::String,
+    let body_format = match body_format {
+        Format::Bytes => WebhookBodyFormat::Bytes,
+        Format::Json { array } => WebhookBodyFormat::Json { array },
+        Format::Text => WebhookBodyFormat::Text,
         // TODO(parkmycar): Make an issue to support more types, or change this to NeverSupported.
         ty => {
             return Err(PlanError::Unsupported {
@@ -462,7 +463,7 @@ pub fn plan_create_webhook_source(
     let mut column_ty = vec![
         // Always include the body of the request as the first column.
         ColumnType {
-            scalar_type: body_scalar_type,
+            scalar_type: ScalarType::from(body_format),
             nullable: false,
         },
     ];
@@ -558,6 +559,7 @@ pub fn plan_create_webhook_source(
             create_sql,
             data_source: DataSourceDesc::Webhook {
                 validate_using,
+                body_format,
                 headers,
             },
             desc,
@@ -1919,7 +1921,7 @@ fn get_encoding_inner(
                     .map_err(|_| sql_err!("CSV delimiter must be an ASCII character"))?,
             })
         }
-        Format::Json => DataEncodingInner::Json,
+        Format::Json { .. } => DataEncodingInner::Json,
         Format::Text => DataEncodingInner::Text,
     }))
 }
@@ -2855,7 +2857,7 @@ fn kafka_sink_builder(
                 csr_connection,
             }
         }
-        Some(Format::Json) => KafkaSinkFormat::Json,
+        Some(Format::Json { .. }) => KafkaSinkFormat::Json,
         Some(format) => bail_unsupported!(format!("sink format {:?}", format)),
         None => bail_unsupported!("sink without format"),
     };

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -465,7 +465,7 @@ async fn purify_create_sink(
             Format::Avro(AvroSchema::InlineSchema { .. })
             | Format::Bytes
             | Format::Csv { .. }
-            | Format::Json
+            | Format::Json { .. }
             | Format::Protobuf(ProtobufSchema::InlineSchema { .. })
             | Format::Regex(..)
             | Format::Text => {}
@@ -1580,7 +1580,11 @@ async fn purify_source_format_single(
             }
             ProtobufSchema::InlineSchema { .. } => {}
         },
-        Format::Bytes | Format::Regex(_) | Format::Json | Format::Text | Format::Csv { .. } => (),
+        Format::Bytes
+        | Format::Regex(_)
+        | Format::Json { .. }
+        | Format::Text
+        | Format::Csv { .. } => (),
     }
     Ok(())
 }

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -320,7 +320,7 @@ this_will_work
 > SELECT body FROM webhook_with_time_based_rejection
 this_will_work
 
-# Unnest batch requests.
+# Unnest batch requests, with a materialize view.
 
 > CREATE SOURCE webhook_for_batch_events IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT JSON
@@ -355,6 +355,61 @@ $ webhook-append name=webhook_for_batch_events
 
 > SELECT COUNT(*) FROM webhook_for_batch_events_flattened
 8
+
+# Unnest batch requests with FORMAT JSON ARRAY.
+
+> CREATE SOURCE webhook_json_array IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT JSON ARRAY
+
+$ webhook-append name=webhook_json_array
+[
+  { "event_name": "a" },
+  { "event_name": "b" },
+  { "event_name": "c" },
+  { "event_name": "a" }
+]
+
+> SELECT body FROM webhook_json_array
+"{\"event_name\":\"a\"}"
+"{\"event_name\":\"a\"}"
+"{\"event_name\":\"b\"}"
+"{\"event_name\":\"c\"}"
+
+$ webhook-append name=webhook_json_array
+{ "event_type": "i am a single event" }
+
+> SELECT body FROM webhook_json_array
+"{\"event_name\":\"a\"}"
+"{\"event_name\":\"a\"}"
+"{\"event_name\":\"b\"}"
+"{\"event_name\":\"c\"}"
+"{\"event_type\":\"i am a single event\"}"
+
+> CREATE SOURCE webhook_json_array_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT JSON ARRAY
+  INCLUDE HEADER 'x-timestamp' as event_timestamp
+  CHECK (
+    WITH ( HEADERS, BODY )
+    decode(headers->'x-signature', 'base64') = hmac(body, 'super_secret_123', 'sha256')
+  )
+
+$ webhook-append name=webhook_json_array_with_headers x-timestamp=200 x-signature=a5nfOLZK7Xp5yuJeukC7A3XhNo5Y0gPQmg9KVDo9hU8=
+[
+  { "event": "coolio_thing" },
+  { "event": "oof_not_good" },
+  { "event": "recovered" }
+]
+
+> SELECT body, event_timestamp FROM webhook_json_array_with_headers
+"{\"event\":\"coolio_thing\"}" 200
+"{\"event\":\"oof_not_good\"}" 200
+"{\"event\":\"recovered\"}" 200
+
+$ webhook-append name=webhook_json_array_with_headers x-timestamp=202 x-signature=aUyjzZBzSvGGZVwMncpZ8mZABmgr2L13quRZy6uaTgA=
+{ "event": "ugh_wish_i_was_batch" }
+
+> SELECT body FROM webhook_json_array_with_headers WHERE event_timestamp = '202'
+"{\"event\":\"ugh_wish_i_was_batch\"}"
 
 # Renaming a webhook source.
 


### PR DESCRIPTION
This PR adds support for batch webhook events using the `BODY FORMAT JSON ARRAY` SQL syntax. In the HTTP handler we now optionally expand a JSON array into individual rows. This is preferred over using a mat view on top of a webhook source because this allows filter pushdown to work.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/23809

### Tips for reviewer

The PR has been broken into four commits, the ones that could use specific attention are 1 and 3

1. **SQL parser changes**
2. Plumbing the new `array` flag around
3. **Changes to the HTTP handler for expanding a JSON body**
4. Tests

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds native support for handling batch JSON events in a webhook source.
