### PR TITLE
ci: Disable auto retries again, cargo-test: Disable flaky test_retry_async_fail_max_duration

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -47,9 +47,6 @@ steps:
         timeout_in_minutes: 60
         agents:
           queue: builder-linux-aarch64
-        # TODO(def-) Remove automatic retry when #24818 is fixed
-        retry:
-          automatic: true
 
       - id: build-wasm
         label: Build WASM
@@ -213,9 +210,6 @@ steps:
               composition: cargo-test
         agents:
           queue: builder-linux-aarch64
-        # TODO(def-) Remove automatic retry when #24818 is fixed
-        retry:
-          automatic: true
 
       - id: miri-test
         label: Miri test (fast)
@@ -231,9 +225,6 @@ steps:
         agents:
           queue: builder-linux-aarch64
         coverage: skip
-        # TODO(def-) Remove automatic retry when #24818 is fixed
-        retry:
-          automatic: true
 
   - id: testdrive
     label: Testdrive %N

--- a/src/ore/src/retry.rs
+++ b/src/ore/src/retry.rs
@@ -749,6 +749,7 @@ mod tests {
 
     #[mz_test_macro::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
+    #[ignore] // TODO: Reenable when #24933 is fixed
     async fn test_retry_async_fail_max_duration() {
         let mut states = vec![];
         let res = Retry::default()


### PR DESCRIPTION
Quite expensive when the failure is just broken code and we retry 3 times

Seen in https://buildkite.com/materialize/tests/builds/74721

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
