### PR TITLE
compute: add node IDs to `Plan`s

### DIFF
--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -39,6 +39,8 @@ breaking:
     - compute-client/src/service.proto
     # reason: does currently not require backward-compatibility
     - compute-types/src/dataflows.proto
+    # reason: does currently not require backward-compatibility
+    - compute-types/src/plan.proto
     # reason: Ignore because plans are currently not persisted.
     - expr/src/relation.proto
     # reason: still under active development

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -48,7 +48,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
         let mode = HumanizedExplain::new(ctx.config.redacted);
 
         match &self {
-            Constant { rows } => match rows {
+            Constant { rows, node_id: _ } => match rows {
                 Ok(rows) => {
                     if !rows.is_empty() {
                         writeln!(f, "{}Constant", ctx.indent)?;
@@ -72,7 +72,12 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                     }
                 }
             },
-            Get { id, keys, plan } => {
+            Get {
+                id,
+                keys,
+                plan,
+                node_id: _,
+            } => {
                 ctx.indent.set(); // mark the current indent level
 
                 // Resolve the id as a string.
@@ -116,13 +121,24 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
 
                 ctx.indent.reset(); // reset the original indent level
             }
-            Let { id, value, body } => {
+            Let {
+                id,
+                value,
+                body,
+                node_id: _,
+            } => {
                 let mut bindings = vec![(id, value.as_ref())];
                 let mut head = body.as_ref();
 
                 // Render Let-blocks nested in the body an outer Let-block in one step
                 // with a flattened list of bindings
-                while let Let { id, value, body } = head {
+                while let Let {
+                    id,
+                    value,
+                    body,
+                    node_id: _,
+                } = head
+                {
                     bindings.push((id, value.as_ref()));
                     head = body.as_ref();
                 }
@@ -143,6 +159,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 values,
                 limits,
                 body,
+                node_id: _,
             } => {
                 let bindings = izip!(ids.iter(), values, limits).collect_vec();
                 let head = body.as_ref();
@@ -166,6 +183,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 input,
                 mfp,
                 input_key_val,
+                node_id: _,
             } => {
                 writeln!(f, "{}Mfp", ctx.indent)?;
                 ctx.indented(|ctx| {
@@ -190,6 +208,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 exprs,
                 mfp_after,
                 input_key,
+                node_id: _,
             } => {
                 let exprs = mode.seq(exprs, None);
                 let exprs = CompactScalars(exprs);
@@ -207,7 +226,11 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                     input.fmt_text(f, ctx)
                 })?;
             }
-            Join { inputs, plan } => {
+            Join {
+                inputs,
+                plan,
+                node_id: _,
+            } => {
                 use crate::plan::join::JoinPlan;
                 match plan {
                     JoinPlan::Linear(plan) => {
@@ -232,6 +255,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 plan,
                 input_key,
                 mfp_after,
+                node_id: _,
             } => {
                 use crate::plan::reduce::ReducePlan;
                 match plan {
@@ -287,7 +311,11 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                     input.fmt_text(f, ctx)
                 })?;
             }
-            TopK { input, top_k_plan } => {
+            TopK {
+                input,
+                top_k_plan,
+                node_id: _,
+            } => {
                 use crate::plan::top_k::TopKPlan;
                 match top_k_plan {
                     TopKPlan::MonotonicTop1(plan) => {
@@ -350,13 +378,14 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 writeln!(f)?;
                 ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
-            Negate { input } => {
+            Negate { input, node_id: _ } => {
                 writeln!(f, "{}Negate", ctx.indent)?;
                 ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             Threshold {
                 input,
                 threshold_plan,
+                node_id: _,
             } => {
                 use crate::plan::threshold::ThresholdPlan;
                 match threshold_plan {
@@ -373,6 +402,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
             Union {
                 inputs,
                 consolidate_output,
+                node_id: _,
             } => {
                 if *consolidate_output {
                     writeln!(
@@ -395,6 +425,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 forms,
                 input_key,
                 input_mfp,
+                node_id: _,
             } => {
                 writeln!(f, "{}ArrangeBy", ctx.indent)?;
                 ctx.indented(|ctx| {

--- a/src/compute-types/src/plan.proto
+++ b/src/compute-types/src/plan.proto
@@ -9,6 +9,8 @@
 
 // See https://developers.google.com/protocol-buffers for what's going on here.
 
+// buf breaking: ignore (does currently not require backward-compatibility)
+
 syntax = "proto3";
 
 import "compute-types/src/plan/join.proto";

--- a/src/compute-types/src/plan.proto
+++ b/src/compute-types/src/plan.proto
@@ -67,8 +67,13 @@ message ProtoPlan {
    }
 
    message ProtoPlanConstant {
+        ProtoPlanRows rows = 1;
+        uint64 node_id = 2;
+   }
+
+   message ProtoPlanRows {
         oneof result {
-            ProtoRowDiffVec rows = 1;
+            ProtoRowDiffVec ok = 1;
             mz_expr.scalar.ProtoEvalError err = 2;
         }
    }
@@ -77,12 +82,14 @@ message ProtoPlan {
         mz_expr.id.ProtoId id = 1;
         ProtoAvailableCollections keys = 2;
         ProtoGetPlan plan = 3;
+        uint64 node_id = 4;
    }
 
    message ProtoPlanLet {
         mz_expr.id.ProtoLocalId id = 1;
         ProtoPlan value = 2;
         ProtoPlan body  = 3;
+        uint64 node_id = 4;
    }
 
    message ProtoPlanLetRec {
@@ -91,6 +98,7 @@ message ProtoPlan {
         repeated ProtoLetRecLimit limits = 4;
         repeated bool limit_is_some = 5;
         ProtoPlan body  = 3;
+        uint64 node_id = 6;
    }
 
    message ProtoPlanInputKeyVal {
@@ -102,6 +110,7 @@ message ProtoPlan {
         ProtoPlan input = 1;
         mz_expr.linear.ProtoMapFilterProject mfp = 2;
         ProtoPlanInputKeyVal input_key_val = 3;
+        uint64 node_id = 4;
    }
 
    message ProtoPlanInputKey {
@@ -114,11 +123,13 @@ message ProtoPlan {
         repeated mz_expr.scalar.ProtoMirScalarExpr exprs = 3;
         mz_expr.linear.ProtoMapFilterProject mfp_after = 4;
         ProtoPlanInputKey input_key = 5;
+        uint64 node_id = 6;
    }
 
    message ProtoPlanJoin {
         repeated ProtoPlan inputs = 1;
         mz_compute_types.plan.join.ProtoJoinPlan plan = 2;
+        uint64 node_id = 3;
    }
 
    message ProtoPlanReduce {
@@ -127,21 +138,30 @@ message ProtoPlan {
         mz_compute_types.plan.reduce.ProtoReducePlan plan = 3;
         ProtoPlanInputKey input_key = 4;
         mz_expr.linear.ProtoMapFilterProject mfp_after = 5;
+        uint64 node_id = 6;
    }
 
    message ProtoPlanTopK {
         ProtoPlan input = 1;
         mz_compute_types.plan.top_k.ProtoTopKPlan top_k_plan = 2;
+        uint64 node_id = 3;
+   }
+
+   message ProtoPlanNegate {
+        ProtoPlan input = 1;
+        uint64 node_id = 2;
    }
 
    message ProtoPlanThreshold {
         ProtoPlan input = 1;
         mz_compute_types.plan.threshold.ProtoThresholdPlan threshold_plan = 2;
+        uint64 node_id = 3;
    }
 
    message ProtoPlanUnion {
         repeated ProtoPlan inputs = 1;
         bool consolidate_output = 2;
+        uint64 node_id = 3;
    }
 
    message ProtoPlanArrangeBy {
@@ -149,6 +169,7 @@ message ProtoPlan {
         ProtoAvailableCollections forms = 2;
         ProtoPlanInputKey input_key = 3;
         mz_expr.linear.ProtoMapFilterProject input_mfp = 4;
+        uint64 node_id = 5;
    }
 
    oneof kind {
@@ -160,7 +181,7 @@ message ProtoPlan {
         ProtoPlanJoin join = 6;
         ProtoPlanReduce reduce = 7;
         ProtoPlanTopK top_k = 8;
-        ProtoPlan negate = 9;
+        ProtoPlanNegate negate = 9;
         ProtoPlanThreshold threshold = 10;
         ProtoPlanUnion union = 11;
         ProtoPlanArrangeBy arrange_by = 12;

--- a/src/compute-types/src/plan/interpret/api.rs
+++ b/src/compute-types/src/plan/interpret/api.rs
@@ -45,6 +45,8 @@ use crate::plan::{AvailableCollections, GetPlan, Plan};
 /// [object algebra]:
 ///     <https://www.cs.utexas.edu/~wcook/Drafts/2012/ecoop2012.pdf>
 /// [tagless final encoding]: <https://okmij.org/ftp/tagless-final/>
+///
+/// TODO(#24943): align this with the `Plan` structure
 pub trait Interpreter<T = mz_repr::Timestamp> {
     type Domain: Debug + Sized;
 
@@ -233,15 +235,25 @@ where
         use Plan::*;
         rg.checked_recur(|_| {
             match expr {
-                Constant { rows } => {
+                Constant { rows, node_id: _ } => {
                     // Interpret the current node.
                     Ok(self.interpret.constant(&self.ctx, rows))
                 }
-                Get { id, keys, plan } => {
+                Get {
+                    id,
+                    keys,
+                    plan,
+                    node_id: _,
+                } => {
                     // Interpret the current node.
                     Ok(self.interpret.get(&self.ctx, id, keys, plan))
                 }
-                Let { id, value, body } => {
+                Let {
+                    id,
+                    value,
+                    body,
+                    node_id: _,
+                } => {
                     // Extend context with the `value` result.
                     let res_value = self.apply_rec(value, rg)?;
                     let old_entry = self
@@ -264,6 +276,7 @@ where
                     values,
                     limits,
                     body,
+                    node_id: _,
                 } => {
                     // Make context recursive and extend it with `bottom` for each recursive
                     // binding. This corresponds to starting with the most optimistic value.
@@ -341,6 +354,7 @@ where
                     input,
                     mfp,
                     input_key_val,
+                    node_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -353,6 +367,7 @@ where
                     exprs,
                     mfp_after: mfp,
                     input_key,
+                    node_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -361,7 +376,11 @@ where
                         .interpret
                         .flat_map(&self.ctx, input, func, exprs, mfp, input_key))
                 }
-                Join { inputs, plan } => {
+                Join {
+                    inputs,
+                    plan,
+                    node_id: _,
+                } => {
                     // Descend recursively into all children.
                     let inputs = inputs
                         .iter()
@@ -376,6 +395,7 @@ where
                     plan,
                     input_key,
                     mfp_after,
+                    node_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -389,13 +409,17 @@ where
                         mfp_after,
                     ))
                 }
-                TopK { input, top_k_plan } => {
+                TopK {
+                    input,
+                    top_k_plan,
+                    node_id: _,
+                } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
                     // Interpret the current node.
                     Ok(self.interpret.top_k(&self.ctx, input, top_k_plan))
                 }
-                Negate { input } => {
+                Negate { input, node_id: _ } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
                     // Interpret the current node.
@@ -404,6 +428,7 @@ where
                 Threshold {
                     input,
                     threshold_plan,
+                    node_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -413,6 +438,7 @@ where
                 Union {
                     inputs,
                     consolidate_output,
+                    node_id: _,
                 } => {
                     // Descend recursively into all children.
                     let inputs = inputs
@@ -427,6 +453,7 @@ where
                     forms,
                     input_key,
                     input_mfp,
+                    node_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -487,7 +514,7 @@ where
         use Plan::*;
         rg.checked_recur(|_| {
             match expr {
-                Constant { rows } => {
+                Constant { rows, node_id: _ } => {
                     // Interpret the current node.
                     let result = self.interpret.constant(&self.ctx, rows);
                     // Mutate the current node using the given `action`.
@@ -495,7 +522,12 @@ where
                     // Pass the interpretation result up.
                     Ok(result)
                 }
-                Get { id, keys, plan } => {
+                Get {
+                    id,
+                    keys,
+                    plan,
+                    node_id: _,
+                } => {
                     // Interpret the current node.
                     let result = self.interpret.get(&self.ctx, id, keys, plan);
                     // Mutate the current node using the given `action`.
@@ -503,7 +535,12 @@ where
                     // Pass the interpretation result up.
                     Ok(result)
                 }
-                Let { id, value, body } => {
+                Let {
+                    id,
+                    value,
+                    body,
+                    node_id: _,
+                } => {
                     // Extend context with the `value` result.
                     let res_value = self.apply_rec(value, rg)?;
                     let old_entry = self
@@ -526,6 +563,7 @@ where
                     values,
                     limits,
                     body,
+                    node_id: _,
                 } => {
                     // Make context recursive and extend it with `bottom` for each recursive
                     // binding. This corresponds to starting with the most optimistic value.
@@ -603,6 +641,7 @@ where
                     input,
                     mfp,
                     input_key_val,
+                    node_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -621,6 +660,7 @@ where
                     exprs,
                     mfp_after: mfp,
                     input_key,
+                    node_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -638,7 +678,11 @@ where
                     // Pass the interpretation result up.
                     Ok(result)
                 }
-                Join { inputs, plan } => {
+                Join {
+                    inputs,
+                    plan,
+                    node_id: _,
+                } => {
                     // Descend recursively into all children.
                     let inputs: Vec<_> = inputs
                         .iter_mut()
@@ -657,6 +701,7 @@ where
                     plan,
                     input_key,
                     mfp_after,
+                    node_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -674,7 +719,11 @@ where
                     // Pass the interpretation result up.
                     Ok(result)
                 }
-                TopK { input, top_k_plan } => {
+                TopK {
+                    input,
+                    top_k_plan,
+                    node_id: _,
+                } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
                     // Interpret the current node.
@@ -684,7 +733,7 @@ where
                     // Pass the interpretation result up.
                     Ok(result)
                 }
-                Negate { input } => {
+                Negate { input, node_id: _ } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
                     // Interpret the current node.
@@ -697,6 +746,7 @@ where
                 Threshold {
                     input,
                     threshold_plan,
+                    node_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -712,6 +762,7 @@ where
                 Union {
                     inputs,
                     consolidate_output,
+                    node_id: _,
                 } => {
                     // Descend recursively into all children.
                     let inputs: Vec<_> = inputs
@@ -732,6 +783,7 @@ where
                     forms,
                     input_key,
                     input_mfp,
+                    node_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -25,11 +25,13 @@ use crate::plan::join::{DeltaJoinPlan, JoinPlan, LinearJoinPlan};
 use crate::plan::reduce::{KeyValPlan, ReducePlan};
 use crate::plan::threshold::ThresholdPlan;
 use crate::plan::top_k::TopKPlan;
-use crate::plan::{AvailableCollections, GetPlan, Plan};
+use crate::plan::{AvailableCollections, GetPlan, NodeId, Plan};
 
 pub(super) struct Context {
     /// Known bindings to (possibly arranged) collections.
     arrangements: BTreeMap<Id, AvailableCollections>,
+    /// Tracks the next available `NodeId`.
+    next_node_id: NodeId,
     /// Information to print along with error messages.
     debug_info: LirDebugInfo,
     /// Whether to enable type-specialization for arrangements.
@@ -46,6 +48,7 @@ impl Context {
     ) -> Self {
         Self {
             arrangements: Default::default(),
+            next_node_id: 0,
             debug_info: LirDebugInfo {
                 debug_name,
                 id: GlobalId::Transient(0),
@@ -53,6 +56,12 @@ impl Context {
             enable_specialized_arrangements,
             enable_reduce_mfp_fusion,
         }
+    }
+
+    fn allocate_node_id(&mut self) -> NodeId {
+        let id = self.next_node_id;
+        self.next_node_id += 1;
+        id
     }
 
     pub fn lower<T: Timestamp>(
@@ -187,6 +196,7 @@ impl Context {
                             .map(|(row, diff)| (row, T::minimum(), diff))
                             .collect()
                     }),
+                    node_id: self.allocate_node_id(),
                 };
                 // The plan, not arranged in any way.
                 (plan, AvailableCollections::new_raw())
@@ -261,6 +271,7 @@ impl Context {
                         id: id.clone(),
                         keys: in_keys,
                         plan,
+                        node_id: self.allocate_node_id(),
                     },
                     out_keys,
                 )
@@ -285,6 +296,7 @@ impl Context {
                         id: id.clone(),
                         value: Box::new(value),
                         body: Box::new(body),
+                        node_id: self.allocate_node_id(),
                     },
                     b_keys,
                 )
@@ -327,6 +339,7 @@ impl Context {
                                 values,
                                 limits,
                                 body,
+                                node_id,
                             } => Plan::LetRec {
                                 ids,
                                 values,
@@ -336,13 +349,16 @@ impl Context {
                                     forms,
                                     input_key,
                                     input_mfp,
+                                    node_id: self.allocate_node_id(),
                                 }),
+                                node_id,
                             },
                             lir_value => Plan::ArrangeBy {
                                 input: Box::new(lir_value),
                                 forms,
                                 input_key,
                                 input_mfp,
+                                node_id: self.allocate_node_id(),
                             },
                         };
                         v_keys.raw = true;
@@ -370,6 +386,7 @@ impl Context {
                         values: lir_values,
                         limits: limits.clone(),
                         body: Box::new(body),
+                        node_id: self.allocate_node_id(),
                     },
                     b_keys,
                 )
@@ -401,6 +418,7 @@ impl Context {
                         exprs: exprs.clone(),
                         mfp_after: mfp,
                         input_key,
+                        node_id: self.allocate_node_id(),
                     },
                     AvailableCollections::new_raw(),
                 )
@@ -523,6 +541,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                             input_plan,
                             Plan::Constant {
                                 rows: Ok(Vec::new()),
+                                node_id: self.allocate_node_id(),
                             },
                         );
                         *input_plan = self.arrange_by(raw_plan, missing, input_keys, arity);
@@ -533,6 +552,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     Plan::Join {
                         inputs: plans,
                         plan,
+                        node_id: self.allocate_node_id(),
                     },
                     AvailableCollections::new_raw(),
                 )
@@ -592,6 +612,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                         plan: reduce_plan,
                         input_key,
                         mfp_after,
+                        node_id: self.allocate_node_id(),
                     },
                     output_keys,
                 )
@@ -630,6 +651,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     Plan::TopK {
                         input: Box::new(input),
                         top_k_plan,
+                        node_id: self.allocate_node_id(),
                     },
                     AvailableCollections::new_raw(),
                 )
@@ -649,6 +671,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 (
                     Plan::Negate {
                         input: Box::new(input),
+                        node_id: self.allocate_node_id(),
                     },
                     AvailableCollections::new_raw(),
                 )
@@ -694,6 +717,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     Plan::Threshold {
                         input: Box::new(plan),
                         threshold_plan,
+                        node_id: self.allocate_node_id(),
                     },
                     output_keys,
                 )
@@ -723,6 +747,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 let plan = Plan::Union {
                     inputs: plans,
                     consolidate_output: false,
+                    node_id: self.allocate_node_id(),
                 };
                 (plan, AvailableCollections::new_raw())
             }
@@ -768,6 +793,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                             forms: input_keys.clone(),
                             input_key,
                             input_mfp,
+                            node_id: self.allocate_node_id(),
                         },
                         input_keys,
                     )
@@ -845,6 +871,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                         input: Box::new(plan),
                         mfp,
                         input_key_val: Some((key, val)),
+                        node_id: self.allocate_node_id(),
                     }
                 }
             } else {
@@ -852,6 +879,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     input: Box::new(plan),
                     mfp,
                     input_key_val,
+                    node_id: self.allocate_node_id(),
                 };
                 keys = AvailableCollections::new_raw();
             }
@@ -874,6 +902,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
             mut forms,
             input_key,
             input_mfp,
+            node_id,
         } = plan
         {
             forms.raw |= collections.raw;
@@ -890,6 +919,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 forms,
                 input_key,
                 input_mfp,
+                node_id,
             }
         } else {
             let (input_key, input_mfp) = if let Some((input_key, permutation, thinning)) =
@@ -906,6 +936,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 forms: collections,
                 input_key,
                 input_mfp,
+                node_id: self.allocate_node_id(),
             }
         }
     }

--- a/src/compute-types/src/plan/mod.rs
+++ b/src/compute-types/src/plan/mod.rs
@@ -995,56 +995,6 @@ impl RustType<ProtoLetRecLimit> for LetRecLimit {
 }
 
 impl<T: timely::progress::Timestamp> Plan<T> {
-    /// Replace the plan with another one
-    /// that has the collection in some additional forms.
-    pub fn arrange_by(
-        self,
-        collections: AvailableCollections,
-        old_collections: &AvailableCollections,
-        arity: usize,
-    ) -> Self {
-        let new_self = if let Self::ArrangeBy {
-            input,
-            mut forms,
-            input_key,
-            input_mfp,
-        } = self
-        {
-            forms.raw |= collections.raw;
-            forms.arranged.extend(collections.arranged);
-            forms.arranged.sort_by(|k1, k2| k1.0.cmp(&k2.0));
-            forms.arranged.dedup_by(|k1, k2| k1.0 == k2.0);
-            if forms.types.is_none() {
-                forms.types = collections.types;
-            } else {
-                assert!(collections.types.is_none() || collections.types == forms.types);
-            }
-            Self::ArrangeBy {
-                input,
-                forms,
-                input_key,
-                input_mfp,
-            }
-        } else {
-            let (input_key, input_mfp) = if let Some((input_key, permutation, thinning)) =
-                old_collections.arbitrary_arrangement()
-            {
-                let mut mfp = MapFilterProject::new(arity);
-                mfp.permute(permutation.clone(), thinning.len() + input_key.len());
-                (Some(input_key.clone()), mfp)
-            } else {
-                (None, MapFilterProject::new(arity))
-            };
-            Self::ArrangeBy {
-                input: Box::new(self),
-                forms: collections,
-                input_key,
-                input_mfp,
-            }
-        };
-        new_self
-    }
-
     /// Convert the dataflow description into one that uses render plans.
     #[tracing::instrument(
         target = "optimizer",

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -642,6 +642,7 @@ where
             values,
             limits,
             body,
+            node_id: _,
         } = plan
         {
             assert_eq!(ids.len(), values.len());
@@ -751,7 +752,7 @@ where
     /// as a stream of data, perhaps as an arrangement, perhaps as a stream of batches.
     pub fn render_plan(&mut self, plan: Plan) -> CollectionBundle<G> {
         match plan {
-            Plan::Constant { rows } => {
+            Plan::Constant { rows, node_id: _ } => {
                 // Produce both rows and errs to avoid conditional dataflow construction.
                 let (rows, errs) = match rows {
                     Ok(rows) => (rows, Vec::new()),
@@ -794,7 +795,12 @@ where
 
                 CollectionBundle::from_collections(ok_collection, err_collection)
             }
-            Plan::Get { id, keys, plan } => {
+            Plan::Get {
+                id,
+                keys,
+                plan,
+                node_id: _,
+            } => {
                 // Recover the collection from `self` and then apply `mfp` to it.
                 // If `mfp` happens to be trivial, we can just return the collection.
                 let mut collection = self
@@ -829,7 +835,12 @@ where
                     }
                 }
             }
-            Plan::Let { id, value, body } => {
+            Plan::Let {
+                id,
+                value,
+                body,
+                node_id: _,
+            } => {
                 // Render `value` and bind it to `id`. Complain if this shadows an id.
                 let value = self.render_plan(*value);
                 let prebound = self.insert_id(Id::Local(id), value);
@@ -846,6 +857,7 @@ where
                 input,
                 mfp,
                 input_key_val,
+                node_id: _,
             } => {
                 let input = self.render_plan(*input);
                 // If `mfp` is non-trivial, we should apply it and produce a collection.
@@ -863,11 +875,16 @@ where
                 exprs,
                 mfp_after: mfp,
                 input_key,
+                node_id: _,
             } => {
                 let input = self.render_plan(*input);
                 self.render_flat_map(input, func, exprs, mfp, input_key)
             }
-            Plan::Join { inputs, plan } => {
+            Plan::Join {
+                inputs,
+                plan,
+                node_id: _,
+            } => {
                 let inputs = inputs
                     .into_iter()
                     .map(|input| self.render_plan(input))
@@ -887,16 +904,21 @@ where
                 plan,
                 input_key,
                 mfp_after,
+                node_id: _,
             } => {
                 let input = self.render_plan(*input);
                 let mfp_option = (!mfp_after.is_identity()).then_some(mfp_after);
                 self.render_reduce(input, key_val_plan, plan, input_key, mfp_option)
             }
-            Plan::TopK { input, top_k_plan } => {
+            Plan::TopK {
+                input,
+                top_k_plan,
+                node_id: _,
+            } => {
                 let input = self.render_plan(*input);
                 self.render_topk(input, top_k_plan)
             }
-            Plan::Negate { input } => {
+            Plan::Negate { input, node_id: _ } => {
                 let input = self.render_plan(*input);
                 let (oks, errs) = input.as_specific_collection(None);
                 CollectionBundle::from_collections(oks.negate(), errs)
@@ -904,6 +926,7 @@ where
             Plan::Threshold {
                 input,
                 threshold_plan,
+                node_id: _,
             } => {
                 let input = self.render_plan(*input);
                 self.render_threshold(input, threshold_plan)
@@ -911,6 +934,7 @@ where
             Plan::Union {
                 inputs,
                 consolidate_output,
+                node_id: _,
             } => {
                 let mut oks = Vec::new();
                 let mut errs = Vec::new();
@@ -931,6 +955,7 @@ where
                 forms: keys,
                 input_key,
                 input_mfp,
+                node_id: _,
             } => {
                 let input = self.render_plan(*input);
                 input.ensure_collections(

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -112,7 +112,8 @@ SELECT 1 / 0
         "Constant": {
           "rows": {
             "Err": "DivisionByZero"
-          }
+          },
+          "node_id": 0
         }
       }
     }
@@ -159,7 +160,8 @@ EXPLAIN PHYSICAL PLAN WITH(no_fast_path) AS JSON FOR
                 1
               ]
             ]
-          }
+          },
+          "node_id": 0
         }
       }
     }
@@ -216,7 +218,8 @@ SELECT * FROM t
               }
             ]
           },
-          "plan": "PassArrangements"
+          "plan": "PassArrangements",
+          "node_id": 0
         }
       }
     }
@@ -246,7 +249,8 @@ SELECT * FROM u
             "arranged": [],
             "types": null
           },
-          "plan": "PassArrangements"
+          "plan": "PassArrangements",
+          "node_id": 0
         }
       }
     }
@@ -346,7 +350,8 @@ SELECT a + b, 1 FROM t
                 "input_arity": 2
               }
             ]
-          }
+          },
+          "node_id": 0
         }
       }
     }
@@ -386,7 +391,8 @@ SELECT c + d, 1 FROM u
               ],
               "input_arity": 2
             }
-          }
+          },
+          "node_id": 0
         }
       }
     }
@@ -487,7 +493,8 @@ SELECT * FROM ov
                       }
                     ]
                   },
