### PR TITLE
fivetran-destination: compile in CA bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4446,6 +4446,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "protobuf-src",
+ "reqwest",
  "serde",
  "serde_json",
  "socket2 0.5.3",

--- a/src/fivetran-destination/Cargo.toml
+++ b/src/fivetran-destination/Cargo.toml
@@ -43,6 +43,7 @@ insta = "1.32"
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
+reqwest = "0.11.13"
 tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/fivetran-destination/build.rs
+++ b/src/fivetran-destination/build.rs
@@ -8,24 +8,41 @@
 // by the Apache License, Version 2.0.
 
 use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+/// URL from which a trusted set of TLS certificate authorities can be
+/// downloaded.
+const CA_BUNDLE_URL: &str = "https://curl.se/ca/cacert.pem";
 
 fn main() {
-    env::set_var("PROTOC", protobuf_src::protoc());
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
-    let mut config = prost_build::Config::new();
-    config.btree_map(["."]);
+    // Build protobufs.
+    {
+        env::set_var("PROTOC", protobuf_src::protoc());
 
-    tonic_build::configure()
-        // Enabling `emit_rerun_if_changed` will rerun the build script when
-        // anything in the include directory (..) changes. This causes quite a
-        // bit of spurious recompilation, so we disable it. The default behavior
-        // is to re-run if any file in the crate changes; that's still a bit too
-        // broad, but it's better.
-        .emit_rerun_if_changed(false)
-        .compile_with_config(
-            config,
-            &["destination_sdk.proto"],
-            &["../../misc/fivetran-sdk"],
-        )
-        .unwrap();
+        let mut config = prost_build::Config::new();
+        config.btree_map(["."]);
+
+        tonic_build::configure()
+            // Enabling `emit_rerun_if_changed` will rerun the build script when
+            // anything in the include directory (..) changes. This causes quite a
+            // bit of spurious recompilation, so we disable it. The default behavior
+            // is to re-run if any file in the crate changes; that's still a bit too
+            // broad, but it's better.
+            .emit_rerun_if_changed(false)
+            .compile_with_config(
+                config,
+                &["destination_sdk.proto"],
+                &["../../misc/fivetran-sdk"],
+            )
+            .unwrap();
+    }
+
+    // Download CA bundle.
+    {
+        let ca_bundle = reqwest::blocking::get(CA_BUNDLE_URL).unwrap().bytes().unwrap();
+        fs::write(out_dir.join("ca-certificate.crt"), ca_bundle).unwrap();
+    }
 }

--- a/src/fivetran-destination/build.rs
+++ b/src/fivetran-destination/build.rs
@@ -42,7 +42,10 @@ fn main() {
 
     // Download CA bundle.
     {
-        let ca_bundle = reqwest::blocking::get(CA_BUNDLE_URL).unwrap().bytes().unwrap();
+        let ca_bundle = reqwest::blocking::get(CA_BUNDLE_URL)
+            .unwrap()
+            .bytes()
+            .unwrap();
         fs::write(out_dir.join("ca-certificate.crt"), ca_bundle).unwrap();
     }
 }

--- a/src/fivetran-destination/src/destination/config.rs
+++ b/src/fivetran-destination/src/destination/config.rs
@@ -11,8 +11,8 @@ use anyhow::{bail, Context};
 use mz_ore::error::ErrorExt;
 use mz_ore::str::StrExt;
 use openssl::ssl::{SslConnector, SslMethod};
-use openssl::x509::X509;
 use openssl::x509::store::X509StoreBuilder;
+use openssl::x509::X509;
 use postgres_openssl::MakeTlsConnector;
 use std::collections::BTreeMap;
 


### PR DESCRIPTION
Since Fivetran's environment does not have a system CA bundle for us to reference.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes an issue reported by Fivetran.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
