### PR TITLE
rust build: Use zstd to compress debug sections

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -14,7 +14,7 @@
 # xcompile.
 rustflags = [
     "-C",
-    "link-arg=-Wl,--compress-debug-sections=zlib-gabi",
+    "link-arg=-Wl,--compress-debug-sections=zstd",
     "-Csymbol-mangling-version=v0",
     "-Ctarget-cpu=x86-64-v3",
     "-Ctarget-feature=+aes",
@@ -32,7 +32,7 @@ rustflags = [
 [target."aarch64-unknown-linux-gnu"]
 rustflags = [
     "-C",
-    "link-arg=-Wl,--compress-debug-sections=zlib-gabi",
+    "link-arg=-Wl,--compress-debug-sections=zstd",
     "-Csymbol-mangling-version=v0",
     "-Ctarget-cpu=neoverse-n1",
     "-Ctarget-feature=+aes,+sha2",

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -279,7 +279,7 @@ ENV CC=$ARCH_GCC-unknown-linux-gnu-cc
 ENV CXX=$ARCH_GCC-unknown-linux-gnu-c++
 ENV CXXSTDLIB=static=stdc++
 ENV LDFLAGS="-fuse-ld=lld -static-libstdc++"
-ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zlib -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/ -Csymbol-mangling-version=v0 -Ctarget-cpu=$RUST_CPU_TARGET -Ctarget-feature=$RUST_TARGET_FEATURES --cfg=tokio_unstable"
+ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zstd -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/ -Csymbol-mangling-version=v0 -Ctarget-cpu=$RUST_CPU_TARGET -Ctarget-feature=$RUST_TARGET_FEATURES --cfg=tokio_unstable"
 ENV TARGET_AR=$AR
 ENV TARGET_CC=$CC
 ENV TARGET_CXX=$CXX

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -105,7 +105,7 @@ def cargo(
     _target_features = ",".join(target_features(arch))
 
     rustflags += [
-        "-Clink-arg=-Wl,--compress-debug-sections=zlib",
+        "-Clink-arg=-Wl,--compress-debug-sections=zstd",
         "-Csymbol-mangling-version=v0",
         f"-Ctarget-cpu={_target_cpu}",
         f"-Ctarget-feature={_target_features}",


### PR DESCRIPTION
For smaller binaries / faster disk access

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
