### PR TITLE
canary-load: Fix overriding mz

### DIFF
--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -38,136 +38,142 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     start_time = time.time()
 
-    host = c.cloud_hostname()
-
     with c.override(
-        Testdrive(
-            no_reset=True,
-            materialize_url=f"postgres://{urllib.parse.quote(USERNAME)}:{urllib.parse.quote(APP_PASSWORD)}@{host}:6875/materialize",
-        ),
-        Mz(region=REGION, environment=ENVIRONMENT, app_password=APP_PASSWORD),
+        Mz(region=REGION, environment=ENVIRONMENT, app_password=APP_PASSWORD)
     ):
-        c.up("testdrive", persistent=True)
+        host = c.cloud_hostname()
 
-        try:
-            while time.time() - start_time < args.runtime:
+        with c.override(
+            Testdrive(
+                no_reset=True,
+                materialize_url=f"postgres://{urllib.parse.quote(USERNAME)}:{urllib.parse.quote(APP_PASSWORD)}@{host}:6875/materialize",
+            ),
+        ):
+            c.up("testdrive", persistent=True)
 
-                c.testdrive(
-                    dedent(
-                        """
-                            > DELETE FROM qa_canary_environment.public_table.table
-                        """
-                    )
-                )
-
-                conn1 = pg8000.connect(
-                    host=host,
-                    user=USERNAME,
-                    password=APP_PASSWORD,
-                    port=6875,
-                    ssl_context=ssl.create_default_context(),
-                )
-                cursor_table = conn1.cursor()
-                cursor_table.execute("BEGIN")
-                cursor_table.execute(
-                    "DECLARE subscribe_table CURSOR FOR SUBSCRIBE (SELECT * FROM qa_canary_environment.public_table.table)"
-                )
-
-                conn2 = pg8000.connect(
-                    host=host,
-                    user=USERNAME,
-                    password=APP_PASSWORD,
-                    port=6875,
-                    ssl_context=ssl.create_default_context(),
-                )
-                cursor_mv = conn2.cursor()
-                cursor_mv.execute("BEGIN")
-                cursor_mv.execute(
-                    "DECLARE subscribe_mv CURSOR FOR SUBSCRIBE (SELECT * FROM qa_canary_environment.public_table.table_mv)"
-                )
-
-                i = 0
-
+            try:
                 while time.time() - start_time < args.runtime:
