### PR TITLE
sql: fix regression in ALTER CLUSTER ... SET (SIZE ...)

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4516,11 +4516,14 @@ pub fn plan_alter_cluster(
                 // The long term plan is to phase out the v1 cluster sizes, at
                 // which point we'll be able to remove the `DISK` option
                 // entirely and simply always enable disk.
-                if is_cluster_size_v2(size) && disk.is_some() {
-                    sql_bail!("DISK option not supported for cluster sizes ending in cc or C because disk is always enabled");
+                if is_cluster_size_v2(size) {
+                    if disk.is_some() {
+                        sql_bail!("DISK option not supported for cluster sizes ending in cc or C because disk is always enabled");
+                    } else {
+                        options.disk = AlterOptionParameter::Set(true);
+                    }
                 }
                 options.size = AlterOptionParameter::Set(size.clone());
-                options.disk = AlterOptionParameter::Set(true);
             }
             if let Some(availability_zones) = availability_zones {
                 options.availability_zones = AlterOptionParameter::Set(availability_zones);

--- a/test/testdrive/cc_cluster_sizes.td
+++ b/test/testdrive/cc_cluster_sizes.td
@@ -8,7 +8,8 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_cc_cluster_sizes = false
+ALTER SYSTEM SET enable_cc_cluster_sizes = false;
+ALTER SYSTEM SET disk_cluster_replicas_default = false;
 
 # Cannot create clusters with cc cluster size naming schemes
 ! CREATE CLUSTER c SIZE '1cc';
@@ -39,13 +40,19 @@ $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.mater
 ALTER SYSTEM SET enable_cc_cluster_sizes = true
 
 > CREATE CLUSTER c SIZE '1cc';
+> SELECT disk FROM mz_clusters WHERE name = 'c'
+true
 > DROP CLUSTER c
 
 > CREATE CLUSTER c SIZE '1C';
+> SELECT disk FROM mz_clusters WHERE name = 'c'
+true
 > DROP CLUSTER c
 
 # Create a cluster with a legacy size with disk enabled.
 > CREATE CLUSTER c SIZE '1', DISK = true
+> SELECT disk FROM mz_clusters WHERE name = 'c'
+true
 
 # Altering to a cc size with disk explicitly toggled is not allowed.
 ! ALTER CLUSTER c SET (SIZE = '1cc', DISK = true)
@@ -57,18 +64,26 @@ contains:DISK option not supported for cluster sizes ending in cc or C
 # even though the cluster's initial creation specified disk explicitly. The
 # DISK value is just forced to true.
 > ALTER CLUSTER c SET (SIZE = '1cc')
+> SELECT disk FROM mz_clusters WHERE name = 'c'
+true
 > DROP CLUSTER c
 
 # Same test as before, except the legacy size cluster has disk explicitly
 # disabled.
 > CREATE CLUSTER c SIZE '1', DISK = false
 > ALTER CLUSTER c SET (SIZE = '1cc')
+> SELECT disk FROM mz_clusters WHERE name = 'c'
+true
 > DROP CLUSTER c
 
 # Same test as before, except the legacy size cluster has no disk explicitly
 # configured.
 > CREATE CLUSTER c SIZE = '1'
+> SELECT disk FROM mz_clusters WHERE name = 'c'
+false
 > ALTER CLUSTER c SET (SIZE = '1cc')
+> SELECT disk FROM mz_clusters WHERE name = 'c'
+true
 
 # Cannot explicitly alter DISK option for new sizes.
 ! ALTER CLUSTER c SET (DISK = false)
@@ -78,6 +93,17 @@ contains:DISK option not supported for cluster sizes ending in cc or C
 
 # But it's okay if you're going back to a legacy size.
 > ALTER CLUSTER c SET (DISK = true, SIZE = '1')
+> SELECT disk FROM mz_clusters WHERE name = 'c'
+true
+> DROP CLUSTER c
+
+# Ensure that altering from a legacy size to a legacy size does not enable disk.
+> CREATE CLUSTER c SIZE = '1'
+> SELECT disk FROM mz_clusters WHERE name = 'c'
+false
+> ALTER CLUSTER c SET (SIZE = '2')
+> SELECT disk FROM mz_clusters WHERE name = 'c'
+false
 > DROP CLUSTER c
 
 # Ensure that disk isn't configurable for the new sizes (as it's force enabled).


### PR DESCRIPTION
Due to a bug in #24748, `ALTER CLUSTER ... SET (SIZE ...)` was inadvertently enabling the `DISK` option, even when not explicitly specified, when resizing between non-v2 sizes.

Huge thanks to @bobbyiliev for catching this ahead of the release.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
