### PR TITLE
feature kafka connection default aws privatelink

### DIFF
--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -461,14 +461,14 @@ CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK db.schema.item, PORT 1234)
 ----
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK = db.schema.item, PORT = 1234)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection_type: Postgres, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection_type: Postgres, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])), port: None })) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }], with_options: [] })
 
 parse-statement
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK db.schema.item, PORT 1234, HOST foo, SSL CERTIFICATE 'cert', SSL CERTIFICATE AUTHORITY 'auth', SSL KEY 'key')
 ----
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK = db.schema.item, PORT = 1234, HOST = foo, SSL CERTIFICATE = 'cert', SSL CERTIFICATE AUTHORITY = 'auth', SSL KEY = 'key')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection_type: Postgres, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("auth"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection_type: Postgres, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])), port: None })) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("auth"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }], with_options: [] })
 
 parse-statement
 CREATE CONNECTION mysqlconn FOR mysql HOST foo, PORT 1234, SSL CERTIFICATE AUTHORITY 'foo', SSH TUNNEL tun, PASSWORD 'pw', SSL CERTIFICATE 'cert', SSL KEY 'key', SSL MODE 'mode', USER 'root'
@@ -482,14 +482,14 @@ CREATE CONNECTION mysqlconn TO MYSQL (AWS PRIVATELINK db.schema.item, PORT 1234)
 ----
 CREATE CONNECTION mysqlconn TO MYSQL (AWS PRIVATELINK = db.schema.item, PORT = 1234)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("mysqlconn")]), connection_type: MySql, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("mysqlconn")]), connection_type: MySql, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])), port: None })) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }], with_options: [] })
 
 parse-statement
 CREATE CONNECTION mysqlconn TO MYSQL (AWS PRIVATELINK db.schema.item, PORT 1234, HOST foo, SSL CERTIFICATE 'cert', SSL CERTIFICATE AUTHORITY 'auth', SSL KEY 'key')
 ----
 CREATE CONNECTION mysqlconn TO MYSQL (AWS PRIVATELINK = db.schema.item, PORT = 1234, HOST = foo, SSL CERTIFICATE = 'cert', SSL CERTIFICATE AUTHORITY = 'auth', SSL KEY = 'key')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("mysqlconn")]), connection_type: MySql, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("auth"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("mysqlconn")]), connection_type: MySql, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])), port: None })) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("auth"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }], with_options: [] })
 
 parse-statement
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red');
@@ -2088,7 +2088,7 @@ CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY URL 'http://localhost:8081
 ----
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (URL = 'http://localhost:8081', USER = 'user', PASSWORD = 'word', PORT = 1234, AWS PRIVATELINK = apl)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Csr, if_not_exists: false, values: [ConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }, ConnectionOption { name: User, value: Some(Value(String("user"))) }, ConnectionOption { name: Password, value: Some(Value(String("word"))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("apl")])))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Csr, if_not_exists: false, values: [ConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }, ConnectionOption { name: User, value: Some(Value(String("user"))) }, ConnectionOption { name: Password, value: Some(Value(String("word"))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: AwsPrivatelink, value: Some(ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("apl")])), port: None })) }], with_options: [] })
 
 parse-statement roundtrip
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (URL = 'http://localhost:8081', USERNAME = 'user', PASSWORD = 'word')
@@ -2101,7 +2101,7 @@ CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (AWS PRIVATELINK db.schema.
 ----
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (AWS PRIVATELINK = db.schema.item, PORT = 8080)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Csr, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, ConnectionOption { name: Port, value: Some(Value(Number("8080"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Csr, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])), port: None })) }, ConnectionOption { name: Port, value: Some(Value(Number("8080"))) }], with_options: [] })
 
 parse-statement
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (SSH TUNNEL ssh, SSL CERTIFICATE 'cert', SSL CERTIFICATE AUTHORITY 'auth', SSL KEY 'key')
@@ -2116,7 +2116,7 @@ CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (AWS PRIVATELINK db.schema.
 ----
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (AWS PRIVATELINK = db.schema.item, PORT = 8080, URL = 'http://localhost:8081')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Csr, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, ConnectionOption { name: Port, value: Some(Value(Number("8080"))) }, ConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Csr, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])), port: None })) }, ConnectionOption { name: Port, value: Some(Value(Number("8080"))) }, ConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }], with_options: [] })
 
 
 parse-statement

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1785,6 +1785,9 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                     .collect(),
             ),
             ConnectionKafkaBroker(broker) => ConnectionKafkaBroker(self.fold_kafka_broker(broker)),
+            ConnectionAwsPrivatelink(privatelink) => {
+                ConnectionAwsPrivatelink(self.fold_connection_default_aws_privatelink(privatelink))
+            }
             RetainHistoryFor(value) => RetainHistoryFor(self.fold_value(value)),
             Refresh(refresh) => Refresh(self.fold_refresh_option_value(refresh)),
         }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2075,6 +2075,13 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
