### PR TITLE
storage: remove kafka producer limits in sinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7439,7 +7439,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#c729f89b70935fb2ad8a4f377cff2845acc197b0"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#357983e11c7969b3669e813f700910f82158c461"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -7455,8 +7455,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.3.0+1.9.2"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#c729f89b70935fb2ad8a4f377cff2845acc197b0"
+version = "4.3.0+2.3.0"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#357983e11c7969b3669e813f700910f82158c461"
 dependencies = [
  "cmake",
  "libc",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -141,6 +141,11 @@ criteria = "safe-to-deploy"
 version = "10.7.0"
 
 [[audits.rdkafka]]
+who = "Petros Angelatos <petrosagg@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.29.0@git:357983e11c7969b3669e813f700910f82158c461"
+
+[[audits.rdkafka]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.29.0@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
@@ -149,6 +154,11 @@ version = "0.29.0@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "4.3.0+1.9.2@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
+
+[[audits.rdkafka-sys]]
+who = "Petros Angelatos <petrosagg@gmail.com>"
+criteria = "safe-to-deploy"
+version = "4.3.0+2.3.0@git:357983e11c7969b3669e813f700910f82158c461"
 
 [[audits.redox_syscall]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"

--- a/test/kafka-auth/test-kafka-ssl.td
+++ b/test/kafka-auth/test-kafka-ssl.td
@@ -44,7 +44,7 @@ contains:Invalid CA certificate
     BROKER 'kafka:9093',
     SSL CERTIFICATE AUTHORITY = 'this is garbage'
   )
-contains:ssl.ca.pem failed: not in PEM format?
+contains:failed to read certificate #0 from ssl.ca.pem: not in PEM format?
 
 # ==> Test without an SSH tunnel. <==
 


### PR DESCRIPTION

### Motivation

The  kafka sink operator has nothing better to do with incoming data other than to buffer them, which provides no additional value than to send them to `librdkafka` and let that buffer them instead.

The operator is already set up to never buffer messages that are ready to send but the current limits are too conservative. If a large snapshot arrives fast enough then it is possible to reach the 10M message limit and cause the sink to restart. I have observed this happening locally during benchmarking.

For this reason this PR disables rdkafka message count and size limits.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
