### PR TITLE
compute: fix non-aggressive readhold downgrades

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2648,22 +2648,20 @@ impl Coordinator {
     }
 
     /// Call into the compute controller to install a finalized dataflow, and
-    /// initialize the read policies for its exported readable objects.
+    /// initialize the read policies for its exported objects.
     pub(crate) async fn ship_dataflow(
         &mut self,
         dataflow: DataflowDescription<Plan>,
         instance: ComputeInstanceId,
     ) {
-        // We must only install read policies for indexes, not for sinks.
-        // Sinks are write-only compute collections that don't have read policies.
-        let index_ids = dataflow.exported_index_ids().collect();
+        let export_ids = dataflow.export_ids().collect();
 
         self.controller
             .active_compute()
             .create_dataflow(instance, dataflow)
             .unwrap_or_terminate("dataflow creation cannot fail");
 
-        self.initialize_compute_read_policies(index_ids, instance, CompactionWindow::Default)
+        self.initialize_compute_read_policies(export_ids, instance, CompactionWindow::Default)
             .await;
     }
 }

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -10,8 +10,7 @@
 use std::fmt::Debug;
 
 use mz_compute_client::controller::error::{
-    CollectionUpdateError, DataflowCreationError, InstanceMissing, PeekError, ReadPolicyError,
-    SubscribeTargetError,
+    CollectionUpdateError, DataflowCreationError, InstanceMissing, PeekError, SubscribeTargetError,
 };
 use mz_controller_types::ClusterId;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -375,16 +374,6 @@ impl ShouldHalt for PeekError {
             | PeekError::InstanceMissing(_)
             | PeekError::CollectionMissing(_)
             | PeekError::ReplicaMissing(_) => false,
-        }
-    }
-}
-
-impl ShouldHalt for ReadPolicyError {
-    fn should_halt(&self) -> bool {
-        match self {
-            ReadPolicyError::InstanceMissing(_)
-            | ReadPolicyError::CollectionMissing(_)
-            | ReadPolicyError::WriteOnlyCollection(_) => false,
         }
     }
 }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -54,8 +54,8 @@ use uuid::Uuid;
 
 use crate::controller::error::{
     CollectionLookupError, CollectionMissing, CollectionUpdateError, DataflowCreationError,
-    InstanceExists, InstanceMissing, PeekError, ReadPolicyError, ReplicaCreationError,
-    ReplicaDropError, SubscribeTargetError,
+    InstanceExists, InstanceMissing, PeekError, ReplicaCreationError, ReplicaDropError,
+    SubscribeTargetError,
 };
 use crate::controller::instance::{ActiveInstance, Instance};
 use crate::controller::replica::ReplicaConfig;
@@ -578,14 +578,11 @@ where
     /// capability is already ahead of it.
     ///
     /// Identifiers not present in `policies` retain their existing read policies.
-    ///
-    /// It is an error to attempt to set a read policy for a collection that is not readable in the
-    /// context of compute. At this time, only indexes are readable compute collections.
     pub fn set_read_policy(
         &mut self,
         instance_id: ComputeInstanceId,
         policies: Vec<(GlobalId, ReadPolicy<T>)>,
-    ) -> Result<(), ReadPolicyError> {
+    ) -> Result<(), CollectionUpdateError> {
         self.instance(instance_id)?.set_read_policy(policies)?;
         Ok(())
     }

--- a/src/compute-client/src/controller/error.rs
+++ b/src/compute-client/src/controller/error.rs
@@ -190,33 +190,6 @@ impl From<CollectionMissing> for CollectionUpdateError {
     }
 }
 
-/// Errors arising during collection read policy assignment.
-#[derive(Error, Debug)]
-pub enum ReadPolicyError {
-    #[error("instance does not exist: {0}")]
-    InstanceMissing(ComputeInstanceId),
-    #[error("collection does not exist: {0}")]
-    CollectionMissing(GlobalId),
-    #[error("collection is write-only: {0}")]
-    WriteOnlyCollection(GlobalId),
-}
-
-impl From<InstanceMissing> for ReadPolicyError {
-    fn from(error: InstanceMissing) -> Self {
-        Self::InstanceMissing(error.0)
-    }
-}
-
-impl From<instance::ReadPolicyError> for ReadPolicyError {
-    fn from(error: instance::ReadPolicyError) -> Self {
-        use instance::ReadPolicyError::*;
-        match error {
-            CollectionMissing(id) => Self::CollectionMissing(id),
-            WriteOnlyCollection(id) => Self::WriteOnlyCollection(id),
-        }
-    }
-}
-
 // Errors arising during subscribe target assignment.
 #[derive(Error, Debug)]
 pub enum SubscribeTargetError {


### PR DESCRIPTION
The flag `enable_compute_aggressive_readhold_downgrades` was meant to make it possible to disable aggressive readhold downgrading for MVs and revert back to the old behavior where read holds are kept at the current system time. As it turns out, the flag doesn't work as advertised because adapter doesn't install read policies for MVs anymore, so when you disable the flag, read frontiers of MVs and their inputs simply become stuck.

This is fixed in this PR by making adapter set read policies for MVs again. These read policies are ignored when
`enable_compute_aggressive_readhold_downgrades` is set, but applied otherwise, letting us revert to the old behavior.

This PR is mostly a revert of e6c647.

### Motivation

  * This PR fixes a previously unreported bug.

Disabling enable_compute_aggressive_readhold_downgrades makes read frontiers of MVs and their dependencies become stuck.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
