### PR TITLE
test: add SLT test case to avoid regression of #24506

### DIFF
--- a/test/sqllogictest/github-24506.slt
+++ b/test/sqllogictest/github-24506.slt
@@ -1,0 +1,95 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_eager_delta_joins TO true;
+----
+COMPLETE 0
+
+# Tests for nested WITH MUTUALLY RECURSIVE
+
+statement ok
+CREATE TABLE edges (src int, dst int);
+
+statement ok
+INSERT INTO edges SELECT x, x + 1 FROM generate_series(0, 9) as x;
+
+statement ok
+INSERT INTO edges VALUES (4, 2), (8, 6);
+
+statement ok
+CREATE VIEW strongly_connected_components AS../.
+WITH MUTUALLY RECURSIVE
+    intra_edges (src int, dst int) as (
+        SELECT * FROM edges
+        EXCEPT ALL
+        SELECT * FROM edges_delayed
+        UNION ALL
+        SELECT src, dst
+        FROM
+            edges,
+            forward_labels f_src,
+            forward_labels f_dst,
+            reverse_labels r_src,
+            reverse_labels r_dst
+        WHERE src = f_src.node
+            AND src = r_src.node
+            AND dst = f_dst.node
+            AND dst = r_dst.node
+            AND f_src.label = f_dst.label
+            AND r_src.label = r_dst.label
+    ),
+    forward_labels (node int, label int) AS (
+        WITH MUTUALLY RECURSIVE
+            label (node int, comp int) AS (
+                SELECT dst, MIN(comp)
+                FROM (
+                    SELECT dst, dst AS comp FROM edges
+                    UNION ALL
+                    SELECT intra_edges.dst, label.comp
+                    FROM intra_edges, label
+                    WHERE intra_edges.src = label.node
+                )
+                GROUP BY dst
+            )
+        SELECT * FROM label
+    ),
+    reverse_labels (node int, label int) AS (
+        WITH MUTUALLY RECURSIVE
+            label (node int, comp int) AS (
+                SELECT src, MIN(comp)
+                FROM (
+                    SELECT src, src AS comp FROM edges
+                    UNION ALL
+                    SELECT intra_edges.src, label.comp
+                    FROM intra_edges, label
+                    WHERE intra_edges.dst = label.node
+                )
+                GROUP BY src
+            )
+        SELECT * FROM label
+    ),
+    edges_delayed (src int, dst int) AS (SELECT * FROM edges)
+SELECT * FROM forward_labels UNION SELECT * FROM reverse_labels;
+
+statement ok
+CREATE DEFAULT INDEX ON strongly_connected_components;
+
+query II
+SELECT size, COUNT(*) FROM (
+    SELECT label, COUNT(*) as size
+    FROM strongly_connected_components
+    GROUP BY label
+)
+GROUP BY size;
+----
+1  5
+3  2

--- a/test/sqllogictest/github-24506.slt
+++ b/test/sqllogictest/github-24506.slt
@@ -26,7 +26,7 @@ statement ok
 INSERT INTO edges VALUES (4, 2), (8, 6);
 
 statement ok
-CREATE VIEW strongly_connected_components AS../.
+CREATE VIEW strongly_connected_components AS
 WITH MUTUALLY RECURSIVE
     intra_edges (src int, dst int) as (
         SELECT * FROM edges


### PR DESCRIPTION
This adds a dedicated SLT test to avoid the regression of #24506.

I confirmed manually that this SLT fails (with values `(1, 11)`) at 62c6f9dd899e0d722f6fd7177892504fab6defe2 (right before @frankmcsherry fix) but succeeds with his fix at 626ed59b51fa95bc0dd39c25c868dc992ac079e4.

This is slightly redundant with `with_mutually_recursive.slt`, but: belt and suspenders.

### Motivation

  * This PR fixes a recognized bug.

     Test for the fix to #24506, missing test from #24728.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
