### PR TITLE
ci: Retry builds on aarch64

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -25,6 +25,9 @@ steps:
     branches: "!v*.*"
     agents:
       queue: builder-linux-aarch64
+    # TODO(def-) Remove automatic retry when #24818 is fixed
+    retry:
+      automatic: true
 
   - wait: ~
 

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -20,6 +20,9 @@ steps:
     # sure we use the exact same version for testing here as was tagged and
     # will be released, and don't build our own version just for the tests.
     if: build.source == "ui" || build.source == "schedule" || build.source == "api"
+    # TODO(def-) Remove automatic retry when #24818 is fixed
+    retry:
+      automatic: true
 
   - wait: ~
 

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -47,6 +47,9 @@ steps:
         timeout_in_minutes: 60
         agents:
           queue: builder-linux-aarch64
+        # TODO(def-) Remove automatic retry when #24818 is fixed
+        retry:
+          automatic: true
 
       - id: build-wasm
         label: Build WASM
@@ -210,6 +213,9 @@ steps:
               composition: cargo-test
         agents:
           queue: builder-linux-aarch64
+        # TODO(def-) Remove automatic retry when #24818 is fixed
+        retry:
+          automatic: true
 
       - id: miri-test
         label: Miri test (fast)
@@ -225,6 +231,9 @@ steps:
         agents:
           queue: builder-linux-aarch64
         coverage: skip
+        # TODO(def-) Remove automatic retry when #24818 is fixed
+        retry:
+          automatic: true
 
   - id: testdrive
     label: Testdrive %N


### PR DESCRIPTION
Until we have a real fix for https://github.com/MaterializeInc/materialize/issues/24818 (maybe just a Rust upgrade?)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