-                  "plan": "PassArrangements"
+                  "plan": "PassArrangements",
+                  "node_id": 0
                 }
               },
               "forms": {
@@ -508,7 +515,8 @@ SELECT * FROM ov
                   1
                 ],
                 "input_arity": 2
-              }
+              },
+              "node_id": 1
             }
           },
           "top_k_plan": {
@@ -545,7 +553,8 @@ SELECT * FROM ov
               "arity": 2,
               "must_consolidate": true
             }
-          }
+          },
+          "node_id": 2
         }
       }
     }
@@ -623,7 +632,8 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                               "input_arity": 2
                             }
                           ]
-                        }
+                        },
+                        "node_id": 0
                       }
                     },
                     {
@@ -649,13 +659,16 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                                 ],
                                 "input_arity": 1
                               }
-                            }
+                            },
+                            "node_id": 1
                           }
-                        }
+                        },
+                        "node_id": 2
                       }
                     }
                   ],
-                  "consolidate_output": true
+                  "consolidate_output": true,
+                  "node_id": 3
                 }
               },
               "forms": {
@@ -688,7 +701,8 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                   0
                 ],
                 "input_arity": 1
-              }
+              },
+              "node_id": 4
             }
           },
           "threshold_plan": {
@@ -705,7 +719,8 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                 []
               ]
             }
