### PR TITLE
fivetran-destination: Refactor errors, automatically retry on some

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4429,7 +4429,6 @@ dependencies = [
 name = "mz-fivetran-destination"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "async-compression",
  "clap",
  "csv-async",
@@ -4449,6 +4448,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2 0.5.3",
+ "thiserror",
  "tokio",
  "tokio-postgres",
  "tokio-stream",

--- a/src/fivetran-destination/Cargo.toml
+++ b/src/fivetran-destination/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 workspace = true
 
 [dependencies]
-anyhow = "1.0.66"
 async-compression = { version = "0.4.5", features = ["gzip", "tokio", "zstd"] }
 clap = { version = "3.2.24", features = ["derive", "env"] }
 csv-async = { version = "1.2.6", default-features = false, features = ["tokio"] }
@@ -27,6 +26,7 @@ prost-types = { version = "0.11.9" }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 socket2 = "0.5.3"
+thiserror = "1.0.37"
 tonic = "0.9.2"
 tokio = { version = "1.32.0", features = ["rt"] }
 tokio-postgres = { version = "0.7.8" }

--- a/src/fivetran-destination/src/bin/mz-fivetran-destination.rs
+++ b/src/fivetran-destination/src/bin/mz-fivetran-destination.rs
@@ -52,7 +52,7 @@ async fn main() {
     }
 }
 
-async fn run(Args { port }: Args) -> Result<(), anyhow::Error> {
+async fn run(Args { port }: Args) -> Result<(), Box<dyn std::error::Error>> {
     let addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, port));
 
     // Fivetran requires us to listen on both IPv4 and IPv6, so we explicitly create a Socket which

