### PR TITLE
canary-environment: materialized_view has been renamed

### DIFF
--- a/test/canary-environment/models/loadgen/sales_product_product_category.sql
+++ b/test/canary-environment/models/loadgen/sales_product_product_category.sql
@@ -10,7 +10,7 @@
 -- depends_on: {{ ref('product') }}
 -- depends_on: {{ ref('product_category') }}
 
-{{ config(materialized='materializedview', cluster="qa_canary_environment_compute", indexes=[{'default': True}]) }}
+{{ config(materialized='materialized_view', cluster="qa_canary_environment_compute", indexes=[{'default': True}]) }}
 
 SELECT
     count(*) AS count_star,

--- a/test/canary-environment/models/pg_cdc/wmr.sql
+++ b/test/canary-environment/models/pg_cdc/wmr.sql
@@ -12,7 +12,7 @@
 -- to ensure the result updates frequently
 
 -- depends_on: {{ ref('pg_cdc') }}
-{{ config(materialized='materializedview', cluster="qa_canary_environment_compute", indexes=[{'default': True}]) }}
+{{ config(materialized='materialized_view', cluster="qa_canary_environment_compute", indexes=[{'default': True}]) }}
 
 WITH MUTUALLY RECURSIVE
     symm (a int, b int) AS (

--- a/test/canary-environment/models/simple_table/table_mv.sql
+++ b/test/canary-environment/models/simple_table/table_mv.sql
@@ -8,6 +8,6 @@
 -- by the Apache License, Version 2.0.
 
 -- depends_on: {{ ref('table') }}
-{{ config(materialized='materializedview', cluster='qa_canary_environment_compute', indexes=[{'default': True}]) }}
+{{ config(materialized='materialized_view', cluster='qa_canary_environment_compute', indexes=[{'default': True}]) }}
 
 SELECT max(c) FROM {{ source('simple_table','table') }}

--- a/test/canary-environment/models/tpch/tpch_q01.sql
+++ b/test/canary-environment/models/tpch/tpch_q01.sql
@@ -10,7 +10,7 @@
 -- TPC-H Query #Q18, chosen for the workload for its GROUP BY clause
 
 -- depends_on: {{ ref('tpch') }}
-{{ config(materialized='materializedview', cluster='qa_canary_environment_compute', indexes=[{'default': True}]) }}
+{{ config(materialized='materialized_view', cluster='qa_canary_environment_compute', indexes=[{'default': True}]) }}
 
 SELECT
     l_returnflag,

--- a/test/canary-environment/models/tpch/tpch_q18.sql
+++ b/test/canary-environment/models/tpch/tpch_q18.sql
@@ -12,7 +12,7 @@
 -- to ensure the result updates frequently
 
 -- depends_on: {{ ref('tpch') }}
-{{ config(materialized='materializedview', cluster='qa_canary_environment_compute', indexes=[{'default': True}]) }}
+{{ config(materialized='materialized_view', cluster='qa_canary_environment_compute', indexes=[{'default': True}]) }}
 
 SELECT
     c_name,


### PR DESCRIPTION
        The `materializedview` materialization name is deprecated and will be
        removed in a future release of dbt-materialize. Please use
        `materialized_view` instead, which is built-in from dbt v1.6:

        {{ config( materialized = 'materialized_view' )}}

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