-          }
+          },
+          "node_id": 5
         }
       }
     }
@@ -776,7 +791,8 @@ SELECT * FROM ov
                       }
                     ]
                   },
-                  "plan": "PassArrangements"
+                  "plan": "PassArrangements",
+                  "node_id": 0
                 }
               },
               "forms": {
@@ -797,7 +813,8 @@ SELECT * FROM ov
                   1
                 ],
                 "input_arity": 2
-              }
+              },
+              "node_id": 1
             }
           },
           "top_k_plan": {
@@ -834,7 +851,8 @@ SELECT * FROM ov
               "arity": 2,
               "must_consolidate": true
             }
-          }
+          },
+          "node_id": 2
         }
       }
     }
@@ -916,7 +934,8 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                   "input_arity": 2
                                 }
                               ]
-                            }
+                            },
+                            "node_id": 0
                           }
                         },
                         {
@@ -942,13 +961,16 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                     ],
                                     "input_arity": 1
                                   }
-                                }
+                                },
+                                "node_id": 1
                               }
-                            }
+                            },
+                            "node_id": 2
                           }
                         }
                       ],
-                      "consolidate_output": true
+                      "consolidate_output": true,
+                      "node_id": 3
                     }
                   },
                   "forms": {
@@ -981,7 +1003,8 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                       0
                     ],
                     "input_arity": 1
