### PR TITLE
compute: fix advancement of replica-targeted subscribe frontiers

### DIFF
--- a/test/testdrive/replica-targeting.td
+++ b/test/testdrive/replica-targeting.td
@@ -73,3 +73,36 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 > FETCH c
 <TIMESTAMP> 1 4
 > COMMIT
+
+# Test that replica-targeted subscribes work when the subscribed collection
+# advances to the empty frontier. Regression test for #24981.
+
+> DROP CLUSTER test CASCADE
+> CREATE CLUSTER test SIZE '4-4', REPLICATION FACTOR 4
+> SET cluster_replica = r1
+
+> CREATE MATERIALIZED VIEW mv AS SELECT 1
+
+> BEGIN
+> DECLARE c CURSOR FOR SUBSCRIBE mv
+> FETCH c
+<TIMESTAMP> 1 1
+> COMMIT
+
+# We want to provoke the case where a non-targeted replica returns a response
+# first, so try multiple times to be sure.
+
+> BEGIN
+> DECLARE c CURSOR FOR SUBSCRIBE mv
+> FETCH c
+<TIMESTAMP> 1 1
+> COMMIT
+
+> BEGIN
+> DECLARE c CURSOR FOR SUBSCRIBE mv
+> FETCH c
+<TIMESTAMP> 1 1
+> COMMIT
+
+# Cleanup
+> DROP CLUSTER test CASCADE


### PR DESCRIPTION
This PR changes how the compute controller handles frontier updates for replica-targeted subscribes. Previously, each replica could advance the global frontier of a subscribe, targeted or not. With this commit, only the targeted replica can cause a global frontier advancement.

This fixes the following error scenario:

 * A non-targeted replica advances to the empty frontier.
 * The compute controller downgrades the subscribe's global frontier to the empty frontier.
 * The compute controller sends an `AllowCompaction([])` command to all replicas.
 * The targeted replica receives the `AllowCompaction([])` and considers the subscribe dropped.
 * The compute controller never receives a subscribe response from the targeted replica.

### Motivation

  * This PR fixes a recognized bug.

Fixes #24981

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
