### PR TITLE
cargo-test: Disable test_stash_fail_after_commit

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,7 +19,7 @@ threads-required = 8
 slow-timeout = { period = "120s", terminate-after = 2 }
 
 [[profile.default.overrides]]
-filter = "package(mz-stash) and test(proptest_stash_migrate_json_to_proto)"
+filter = "package(mz-stash) and (test(proptest_stash_migrate_json_to_proto) or test(test_stash_batch_large_number_updates))"
 slow-timeout = { period = "120s", terminate-after = 2 }
 
 [profile.ci]

--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -498,6 +498,7 @@ where
 
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+#[ignore] // TODO: Reenable when #24961 is fixed
 async fn test_stash_fail_after_commit() {
     Stash::with_debug_stash(|mut stash| async move {
         let col = collection::<i64, i64>(&mut stash, "c1").await.unwrap();


### PR DESCRIPTION
See https://github.com/MaterializeInc/materialize/issues/24961

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
