### PR TITLE
adapter: Prevent EXPLAIN from being linearized

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -620,6 +620,7 @@ impl Coordinator {
                 &id_bundle,
                 &source_ids,
                 real_time_recency_ts,
+                true,
             )
             .await;
 
@@ -975,6 +976,7 @@ impl Coordinator {
         source_bundle: &CollectionIdBundle,
         source_ids: &BTreeSet<GlobalId>,
         real_time_recency_ts: Option<Timestamp>,
+        requires_linearization: bool,
     ) -> Result<TimestampDetermination<Timestamp>, AdapterError> {
         let in_immediate_multi_stmt_txn = session.transaction().in_immediate_multi_stmt_txn(when);
         let timedomain_bundle;
@@ -1070,6 +1072,7 @@ impl Coordinator {
             session.add_transaction_ops(TransactionOps::Peeks {
                 determination: transaction_determination,
                 cluster_id,
+                requires_linearization,
             })?;
         } else if matches!(session.transaction(), &TransactionStatus::InTransaction(_)) {
             // If the query uses AS OF, then ignore the timestamp.
@@ -1077,6 +1080,7 @@ impl Coordinator {
             session.add_transaction_ops(TransactionOps::Peeks {
                 determination: transaction_determination,
                 cluster_id,
+                requires_linearization,
             })?;
         };
 

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -43,7 +43,7 @@ use crate::error::AdapterError;
 use crate::explain::optimizer_trace::OptimizerTrace;
 use crate::notice::AdapterNotice;
 use crate::optimize::{self, Optimize};
-use crate::session::{Session, TransactionOps, TransactionStatus};
+use crate::session::{RequireLinearization, Session, TransactionOps, TransactionStatus};
 use crate::statement_logging::StatementLifecycleEvent;
 
 impl Coordinator {
@@ -620,7 +620,7 @@ impl Coordinator {
                 &id_bundle,
                 &source_ids,
                 real_time_recency_ts,
-                true,
+                RequireLinearization::Required,
             )
             .await;
 
@@ -976,7 +976,7 @@ impl Coordinator {
         source_bundle: &CollectionIdBundle,
         source_ids: &BTreeSet<GlobalId>,
         real_time_recency_ts: Option<Timestamp>,
-        requires_linearization: bool,
+        requires_linearization: RequireLinearization,
     ) -> Result<TimestampDetermination<Timestamp>, AdapterError> {
         let in_immediate_multi_stmt_txn = session.transaction().in_immediate_multi_stmt_txn(when);
         let timedomain_bundle;

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -3820,3 +3820,35 @@ async fn test_constant_materialized_view() {
         }
     }
 }
+
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[cfg_attr(miri, ignore)] // too slow
+async fn test_explain_timestamp_blocking() {
+    let server = test_util::TestHarness::default().start().await;
+    server
+        .enable_feature_flags(&["enable_refresh_every_mvs"])
+        .await;
+    let client = server.connect().await.unwrap();
+    // This test will break in the year 30,000 after Jan 1st. When that happens, increase the year
+    // to fix the test.
+    client
+        .batch_execute(
+            "CREATE MATERIALIZED VIEW const_mv WITH (REFRESH AT '30000-01-01 23:59') AS SELECT 2;",
+        )
+        .await
+        .unwrap();
+
+    let mv_timestamp = get_explain_timestamp("const_mv", &client).await;
+
+    let row = client
+        .query_one("SELECT mz_now()::text;", &[])
+        .await
+        .unwrap();
+    let mz_now_ts_raw: String = row.get(0);
+    let mz_now_timestamp: EpochMillis = mz_now_ts_raw.parse().unwrap();
+
+    assert!(
+        mv_timestamp > mz_now_timestamp,
+        "read against mv at timestamp {mv_timestamp} should be in the future compared to now, {mz_now_timestamp}"
+    );
+}


### PR DESCRIPTION
If a peek is executed at a timestamp larger than the timestamp oracle's read timestamp, then that peek must be linearized. Linearized here means that the peek must wait for the timestamp oracle's read timestamp to catch up to the timestamp of the read before returning a result to the client.

Previously, Since `EXPLAIN` and `EXPLAIN TIMESTAMP` share the same code path as peeks, they also were linearized. This is unnecessary because `EXPLAIN` and `EXPLAIN TIMESTAMP` don't actually return data at some timestamp, but rather explain how a query would be executed at some timestamp. This is especially bad for `EXPLAIN TIMESTAMP`, where the user may want to know if a query would block without blocking the `EXPLAIN TIMESTAMP` query. This commit fixes the issue by not linearizing `EXPLAIN` and `EXPLAIN TIMESTAMP` statements.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Prevent `EXPLAIN` and `EXPLAIN TIMESTAMP` queries from blocking for linearization.
