### PR TITLE
sql: remove Option wrapper around PostgresColumnDesc col_num

### DIFF
--- a/src/postgres-util/src/desc.proto
+++ b/src/postgres-util/src/desc.proto
@@ -34,7 +34,8 @@ message ProtoPostgresColumnDesc {
     uint32 type_oid = 2;
     int32 type_mod = 3;
     bool nullable = 4;
-    // TODO(migration): remove optional in version v.51 (released in v0.49 + 1
-    // additional release)
+    // This field does not need to be optional, but was originally marked as
+    // optional when it was added, and the migration required to remove the
+    // optional marker is more convoluted than it's worth.
     optional uint32 col_num = 6;
 }

--- a/src/postgres-util/src/schemas.rs
+++ b/src/postgres-util/src/schemas.rs
@@ -137,11 +137,10 @@ pub async fn publication_info(
             .map(|row| {
                 let name: String = row.get("name");
                 let type_oid = row.get("typoid");
-                let col_num = Some(
-                    row.get::<_, i16>("colnum")
-                        .try_into()
-                        .expect("non-negative values"),
-                );
+                let col_num = row
+                    .get::<_, i16>("colnum")
+                    .try_into()
+                    .expect("non-negative values");
                 let type_mod: i32 = row.get("typmod");
                 let not_null: bool = row.get("not_null");
                 Ok(PostgresColumnDesc {

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -232,7 +232,7 @@ where
                     table
                         .columns
                         .iter()
-                        .find(|col| col.col_num == Some(col_num))
+                        .find(|col| col.col_num == col_num)
                         .expect("key exists as column")
                         .name
                         .clone(),


### PR DESCRIPTION
When introducing col_num, we needed to introduce it as an option because existing sources did not have the field and it needed to be backfilled. However, any subsources that did not have this value backfilled by a migration would have errored as soon as it produced data (we would have seen the schemas as incompatible).

This has been the case for 11 months now, so I suggest that this is safe to remove because, for it to be an issue, customers would have had a source stuck in an errored state for that duration of time.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
