### PR TITLE
webhooks: Support `NDJSON`

### DIFF
--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -385,6 +385,34 @@ $ webhook-append name=webhook_json_array
 "{\"event_name\":\"c\"}"
 "{\"event_type\":\"i am a single event\"}"
 
+$ webhook-append name=webhook_json_array
+[ { "nested_array": "a_1" }, { "nested_array": "a_2" } ]
+[ { "nested_array": "b_1" }, { "nested_array": "b_2" } ]
+
+> SELECT body FROM webhook_json_array
+"{\"event_name\":\"a\"}"
+"{\"event_name\":\"a\"}"
+"{\"event_name\":\"b\"}"
+"{\"event_name\":\"c\"}"
+"{\"event_type\":\"i am a single event\"}"
+"{\"nested_array\":\"a_1\"}"
+"{\"nested_array\":\"a_2\"}"
+"{\"nested_array\":\"b_1\"}"
+"{\"nested_array\":\"b_2\"}"
+
+> CREATE SOURCE webhook_ndjson IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT JSON
+
+$ webhook-append name=webhook_ndjson
+{ "name": "bill" }
+{ "name": "john" }
+{ "name": "alex" }
+
+> SELECT body FROM webhook_ndjson
+"{\"name\":\"bill\"}"
+"{\"name\":\"john\"}"
+"{\"name\":\"alex\"}"
+
 > CREATE SOURCE webhook_json_array_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT JSON ARRAY
   INCLUDE HEADER 'x-timestamp' as event_timestamp


### PR DESCRIPTION
This PR implements support for newline delimited JSON for webhooks by using [`serde_json::StreamDeserializer`](https://docs.rs/serde_json/latest/serde_json/struct.StreamDeserializer.html). There are no syntax changes, newline delimited JSON will get parsed as an array by any `BODY FORMAT JSON` webhook request.

Newline delimited JSON are batches of JSON objects that are presented as individual objects separated by newlines. It's a fairly popular format is supported by other products like [DuckDB](https://duckdb.org/docs/extensions/json.html#json-table-functions) and [Snowflake](https://docs.snowflake.com/en/sql-reference/sql/create-file-format#required-parameters).

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/24913

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds support for newline delimited JSON to webhooks.
