### PR TITLE
storage-controller: downgrade some asserts to soft_assert_or_log

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -27,6 +27,7 @@ use mz_cluster_client::ReplicaId;
 
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
+use mz_ore::soft_assert_or_log;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::critical::SinceHandle;
 use mz_persist_client::read::ReadHandle;
@@ -2956,7 +2957,7 @@ where
 
                 // We have to re-borrow.
                 let collection = self.collection(id).expect("known to exist");
-                assert!(
+                soft_assert_or_log!(
                     collection.implied_capability == dependency_since,
                     "monkey patching the implied_capability to {:?} did not work, is still {:?}",
                     dependency_since,
@@ -2967,7 +2968,7 @@ where
             // Fill in the storage dependencies.
             let collection = self.collection_mut(id).expect("known to exist");
 
-            assert!(
+            soft_assert_or_log!(
                 PartialOrder::less_than(&collection.implied_capability, &collection.write_frontier)
                     // Whenever a collection is being initialized, this state is
                     // acceptable.
@@ -2982,7 +2983,7 @@ where
                 .storage_dependencies
                 .extend(storage_dependencies.iter().cloned());
 
-            assert!(
+            soft_assert_or_log!(
                 !PartialOrder::less_than(
                     &collection.read_capabilities.frontier(),
                     &collection.implied_capability.borrow()


### PR DESCRIPTION
assertions in the storage controller panic envd and prevent a customer's environment from booting after e.g. version upgrades. We have a customer whose environment is known to be in a state that can trigger these asserts, but we do not want their environment to be un-upgradeable. To resolve this, downgrade the asserts to soft_assert_or_log so that we can both turn on their environment and be notified if the assertion triggers (in this case via Sentry).

### Motivation

 This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
