### PR TITLE
dyncfg: replace `Config::new` with macro for named args

### DIFF
--- a/src/dyncfg/Cargo.toml
+++ b/src/dyncfg/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 workspace = true
 
 [dependencies]
-mz-ore = { path = "../ore", default-features = false, features = ["proptest"] }
+mz-ore = { path = "../ore", default-features = false, features = ["proptest", "test"] }
 mz-proto = { path = "../proto" }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -23,7 +23,7 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use futures_util::stream::{FuturesUnordered, StreamExt};
-use mz_dyncfg::Config;
+use mz_dyncfg::{config, Config};
 use mz_ore::cast::CastFrom;
 use mz_ore::task::{JoinHandle, JoinHandleExt};
 use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsBuilder};
@@ -225,11 +225,11 @@ pub struct BatchBuilderConfig {
 }
 
 // TODO: Remove this once we're comfortable that there aren't any bugs.
-pub(crate) const BATCH_DELETE_ENABLED: Config<bool> = Config::new(
-    "persist_batch_delete_enabled",
-    false,
-    "Whether to actually delete blobs when batch delete is called (Materialize).",
-);
+pub(crate) const BATCH_DELETE_ENABLED: Config<bool> = config! {
+    name: "persist_batch_delete_enabled",
+    default: false,
+    desc: "Whether to actually delete blobs when batch delete is called (Materialize).",
+};
 
 /// A target maximum size of blob payloads in bytes. If a logical "batch" is
 /// bigger than this, it will be broken up into smaller, independent pieces.
