### PR TITLE
doc/user: polish v0.85 release notes

### DIFF
--- a/doc/user/content/releases/v0.85.md
+++ b/doc/user/content/releases/v0.85.md
@@ -7,4 +7,10 @@ patch: 2
 
 ## v0.85
 
-**WIP**
+#### Bug fixes and other improvements
+
+* Fix a bug where [`DISCARD ALL`](/sql/discard/) did not consider system or role
+  defaults {{% gh 24601 %}}.
+
+* Fix a bug causing the `mz_monitor` and `mz_monitor_redacted` system roles to
+  not show up in the `mz_roles` system catalog table {{% gh 24617 %}}.

--- a/doc/user/content/releases/v0.85.md
+++ b/doc/user/content/releases/v0.85.md
@@ -1,11 +1,10 @@
 ---
 title: "Materialize v0.85"
 date: 2024-01-31
-released: false
+released: true
+patch: 2
 ---
 
 ## v0.85
 
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
+**WIP**

--- a/doc/user/content/releases/v0.86.md
+++ b/doc/user/content/releases/v0.86.md
@@ -1,0 +1,11 @@
+---
+title: "Materialize v0.86"
+date: 2024-02-07
+released: false
+---
+
+## v0.86
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}


### PR DESCRIPTION
Release notes for v0.85. 🛌 

@edude03 @aalexandrov: this covers the step of bumping the release version in the docs.