### PR TITLE
compute: fix non-aggressive readhold downgrades

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -758,6 +758,19 @@ impl Coordinator {
                 continue;
             }
 
+            if !self
+                .controller
+                .compute
+                .enable_aggressive_readhold_downgrades()
+            {
+                // If aggressive downgrades are disabled, compute sinks have read policies that we
+                // must drop.
+                if !self.drop_compute_read_policy(&sink.global_id) {
+                    tracing::error!("Instructed to drop a compute sink that isn't one");
+                    continue;
+                }
+            }
+
             by_cluster
                 .entry(sink.cluster_id)
                 .or_default()
@@ -813,6 +826,19 @@ impl Coordinator {
         let mut by_cluster: BTreeMap<_, Vec<_>> = BTreeMap::new();
         let mut source_ids = Vec::new();
         for (cluster_id, id) in mviews {
+            if !self
+                .controller
+                .compute
+                .enable_aggressive_readhold_downgrades()
+            {
+                // If aggressive downgrades are disabled, MV dataflows have read policies that we
+                // must drop.
+                if !self.drop_compute_read_policy(&id) {
+                    tracing::error!("Instructed to drop a materialized view that isn't one");
+                    continue;
+                }
+            }
+
             by_cluster.entry(cluster_id).or_default().push(id);
             source_ids.push(id);
         }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -248,6 +248,10 @@ impl<T: Timestamp> ComputeController<T> {
         self.default_arrangement_exert_proportionality = value;
     }
 
+    pub fn enable_aggressive_readhold_downgrades(&self) -> bool {
+        self.enable_aggressive_readhold_downgrades
+    }
+
     pub fn set_enable_aggressive_readhold_downgrades(&mut self, value: bool) {
         self.enable_aggressive_readhold_downgrades = value;
     }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -3124,3 +3124,70 @@ def workflow_test_subscribe_hydration_status(
             """
         )
     )
+
+
+def workflow_test_compute_aggressive_readhold_downgrades_disabled(
+    c: Composition, parser: WorkflowArgumentParser
+) -> None:
+    """
+    Test that frontiers of MVs don't become stuck with aggressive read
+    hold downgrading disabled.
+    """
+
+    c.down(destroy_volumes=True)
+
+    with c.override(
+        Materialized(
+            additional_system_parameter_defaults={
+                "enable_compute_aggressive_readhold_downgrades": "false",
+            },
+        ),
+        Testdrive(no_reset=True),
+    ):
+        c.up("materialized")
+        c.up("testdrive", persistent=True)
+
+        c.sql(
+            """
+            CREATE TABLE t (a int);
+            CREATE MATERIALIZED VIEW mv AS SELECT * FROM t;
+            SELECT * FROM mv;
+            """
+        )
+
+        # Wait for `t`'s read frontier to be available.
+        c.testdrive(
+            input=dedent(
+                """
+                > SELECT true
+                  FROM mz_internal.mz_frontiers
+                  JOIN mz_tables ON (id = object_id)
+                  WHERE name = 't'
+                true
+                """
+            )
+        )
+
+        # Retrieve the current read frontier.
+        output = c.sql_query(
+            """
+            SELECT read_frontier
+            FROM mz_internal.mz_frontiers
+            JOIN mz_tables ON (id = object_id)
+            WHERE name = 't'
+            """
+        )
+        read_frontier = int(output[0][0])
+
+        # Verify that `t`'s read frontier advances.
+        c.testdrive(
+            input=dedent(
+                f"""
+                > SELECT read_frontier > {read_frontier}
+                  FROM mz_internal.mz_frontiers
+                  JOIN mz_tables ON (id = object_id)
+                  WHERE name = 't'
+                true
+                """
+            )
+        )


### PR DESCRIPTION
The flag `enable_compute_aggressive_readhold_downgrades` was meant to make it possible to disable aggressive readhold downgrading for MVs and revert back to the old behavior where read holds are kept at the current system time. As it turns out, the flag doesn't work as advertised because adapter doesn't install read policies for MVs anymore, so when you disable the flag, read frontiers of MVs and their inputs simply become stuck.

This is fixed in this PR by making adapter also check the feature flag and installing read policies if it is not set.

Note that adapter queries the flag's value from the compute controller, rather than the system config. That's to ensure we don't run into inconsistencies when the system config changes (i.e. someone runs `ALTER SYSTEM SET`). Changing the system config for this flag only takes affect after an environmentd restart, so we need to always base our decision on the initial value.

### Motivation

  * This PR fixes a previously unreported bug.

Disabling enable_compute_aggressive_readhold_downgrades makes read frontiers of MVs and their dependencies become stuck.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
