### PR TITLE
fivetran-destination: Small fix and test updates

### DIFF
--- a/misc/python/materialize/mzcompose/services/fivetran_destination_tester.py
+++ b/misc/python/materialize/mzcompose/services/fivetran_destination_tester.py
@@ -9,7 +9,7 @@
 
 from materialize.mzcompose.service import Service
 
-FIVETRAN_TESTER_VERSION = "024.0125.001"
+FIVETRAN_TESTER_VERSION = "024.0202.001"
 
 
 class FivetranDestinationTester(Service):
@@ -28,7 +28,7 @@ class FivetranDestinationTester(Service):
         super().__init__(
             name="fivetran-destination-tester",
             config={
-                "image": f"it5t/fivetran-sdk-destination-tester:{FIVETRAN_TESTER_VERSION}",
+                "image": f"fivetrandocker/sdk-destination-tester:{FIVETRAN_TESTER_VERSION}",
                 "command": command,
                 "environment": environment,
                 "volumes": volumes_extra,

--- a/src/fivetran-destination/src/destination.rs
+++ b/src/fivetran-destination/src/destination.rs
@@ -24,6 +24,13 @@ mod config;
 mod ddl;
 mod dml;
 
+/// Tracks if a row has been "soft deleted" if this column to true.
+const FIVETRAN_SYSTEM_COLUMN_DELETE: &str = "_fivetran_deleted";
+/// Tracks the last time this Row was modified by Fivetran.
+const FIVETRAN_SYSTEM_COLUMN_SYNCED: &str = "_fivetran_synced";
+/// Fivetran will synthesize a primary key column when one doesn't exist.
+const FIVETRAN_SYSTEM_COLUMN_ID: &str = "_fivetran_id";
+
 pub struct MaterializeDestination;
 
 #[tonic::async_trait]

--- a/src/fivetran-destination/src/destination/dml.rs
+++ b/src/fivetran-destination/src/destination/dml.rs
@@ -25,18 +25,13 @@ use tokio_postgres::types::{to_sql_checked, Format, IsNull, ToSql, Type};
 use tokio_util::io::ReaderStream;
 
 use crate::crypto::AsyncAesDecrypter;
-use crate::destination::config;
+use crate::destination::{
+    config, FIVETRAN_SYSTEM_COLUMN_DELETE, FIVETRAN_SYSTEM_COLUMN_ID, FIVETRAN_SYSTEM_COLUMN_SYNCED,
+};
 use crate::error::{Context, OpError, OpErrorKind};
 use crate::fivetran_sdk::write_batch_request::FileParams;
 use crate::fivetran_sdk::{Compression, Encryption, Table, TruncateRequest, WriteBatchRequest};
 use crate::utils;
-
-/// Tracks if a row has been "soft deleted" if this column to true.
-const FIVETRAN_SYSTEM_COLUMN_DELETE: &str = "_fivetran_deleted";
-/// Tracks the last time this Row was modified by Fivetran.
-const FIVETRAN_SYSTEM_COLUMN_SYNCED: &str = "_fivetran_synced";
-/// Fivetran will synthesize a primary key column when one doesn't exist.
-const FIVETRAN_SYSTEM_COLUMN_ID: &str = "_fivetran_id";
 
 pub async fn handle_truncate_table(request: TruncateRequest) -> Result<(), OpError> {
     let delete_before = {

--- a/test/fivetran-destination/mzcompose.py
+++ b/test/fivetran-destination/mzcompose.py
@@ -79,9 +79,7 @@ SERVICES = [
 ]
 
 # Tests that are currently broken because the Fivetran Tester seems to do the wrong thing.
-#
-# 'test-truncate': https://materializeinc.slack.com/archives/C060KAR4802/p1706651239233319
-BROKEN_TESTS = ["test-truncate"]
+BROKEN_TESTS = []
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:


### PR DESCRIPTION
When responding to a `DescribeTableRequest` do not strip out the `_fivetran_*` system columns. Also update the Fivetran provider Docker image for testing to re-enable the truncate test.

### Motivation

Bug report from Emrah, https://materializeinc.slack.com/archives/C060KAR4802/p1707202803646169

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
