### PR TITLE
explain: rework `FastPath` handling

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -145,7 +145,7 @@ use crate::config::{SynchronizedParameters, SystemParameterFrontend, SystemParam
 use crate::coord::appends::{Deferred, GroupCommitPermit, PendingWriteTxn};
 use crate::coord::catalog_oracle::CatalogTimestampPersistence;
 use crate::coord::id_bundle::CollectionIdBundle;
-use crate::coord::peek::{FastPathPlan, PendingPeek};
+use crate::coord::peek::PendingPeek;
 use crate::coord::timeline::{TimelineContext, TimelineState};
 use crate::coord::timestamp_selection::{TimestampContext, TimestampDetermination};
 use crate::error::AdapterError;
@@ -499,7 +499,6 @@ pub struct PeekStageExplain {
     validity: PlanValidity,
     select_id: GlobalId,
     finishing: RowSetFinishing,
-    fast_path_plan: Option<FastPathPlan>,
     df_meta: DataflowMetainfo,
     used_indexes: UsedIndexes,
     explain_ctx: ExplainContext,

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -414,18 +414,10 @@ impl FastPathPlan {
             FastPathPlan::PeekExisting(_coll_id, idx_id, literal_constraints, _mfp) => {
                 if literal_constraints.is_some() {
                     UsedIndexes::new([(*idx_id, vec![IndexUsageType::Lookup(*idx_id)])].into())
+                } else if finishing.map_or(false, |f| f.limit.is_some() && f.order_by.is_empty()) {
+                    UsedIndexes::new([(*idx_id, vec![IndexUsageType::FastPathLimit])].into())
                 } else {
-                    if let Some(finishing) = finishing {
-                        if finishing.limit.is_some() && finishing.order_by.is_empty() {
-                            UsedIndexes::new(
-                                [(*idx_id, vec![IndexUsageType::FastPathLimit])].into(),
-                            )
-                        } else {
-                            UsedIndexes::new([(*idx_id, vec![IndexUsageType::FullScan])].into())
-                        }
-                    } else {
-                        UsedIndexes::new([(*idx_id, vec![IndexUsageType::FullScan])].into())
-                    }
+                    UsedIndexes::new([(*idx_id, vec![IndexUsageType::FullScan])].into())
                 }
             }
             FastPathPlan::PeekPersist(..) => UsedIndexes::default(),

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -28,7 +28,8 @@ use mz_compute_types::ComputeInstanceId;
 use mz_controller_types::ClusterId;
 use mz_expr::explain::{fmt_text_constant_rows, HumanizedExplain, HumanizerMode};
 use mz_expr::{
-    EvalError, Id, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing,
+    permutation_for_arrangement, EvalError, Id, MirRelationExpr, MirScalarExpr,
+    OptimizedMirRelationExpr, RowSetFinishing,
 };
 use mz_ore::cast::CastFrom;
 use mz_ore::str::{separated, StrExt};
@@ -73,7 +74,7 @@ pub enum PeekResponseUnary {
     Canceled,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PeekDataflowPlan<T = mz_repr::Timestamp> {
     pub(crate) desc: DataflowDescription<mz_compute_types::plan::Plan<T>, (), T>,
     pub(crate) id: GlobalId,
@@ -86,21 +87,26 @@ impl<T> PeekDataflowPlan<T> {
     pub fn new(
         desc: DataflowDescription<mz_compute_types::plan::Plan<T>, (), T>,
         id: GlobalId,
-        key: Vec<MirScalarExpr>,
-        permutation: BTreeMap<usize, usize>,
-        thinned_arity: usize,
+        typ: &RelationType,
     ) -> Self {
+        let arity = typ.arity();
+        let key = typ
+            .default_key()
+            .into_iter()
+            .map(MirScalarExpr::Column)
+            .collect::<Vec<_>>();
+        let (permutation, thinning) = permutation_for_arrangement(&key, arity);
         Self {
             desc,
             id,
             key,
             permutation,
-            thinned_arity,
+            thinned_arity: thinning.len(),
         }
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
 pub enum FastPathPlan {
     /// The view evaluates to a constant result that can be returned.
     ///
@@ -256,7 +262,7 @@ pub struct PlannedPeek {
 }
 
 /// Possible ways in which the coordinator could produce the result for a goal view.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum PeekPlan<T = mz_repr::Timestamp> {
     FastPath(FastPathPlan),
     /// The view must be installed as a dataflow and then read.
@@ -408,7 +414,7 @@ pub fn create_fast_path_plan<T: Timestamp>(
 }
 
 impl FastPathPlan {
-    pub fn used_indexes(&self, finishing: &Option<RowSetFinishing>) -> UsedIndexes {
+    pub fn used_indexes(&self, finishing: Option<&RowSetFinishing>) -> UsedIndexes {
         match self {
             FastPathPlan::Constant(..) => UsedIndexes::default(),
             FastPathPlan::PeekExisting(_coll_id, idx_id, literal_constraints, _mfp) => {

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -489,7 +489,6 @@ impl Coordinator {
             &expr_humanizer,
             None,
             used_indexes,
-            None,
             df_meta,
         )?;
 

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -625,7 +625,6 @@ impl Coordinator {
             &expr_humanizer,
             None,
             used_indexes,
-            None,
             df_meta,
         )?;
 

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -137,6 +137,8 @@ where
 pub struct OptimizerConfig {
     /// The mode in which the optimizer runs.
     pub mode: OptimizeMode,
+    /// Enable fast path optimization.
+    pub enable_fast_path: bool,
     /// Enable consolidation of unions that happen immediately after negate.
     ///
     /// The refinement happens in the LIR ⇒ LIR phase.
@@ -172,6 +174,7 @@ impl From<&SystemVars> for OptimizerConfig {
     fn from(vars: &SystemVars) -> Self {
         Self {
             mode: OptimizeMode::Execute,
+            enable_fast_path: true, // Always enable fast path if available.
             enable_consolidate_after_union_negate: vars.enable_consolidate_after_union_negate(),
             enable_specialized_arrangements: vars.enable_specialized_arrangements(),
             persist_fast_path_limit: vars.persist_fast_path_limit(),
@@ -188,6 +191,7 @@ impl From<(&SystemVars, &ExplainConfig)> for OptimizerConfig {
         let mut config = Self::from(vars);
         // We are calling this constructor from an 'Explain' mode context.
         config.mode = OptimizeMode::Explain;
+        config.enable_fast_path = !explain_config.no_fast_path;
         // Override feature flags that can be enabled in the EXPLAIN config.
         if let Some(explain_flag) = explain_config.enable_new_outer_join_lowering {
             config.enable_new_outer_join_lowering = explain_flag;

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -15,10 +15,7 @@ use std::sync::Arc;
 use mz_compute_types::dataflows::IndexDesc;
 use mz_compute_types::plan::Plan;
 use mz_compute_types::ComputeInstanceId;
-use mz_expr::{
-    permutation_for_arrangement, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr,
-    RowSetFinishing,
-};
+use mz_expr::{MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_repr::explain::trace_plan;
 use mz_repr::{GlobalId, RelationType, Timestamp};
 use mz_sql::plan::HirRelationExpr;
@@ -27,7 +24,7 @@ use mz_transform::normalize_lets::normalize_lets;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
 use mz_transform::{Optimizer as TransformOptimizer, StatisticsOracle};
 use timely::progress::Antichain;
-use tracing::{span, warn, Level};
+use tracing::{debug_span, warn};
 
 use crate::catalog::Catalog;
 use crate::coord::peek::{create_fast_path_plan, PeekDataflowPlan, PeekPlan};
@@ -195,6 +192,11 @@ impl Optimize<HirRelationExpr> for Optimizer {
     type To = LocalMirPlan;
 
     fn optimize(&mut self, expr: HirRelationExpr) -> Result<Self::To, OptimizerError> {
+        // Trace the pipeline input under `optimize/raw`.
+        debug_span!(target: "optimizer", "raw").in_scope(|| {
+            trace_plan(&expr);
+        });
+
         // HIR ⇒ MIR lowering and decorrelation
         let expr = expr.lower(&self.config)?;
 
@@ -208,7 +210,7 @@ impl Optimize<MirRelationExpr> for Optimizer {
 
     fn optimize(&mut self, expr: MirRelationExpr) -> Result<Self::To, OptimizerError> {
         // MIR ⇒ MIR optimization (local)
-        let expr = span!(target: "optimizer", Level::DEBUG, "local").in_scope(|| {
+        let expr = debug_span!(target: "optimizer", "local").in_scope(|| {
             #[allow(deprecated)]
             let optimizer = TransformOptimizer::logical_optimizer(&self.typecheck_ctx);
             let expr = optimizer.optimize(expr)?.into_inner();
@@ -361,7 +363,6 @@ impl GlobalMirPlan<Unresolved> {
 impl<'s> Optimize<GlobalMirPlan<ResolvedGlobal<'s>>> for Optimizer {
     type To = GlobalLirPlan;
 
-    // TODO: make Coordinator::plan_peek part of this `optimize` call.
     fn optimize(
         &mut self,
         plan: GlobalMirPlan<ResolvedGlobal<'s>>,
@@ -407,30 +408,19 @@ impl<'s> Optimize<GlobalMirPlan<ResolvedGlobal<'s>>> for Optimizer {
             Some(&self.finishing),
             self.config.persist_fast_path_limit,
         )? {
-            Some(plan) => {
-                // An ugly way to prevent panics when explaining the physical
-                // plan of a fast-path query.
-                //
-                // TODO: get rid of this.
-                if self.config.mode == OptimizeMode::Explain {
-                    // Finalize the dataflow. This includes:
-                    // - MIR ⇒ LIR lowering
-                    // - LIR ⇒ LIR transforms
-                    let _ = Plan::<Timestamp>::finalize_dataflow(
-                        df_desc,
-                        self.config.enable_consolidate_after_union_negate,
-                        self.config.enable_specialized_arrangements,
-                        self.config.enable_reduce_mfp_fusion,
-                    )
-                    .map_err(OptimizerError::Internal)?;
-                }
+            Some(plan) if self.config.enable_fast_path => {
+                // Trace the pipeline input under `optimize/raw`.
+                debug_span!(target: "optimizer", "fast_path").in_scope(|| {
+                    trace_plan(&plan);
+                });
+
+                // Trace the final plan
+                trace_plan(&plan);
 
                 // Build the PeekPlan
-                let peek_plan = PeekPlan::FastPath(plan);
-
-                peek_plan
+                PeekPlan::FastPath(plan)
             }
-            None => {
+            _ => {
                 // Ensure all expressions are normalized before finalizing.
                 for build in df_desc.objects_to_build.iter_mut() {
                     normalize_lets(&mut build.plan.0)?
@@ -447,25 +437,11 @@ impl<'s> Optimize<GlobalMirPlan<ResolvedGlobal<'s>>> for Optimizer {
                 )
                 .map_err(OptimizerError::Internal)?;
 
-                // Build the PeekPlan
-                let peek_plan = {
-                    let arity = typ.arity();
-                    let key = typ
-                        .default_key()
-                        .into_iter()
-                        .map(MirScalarExpr::Column)
-                        .collect::<Vec<_>>();
-                    let (permutation, thinning) = permutation_for_arrangement(&key, arity);
-                    PeekPlan::SlowPath(PeekDataflowPlan::new(
-                        df_desc.clone(),
-                        self.index_id(),
-                        key,
-                        permutation,
-                        thinning.len(),
-                    ))
-                };
+                // Trace the final plan
+                trace_plan(&df_desc);
 
-                peek_plan
+                // Build the PeekPlan
+                PeekPlan::SlowPath(PeekDataflowPlan::new(df_desc, self.index_id(), &typ))
             }
         };
 
@@ -479,7 +455,7 @@ impl<'s> Optimize<GlobalMirPlan<ResolvedGlobal<'s>>> for Optimizer {
 
 impl GlobalLirPlan {
     /// Unwraps the parts of the final result of the optimization pipeline.
-    pub fn unapply(self) -> (PeekPlan, DataflowMetainfo) {
-        (self.peek_plan, self.df_meta)
+    pub fn unapply(self) -> (PeekPlan, DataflowMetainfo, RelationType) {
+        (self.peek_plan, self.df_meta, self.typ)
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3389,12 +3389,25 @@ pub enum ExplainStage {
 impl ExplainStage {
     /// Return the tracing path that corresponds to a given stage.
     pub fn path(&self) -> Option<&'static str> {
+        use NamedPlan::*;
         match self {
-            ExplainStage::RawPlan => Some("optimize/raw"),
-            ExplainStage::DecorrelatedPlan => Some("optimize/hir_to_mir"),
-            ExplainStage::OptimizedPlan => Some("optimize/global"),
-            ExplainStage::PhysicalPlan => Some("optimize/finalize_dataflow"),
-            ExplainStage::Trace => None,
+            Self::RawPlan => Some(Raw.path()),
+            Self::DecorrelatedPlan => Some(Decorrelated.path()),
+            Self::OptimizedPlan => Some(Optimized.path()),
+            Self::PhysicalPlan => Some(Physical.path()),
+            Self::Trace => None,
+        }
+    }
+
+    // Whether instead of the plan associated with this [`ExplainStage`] we
+    // should show the [`NamedPlan::FastPath`] plan if available.
+    pub fn show_fast_path(&self) -> bool {
+        match self {
+            Self::RawPlan => false,
+            Self::DecorrelatedPlan => false,
+            Self::OptimizedPlan => true,
+            Self::PhysicalPlan => true,
+            Self::Trace => false,
         }
     }
 }
@@ -3402,15 +3415,39 @@ impl ExplainStage {
 impl AstDisplay for ExplainStage {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            ExplainStage::RawPlan => f.write_str("RAW PLAN"),
-            ExplainStage::DecorrelatedPlan => f.write_str("DECORRELATED PLAN"),
-            ExplainStage::OptimizedPlan => f.write_str("OPTIMIZED PLAN"),
-            ExplainStage::PhysicalPlan => f.write_str("PHYSICAL PLAN"),
-            ExplainStage::Trace => f.write_str("OPTIMIZER TRACE"),
+            Self::RawPlan => f.write_str("RAW PLAN"),
+            Self::DecorrelatedPlan => f.write_str("DECORRELATED PLAN"),
+            Self::OptimizedPlan => f.write_str("OPTIMIZED PLAN"),
+            Self::PhysicalPlan => f.write_str("PHYSICAL PLAN"),
+            Self::Trace => f.write_str("OPTIMIZER TRACE"),
         }
     }
 }
 impl_display!(ExplainStage);
+
+/// An enum of named plans that identifies specific stages in an optimizer trace
+/// where these plans can be found.
+pub enum NamedPlan {
+    Raw,
+    Decorrelated,
+    Optimized,
+    Physical,
+    FastPath,
+}
+
+impl NamedPlan {
+    /// Return the tracing path under which the plan can be found in an
+    /// optimizer trace.
+    pub fn path(&self) -> &'static str {
+        match self {
+            Self::Raw => "optimize/raw",
+            Self::Decorrelated => "optimize/hir_to_mir",
+            Self::Optimized => "optimize/global",
+            Self::Physical => "optimize/finalize_dataflow",
+            Self::FastPath => "optimize/fast_path",
+        }
+    }
+}
 
 /// What is being explained.
 /// The bools mean whether this is an EXPLAIN BROKEN.


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

First of a series of commits that will substantially minimize of the `EXPLAIN` related code that needs to live in the `Coordinator` methods. This should make it pretty easy to add and maintain `EXPLAIN` for the missing statement types (`VIEW`, `SUBSCRIBE`) in the future.

### Tips for reviewer

Until now `FastPath` selection was modeled as a side effect of an optimizer pipeline run. This PR refactor the code so now

1. The optimizer trace will contain a dedicated `optimize/fast_path` stage which will follow `optimize/global` instead of `optimize/finalize_dataflow` when fast path is selected.
2. The `fast_path_plan` parameter disappears from a bunch of structs and methods related to `EXPLAIN` handling (as due to (1) it is now treated as just another `OptimizerTrace` entry).
3. The plan extraction & rendering code of `OptimizerTrace` is taught to lookup the plan under `optimize/fast_path` if present (and if `no_fast_path` is not set) when handling `EXPLAIN [OPTIMIZED|PYSICAL] PLAN` responses.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered (Relying on existing `EXPLAIN` tests).
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