-                  }
+                  },
+                  "node_id": 4
                 }
               },
               "threshold_plan": {
@@ -998,7 +1021,8 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                     []
                   ]
                 }
-              }
+              },
+              "node_id": 5
             }
           },
           "body": {
@@ -1073,7 +1097,8 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                           "input_arity": 1
                         }
                       ]
-                    }
+                    },
+                    "node_id": 6
                   }
                 },
                 {
@@ -1145,13 +1170,16 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                           "input_arity": 1
                         }
                       ]
-                    }
+                    },
+                    "node_id": 7
                   }
                 }
               ],
-              "consolidate_output": false
+              "consolidate_output": false,
+              "node_id": 8
             }
-          }
+          },
+          "node_id": 9
         }
       }
     }
@@ -1232,7 +1260,8 @@ SELECT x * 5 FROM cte WHERE x = 5
                                       }
                                     ]
                                   },
-                                  "plan": "PassArrangements"
+                                  "plan": "PassArrangements",
+                                  "node_id": 0
                                 }
                               },
                               {
@@ -1252,7 +1281,8 @@ SELECT x * 5 FROM cte WHERE x = 5
                                             1
                                           ]
                                         ]
-                                      }
+                                      },
+                                      "node_id": 1
                                     }
                                   },
                                   "forms": {
@@ -1285,7 +1315,8 @@ SELECT x * 5 FROM cte WHERE x = 5
                                       0
                                     ],
                                     "input_arity": 1
