### PR TITLE
dbt-materialize: update address for support

### DIFF
--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -31,7 +31,7 @@ setup(
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",
     author="Materialize, Inc.",
-    author_email="devex@materialize.com",
+    author_email="support@materialize.com",
     url="https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize",
     packages=find_packages(),
     package_data={


### PR DESCRIPTION
Point the support address used in the dbt adapter to the new dedicated mailing list.