### PR TITLE
sql: Fix casting negative intervals to time

### DIFF
--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -248,47 +248,26 @@ pub trait CastLossy<T> {
     fn cast_lossy(from: T) -> Self;
 }
 
-impl CastLossy<usize> for f64 {
-    #[allow(clippy::as_conversions)]
-    fn cast_lossy(from: usize) -> Self {
-        from as f64
-    }
+/// Implement `CastLossy` for the specified types.
+macro_rules! cast_lossy {
+    ($from:ty, $to:ty) => {
+        impl crate::cast::CastLossy<$from> for $to {
+            #[allow(clippy::as_conversions)]
+            fn cast_lossy(from: $from) -> $to {
+                from as $to
+            }
+        }
+    };
 }
 
-impl CastLossy<isize> for f64 {
-    #[allow(clippy::as_conversions)]
-    fn cast_lossy(from: isize) -> Self {
-        from as f64
-    }
-}
-
-impl CastLossy<f64> for usize {
-    #[allow(clippy::as_conversions)]
-    fn cast_lossy(from: f64) -> Self {
-        from as usize
-    }
-}
-
-impl CastLossy<i64> for f64 {
-    #[allow(clippy::as_conversions)]
-    fn cast_lossy(from: i64) -> Self {
-        from as f64
-    }
-}
-
-impl CastLossy<u64> for f64 {
-    #[allow(clippy::as_conversions)]
-    fn cast_lossy(from: u64) -> Self {
-        from as f64
-    }
-}
-
-impl CastLossy<f64> for u64 {
-    #[allow(clippy::as_conversions)]
-    fn cast_lossy(from: f64) -> Self {
-        from as u64
-    }
-}
+cast_lossy!(usize, f64);
+cast_lossy!(isize, f64);
+cast_lossy!(f64, usize);
+cast_lossy!(i64, f64);
+cast_lossy!(f64, i64);
+cast_lossy!(u64, f64);
+cast_lossy!(f64, u64);
+cast_lossy!(f64, u32);
 
 #[mz_test_macro::test]
 fn test_try_cast_from() {

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -106,7 +106,7 @@ static DAY_OVERFLOW_ERROR: Lazy<String> = Lazy::new(|| {
         i32::MIN,
     )
 });
-static USECS_PER_DAY: Lazy<i64> = Lazy::new(|| {
+pub static USECS_PER_DAY: Lazy<i64> = Lazy::new(|| {
     Interval::convert_date_time_unit(DateTimeField::Day, DateTimeField::Microseconds, 1i64).unwrap()
 });
 

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -1234,6 +1234,11 @@ SELECT INTERVAL '7 months'::time;
 ----
 00:00:00
 
+query T
+SELECT INTERVAL '-86400000001 us'::time;
+----
+23:59:59.999999
+
 # Sub microseconds get rounded to microseconds
 query T
 SELECT INTERVAL '01:00:01.00000009';

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -1239,6 +1239,16 @@ SELECT INTERVAL '-86400000001 us'::time;
 ----
 23:59:59.999999
 
+query T
+SELECT CAST(interval '-02:03' AS time) AS "21:57:00";
+----
+21:57:00
+
+query T
+SELECT CAST(interval '-9223372022400000000 us' AS time) AS "00:00:00";
+----
+00:00:00
+
 # Sub microseconds get rounded to microseconds
 query T
 SELECT INTERVAL '01:00:01.00000009';


### PR DESCRIPTION
This commit fixes how negative intervals are cast to the time type. The previous implementation would overflow if the interval was smaller than -86_400_000_000 microseconds (i.e. 1 day). The current implementation has been re-written to match PostgreSQL's implementation: https://github.com/postgres/postgres/blob/6a1ea02c491d16474a6214603dce40b5b122d4d1/src/backend/utils/adt/date.c#L2003-L2027

Fixes #24684

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix casts from interval to time for large negative intervals.
