### PR TITLE
ci: Run K8s recovery tests on aarch64 too

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -868,7 +868,7 @@ steps:
         label: "K8s recovery: storage on failing node"
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         inputs:
           - test/cloudtest
@@ -884,7 +884,7 @@ steps:
         label: "K8s recovery: compute on failing node"
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         inputs:
           - test/cloudtest
@@ -900,7 +900,7 @@ steps:
         label: "K8s recovery: replicated compute on failing node"
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         inputs:
           - test/cloudtest
@@ -916,7 +916,7 @@ steps:
         label: "K8s recovery: envd on failing node"
         timeout_in_minutes: 30
         agents:
-          queue: linux-x86_64
+          queue: linux-aarch64
         artifact_paths: junit_*.xml
         inputs:
           - test/cloudtest


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
