### PR TITLE
deps: upgrade to rdkafka with background drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7463,7 +7463,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#8ea07c4d2b96636ff093e670bc921892aee0d56a"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -7480,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "4.3.0+1.9.2"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#8ea07c4d2b96636ff093e670bc921892aee0d56a"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
 dependencies = [
  "cmake",
  "libc",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -140,6 +140,16 @@ who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
 version = "10.7.0"
 
+[[audits.rdkafka]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.29.0@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
+
+[[audits.rdkafka-sys]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "4.3.0+1.9.2@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
+
 [[audits.redox_syscall]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -1194,14 +1194,6 @@ criteria = "safe-to-deploy"
 version = "0.3.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.rdkafka]]
-version = "0.29.0@git:8ea07c4d2b96636ff093e670bc921892aee0d56a"
-criteria = "safe-to-deploy"
-
-[[exemptions.rdkafka-sys]]
-version = "4.3.0+1.9.2@git:8ea07c4d2b96636ff093e670bc921892aee0d56a"
-criteria = "safe-to-deploy"
-
 [[exemptions.redox_syscall]]
 version = "0.2.10"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
The upgraded rdkafka incorporates MaterializeInc/rust-rdkafka@ed2a45d, which fixes a memory error in MaterializeInc/rust-rdkafka@c729f89. It does *not* include the upgrade to librdkafka v2.3.0, as the latest version of librdkafka seems to have other unsoundness.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

Please scrutinize my librdkafka change since I clearly got it wrong the first time.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