+        name: enable_default_kafka_aws_private_link,
+        desc: "the top-level Aws Privatelink feature for kafka connections",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
         name: enable_time_at_time_zone,
         desc: "use of AT TIME ZONE or timezone() with time type",
         default: false,

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -17,8 +17,10 @@ use std::sync::Arc;
 use anyhow::{anyhow, Context};
 use itertools::Itertools;
 use mz_ccsr::tls::{Certificate, Identity};
-use mz_cloud_resources::{AwsExternalIdPrefix, CloudResourceReader};
-use mz_kafka_util::client::{BrokerRewrite, MzClientContext, MzKafkaError, TunnelingClientContext};
+use mz_cloud_resources::{vpc_endpoint_host, AwsExternalIdPrefix, CloudResourceReader};
+use mz_kafka_util::client::{
+    BrokerRewrite, MzClientContext, MzKafkaError, TunnelConfig, TunnelingClientContext,
+};
 use mz_ore::error::ErrorExt;
 use mz_proto::tokio_postgres::any_ssl_mode;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
@@ -472,10 +474,23 @@ impl KafkaConnection {
         // partitions.
         options.insert("allow.auto.create.topics".into(), "false".into());
 
-        options.insert(
-            "bootstrap.servers".into(),
-            self.brokers.iter().map(|b| &b.address).join(",").into(),
-        );
+        let brokers = match &self.default_tunnel {
+            Tunnel::AwsPrivatelink(t) => {
+                assert!(&self.brokers.is_empty());
+                // When using a default privatelink tunnel broker/brokers cannot be specified
+                // instead the tunnel connection_id and port are used for the initial connection.
+                format!(
+                    "{}:{}",
+                    vpc_endpoint_host(
+                        t.connection_id,
+                        None, // Default tunnel does not support availability zones.
+                    ),
+                    t.port.unwrap_or(9092)
+                )
+            }
+            _ => self.brokers.iter().map(|b| &b.address).join(","),
+        };
+        options.insert("bootstrap.servers".into(), brokers.into());
         let security_protocol = match (self.tls.is_some(), self.sasl.is_some()) {
             (false, false) => "PLAINTEXT",
             (true, false) => "SSL",
@@ -533,8 +548,11 @@ impl KafkaConnection {
             Tunnel::Direct => {
                 // By default, don't offer a default override for broker address lookup.
             }
-            Tunnel::AwsPrivatelink(_) => {
-                unreachable!("top-level AwsPrivatelink tunnels are not supported yet")
+            Tunnel::AwsPrivatelink(pl) => {
+                context.set_default_tunnel(TunnelConfig::StaticHost(vpc_endpoint_host(
+                    pl.connection_id,
+                    None, // Default tunnel does not support availability zones.
+                )));
             }
             Tunnel::Ssh(ssh_tunnel) => {
                 let secret = storage_configuration
@@ -544,12 +562,12 @@ impl KafkaConnection {
                     .await?;
                 let key_pair = SshKeyPair::from_bytes(&secret)?;
 
-                context.set_default_ssh_tunnel(SshTunnelConfig {
+                context.set_default_tunnel(TunnelConfig::Ssh(SshTunnelConfig {
                     host: ssh_tunnel.connection.host.clone(),
                     port: ssh_tunnel.connection.port,
                     user: ssh_tunnel.connection.user.clone(),
                     key_pair,
-                });
+                }));
             }
         }
 

--- a/test/cloudtest/test_privatelink_connection.py
+++ b/test/cloudtest/test_privatelink_connection.py
@@ -10,7 +10,7 @@
 from textwrap import dedent
 
 import pytest
-from pg8000.dbapi import ProgrammingError
+from pg8000.dbapi import DatabaseError, ProgrammingError
 
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 from materialize.cloudtest.util.exists import exists, not_exists
@@ -47,6 +47,11 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
 
     mz.environmentd.sql(
         "ALTER SYSTEM SET max_aws_privatelink_connections = 5",
+        port="internal",
+        user="mz_system",
+    )
+    mz.environmentd.sql(
+        "ALTER SYSTEM SET enable_default_kafka_aws_private_link = true",
         port="internal",
         user="mz_system",
     )
@@ -99,6 +104,21 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
     assert principal == (
         f"arn:aws:iam::123456789000:role/mz_eb5cb59b-e2fe-41f3-87ca-d2176a495345_{aws_connection_id}"
     )
+
+    # Validate default privatelink connections for kafka
+    mz.environmentd.sql(
+        dedent(
+            """\
+            CREATE CONNECTION kafkaconn_alt TO KAFKA (
+                AWS PRIVATELINK privatelinkconn (PORT 9092),
+                SECURITY PROTOCOL PLAINTEXT
+            ) WITH (VALIDATE = false);
+            """
+        )
+    )
+    mz.environmentd.sql_query(
+        "SELECT id FROM mz_connections WHERE name = 'kafkaconn_alt'"
+    )[0][0]
 
     mz.environmentd.sql(
         dedent(
@@ -160,7 +180,42 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
             )
         )
 
-    mz.environmentd.sql("DROP CONNECTION kafkaconn")
-    mz.environmentd.sql("DROP CONNECTION privatelinkconn")
+    with pytest.raises(
+        DatabaseError,
+        match="invalid CONNECTION: can only set one of BROKER, BROKERS, or AWS PRIVATELINK",
+    ):
+        mz.environmentd.sql(
+            dedent(
+                """\
+                CREATE CONNECTION kafkaconn2_alt TO KAFKA (
+                    AWS PRIVATELINK privatelinkconn (PORT 9092),
+                    BROKERS (
+                        'customer-hostname-3:9092' USING AWS PRIVATELINK privatelinkconn (PORT 9093)
+                    ),
+                    SECURITY PROTOCOL PLAINTEXT
+                ) WITH (VALIDATE = false);
+                """
+            )
+        )
+    with pytest.raises(
+        ProgrammingError,
+        match="invalid CONNECTION: PORT in AWS PRIVATELINK is only supported for kafka",
+    ):
+        mz.environmentd.sql(
+            dedent(
+                """\
+            CREATE CONNECTION pg TO POSTGRES (
+                HOST 'postgres',
+                DATABASE postgres,
+                USER postgres,
+                AWS PRIVATELINK privatelinkconn ( PORT 1234 ),
+                PORT 1234
+            ) WITH (VALIDATE = false);
+            """
+            )
+        )
+
+    mz.environmentd.sql("DROP CONNECTION kafkaconn CASCADE")
+    mz.environmentd.sql("DROP CONNECTION privatelinkconn CASCADE")
 
     not_exists(resource=f"vpcendpoint/connection-{aws_connection_id}")

--- a/test/testdrive/connection-alter.td
+++ b/test/testdrive/connection-alter.td
@@ -41,7 +41,7 @@ first second
 1     2
 
 ! ALTER CONNECTION conn RESET (broker);
-contains:invalid ALTER CONNECTION: invalid CONNECTION: must set either BROKER or BROKERS
+contains:invalid ALTER CONNECTION: invalid CONNECTION: must set one of BROKER, BROKERS, or AWS PRIVATELINK
 
 ! ALTER CONNECTION conn SET (broker = 'abcd') WITH (validate = true);
 contains:Failed to resolve hostname
@@ -92,7 +92,7 @@ contains:BROKER specified more than once
 contains:BROKER specified more than once
 
 ! ALTER CONNECTION conn SET (BROKER '${testdrive.kafka-addr}'), SET (BROKERS ['${testdrive.kafka-addr}'])
-contains:invalid ALTER CONNECTION: invalid CONNECTION: cannot set BROKER and BROKERS
+contains:invalid ALTER CONNECTION: invalid CONNECTION: can only set one of BROKER, BROKERS, or AWS PRIVATELINK
 
 ! ALTER CONNECTION conn SET (BROKER '${testdrive.kafka-addr}'), DROP (BROKERS)
 contains:cannot both SET and DROP/RESET mutually exclusive KAFKA options BROKER, BROKERS
@@ -102,7 +102,7 @@ contains:cannot both SET and DROP/RESET mutually exclusive KAFKA options BROKER,
 
 # We permit resetting both of these options, and the error occurs later in planning
 ! ALTER CONNECTION conn RESET (BROKER), RESET (BROKERS);
-contains:invalid ALTER CONNECTION: invalid CONNECTION: must set either BROKER or BROKERS
+contains:invalid ALTER CONNECTION: invalid CONNECTION: must set one of BROKER, BROKERS, or AWS PRIVATELINK
 
 > ALTER CONNECTION conn SET (BROKER = '${testdrive.kafka-addr}');
 

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -356,14 +356,14 @@ contains:BROKER specified more than once
 ! CREATE CONNECTION no_broker TO KAFKA (
     SECURITY PROTOCOL PLAINTEXT
   );
-contains:must set either BROKER or BROKERS
+contains:must set one of BROKER, BROKERS, or AWS PRIVATELINK
 
 ! CREATE CONNECTION ssl_underspeced TO KAFKA (
     BROKER 'kafka:9092',
     BROKERS ['kafka:9092', 'kafka:9093'],
     SECURITY PROTOCOL PLAINTEXT
   );
-contains:cannot set BROKER and BROKERS
+contains:can only set one of BROKER, BROKERS, or AWS PRIVATELINK
 
 ! CREATE CONNECTION ssl_underspeced TO KAFKA (
     BROKER 'kafka:9092',


### PR DESCRIPTION
        add feature to allow for default aws privatelink
        setting for kafka connections. This will set a
        static host re-rewite for all kafka brokers while
        maintaining their ports. The connection and port
        specified in the default connection will be used
        as the bootstrap server.

        adjusts parsers to enable top level privatelink
        to take in a port

        adds static host rewrite option for kakfa

        adjusts kafka source connections to use
        privatelink connection if specified

        adds tests to validate new syntax and
        ensure new option conflicts are respected

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
https://github.com/MaterializeInc/materialize/issues/24712

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
