### PR TITLE
persist: move parquet decoding from tokio threads to timely ones

### DIFF
--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -41,7 +41,7 @@ use tracing::{debug, trace};
 
 use crate::batch::BLOB_TARGET_SIZE;
 use crate::cfg::RetryParameters;
-use crate::fetch::{FetchedPart, SerdeLeasedBatchPart};
+use crate::fetch::{FetchedBlob, SerdeLeasedBatchPart};
 use crate::read::SubscriptionLeaseReturner;
 use crate::stats::{PartStats, STATS_AUDIT_PERCENT, STATS_FILTER_ENABLED};
 use crate::{Diagnostics, PersistClient, ShardId};
@@ -74,7 +74,7 @@ pub fn shard_source<'g, K, V, T, D, F, DT, G, C>(
     // If Some, an override for the default listen sleep retry parameters.
     listen_sleep: Option<impl Fn() -> RetryParameters + 'static>,
 ) -> (
-    Stream<Child<'g, G, T>, FetchedPart<K, V, G::Timestamp, D>>,
+    Stream<Child<'g, G, T>, FetchedBlob<K, V, G::Timestamp, D>>,
     Vec<PressOnDropButton>,
 )
 where
@@ -435,7 +435,7 @@ pub(crate) fn shard_source_fetch<K, V, T, D, G>(
     key_schema: Arc<K::Schema>,
     val_schema: Arc<V::Schema>,
 ) -> (
-    Stream<G, FetchedPart<K, V, T, D>>,
+    Stream<G, FetchedBlob<K, V, T, D>>,
     Stream<G, SerdeLeasedBatchPart>,
     PressOnDropButton,
 )

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -422,7 +422,7 @@ where
             Arc::clone(&self.handle.metrics),
             &self.handle.metrics.read.listen,
             &self.handle.machine.applier.shard_metrics,
-            Some(&self.handle.reader_id),
+            &self.handle.reader_id,
             self.handle.schemas.clone(),
         )
         .await;
@@ -1029,7 +1029,7 @@ where
                 Arc::clone(&self.metrics),
                 &self.metrics.read.snapshot,
                 &self.machine.applier.shard_metrics,
-                Some(&self.reader_id),
+                &self.reader_id,
                 self.schemas.clone(),
             )
             .await;
@@ -1162,7 +1162,7 @@ where
                     Arc::clone(&metrics),
                     &snapshot_metrics,
                     &shard_metrics,
-                    Some(&reader_id),
+                    &reader_id,
                     schemas.clone(),
                 )
                 .await;

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -590,6 +590,7 @@ impl DataSubscribe {
             });
             let (mut data, mut txns) = (ProbeHandle::new(), ProbeHandle::new());
             let data_stream = data_stream.flat_map(|part| {
+                let part = part.parse();
                 part.map(|((k, v), t, d)| {
                     let (k, ()) = (k.unwrap(), v.unwrap());
                     (k, t, d)

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -23,8 +23,8 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::{PersistConfig, RetryParameters};
-use mz_persist_client::fetch::FetchedPart;
 use mz_persist_client::fetch::SerdeLeasedBatchPart;
+use mz_persist_client::fetch::{FetchedBlob, FetchedPart};
 use mz_persist_client::operators::shard_source::{shard_source, SnapshotMode};
 use mz_persist_txn::operator::txns_progress;
 use mz_persist_types::codec_impls::UnitSchema;
@@ -376,7 +376,7 @@ fn filter_may_match(
 
 pub fn decode_and_mfp<G>(
     cfg: PersistConfig,
-    fetched: &Stream<G, FetchedPart<SourceData, (), Timestamp, Diff>>,
+    fetched: &Stream<G, FetchedBlob<SourceData, (), Timestamp, Diff>>,
     name: &str,
     until: Antichain<Timestamp>,
     mut map_filter_project: Option<&mut MfpPlan>,
@@ -414,10 +414,10 @@ where
             fetched_input.for_each(|time, data| {
                 data.swap(&mut buffer);
                 let capability = time.retain();
-                for fetched_part in buffer.drain(..) {
+                for fetched_blob in buffer.drain(..) {
                     pending_work.push_back(PendingWork {
                         capability: capability.clone(),
-                        fetched_part,
+                        part: PendingPart::Blob(fetched_blob),
                     })
                 }
             });
@@ -461,7 +461,27 @@ struct PendingWork {
     /// The time at which the work should happen.
     capability: Capability<(mz_repr::Timestamp, Subtime)>,
     /// Pending fetched part.
-    fetched_part: FetchedPart<SourceData, (), Timestamp, Diff>,
+    part: PendingPart,
+}
+
+enum PendingPart {
+    Blob(FetchedBlob<SourceData, (), Timestamp, Diff>),
+    Part(FetchedPart<SourceData, (), Timestamp, Diff>),
+}
+
+impl PendingPart {
+    /// Returns the contained `FetchedPart`, first parsing it from a
+    /// `FetchedBlob` if necessary.
+    fn part_mut(&mut self) -> &mut FetchedPart<SourceData, (), Timestamp, Diff> {
+        match self {
+            PendingPart::Blob(x) => {
+                *self = PendingPart::Part(x.parse());
+                // Won't recurse any further.
+                self.part_mut()
+            }
+            PendingPart::Part(x) => x,
+        }
+    }
 }
 
 impl PendingWork {
@@ -497,8 +517,9 @@ impl PendingWork {
         >,
         YFn: Fn(Instant, usize) -> bool,
     {
-        let is_filter_pushdown_audit = self.fetched_part.is_filter_pushdown_audit();
-        while let Some(((key, val), time, diff)) = self.fetched_part.next() {
+        let fetched_part = self.part.part_mut();
+        let is_filter_pushdown_audit = fetched_part.is_filter_pushdown_audit();
+        while let Some(((key, val), time, diff)) = fetched_part.next() {
             if until.less_equal(&time) {
                 continue;
             }


### PR DESCRIPTION
The immediate motivation is that this will probably help a small bit with the spike of allocations during rehydration. Long term, it seems likely that those will move into lgalloc, but this still feels like the right place for this work to be done.

Touches #23332

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

The EncodedPart/FetchedPart stuff already felt a bit organic to me, and this makes that worse, but I played with it a bit and didn't see any easy cleanups. I also don't want to spend too much time on that because who knows how much all the fetch.rs stuff will change with the schema migration work.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
