### PR TITLE
ci coverage: Make runs greener

### DIFF
--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -9,7 +9,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-set -euo pipefail
+# -x to debug mysterious failures without any logging
+set -euxo pipefail
 
 . misc/shlib/shlib.bash
 

--- a/misc/python/materialize/checks/all_checks/jsonb_type.py
+++ b/misc/python/materialize/checks/all_checks/jsonb_type.py
@@ -44,6 +44,7 @@ class JsonbType(Check):
                       jsonb_col <@ '{"boolean_element": true}' AS c11,
                       jsonb_col ? 'number_element' AS c12
                     FROM jsonb_type_table, cte;
+                > SET statement_timeout = '120s'
                 > INSERT INTO jsonb_type_table SELECT * FROM jsonb_type_table LIMIT 1;
                 """,
                 """
@@ -63,6 +64,7 @@ class JsonbType(Check):
                       jsonb_col <@ '{"boolean_element": true}' AS c11,
                       jsonb_col ? 'number_element' AS c12
                     FROM jsonb_type_table, cte;
+                > SET statement_timeout = '120s'
                 > INSERT INTO jsonb_type_table SELECT * FROM jsonb_type_table LIMIT 1;
                 """,
             ]

--- a/misc/python/materialize/checks/all_checks/nested_types.py
+++ b/misc/python/materialize/checks/all_checks/nested_types.py
@@ -42,6 +42,7 @@ class NestedTypes(Check):
                   array_col, ARRAY[ARRAY['a', 'b'], ARRAY['c', 'd']]
                   FROM nested_types_table;
 
+                > SET statement_timeout = '120s'
                 > INSERT INTO nested_types_table SELECT * FROM nested_types_table LIMIT 1;
                 """,
                 """

--- a/misc/python/materialize/checks/all_checks/top_k.py
+++ b/misc/python/materialize/checks/all_checks/top_k.py
@@ -45,9 +45,11 @@ class BasicTopK(Check):
                 """
                 > INSERT INTO basic_topk_table SELECT * FROM basic_topk_table
                 > CREATE MATERIALIZED VIEW basic_topk_view1 AS SELECT f1, COUNT(f1) FROM basic_topk_table GROUP BY f1 ORDER BY f1 DESC NULLS LAST LIMIT 2;
+                > SET statement_timeout = '120s'
                 > INSERT INTO basic_topk_table SELECT * FROM basic_topk_table;
                 """,
                 """
+                > SET statement_timeout = '120s'
                 > INSERT INTO basic_topk_table SELECT * FROM basic_topk_table;
                 > CREATE MATERIALIZED VIEW basic_topk_view2 AS SELECT f1, COUNT(f1) FROM basic_topk_table GROUP BY f1 ORDER BY f1 ASC NULLS FIRST LIMIT 2;
                 > INSERT INTO basic_topk_table SELECT * FROM basic_topk_table;

--- a/test/persistence/user-tables/table-persistence-before-large-transaction.td
+++ b/test/persistence/user-tables/table-persistence-before-large-transaction.td
@@ -22,6 +22,7 @@
 > CREATE TABLE long_transaction (f1 INTEGER);
 
 # Insert 1M unique rows
+> SET statement_timeout = '120s'
 > INSERT INTO long_transaction
   SELECT (a1.f1 * 1) +
          (a2.f1 * 10) +

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -453,6 +453,7 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
                 no_reset=True,
                 materialize_params={"cluster": "cluster1"},
                 seed=id,
+                default_timeout="300s",
             )
         ):
             populate(c)


### PR DESCRIPTION
Based on the failures seen in https://buildkite.com/materialize/coverage/builds/348

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
