### PR TITLE
persist: add flexibility to persist retry timings

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -45,8 +45,9 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_dangerous_functions": "true",  # former name of 'enable_unsafe_functions'
     # -----
     # To reduce CRDB load as we are struggling with it in CI (values based on load test environment):
-    "persist_next_listen_batch_retryer_clamp": "100ms",
-    "persist_next_listen_batch_retryer_initial_backoff": "1200ms",
+    "persist_next_listen_batch_retryer_clamp": "16s",
+    "persist_next_listen_batch_retryer_initial_backoff": "100ms",
+    "persist_next_listen_batch_retryer_fixed_sleep": "1200ms",
     # -----
     # Persist internals changes: advance coverage
     "persist_streaming_compaction_enabled": "true",

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -281,6 +281,7 @@ pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::internal::compact::COMPACTION_MINIMUM_TIMEOUT)
         .add(&crate::internal::compact::STREAMING_COMPACTION_ENABLED)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_CLAMP)
+        .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_FIXED_SLEEP)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER)
         .add(&crate::internal::state::ROLLUP_THRESHOLD)
@@ -415,6 +416,7 @@ pub struct DynamicConfig {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Arbitrary, Serialize, Deserialize)]
 pub struct RetryParameters {
+    pub fixed_sleep: Duration,
     pub initial_backoff: Duration,
     pub multiplier: u32,
     pub clamp: Duration,
@@ -426,6 +428,7 @@ impl RetryParameters {
             .duration_since(UNIX_EPOCH)
             .map_or(0, |x| u64::from(x.subsec_nanos()));
         Retry {
+            fixed_sleep: self.fixed_sleep,
             initial_backoff: self.initial_backoff,
             multiplier: self.multiplier,
             clamp_backoff: self.clamp,

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1106,6 +1106,13 @@ where
     }
 }
 
+pub(crate) const NEXT_LISTEN_BATCH_RETRYER_FIXED_SLEEP: Config<Duration> = Config::new(
+    "persist_next_listen_batch_retryer_fixed_sleep",
+    Duration::ZERO,
+    "\
+    The fixed sleep when polling for new batches from a Listen or Subscribe. Skipped if zero.",
+);
+
 pub(crate) const NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF: Config<Duration> = Config::new(
     "persist_next_listen_batch_retryer_initial_backoff",
     Duration::from_millis(1200), // pubsub is on by default!
@@ -1120,12 +1127,13 @@ pub(crate) const NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER: Config<u32> = Config::new
 
 pub(crate) const NEXT_LISTEN_BATCH_RETRYER_CLAMP: Config<Duration> = Config::new(
     "persist_next_listen_batch_retryer_clamp",
-    Duration::from_millis(100), // pubsub is on by default!
+    Duration::from_secs(1), // pubsub is on by default!
     "The backoff clamp duration when polling for new batches from a Listen or Subscribe.",
 );
 
 fn next_listen_batch_retry_params(cfg: &ConfigSet) -> RetryParameters {
     RetryParameters {
+        fixed_sleep: NEXT_LISTEN_BATCH_RETRYER_FIXED_SLEEP.get(cfg),
         initial_backoff: NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF.get(cfg),
         multiplier: NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER.get(cfg),
         clamp: NEXT_LISTEN_BATCH_RETRYER_CLAMP.get(cfg),

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -463,6 +463,7 @@ pub(crate) const DATA_SHARD_RETRYER_CLAMP: Config<Duration> = Config::new(
 /// `next_listen_batch`.
 pub fn txns_data_shard_retry_params(cfg: &ConfigSet) -> RetryParameters {
     RetryParameters {
+        fixed_sleep: Duration::ZERO,
         initial_backoff: DATA_SHARD_RETRYER_INITIAL_BACKOFF.get(cfg),
         multiplier: DATA_SHARD_RETRYER_MULTIPLIER.get(cfg),
         clamp: DATA_SHARD_RETRYER_CLAMP.get(cfg),

--- a/src/persist-txn/src/txns.rs
+++ b/src/persist-txn/src/txns.rs
@@ -1300,6 +1300,7 @@ mod tests {
         clients
             .cfg()
             .set_next_listen_batch_retryer(RetryParameters {
+                fixed_sleep: Duration::ZERO,
                 initial_backoff: Duration::from_millis(1),
                 multiplier: 1,
                 clamp: Duration::from_millis(1),


### PR DESCRIPTION
We currently have a bit of unresolvable tension with our retry tunings between the following:

- When a shard is not advancing (the cluster maintaining it is down, rehydrating, etc) and so the upper is not doing its normal pattern of advancing once per second, minimize the traffic of CRDB retries.
- When pubsub fails, continue to serve queries promptly, ideally within a few hundred ms.

This adds the ability to produce the following set of retry timings, which _does_ satisfy both of the above: 1200ms, 100ms, 200ms, 400ms, ...

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

I haven't tested this particularly extensively yet, wanted to get your thoughts on the approach before I spent too much more time on it.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
