### PR TITLE
storage: fix librdkafka segfaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7463,7 +7463,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#c729f89b70935fb2ad8a4f377cff2845acc197b0"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#357983e11c7969b3669e813f700910f82158c461"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -7479,8 +7479,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.3.0+1.9.2"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#c729f89b70935fb2ad8a4f377cff2845acc197b0"
+version = "4.3.0+2.3.0"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#357983e11c7969b3669e813f700910f82158c461"
 dependencies = [
  "cmake",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7463,7 +7463,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#357983e11c7969b3669e813f700910f82158c461"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#ed2a45d83befc465ef46459d7181457aef831603"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -7480,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "4.3.0+2.3.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#357983e11c7969b3669e813f700910f82158c461"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#ed2a45d83befc465ef46459d7181457aef831603"
 dependencies = [
  "cmake",
  "libc",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -141,6 +141,11 @@ criteria = "safe-to-deploy"
 version = "10.7.0"
 
 [[audits.rdkafka]]
+who = "Petros Angelatos <petrosagg@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.29.0@git:357983e11c7969b3669e813f700910f82158c461"
+
+[[audits.rdkafka]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.29.0@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
@@ -149,6 +154,11 @@ version = "0.29.0@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "4.3.0+1.9.2@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
+
+[[audits.rdkafka-sys]]
+who = "Petros Angelatos <petrosagg@gmail.com>"
+criteria = "safe-to-deploy"
+version = "4.3.0+2.3.0@git:357983e11c7969b3669e813f700910f82158c461"
 
 [[audits.redox_syscall]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -150,6 +150,11 @@ who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.29.0@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
 
+[[audits.rdkafka]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.29.0@git:ed2a45d83befc465ef46459d7181457aef831603"
+
 [[audits.rdkafka-sys]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
@@ -159,6 +164,11 @@ version = "4.3.0+1.9.2@git:c729f89b70935fb2ad8a4f377cff2845acc197b0"
 who = "Petros Angelatos <petrosagg@gmail.com>"
 criteria = "safe-to-deploy"
 version = "4.3.0+2.3.0@git:357983e11c7969b3669e813f700910f82158c461"
+
+[[audits.rdkafka-sys]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "4.3.0+2.3.0@git:ed2a45d83befc465ef46459d7181457aef831603"
 
 [[audits.redox_syscall]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"

--- a/test/kafka-auth/test-kafka-ssl.td
+++ b/test/kafka-auth/test-kafka-ssl.td
@@ -44,7 +44,7 @@ contains:Invalid CA certificate
     BROKER 'kafka:9093',
     SSL CERTIFICATE AUTHORITY = 'this is garbage'
   )
-contains:ssl.ca.pem failed: not in PEM format?
+contains:failed to read certificate #0 from ssl.ca.pem: not in PEM format?
 
 # ==> Test without an SSH tunnel. <==
 


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

The first commit brings back https://github.com/MaterializeInc/materialize/pull/24784.

The second commit incorporates https://github.com/MaterializeInc/rust-rdkafka/commit/ed2a45d83befc465ef46459d7181457aef831603, which fixes a memory error in https://github.com/MaterializeInc/rust-rdkafka/commit/c729f89b70935fb2ad8a4f377cff2845acc197b0. This deserves extra scrutiny since I clearly got it wrong the first time.

Fix #24864.
Fix #24858.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
