### PR TITLE
storage/sinks/kafka: remove rdkafka queue limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7465,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#a7dc07032f73dac50cbb1c2b0cbe87d94cbc4b4c"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -7481,8 +7481,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.3.0+1.9.2"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
+version = "4.3.0+2.3.0"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#a7dc07032f73dac50cbb1c2b0cbe87d94cbc4b4c"
 dependencies = [
  "cmake",
  "libc",

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -818,7 +818,7 @@ steps:
 
       - id: checks-upgrade-matrix
         label: "Random upgrades over the entire matrix %N"
-        timeout_in_minutes: 150
+        timeout_in_minutes: 180
         parallelism: 4
         agents:
           queue: linux-aarch64

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -143,12 +143,32 @@ version = "10.7.0"
 [[audits.rdkafka]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
+version = "0.29.0@git:73b84a9e07367575f057d8e0414304f34a7eaf09"
+
+[[audits.rdkafka]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
 version = "0.29.0@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
+
+[[audits.rdkafka]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.29.0@git:a7dc07032f73dac50cbb1c2b0cbe87d94cbc4b4c"
 
 [[audits.rdkafka-sys]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "4.3.0+1.9.2@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
+
+[[audits.rdkafka-sys]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "4.3.0+2.3.0@git:73b84a9e07367575f057d8e0414304f34a7eaf09"
+
+[[audits.rdkafka-sys]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "4.3.0+2.3.0@git:a7dc07032f73dac50cbb1c2b0cbe87d94cbc4b4c"
 
 [[audits.redox_syscall]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"


### PR DESCRIPTION
This is another attempt to land https://github.com/MaterializeInc/materialize/pull/24784, which requires upgrading to librdkafka v2.3.0.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

This is based on the librdkafka v2.3 upgrade PR: https://github.com/MaterializeInc/materialize/pull/24931. I'm delicately stacking these PRs to try to isolate which is responsible for the segfaults we were seeing previously.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
