### PR TITLE
fivetran-destination: Set application name for SQL client

### DIFF
--- a/src/fivetran-destination/src/destination/config.rs
+++ b/src/fivetran-destination/src/destination/config.rs
@@ -19,6 +19,8 @@ use crate::fivetran_sdk::{
     ConfigurationFormResponse, ConfigurationTest, FormField, TestRequest, TestResponse, TextField,
 };
 
+pub const FIVETRAN_DESTINATION_APPLICATION_NAME: &str = "mz_fivetran_destination";
+
 pub fn handle_configuration_form_request() -> ConfigurationFormResponse {
     ConfigurationFormResponse {
         schema_selection_supported: true,
@@ -132,6 +134,7 @@ pub async fn connect(
         .port(6875)
         .password(app_password)
         .dbname(&dbname)
+        .application_name(FIVETRAN_DESTINATION_APPLICATION_NAME)
         .connect(tls_connector)
         .await
         .context("connecting to Materialize")?;

--- a/src/fivetran-destination/src/destination/config.rs
+++ b/src/fivetran-destination/src/destination/config.rs
@@ -19,7 +19,7 @@ use crate::fivetran_sdk::{
     ConfigurationFormResponse, ConfigurationTest, FormField, TestRequest, TestResponse, TextField,
 };
 
-pub const FIVETRAN_DESTINATION_APPLICATION_NAME: &str = "mz_fivetran_destination";
+pub const FIVETRAN_DESTINATION_APPLICATION_NAME: &str = "materialize_fivetran_destination";
 
 pub fn handle_configuration_form_request() -> ConfigurationFormResponse {
     ConfigurationFormResponse {

--- a/src/sql/src/session/hint.rs
+++ b/src/sql/src/session/hint.rs
@@ -21,6 +21,8 @@ const DBT_LABEL: &str = "dbt";
 const WEB_CONSOLE_LABEL: &str = "web_console";
 /// Prometheus label for [`ApplicationNameHint::MzPsql`].
 const MZ_PSQL_LABEL: &str = "mz_psql";
+/// Prometheus label for [`ApplicationNameHint::MzFivetranDestination`]
+const MZ_FIVETRAN_DESTINATION: &str = "mz_fivetran_destination";
 
 /// A hint for what application is making a request to the adapter.
 ///
@@ -45,6 +47,8 @@ pub enum ApplicationNameHint {
     WebConsole(Private),
     /// Request came from the `psql` shell spawned by `mz`.
     MzPsql(Private),
+    /// Request came from our Fivetran Destination,
+    MzFivetranDestination(Private),
 }
 
 impl ApplicationNameHint {
@@ -54,6 +58,8 @@ impl ApplicationNameHint {
             "dbt" => ApplicationNameHint::Dbt(Private),
             "web_console" => ApplicationNameHint::WebConsole(Private),
             "mz_psql" => ApplicationNameHint::MzPsql(Private),
+            // Note: Make sure this is kept in sync with the `fivetran-destination` crate.
+            "mz_fivetran_destination" => ApplicationNameHint::MzFivetranDestination(Private),
             "" => ApplicationNameHint::Unspecified(Private),
             // TODO(parkertimmerman): We should keep some record of these "unrecognized"
             // names, and possibly support more popular ones in the future.
@@ -69,6 +75,7 @@ impl ApplicationNameHint {
             ApplicationNameHint::Dbt(_) => DBT_LABEL,
             ApplicationNameHint::WebConsole(_) => WEB_CONSOLE_LABEL,
             ApplicationNameHint::MzPsql(_) => MZ_PSQL_LABEL,
+            ApplicationNameHint::MzFivetranDestination(_) => MZ_FIVETRAN_DESTINATION,
         }
     }
 }

--- a/src/sql/src/session/hint.rs
+++ b/src/sql/src/session/hint.rs
@@ -21,8 +21,8 @@ const DBT_LABEL: &str = "dbt";
 const WEB_CONSOLE_LABEL: &str = "web_console";
 /// Prometheus label for [`ApplicationNameHint::MzPsql`].
 const MZ_PSQL_LABEL: &str = "mz_psql";
-/// Prometheus label for [`ApplicationNameHint::MzFivetranDestination`]
-const MZ_FIVETRAN_DESTINATION: &str = "mz_fivetran_destination";
+/// Prometheus label for [`ApplicationNameHint::MaterializeFivetranDestination`]
+const MATERIALIZE_FIVETRAN_DESTINATION: &str = "materialize_fivetran_destination";
 
 /// A hint for what application is making a request to the adapter.
 ///
@@ -48,7 +48,7 @@ pub enum ApplicationNameHint {
     /// Request came from the `psql` shell spawned by `mz`.
     MzPsql(Private),
     /// Request came from our Fivetran Destination,
-    MzFivetranDestination(Private),
+    MaterializeFivetranDestination(Private),
 }
 
 impl ApplicationNameHint {
@@ -59,7 +59,9 @@ impl ApplicationNameHint {
             "web_console" => ApplicationNameHint::WebConsole(Private),
             "mz_psql" => ApplicationNameHint::MzPsql(Private),
             // Note: Make sure this is kept in sync with the `fivetran-destination` crate.
-            "mz_fivetran_destination" => ApplicationNameHint::MzFivetranDestination(Private),
+            "materialize_fivetran_destination" => {
+                ApplicationNameHint::MaterializeFivetranDestination(Private)
+            }
             "" => ApplicationNameHint::Unspecified(Private),
             // TODO(parkertimmerman): We should keep some record of these "unrecognized"
             // names, and possibly support more popular ones in the future.
@@ -75,7 +77,9 @@ impl ApplicationNameHint {
             ApplicationNameHint::Dbt(_) => DBT_LABEL,
             ApplicationNameHint::WebConsole(_) => WEB_CONSOLE_LABEL,
             ApplicationNameHint::MzPsql(_) => MZ_PSQL_LABEL,
-            ApplicationNameHint::MzFivetranDestination(_) => MZ_FIVETRAN_DESTINATION,
+            ApplicationNameHint::MaterializeFivetranDestination(_) => {
+                MATERIALIZE_FIVETRAN_DESTINATION
+            }
         }
     }
 }


### PR DESCRIPTION
This PR sets the application name of the client the Fivetran destination uses to send requests to Materialize to `mz_fivetran_destination`. It also adds the name to the set of application names we tag Prometheus metrics with.

### Motivation

More easily debug and track usage of the Fivetran destination

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
