### PR TITLE
storage: add topic column to mz_kafka_sources

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -336,7 +336,7 @@ The `mz_kafka_sources` table contains a row for each Kafka source in the system.
 |------------------------|----------------|-----------------------------------------------------------------------------------------------------------|
 | `id`                   | [`text`]       | The ID of the Kafka source. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources).        |
 | `group_id_prefix`      | [`text`]       | The value of the `GROUP ID PREFIX` connection option.                                                     |
-| `topic          `      | [`text`]       | The topic this Kafka source is reading from.                                                              |
+| `topic          `      | [`text`]       | The name of the Kafka topic the source is reading from.                                                              |
 
 ### `mz_materialization_lag`
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -336,6 +336,7 @@ The `mz_kafka_sources` table contains a row for each Kafka source in the system.
 |------------------------|----------------|-----------------------------------------------------------------------------------------------------------|
 | `id`                   | [`text`]       | The ID of the Kafka source. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources).        |
 | `group_id_prefix`      | [`text`]       | The value of the `GROUP ID PREFIX` connection option.                                                     |
+| `topic          `      | [`text`]       | The topic this Kafka source is reading from.                                                              |
 
 ### `mz_materialization_lag`
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -579,6 +579,7 @@ impl CatalogState {
             row: Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::String(&kafka.group_id(&self.config.connection_context, id)),
+                Datum::String(&kafka.topic),
             ]),
             diff,
         }]

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -1902,7 +1902,8 @@ pub static MZ_KAFKA_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
-        .with_column("group_id_prefix", ScalarType::String.nullable(false)),
+        .with_column("group_id_prefix", ScalarType::String.nullable(false))
+        .with_column("topic", ScalarType::String.nullable(false)),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -196,6 +196,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 ----
 1  id  text
 2  group_id_prefix  text
+3  topic            text
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_materialization_lag' ORDER BY position

--- a/test/testdrive/mz-kafka-sources.td
+++ b/test/testdrive/mz-kafka-sources.td
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that the source ingestion pipeline commits offsets back to Kafka with
+# the expected group ID.
+
+# Initial setup.
+
+$ kafka-create-topic topic=topic partitions=1
+
+> CREATE CONNECTION conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
+
+> CREATE CLUSTER topic_cluster SIZE '${arg.default-storage-size}';
+
+> CREATE SOURCE topic
+  IN CLUSTER topic_cluster
+  FROM KAFKA CONNECTION conn (
+    TOPIC 'testdrive-topic-${testdrive.seed}'
+  )
+  FORMAT BYTES
+
+> SELECT
+    ks.topic
+  FROM mz_sources s
+  JOIN mz_internal.mz_kafka_sources ks ON s.id = ks.id
+  WHERE s.name = 'topic'
+testdrive-topic-${testdrive.seed}


### PR DESCRIPTION
Closes #24996

The fingerprint of the table is changing, so this change is backward compatible.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - add `topic` column to `mz_internal.mz_kafka_sources`
