### PR TITLE
storage: (MySQL) Only enforce replica_preserve_commit_order setting if connected to a replica

### DIFF
--- a/src/mysql-util/src/replication.rs
+++ b/src/mysql-util/src/replication.rs
@@ -57,9 +57,7 @@ pub async fn ensure_gtid_consistency(conn: &mut Conn) -> Result<(), MySqlError> 
 pub async fn ensure_replication_commit_order(conn: &mut Conn) -> Result<(), MySqlError> {
     // Determine if this is a replica by checking if there are any rows in the replica connection table
     let res: u8 = conn
-        .query_first(
-            "SELECT COUNT(*) FROM performance_schema.replication_connection_configuration LIMIT 1",
-        )
+        .query_first("SELECT COUNT(*) FROM performance_schema.replication_connection_configuration")
         .await?
         .unwrap();
     if res > 0 {

--- a/src/mysql-util/src/replication.rs
+++ b/src/mysql-util/src/replication.rs
@@ -51,13 +51,24 @@ pub async fn ensure_gtid_consistency(conn: &mut Conn) -> Result<(), MySqlError> 
     Ok(())
 }
 
-// TODO: This only applies if connecting to a replica, to ensure that the replica preserves
-// all transactions in the order they were committed on the primary which implies
-// monotonically increasing transaction ids
+/// When connected to a MySQL Replica we ensure that the replica preserves
+/// all transactions in the order they were committed on the primary which implies
+/// consecutive monotonically increasing transaction ids.
 pub async fn ensure_replication_commit_order(conn: &mut Conn) -> Result<(), MySqlError> {
-    // This system variable was renamed between MySQL 5.7 and 8.0
-    match verify_sys_setting(conn, "replica_preserve_commit_order", "1").await {
-        Ok(_) => Ok(()),
-        Err(_) => verify_sys_setting(conn, "slave_preserve_commit_order", "1").await,
+    // Determine if this is a replica by checking if there are any rows in the replica connection table
+    let res: u8 = conn
+        .query_first(
+            "SELECT COUNT(*) FROM performance_schema.replication_connection_configuration LIMIT 1",
+        )
+        .await?
+        .unwrap();
+    if res > 0 {
+        // This system variable was renamed between MySQL 5.7 and 8.0
+        match verify_sys_setting(conn, "replica_preserve_commit_order", "1").await {
+            Ok(_) => Ok(()),
+            Err(_) => verify_sys_setting(conn, "slave_preserve_commit_order", "1").await,
+        }
+    } else {
+        Ok(())
     }
 }

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -26,7 +26,17 @@ SERVICES = [
             "--binlog-format=row",
             "--log-slave-updates",
             "--binlog-row-image=full",
+            "--server-id=1",
         ]
+    ),
+    MySql(
+        name="mysql-replica",
+        additional_args=[
+            "--gtid_mode=ON",
+            "--enforce_gtid_consistency=ON",
+            "--skip-replica-start",
+            "--server-id=2",
+        ],
     ),
     Testdrive(default_timeout="60s"),
 ]
@@ -46,4 +56,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     c.run_testdrive_files(
         f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
         *args.filter,
+    )
+
+
+def workflow_replica_connection(c: Composition, parser: WorkflowArgumentParser) -> None:
+    c.up("materialized", "mysql", "mysql-replica")
+    c.run_testdrive_files(
+        f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
+        "override/10-replica-connection.td",
     )

--- a/test/mysql-cdc/override/10-replica-connection.td
+++ b/test/mysql-cdc/override/10-replica-connection.td
@@ -1,0 +1,72 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set-max-tries max-tries=20
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_mysql_source = true
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-connect name=mysql-replica url=mysql://root@mysql-replica password=${arg.mysql-root-password}
+
+#
+# Create some data on the primary
+#
+$ mysql-execute name=mysql
+CREATE DATABASE public;
+USE public;
+CREATE TABLE t1 (f1 INTEGER);
+INSERT INTO t1 VALUES (1);
+
+#
+# Create a connection from MZ to the replica
+#
+> CREATE CONNECTION mysq_replica TO MYSQL (
+    HOST 'mysql-replica',
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+#
+# Turn off the required 'replica_preserve_commit_order' setting for this replica
+# and start replication on the replica
+#
+$ mysql-execute name=mysql-replica
+STOP REPLICA;
+SET GLOBAL replica_preserve_commit_order=OFF;
+CHANGE REPLICATION SOURCE TO SOURCE_HOST='mysql', SOURCE_PORT=3306, SOURCE_USER='root', SOURCE_PASSWORD='${arg.mysql-root-password}', SOURCE_AUTO_POSITION=1;
+START REPLICA;
+
+#
+# Now try creating a source for this replica, and we should hit an error
+#
+! CREATE SOURCE replica_source FROM MYSQL CONNECTION mysq_replica FOR ALL TABLES;
+contains:Invalid MySQL system replication settings
+
+#
+# Now fix the setting on the mysql replica
+#
+$ mysql-execute name=mysql-replica
+STOP REPLICA;
+SET GLOBAL replica_preserve_commit_order=ON;
+START REPLICA;
+
+#
+# Let the replica catch up to the primary
+#
+> SELECT mz_unsafe.mz_sleep(3)
+<null>
+
+#
+# Validate we can now create a source to this replica
+#
+> CREATE SOURCE replica_source FROM MYSQL CONNECTION mysq_replica FOR ALL TABLES;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

    Only enforce the `replica_preserve_commit_order` setting when creating a MySQL Source if connected to a replica server.

    The `replica_preserve_commit_order` setting on MySQL is used to ensure that when connected to a MySQL replica, the original order of transactions received from the primary is respected, to ensure data consistency between the primary and replica. This has been highlighted as a cause of data-inconsistency issues in a recent Jepsen [report](https://jepsen.io/analyses/mysql-8.0.34) on MySQL.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]



   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

cc @nrainer-materialize - there are some additions to the `mysql-cdc` test config here that might be interesting for other test scenarios (setting up a primary-replica cluster and connecting to the replica).

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
