### PR TITLE
deps: upgrade to librdkafka v2.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8137,7 +8137,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -8153,8 +8153,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.3.0+1.9.2"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
+version = "4.3.0+2.4.0"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
 dependencies = [
  "cmake",
  "libc",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -733,10 +733,20 @@ who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.29.0@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
 
+[[audits.rdkafka]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.29.0@git:f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
+
 [[audits.rdkafka-sys]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "4.3.0+1.9.2@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
+
+[[audits.rdkafka-sys]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "4.3.0+2.4.0@git:f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
 
 [[audits.redox_syscall]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -33,7 +33,7 @@ def test_secrets(mz: MaterializeApplication) -> None:
                 SASL USERNAME = SECRET username,
                 SASL PASSWORD = SECRET password
               );
-            contains:SSL handshake failed
+            contains:Broker does not support SSL connections
             """
         )
     )

--- a/test/kafka-auth/test-kafka-sasl-plaintext.td
+++ b/test/kafka-auth/test-kafka-sasl-plaintext.td
@@ -26,7 +26,7 @@ banana
     -- SECURITY PROTOCOL defaults to SASL_SSL when other SASL options are
     -- specified.
   )
-contains:SSL handshake failed
+contains:Broker does not support SSL connections
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9095',
@@ -35,7 +35,7 @@ contains:SSL handshake failed
     SASL PASSWORD SECRET password,
     SECURITY PROTOCOL SASL_SSL
   )
-contains:SSL handshake failed
+contains:Broker does not support SSL connections
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9095',

--- a/test/kafka-auth/test-kafka-sasl-ssl.td
+++ b/test/kafka-auth/test-kafka-sasl-ssl.td
@@ -92,7 +92,7 @@ contains:Invalid username or password
     SASL USERNAME 'materialize',
     SASL PASSWORD SECRET password
   )
-contains:certificate verify failed
+contains:Invalid CA certificate
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9096',
@@ -101,7 +101,7 @@ contains:certificate verify failed
     SASL PASSWORD SECRET password,
     SSL CERTIFICATE AUTHORITY = '${ca-selective-crt}'
   )
-contains:certificate verify failed
+contains:Invalid CA certificate
 
 # ==> Test without an SSH tunnel. <==
 

--- a/test/kafka-auth/test-kafka-ssl.td
+++ b/test/kafka-auth/test-kafka-ssl.td
@@ -32,13 +32,13 @@ contains:Disconnected during handshake; broker might require SSL encryption
     BROKER 'kafka:9093'
     -- SECURITY PROTOCOL defaults to SSL when no SASL options are specified.
   )
-contains:certificate verify failed
+contains:Invalid CA certificate
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9093',
     SSL CERTIFICATE AUTHORITY = '${ca-selective-crt}'
   )
-contains:certificate verify failed
+contains:Invalid CA certificate
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9093',
@@ -100,10 +100,10 @@ contains:Client creation error
 > ALTER CONNECTION kafka RESET (SSL CERTIFICATE) WITH (VALIDATE = true);
 
 ! ALTER CONNECTION kafka RESET (SSL CERTIFICATE AUTHORITY) WITH (VALIDATE = true);
-contains:certificate verify failed
+contains:Invalid CA certificate
 
 ! ALTER CONNECTION kafka RESET (SSL KEY), RESET (SSL CERTIFICATE), RESET (SSL CERTIFICATE AUTHORITY) WITH (VALIDATE = true);
-contains:certificate verify failed
+contains:Invalid CA certificate
 
 > ALTER CONNECTION kafka RESET (SSL KEY), RESET (SSL CERTIFICATE), RESET (SSL CERTIFICATE AUTHORITY) WITH (VALIDATE = false);
 

--- a/test/testdrive/connection-alter.td
+++ b/test/testdrive/connection-alter.td
@@ -84,7 +84,7 @@ name   create_sql
 materialize.public.conn   "CREATE CONNECTION \"materialize\".\"public\".\"conn\" TO KAFKA (BROKERS = ('${testdrive.kafka-addr}'), SECURITY PROTOCOL = \"plaintext\")"
 
 ! ALTER CONNECTION conn DROP (SECURITY PROTOCOL);
-contains:SSL handshake failed
+contains:Broker does not support SSL connections
 
 ! ALTER CONNECTION conn SET (BROKER '${testdrive.kafka-addr}'), RESET (BROKER);
 contains:cannot both SET and DROP/RESET options BROKER


### PR DESCRIPTION
Trying the upgrade to librdkafka v2.3.0 in isolation, on top of the current main.

### Motivation

* This PR upgrades dependencies.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
