### PR TITLE
Map unnest

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -667,6 +667,8 @@
     description: Expands the array `a` into a set of rows.
   - signature: 'unnest(l: anylist)'
     description: Expands the list `l` into a set of rows.
+  - signature: "unnest(m: anymap)"
+    description: Explands the map `m` in a set of rows with the columns `key` and `value`.
 
 - type: Array
   functions:

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -123,7 +123,8 @@
     - signature: 'map_build(kvs: list record(text, T)) -> map[text=>T]'
       description: >-
         Builds a map from a list of records whose fields are two elements, the
-        first of which is `text`. This function's current implementation is
+        first of which is `text`. In the face of duplicate keys, `map_build` retains
+        value from the record in the latest positition. This function is
         purpose-built to process [Kafka headers](/sql/create-source/kafka/#headers).
     - signature: 'map_agg(keys: text, values: T) -> map[text=>T]'
       description: Aggregate keys and values (including nulls) as a map. ([docs](/sql/functions/map_agg))

--- a/src/expr/src/relation.proto
+++ b/src/expr/src/relation.proto
@@ -188,5 +188,6 @@ message ProtoTableFunc {
         ProtoTabletizedScalar tabletized_scalar = 15;
         google.protobuf.Empty acl_explode = 16;
         google.protobuf.Empty mz_acl_explode = 17;
+        mz_repr.relation_and_scalar.ProtoScalarType unnest_map = 18;
     }
 }

--- a/src/pgrepr-consts/src/oid.rs
+++ b/src/pgrepr-consts/src/oid.rs
@@ -373,3 +373,4 @@ pub const FUNC_CONNECTION_OID_OID: u32 = 16_650;
 pub const FUNC_SECRET_OID_OID: u32 = 16_651;
 pub const FUNC_MAP_BUILD: u32 = 16_652;
 pub const FUNC_MAP_AGG: u32 = 16_653;
+pub const FUNC_UNNEST_MAP_OID: u32 = 16_654;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3806,6 +3806,18 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
             }) =>
                 // This return type should be equivalent to "ListElementAny", but this would be its sole use.
                 ReturnType::set_of(Any), oid::FUNC_UNNEST_LIST_OID;
+            vec![MapAny] => Operation::unary(move |ecx, e| {
+                let value_type = ecx.scalar_type(&e).unwrap_map_value_type().clone();
+                Ok(TableFuncPlan {
+                    expr: HirRelationExpr::CallTable {
+                        func: TableFunc::UnnestMap { value_type },
+                        exprs: vec![e],
+                    },
+                    column_names: vec!["key".into(), "value".into()],
+                })
+            }) =>
+                // This return type should be equivalent to "ListElementAny", but this would be its sole use.
+                ReturnType::set_of(Any), oid::FUNC_UNNEST_MAP_OID;
         }
     }
 });

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -788,3 +788,41 @@ query T
 SELECT (map_agg(a::TEXT, a) FILTER (WHERE a = 1))::TEXT FROM t1
 ----
 {1=>1}
+
+# unnest
+
+query TT colnames
+SELECT key, value FROM unnest('{a=>NULL}'::map[text=>int4]);
+----
+key value
+a   NULL
+
+query TT
+SELECT upper(key), value * 100 FROM unnest('{a=>1}'::map[text=>int4]);
+----
+A   100
+
+query T
+WITH v (a) AS (
+    SELECT '{a=>1}'::map[text=>int]
+),
+unnest (key, value) AS (
+    SELECT (a).key, (a).value FROM (
+        SELECT unnest(a) FROM v
+    ) AS u (a)
+),
+manipulate (key, value) AS (
+    SELECT upper(key), value * 100 FROM unnest
+)
+SELECT map_agg(key, value)::TEXT FROM manipulate;
+----
+{A=>100}
+
+query T
+SELECT unnest(NULL::map[text=>int4]);
+----
+
+query T
+SELECT unnest('{a=>NULL}'::map[text=>int4]);
+----
+(a,)


### PR DESCRIPTION
with `unnest` and `map_agg`, you can somewhat easily manipulate the data in a `map`--we had `map_agg` but not `unnest` so added it.

### Motivation

- This PR adds a feature that has not yet been specified. `unnest` seems like a good general purpose tool for maps.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add functions to make using `map` values easier including `unnest`, `map_agg`, and `map_build` (specifically to handle Kafka headers)`.
