### PR TITLE
scratch: fix errors occurring with submodules

### DIFF
--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -287,7 +287,7 @@ def mkrepo(i: Instance, rev: str, init: bool = True, force: bool = False) -> Non
     )
     mssh(
         i,
-        f"cd materialize && git config core.bare false && git checkout {rev}",
+        f"cd materialize && git config core.bare false && git checkout {rev} && git submodule sync --recursive && git submodule update --recursive",
     )
 
 

--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -275,6 +275,7 @@ def mkrepo(i: Instance, rev: str, init: bool = True, force: bool = False) -> Non
         # Explicit refspec is required if the host repository is in detached
         # HEAD mode.
         f"{rev}:refs/heads/scratch",
+        "--no-recurse-submodules",
     ]
     if force:
         cmd.append("--force")


### PR DESCRIPTION
This fixes errors like

```
$ git push --no-verify ubuntu@i-042bfd431ce875866:materialize/.git 2b71f8ff2b7cdcb8d49845ab8ad890fab5e99823:refs/heads/scratch --force
Pushing submodule 'misc/fivetran-sdk'
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD)
state now, use

    git push origin HEAD:<name-of-remote-branch>

Unable to push submodule 'misc/fivetran-sdk'
fatal: failed to push all needed submodules
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/nrainer/Workspaces/mz-repo-2/misc/python/materialize/cli/scratch/__main__.py", line 81, in <module>
    main()
  File "/Users/nrainer/Workspaces/mz-repo-2/misc/python/materialize/cli/scratch/__main__.py", line 77, in main
    args.run(args)
  File "/Users/nrainer/Workspaces/mz-repo-2/misc/python/materialize/cli/scratch/push.py", line 28, in run
    mkrepo(instance, args.rev, init=False, force=True)
  File "/Users/nrainer/Workspaces/mz-repo-2/misc/python/materialize/scratch.py", line 282, in mkrepo
    spawn.runv(
  File "/Users/nrainer/Workspaces/mz-repo-2/misc/python/materialize/spawn.py", line 72, in runv
    return subprocess.run(
           ^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'push', '--no-verify', 'ubuntu@i-042bfd431ce875866:materialize/.git', '2b71f8ff2b7cdcb8d49845ab8ad890fab5e99823:refs/heads/scratch', '--force']' returned non-zero exit status 128.
nrainer@mz-nrainer mz-repo-2 % fatal: the remote end hung up unexpectedly
```