### PR TITLE
persist: support one minor version of forward compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,6 +4309,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rlimit",
+ "semver",
  "sentry",
  "sentry-tracing",
  "serde",

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -95,6 +95,7 @@ rand = "0.8.5"
 regex = { version = "1.7.0", optional = true }
 reqwest = { version = "0.11.13", features = ["json"] }
 rlimit = "0.8.3"
+semver = "1.0.16"
 sentry = { version = "0.29.1", optional = true }
 sentry-tracing = "0.29.1"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -104,6 +104,7 @@ pub struct TestHarness {
     system_parameter_defaults: BTreeMap<String, String>,
     internal_console_redirect_url: Option<String>,
     metrics_registry: Option<MetricsRegistry>,
+    code_version: semver::Version,
     pub environment_id: EnvironmentId,
 }
 
@@ -137,6 +138,7 @@ impl Default for TestHarness {
                 startup_log_filter: CloneableEnvFilter::from_str("error").expect("must parse"),
                 ..Default::default()
             },
+            code_version: crate::BUILD_INFO.semver_version(),
             environment_id: EnvironmentId::for_tests(),
         }
     }
@@ -267,6 +269,11 @@ impl TestHarness {
         self.metrics_registry = Some(registry);
         self
     }
+
+    pub fn with_code_version(mut self, version: semver::Version) -> Self {
+        self.code_version = version;
+        self
+    }
 }
 
 pub struct Listeners {
@@ -340,6 +347,7 @@ impl Listeners {
         let persist_now = SYSTEM_TIME.clone();
         let mut persist_cfg =
             PersistConfig::new(&crate::BUILD_INFO, persist_now.clone(), all_dyn_configs());
+        persist_cfg.build_version = config.code_version;
         // Tune down the number of connections to make this all work a little easier
         // with local postgres.
         persist_cfg.consensus_connection_pool_max_size = 1;

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -92,7 +92,7 @@ use crate::read::{READER_LEASE_DURATION, STREAMING_SNAPSHOT_AND_FETCH_ENABLED};
 #[derive(Debug, Clone)]
 pub struct PersistConfig {
     /// Info about which version of the code is running.
-    pub(crate) build_version: Version,
+    pub build_version: Version,
     /// Hostname of this persist user. Stored in state and used for debugging.
     pub hostname: String,
     /// A clock to use for all leasing and other non-debugging use.

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1152,8 +1152,13 @@ where
     where
         WorkFn: FnMut(SeqNo, &PersistConfig, &mut StateCollections<T>) -> ControlFlow<E, R>,
     {
+        // Now that we support one minor version of forward compatibility, tag
+        // each version of state with the _max_ version of code that has ever
+        // contributed to it. Otherwise, we'd erroneously allow rolling back an
+        // arbitrary number of versions if they were done one-by-one.
+        let new_applier_version = std::cmp::max(&self.applier_version, &cfg.build_version);
         let mut new_state = State {
-            applier_version: cfg.build_version.clone(),
+            applier_version: new_applier_version.clone(),
             shard_id: self.shard_id,
             seqno: self.seqno.next(),
             walltime_ms: (cfg.now)(),
@@ -1498,9 +1503,12 @@ pub(crate) mod tests {
     use proptest::prelude::*;
     use proptest::strategy::ValueTree;
 
+    use crate::cache::PersistClientCache;
     use crate::internal::paths::RollupId;
     use crate::internal::trace::tests::any_trace;
+    use crate::tests::new_test_client_cache;
     use crate::InvalidUsage::{InvalidBounds, InvalidEmptyTimeInterval};
+    use crate::PersistLocation;
 
     use super::*;
 
@@ -2384,5 +2392,48 @@ pub(crate) mod tests {
             "\n\nNEW GOLDEN\n{}\n",
             json
         );
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // too slow
+    async fn sneaky_downgrades() {
+        let mut clients = new_test_client_cache();
+        let shard_id = ShardId::new();
+
+        async fn open_and_write(
+            clients: &mut PersistClientCache,
+            version: semver::Version,
+            shard_id: ShardId,
+        ) -> Result<(), tokio::task::JoinError> {
+            clients.cfg.build_version = version.clone();
+            clients.clear_state_cache();
+            let client = clients.open(PersistLocation::new_in_mem()).await.unwrap();
+            // Run in a task so we can catch the panic.
+            mz_ore::task::spawn(|| version.to_string(), async move {
+                let (mut write, _) = client.expect_open::<String, (), u64, i64>(shard_id).await;
+                let current = *write.upper().as_option().unwrap();
+                // Do a write so that we tag the state with the version.
+                write
+                    .expect_compare_and_append_batch(&mut [], current, current + 1)
+                    .await;
+            })
+            .await
+        }
+
+        // Start at v0.10.0.
+        let res = open_and_write(&mut clients, Version::new(0, 10, 0), shard_id).await;
+        assert!(res.is_ok());
+
+        // Upgrade to v0.11.0 is allowed.
+        let res = open_and_write(&mut clients, Version::new(0, 11, 0), shard_id).await;
+        assert!(res.is_ok());
+
+        // Downgrade to v0.10.0 is allowed.
+        let res = open_and_write(&mut clients, Version::new(0, 10, 0), shard_id).await;
+        assert!(res.is_ok());
+
+        // Downgrade to v0.9.0 is _NOT_ allowed.
+        let res = open_and_write(&mut clients, Version::new(0, 9, 0), shard_id).await;
+        assert!(res.unwrap_err().is_panic());
     }
 }


### PR DESCRIPTION
Long-term, this will be necessary for zero downtime upgrades. In the short term, it's necessary to prevent the new persist catalog impl from breaking the preflight checks (without this, just running the preflight checks fences out the old version).

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

This probably wants to be checked with #24812 before being merged.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
