### PR TITLE
adapter: Introducing peek context enum

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -383,9 +383,9 @@ impl RealTimeRecencyContext {
 
 #[derive(Debug)]
 pub enum PeekContext {
-    /// Peek was initiated from SELECT stmt
+    /// Peek was initiated from SELECT stmt.
     Select,
-    /// Peek was initiated with an EXPLAIN stmt
+    /// Peek was initiated with an EXPLAIN stmt.
     Explain(ExplainContext),
 }
 
@@ -418,7 +418,7 @@ impl PeekStage {
 pub struct PeekStageValidate {
     plan: mz_sql::plan::SelectPlan,
     target_cluster: TargetCluster,
-    /// Context from where this peek initiated from
+    /// Context from where this peek initiated.
     peek_ctx: PeekContext,
 }
 
@@ -431,7 +431,7 @@ pub struct PeekStageTimestamp {
     timeline_context: TimelineContext,
     in_immediate_multi_stmt_txn: bool,
     optimizer: optimize::peek::Optimizer,
-    /// Context from where this peek initiated from
+    /// Context from where this peek initiated.
     peek_ctx: PeekContext,
 }
 
@@ -445,7 +445,7 @@ pub struct PeekStageOptimizeMir {
     oracle_read_ts: Option<Timestamp>,
     in_immediate_multi_stmt_txn: bool,
     optimizer: optimize::peek::Optimizer,
-    /// Context from where this peek initiated from
+    /// Context from where this peek initiated.
     peek_ctx: PeekContext,
 }
 
@@ -461,7 +461,7 @@ pub struct PeekStageRealTimeRecency {
     in_immediate_multi_stmt_txn: bool,
     optimizer: optimize::peek::Optimizer,
     global_mir_plan: optimize::peek::GlobalMirPlan,
-    /// Context from where this peek initiated from
+    /// Context from where this peek initiated.
     peek_ctx: PeekContext,
 }
 
@@ -477,7 +477,7 @@ pub struct PeekStageOptimizeLir {
     real_time_recency_ts: Option<mz_repr::Timestamp>,
     optimizer: optimize::peek::Optimizer,
     global_mir_plan: optimize::peek::GlobalMirPlan,
-    /// Context from where this peek initiated from
+    /// Context from where this peek initiated.
     peek_ctx: PeekContext,
 }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -368,7 +368,7 @@ pub enum RealTimeRecencyContext {
         in_immediate_multi_stmt_txn: bool,
         optimizer: optimize::peek::Optimizer,
         global_mir_plan: optimize::peek::GlobalMirPlan,
-        explain_ctx: Option<ExplainContext>,
+        peek_ctx: PeekContext,
     },
 }
 
@@ -379,6 +379,14 @@ impl RealTimeRecencyContext {
             | RealTimeRecencyContext::Peek { ctx, .. } => ctx,
         }
     }
+}
+
+#[derive(Debug)]
+pub enum PeekContext {
+    /// Peek was initiated from SELECT stmt
+    Select,
+    /// Peek was initiated with an EXPLAIN stmt
+    Explain(ExplainContext),
 }
 
 #[derive(Debug)]
