### PR TITLE
Fix implementation of RETAIN HISTORY for indexes

### DIFF
--- a/misc/python/materialize/checks/all_checks/alter_index.py
+++ b/misc/python/materialize/checks/all_checks/alter_index.py
@@ -56,8 +56,8 @@ class AlterIndex(Check):
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "B${kafka-ingest.iteration}"}
 
-                > ALTER INDEX alter_index_table_primary_idx SET (LOGICAL COMPACTION WINDOW = '1ms');
-                > ALTER INDEX alter_index_source_primary_idx SET (LOGICAL COMPACTION WINDOW = '1ms');
+                > ALTER INDEX alter_index_table_primary_idx SET (RETAIN HISTORY = FOR '1ms');
+                > ALTER INDEX alter_index_source_primary_idx SET (RETAIN HISTORY = FOR '1ms');
 
                 > INSERT INTO alter_index_table SELECT 'C' || generate_series FROM generate_series(1,10000);
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
@@ -79,8 +79,8 @@ class AlterIndex(Check):
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "D${kafka-ingest.iteration}"}
 
-                > ALTER INDEX alter_index_table_primary_idx SET (LOGICAL COMPACTION WINDOW = '1h');
-                > ALTER INDEX alter_index_source_primary_idx SET (LOGICAL COMPACTION WINDOW = '1h');
+                > ALTER INDEX alter_index_table_primary_idx SET (RETAIN HISTORY = FOR '1h');
+                > ALTER INDEX alter_index_source_primary_idx SET (RETAIN HISTORY = FOR '1h');
 
                 > INSERT INTO alter_index_table SELECT 'E' || generate_series FROM generate_series(1,10000);
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000

--- a/src/adapter-types/src/compaction.rs
+++ b/src/adapter-types/src/compaction.rs
@@ -42,6 +42,12 @@ pub enum CompactionWindow {
     Duration(Timestamp),
 }
 
