### PR TITLE
docs: Add `BODY FORMAT JSON ARRAY`

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/create-source-webhook.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-webhook.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="897" height="729">
+<svg xmlns="http://www.w3.org/2000/svg" width="897" height="761">
    <polygon points="11 17 3 13 3 21"/>
    <polygon points="19 17 11 13 11 21"/>
    <rect x="33" y="3" width="140" height="32" rx="10"/>
@@ -55,167 +55,175 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="557" y="119">BODY FORMAT</text>
-   <rect x="418" y="167" width="56" height="32" rx="10"/>
-   <rect x="416"
+   <rect x="357" y="167" width="56" height="32" rx="10"/>
+   <rect x="355"
          y="165"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="426" y="185">TEXT</text>
-   <rect x="418" y="211" width="58" height="32" rx="10"/>
-   <rect x="416"
+   <text class="terminal" x="365" y="185">TEXT</text>
+   <rect x="357" y="211" width="58" height="32" rx="10"/>
+   <rect x="355"
          y="209"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="426" y="229">JSON</text>
-   <rect x="418" y="255" width="66" height="32" rx="10"/>
-   <rect x="416"
-         y="253"
-         width="66"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="426" y="273">BYTES</text>
-   <rect x="160" y="353" width="144" height="32" rx="10"/>
-   <rect x="158"
-         y="351"
-         width="144"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="168" y="371">INCLUDE HEADER</text>
-   <rect x="324" y="353" width="108" height="32"/>
-   <rect x="322" y="351" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="332" y="371">header_name</text>
-   <rect x="452" y="353" width="40" height="32" rx="10"/>
-   <rect x="450"
-         y="351"
-         width="40"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="460" y="371">AS</text>
-   <rect x="512" y="353" width="104" height="32"/>
-   <rect x="510" y="351" width="104" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="520" y="371">column_alias</text>
-   <rect x="656" y="385" width="66" height="32" rx="10"/>
-   <rect x="654"
-         y="383"
-         width="66"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="664" y="403">BYTES</text>
-   <rect x="160" y="473" width="152" height="32" rx="10"/>
-   <rect x="158"
-         y="471"
-         width="152"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="168" y="491">INCLUDE HEADERS</text>
-   <rect x="352" y="473" width="26" height="32" rx="10"/>
-   <rect x="350"
-         y="471"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="360" y="491">(</text>
-   <rect x="438" y="505" width="50" height="32" rx="10"/>
-   <rect x="436"
-         y="503"
-         width="50"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="446" y="523">NOT</text>
-   <rect x="528" y="473" width="108" height="32"/>
-   <rect x="526" y="471" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="536" y="491">header_name</text>
-   <rect x="418" y="429" width="24" height="32" rx="10"/>
-   <rect x="416"
-         y="427"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="426" y="447">,</text>
-   <rect x="676" y="473" width="26" height="32" rx="10"/>
-   <rect x="674"
-         y="471"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="684" y="491">)</text>
-   <rect x="45" y="647" width="70" height="32" rx="10"/>
-   <rect x="43"
-         y="645"
+   <text class="terminal" x="365" y="229">JSON</text>
+   <rect x="455" y="243" width="70" height="32" rx="10"/>
+   <rect x="453"
+         y="241"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="665">CHECK</text>
-   <rect x="135" y="647" width="26" height="32" rx="10"/>
-   <rect x="133"
-         y="645"
+   <text class="terminal" x="463" y="261">ARRAY</text>
+   <rect x="357" y="287" width="66" height="32" rx="10"/>
+   <rect x="355"
+         y="285"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="365" y="305">BYTES</text>
+   <rect x="160" y="385" width="144" height="32" rx="10"/>
+   <rect x="158"
+         y="383"
+         width="144"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="168" y="403">INCLUDE HEADER</text>
+   <rect x="324" y="385" width="108" height="32"/>
+   <rect x="322" y="383" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="332" y="403">header_name</text>
+   <rect x="452" y="385" width="40" height="32" rx="10"/>
+   <rect x="450"
+         y="383"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="460" y="403">AS</text>
+   <rect x="512" y="385" width="104" height="32"/>
+   <rect x="510" y="383" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="520" y="403">column_alias</text>
+   <rect x="656" y="417" width="66" height="32" rx="10"/>
+   <rect x="654"
+         y="415"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="664" y="435">BYTES</text>
+   <rect x="160" y="505" width="152" height="32" rx="10"/>
+   <rect x="158"
+         y="503"
+         width="152"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="168" y="523">INCLUDE HEADERS</text>
+   <rect x="352" y="505" width="26" height="32" rx="10"/>
+   <rect x="350"
+         y="503"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="143" y="665">(</text>
-   <rect x="201" y="647" width="58" height="32" rx="10"/>
-   <rect x="199"
-         y="645"
-         width="58"
+   <text class="terminal" x="360" y="523">(</text>
+   <rect x="438" y="537" width="50" height="32" rx="10"/>
+   <rect x="436"
+         y="535"
+         width="50"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="209" y="665">WITH</text>
-   <rect x="279" y="647" width="26" height="32" rx="10"/>
-   <rect x="277"
-         y="645"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="287" y="665">(</text>
-   <rect x="365" y="647" width="174" height="32"/>
-   <rect x="363" y="645" width="174" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="373" y="665">webhook_check_option</text>
-   <rect x="365" y="603" width="24" height="32" rx="10"/>
-   <rect x="363"
-         y="601"
+   <text class="terminal" x="446" y="555">NOT</text>
+   <rect x="528" y="505" width="108" height="32"/>
+   <rect x="526" y="503" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="536" y="523">header_name</text>
+   <rect x="418" y="461" width="24" height="32" rx="10"/>
+   <rect x="416"
+         y="459"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="373" y="621">,</text>
-   <rect x="599" y="647" width="26" height="32" rx="10"/>
+   <text class="terminal" x="426" y="479">,</text>
+   <rect x="676" y="505" width="26" height="32" rx="10"/>
+   <rect x="674"
+         y="503"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="684" y="523">)</text>
+   <rect x="45" y="679" width="70" height="32" rx="10"/>
+   <rect x="43"
+         y="677"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="697">CHECK</text>
+   <rect x="135" y="679" width="26" height="32" rx="10"/>
+   <rect x="133"
+         y="677"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="697">(</text>
+   <rect x="201" y="679" width="58" height="32" rx="10"/>
+   <rect x="199"
+         y="677"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="209" y="697">WITH</text>
+   <rect x="279" y="679" width="26" height="32" rx="10"/>
+   <rect x="277"
+         y="677"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="287" y="697">(</text>
+   <rect x="365" y="679" width="174" height="32"/>
+   <rect x="363" y="677" width="174" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="373" y="697">webhook_check_option</text>
+   <rect x="365" y="635" width="24" height="32" rx="10"/>
+   <rect x="363"
+         y="633"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="373" y="653">,</text>
+   <rect x="599" y="679" width="26" height="32" rx="10"/>
    <rect x="597"
-         y="645"
+         y="677"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="607" y="665">)</text>
-   <rect x="665" y="647" width="138" height="32"/>
-   <rect x="663" y="645" width="138" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="673" y="665">check_expression</text>
-   <rect x="823" y="647" width="26" height="32" rx="10"/>
+   <text class="terminal" x="607" y="697">)</text>
+   <rect x="665" y="679" width="138" height="32"/>
+   <rect x="663" y="677" width="138" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="673" y="697">check_expression</text>
+   <rect x="823" y="679" width="26" height="32" rx="10"/>
    <rect x="821"
-         y="645"
+         y="677"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="831" y="665">)</text>
+   <text class="terminal" x="831" y="697">)</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m104 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-396 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m108 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m126 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-321 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v24 m106 0 v-24 m-106 24 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m58 0 h10 m0 0 h8 m-96 -10 v20 m106 0 v-20 m-106 20 v24 m106 0 v-24 m-106 24 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-448 154 l2 0 m2 0 l2 0 m2 0 l2 0 m62 0 h10 m0 0 h592 m-622 0 h20 m602 0 h20 m-642 0 q10 0 10 10 m622 0 q0 -10 10 -10 m-632 10 v12 m622 0 v-12 m-622 12 q0 10 10 10 m602 0 q10 0 10 -10 m-612 10 h10 m144 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m104 0 h10 m20 0 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m-592 -42 v20 m622 0 v-20 m-622 20 v100 m622 0 v-100 m-622 100 q0 10 10 10 m602 0 q10 0 10 -10 m-612 10 h10 m152 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m0 0 h60 m-90 0 h20 m70 0 h20 m-110 0 q10 0 10 10 m90 0 q0 -10 10 -10 m-100 10 v12 m90 0 v-12 m-90 12 q0 10 10 10 m70 0 q10 0 10 -10 m-80 10 h10 m50 0 h10 m20 -32 h10 m108 0 h10 m-258 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m238 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-238 0 h10 m24 0 h10 m0 0 h194 m20 44 h10 m26 0 h10 m-390 0 h20 m370 0 h20 m-410 0 q10 0 10 10 m390 0 q0 -10 10 -10 m-400 10 v46 m390 0 v-46 m-390 46 q0 10 10 10 m370 0 q10 0 10 -10 m-380 10 h10 m0 0 h360 m20 -66 h20 m-642 -152 l20 0 m-1 0 q-9 0 -9 -10 l0 4 q0 -10 10 -10 m642 16 l20 0 m-20 0 q10 0 10 -10 l0 4 q0 -10 -10 -10 m-642 0 h10 m0 0 h632 m-682 16 h20 m682 0 h20 m-722 0 q10 0 10 10 m702 0 q0 -10 10 -10 m-712 10 v214 m702 0 v-214 m-702 214 q0 10 10 10 m682 0 q10 0 10 -10 m-692 10 h10 m0 0 h672 m22 -234 l2 0 m2 0 l2 0 m2 0 l2 0 m-821 326 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m70 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m40 0 h10 m174 0 h10 m-214 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m194 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-194 0 h10 m24 0 h10 m0 0 h150 m-234 44 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v14 m254 0 v-14 m-254 14 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m0 0 h224 m20 -34 h10 m26 0 h10 m-464 0 h20 m444 0 h20 m-484 0 q10 0 10 10 m464 0 q0 -10 10 -10 m-474 10 v30 m464 0 v-30 m-464 30 q0 10 10 10 m444 0 q10 0 10 -10 m-454 10 h10 m0 0 h434 m20 -50 h10 m138 0 h10 m0 0 h10 m26 0 h10 m-844 0 h20 m824 0 h20 m-864 0 q10 0 10 10 m844 0 q0 -10 10 -10 m-854 10 v46 m844 0 v-46 m-844 46 q0 10 10 10 m824 0 q10 0 10 -10 m-834 10 h10 m0 0 h814 m23 -66 h-3"/>
-   <polygon points="887 661 895 657 895 665"/>
-   <polygon points="887 661 879 657 879 665"/>
+         d="m19 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m104 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-396 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m108 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m126 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-382 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h132 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m58 0 h10 m20 0 h10 m0 0 h80 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v12 m110 0 v-12 m-110 12 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m70 0 h10 m-198 -42 v20 m228 0 v-20 m-228 20 v56 m228 0 v-56 m-228 56 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m66 0 h10 m0 0 h122 m22 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-509 186 l2 0 m2 0 l2 0 m2 0 l2 0 m62 0 h10 m0 0 h592 m-622 0 h20 m602 0 h20 m-642 0 q10 0 10 10 m622 0 q0 -10 10 -10 m-632 10 v12 m622 0 v-12 m-622 12 q0 10 10 10 m602 0 q10 0 10 -10 m-612 10 h10 m144 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m104 0 h10 m20 0 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m-592 -42 v20 m622 0 v-20 m-622 20 v100 m622 0 v-100 m-622 100 q0 10 10 10 m602 0 q10 0 10 -10 m-612 10 h10 m152 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m0 0 h60 m-90 0 h20 m70 0 h20 m-110 0 q10 0 10 10 m90 0 q0 -10 10 -10 m-100 10 v12 m90 0 v-12 m-90 12 q0 10 10 10 m70 0 q10 0 10 -10 m-80 10 h10 m50 0 h10 m20 -32 h10 m108 0 h10 m-258 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m238 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-238 0 h10 m24 0 h10 m0 0 h194 m20 44 h10 m26 0 h10 m-390 0 h20 m370 0 h20 m-410 0 q10 0 10 10 m390 0 q0 -10 10 -10 m-400 10 v46 m390 0 v-46 m-390 46 q0 10 10 10 m370 0 q10 0 10 -10 m-380 10 h10 m0 0 h360 m20 -66 h20 m-642 -152 l20 0 m-1 0 q-9 0 -9 -10 l0 4 q0 -10 10 -10 m642 16 l20 0 m-20 0 q10 0 10 -10 l0 4 q0 -10 -10 -10 m-642 0 h10 m0 0 h632 m-682 16 h20 m682 0 h20 m-722 0 q10 0 10 10 m702 0 q0 -10 10 -10 m-712 10 v214 m702 0 v-214 m-702 214 q0 10 10 10 m682 0 q10 0 10 -10 m-692 10 h10 m0 0 h672 m22 -234 l2 0 m2 0 l2 0 m2 0 l2 0 m-821 326 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m70 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m40 0 h10 m174 0 h10 m-214 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m194 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-194 0 h10 m24 0 h10 m0 0 h150 m-234 44 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v14 m254 0 v-14 m-254 14 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m0 0 h224 m20 -34 h10 m26 0 h10 m-464 0 h20 m444 0 h20 m-484 0 q10 0 10 10 m464 0 q0 -10 10 -10 m-474 10 v30 m464 0 v-30 m-464 30 q0 10 10 10 m444 0 q10 0 10 -10 m-454 10 h10 m0 0 h434 m20 -50 h10 m138 0 h10 m0 0 h10 m26 0 h10 m-844 0 h20 m824 0 h20 m-864 0 q10 0 10 10 m844 0 q0 -10 10 -10 m-854 10 v46 m844 0 v-46 m-844 46 q0 10 10 10 m824 0 q10 0 10 -10 m-834 10 h10 m0 0 h814 m23 -66 h-3"/>
+   <polygon points="887 693 895 689 895 697"/>
+   <polygon points="887 693 879 689 879 697"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -198,7 +198,7 @@ create_source_webhook ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   'IN CLUSTER' cluster_name
   'FROM' 'WEBHOOK'
-  'BODY FORMAT' ('TEXT' | 'JSON' | 'BYTES')
+  'BODY FORMAT' ('TEXT' | 'JSON' ('ARRAY')? | 'BYTES')
   (
     ('INCLUDE HEADER'  header_name 'AS' column_alias ('BYTES')? )? |
     ('INCLUDE HEADERS' ( '(' ('NOT')? header_name ( ',' ('NOT')? header_name )* ')' )?)?


### PR DESCRIPTION
# [Preview Docs](https://preview.materialize.com/materialize/24787/sql/create-source/webhook/)

### Motivation

Add docs for https://github.com/MaterializeInc/materialize/pull/24753

Will not merge until that PR gets released to users.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Documents the new `BODY FORMAT JSON ARRAY` for webhook sources
