### PR TITLE
canary-environment: Fix simple_table

### DIFF
--- a/test/canary-environment/dbt_project.yml
+++ b/test/canary-environment/dbt_project.yml
@@ -30,6 +30,8 @@ models:
       schema: tpch
     pg_cdc:
       schema: pg_cdc
+    simple_table:
+      schema: simple_table
 
 tests:
     +cluster: qa_canary_environment_compute

--- a/test/canary-environment/models/simple_table/schema.yml
+++ b/test/canary-environment/models/simple_table/schema.yml
@@ -10,7 +10,7 @@
 version: 2
 
 sources:
-  - name: table
+  - name: simple_table
     schema: public_table
     tables:
       - name: table

--- a/test/canary-environment/models/simple_table/table_mv.sql
+++ b/test/canary-environment/models/simple_table/table_mv.sql
@@ -10,4 +10,4 @@
 -- depends_on: {{ ref('table') }}
 {{ config(materialized='materializedview', cluster='qa_canary_environment_compute', indexes=[{'default': True}]) }}
 
-SELECT max(c) FROM {{ source('public_table','table' }}
+SELECT max(c) FROM {{ source('simple_table','table') }}


### PR DESCRIPTION
Verified locally that `./mzcompose run test` now works again.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