-                                  }
+                                  },
+                                  "node_id": 2
                                 }
                               }
                             ],
@@ -1329,7 +1360,8 @@ SELECT x * 5 FROM cte WHERE x = 5
                                 ],
                                 "final_closure": null
                               }
-                            }
+                            },
+                            "node_id": 3
                           }
                         },
                         {
@@ -1355,13 +1387,16 @@ SELECT x * 5 FROM cte WHERE x = 5
                                     ],
                                     "input_arity": 1
                                   }
-                                }
+                                },
+                                "node_id": 4
                               }
-                            }
+                            },
+                            "node_id": 5
                           }
                         }
                       ],
-                      "consolidate_output": true
+                      "consolidate_output": true,
+                      "node_id": 6
                     }
                   },
                   "forms": {
@@ -1394,7 +1429,8 @@ SELECT x * 5 FROM cte WHERE x = 5
                       0
                     ],
                     "input_arity": 1
-                  }
+                  },
+                  "node_id": 7
                 }
               },
               "threshold_plan": {
@@ -1411,7 +1447,8 @@ SELECT x * 5 FROM cte WHERE x = 5
                     []
                   ]
                 }
-              }
+              },
+              "node_id": 8
             }
           },
           "mfp": {
@@ -1446,7 +1483,8 @@ SELECT x * 5 FROM cte WHERE x = 5
               }
             ],
             null