@@ -410,9 +418,8 @@ impl PeekStage {
 pub struct PeekStageValidate {
     plan: mz_sql::plan::SelectPlan,
     target_cluster: TargetCluster,
-    /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
-    explain_ctx: Option<ExplainContext>,
+    /// Context from where this peek initiated from
+    peek_ctx: PeekContext,
 }
 
 #[derive(Debug)]
@@ -424,9 +431,8 @@ pub struct PeekStageTimestamp {
     timeline_context: TimelineContext,
     in_immediate_multi_stmt_txn: bool,
     optimizer: optimize::peek::Optimizer,
-    /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
-    explain_ctx: Option<ExplainContext>,
+    /// Context from where this peek initiated from
+    peek_ctx: PeekContext,
 }
 
 #[derive(Debug)]
@@ -439,9 +445,8 @@ pub struct PeekStageOptimizeMir {
     oracle_read_ts: Option<Timestamp>,
     in_immediate_multi_stmt_txn: bool,
     optimizer: optimize::peek::Optimizer,
-    /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
-    explain_ctx: Option<ExplainContext>,
+    /// Context from where this peek initiated from
+    peek_ctx: PeekContext,
 }
 
 #[derive(Debug)]
@@ -456,9 +461,8 @@ pub struct PeekStageRealTimeRecency {
     in_immediate_multi_stmt_txn: bool,
     optimizer: optimize::peek::Optimizer,
     global_mir_plan: optimize::peek::GlobalMirPlan,
-    /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
-    explain_ctx: Option<ExplainContext>,
+    /// Context from where this peek initiated from
+    peek_ctx: PeekContext,
 }
 
 #[derive(Debug)]
@@ -473,9 +477,8 @@ pub struct PeekStageOptimizeLir {
     real_time_recency_ts: Option<mz_repr::Timestamp>,
     optimizer: optimize::peek::Optimizer,
     global_mir_plan: optimize::peek::GlobalMirPlan,
-    /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
-    explain_ctx: Option<ExplainContext>,
+    /// Context from where this peek initiated from
+    peek_ctx: PeekContext,
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -857,7 +857,7 @@ impl Coordinator {
                 in_immediate_multi_stmt_txn: _,
                 optimizer,
                 global_mir_plan,
-                explain_ctx,
+                peek_ctx,
             } => {
                 self.execute_peek_stage(
                     ctx,
@@ -873,7 +873,7 @@ impl Coordinator {
                         real_time_recency_ts: Some(real_time_recency_ts),
                         optimizer,
                         global_mir_plan,
-                        explain_ctx,
+                        peek_ctx,
                     }),
                 )
                 .await;

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -35,7 +35,7 @@ use crate::coord::timestamp_selection::{
     TimestampContext, TimestampDetermination, TimestampProvider,
 };
 use crate::coord::{
-    Coordinator, ExecuteContext, ExplainContext, Message, PeekStage, PeekStageExplain,
+    Coordinator, ExecuteContext, ExplainContext, Message, PeekContext, PeekStage, PeekStageExplain,
     PeekStageFinish, PeekStageOptimizeLir, PeekStageOptimizeMir, PeekStageRealTimeRecency,
     PeekStageTimestamp, PeekStageValidate, PlanValidity, RealTimeRecencyContext, TargetCluster,
 };
@@ -68,7 +68,7 @@ impl Coordinator {
             PeekStage::Validate(PeekStageValidate {
                 plan,
                 target_cluster,
-                explain_ctx: None,
+                peek_ctx: PeekContext::Select,
             }),
         )
         .await;
@@ -107,7 +107,7 @@ impl Coordinator {
             PeekStage::Validate(PeekStageValidate {
                 plan,
                 target_cluster,
-                explain_ctx: Some(ExplainContext {
+                peek_ctx: PeekContext::Explain(ExplainContext {
                     broken,
                     config,
                     format,
@@ -193,7 +193,7 @@ impl Coordinator {
         PeekStageValidate {
             plan,
             target_cluster,
-            explain_ctx,
+            peek_ctx,
         }: PeekStageValidate,
     ) -> Result<PeekStageTimestamp, AdapterError> {
         // Collect optimizer parameters.
@@ -204,7 +204,7 @@ impl Coordinator {
             .expect("compute instance does not exist");
         let view_id = self.allocate_transient_id()?;
         let index_id = self.allocate_transient_id()?;
-        let optimizer_config = if let Some(explain_ctx) = explain_ctx.as_ref() {
+        let optimizer_config = if let PeekContext::Explain(explain_ctx) = &peek_ctx {
             optimize::OptimizerConfig::from((self.catalog().system_config(), &explain_ctx.config))
         } else {
             optimize::OptimizerConfig::from(self.catalog().system_config())
@@ -276,7 +276,7 @@ impl Coordinator {
             timeline_context,
             in_immediate_multi_stmt_txn,
             optimizer,
-            explain_ctx,
+            peek_ctx,
         })
     }
 
@@ -295,7 +295,7 @@ impl Coordinator {
             timeline_context,
             in_immediate_multi_stmt_txn,
             optimizer,
-            explain_ctx,
+            peek_ctx,
         }: PeekStageTimestamp,
     ) {
         let isolation_level = ctx.session.vars().transaction_isolation().clone();
@@ -315,7 +315,7 @@ impl Coordinator {
                     oracle_read_ts,
                     in_immediate_multi_stmt_txn,
                     optimizer,
-                    explain_ctx,
+                    peek_ctx,
                 }
             };
 
@@ -383,7 +383,7 @@ impl Coordinator {
             oracle_read_ts,
             in_immediate_multi_stmt_txn,
             mut optimizer,
-            explain_ctx,
+            peek_ctx,
         }: PeekStageOptimizeMir,
     ) {
         // Generate data structures that can be moved to another task where we will perform possibly
@@ -431,7 +431,7 @@ impl Coordinator {
                 let pipeline = || -> Result<optimize::peek::GlobalMirPlan, AdapterError> {
                     // In `explain_~` contexts, set the trace-derived dispatch
                     // as default while optimizing.
-                    let _dispatch_guard = if let Some(explain_ctx) = explain_ctx.as_ref() {
+                    let _dispatch_guard = if let PeekContext::Explain(explain_ctx) = &peek_ctx {
                         let dispatch = tracing::Dispatch::from(&explain_ctx.optimizer_trace);
                         Some(tracing::dispatcher::set_default(&dispatch))
                     } else {
@@ -468,12 +468,12 @@ impl Coordinator {
                         in_immediate_multi_stmt_txn,
                         optimizer,
                         global_mir_plan,
-                        explain_ctx,
+                        peek_ctx,
                     }),
                     // Internal optimizer errors are handled differently
                     // depending on the caller.
                     Err(err) => {
-                        let Some(explain_ctx) = explain_ctx else {
+                        let PeekContext::Explain(explain_ctx) = peek_ctx else {
                             // In `sequence_~` contexts, immediately retire the
                             // execution with the error.
                             return ctx.retire(Err(err.into()));
@@ -526,7 +526,7 @@ impl Coordinator {
             in_immediate_multi_stmt_txn,
             optimizer,
             global_mir_plan,
-            explain_ctx,
+            peek_ctx,
         }: PeekStageRealTimeRecency,
     ) -> Option<(ExecuteContext, PeekStageOptimizeLir)> {
         match self.recent_timestamp(ctx.session(), source_ids.iter().cloned()) {
@@ -546,7 +546,7 @@ impl Coordinator {
                         in_immediate_multi_stmt_txn,
                         optimizer,
                         global_mir_plan,
-                        explain_ctx,
+                        peek_ctx,
                     },
                 );
                 task::spawn(|| "real_time_recency_peek", async move {
@@ -576,7 +576,7 @@ impl Coordinator {
                     real_time_recency_ts: None,
                     optimizer,
                     global_mir_plan,
-                    explain_ctx,
+                    peek_ctx,
                 },
             )),
         }
@@ -598,7 +598,7 @@ impl Coordinator {
             real_time_recency_ts,
             mut optimizer,
             global_mir_plan,
-            explain_ctx,
+            peek_ctx,
         }: PeekStageOptimizeLir,
     ) {
         // Generate data structures that can be moved to another task where we will perform possibly
@@ -633,7 +633,7 @@ impl Coordinator {
                     || -> Result<(optimize::peek::GlobalLirPlan, UsedIndexes), AdapterError> {
                         // In `explain_~` contexts, set the trace-derived dispatch
                         // as default while optimizing.
-                        let _dispatch_guard = if let Some(explain_ctx) = explain_ctx.as_ref() {
+                        let _dispatch_guard = if let PeekContext::Explain(explain_ctx) = &peek_ctx {
                             let dispatch = tracing::Dispatch::from(&explain_ctx.optimizer_trace);
                             Some(tracing::dispatcher::set_default(&dispatch))
                         } else {
@@ -687,7 +687,7 @@ impl Coordinator {
 
                 let stage = match pipeline() {
                     Ok((global_lir_plan, used_indexes)) => {
-                        if let Some(explain_ctx) = explain_ctx {
+                        if let PeekContext::Explain(explain_ctx) = peek_ctx {
                             let (peek_plan, df_meta) = global_lir_plan.unapply();
                             PeekStage::Explain(PeekStageExplain {
                                 validity,
@@ -718,7 +718,7 @@ impl Coordinator {
                     // Internal optimizer errors are handled differently
                     // depending on the caller.
                     Err(err) => {
-                        let Some(explain_ctx) = explain_ctx else {
+                        let PeekContext::Explain(explain_ctx) = peek_ctx else {
                             // In `sequence_~` contexts, immediately retire the
                             // execution with the error.
                             return ctx.retire(Err(err.into()));

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -686,8 +686,8 @@ impl Coordinator {
                     };
 
                 let stage = match pipeline() {
-                    Ok((global_lir_plan, used_indexes)) => {
-                        if let PeekContext::Explain(explain_ctx) = peek_ctx {
+                    Ok((global_lir_plan, used_indexes)) => match peek_ctx {
+                        PeekContext::Explain(explain_ctx) => {
                             let (peek_plan, df_meta) = global_lir_plan.unapply();
                             PeekStage::Explain(PeekStageExplain {
                                 validity,
@@ -701,20 +701,19 @@ impl Coordinator {
                                 used_indexes,
                                 explain_ctx,
                             })
-                        } else {
-                            PeekStage::Finish(PeekStageFinish {
-                                validity,
-                                plan,
-                                id_bundle,
-                                target_replica,
-                                source_ids,
-                                determination,
-                                timestamp_context,
-                                optimizer,
-                                global_lir_plan,
-                            })
                         }
-                    }
+                        PeekContext::Select => PeekStage::Finish(PeekStageFinish {
+                            validity,
+                            plan,
+                            id_bundle,
+                            target_replica,
+                            source_ids,
+                            determination,
+                            timestamp_context,
+                            optimizer,
+                            global_lir_plan,
+                        }),
+                    },
                     // Internal optimizer errors are handled differently
                     // depending on the caller.
                     Err(err) => {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Changing the `explain_ctx` from a `Option` to a `PeekContext` enum https://github.com/MaterializeInc/materialize/pull/24562#issuecomment-1915827388. Later this will be used to add another enum value for copy to context in https://github.com/MaterializeInc/materialize/pull/24562.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->

cc @mjibson 