@@ -237,11 +237,11 @@ pub(crate) const BATCH_DELETE_ENABLED: Config<bool> = Config::new(
 /// always respect it). This target size doesn't apply for an individual update
 /// that exceeds it in size, but that scenario is almost certainly a mis-use of
 /// the system.
-pub(crate) const BLOB_TARGET_SIZE: Config<usize> = Config::new(
-    "persist_blob_target_size",
-    128 * MiB,
-    "A target maximum size of persist blob payloads in bytes (Materialize).",
-);
+pub(crate) const BLOB_TARGET_SIZE: Config<usize> = config! {
+    name: "persist_blob_target_size",
+    default: 128 * MiB,
+    desc: "A target maximum size of persist blob payloads in bytes (Materialize).",
+};
 
 impl BatchBuilderConfig {
     /// Initialize a batch builder config based on a snapshot of the Persist config.

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use mz_build_info::BuildInfo;
-use mz_dyncfg::{Config, ConfigSet, ConfigType, ConfigUpdates};
+use mz_dyncfg::{config, Config, ConfigSet, ConfigType, ConfigUpdates};
 use mz_ore::now::NowFn;
 use mz_persist::cfg::BlobKnobs;
 use mz_persist::retry::Retry;
@@ -315,13 +315,13 @@ impl PersistConfig {
 /// The minimum TTL of a connection to Postgres/CRDB before it is proactively
 /// terminated. Connections are routinely culled to balance load against the
 /// downstream database.
-const CONSENSUS_CONNECTION_POOL_TTL: Config<Duration> = Config::new(
-    "persist_consensus_connection_pool_ttl",
-    Duration::from_secs(300),
-    "\
+const CONSENSUS_CONNECTION_POOL_TTL: Config<Duration> = config! {
+    name: "persist_consensus_connection_pool_ttl",
+    default: Duration::from_secs(300),
+    desc: "\
     The minimum TTL of a Consensus connection to Postgres/CRDB before it is \
     proactively terminated",
-);
+};
 
 /// The minimum time between TTLing connections to Postgres/CRDB. This delay is
 /// used to stagger reconnections to avoid stampedes and high tail latencies.
@@ -330,31 +330,31 @@ const CONSENSUS_CONNECTION_POOL_TTL: Config<Duration> = Config::new(
 /// value of `consensus_connection_pool_ttl /
 /// consensus_connection_pool_max_size` is likely a good place to start so that
 /// all connections are rotated when the pool is fully used.
-const CONSENSUS_CONNECTION_POOL_TTL_STAGGER: Config<Duration> = Config::new(
-    "persist_consensus_connection_pool_ttl_stagger",
-    Duration::from_secs(6),
-    "The minimum time between TTLing Consensus connections to Postgres/CRDB.",
-);
+const CONSENSUS_CONNECTION_POOL_TTL_STAGGER: Config<Duration> = config! {
+    name: "persist_consensus_connection_pool_ttl_stagger",
+    default: Duration::from_secs(6),
+    desc: "The minimum time between TTLing Consensus connections to Postgres/CRDB.",
+};
 
 /// The duration to wait for a Consensus Postgres/CRDB connection to be made
 /// before retrying.
-pub const CRDB_CONNECT_TIMEOUT: Config<Duration> = Config::new(
-    "crdb_connect_timeout",
-    Duration::from_secs(5),
-    "The time to connect to CockroachDB before timing out and retrying.",
-);
+pub const CRDB_CONNECT_TIMEOUT: Config<Duration> = config! {
+    name: "crdb_connect_timeout",
+    default: Duration::from_secs(5),
+    desc: "The time to connect to CockroachDB before timing out and retrying.",
+};
 
 /// The TCP user timeout for a Consensus Postgres/CRDB connection. Specifies the
 /// amount of time that transmitted data may remain unacknowledged before the
 /// TCP connection is forcibly closed.
-pub const CRDB_TCP_USER_TIMEOUT: Config<Duration> = Config::new(
-    "crdb_tcp_user_timeout",
-    Duration::from_secs(30),
-    "\
+pub const CRDB_TCP_USER_TIMEOUT: Config<Duration> = config! {
+    name: "crdb_tcp_user_timeout",
+    default: Duration::from_secs(30),
+    desc: "\
     The TCP timeout for connections to CockroachDB. Specifies the amount of \
     time that transmitted data may remain unacknowledged before the TCP \
     connection is forcibly closed.",
-);
+};
 
 impl PostgresClientKnobs for PersistConfig {
     fn connection_pool_max_size(&self) -> usize {

--- a/src/persist-client/src/internal/cache.rs
+++ b/src/persist-client/src/internal/cache.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use mz_dyncfg::{Config, ConfigSet};
+use mz_dyncfg::{config, Config, ConfigSet};
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastFrom;
 use mz_persist::location::{Atomicity, Blob, BlobMetadata, ExternalError};
@@ -30,16 +30,16 @@ pub struct BlobMemCache {
     blob: Arc<dyn Blob + Send + Sync>,
 }
 
-pub(crate) const BLOB_CACHE_MEM_LIMIT_BYTES: Config<usize> = Config::new(
-    "persist_blob_cache_mem_limit_bytes",
+pub(crate) const BLOB_CACHE_MEM_LIMIT_BYTES: Config<usize> = config! {
+    name: "persist_blob_cache_mem_limit_bytes",
     // This initial value was tuned via a one-time experiment that showed an
     // environment running our demo "auction" source + mv got 90%+ cache hits
     // with a 1 MiB cache. This doesn't scale up to prod data sizes and doesn't
     // help with multi-process replicas, but the memory usage seems
     // unobjectionable enough to have it for the cases that it does help.
-    1024 * 1024,
-    "Capacity of in-mem blob cache in bytes. Only takes effect on restart (Materialize).",
-);
+    default: 1024 * 1024,
+    desc: "Capacity of in-mem blob cache in bytes. Only takes effect on restart (Materialize).",
+};
 
 impl BlobMemCache {
     pub fn new(

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -19,7 +19,7 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use futures_util::TryFutureExt;
-use mz_dyncfg::Config;
+use mz_dyncfg::{config, Config};
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
 use mz_ore::task::{spawn, JoinHandle};
@@ -69,11 +69,11 @@ pub struct CompactRes<T> {
     pub output: HollowBatch<T>,
 }
 
-pub(crate) const STREAMING_COMPACTION_ENABLED: Config<bool> = Config::new(
-    "persist_streaming_compaction_enabled",
-    false,
-    "use the new streaming consolidate during compaction",
-);
+pub(crate) const STREAMING_COMPACTION_ENABLED: Config<bool> = config! {
+    name: "persist_streaming_compaction_enabled",
+    default: false,
+    desc: "use the new streaming consolidate during compaction",
+};
 
 /// A snapshot of dynamic configs to make it easier to reason about an
 /// individual run of compaction.
@@ -131,13 +131,13 @@ impl<K, V, T, D> Clone for Compactor<K, V, T, D> {
 /// In Compactor::compact_and_apply_background, the minimum amount of time to
 /// allow a compaction request to run before timing it out. A request may be
 /// given a timeout greater than this value depending on the inputs' size
-pub(crate) const COMPACTION_MINIMUM_TIMEOUT: Config<Duration> = Config::new(
-    "persist_compaction_minimum_timeout",
-    Duration::from_secs(90),
-    "\
+pub(crate) const COMPACTION_MINIMUM_TIMEOUT: Config<Duration> = config! {
+    name: "persist_compaction_minimum_timeout",
+    default: Duration::from_secs(90),
+    desc: "\
     The minimum amount of time to allow a persist compaction request to run \
     before timing it out (Materialize).",
-);
+};
 
 impl<K, V, T, D> Compactor<K, V, T, D>
 where

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -19,7 +19,7 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use futures::stream::{FuturesUnordered, StreamExt};
 use futures::FutureExt;
-use mz_dyncfg::{Config, ConfigSet};
+use mz_dyncfg::{config, Config, ConfigSet};
 use mz_ore::error::ErrorExt;
 #[allow(unused_imports)] // False positive.
 use mz_ore::fmt::FormatBuffer;
@@ -1106,23 +1106,23 @@ where
     }
 }
 
-pub(crate) const NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF: Config<Duration> = Config::new(
-    "persist_next_listen_batch_retryer_initial_backoff",
-    Duration::from_millis(1200), // pubsub is on by default!
-    "The initial backoff when polling for new batches from a Listen or Subscribe.",
-);
+pub(crate) const NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF: Config<Duration> = config! {
+    name: "persist_next_listen_batch_retryer_initial_backoff",
+    default: Duration::from_millis(1200), // pubsub is on by default!
+    desc: "The initial backoff when polling for new batches from a Listen or Subscribe.",
+};
 
-pub(crate) const NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER: Config<u32> = Config::new(
-    "persist_next_listen_batch_retryer_multiplier",
-    2,
-    "The backoff multiplier when polling for new batches from a Listen or Subscribe.",
-);
+pub(crate) const NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER: Config<u32> = config! {
+    name: "persist_next_listen_batch_retryer_multiplier",
+    default: 2,
+    desc: "The backoff multiplier when polling for new batches from a Listen or Subscribe.",
+};
 
-pub(crate) const NEXT_LISTEN_BATCH_RETRYER_CLAMP: Config<Duration> = Config::new(
-    "persist_next_listen_batch_retryer_clamp",
-    Duration::from_millis(100), // pubsub is on by default!
-    "The backoff clamp duration when polling for new batches from a Listen or Subscribe.",
-);
+pub(crate) const NEXT_LISTEN_BATCH_RETRYER_CLAMP: Config<Duration> = config! {
+    name: "persist_next_listen_batch_retryer_clamp",
+    default: Duration::from_millis(100), // pubsub is on by default!
+    desc: "The backoff clamp duration when polling for new batches from a Listen or Subscribe.",
+};
 
 fn next_listen_batch_retry_params(cfg: &ConfigSet) -> RetryParameters {
     RetryParameters {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
-use mz_dyncfg::Config;
+use mz_dyncfg::{config, Config};
 use mz_ore::cast::CastFrom;
 use mz_ore::now::EpochMillis;
 use mz_persist::location::SeqNo;
@@ -60,11 +60,11 @@ include!(concat!(
 /// incremental GC, this threshold will determine about how many live diffs are
 /// held in Consensus. Lowering this value decreases the live diff count at the
 /// cost of more maintenance work + blob writes.
-pub(crate) const ROLLUP_THRESHOLD: Config<usize> = Config::new(
-    "persist_rollup_threshold",
-    128,
-    "The number of seqnos between rollups.",
-);
+pub(crate) const ROLLUP_THRESHOLD: Config<usize> = config! {
+    name: "persist_rollup_threshold",
+    default: 128,
+    desc: "The number of seqnos between rollups.",
+};
 
 /// A token to disambiguate state commands that could not otherwise be
 /// idempotent.

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -74,41 +74,41 @@ pub mod metrics {
 pub mod operators {
     //! [timely] operators for reading and writing persist Shards.
 
-    use mz_dyncfg::Config;
+    use mz_dyncfg::{config, Config};
 
     pub mod shard_source;
 
     // TODO(cfg): Move this next to the use.
-    pub(crate) const PERSIST_SINK_MINIMUM_BATCH_UPDATES: Config<usize> = Config::new(
-        "persist_sink_minimum_batch_updates",
-        0,
-        "\
+    pub(crate) const PERSIST_SINK_MINIMUM_BATCH_UPDATES: Config<usize> = config! {
+        name: "persist_sink_minimum_batch_updates",
+        default: 0,
+        desc: "\
     In the compute persist sink, workers with less than the minimum number of \
     updates will flush their records to single downstream worker to be batched \
     up there... in the hopes of grouping our updates into fewer, larger \
     batches.",
-    );
+    };
 
     // TODO(cfg): Move this next to the use.
-    pub(crate) const STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES: Config<usize> = Config::new(
-        "storage_persist_sink_minimum_batch_updates",
+    pub(crate) const STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES: Config<usize> = config! {
+        name: "storage_persist_sink_minimum_batch_updates",
         // Reasonable default based on our experience in production.
-        1024,
-        "\
+        default: 1024,
+        desc: "\
     In the storage persist sink, workers with less than the minimum number of \
     updates will flush their records to single downstream worker to be batched \
     up there... in the hopes of grouping our updates into fewer, larger \
     batches.",
-    );
+    };
 
     // TODO(cfg): Move this next to the use.
-    pub(crate) const STORAGE_SOURCE_DECODE_FUEL: Config<usize> = Config::new(
-        "storage_source_decode_fuel",
-        1_000_000,
-        "\
+    pub(crate) const STORAGE_SOURCE_DECODE_FUEL: Config<usize> = config! {
+        name: "storage_source_decode_fuel",
+        default: 1_000_000,
+        desc: "\
         The maximum amount of work to do in the persist_source mfp_and_decode \
         operator before yielding.",
-    );
+    };
 }
 pub mod iter;
 pub mod read;

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -20,7 +20,7 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use futures::Stream;
-use mz_dyncfg::Config;
+use mz_dyncfg::{config, Config};
 use mz_ore::now::EpochMillis;
 use mz_ore::task::{AbortOnDropHandle, JoinHandle, RuntimeExt};
 use mz_persist::location::{Blob, SeqNo};
@@ -554,11 +554,11 @@ where
 
 /// Length of time after a reader's last operation after which the reader may be
 /// expired.
-pub(crate) const READER_LEASE_DURATION: Config<Duration> = Config::new(
-    "persist_reader_lease_duration",
-    Duration::from_secs(60 * 15),
-    "The time after which we'll clean up stale read leases",
-);
+pub(crate) const READER_LEASE_DURATION: Config<Duration> = config! {
+    name: "persist_reader_lease_duration",
+    default: Duration::from_secs(60 * 15),
+    desc: "The time after which we'll clean up stale read leases",
+};
 
 impl<K, V, T, D> ReadHandle<K, V, T, D>
 where
@@ -983,11 +983,11 @@ where
     }
 }
 
-pub(crate) const STREAMING_SNAPSHOT_AND_FETCH_ENABLED: Config<bool> = Config::new(
-    "persist_streaming_snapshot_and_fetch_enabled",
-    false,
-    "use the new streaming consolidate during snapshot_and_fetch",
-);
+pub(crate) const STREAMING_SNAPSHOT_AND_FETCH_ENABLED: Config<bool> = config! {
+    name: "persist_streaming_snapshot_and_fetch_enabled",
+    default: false,
+    desc: "use the new streaming consolidate during snapshot_and_fetch",
+};
 
 impl<K, V, T, D> ReadHandle<K, V, T, D>
 where

--- a/src/persist-client/src/rpc.rs
+++ b/src/persist-client/src/rpc.rs
@@ -23,7 +23,7 @@ use anyhow::{anyhow, Error};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::Stream;
-use mz_dyncfg::Config;
+use mz_dyncfg::{config, Config};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::{HashMap, HashSet};
 use mz_ore::metrics::MetricsRegistry;
@@ -55,20 +55,20 @@ use crate::metrics::Metrics;
 use crate::ShardId;
 
 /// Determines whether PubSub clients should connect to the PubSub server.
-pub(crate) const PUBSUB_CLIENT_ENABLED: Config<bool> = Config::new(
-    "persist_pubsub_client_enabled",
-    true,
-    "Whether to connect to the Persist PubSub service.",
-);
+pub(crate) const PUBSUB_CLIENT_ENABLED: Config<bool> = config! {
+    name: "persist_pubsub_client_enabled",
+    default: true,
+    desc: "Whether to connect to the Persist PubSub service.",
+};
 
 /// For connected clients, determines whether to push state diffs to the PubSub
 /// server. For the server, determines whether to broadcast state diffs to
 /// subscribed clients.
-pub(crate) const PUBSUB_PUSH_DIFF_ENABLED: Config<bool> = Config::new(
-    "persist_pubsub_push_diff_enabled",
-    true,
-    "Whether to push state diffs to Persist PubSub.",
-);
+pub(crate) const PUBSUB_PUSH_DIFF_ENABLED: Config<bool> = config! {
+    name: "persist_pubsub_push_diff_enabled",
+    default: true,
+    desc: "Whether to push state diffs to Persist PubSub.",
+};
 
 /// Top-level Trait to create a PubSubClient.
 ///

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -11,7 +11,7 @@
 
 use std::borrow::Cow;
 
-use mz_dyncfg::{Config, ConfigSet};
+use mz_dyncfg::{config, Config, ConfigSet};
 use mz_persist::indexed::columnar::ColumnarRecords;
 use mz_persist_types::columnar::{PartEncoder, Schema};
 use mz_persist_types::part::{Part, PartBuilder};
@@ -24,49 +24,49 @@ use crate::internal::encoding::Schemas;
 use crate::ShardId;
 
 /// Percent of filtered data to opt in to correctness auditing.
-pub(crate) const STATS_AUDIT_PERCENT: Config<usize> = Config::new(
-    "persist_stats_audit_percent",
-    0,
-    "Percent of filtered data to opt in to correctness auditing (Materialize).",
-);
+pub(crate) const STATS_AUDIT_PERCENT: Config<usize> = config! {
+    name: "persist_stats_audit_percent",
+    default: 0,
+    desc: "Percent of filtered data to opt in to correctness auditing (Materialize).",
+};
 
 /// Computes and stores statistics about each batch part.
 ///
 /// These can be used at read time to entirely skip fetching a part based on its
 /// statistics. See [STATS_FILTER_ENABLED].
-pub(crate) const STATS_COLLECTION_ENABLED: Config<bool> = Config::new(
-    "persist_stats_collection_enabled",
-    true,
-    "\
+pub(crate) const STATS_COLLECTION_ENABLED: Config<bool> = config! {
+    name: "persist_stats_collection_enabled",
+    default: true,
+    desc: "\
     Whether to calculate and record statistics about the data stored in \
     persist to be used at read time, see persist_stats_filter_enabled \
     (Materialize).",
-);
+};
 
 /// Uses previously computed statistics about batch parts to entirely skip
 /// fetching them at read time.
 ///
 /// See `STATS_COLLECTION_ENABLED`.
-pub const STATS_FILTER_ENABLED: Config<bool> = Config::new(
-    "persist_stats_filter_enabled",
-    true,
-    "\
+pub const STATS_FILTER_ENABLED: Config<bool> = config! {
+    name: "persist_stats_filter_enabled",
+    default: true,
+    desc: "\
     Whether to use recorded statistics about the data stored in persist to \
     filter at read time, see persist_stats_collection_enabled (Materialize).",
-);
+};
 
 /// The budget (in bytes) of how many stats to write down per batch part. When
 /// the budget is exceeded, stats will be trimmed away according to a variety of
 /// heuristics.
-pub(crate) const STATS_BUDGET_BYTES: Config<usize> = Config::new(
-    "persist_stats_budget_bytes",
-    1024,
-    "The budget (in bytes) of how many stats to maintain per batch part.",
-);
+pub(crate) const STATS_BUDGET_BYTES: Config<usize> = config! {
+    name: "persist_stats_budget_bytes",
+    default: 1024,
+    desc: "The budget (in bytes) of how many stats to maintain per batch part.",
+};
 
-pub(crate) const STATS_UNTRIMMABLE_COLUMNS_EQUALS: Config<String> = Config::new(
-    "persist_stats_untrimmable_columns_equals",
-    concat!(
+pub(crate) const STATS_UNTRIMMABLE_COLUMNS_EQUALS: Config<String> = config! {
+    name: "persist_stats_untrimmable_columns_equals",
+    default: concat!(
         // If we trim the "err" column, then we can't ever use pushdown on a
         // part (because it could have >0 errors).
         "err,",
@@ -78,29 +78,29 @@ pub(crate) const STATS_UNTRIMMABLE_COLUMNS_EQUALS: Config<String> = Config::new(
         // See <https://fivetran.com/docs/using-fivetran/features#capturedeletes>.
         "_fivetran_deleted,",
     ),
-    "\
+    desc: "\
     Which columns to always retain during persist stats trimming. Any column \
     with a name exactly equal (case-insensitive) to one of these will be kept. \
     Comma separated list.",
-);
+};
 
-pub(crate) const STATS_UNTRIMMABLE_COLUMNS_PREFIX: Config<String> = Config::new(
-    "persist_stats_untrimmable_columns_prefix",
-    concat!("last_,",),
-    "\
+pub(crate) const STATS_UNTRIMMABLE_COLUMNS_PREFIX: Config<String> = config! {
+    name: "persist_stats_untrimmable_columns_prefix",
+    default: concat!("last_,",),
+    desc: "\
     Which columns to always retain during persist stats trimming. Any column \
     with a name starting with (case-insensitive) one of these will be kept. \
     Comma separated list.",
-);
+};
 
-pub(crate) const STATS_UNTRIMMABLE_COLUMNS_SUFFIX: Config<String> = Config::new(
-    "persist_stats_untrimmable_columns_suffix",
-    concat!("timestamp,", "time,", "_at,", "_tstamp,"),
-    "\
+pub(crate) const STATS_UNTRIMMABLE_COLUMNS_SUFFIX: Config<String> = config! {
+    name: "persist_stats_untrimmable_columns_suffix",
+    default: concat!("timestamp,", "time,", "_at,", "_tstamp,"),
+    desc: "\
     Which columns to always retain during persist stats trimming. Any column \
     with a name ending with (case-insensitive) one of these will be kept. \
     Comma separated list.",
-);
+};
 
 pub(crate) fn untrimmable_columns(cfg: &ConfigSet) -> UntrimmableColumns {
     fn split(x: String) -> Vec<Cow<'static, str>> {

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::Hashable;
-use mz_dyncfg::{Config, ConfigSet};
+use mz_dyncfg::{config, Config, ConfigSet};
 use mz_ore::cast::CastFrom;
 use mz_persist_client::cfg::RetryParameters;
 use mz_persist_client::operators::shard_source::{shard_source, SnapshotMode};
@@ -421,23 +421,23 @@ where
     (passthrough_stream, shutdown_button.press_on_drop())
 }
 
-pub(crate) const DATA_SHARD_RETRYER_INITIAL_BACKOFF: Config<Duration> = Config::new(
-    "persist_txns_data_shard_retryer_initial_backoff",
-    Duration::from_millis(1024),
-    "The initial backoff when polling for new batches from a txns data shard persist_source.",
-);
+pub(crate) const DATA_SHARD_RETRYER_INITIAL_BACKOFF: Config<Duration> = config! {
+    name: "persist_txns_data_shard_retryer_initial_backoff",
+    default: Duration::from_millis(1024),
+    desc: "The initial backoff when polling for new batches from a txns data shard persist_source.",
+};
 
-pub(crate) const DATA_SHARD_RETRYER_MULTIPLIER: Config<u32> = Config::new(
-    "persist_txns_data_shard_retryer_multiplier",
-    2,
-    "The backoff multiplier when polling for new batches from a txns data shard persist_source.",
-);
+pub(crate) const DATA_SHARD_RETRYER_MULTIPLIER: Config<u32> = config! {
+    name: "persist_txns_data_shard_retryer_multiplier",
+    default: 2,
+    desc: "The backoff multiplier when polling for new batches from a txns data shard persist_source.",
+};
 
-pub(crate) const DATA_SHARD_RETRYER_CLAMP: Config<Duration> = Config::new(
-    "persist_txns_data_shard_retryer_clamp",
-    Duration::from_secs(16),
-    "The backoff clamp duration when polling for new batches from a txns data shard persist_source.",
-);
+pub(crate) const DATA_SHARD_RETRYER_CLAMP: Config<Duration> = config! {
+    name: "persist_txns_data_shard_retryer_clamp",
+    default: Duration::from_secs(16),
+    desc: "The backoff clamp duration when polling for new batches from a txns data shard persist_source.",
+};
 
 /// Retry configuration for persist-txns data shard override of
 /// `next_listen_batch`.


### PR DESCRIPTION
Resolving a code review comment from when the library was introduced.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

I can't decide how I feel about this overall! Scattered thoughts:
- Looking at the diff, I personally don't find it to be a big readability win. Nikhil, since this was originally your comment, very curious if you do.
- As always, the macro invocation semi-breaks rustfmt
- We'd need a macro to get file and line numbers, but it doesn't really get us anything right now and unclear if it gets us much long-term.
  - If we wanted to expose this to Vars (append it into the description?) could be pretty cool.
  - Could also use it to allow duplicate registration of the same name, from the same file+line. Combined with static registry, this would let you put a config directly into the method it's used. For configs used in a single place, I'm fond of the idea of being able to put the definition right next to the usage, even for impls with generic args, but maybe that's going a little far? Example:

        impl<T> Foo<T>
            fn foo(cfg: &ConfigSet) {
                const BAR: Config<usize> = config! { ... };
                if BAR.get(cfg) { ... }
            }
        }

- Requires an extra import, which is fine, but a little clunky.
- I recall the macro being necessary to implement a static reg using `inventory` but dunno if the same is true for `ctor`.
- Feels like the macro gives us some options that might help ergonomics for e.g. Dennis's "config category" ask, but I haven't thought about this much.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