-          ]
+          ],
+          "node_id": 9
         }
       }
     }
@@ -1544,7 +1582,8 @@ SELECT generate_series(a, b) from t
                   }
                 ]
               },
-              "plan": "PassArrangements"
+              "plan": "PassArrangements",
+              "node_id": 0
             }
           },
           "func": "GenerateSeriesInt32",
@@ -1584,7 +1623,8 @@ SELECT generate_series(a, b) from t
             {
               "Column": 0
             }
-          ]
+          ],
+          "node_id": 1
         }
       }
     }
@@ -1640,7 +1680,8 @@ SELECT DISTINCT a, b FROM t
                   }
                 ]
               },
-              "plan": "PassArrangements"
+              "plan": "PassArrangements",
+              "node_id": 0
             }
           },
           "key_val_plan": {
@@ -1678,7 +1719,8 @@ SELECT DISTINCT a, b FROM t
               1
             ],
             "input_arity": 2
-          }
+          },
+          "node_id": 1
         }
       }
     }
@@ -1739,7 +1781,8 @@ GROUP BY a
                   }
                 ]
               },
-              "plan": "PassArrangements"
+              "plan": "PassArrangements",
+              "node_id": 0
             }
           },
           "key_val_plan": {
@@ -1825,7 +1868,8 @@ GROUP BY a
               2
             ],
             "input_arity": 3
-          }
+          },
+          "node_id": 1
         }
       }
     }
@@ -1904,7 +1948,8 @@ FROM t
                         "input_arity": 2
                       }
                     ]
-                  }
+                  },
+                  "node_id": 0
                 }
               },
               "key_val_plan": {
@@ -1983,7 +2028,8 @@ FROM t
                   1
                 ],
                 "input_arity": 2
-              }
+              },
+              "node_id": 1
             }
           },
           "body": {
@@ -2013,7 +2059,8 @@ FROM t
                           ],
                           "types": null
                         },
-                        "plan": "PassArrangements"
+                        "plan": "PassArrangements",
+                        "node_id": 2
                       }
                     },
                     "forms": {
@@ -2030,7 +2077,8 @@ FROM t
                         1
                       ],
                       "input_arity": 2
-                    }
+                    },
+                    "node_id": 8
                   }
                 },
                 {
@@ -2073,9 +2121,11 @@ FROM t
                                         "input_arity": 2
                                       }
                                     ]
-                                  }
+                                  },
+                                  "node_id": 3
                                 }
-                              }
+                              },
+                              "node_id": 4
                             }
                           },
                           {
@@ -2090,11 +2140,13 @@ FROM t
                                     1
                                   ]
                                 ]
-                              }
+                              },
+                              "node_id": 5
                             }
                           }
                         ],
-                        "consolidate_output": true
+                        "consolidate_output": true,
+                        "node_id": 6
                       }
                     },
                     "mfp": {
@@ -2137,13 +2189,16 @@ FROM t
                       ],
                       "input_arity": 0
                     },
-                    "input_key_val": null
+                    "input_key_val": null,
+                    "node_id": 7
                   }
                 }
               ],
-              "consolidate_output": false
+              "consolidate_output": false,
+              "node_id": 9
             }
-          }
+          },
+          "node_id": 10
         }
       }
     }
@@ -2199,7 +2254,8 @@ SELECT * FROM hierarchical_group_by
                   }
                 ]
               },
-              "plan": "PassArrangements"
+              "plan": "PassArrangements",
+              "node_id": 0
             }
           },
           "key_val_plan": {
@@ -2254,7 +2310,8 @@ SELECT * FROM hierarchical_group_by
               2
             ],
             "input_arity": 3
-          }
+          },
+          "node_id": 1
         }
       }
     }
@@ -2330,7 +2387,8 @@ MATERIALIZED VIEW hierarchical_global_mv
                         "input_arity": 2
                       }
                     ]
-                  }
+                  },
+                  "node_id": 0
                 }
               },
               "key_val_plan": {
@@ -2386,7 +2444,8 @@ MATERIALIZED VIEW hierarchical_global_mv
                   1
                 ],
                 "input_arity": 2
-              }
+              },
+              "node_id": 1
             }
           },
           "body": {
@@ -2416,7 +2475,8 @@ MATERIALIZED VIEW hierarchical_global_mv
                           ],
                           "types": null
                         },
-                        "plan": "PassArrangements"
+                        "plan": "PassArrangements",
+                        "node_id": 2
                       }
                     },
                     "forms": {
@@ -2433,7 +2493,8 @@ MATERIALIZED VIEW hierarchical_global_mv
                         1
                       ],
                       "input_arity": 2
-                    }
+                    },
+                    "node_id": 8
                   }
                 },
                 {
@@ -2476,9 +2537,11 @@ MATERIALIZED VIEW hierarchical_global_mv
                                         "input_arity": 2
                                       }
                                     ]
-                                  }
+                                  },
+                                  "node_id": 3
                                 }
-                              }
+                              },
+                              "node_id": 4
                             }
                           },
                           {
@@ -2493,11 +2556,13 @@ MATERIALIZED VIEW hierarchical_global_mv
                                     1
                                   ]
                                 ]
-                              }
+                              },
+                              "node_id": 5
                             }
                           }
                         ],
-                        "consolidate_output": true
+                        "consolidate_output": true,
+                        "node_id": 6
                       }
                     },
                     "mfp": {
@@ -2540,13 +2605,16 @@ MATERIALIZED VIEW hierarchical_global_mv
                       ],
                       "input_arity": 0
                     },
-                    "input_key_val": null
+                    "input_key_val": null,
+                    "node_id": 7
                   }
                 }
               ],
-              "consolidate_output": false
+              "consolidate_output": false,
+              "node_id": 9
             }
-          }
+          },
+          "node_id": 10
         }
       }
     }
@@ -2622,7 +2690,8 @@ SELECT * FROM hierarchical_global
                         "input_arity": 2
                       }
                     ]
-                  }
+                  },
+                  "node_id": 0
                 }
               },
               "key_val_plan": {
@@ -2670,7 +2739,8 @@ SELECT * FROM hierarchical_global
                   1
                 ],
                 "input_arity": 2
-              }
+              },
+              "node_id": 1
             }
           },
           "body": {
@@ -2700,7 +2770,8 @@ SELECT * FROM hierarchical_global
                           ],
                           "types": null
                         },
-                        "plan": "PassArrangements"
+                        "plan": "PassArrangements",
+                        "node_id": 2
                       }
                     },
                     "forms": {
@@ -2717,7 +2788,8 @@ SELECT * FROM hierarchical_global
                         1
                       ],
                       "input_arity": 2
