### PR TITLE
platform-checks: Add preflight check scenarios

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -205,6 +205,8 @@ case "$cmd" in
             --env AWS_SESSION_TOKEN
             --env CI
             --env CI_COVERAGE_ENABLED
+            --env CI_FINAL_PREFLIGHT_CHECK_VERSION
+            --env CI_FINAL_PREFLIGHT_CHECK_ROLLBACK
             --env CI_TEST_SELECTION
             --env CLOUDTEST_CLUSTER_DEFINITION_FILE
             --env CONFLUENT_CLOUD_DEVEX_KAFKA_PASSWORD

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -637,6 +637,28 @@ steps:
               composition: platform-checks
               args: [--scenario=UpgradeEntireMz]
 
+      - id: checks-preflight-check-continue
+        label: "Checks preflight-check and continue upgrade"
+        timeout_in_minutes: 60
+        agents:
+          queue: linux-aarch64-large
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=PreflightCheckContinue]
+
+      - id: checks-preflight-check-rollback
+        label: "Checks preflight-check and roll back upgrade"
+        timeout_in_minutes: 60
+        agents:
+          queue: linux-aarch64-large
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=PreflightCheckRollback]
+
       - id: checks-upgrade-entire-mz-previous-version
         label: "Checks upgrade from previous version, whole-Mz restart"
         timeout_in_minutes: 60

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -165,6 +165,53 @@ steps:
             composition: sqlsmith
             args: [--max-joins=15, --explain-only, --runtime=6000]
 
+  - id: tests-preflight-check-rollback
+    label: Tests with preflight check and rollback
+    trigger: tests
+    async: false
+    build:
+      # TODO(def-): How to get the last release version here? For now v0.84.3
+      commit: "19827035bbeb59a90617491f3b12f33e80232a48"
+      branch: "v0.84.3"
+      env:
+        CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
+        CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 1
+
+  - id: tests-preflight-check-upgrade
+    label: Tests with preflight check and upgrade
+    trigger: tests
+    async: false
+    build:
+      # TODO(def-): How to get the last release version here? For now v0.84.3
+      commit: "19827035bbeb59a90617491f3b12f33e80232a48"
+      branch: "v0.84.3"
+      env:
+        CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
+        CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 0
+  - id: nightlies-preflight-check-rollback
+    label: Nightlies with preflight check and rollback
+    trigger: nightlies
+    async: false
+    build:
+      # TODO(def-): How to get the last release version here? For now v0.84.3
+      commit: "19827035bbeb59a90617491f3b12f33e80232a48"
+      branch: "v0.84.3"
+      env:
+        CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
+        CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 1
+
+  - id: nightlies-preflight-check-upgrade
+    label: Nightlies with preflight check and upgrade
+    trigger: nightlies
+    async: false
+    build:
+      # TODO(def-): How to get the last release version here? For now v0.84.3
+      commit: "19827035bbeb59a90617491f3b12f33e80232a48"
+      branch: "v0.84.3"
+      env:
+        CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
+        CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 0
+
 
   - wait: ~
     continue_on_failure: true

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -95,6 +95,9 @@ class StartMz(MzcomposeAction):
         with c.override(mz):
             c.up("materialized" if self.mz_service is None else self.mz_service)
 
+            # If we start up Materialize with MZ_DEPLOY_GENERATION, then it
+            # stays in a stuck state when the preflight-check is completed. So
+            # we can't connect to it yet to run any commands.
             if any(
                 env.startswith("MZ_DEPLOY_GENERATION=")
                 for env in self.environment_extra

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -86,7 +86,10 @@ class Scenario:
 
         for index, action in enumerate(actions):
             # Implicitly call configure to raise version-dependent limits
-            if isinstance(action, StartMz):
+            if isinstance(action, StartMz) and not any(
+                env.startswith("MZ_DEPLOY_GENERATION=")
+                for env in action.environment_extra
+            ):
                 actions.insert(
                     index + 1, ConfigureMz(self, mz_service=action.mz_service)
                 )

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -70,7 +70,7 @@ class UpgradeEntireMz(Scenario):
             Manipulate(self, phase=2),
             Validate(self),
             # A second restart while already on the new version
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(self, tag=None),
             Validate(self),
         ]
@@ -266,7 +266,12 @@ class PreflightCheckContinue(Scenario):
                 self,
                 tag=None,
                 environment_extra=["MZ_DEPLOY_GENERATION=1"],
-                healthcheck=False,
+                healthcheck=[
+                    "CMD",
+                    "curl",
+                    "-f",
+                    "localhost:6878/api/leader/status",
+                ],
             ),
             WaitReadyMz(),
             PromoteMz(),
@@ -274,7 +279,7 @@ class PreflightCheckContinue(Scenario):
             Validate(self),
             # A second restart while already on the new version
             KillMz(),
-            StartMz(self, tag=None, environment_extra=["MZ_DEPLOY_GENERATION=1"]),
+            StartMz(self, tag=None),
             Validate(self),
         ]
 
@@ -298,7 +303,12 @@ class PreflightCheckRollback(Scenario):
                 self,
                 tag=None,
                 environment_extra=["MZ_DEPLOY_GENERATION=1"],
