### PR TITLE
tests: product limits: reduce case-when count

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1140,9 +1140,9 @@ class UnionsNested(Generator):
 class CaseWhen(Generator):
     # Originally this was working with 1000, but after moving lowering and
     # decorrelation from the `plan_~` to the `sequence_~` method we had to
-    # reduce it a bit in order to avoid overflowing the stack. See 24076 for
-    # the latest occurence of this.
-    COUNT = 700
+    # reduce it a bit in order to avoid overflowing the stack. See #24076
+    # and #24820 for the latest occurrences of this.
+    COUNT = 600
 
     @classmethod
     def body(cls) -> None:


### PR DESCRIPTION
This fixes https://github.com/MaterializeInc/materialize/issues/24820, which was observed in https://buildkite.com/materialize/nightlies/builds/6219#018d5719-3950-4b28-83e9-48d2d5d44ffa.

Nightly: https://buildkite.com/materialize/nightlies/builds/6236