-                    }
+                    },
+                    "node_id": 8
                   }
                 },
                 {
@@ -2760,9 +2832,11 @@ SELECT * FROM hierarchical_global
                                         "input_arity": 2
                                       }
                                     ]
-                                  }
+                                  },
+                                  "node_id": 3
                                 }
-                              }
+                              },
+                              "node_id": 4
                             }
                           },
                           {
@@ -2777,11 +2851,13 @@ SELECT * FROM hierarchical_global
                                     1
                                   ]
                                 ]
-                              }
+                              },
+                              "node_id": 5
                             }
                           }
                         ],
-                        "consolidate_output": true
+                        "consolidate_output": true,
+                        "node_id": 6
                       }
                     },
                     "mfp": {
@@ -2824,13 +2900,16 @@ SELECT * FROM hierarchical_global
                       ],
                       "input_arity": 0
                     },
-                    "input_key_val": null
+                    "input_key_val": null,
+                    "node_id": 7
                   }
                 }
               ],
-              "consolidate_output": false
+              "consolidate_output": false,
+              "node_id": 9
             }
-          }
+          },
+          "node_id": 10
         }
       }
     }
@@ -2891,7 +2970,8 @@ GROUP BY a
                   }
                 ]
               },
-              "plan": "PassArrangements"
+              "plan": "PassArrangements",
+              "node_id": 0
             }
           },
           "key_val_plan": {
@@ -3260,7 +3340,8 @@ GROUP BY a
               2
             ],
             "input_arity": 3
-          }
+          },
+          "node_id": 1
         }
       }
     }
@@ -3339,7 +3420,8 @@ FROM t
                         "input_arity": 2
                       }
                     ]
-                  }
+                  },
+                  "node_id": 0
                 }
               },
               "key_val_plan": {
@@ -3701,7 +3783,8 @@ FROM t
                   1
                 ],
                 "input_arity": 2
-              }
+              },
+              "node_id": 1
             }
           },
           "body": {
@@ -3731,7 +3814,8 @@ FROM t
                           ],
                           "types": null
                         },
-                        "plan": "PassArrangements"
+                        "plan": "PassArrangements",
+                        "node_id": 2
                       }
                     },
                     "forms": {
@@ -3748,7 +3832,8 @@ FROM t
                         1
                       ],
                       "input_arity": 2
-                    }
+                    },
+                    "node_id": 8
                   }
                 },
                 {
@@ -3791,9 +3876,11 @@ FROM t
                                         "input_arity": 2
                                       }
                                     ]
-                                  }
+                                  },
+                                  "node_id": 3
                                 }
-                              }
+                              },
+                              "node_id": 4
                             }
                           },
                           {
@@ -3808,11 +3895,13 @@ FROM t
                                     1
                                   ]
                                 ]
-                              }
+                              },
+                              "node_id": 5
                             }
                           }
                         ],
-                        "consolidate_output": true
+                        "consolidate_output": true,
+                        "node_id": 6
                       }
                     },
                     "mfp": {
@@ -3855,13 +3944,16 @@ FROM t
                       ],
                       "input_arity": 0
                     },
-                    "input_key_val": null
+                    "input_key_val": null,
+                    "node_id": 7
                   }
                 }
               ],
-              "consolidate_output": false
+              "consolidate_output": false,
+              "node_id": 9
             }
-          }
+          },
+          "node_id": 10
         }
       }
     }
@@ -3917,7 +4009,8 @@ MATERIALIZED VIEW collated_group_by_mv
                   }
                 ]
               },
-              "plan": "PassArrangements"
+              "plan": "PassArrangements",
+              "node_id": 0
             }
           },
           "key_val_plan": {
@@ -4369,7 +4462,8 @@ MATERIALIZED VIEW collated_group_by_mv
               6
             ],
             "input_arity": 7
-          }
+          },
+          "node_id": 1
         }
       }
     }
@@ -4425,7 +4519,8 @@ SELECT * FROM collated_group_by
                   }
                 ]
               },
-              "plan": "PassArrangements"
+              "plan": "PassArrangements",
+              "node_id": 0
             }
           },
           "key_val_plan": {
@@ -4869,7 +4964,8 @@ SELECT * FROM collated_group_by
               6
             ],
             "input_arity": 7
-          }
+          },
+          "node_id": 1
         }
       }
     }
@@ -4945,7 +5041,8 @@ MATERIALIZED VIEW collated_global_mv
                         "input_arity": 2
                       }
                     ]
-                  }
+                  },
+                  "node_id": 0
                 }
               },
               "key_val_plan": {
@@ -5390,7 +5487,8 @@ MATERIALIZED VIEW collated_global_mv
                   5
                 ],
                 "input_arity": 6
-              }
+              },
+              "node_id": 1
             }
           },
           "body": {
@@ -5428,7 +5526,8 @@ MATERIALIZED VIEW collated_global_mv
                           ],
                           "types": null
                         },
-                        "plan": "PassArrangements"
+                        "plan": "PassArrangements",
+                        "node_id": 2
                       }
                     },
                     "forms": {
@@ -5449,7 +5548,8 @@ MATERIALIZED VIEW collated_global_mv
                         5
                       ],
                       "input_arity": 6
-                    }
+                    },
+                    "node_id": 8
                   }
                 },
                 {
@@ -5500,9 +5600,11 @@ MATERIALIZED VIEW collated_global_mv
                                         "input_arity": 6
                                       }
                                     ]
-                                  }
+                                  },
+                                  "node_id": 3
                                 }
-                              }
+                              },
+                              "node_id": 4
                             }
                           },
                           {
@@ -5517,11 +5619,13 @@ MATERIALIZED VIEW collated_global_mv
                                     1
                                   ]
                                 ]
-                              }
+                              },
+                              "node_id": 5
                             }
                           }
                         ],
-                        "consolidate_output": true
+                        "consolidate_output": true,
+                        "node_id": 6
                       }
                     },
                     "mfp": {
@@ -5628,13 +5732,16 @@ MATERIALIZED VIEW collated_global_mv
                       ],
                       "input_arity": 0
                     },
-                    "input_key_val": null
+                    "input_key_val": null,
+                    "node_id": 7
                   }
                 }
               ],
-              "consolidate_output": false
+              "consolidate_output": false,
+              "node_id": 9
             }
-          }
+          },
+          "node_id": 10
         }
       }
     }
@@ -5710,7 +5817,8 @@ SELECT * FROM collated_global
                         "input_arity": 2
                       }
                     ]
