### PR TITLE
storage: handle librdkafka queue saturation in sinks

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -204,6 +204,8 @@ struct TransactionalProducer {
     staged_bytes: u64,
     /// The timeout to use for network operations.
     socket_timeout: Duration,
+    /// The maximum duration of a transaction.
+    transaction_timeout: Duration,
 }
 
 impl TransactionalProducer {
@@ -274,6 +276,7 @@ impl TransactionalProducer {
             staged_messages: 0,
             staged_bytes: 0,
             socket_timeout: timeout_config.socket_timeout,
+            transaction_timeout: timeout_config.transaction_timeout,
         };
 
         let timeout = timeout_config.socket_timeout;
@@ -305,7 +308,7 @@ impl TransactionalProducer {
             .await
     }
 
-    async fn begin_transaction<'a>(&'a mut self) -> Result<(), ContextCreationError> {
+    async fn begin_transaction(&mut self) -> Result<(), ContextCreationError> {
         self.spawn_blocking(|p| p.begin_transaction()).await
     }
 
@@ -314,13 +317,13 @@ impl TransactionalProducer {
     /// retrying is equivalent to adjusting the maximum number of queued items in rdkafka so it is
     /// adviced that callers only handle this error in order to apply backpressure to the rest of
     /// the system.
-    fn send(
+    async fn send(
         &mut self,
         key: Option<&[u8]>,
         value: Option<&[u8]>,
         time: Timestamp,
         diff: Diff,
-    ) -> Result<(), KafkaError> {
+    ) -> Result<(), ContextCreationError> {
         assert_eq!(diff, 1, "invalid sink update");
 
         let headers = OwnedHeaders::new().insert(Header {
@@ -343,7 +346,19 @@ impl TransactionalProducer {
         self.staged_messages += 1;
         self.statistics.inc_bytes_staged_by(record_size);
         self.staged_bytes += record_size;
-        self.producer.send(record).map_err(|(e, _)| e)
+        match self.producer.send(record) {
+            Ok(()) => Ok(()),
+            Err((err, record)) => match err.rdkafka_error_code() {
+                Some(RDKafkaErrorCode::QueueFull) => {
+                    // If the internal rdkafka queue is full we have no other option than to flush
+                    // TODO(petrosagg): remove this logic once we fix #24864
+                    let timeout = self.transaction_timeout;
+                    self.spawn_blocking(move |p| p.flush(timeout)).await?;
+                    self.producer.send(record).map_err(|(err, _)| err.into())
+                }
+                _ => Err(err.into()),
+            },
+        }
     }
 
     /// Commits all the staged updates of the currently open transaction plus a progress record
@@ -540,7 +555,9 @@ fn sink_collection<G: Scope<Timestamp = Timestamp>>(
                                         producer.begin_transaction().await?;
                                         transaction_begun = true;
                                     }
-                                    producer.send(key.as_deref(), value.as_deref(), time, diff)?;
+                                    producer
+                                        .send(key.as_deref(), value.as_deref(), time, diff)
+                                        .await?;
                                 }
                                 Ordering::Greater => continue,
                             }
@@ -582,7 +599,9 @@ fn sink_collection<G: Scope<Timestamp = Timestamp>>(
                         );
                         extra_updates.sort_unstable_by(|a, b| a.1.cmp(&b.1));
                         for ((key, value), time, diff) in extra_updates.drain(..) {
-                            producer.send(key.as_deref(), value.as_deref(), time, diff)?;
+                            producer
+                                .send(key.as_deref(), value.as_deref(), time, diff)
+                                .await?;
                         }
 
                         info!("{name}: committing transaction for {}", progress.pretty());


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

An interim solution until we figure out https://github.com/MaterializeInc/materialize/issues/24864 and revert this revert https://github.com/MaterializeInc/materialize/pull/24865.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
