### PR TITLE
storage: Remove rdkafka full queue workaround

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -351,7 +351,8 @@ impl TransactionalProducer {
             Err((err, record)) => match err.rdkafka_error_code() {
                 Some(RDKafkaErrorCode::QueueFull) => {
                     // If the internal rdkafka queue is full we have no other option than to flush
-                    // TODO(petrosagg): remove this logic once we fix #24864
+                    // TODO(petrosagg): remove this logic once we fix upgrade to librdkafka 2.3 and
+                    // increase the queue limits
                     let timeout = self.transaction_timeout;
                     self.spawn_blocking(move |p| p.flush(timeout)).await?;
                     self.producer.send(record).map_err(|(err, _)| err.into())


### PR DESCRIPTION
Since #24864 has been fixed. via https://buildkite.com/materialize/nightlies/builds/6316#018d7940-69f7-4163-9359-6990c01ed1e0

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