+impl Default for CompactionWindow {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
 impl From<CompactionWindow> for ReadPolicy<Timestamp> {
     fn from(value: CompactionWindow) -> Self {
         let time = match value {

--- a/src/adapter-types/src/compaction.rs
+++ b/src/adapter-types/src/compaction.rs
@@ -32,20 +32,15 @@ pub const SINCE_GRANULARITY: mz_repr::Timestamp = mz_repr::Timestamp::new(1000);
 
 // A common type (that is usable by the sql crate and also can implement various methods on types in
 // storage) to express compaction windows.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Default, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CompactionWindow {
     /// Unspecified by the user, use a system-provided default.
+    #[default]
     Default,
     /// Disable compaction.
     DisableCompaction,
     /// Create a compaction window for a specified duration.
     Duration(Timestamp),
-}
-
-impl Default for CompactionWindow {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 impl From<CompactionWindow> for ReadPolicy<Timestamp> {

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -959,7 +959,8 @@ impl CatalogState {
                 conn_id: None,
                 resolved_ids,
                 cluster_id: index.cluster_id,
-                custom_logical_compaction_window,
+                custom_logical_compaction_window: custom_logical_compaction_window
+                    .or(index.compaction_window),
                 is_retained_metrics_object,
             }),
             Plan::CreateSink(CreateSinkPlan {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2236,23 +2236,6 @@ impl Coordinator {
             return min_as_of;
         }
 
-        // // Advancing the `as_of` to the write frontier means that we lose some historical data.
-        // // That might be acceptable for the default 1-second index compaction window, but not for
-        // // retained-metrics indexes. So we need to regress the write frontier by the retention
-        // // duration of the index.
-        // //
-        // // NOTE: If we ever allow custom index compaction windows, we'll need to apply those here
-        // // as well.
-        // let lag = if is_retained_metrics_index {
-        //     let retention = self.catalog().state().system_config().metrics_retention();
-        //     Timestamp::new(u64::try_from(retention.as_millis()).unwrap_or_else(|_| {
-        //         tracing::error!("absurd metrics retention duration: {retention:?}");
-        //         u64::MAX
-        //     }))
-        // } else {
-        //     DEFAULT_LOGICAL_COMPACTION_WINDOW_TS
-        // };
-
         let max_compaction_frontier = if let Some(lag) = compaction_lag {
             let time = write_frontier.clone().into_option().expect("checked above");
             let time = time.saturating_sub(lag);

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2693,7 +2693,13 @@ impl Coordinator {
         &mut self,
         plan: plan::AlterIndexSetOptionsPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        self.set_index_options(plan.id, plan.options)?;
+        for o in plan.options {
+            match o {
+                IndexOption::RetainHistory(window) => {
+                    self.set_index_compaction_window(plan.id, window)?;
+                }
+            }
+        }
         Ok(ExecuteResponse::AlteredObject(ObjectType::Index))
     }
 
@@ -2701,39 +2707,29 @@ impl Coordinator {
         &mut self,
         plan: plan::AlterIndexResetOptionsPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let mut options = Vec::with_capacity(plan.options.len());
         for o in plan.options {
-            options.push(match o {
-                IndexOptionName::LogicalCompactionWindow => {
-                    IndexOption::LogicalCompactionWindow(CompactionWindow::Default)
-                }
-            });
-        }
-
-        self.set_index_options(plan.id, options)?;
-
-        Ok(ExecuteResponse::AlteredObject(ObjectType::Index))
-    }
-
-    pub(super) fn set_index_options(
-        &mut self,
-        id: GlobalId,
-        options: Vec<IndexOption>,
-    ) -> Result<(), AdapterError> {
-        for o in options {
             match o {
-                IndexOption::LogicalCompactionWindow(window) => {
-                    // The index is on a specific cluster.
-                    let cluster = self
-                        .catalog()
-                        .get_entry(&id)
-                        .index()
-                        .expect("setting options on index")
-                        .cluster_id;
-                    self.update_compute_base_read_policy(cluster, id, window.into());
+                IndexOptionName::RetainHistory => {
+                    self.set_index_compaction_window(plan.id, CompactionWindow::Default)?;
                 }
             }
         }
+        Ok(ExecuteResponse::AlteredObject(ObjectType::Index))
+    }
+
+    pub(super) fn set_index_compaction_window(
+        &mut self,
+        id: GlobalId,
+        window: CompactionWindow,
+    ) -> Result<(), AdapterError> {
+        // The index is on a specific cluster.
+        let cluster = self
+            .catalog()
+            .get_entry(&id)
+            .index()
+            .expect("setting options on index")
+            .cluster_id;
+        self.update_compute_base_read_policy(cluster, id, window.into());
         Ok(())
     }
 

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -338,8 +338,8 @@ impl Coordinator {
                             on,
                             keys,
                             cluster_id,
+                            compaction_window,
                         },
-                    options,
                     if_not_exists,
                 },
             resolved_ids,
@@ -360,7 +360,7 @@ impl Coordinator {
                 resolved_ids,
                 cluster_id,
                 is_retained_metrics_object: false,
-                custom_logical_compaction_window: None,
+                custom_logical_compaction_window: compaction_window,
             }),
             owner_id: *self.catalog().get_entry(&on).owner_id(),
         }];
@@ -423,7 +423,10 @@ impl Coordinator {
                 }
 
                 coord
-                    .set_index_options(exported_index_id, options)
+                    .set_index_compaction_window(
+                        exported_index_id,
+                        compaction_window.unwrap_or_default(),
+                    )
                     .expect("index enabled");
             })
             .await;

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -504,7 +504,7 @@ fn test_subscribe_basic() {
         .batch_execute("CREATE TABLE t (data text)")
         .unwrap();
     client_writes
-        .batch_execute("CREATE DEFAULT INDEX t_primary_idx ON t WITH (LOGICAL COMPACTION WINDOW 0)")
+        .batch_execute("CREATE DEFAULT INDEX t_primary_idx ON t WITH (RETAIN HISTORY FOR 0)")
         .unwrap();
     // Now that the index (and its since) are initialized to 0, we can resume using
     // system time. Do a read to bump the oracle's state so it will read from the
@@ -612,7 +612,7 @@ fn test_subscribe_basic() {
     // view derived from the index. This previously selected an invalid
     // `AS OF` timestamp (#5391).
     client_writes
-        .batch_execute("ALTER INDEX t_primary_idx SET (LOGICAL COMPACTION WINDOW = '1ms')")
+        .batch_execute("ALTER INDEX t_primary_idx SET (RETAIN HISTORY = FOR '1ms')")
         .unwrap();
     client_writes
         .batch_execute("CREATE VIEW v AS SELECT * FROM t")

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1406,15 +1406,15 @@ impl_display_t!(CreateIndexStatement);
 /// An option in a `CREATE CLUSTER` statement.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum IndexOptionName {
-    // The `LOGICAL COMPACTION WINDOW` option
-    LogicalCompactionWindow,
+    // The `RETAIN HISTORY` option
+    RetainHistory,
 }
 
 impl AstDisplay for IndexOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            IndexOptionName::LogicalCompactionWindow => {
-                f.write_str("LOGICAL COMPACTION WINDOW");
+            IndexOptionName::RetainHistory => {
+                f.write_str("RETAIN HISTORY");
             }
         }
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3388,13 +3388,15 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_index_option_name(&mut self) -> Result<IndexOptionName, ParserError> {
-        self.expect_keywords(&[LOGICAL, COMPACTION, WINDOW])?;
-        Ok(IndexOptionName::LogicalCompactionWindow)
+        self.expect_keywords(&[RETAIN, HISTORY])?;
+        Ok(IndexOptionName::RetainHistory)
     }
 
     fn parse_index_option(&mut self) -> Result<IndexOption<Raw>, ParserError> {
         let name = self.parse_index_option_name()?;
-        let value = self.parse_optional_option_value()?;
+        let value = match name {
+            IndexOptionName::RetainHistory => self.parse_option_retain_history(),
+        }?;
         Ok(IndexOption { name, value })
     }
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -696,11 +696,11 @@ CREATE INDEX foo ON myschema.bar (a, b)
 CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
-CREATE INDEX foo ON myschema.bar (a, b) WITH (LOGICAL COMPACTION WINDOW = 0)
+CREATE INDEX foo ON myschema.bar (a, b) WITH (RETAIN HISTORY = FOR 0)
 ----
-CREATE INDEX foo ON myschema.bar (a, b) WITH (LOGICAL COMPACTION WINDOW = 0)
+CREATE INDEX foo ON myschema.bar (a, b) WITH (RETAIN HISTORY = FOR 0)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [IndexOption { name: LogicalCompactionWindow, value: Some(Value(Number("0"))) }], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [IndexOption { name: RetainHistory, value: Some(RetainHistoryFor(Number("0"))) }], if_not_exists: false })
 
 parse-statement
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
@@ -1136,49 +1136,49 @@ CREATE TABLE IF NOT EXISTS foo (bar int4)
 parse-statement
 ALTER INDEX name SET (property = true)
 ----
-error: Expected LOGICAL, found identifier "property"
+error: Expected RETAIN, found identifier "property"
 ALTER INDEX name SET (property = true)
                       ^
 
 parse-statement
 ALTER INDEX name RESET (property)
 ----
-error: Expected LOGICAL, found identifier "property"
+error: Expected RETAIN, found identifier "property"
 ALTER INDEX name RESET (property)
                         ^
 
 parse-statement
 ALTER INDEX IF EXISTS name SET (property = true)
 ----
-error: Expected LOGICAL, found identifier "property"
+error: Expected RETAIN, found identifier "property"
 ALTER INDEX IF EXISTS name SET (property = true)
                                 ^
 
 parse-statement
 ALTER INDEX name SET ()
 ----
-error: Expected LOGICAL, found right parenthesis
+error: Expected RETAIN, found right parenthesis
 ALTER INDEX name SET ()
                       ^
 
 parse-statement
 ALTER INDEX name RESET ()
 ----
-error: Expected LOGICAL, found right parenthesis
+error: Expected RETAIN, found right parenthesis
 ALTER INDEX name RESET ()
                         ^
 
 parse-statement
 ALTER INDEX name SET (property)
 ----
-error: Expected LOGICAL, found identifier "property"
+error: Expected RETAIN, found identifier "property"
 ALTER INDEX name SET (property)
                       ^
 
 parse-statement
 ALTER INDEX name RESET (property = true)
 ----
-error: Expected LOGICAL, found identifier "property"
+error: Expected RETAIN, found identifier "property"
 ALTER INDEX name RESET (property = true)
                         ^
 
@@ -2621,18 +2621,18 @@ DROP OWNED BY joe, mike CASCADE
 DropOwned(DropOwnedStatement { role_names: [Ident("joe"), Ident("mike")], cascade: true })
 
 parse-statement
-ALTER INDEX IF EXISTS alter_index_table_primary_idx SET (LOGICAL COMPACTION WINDOW = '1ms')
+ALTER INDEX IF EXISTS alter_index_table_primary_idx SET (RETAIN HISTORY = FOR '1ms')
 ----
-ALTER INDEX IF EXISTS alter_index_table_primary_idx SET (LOGICAL COMPACTION WINDOW = '1ms')
+ALTER INDEX IF EXISTS alter_index_table_primary_idx SET (RETAIN HISTORY = FOR '1ms')
 =>
-AlterIndex(AlterIndexStatement { index_name: UnresolvedItemName([Ident("alter_index_table_primary_idx")]), if_exists: true, action: SetOptions([IndexOption { name: LogicalCompactionWindow, value: Some(Value(String("1ms"))) }]) })
+AlterIndex(AlterIndexStatement { index_name: UnresolvedItemName([Ident("alter_index_table_primary_idx")]), if_exists: true, action: SetOptions([IndexOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1ms"))) }]) })
 
 parse-statement
-ALTER INDEX IF EXISTS alter_index_table_primary_idx RESET (LOGICAL COMPACTION WINDOW)
+ALTER INDEX IF EXISTS alter_index_table_primary_idx RESET (RETAIN HISTORY)
 ----
-ALTER INDEX IF EXISTS alter_index_table_primary_idx RESET (LOGICAL COMPACTION WINDOW)
+ALTER INDEX IF EXISTS alter_index_table_primary_idx RESET (RETAIN HISTORY)
 =>
-AlterIndex(AlterIndexStatement { index_name: UnresolvedItemName([Ident("alter_index_table_primary_idx")]), if_exists: true, action: ResetOptions([LogicalCompactionWindow]) })
+AlterIndex(AlterIndexStatement { index_name: UnresolvedItemName([Ident("alter_index_table_primary_idx")]), if_exists: true, action: ResetOptions([RetainHistory]) })
 
 parse-statement
 ALTER CONNECTION IF EXISTS mc RENAME TO ic

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -644,7 +644,6 @@ pub struct CreateMaterializedViewPlan {
 pub struct CreateIndexPlan {
     pub name: QualifiedItemName,
     pub index: Index,
-    pub options: Vec<IndexOption>,
     pub if_not_exists: bool,
 }
 
@@ -1444,6 +1443,7 @@ pub struct Index {
     pub create_sql: String,
     pub on: GlobalId,
     pub keys: Vec<mz_expr::MirScalarExpr>,
+    pub compaction_window: Option<CompactionWindow>,
     pub cluster_id: ClusterId,
 }
 
@@ -1552,7 +1552,7 @@ pub enum ExecuteTimeout {
 #[derive(Clone, Debug)]
 pub enum IndexOption {
     /// Configures the logical compaction window for an index.
-    LogicalCompactionWindow(CompactionWindow),
+    RetainHistory(CompactionWindow),
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -542,7 +542,6 @@ fn generate_rbac_requirements(
         Plan::CreateIndex(plan::CreateIndexPlan {
             name,
             index,
-            options: _,
             if_not_exists: _,
         }) => RbacRequirements {
             ownership: vec![ObjectId::Item(index.on)],

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1833,8 +1833,9 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
+
         name: enable_logical_compaction_window,
-        desc: "LOGICAL COMPACTION WINDOW",
+        desc: "RETAIN HISTORY",
         default: false,
         internal: true,
         enable_for_item_parsing: true,

--- a/test/pgtest-mz/notice.pt
+++ b/test/pgtest-mz/notice.pt
@@ -387,11 +387,9 @@ send
 Query {"query": "CREATE ROLE joe"}
 Query {"query": "ALTER CLUSTER IF EXISTS foo OWNER TO joe"}
 Query {"query": "ALTER CLUSTER REPLICA IF EXISTS quickstart.quickstart RENAME TO bar_foo"}
-Query {"query": "ALTER INDEX IF EXISTS t SET (LOGICAL COMPACTION WINDOW)"}
 ----
 
 until
-ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ReadyForQuery
@@ -403,7 +401,4 @@ CommandComplete {"tag":"ALTER CLUSTER"}
 ReadyForQuery {"status":"I"}
 NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"42704"},{"typ":"M","value":"CLUSTER REPLICA \"quickstart.quickstart\" does not exist, skipping"}]}
 CommandComplete {"tag":"ALTER CLUSTER REPLICA"}
-ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"42704"},{"typ":"M","value":"INDEX \"t\" does not exist, skipping"}]}
-CommandComplete {"tag":"ALTER INDEX"}
 ReadyForQuery {"status":"I"}

--- a/test/retain-history/mzcompose.py
+++ b/test/retain-history/mzcompose.py
@@ -30,6 +30,7 @@ def workflow_default(c: Composition) -> None:
     run_test_with_counter_source(c)
     # TODO: #24479 needs to be fixed
     # run_test_gh_24479(c)
+    run_test_with_index(c)
 
 
 def setup(c: Composition) -> None:
@@ -274,6 +275,22 @@ def _validate_count_of_counter_source(c: Composition, object_name: str) -> None:
     assert (
         count_at_mz_time2 > count_at_mz_time1
     ), f"value at time2 did not progress ({count_at_mz_time2} vs. {count_at_mz_time1}), consider increasing 'sleep_duration_between_mz_time1_and_mz_time2'"
+
+
+def run_test_with_index(c: Composition) -> None:
+    c.testdrive(
+        dedent(
+            """
+            > CREATE SOURCE retain_history_source3
+              FROM LOAD GENERATOR COUNTER
+              (TICK INTERVAL '100ms');
+            > CREATE DEFAULT INDEX retain_history_idx
+              ON retain_history_source2
+              WITH (RETAIN HISTORY FOR '10s');
+            """
+        )
+    )
+    _validate_count_of_counter_source(c, "retain_history_source3")
 
 
 def run_test_gh_24479(c: Composition) -> None:

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -273,7 +273,7 @@ SELECT mz_roles.name
 materialize
 
 statement ok
-ALTER INDEX mt_ind SET (LOGICAL COMPACTION WINDOW = 0)
+ALTER INDEX mt_ind SET (RETAIN HISTORY = FOR 0)
 
 statement ok
 ALTER INDEX mt_ind RENAME TO ICs
@@ -304,7 +304,7 @@ statement error must be owner of INDEX materialize.public.jt_ind
 ALTER INDEX jt_ind OWNER TO group_materialize
 
 statement error must be owner of INDEX materialize.public.jt_ind
-ALTER INDEX jt_ind SET (LOGICAL COMPACTION WINDOW = 0)
+ALTER INDEX jt_ind SET (RETAIN HISTORY = FOR 0)
 
 ## Sources
 

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -792,8 +792,8 @@ CREATE DEFAULT INDEX ON s
 statement ok
 BEGIN
 
-statement error db error: ERROR: ALTER INDEX s_primary_idx SET \(LOGICAL COMPACTION WINDOW = 0\) cannot be run inside a transaction block
-ALTER INDEX s_primary_idx SET (LOGICAL COMPACTION WINDOW = 0)
+statement error db error: ERROR: ALTER INDEX s_primary_idx SET \(RETAIN HISTORY = FOR 0\) cannot be run inside a transaction block
+ALTER INDEX s_primary_idx SET (RETAIN HISTORY = FOR 0)
 
 query error db error: ERROR: current transaction is aborted, commands ignored until end of transaction block
 SELECT 1

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -109,7 +109,7 @@ $ kafka-create-topic topic=nums
 
 # Disable logical compaction, to ensure we can view historical detail.
 > ALTER INDEX materialize.public.nums_primary_idx
-  SET (LOGICAL COMPACTION WINDOW = 0)
+  SET (RETAIN HISTORY = FOR 0)
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
@@ -193,7 +193,7 @@ mz_timestamp  mz_diff  num
 # 4.
 
 > ALTER INDEX materialize.public.nums_primary_idx
-  SET (LOGICAL COMPACTION WINDOW = '1ms')
+  SET (RETAIN HISTORY = FOR '1ms')
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
 {"array":[{"data":{"num":5},"time":4,"diff":-1}]}
@@ -213,11 +213,11 @@ contains:Timestamp (3) is not valid for all inputs
 # Set the compaction window back to off and advance the number in transactions 5 and 6.
 
 > ALTER INDEX materialize.public.nums_primary_idx
-  SET (LOGICAL COMPACTION WINDOW = 0)
+  SET (RETAIN HISTORY = FOR 0)
 
 # But also create an index that compacts frequently.
 > CREATE VIEW nums_compacted AS SELECT * FROM nums
-> CREATE DEFAULT INDEX ON nums_compacted WITH (LOGICAL COMPACTION WINDOW = '1ms')
+> CREATE DEFAULT INDEX ON nums_compacted WITH (RETAIN HISTORY = FOR '1ms')
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
 {"array":[{"data":{"num":6},"time":5,"diff":-1}]}


### PR DESCRIPTION
We already supported `LOGICAL COMPACTION WINDOW` behind a feature flag, but it has bit-rotted over the years and needed to be plumbed through to a few more places.

Fixes: https://github.com/MaterializeInc/materialize/issues/24824

NOTE: we are still iterating on some questions like whether it's okay that retaining history on one object implicitly retains history on its dependencies. This PR just punts on that question.