### PR TITLE
doc/user: update Terraform example

### DIFF
--- a/doc/user/content/manage/terraform.md
+++ b/doc/user/content/manage/terraform.md
@@ -253,7 +253,7 @@ resource "materialize_connection_postgres" "example_postgres_connection" {
 resource "materialize_source_postgres" "example_source_postgres" {
   name        = "source_postgres"
   schema_name = "schema"
-  size        = "3xsmall"
+  cluster_name = "quickstart"
   postgres_connection {
     name = "pg_connection"
     # Optional parameters


### PR DESCRIPTION
Removes a vestigial `size` left behind in one of the examples in the Terraform docs.