### PR TITLE
misc: correctly set cluster in scalability test

### DIFF
--- a/misc/python/materialize/scalability/schema.py
+++ b/misc/python/materialize/scalability/schema.py
@@ -64,7 +64,7 @@ class Schema:
     def connect_sqls(self) -> list[str]:
         init_sqls = [f"SET SCHEMA = {self.schema};"]
         if self.cluster_name is not None:
-            init_sqls.append(f"SET cluster_name = {self.cluster_name};")
+            init_sqls.append(f"SET CLUSTER = {self.cluster_name};")
 
         if self.transaction_isolation is not None:
             init_sqls.append(


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a