### PR TITLE
coord: Update warn! tracing of slow coordinator messages

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2429,6 +2429,10 @@ impl Coordinator {
                 .catalog
                 .system_config()
                 .coord_slow_message_reporting_threshold();
+            let warn_threshold = self
+                .catalog()
+                .system_config()
+                .coord_slow_message_warn_threshold();
 
             loop {
                 // Before adding a branch to this select loop, please ensure that the branch is
@@ -2551,9 +2555,8 @@ impl Coordinator {
                 }
 
                 // If something is _really_ slow, print a trace id for debugging, if OTEL is enabled.
-                let trace_id_threshold = Duration::from_secs(5).min(prometheus_threshold * 25);
-                if duration > trace_id_threshold && otel_context.is_valid() {
-                    let trace_id = otel_context.trace_id();
+                if duration > warn_threshold {
+                    let trace_id = otel_context.is_valid().then(|| otel_context.trace_id());
                     tracing::warn!(
                         ?msg_kind,
                         ?trace_id,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -950,6 +950,14 @@ const COORD_SLOW_MESSAGE_REPORTING_THRESHOLD: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
+const COORD_SLOW_MESSAGE_WARN_THRESHOLD: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("coord_slow_message_warn_threshold"),
+    // Note(parkmycar): This value was chosen arbitrarily.
+    value: Duration::from_secs(5),
+    description: "Sets the threshold at which we will warn! for a coordinator message being slow.",
+    internal: true,
+};
+
 /// Controls the connect_timeout setting when connecting to PG via `mz_postgres_util`.
 const PG_SOURCE_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
     name: UncasedStr::new("pg_source_connect_timeout"),
@@ -2938,6 +2946,7 @@ impl SystemVars {
             .with_var(&SENTRY_FILTERS)
             .with_var(&WEBHOOKS_SECRETS_CACHING_TTL_SECS)
             .with_var(&COORD_SLOW_MESSAGE_REPORTING_THRESHOLD)
+            .with_var(&COORD_SLOW_MESSAGE_WARN_THRESHOLD)
             .with_var(&grpc_client::CONNECT_TIMEOUT)
             .with_var(&grpc_client::HTTP2_KEEP_ALIVE_INTERVAL)
             .with_var(&grpc_client::HTTP2_KEEP_ALIVE_TIMEOUT)
@@ -3740,6 +3749,10 @@ impl SystemVars {
 
     pub fn coord_slow_message_reporting_threshold(&self) -> Duration {
         *self.expect_value(&COORD_SLOW_MESSAGE_REPORTING_THRESHOLD)
+    }
+
+    pub fn coord_slow_message_warn_threshold(&self) -> Duration {
+        *self.expect_value(&COORD_SLOW_MESSAGE_WARN_THRESHOLD)
     }
 
     pub fn grpc_client_http2_keep_alive_interval(&self) -> Duration {


### PR DESCRIPTION
This PR makes it such that we always trace a `warn!` for slow coordinator messages, even if we don't have a valid OTEL context. It also adds a LaunchDarkly configurable threshold for tracing them.

### Motivation

Chatted about this in our team weekly

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