-                    current_time = time.time()
 
                     c.testdrive(
                         dedent(
-                            f"""
-                                > SELECT 1
-                                1
-
-                                > INSERT INTO qa_canary_environment.public_table.table VALUES {", ".join(f"({i*100+j})" for j in range(100))}
-
-                                > SELECT COUNT(DISTINCT l_returnflag) FROM qa_canary_environment.public_tpch.tpch_q01 WHERE sum_charge < 0
-                                0
-
-                                > SELECT COUNT(DISTINCT c_name) FROM qa_canary_environment.public_tpch.tpch_q18 WHERE o_orderdate >= '2023-01-01'
-                                0
-
-                                > SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_pg_cdc.wmr WHERE degree > 2
-                                0
-
-                                > SELECT COUNT(DISTINCT count_star) FROM qa_canary_environment.public_loadgen.sales_product_product_category WHERE count_distinct_product_id < 0
-                                0
-
-                                > SELECT * FROM qa_canary_environment.public_table.table_mv
-                                {i * 100 + 99}
-
-                                > SELECT min(c), max(c), count(*) FROM qa_canary_environment.public_table.table
-                                0 {i * 100 + 99} {(i + 1) * 100}
+                            """
+                                > DELETE FROM qa_canary_environment.public_table.table
                             """
                         )
                     )
 
-                    cursor_table.execute(
-                        "FETCH ALL subscribe_table WITH (timeout='5s')"
+                    conn1 = pg8000.connect(
+                        host=host,
+                        user=USERNAME,
+                        password=APP_PASSWORD,
+                        port=6875,
+                        ssl_context=ssl.create_default_context(),
                     )
-                    results = cursor_table.fetchall()
-                    assert len(results) == 100, f"Unexpected results: {results}"
-                    for result in results:
+                    cursor_table = conn1.cursor()
+                    cursor_table.execute("BEGIN")
+                    cursor_table.execute(
+                        "DECLARE subscribe_table CURSOR FOR SUBSCRIBE (SELECT * FROM qa_canary_environment.public_table.table)"
+                    )
+
+                    conn2 = pg8000.connect(
+                        host=host,
+                        user=USERNAME,
+                        password=APP_PASSWORD,
+                        port=6875,
+                        ssl_context=ssl.create_default_context(),
+                    )
+                    cursor_mv = conn2.cursor()
+                    cursor_mv.execute("BEGIN")
+                    cursor_mv.execute(
+                        "DECLARE subscribe_mv CURSOR FOR SUBSCRIBE (SELECT * FROM qa_canary_environment.public_table.table_mv)"
+                    )
+
+                    i = 0
+
+                    while time.time() - start_time < args.runtime:
+                        current_time = time.time()
+
+                        c.testdrive(
+                            dedent(
+                                f"""
+                                    > SELECT 1
+                                    1
+
+                                    > INSERT INTO qa_canary_environment.public_table.table VALUES {", ".join(f"({i*100+j})" for j in range(100))}
+
+                                    > SELECT COUNT(DISTINCT l_returnflag) FROM qa_canary_environment.public_tpch.tpch_q01 WHERE sum_charge < 0
+                                    0
+
+                                    > SELECT COUNT(DISTINCT c_name) FROM qa_canary_environment.public_tpch.tpch_q18 WHERE o_orderdate >= '2023-01-01'
+                                    0
+
+                                    > SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_pg_cdc.wmr WHERE degree > 2
+                                    0
+
+                                    > SELECT COUNT(DISTINCT count_star) FROM qa_canary_environment.public_loadgen.sales_product_product_category WHERE count_distinct_product_id < 0
+                                    0
+
+                                    > SELECT * FROM qa_canary_environment.public_table.table_mv
+                                    {i * 100 + 99}
+
+                                    > SELECT min(c), max(c), count(*) FROM qa_canary_environment.public_table.table
+                                    0 {i * 100 + 99} {(i + 1) * 100}
+                                """
+                            )
+                        )
+
+                        cursor_table.execute(
+                            "FETCH ALL subscribe_table WITH (timeout='5s')"
+                        )
+                        results = cursor_table.fetchall()
+                        assert len(results) == 100, f"Unexpected results: {results}"
+                        for result in results:
+                            assert (
+                                int(result[0]) >= current_time
+                            ), f"Unexpected results: {results}"
+                            assert int(result[1]) == 1, f"Unexpected results: {results}"
+                            assert (
+                                i * 100 <= int(result[2]) < (i + 1) * 100
+                            ), f"Unexpected results: {results}"
+
+                        cursor_mv.execute("FETCH ALL subscribe_mv WITH (timeout='5s')")
+                        results = cursor_mv.fetchall()
+                        # First the removal, then the addition if it happens at the same timestamp
+                        r = sorted(list(results))  # type: ignore
+                        if i == 0:
+                            assert len(r) == 1, f"Unexpected results: {r}"
+                        else:
+                            assert len(r) == 2, f"Unexpected results: {r}"
+                            assert (
+                                int(r[0][0]) >= current_time
+                            ), f"Unexpected results: {r}"
+                            assert int(r[0][1]) == -1, f"Unexpected results: {r}"
+                            assert (
+                                int(r[0][2]) == i * 100 - 1
+                            ), f"Unexpected results: {r}"
+                        assert int(r[-1][0]) >= current_time, f"Unexpected results: {r}"
+                        assert int(r[-1][1]) == 1, f"Unexpected results: {r}"
                         assert (
-                            int(result[0]) >= current_time
-                        ), f"Unexpected results: {results}"
-                        assert int(result[1]) == 1, f"Unexpected results: {results}"
-                        assert (
-                            i * 100 <= int(result[2]) < (i + 1) * 100
-                        ), f"Unexpected results: {results}"
+                            int(r[-1][2]) == (i + 1) * 100 - 1
+                        ), f"Unexpected results: {r}"
 
-                    cursor_mv.execute("FETCH ALL subscribe_mv WITH (timeout='5s')")
-                    results = cursor_mv.fetchall()
-                    # First the removal, then the addition if it happens at the same timestamp
-                    r = sorted(list(results))  # type: ignore
-                    if i == 0:
-                        assert len(r) == 1, f"Unexpected results: {r}"
-                    else:
-                        assert len(r) == 2, f"Unexpected results: {r}"
-                        assert int(r[0][0]) >= current_time, f"Unexpected results: {r}"
-                        assert int(r[0][1]) == -1, f"Unexpected results: {r}"
-                        assert int(r[0][2]) == i * 100 - 1, f"Unexpected results: {r}"
-                    assert int(r[-1][0]) >= current_time, f"Unexpected results: {r}"
-                    assert int(r[-1][1]) == 1, f"Unexpected results: {r}"
-                    assert (
-                        int(r[-1][2]) == (i + 1) * 100 - 1
-                    ), f"Unexpected results: {r}"
+                        i += 1
 
-                    i += 1
+                    cursor_table.execute("CLOSE subscribe_table")
+                    cursor_table.execute("ROLLBACK")
+                    cursor_table.close()
+                    conn1.close()
 
-                cursor_table.execute("CLOSE subscribe_table")
-                cursor_table.execute("ROLLBACK")
-                cursor_table.close()
-                conn1.close()
+                    cursor_mv.execute("CLOSE subscribe_mv")
+                    cursor_mv.execute("ROLLBACK")
+                    cursor_mv.close()
+                    conn2.close()
 
-                cursor_mv.execute("CLOSE subscribe_mv")
-                cursor_mv.execute("ROLLBACK")
-                cursor_mv.close()
-                conn2.close()
-
-        except InterfaceError as e:
-            if "network error" in str(e):
-                print(
-                    "Network error received, probably a cloud downtime, retrying in 1 min"
-                )
-                time.sleep(60)
-            else:
-                raise
+            except InterfaceError as e:
+                if "network error" in str(e):
+                    print(
+                        "Network error received, probably a cloud downtime, retrying in 1 min"
+                    )
+                    time.sleep(60)
+                else:
+                    raise


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/24750

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
