### PR TITLE
storage: add LD flag to disable asserts in install_dependency_read_holds

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -181,6 +181,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             fallback_to_strict_count: config.pg_source_snapshot_fallback_to_strict_count(),
             wait_for_count: config.pg_source_snapshot_wait_for_count(),
         },
+        enable_dependency_read_hold_asserts: config.enable_dependency_read_hold_asserts(),
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1518,6 +1518,16 @@ pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
+const ENABLE_DEPENDENCY_READ_HOLD_ASSERTS: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_dependency_read_hold_asserts"),
+    value: true,
+    description:
+        "Whether to have the storage client check if a subsource's implied capability is less than \
+        its write frontier. This should only be set to false in cases where customer envs cannot
+        boot (Materialize).",
+    internal: true,
+};
+
 /// Configuration for gRPC client connections.
 mod grpc_client {
     use super::*;
@@ -2992,6 +3002,7 @@ impl SystemVars {
             .with_var(&WEBHOOK_CONCURRENT_REQUEST_LIMIT)
             .with_var(&ENABLE_COLUMNATION_LGALLOC)
             .with_var(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
+            .with_var(&ENABLE_DEPENDENCY_READ_HOLD_ASSERTS)
             .with_var(&TIMESTAMP_ORACLE_IMPL)
             .with_var(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE)
             .with_var(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT)
@@ -3892,6 +3903,10 @@ impl SystemVars {
     /// Returns the `pg_timestamp_oracle_connection_pool_ttl_stagger` configuration parameter.
     pub fn pg_timestamp_oracle_connection_pool_ttl_stagger(&self) -> Duration {
         *self.expect_value(&PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER)
+    }
+
+    pub fn enable_dependency_read_hold_asserts(&self) -> bool {
+        *self.expect_value(&ENABLE_DEPENDENCY_READ_HOLD_ASSERTS)
     }
 }
 

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -40,6 +40,7 @@ message ProtoStorageParameters {
     mz_proto.ProtoDuration statistics_interval = 22;
     mz_proto.ProtoDuration statistics_collection_interval = 23;
     ProtoPgSourceSnapshotConfig pg_snapshot_config = 24;
+    bool enable_dependency_read_hold_asserts = 27;
 }
 
 

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -72,6 +72,7 @@ pub struct StorageParameters {
     // but people mostly care about either rates, or the values to within 1 minute.
     pub statistics_collection_interval: Duration,
     pub pg_snapshot_config: PgSourceSnapshotConfig,
+    pub enable_dependency_read_hold_asserts: bool,
 }
 
 pub const STATISTICS_INTERVAL_DEFAULT: Duration = Duration::from_secs(60);
@@ -102,6 +103,7 @@ impl Default for StorageParameters {
             statistics_interval: STATISTICS_INTERVAL_DEFAULT,
             statistics_collection_interval: STATISTICS_COLLECTION_INTERVAL_DEFAULT,
             pg_snapshot_config: Default::default(),
+            enable_dependency_read_hold_asserts: true,
         }
     }
 }
@@ -198,6 +200,7 @@ impl StorageParameters {
             statistics_interval,
             statistics_collection_interval,
             pg_snapshot_config,
+            enable_dependency_read_hold_asserts,
         }: StorageParameters,
     ) {
         self.persist.update(persist);
@@ -223,6 +226,7 @@ impl StorageParameters {
         self.statistics_interval = statistics_interval;
         self.statistics_collection_interval = statistics_collection_interval;
         self.pg_snapshot_config = pg_snapshot_config;
+        self.enable_dependency_read_hold_asserts = enable_dependency_read_hold_asserts;
     }
 }
 
@@ -261,6 +265,7 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             statistics_interval: Some(self.statistics_interval.into_proto()),
             statistics_collection_interval: Some(self.statistics_collection_interval.into_proto()),
             pg_snapshot_config: Some(self.pg_snapshot_config.into_proto()),
+            enable_dependency_read_hold_asserts: self.enable_dependency_read_hold_asserts,
         }
     }
 
@@ -324,6 +329,7 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             pg_snapshot_config: proto
                 .pg_snapshot_config
                 .into_rust_if_some("ProtoStorageParameters::pg_snapshot_config")?,
+            enable_dependency_read_hold_asserts: proto.enable_dependency_read_hold_asserts,
         })
     }
 }


### PR DESCRIPTION
We have a customer whose collection's frontiers are known to be incompatible with the asserts in install_dependency_read_holds; we want to disable these assertions for this env specifically. To do this, introduce an LDF flag.

### Motivation

 This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