-                healthcheck=False,
+                healthcheck=[
+                    "CMD",
+                    "curl",
+                    "-f",
+                    "localhost:6878/api/leader/status",
+                ],
             ),
             WaitReadyMz(),
             KillMz(capture_logs=True),
@@ -306,11 +316,10 @@ class PreflightCheckRollback(Scenario):
             Manipulate(self, phase=2),
             Validate(self),
             # A second restart while still on old version
-            KillMz(),
+            KillMz(capture_logs=True),
             StartMz(
                 self,
                 tag=self.base_version(),
-                environment_extra=["MZ_DEPLOY_GENERATION=0"],
             ),
             Validate(self),
         ]

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -45,6 +45,7 @@ from pg8000 import Connection, Cursor
 from materialize import MZ_ROOT, mzbuild, spawn, ui
 from materialize.mzcompose import loader
 from materialize.mzcompose.service import Service
+from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import minio_blob_uri
 from materialize.mzcompose.test_result import (
     FailedTestExecutionError,
@@ -398,7 +399,10 @@ class Composition:
                 # trivial help message.
                 parser.parse_args()
                 func(self)
-            self.sanity_restart_mz()
+            if os.getenv("CI_FINAL_PREFLIGHT_CHECK_VERSION") != None:
+                self.final_preflight_check()
+            else:
+                self.sanity_restart_mz()
         finally:
             loader.composition_path = None
 
@@ -824,6 +828,86 @@ class Composition:
 
         return None
 
+    def final_preflight_check(self) -> None:
+        """Check if Mz can do the preflight-check and upgrade/rollback with specified version."""
+        version = os.getenv("CI_FINAL_PREFLIGHT_CHECK_VERSION")
+        if version == None:
+            return
+        rollback = ui.env_is_truthy("CI_FINAL_PREFLIGHT_CHECK_ROLLBACK")
+        if "materialized" in self.compose["services"]:
+            ui.header("Final Preflight Check")
+            ps = self.invoke("ps", "materialized", "--quiet", capture=True)
+            if len(ps.stdout) == 0:
+                print("Service materialized not running, will not upgrade it.")
+                return
+
+            self.kill("materialized")
+            with self.override(
+                Materialized(
+                    image=f"materialize/materialized:{version}",
+                    environment_extra=["MZ_DEPLOY_GENERATION=1"],
+                    healthcheck=[
+                        "CMD",
+                        "curl",
+                        "-f",
+                        "localhost:6878/api/leader/status",
+                    ],
+                )
+            ):
+                self.up("materialized")
+                while True:
+                    result = json.loads(
+                        self.exec(
+                            "materialized",
+                            "curl",
+                            "localhost:6878/api/leader/status",
+                            capture=True,
+                        ).stdout
+                    )
+                    if result["status"] == "ReadyToPromote":
+                        return
+                    assert (
+                        result["status"] == "Initializing"
+                    ), f"Unexpected status {result}"
+                    print("Not ready yet, waiting 1 s")
+                    time.sleep(1)
+                if rollback:
+                    with self.override(Materialized()):
+                        self.up("materialized")
+                else:
+                    result = json.loads(
+                        self.exec(
+                            "materialized",
+                            "curl",
+                            "-X",
+                            "POST",
+                            "localhost:6878/api/leader/promote",
+                            capture=True,
+                        ).stdout
+                    )
+                    assert result["result"] == "Success", f"Unexpected result {result}"
+            self.sql("SELECT 1")
+
+            NUM_RETRIES = 60
+            for i in range(NUM_RETRIES + 1):
+                error = self.validate_sources_sinks_clusters()
+                if not error:
+                    break
+                if i == NUM_RETRIES:
+                    raise ValueError(error)
+                # Sources and cluster replicas need a few seconds to start up
+                print(f"Retrying ({i+1}/{NUM_RETRIES})...")
+                time.sleep(1)
+
+            # In case the test has to continue, reset state
+            self.kill("materialized")
+            self.up("materialized")
+
+        else:
+            ui.header(
+                "Persist Catalog Forward Compatibility Check skipped because Mz not in services"
+            )
+
     def sanity_restart_mz(self) -> None:
         """Restart Materialized if it is part of the composition to find
         problems with persisted objects, functions as a sanity check."""
@@ -881,7 +965,9 @@ class Composition:
             sanity_restart_mz: Try restarting materialize first if it is part
                 of the composition, as a sanity check.
         """
-        if sanity_restart_mz:
+        if os.getenv("CI_FINAL_PREFLIGHT_CHECK_VERSION") != None:
+            self.final_preflight_check()
+        elif sanity_restart_mz:
             self.sanity_restart_mz()
         self.capture_logs()
         self.invoke(


### PR DESCRIPTION
See https://www.notion.so/materialize/platform-v2-Persist-Catalog-Forward-Compatibility-6eaecaaa767e4860b6bd257471b985c4
![Screenshot 2024-01-29 at 23 42 40](https://github.com/MaterializeInc/materialize/assets/2335377/6c6e7f8b-0910-4e36-a45f-236eb33c420f)
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
