### PR TITLE
Streamline row packing

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -508,21 +508,11 @@ where
     pub fn as_collection(&self) -> (Collection<S, Row, Diff>, Collection<S, DataflowError, Diff>) {
         match &self {
             ArrangementFlavor::Local(oks, errs) => (
-                oks.as_collection(move |borrow| {
-                    let binding = SharedRow::get();
-                    let mut row_buf = binding.borrow_mut();
-                    row_buf.packer().extend(&**borrow);
-                    row_buf.clone()
-                }),
+                oks.as_collection(move |borrow| SharedRow::pack(&**borrow)),
                 errs.as_collection(|k, &()| k.clone()),
             ),
             ArrangementFlavor::Trace(_, oks, errs) => (
-                oks.as_collection(move |borrow| {
-                    let binding = SharedRow::get();
-                    let mut row_buf = binding.borrow_mut();
-                    row_buf.packer().extend(&**borrow);
-                    row_buf.clone()
-                }),
+                oks.as_collection(move |borrow| SharedRow::pack(&**borrow)),
                 errs.as_collection(|k, &()| k.clone()),
             ),
         }

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -1083,12 +1083,7 @@ impl Pairer {
         I1: IntoIterator<Item = Datum<'a>>,
         I2: IntoIterator<Item = Datum<'a>>,
     {
-        let binding = SharedRow::get();
-        let mut row_builder = binding.borrow_mut();
-        let mut row_packer = row_builder.packer();
-        row_packer.extend(first);
-        row_packer.extend(second);
-        row_builder.clone()
+        SharedRow::pack(first.into_iter().chain(second))
     }
 
     /// Splits a datum iterator into a pair of `Row` instances.
@@ -1096,11 +1091,8 @@ impl Pairer {
         let mut datum_iter = datum_iter.into_iter();
         let binding = SharedRow::get();
         let mut row_builder = binding.borrow_mut();
-        let mut row_packer = row_builder.packer();
-        row_packer.extend(datum_iter.by_ref().take(self.split_arity));
-        let first = row_builder.clone();
-        row_packer = row_builder.packer();
-        row_packer.extend(datum_iter);
-        (first, row_builder.clone())
+        let first = row_builder.pack_using(datum_iter.by_ref().take(self.split_arity));
+        let second = row_builder.pack_using(datum_iter);
+        (first, second)
     }
 }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -1566,6 +1566,19 @@ impl Row {
         row
     }
 
+    /// Use `self` to pack `iter`, and then clone the result.
+    ///
+    /// This is a convenience method meant to reduce boilerplate around row
+    /// formation.
+    pub fn pack_using<'a, I, D>(&mut self, iter: I) -> Row
+    where
+        I: IntoIterator<Item = D>,
+        D: Borrow<Datum<'a>>,
+    {
+        self.packer().extend(iter);
+        self.clone()
+    }
+
     /// Like [`Row::pack`], but the provided iterator is allowed to produce an
     /// error, in which case the packing operation is aborted and the error
     /// returned.
@@ -2379,6 +2392,19 @@ impl SharedRow {
         // Clear row
         row.borrow_mut().packer();
         Self(row)
+    }
+
+    /// Gets the shared row and uses it to pack `iter`.
+    pub fn pack<'a, I, D>(iter: I) -> Row
+    where
+        I: IntoIterator<Item = D>,
+        D: Borrow<Datum<'a>>,
+    {
+        let binding = Self::SHARED_ROW.with(Rc::clone);
+        let mut row_builder = binding.borrow_mut();
+        let mut row_packer = row_builder.packer();
+        row_packer.extend(iter);
+        row_builder.clone()
     }
 }
 


### PR DESCRIPTION
We have a lot of boilerplate around packing rows, which makes our code harder to read and reason about. This PR introduces two convenience methods, on `SharedRow` and `Row`, that allow row packing with fewer lines and symbols.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
