### PR TITLE
Revert "storage: remove kafka producer limits in sinks"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7461,7 +7461,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#357983e11c7969b3669e813f700910f82158c461"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#c729f89b70935fb2ad8a4f377cff2845acc197b0"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -7477,8 +7477,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.3.0+2.3.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#357983e11c7969b3669e813f700910f82158c461"
+version = "4.3.0+1.9.2"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#c729f89b70935fb2ad8a4f377cff2845acc197b0"
 dependencies = [
  "cmake",
  "libc",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -141,11 +141,6 @@ criteria = "safe-to-deploy"
 version = "10.7.0"
 
 [[audits.rdkafka]]
-who = "Petros Angelatos <petrosagg@gmail.com>"
-criteria = "safe-to-deploy"
-version = "0.29.0@git:357983e11c7969b3669e813f700910f82158c461"
-
-[[audits.rdkafka]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.29.0@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
@@ -154,11 +149,6 @@ version = "0.29.0@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "4.3.0+1.9.2@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
-
-[[audits.rdkafka-sys]]
-who = "Petros Angelatos <petrosagg@gmail.com>"
-criteria = "safe-to-deploy"
-version = "4.3.0+2.3.0@git:357983e11c7969b3669e813f700910f82158c461"
 
 [[audits.redox_syscall]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -231,12 +231,17 @@ impl TransactionalProducer {
             "compression.type",
             connection.compression_type.to_librdkafka_option().into(),
         );
-        // Set the maximum buffer size limit. We don't want to impose anything lower than the max
-        // here as the operator has nothing better to do with the data than to buffer them.
-        options.insert("queue.buffering.max.kbytes", "2147483647".into());
-        // Disable the default buffer limit of 100k messages. We don't want to impose any limit
-        // here as the operator has nothing better to do with the data than to buffer them.
-        options.insert("queue.buffering.max.messages", "0".into());
+        // Increase limits for the Kafka producer's internal buffering of messages. Currently we
+        // don't have a great backpressure mechanism to tell indexes or views to slow down, so the
+        // only thing we can do with a message that we can't immediately send is to put it in a
+        // buffer and there's no point having buffers within the dataflow layer and Kafka. If the
+        // sink starts falling behind and the buffers start consuming too much memory the best
+        // thing to do is to drop the sink. Sets the buffer size to be 16 GB (note that this
+        // setting is in KB)
+        options.insert("queue.buffering.max.kbytes", format!("{}", 16 << 20));
+        // Set the max messages buffered by the producer at any time to 10MM which is the maximum
+        // allowed value.
+        options.insert("queue.buffering.max.messages", format!("{}", 10_000_000));
         // Make the Kafka producer wait at least 10 ms before sending out MessageSets
         options.insert("queue.buffering.max.ms", format!("{}", 10));
         // Time out transactions after 60 seconds

--- a/test/kafka-auth/test-kafka-ssl.td
+++ b/test/kafka-auth/test-kafka-ssl.td
@@ -44,7 +44,7 @@ contains:Invalid CA certificate
     BROKER 'kafka:9093',
     SSL CERTIFICATE AUTHORITY = 'this is garbage'
   )
-contains:failed to read certificate #0 from ssl.ca.pem: not in PEM format?
+contains:ssl.ca.pem failed: not in PEM format?
 
 # ==> Test without an SSH tunnel. <==
 


### PR DESCRIPTION
Reverts MaterializeInc/materialize#24784

This would hopefully make tests pipeline green again, see https://github.com/MaterializeInc/materialize/issues/24864 (until there is a real fix)