### PR TITLE
catalog: Cleanup durable catalog tests

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -388,6 +388,22 @@ pub async fn migrate_from_stash_to_persist_state(
     )
 }
 
+/// Creates an openable durable catalog state that migrates the current state from the stash to
+/// persist that is meant to be used in tests.
+pub async fn test_migrate_from_stash_to_persist_state(
+    stash_config: StashConfig,
+    persist_client: PersistClient,
+    organization_id: Uuid,
+) -> CatalogMigrator {
+    let openable_stash = stash_backed_catalog_state(stash_config);
+    let openable_persist = test_persist_backed_catalog_state(persist_client, organization_id).await;
+    CatalogMigrator::new(
+        openable_stash,
+        openable_persist,
+        Direction::MigrateToPersist,
+    )
+}
+
 /// Creates an openable durable catalog state that rolls back the current state from persist to
 /// the stash.
 pub async fn rollback_from_persist_to_stash_state(
@@ -399,6 +415,18 @@ pub async fn rollback_from_persist_to_stash_state(
     let openable_stash = stash_backed_catalog_state(stash_config);
     let openable_persist =
         persist_backed_catalog_state(persist_client, organization_id, persist_metrics).await;
+    CatalogMigrator::new(openable_stash, openable_persist, Direction::RollbackToStash)
+}
+
+/// Creates an openable durable catalog state that rolls back the current state from persist to
+/// the stash that is meant to be used in tests.
+pub async fn test_rollback_from_persist_to_stash_state(
+    stash_config: StashConfig,
+    persist_client: PersistClient,
+    organization_id: Uuid,
+) -> CatalogMigrator {
+    let openable_stash = stash_backed_catalog_state(stash_config);
+    let openable_persist = test_persist_backed_catalog_state(persist_client, organization_id).await;
     CatalogMigrator::new(openable_stash, openable_persist, Direction::RollbackToStash)
 }
 

--- a/src/catalog/src/durable/impls/migrate.rs
+++ b/src/catalog/src/durable/impls/migrate.rs
@@ -402,7 +402,7 @@ mod tests {
 
     use crate::durable::impls::migrate::{Direction, TargetImplementation};
     use crate::durable::{
-        migrate_from_stash_to_persist_state, rollback_from_persist_to_stash_state,
+        rollback_from_persist_to_stash_state, test_migrate_from_stash_to_persist_state,
         test_stash_config, Metrics, OpenableDurableCatalogState,
     };
 
@@ -415,11 +415,10 @@ mod tests {
         let persist_metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
 
         {
-            let mut catalog = migrate_from_stash_to_persist_state(
+            let mut catalog = test_migrate_from_stash_to_persist_state(
                 stash_config.clone(),
                 persist_client.clone(),
                 organization_id.clone(),
-                Arc::clone(&persist_metrics),
             )
             .await;
             assert_eq!(


### PR DESCRIPTION
This commit cleans the durable catalog tests so that they initialize catalogs via test constructor methods. This significantly reduces the number of callers to the non-test constructor, making it easier to change in the future.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
