### PR TITLE
adapter: refactor to use compaction window type more

### DIFF
--- a/src/adapter-types/src/compaction.rs
+++ b/src/adapter-types/src/compaction.rs
@@ -21,7 +21,7 @@ use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 const DEFAULT_LOGICAL_COMPACTION_WINDOW_MILLIS: u64 = 1000;
 
 /// `DEFAULT_LOGICAL_COMPACTION_WINDOW` as an `EpochMillis` timestamp
-pub const DEFAULT_LOGICAL_COMPACTION_WINDOW_TS: Timestamp =
+const DEFAULT_LOGICAL_COMPACTION_WINDOW_TS: Timestamp =
     Timestamp::new(DEFAULT_LOGICAL_COMPACTION_WINDOW_MILLIS);
 
 /// The value to round all `since` frontiers to.
@@ -41,6 +41,17 @@ pub enum CompactionWindow {
     DisableCompaction,
     /// Create a compaction window for a specified duration.
     Duration(Timestamp),
+}
+
+impl CompactionWindow {
+    pub fn lag_from(&self, from: Timestamp) -> Timestamp {
+        let lag = match self {
+            CompactionWindow::Default => DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
+            CompactionWindow::DisableCompaction => return Timestamp::minimum(),
+            CompactionWindow::Duration(d) => *d,
+        };
+        from.saturating_sub(lag)
+    }
 }
 
 impl From<CompactionWindow> for ReadPolicy<Timestamp> {


### PR DESCRIPTION
Avoid passing around `Option<Timestamp>` in favor
of passing around a `CompactionWindow` and
teaching that type how to do various operations.
This allows DEFAULT_LOGICAL_COMPACTION_WINDOW_TS
to be referenced in only a single file.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a