### PR TITLE
adapter: refactor notices

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1248,7 +1248,11 @@ impl Catalog {
         let dropped_notices = self.drop_plans_and_metainfos(&drop_ids);
         if self.state().system_config().enable_mz_notices() {
             // Generate retractions for the Builtin tables.
-            self.pack_optimizer_notices(&mut builtin_table_updates, dropped_notices.iter(), -1);
+            self.state().pack_optimizer_notices(
+                &mut builtin_table_updates,
+                dropped_notices.iter(),
+                -1,
+            );
         }
 
         Ok(TransactionResult {

--- a/src/adapter/src/catalog/builtin_table_updates/notice.rs
+++ b/src/adapter/src/catalog/builtin_table_updates/notice.rs
@@ -17,37 +17,9 @@ use mz_transform::notice::{
     RawOptimizerNotice,
 };
 
-use crate::catalog::{BuiltinTableUpdate, Catalog, CatalogState};
+use crate::catalog::{BuiltinTableUpdate, Catalog};
 
 impl Catalog {
-    /// Transform the [`DataflowMetainfo`] by rendering an [`OptimizerNotice`]
-    /// for each [`RawOptimizerNotice`].
-    ///
-    /// Delegates to [`CatalogState::render_notices`].
-    pub fn render_notices(
-        &self,
-        df_meta: DataflowMetainfo<RawOptimizerNotice>,
-        notice_ids: Vec<GlobalId>,
-        item_id: Option<GlobalId>,
-    ) -> DataflowMetainfo<Arc<OptimizerNotice>> {
-        self.state.render_notices(df_meta, notice_ids, item_id)
-    }
-
-    /// Pack a [`BuiltinTableUpdate`] with the given `diff` for each
-    /// [`OptimizerNotice`] in `notices` into `updates`.
-    ///
-    /// Delegates to [`CatalogState::pack_optimizer_notices`].
-    pub fn pack_optimizer_notices<'a>(
-        &self,
-        updates: &mut Vec<BuiltinTableUpdate>,
-        notices: impl Iterator<Item = &'a Arc<OptimizerNotice>>,
-        diff: Diff,
-    ) {
-        self.state.pack_optimizer_notices(updates, notices, diff);
-    }
-}
-
-impl CatalogState {
     /// Transform the [`DataflowMetainfo`] by rendering an [`OptimizerNotice`]
     /// for each [`RawOptimizerNotice`].
     pub fn render_notices(
@@ -68,31 +40,39 @@ impl CatalogState {
             }
         }
 
+        // These notices will be persisted in a system table, so should not be
+        // relative to any user's session.
+        let conn_catalog = self.for_system_session();
+
         let optimizer_notices = std::iter::zip(
             df_meta.optimizer_notices.into_iter(),
             notice_ids.into_iter(),
         )
         .map(|(notice, id)| {
             // Render non-redacted fields.
-            let message = notice.message(self, false).to_string();
-            let hint = notice.hint(self, false).to_string();
-            let action = match notice.action_kind(self) {
+            let message = notice.message(&conn_catalog, false).to_string();
+            let hint = notice.hint(&conn_catalog, false).to_string();
+            let action = match notice.action_kind(&conn_catalog) {
                 ActionKind::SqlStatements => {
-                    Action::SqlStatements(notice.action(self, false).to_string())
+                    Action::SqlStatements(notice.action(&conn_catalog, false).to_string())
                 }
-                ActionKind::PlainText => Action::PlainText(notice.action(self, false).to_string()),
+                ActionKind::PlainText => {
+                    Action::PlainText(notice.action(&conn_catalog, false).to_string())
+                }
                 ActionKind::None => {
                     Action::None // No concrete action.
                 }
             };
             // Render redacted fields.
-            let message_redacted = notice.message(self, true).to_string();
-            let hint_redacted = notice.hint(self, true).to_string();
-            let action_redacted = match notice.action_kind(self) {
+            let message_redacted = notice.message(&conn_catalog, true).to_string();
+            let hint_redacted = notice.hint(&conn_catalog, true).to_string();
+            let action_redacted = match notice.action_kind(&conn_catalog) {
                 ActionKind::SqlStatements => {
-                    Action::SqlStatements(notice.action(self, true).to_string())
+                    Action::SqlStatements(notice.action(&conn_catalog, true).to_string())
                 }
-                ActionKind::PlainText => Action::PlainText(notice.action(self, true).to_string()),
+                ActionKind::PlainText => {
+                    Action::PlainText(notice.action(&conn_catalog, true).to_string())
+                }
                 ActionKind::None => {
                     Action::None // No concrete action.
                 }

--- a/src/adapter/src/catalog/builtin_table_updates/notice.rs
+++ b/src/adapter/src/catalog/builtin_table_updates/notice.rs
@@ -17,7 +17,7 @@ use mz_transform::notice::{
     RawOptimizerNotice,
 };
 
-use crate::catalog::{BuiltinTableUpdate, Catalog};
+use crate::catalog::{BuiltinTableUpdate, Catalog, CatalogState};
 
 impl Catalog {
     /// Transform the [`DataflowMetainfo`] by rendering an [`OptimizerNotice`]
@@ -100,10 +100,12 @@ impl Catalog {
             index_usage_types: df_meta.index_usage_types,
         }
     }
+}
 
+impl CatalogState {
     /// Pack a [`BuiltinTableUpdate`] with the given `diff` for each
     /// [`OptimizerNotice`] in `notices` into `updates`.
-    pub fn pack_optimizer_notices<'a>(
+    pub(crate) fn pack_optimizer_notices<'a>(
         &self,
         updates: &mut Vec<BuiltinTableUpdate>,
         notices: impl Iterator<Item = &'a Arc<OptimizerNotice>>,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -47,17 +47,15 @@ use mz_expr::MirScalarExpr;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::{to_datetime, EpochMillis, NOW_ZERO};
-use mz_ore::option::FallibleMapExt;
 use mz_ore::soft_assert_no_log;
 use mz_ore::str::StrExt;
 use mz_repr::adt::mz_acl_item::PrivilegeMap;
-use mz_repr::explain::ExprHumanizer;
 use mz_repr::namespaces::{
     INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_TEMP_SCHEMA, MZ_UNSAFE_SCHEMA,
     PG_CATALOG_SCHEMA,
 };
 use mz_repr::role_id::RoleId;
-use mz_repr::{GlobalId, RelationDesc, ScalarType};
+use mz_repr::{GlobalId, RelationDesc};
 use mz_secrets::InMemorySecretsController;
 use mz_sql::catalog::{
     CatalogCluster, CatalogClusterReplica, CatalogConfig, CatalogDatabase,
@@ -2269,97 +2267,5 @@ impl ConnectionResolver for CatalogState {
             AwsPrivatelink(conn) => AwsPrivatelink(conn),
             MySql(conn) => MySql(conn.into_inline_connection(self)),
         }
-    }
-}
-
-impl ExprHumanizer for CatalogState {
-    fn humanize_id(&self, id: GlobalId) -> Option<String> {
-        self.entry_by_id
-            .get(&id)
-            .map(|entry| entry.name())
-            .map(|name| self.resolve_full_name(name, None).to_string())
-    }
-
-    fn humanize_id_unqualified(&self, id: GlobalId) -> Option<String> {
-        self.entry_by_id
-            .get(&id)
-            .map(|entry| entry.name())
-            .map(|name| name.item.clone())
-    }
-
-    fn humanize_scalar_type(&self, typ: &ScalarType) -> String {
-        use ScalarType::*;
-
-        match typ {
-            Array(t) => format!("{}[]", self.humanize_scalar_type(t)),
-            List {
-                custom_id: Some(global_id),
-                ..
-            }
-            | Map {
-                custom_id: Some(global_id),
-                ..
-            } => {
-                let item = self.get_entry(global_id);
-                self.resolve_full_name(item.name(), None).to_string()
-            }
-            List { element_type, .. } => {
-                format!("{} list", self.humanize_scalar_type(element_type))
-            }
-            Map { value_type, .. } => format!(
-                "map[{}=>{}]",
-                self.humanize_scalar_type(&ScalarType::String),
-                self.humanize_scalar_type(value_type)
-            ),
-            Record {
-                custom_id: Some(id),
-                ..
-            } => {
-                let item = self.get_entry(id);
-                self.resolve_full_name(item.name(), None).to_string()
-            }
-            Record { fields, .. } => format!(
-                "record({})",
-                fields
-                    .iter()
-                    .map(|f| format!("{}: {}", f.0, self.humanize_column_type(&f.1)))
-                    .join(",")
-            ),
-            PgLegacyChar => "\"char\"".into(),
-            UInt16 => "uint2".into(),
-            UInt32 => "uint4".into(),
-            UInt64 => "uint8".into(),
-            ty => {
-                let name = QualifiedItemName {
-                    qualifiers: ItemQualifiers {
-                        database_spec: ResolvedDatabaseSpecifier::Ambient,
-                        schema_spec: SchemaSpecifier::Id(*self.get_pg_catalog_schema_id()),
-                    },
-                    item: mz_pgrepr::Type::from(ty).name().to_string(),
-                };
-
-                self.resolve_full_name(&name, None).to_string()
-            }
-        }
-    }
-
-    fn column_names_for_id(&self, id: GlobalId) -> Option<Vec<String>> {
-        self.entry_by_id
-            .get(&id)
-            .try_map(|entry| {
-                Ok::<_, SqlCatalogError>(
-                    entry
-                        .desc(&self.resolve_full_name(entry.name(), None))?
-                        .iter_names()
-                        .cloned()
-                        .map(|col_name| col_name.to_string())
-                        .collect(),
-                )
-            })
-            .unwrap_or(None)
-    }
-
-    fn id_exists(&self, id: GlobalId) -> bool {
-        self.entry_by_id.get(&id).is_some()
     }
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1625,7 +1625,7 @@ impl Coordinator {
 
                         if self.catalog().state().system_config().enable_mz_notices() {
                             // Collect optimization hint updates.
-                            self.catalog().pack_optimizer_notices(
+                            self.catalog().state().pack_optimizer_notices(
                                 &mut builtin_table_updates,
                                 df_meta.optimizer_notices.iter(),
                                 1,
@@ -1685,7 +1685,7 @@ impl Coordinator {
 
                     if self.catalog().state().system_config().enable_mz_notices() {
                         // Collect optimization hint updates.
-                        self.catalog().pack_optimizer_notices(
+                        self.catalog().state().pack_optimizer_notices(
                             &mut builtin_table_updates,
                             df_meta.optimizer_notices.iter(),
                             1,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4994,7 +4994,7 @@ impl Coordinator {
         session: &Session,
         notices: &Vec<RawOptimizerNotice>,
     ) {
-        let humanizer = self.catalog().state();
+        let humanizer = self.catalog.for_session(session);
         let system_vars = self.catalog.system_config();
         for notice in notices {
             let kind = OptimizerNoticeKind::from(notice);
@@ -5011,8 +5011,8 @@ impl Coordinator {
                 // `emit_optimizer_notices` is onlyy called by the `sequence_~`
                 // method for the DDL that produces that notice.
                 session.add_notice(AdapterNotice::OptimizerNotice {
-                    notice: notice.message(humanizer, false).to_string(),
-                    hint: notice.hint(humanizer, false).to_string(),
+                    notice: notice.message(&humanizer, false).to_string(),
+                    hint: notice.hint(&humanizer, false).to_string(),
                 });
             }
             self.metrics

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -404,7 +404,7 @@ impl Coordinator {
                     let mut builtin_table_updates =
                         Vec::with_capacity(df_meta.optimizer_notices.len());
                     // Collect optimization hint updates.
-                    coord.catalog().pack_optimizer_notices(
+                    coord.catalog().state().pack_optimizer_notices(
                         &mut builtin_table_updates,
                         df_meta.optimizer_notices.iter(),
                         1,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -543,7 +543,7 @@ impl Coordinator {
                     let mut builtin_table_updates =
                         Vec::with_capacity(df_meta.optimizer_notices.len());
                     // Collect optimization hint updates.
-                    coord.catalog().pack_optimizer_notices(
+                    coord.catalog().state().pack_optimizer_notices(
                         &mut builtin_table_updates,
                         df_meta.optimizer_notices.iter(),
                         1,

--- a/src/transform/src/notice/index_key_empty.rs
+++ b/src/transform/src/notice/index_key_empty.rs
@@ -70,7 +70,7 @@ impl OptimizerNoticeApi for IndexKeyEmpty {
     ) -> fmt::Result {
         write!(
             f,
-            "Drop the encosing index and re-create it using `CREATE DEFAULT INDEX ON` instead."
+            "Drop the enclosing index and re-create it using `CREATE DEFAULT INDEX ON` instead."
         )
     }
 


### PR DESCRIPTION
I saw the duplicative implementation of `ExprHumanizer` and think we can factor it away. Also so a few small things I'd fix.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
