### PR TITLE
compute: fix non-aggressive readhold downgrades

### DIFF
--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -418,7 +418,7 @@ where
             config.storage_stash_url,
             config.persist_location,
             config.persist_clients,
-            config.now,
+            config.now.clone(),
             config.stash_metrics,
             envd_epoch,
             config.metrics_registry.clone(),
@@ -427,10 +427,12 @@ where
         )
         .await;
 
+        let now_fn = NowFn::from(move || T::from((config.now)()));
         let compute_controller = ComputeController::new(
             config.build_info,
             envd_epoch,
             config.metrics_registry.clone(),
+            now_fn,
         );
         let (metrics_tx, metrics_rx) = mpsc::unbounded_channel();
 


### PR DESCRIPTION
The flag `enable_compute_aggressive_readhold_downgrades` was meant to make it possible to disable aggressive readhold downgrading for MVs and revert back to the old behavior where read holds are kept at the current system time. As it turns out, the flag doesn't work as advertised because adapter doesn't install read policies for MVs anymore, so when you disable the flag, read frontiers of MVs and their inputs simply become stuck.

To keep the changes at small as possible, this commit doesn't bring back the read policy management for MVs in adapter. Instead it makes the compute controller hold back the read frontier of sink dataflows to the current time, as indicated by a `NowFn` passed in by adapter. This doesn't exactly restore the previous behavior but enough to work around make warming up of REFRESH MVs work again.

I expect that we can remove dependency on the `NowFn` again once we have implemented #24966.

### Motivation

  * This PR fixes a previously unreported bug.

Disabling `enable_compute_aggressive_readhold_downgrades` makes read frontiers of MVs and their dependencies become stuck.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
