### PR TITLE
ld: Remove `enable_role_vars` feature flag

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5476,7 +5476,7 @@ pub fn describe_alter_role(
 }
 
 pub fn plan_alter_role(
-    scx: &StatementContext,
+    _scx: &StatementContext,
     AlterRoleStatement { name, option }: AlterRoleStatement<Aug>,
 ) -> Result<Plan, PlanError> {
     let option = match option {
@@ -5485,9 +5485,6 @@ pub fn plan_alter_role(
             PlannedAlterRoleOption::Attributes(attrs)
         }
         AlterRoleOption::Variable(variable) => {
-            // Make sure the LaunchDarkly flag is enabled.
-            scx.require_feature_flag(&vars::ENABLE_ROLE_VARS)?;
-
             let var = plan_role_variable(variable)?;
             PlannedAlterRoleOption::Variable(var)
         }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2001,13 +2001,6 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_role_vars,
-        desc: "setting default session variables for a role",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_jemalloc_profiling,
         desc: "jemalloc heap memory profiling",
         default: true,

--- a/test/legacy-upgrade/create-in-v0.71.0-role-var.td
+++ b/test/legacy-upgrade/create-in-v0.71.0-role-var.td
@@ -9,7 +9,7 @@
 
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 
-$ [version<=8500] postgres-execute connection=mz_system
+$[version<=8500] postgres-execute connection=mz_system
 ALTER SYSTEM SET enable_role_vars = true;
 
 > ALTER ROLE materialize SET application_name TO foo_bar_baz;

--- a/test/legacy-upgrade/create-in-v0.71.0-role-var.td
+++ b/test/legacy-upgrade/create-in-v0.71.0-role-var.td
@@ -9,7 +9,7 @@
 
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 
-$ postgres-execute connection=mz_system
+$ [version<=8500] postgres-execute connection=mz_system
 ALTER SYSTEM SET enable_role_vars = true;
 
 > ALTER ROLE materialize SET application_name TO foo_bar_baz;


### PR DESCRIPTION
We've release Role Default variables to 100% of users, and the feature flag has a default value of `true`. We no longer need this feature flag so get rid of it!

### Motivation

Clean up a 100% released feature flag

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
