### PR TITLE
platform-checks: Fix retain history for indexes during upgrade

### DIFF
--- a/misc/python/materialize/checks/all_checks/alter_index.py
+++ b/misc/python/materialize/checks/all_checks/alter_index.py
@@ -56,8 +56,8 @@ class AlterIndex(Check):
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "B${kafka-ingest.iteration}"}
 
-                > ALTER INDEX alter_index_table_primary_idx SET (RETAIN HISTORY = FOR '1ms');
-                > ALTER INDEX alter_index_source_primary_idx SET (RETAIN HISTORY = FOR '1ms');
+                >[version>=8700] ALTER INDEX alter_index_table_primary_idx SET (RETAIN HISTORY = FOR '1ms');
+                >[version>=8700] ALTER INDEX alter_index_source_primary_idx SET (RETAIN HISTORY = FOR '1ms');
 
                 > INSERT INTO alter_index_table SELECT 'C' || generate_series FROM generate_series(1,10000);
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
@@ -79,8 +79,8 @@ class AlterIndex(Check):
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "D${kafka-ingest.iteration}"}
 
-                > ALTER INDEX alter_index_table_primary_idx SET (RETAIN HISTORY = FOR '1h');
-                > ALTER INDEX alter_index_source_primary_idx SET (RETAIN HISTORY = FOR '1h');
+                >[version>=8700] ALTER INDEX alter_index_table_primary_idx SET (RETAIN HISTORY = FOR '1h');
+                >[version>=8700] ALTER INDEX alter_index_source_primary_idx SET (RETAIN HISTORY = FOR '1h');
 
                 > INSERT INTO alter_index_table SELECT 'E' || generate_series FROM generate_series(1,10000);
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000


### PR DESCRIPTION
Follow-up to #24855

Seen in https://buildkite.com/materialize/nightlies/builds/6323#018d7a89-dce2-4f91-9761-9a2b47d5dffb

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
