### PR TITLE
adapter: Make also the new EXPLAIN pipeline not linearize

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -620,7 +620,7 @@ impl Coordinator {
                 &id_bundle,
                 &source_ids,
                 real_time_recency_ts,
-                RequireLinearization::Required,
+                (&peek_ctx).into(),
             )
             .await;
 

--- a/src/adapter/src/explain/optimizer_trace.rs
+++ b/src/adapter/src/explain/optimizer_trace.rs
@@ -42,7 +42,7 @@ use crate::explain::Explainable;
 /// The [`OptimizerTrace::drain_all`] method on the created instance can be
 /// then used to collect the trace, and [`OptimizerTrace::drain_all`] to obtain
 /// the collected trace as a vector of [`TraceEntry`] instances.
-pub(crate) struct OptimizerTrace(dispatcher::Dispatch);
+pub struct OptimizerTrace(dispatcher::Dispatch);
 
 impl std::fmt::Debug for OptimizerTrace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -51,6 +51,7 @@ use crate::client::RecordFirstRowStream;
 use crate::coord::peek::PeekResponseUnary;
 use crate::coord::statement_logging::PreparedStatementLoggingInfo;
 use crate::coord::timestamp_selection::{TimestampContext, TimestampDetermination};
+use crate::coord::PeekContext;
 use crate::error::AdapterError;
 use crate::AdapterNotice;
 
@@ -1347,4 +1348,13 @@ pub enum RequireLinearization {
     Required,
     /// Linearization is required.
     NotRequired,
+}
+
+impl From<&PeekContext> for RequireLinearization {
+    fn from(ctx: &PeekContext) -> Self {
+        match ctx {
+            PeekContext::Select => RequireLinearization::Required,
+            PeekContext::Explain(..) => RequireLinearization::NotRequired,
+        }
+    }
 }

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1027,3 +1027,15 @@ create materialized view mv4 with (refresh at creation) as
 select * from
   (select mz_unsafe.mz_sleep(3)),
   (select * from t2);
+
+# EXPLAIN and EXPLAIN TIMESTAMP on an MV that hasn't had its first refresh yet shouldn't block
+# See also `test_explain_timestamp_blocking`
+statement ok
+CREATE MATERIALIZED VIEW mv5 WITH (REFRESH AT mz_now()::text::int8 + 1000000) AS
+SELECT x+y+z from t2;
+
+statement ok
+EXPLAIN SELECT * FROM mv5;
+
+statement ok
+EXPLAIN TIMESTAMP FOR SELECT * FROM mv5;


### PR DESCRIPTION
This is a followup from https://github.com/MaterializeInc/materialize/pull/24828. That PR made EXPLAIN TIMESTAMP and the old EXPLAIN peek pipeline (that is called by `sequence_explain_plan` when `enable_off_thread_optimization` is off) not linearize. This PR makes the new (off-thread) EXPLAIN peek pipeline also not linearize.

### Motivation

  * This PR fixes a recognized bug: Finishes the fix for https://github.com/MaterializeInc/materialize/issues/24244

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
