### PR TITLE
explain: move `used_indexes` computation deeper in the call stack

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -107,7 +107,7 @@ use mz_ore::tracing::{OpenTelemetryContext, TracingHandle};
 use mz_ore::{soft_panic_or_log, stack};
 use mz_persist_client::usage::{ShardsUsageReferenced, StorageUsageClient};
 use mz_pgcopy::CopyFormatParams;
-use mz_repr::explain::{ExplainConfig, ExplainFormat, UsedIndexes};
+use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::role_id::RoleId;
 use mz_repr::{GlobalId, RelationDesc, Timestamp};
 use mz_secrets::cache::CachingSecretsReader;
@@ -528,7 +528,6 @@ pub struct PeekStageExplain {
     select_id: GlobalId,
     finishing: RowSetFinishing,
     df_meta: DataflowMetainfo,
-    used_indexes: UsedIndexes,
     explain_ctx: ExplainContext,
 }
 
@@ -586,7 +585,6 @@ pub struct CreateIndexExplain {
     exported_index_id: GlobalId,
     plan: plan::CreateIndexPlan,
     df_meta: DataflowMetainfo,
-    used_indexes: UsedIndexes,
     explain_ctx: ExplainContext,
 }
 
@@ -694,7 +692,6 @@ pub struct CreateMaterializedViewExplain {
     exported_sink_id: GlobalId,
     plan: plan::CreateMaterializedViewPlan,
     df_meta: DataflowMetainfo,
-    used_indexes: UsedIndexes,
     explain_ctx: ExplainContext,
 }
 

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeSet;
 use maplit::btreemap;
 use mz_catalog::memory::objects::{CatalogItem, Index};
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::explain::{trace_plan, ExprHumanizerExt, TransientItem, UsedIndexes};
+use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan;
@@ -219,7 +219,6 @@ impl Coordinator {
                 let mut pipeline = || -> Result<(
                     optimize::index::GlobalMirPlan,
                     optimize::index::GlobalLirPlan,
-                    UsedIndexes,
                 ), AdapterError> {
                     // In `explain_~` contexts, set the trace-derived dispatch
                     // as default while optimizing.
@@ -232,37 +231,19 @@ impl Coordinator {
 
                     let _span_guard = tracing::debug_span!(target: "optimizer", "optimize").entered();
 
-                    // MIR ⇒ MIR optimization (global)
                     let index_plan =
                         optimize::index::Index::new(&plan.name, &plan.index.on, &plan.index.keys);
+
+                    // MIR ⇒ MIR optimization (global)
                     let global_mir_plan = optimizer.catch_unwind_optimize(index_plan)?;
-
-                    // Collect the list of indexes used by the dataflow at this point
-                    let used_indexes = {
-                        let df_desc = global_mir_plan.df_desc();
-                        let df_meta = global_mir_plan.df_meta();
-                        UsedIndexes::new(
-                            df_desc
-                                .index_imports
-                                .iter()
-                                .map(|(id, _index_import)| {
-                                    (*id, df_meta.index_usage_types.get(id).expect("prune_and_annotate_dataflow_index_imports should have been called already").clone())
-                                })
-                                .collect(),
-                        )
-                    };
-
                     // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
                     let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan.clone())?;
 
-                    // Trace the resulting plan for the top-level `optimize` path.
-                    trace_plan(global_lir_plan.df_desc());
-
-                    Ok((global_mir_plan, global_lir_plan, used_indexes))
+                    Ok((global_mir_plan, global_lir_plan))
                 };
 
                 let stage = match pipeline() {
-                    Ok((global_mir_plan, global_lir_plan, used_indexes)) => {
+                    Ok((global_mir_plan, global_lir_plan)) => {
                         if let Some(explain_ctx) = explain_ctx {
                             let (_, df_meta) = global_lir_plan.unapply();
                             CreateIndexStage::Explain(CreateIndexExplain {
@@ -270,7 +251,6 @@ impl Coordinator {
                                 exported_index_id,
                                 plan,
                                 df_meta,
-                                used_indexes,
                                 explain_ctx,
                             })
                         } else {
@@ -303,7 +283,6 @@ impl Coordinator {
                                 exported_index_id,
                                 plan,
                                 df_meta: Default::default(),
-                                used_indexes: Default::default(),
                                 explain_ctx,
                             })
                         } else {
@@ -454,7 +433,6 @@ impl Coordinator {
             exported_index_id,
             plan: plan::CreateIndexPlan { name, index, .. },
             df_meta,
-            used_indexes,
             explain_ctx:
                 ExplainContext {
                     broken,
@@ -490,7 +468,6 @@ impl Coordinator {
             &config,
             &expr_humanizer,
             None,
-            used_indexes,
             df_meta,
             stage,
             plan::ExplaineeStatementKind::CreateIndex,

--- a/src/adapter/src/explain/mod.rs
+++ b/src/adapter/src/explain/mod.rs
@@ -15,13 +15,10 @@
 //! implementations for some structs (see the [`mir`]) module for details.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_expr::explain::ExplainContext;
-use mz_repr::explain::{
-    Explain, ExplainConfig, ExplainError, ExplainFormat, ExprHumanizer, UsedIndexes,
-};
+use mz_repr::explain::{Explain, ExplainConfig, ExplainError, ExplainFormat, ExprHumanizer};
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::notice::OptimizerNotice;
 
@@ -57,14 +54,7 @@ where
     for<'a> Explainable<'a, DataflowDescription<T>>: Explain<'a, Context = ExplainContext<'a>>,
 {
     // Collect the list of indexes used by the dataflow at this point.
-    let used_indexes = UsedIndexes::new(
-        plan.index_imports
-            .iter()
-            .map(|(id, _index_import)| {
-                (*id, dataflow_metainfo.index_usage_types.get(id).expect("prune_and_annotate_dataflow_index_imports should have been called already").clone())
-            })
-            .collect(),
-    );
+    let used_indexes = dataflow_metainfo.used_indexes(&plan);
 
     let optimizer_notices = OptimizerNotice::explain(
         &dataflow_metainfo.optimizer_notices,
@@ -77,8 +67,8 @@ where
         config,
         humanizer,
         used_indexes,
-        finishing: None,
-        duration: Duration::default(),
+        finishing: Default::default(),
+        duration: Default::default(),
         optimizer_notices,
     };
 

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -761,7 +761,7 @@ impl<'a> fmt::Display for HumanizedAttributes<'a> {
 ///
 /// Using a `BTreeSet` here ensures a deterministic iteration order, which in turn ensures that
 /// the corresponding EXPLAIN output is determistic as well.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct UsedIndexes(BTreeSet<(GlobalId, Vec<IndexUsageType>)>);
 
 impl UsedIndexes {
@@ -812,7 +812,8 @@ pub enum IndexUsageType {
     /// an `ArrangeBy` marking for some operator other than a `Join`. (Which is fine, but please
     /// update `CollectIndexRequests`.)
     DanglingArrangeBy,
-    /// Internal error in `CollectIndexRequests`.
+    /// Internal error in `CollectIndexRequests` or a failed attempt to lookup
+    /// an index in `DataflowMetainfo::used_indexes`.
     Unknown,
 }
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3437,6 +3437,18 @@ pub enum NamedPlan {
 }
 
 impl NamedPlan {
+    /// Return the [`NamedPlan`] for a given `path` if it exists.
+    pub fn of_path(value: &str) -> Option<Self> {
+        match value {
+            "optimize/raw" => Some(Self::Raw),
+            "optimize/hir_to_mir" => Some(Self::Decorrelated),
+            "optimize/global" => Some(Self::Optimized),
+            "optimize/finalize_dataflow" => Some(Self::Physical),
+            "optimize/fast_path" => Some(Self::FastPath),
+            _ => None,
+        }
+    }
+
     /// Return the tracing path under which the plan can be found in an
     /// optimizer trace.
     pub fn path(&self) -> &'static str {

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -18,7 +18,6 @@
 mod tests {
     use std::collections::BTreeMap;
     use std::fmt::Write;
-    use std::time::Duration;
 
     use anyhow::{anyhow, Error};
     use mz_expr::explain::ExplainContext;
@@ -29,7 +28,7 @@ mod tests {
     use mz_lowertest::{deserialize, tokenize};
     use mz_ore::collections::HashMap;
     use mz_ore::str::separated;
-    use mz_repr::explain::{Explain, ExplainConfig, ExplainFormat, UsedIndexes};
+    use mz_repr::explain::{Explain, ExplainConfig, ExplainFormat};
     use mz_repr::GlobalId;
     use mz_transform::dataflow::{
         optimize_dataflow_demand_inner, optimize_dataflow_filters_inner, DataflowMetainfo,
@@ -146,9 +145,9 @@ mod tests {
                 let context = ExplainContext {
                     config: &config,
                     humanizer: cat,
-                    used_indexes: UsedIndexes::default(),
-                    finishing: None,
-                    duration: Duration::default(),
+                    used_indexes: Default::default(),
+                    finishing: Default::default(),
+                    duration: Default::default(),
                     optimizer_notices: Vec::new(),
                 };
 

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -8,13 +8,12 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::BTreeSet;
-use std::time::Duration;
 
 use mz_expr::explain::{enforce_linear_chains, ExplainContext};
 use mz_expr_parser::{handle_define, try_parse_mir, TestCatalog};
 use mz_ore::str::Indent;
 use mz_repr::explain::text::text_string_at;
-use mz_repr::explain::{ExplainConfig, PlanRenderingContext, UsedIndexes};
+use mz_repr::explain::{ExplainConfig, PlanRenderingContext};
 use mz_transform::attribute::annotate_plan;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::typecheck::TypeErrorHumanizer;
@@ -57,9 +56,9 @@ fn handle_explain(
     let context = ExplainContext {
         config: &config,
         humanizer: catalog,
-        used_indexes: UsedIndexes::default(),
-        finishing: None,
-        duration: Duration::default(),
+        used_indexes: Default::default(),
+        finishing: Default::default(),
+        duration: Default::default(),
         optimizer_notices: Vec::default(),
     };
 

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -124,6 +124,19 @@ Explained Query:
 
 EOF
 
+# FastPathPlan is show instead of PHYSICAL PLAN if present.
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+SELECT * FROM t where a = 5
+----
+Explained Query (fast path):
+  Project (#0, #1)
+    ReadIndex on=materialize.public.t t_a_idx=[lookup value=(5)]
+
+Used Indexes:
+  - materialize.public.t_a_idx (lookup)
+
+EOF
 
 # Test basic linear chains.
 


### PR DESCRIPTION
The code is littered with instances of the same pattern:

```rust
// Collect the list of indexes used by the dataflow at this point
let used_indexes = {
    let df_desc = global_mir_plan.df_desc();
    let df_meta = global_mir_plan.df_meta();
    UsedIndexes::new(
        df_desc
            .index_imports
            .iter()
            .map(|(id, _index_import)| {
                (*id, df_meta.index_usage_types.get(id).expect("prune_and_annotate_dataflow_index_imports should have been called already").clone())
            })
            .collect(),
    )
};
```

Simplify the code of the various `sequence_` methods that currently have this code duplicated and move it to its own method. In addition, change the `OptimizerTrace` implementation so `UsedIndexes` structs can be directly recorded there, which should alleviate the need to pass `used_indexes: UsedIndexes` parameters around.


### Motivation

   * This PR refactors existing code.

### Tips for reviewer

There are several things that are accomplished from the single commit in this PR:

1. Extend `OptimizerTrace` with a layer that allows to record `UsedIndexes` structures.
2. Extend `OptimizerTrace::drain_all` with code that looks up  `used_indexes: UsedIndexes` from the new layer (see also `PlanTrace<UsedIndexes>::used_indexes_for`).
3. Simplify the `Coordinator` code - don't compute and pass around `used_indexes: UsedIndex` in the `inner/*.rs` code.
4. Instead, introduce a `DataflowMetainfo::used_indexes` helper function.
5. Use the above to trace `used_indexes` for the `NamedPlan` optimizer stages where they are needed in the `optimize/*.rs` implementations.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered (Relying on existing `EXPLAIN` tests).
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
