### PR TITLE
persist: remove some unnecessary intermediate Vecs

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -144,15 +144,12 @@ impl<T: Timestamp + Lattice> FetchBatchFilter<T> {
     {
         match &meta {
             SerdeLeasedBatchPartMetadata::Snapshot { as_of } => {
-                let as_of =
-                    Antichain::from(as_of.iter().map(|x| T::decode(*x)).collect::<Vec<_>>());
+                let as_of = Antichain::from_iter(as_of.iter().map(|x| T::decode(*x)));
                 FetchBatchFilter::Snapshot { as_of }
             }
             SerdeLeasedBatchPartMetadata::Listen { as_of, lower } => {
-                let as_of =
-                    Antichain::from(as_of.iter().map(|x| T::decode(*x)).collect::<Vec<_>>());
-                let lower =
-                    Antichain::from(lower.iter().map(|x| T::decode(*x)).collect::<Vec<_>>());
+                let as_of = Antichain::from_iter(as_of.iter().map(|x| T::decode(*x)));
+                let lower = Antichain::from_iter(lower.iter().map(|x| T::decode(*x)));
                 FetchBatchFilter::Listen { as_of, lower }
             }
         }
@@ -830,9 +827,9 @@ impl<T: Timestamp + Codec64> LeasedBatchPart<T> {
             shard_id: x.shard_id,
             metadata: x.metadata,
             desc: Description::new(
-                Antichain::from(x.lower.into_iter().map(T::decode).collect::<Vec<_>>()),
-                Antichain::from(x.upper.into_iter().map(T::decode).collect::<Vec<_>>()),
-                Antichain::from(x.since.into_iter().map(T::decode).collect::<Vec<_>>()),
+                Antichain::from_iter(x.lower.into_iter().map(T::decode)),
+                Antichain::from_iter(x.upper.into_iter().map(T::decode)),
+                Antichain::from_iter(x.since.into_iter().map(T::decode)),
             ),
             key: x.key,
             encoded_size_bytes: x.encoded_size_bytes,


### PR DESCRIPTION
Instead of collecting an iterator into a `Vec` and then handing it to `Antichain::from`, we can construct the Antichain directly from the iterator. I did a quick audit and none of these seem to be on a particularly hot path, but this is so easy that may as well.

h/t Moritz for the idea

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