--- a/src/fivetran-destination/src/crypto.rs
+++ b/src/fivetran-destination/src/crypto.rs
@@ -29,7 +29,11 @@ pub struct AsyncAesDecrypter<R> {
 }
 
 impl<R> AsyncAesDecrypter<R> {
-    pub fn new(input: R, key: &[u8], iv: &[u8]) -> Result<AsyncAesDecrypter<R>, anyhow::Error> {
+    pub fn new(
+        input: R,
+        key: &[u8],
+        iv: &[u8],
+    ) -> Result<AsyncAesDecrypter<R>, openssl::error::ErrorStack> {
         Ok(AsyncAesDecrypter {
             input,
             crypter: Crypter::new(

--- a/src/fivetran-destination/src/destination/config.rs
+++ b/src/fivetran-destination/src/destination/config.rs
@@ -7,16 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use anyhow::{bail, Context};
-use mz_ore::error::ErrorExt;
-use mz_ore::str::StrExt;
 use openssl::ssl::{SslConnector, SslMethod};
 use postgres_openssl::MakeTlsConnector;
 use std::collections::BTreeMap;
 
+use crate::error::{Context, OpError, OpErrorKind};
 use crate::fivetran_sdk::form_field::Type;
 use crate::fivetran_sdk::{
-    ConfigurationFormResponse, ConfigurationTest, FormField, TestRequest, TestResponse, TextField,
+    ConfigurationFormResponse, ConfigurationTest, FormField, TestRequest, TextField,
 };
 
 pub const FIVETRAN_DESTINATION_APPLICATION_NAME: &str = "materialize_fivetran_destination";
@@ -68,30 +66,28 @@ pub fn handle_configuration_form_request() -> ConfigurationFormResponse {
     }
 }
 
-pub async fn handle_test_request(request: TestRequest) -> Result<TestResponse, anyhow::Error> {
-    use crate::fivetran_sdk::test_response::Response;
-
-    let result = match request.name.as_str() {
-        "connect" => test_connect(request.configuration).await,
-        "permissions" => test_permissions(request.configuration).await,
+pub async fn handle_test_request(request: TestRequest) -> Result<(), OpError> {
+    match request.name.as_str() {
+        "connect" => test_connect(request.configuration)
+            .await
+            .context("test_connect"),
+        "permissions" => test_permissions(request.configuration)
+            .await
+            .context("test_permissions"),
         "ping" => Ok(()),
-        name => bail!("unknown test {}", name.quoted()),
-    };
-    let response = match result {
-        Ok(()) => Response::Success(true),
-        Err(e) => Response::Failure(e.display_with_causes().to_string()),
-    };
-    Ok(TestResponse {
-        response: Some(response),
-    })
+        name => {
+            let error = OpErrorKind::UnknownRequest(name.to_string());
+            Err(error.into())
+        }
+    }
 }
 
-async fn test_connect(config: BTreeMap<String, String>) -> Result<(), anyhow::Error> {
+async fn test_connect(config: BTreeMap<String, String>) -> Result<(), OpError> {
     let _ = connect(config).await?;
     Ok(())
 }
 
-async fn test_permissions(config: BTreeMap<String, String>) -> Result<(), anyhow::Error> {
+async fn test_permissions(config: BTreeMap<String, String>) -> Result<(), OpError> {
     let (dbname, client) = connect(config).await?;
     let row = client
         .query_one(
@@ -101,30 +97,33 @@ async fn test_permissions(config: BTreeMap<String, String>) -> Result<(), anyhow
         .await
         .context("querying privileges")?;
     let has_create: bool = row.get("has_create");
+
     if !has_create {
-        bail!(
-            "user lacks \"CREATE\" privilege on database ({})",
-            dbname.quoted()
-        );
+        let err = OpErrorKind::MissingPrivilege {
+            privilege: "CREATE",
+            object: dbname,
+        }
+        .into();
+        return Err(err);
     }
     Ok(())
 }
 
 pub async fn connect(
     mut config: BTreeMap<String, String>,
-) -> Result<(String, tokio_postgres::Client), anyhow::Error> {
-    let Some(host) = config.remove("host") else {
-        bail!("internal error: \"host\" configuration parameter missing");
-    };
-    let Some(user) = config.remove("user") else {
-        bail!("internal error: \"user\" configuration parameter missing");
-    };
-    let Some(app_password) = config.remove("app_password") else {
-        bail!("internal error: \"app_password\" configuration parameter missing");
-    };
-    let Some(dbname) = config.remove("dbname") else {
-        bail!("internal error: \"dbname\" configuration parameter missing");
-    };
+) -> Result<(String, tokio_postgres::Client), OpError> {
+    let host = config
+        .remove("host")
+        .ok_or(OpErrorKind::FieldMissing("host"))?;
+    let user = config
+        .remove("user")
+        .ok_or(OpErrorKind::FieldMissing("user"))?;
+    let app_password = config
+        .remove("app_password")
+        .ok_or(OpErrorKind::FieldMissing("app_password"))?;
+    let dbname = config
+        .remove("dbname")
+        .ok_or(OpErrorKind::FieldMissing("dbname"))?;
 
     let builder = SslConnector::builder(SslMethod::tls_client())?;
     let tls_connector = MakeTlsConnector::new(builder.build());
@@ -136,8 +135,7 @@ pub async fn connect(
         .dbname(&dbname)
         .application_name(FIVETRAN_DESTINATION_APPLICATION_NAME)
         .connect(tls_connector)
-        .await
-        .context("connecting to Materialize")?;
+        .await?;
 
     mz_ore::task::spawn(|| "postgres_connection", async move {
         if let Err(e) = conn.await {

--- a/src/fivetran-destination/src/error.rs
+++ b/src/fivetran-destination/src/error.rs
@@ -1,0 +1,211 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::borrow::Cow;
+use std::fmt;
+
+/// Error that gets returned by internal operations of our Fivetran connector.
+///
+/// Note: We made our own error kind instead of using `anyhow::Error` because we want to internally
+/// retry specific failures. Given a lot of the operations run by the connector are SQL queries, we
+/// also want to track the context of where these queries were run, hence this relatively complex
+/// error type.
+#[derive(Debug)]
+pub struct OpError {
+    kind: OpErrorKind,
+    context: Vec<Cow<'static, str>>,
+}
+
+impl OpError {
+    pub fn new(kind: OpErrorKind) -> Self {
+        OpError {
+            kind,
+            context: Vec::new(),
+        }
+    }
+
+    pub fn kind(&self) -> &OpErrorKind {
+        &self.kind
+    }
+}
+
+impl<T: Into<OpErrorKind>> From<T> for OpError {
+    fn from(value: T) -> Self {
+        OpError::new(value.into())
+    }
+}
+
+impl fmt::Display for OpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.kind)?;
+        for cause in &self.context {
+            write!(f, ": {}", cause)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum OpErrorKind {
+    #[error("the required field '{0}' is missing")]
+    FieldMissing(&'static str),
+    #[error("failed to create a temporary resource")]
+    TemporaryResource(tokio_postgres::Error),
+    #[error("internal invariant was violated: {0}")]
+    InvariantViolated(String),
+    #[error("error when calling Materialize: {0:?}")]
+    MaterializeError(#[from] tokio_postgres::Error),
+    #[error("postgres type error: {0:?}")]
+    PgTypeError(#[from] mz_pgrepr::TypeFromOidError),
+    #[error("user lacks privilege \"{privilege}\" on object \"{object}\"")]
+    MissingPrivilege {
+        privilege: &'static str,
+        object: String,
+    },
+    #[error("filesystem error: {0:?}")]
+    Filesystem(#[from] std::io::Error),
+    #[error("cryptography error: {0:?}")]
+    Crypto(#[from] openssl::error::ErrorStack),
+    #[error("failure when parsing csv: {0:?}")]
+    CSV(#[from] csv_async::Error),
+    #[error("this feature is unsupported: {0}")]
+    Unsupported(String),
+    #[error("invalid identifier: {0:?}")]
+    IdentError(#[from] mz_sql_parser::ast::IdentError),
+    #[error("unknown request: {0}")]
+    UnknownRequest(String),
+}
+
+impl OpErrorKind {
+    /// Returns whether or not the error should be retried.
+    pub fn can_retry(&self) -> bool {
+        use OpErrorKind::*;
+
+        match self {
+            e @ TemporaryResource(err) | e @ MaterializeError(err) => {
+                use tokio_postgres::error::SqlState;
+
+                let Some(db_error) = err.as_db_error() else {
+                    return false;
+                };
+
+                // Note: This list was chosen fairly conservatively, feel free to add more errors
+                // as seen fit.
+                match *db_error.code() {
+                    SqlState::CONNECTION_EXCEPTION
+                    | SqlState::CONNECTION_FAILURE
+                    | SqlState::CONNECTION_DOES_NOT_EXIST
+                    | SqlState::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION
+                    | SqlState::TRANSACTION_RESOLUTION_UNKNOWN => true,
+                    SqlState::DUPLICATE_OBJECT | SqlState::DUPLICATE_TABLE
+                        if matches!(e, TemporaryResource(_)) =>
+                    {
+                        true
+                    }
+                    _ => false,
+                }
+            }
+            e @ Filesystem(_) | e @ CSV(_) => {
+                use std::io::ErrorKind::*;
+
+                let io_error_kind = match e {
+                    Filesystem(err) => err.kind(),
+                    CSV(err) => match err.kind() {
+                        csv_async::ErrorKind::Io(io_err) => io_err.kind(),
+                        _ => return false,
+                    },
+                    e => unreachable!("programming error, {e:?} should have been matched above"),
+                };
+
+                // Note: We don't expect to receive the network related errors, but for
+                // completeness we include them here.
+                match io_error_kind {
+                    NotFound | ConnectionReset | ConnectionAborted | BrokenPipe | TimedOut
+                    | Interrupted | UnexpectedEof => true,
+                    _ => false,
+                }
+            }
+            FieldMissing(_)
+            | InvariantViolated(_)
+            | PgTypeError(_)
+            | MissingPrivilege { .. }
+            | Crypto(_)
+            | Unsupported(_)
+            | IdentError(_)
+            | UnknownRequest(_) => false,
+        }
+    }
+}
+
+pub trait Context {
+    type TransformType;
+
+    fn context(self, context: &'static str) -> Self::TransformType;
+    fn with_context(self, f: impl FnOnce() -> String) -> Self::TransformType;
+}
+
+impl Context for OpErrorKind {
+    type TransformType = OpError;
+
+    fn context(self, context: &'static str) -> Self::TransformType {
+        OpError {
+            kind: self,
+            context: vec![context.into()],
+        }
+    }
+
+    fn with_context(self, f: impl FnOnce() -> String) -> Self::TransformType {
+        OpError {
+            kind: self,
+            context: vec![f().into()],
+        }
+    }
+}
+
+impl<T> Context for Result<T, OpError> {
+    type TransformType = Result<T, OpError>;
+
+    fn context(mut self, context: &'static str) -> Self::TransformType {
+        if let Err(err) = &mut self {
+            err.context.push(context.into());
+        }
+        self
+    }
+
+    fn with_context(mut self, f: impl FnOnce() -> String) -> Self::TransformType {
+        if let Err(err) = &mut self {
+            err.context.push(f().into());
+        }
+        self
+    }
+}
+
+impl<T, E: Into<OpErrorKind>> Context for Result<T, E> {
+    type TransformType = Result<T, OpError>;
+
+    fn context(self, context: &'static str) -> Self::TransformType {
+        self.map_err(|err| {
+            let kind: OpErrorKind = err.into();
+            OpError {
+                kind,
+                context: vec![context.into()],
+            }
+        })
+    }
+
+    fn with_context(self, f: impl FnOnce() -> String) -> Self::TransformType {
+        self.map_err(|err| {
+            let kind: OpErrorKind = err.into();
+            OpError {
+                kind,
+                context: vec![f().into()],
+            }
+        })
+    }
+}

--- a/src/fivetran-destination/src/lib.rs
+++ b/src/fivetran-destination/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod crypto;
 mod destination;
+mod error;
 mod fivetran_sdk;
 
 pub mod logging;

--- a/test/fivetran-destination/test-no-database/02-verify.json
+++ b/test/fivetran-destination/test-no-database/02-verify.json
@@ -1,2 +1,2 @@
 {}
-// FAIL: database "test" does not exist
+// FAIL: database \"test\" does not exist

--- a/test/fivetran-destination/test-no-permissions/02-verify.json
+++ b/test/fivetran-destination/test-no-permissions/02-verify.json
@@ -1,2 +1,2 @@
 {}
-// FAIL: user lacks "CREATE" privilege on database ("test")
+// FAIL: user lacks privilege "CREATE" on object "test"


### PR DESCRIPTION
This PR refactors the error handling in the Fivetran Destination to do a few things:

1. We define a custom `OpError` that uses `thiserror` instead of returning `anyhow::Error`
2. Refactors the gRPC interface, "flattening" it a bit, to log on errors and automatically retry transient errors upto 3 times

### Motivation

Make our Fivetran Destination more resilient to temporary failures

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
