### PR TITLE
Enable warm up of REFRESH materialized views (NowFn read holds)

### DIFF
--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -418,7 +418,7 @@ where
             config.storage_stash_url,
             config.persist_location,
             config.persist_clients,
-            config.now,
+            config.now.clone(),
             config.stash_metrics,
             envd_epoch,
             config.metrics_registry.clone(),
@@ -427,10 +427,12 @@ where
         )
         .await;
 
+        let now = NowFn::from(move || (config.now)().into());
         let compute_controller = ComputeController::new(
             config.build_info,
             envd_epoch,
             config.metrics_registry.clone(),
+            now,
         );
         let (metrics_tx, metrics_rx) = mpsc::unbounded_channel();
 


### PR DESCRIPTION
This commit makes the compute controller hold back the read frontiers of write-only collections to a current time, based on a `NowFn` passed to its constructor. This enables warming up REFRESH materialized views by spawning their dataflows prior to the next refresh time.

This introduces the assumption that all collection timelines are `EpochMilliseconds`, i.e. collection time follows roughly the system time.

This solves the same issue as https://github.com/MaterializeInc/materialize/pull/24979, but with the benefit that collections that advance to the empty frontier are dropped early.

### Motivation

  * This PR adds a known-desirable feature.

Closes https://github.com/MaterializeInc/materialize/issues/24966

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
