### PR TITLE
sql: further protect against stack overflow in NameResolver

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2274,7 +2274,6 @@ fn test_idle_in_transaction_session_timeout() {
 }
 
 #[mz_ore::test]
-#[ignore] // TODO: Reenable when #24809 is fixed
 fn test_coord_startup_blocking() {
     let initial_time = 0;
     let now = Arc::new(Mutex::new(initial_time));

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1525,7 +1525,8 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
 
         let result = Query {
             ctes,
-            body: self.fold_set_expr(q.body),
+            // Queries can be recursive, so need the ability to grow the stack.
+            body: mz_ore::stack::maybe_grow(|| self.fold_set_expr(q.body)),
             limit: q.limit.map(|l| self.fold_limit(l)),
             offset: q.offset.map(|l| self.fold_expr(l)),
             order_by: q


### PR DESCRIPTION
The NameResolver can recurse deeply, so it needs to be careful to grow the stack at key points of recursion--particular in debug builds where stack frames are large. Add another call to `mz_ore::stack::maybe_grow`, following in the footsteps of 0d1ab7b, to cover recursion into nested SELECTs.

Fix #24809.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
