### PR TITLE
environmentd: improve test connection polling

### DIFF
--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -758,7 +758,14 @@ where
                         Ok(msg) => {
                             tracing::debug!(?msg, "Dropping message from database");
                         }
-                        Err(e) => panic!("connection error: {e}"),
+                        Err(e) => {
+                            // tokio_postgres::Connection docs say:
+                            // > Return values of None or Some(Err(_)) are “terminal”; callers
+                            // > should not invoke this method again after receiving one of those
+                            // > values.
+                            tracing::info!("connection error: {e}");
+                            break;
+                        }
                     }
                 }
                 tracing::info!("connection closed");


### PR DESCRIPTION
Previously a race condition between a client and server drop could cause the connection half of the client to get `Some(Err(_))` messages, and then choose to panic on those. However errors can happen here when the server side goes away, and it's not necessarily panic-worthy (and perhaps should never panic). If the server's ListenHandle dropped before the connection noticed that the client dropped, this would cause panics.

This was happening for me locally. I'm confused why it is not happening in CI.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a