-                  }
+                  },
+                  "node_id": 0
                 }
               },
               "key_val_plan": {
@@ -6147,7 +6255,8 @@ SELECT * FROM collated_global
                   5
                 ],
                 "input_arity": 6
-              }
+              },
+              "node_id": 1
             }
           },
           "body": {
@@ -6185,7 +6294,8 @@ SELECT * FROM collated_global
                           ],
                           "types": null
                         },
-                        "plan": "PassArrangements"
+                        "plan": "PassArrangements",
+                        "node_id": 2
                       }
                     },
                     "forms": {
@@ -6206,7 +6316,8 @@ SELECT * FROM collated_global
                         5
                       ],
                       "input_arity": 6
-                    }
+                    },
+                    "node_id": 8
                   }
                 },
                 {
@@ -6257,9 +6368,11 @@ SELECT * FROM collated_global
                                         "input_arity": 6
                                       }
                                     ]
-                                  }
+                                  },
+                                  "node_id": 3
                                 }
-                              }
+                              },
+                              "node_id": 4
                             }
                           },
                           {
@@ -6274,11 +6387,13 @@ SELECT * FROM collated_global
                                     1
                                   ]
                                 ]
-                              }
+                              },
+                              "node_id": 5
                             }
                           }
                         ],
-                        "consolidate_output": true
+                        "consolidate_output": true,
+                        "node_id": 6
                       }
                     },
                     "mfp": {
@@ -6385,13 +6500,16 @@ SELECT * FROM collated_global
                       ],
                       "input_arity": 0
                     },
-                    "input_key_val": null
+                    "input_key_val": null,
+                    "node_id": 7
                   }
                 }
               ],
-              "consolidate_output": false
+              "consolidate_output": false,
+              "node_id": 9
             }
-          }
+          },
+          "node_id": 10
         }
       }
     }
@@ -6450,7 +6568,8 @@ WHERE a = c AND d = e AND b + d > 42
                     }
                   ]
                 },
-                "plan": "PassArrangements"
+                "plan": "PassArrangements",
+                "node_id": 0
               }
             },
             {
@@ -6477,7 +6596,8 @@ WHERE a = c AND d = e AND b + d > 42
                         ],
                         "input_arity": 2
                       }
-                    }
+                    },
+                    "node_id": 1
                   }
                 },
                 "forms": {
@@ -6532,7 +6652,8 @@ WHERE a = c AND d = e AND b + d > 42
                     1
                   ],
                   "input_arity": 2
-                }
+                },
+                "node_id": 2
               }
             },
             {
@@ -6558,7 +6679,8 @@ WHERE a = c AND d = e AND b + d > 42
                         ],
                         "input_arity": 1
                       }
-                    }
+                    },
+                    "node_id": 3
                   }
                 },
                 "forms": {
@@ -6591,7 +6713,8 @@ WHERE a = c AND d = e AND b + d > 42
                     0
                   ],
                   "input_arity": 1
-                }
+                },
+                "node_id": 4
               }
             }
           ],
@@ -7112,7 +7235,8 @@ WHERE a = c AND d = e AND b + d > 42
                 }
               ]
             }
-          }
+          },
+          "node_id": 5
         }
       }
     }
@@ -7272,7 +7396,8 @@ WHERE a = c AND d = e AND f = a
                     }
                   ]
                 },
-                "plan": "PassArrangements"
+                "plan": "PassArrangements",
+                "node_id": 0
               }
             },
             {
@@ -7372,7 +7497,8 @@ WHERE a = c AND d = e AND f = a
                           "input_arity": 2
                         }
                       ]
-                    }
+                    },
+                    "node_id": 1
                   }
                 },
                 "forms": {
@@ -7428,7 +7554,8 @@ WHERE a = c AND d = e AND f = a
                     1
                   ],
                   "input_arity": 2
-                }
+                },
+                "node_id": 2
               }
             },
             {
@@ -7528,7 +7655,8 @@ WHERE a = c AND d = e AND f = a
                           "input_arity": 2
                         }
                       ]
-                    }
+                    },
+                    "node_id": 3
                   }
                 },
                 "forms": {
@@ -7570,7 +7698,8 @@ WHERE a = c AND d = e AND f = a
                     1
                   ],
                   "input_arity": 2
-                }
+                },
+                "node_id": 4
               }
             }
           ],
@@ -7969,7 +8098,8 @@ WHERE a = c AND d = e AND f = a
                 }
               ]
             }
-          }
+          },
+          "node_id": 5
         }
       }
     }
@@ -8028,7 +8158,8 @@ WHERE a = c and a = e
                     }
                   ]
                 },
-                "plan": "PassArrangements"
+                "plan": "PassArrangements",
+                "node_id": 0
               }
             },
             {
@@ -8067,7 +8198,8 @@ WHERE a = c and a = e
                     }
                   ]
                 },
-                "plan": "PassArrangements"
+                "plan": "PassArrangements",
+                "node_id": 1
               }
             },
             {
@@ -8106,7 +8238,8 @@ WHERE a = c and a = e
                     }
                   ]
                 },
-                "plan": "PassArrangements"
+                "plan": "PassArrangements",
+                "node_id": 2
               }
             }
           ],
@@ -8500,7 +8633,8 @@ WHERE a = c and a = e
                 }
               ]
             }
-          }
+          },
+          "node_id": 3
         }
       }
     }


### PR DESCRIPTION
This PR extends all `Plan` variants with `node_id` fields and makes the MIR->LIR lowering assign node IDs as `Plan`s are created. Making use of the new IDs is left as follow-up work.

This is part of the Operator Hydration Status Tracking design (https://github.com/MaterializeInc/materialize/pull/24265).

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/materialize/issues/23859.

### Tips for reviewer

Commits can be reviewed separately.

There is some duplication involved here that comes from the `node_id` field being repeated in every `Plan` variant. An alternative implementation that avoids this would be to wrap the `Plan` enum into a struct, like this:

```rust
struct Plan {
    node_id: NodeId,
    inner: PlanInner,
}

enum PlanInner {
    Constant { ... },
    ...
}
```

I tried out this alternative too, but it doesn't lead to less boilerplate:
* This affects all methods that work with `Plan`s, whereas the repeated-`node_id` approach only requires us to touch methods that aren't using `..` wildcards when matching on the enum.
* Methods working on `Plan`s usually (always?) need to unwrap and then wrap the `PlanInner` again.
* Matching on the enum becomes more verbose (e.g. `PlanInner::Constant` instead of `Plan::Constant`).
* We run into borrowing issues in some cases (e.g. `refine_source_mfps`).

In the end, working with a single recursive type is simpler than working with two mutually recursive ones.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
