### PR TITLE
fivetran-destination: Update build instructions

### DIFF
--- a/src/fivetran-destination/README.md
+++ b/src/fivetran-destination/README.md
@@ -20,10 +20,18 @@ for instructions.
 
 ### Binary distribution
 
-To build the destination into a static Rust binary for distribution, run:
+To build the destination into a static Rust binary for distribution, first make sure you have
+updated the `misc/fivetran_sdk` submodule, this is how we include the protobuf definitions for the
+SDK. From the root of the Materialize repository run:
 
 ```shell
-cargo build --bin mz-fivetran-destination
+git submodule update --init --recursize misc/fivetran_sdk
+```
+
+Once you have the `fivetran_sdk` submodule updated, run:
+
+```shell
+cargo build --release --bin mz-fivetran-destination
 ```
 
 Cargo will emit the built binary at

--- a/src/fivetran-destination/README.md
+++ b/src/fivetran-destination/README.md
@@ -25,7 +25,7 @@ updated the `misc/fivetran_sdk` submodule, this is how we include the protobuf d
 SDK. From the root of the Materialize repository run:
 
 ```shell
-git submodule update --init --recursize misc/fivetran_sdk
+git submodule update --init --recursive misc/fivetran_sdk
 ```
 
 Once you have the `fivetran_sdk` submodule updated, run:


### PR DESCRIPTION
Updated the build instructions to assume a fresh clone of the MZ repo.

### Motivation

Emrah reached out because he hit an issue with the `misc/fivetran_sdk` submodule not being cloned.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
