### PR TITLE
ci: Always add concurrency group for aarch64

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -469,17 +469,15 @@ def trim_builds(pipeline: Any, coverage: bool) -> None:
                 step["concurrency"] = 1
                 step["concurrency_group"] = f"build-x86_64/{hash(deps)}"
         if step.get("id") == "build-aarch64":
-            branch = os.environ["BUILDKITE_BRANCH"]
             deps = deps_publish(Arch.AARCH64)
-            if branch == "main" or branch.startswith("v") and "." in branch:
-                if deps.check():
-                    step["skip"] = True
-                else:
-                    # Make sure that builds in different pipelines for the same
-                    # hash at least don't run concurrently, leading to wasted
-                    # resources.
-                    step["concurrency"] = 1
-                    step["concurrency_group"] = f"build-aarch64/{hash(deps)}"
+            if deps.check():
+                step["skip"] = True
+            else:
+                # Make sure that builds in different pipelines for the same
+                # hash at least don't run concurrently, leading to wasted
+                # resources.
+                step["concurrency"] = 1
+                step["concurrency_group"] = f"build-aarch64/{hash(deps)}"
 
     for step in pipeline["steps"]:
         visit(step)


### PR DESCRIPTION
As noticed by Nikhil in https://materializeinc.slack.com/archives/C01LKF361MZ/p1707070177405639

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
