### PR TITLE
storage: MySQL Source TLS/SSL support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3435,8 +3435,7 @@ dependencies = [
 [[package]]
 name = "mysql_async"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6750b17ce50f8f112ef1a8394121090d47c596b56a6a17569ca680a9626e2ef2"
+source = "git+https://github.com/MaterializeInc/mysql_async.git?rev=ecc4908e7c98ce1050fc536739c41ec444d03349#ecc4908e7c98ce1050fc536739c41ec444d03349"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -3449,6 +3448,7 @@ dependencies = [
  "lru",
  "mio",
  "mysql_common",
+ "native-tls",
  "once_cell",
  "pem",
  "percent-encoding",
@@ -3459,6 +3459,7 @@ dependencies = [
  "socket2 0.5.3",
  "thiserror",
  "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "tracing",
  "twox-hash",
@@ -3882,6 +3883,7 @@ dependencies = [
  "anyhow",
  "hyper",
  "mz-ore",
+ "mz-tls-util",
  "native-tls",
  "once_cell",
  "openssl",
@@ -6007,6 +6009,7 @@ dependencies = [
  "mz-ssh-util",
  "mz-stash-types",
  "mz-timely-util",
+ "mz-tls-util",
  "mz-tracing",
  "native-tls",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,9 @@ postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres" }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
 
+# Waiting on https://github.com/blackbeam/mysql_async/pull/288
+mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "ecc4908e7c98ce1050fc536739c41ec444d03349" }
+
 # Waiting on https://github.com/MaterializeInc/serde-value/pull/35.
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.11.13", features = [
     "json",
     "native-tls-vendored",
 ] }
+mz-tls-util = { path = "../tls-util" }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 url = { version = "2.3.1", features = ["serde"] }

--- a/src/ccsr/src/tls.rs
+++ b/src/ccsr/src/tls.rs
@@ -9,11 +9,9 @@
 
 //! TLS certificates and identities.
 
-use openssl::pkcs12::Pkcs12;
-use openssl::pkey::PKey;
-use openssl::stack::Stack;
-use openssl::x509::X509;
 use serde::{Deserialize, Serialize};
+
+use mz_tls_util::pkcs12der_from_pem;
 
 /// A [Serde][serde]-enabled wrapper around [`reqwest::Identity`].
 ///
@@ -28,40 +26,12 @@ impl Identity {
     /// Reimplements [`reqwest::Certificate::from_pem`] in terms of OpenSSL.
     ///
     /// The implementation in reqwest requires rustls.
-    pub fn from_pem(pem: &[u8]) -> Result<Self, openssl::error::ErrorStack> {
-        let pkey = PKey::private_key_from_pem(pem)?;
-        let mut certs = Stack::new()?;
-
-        // `X509::stack_from_pem` in openssl as of at least versions <= 0.10.48
-        // does not guarantee that it will either error or return at least 1
-        // element; in fact, it doesn't if the `pem` is not a well-formed
-        // representation of a PEM file. For example, if the represented file
-        // contains a well-formed key but a malformed certificate.
-        //
-        // To circumvent this issue, if `X509::stack_from_pem` returns no
-        // certificates, rely on getting the error message from
-        // `X509::from_pem`.
-        let mut cert_iter = X509::stack_from_pem(pem)?.into_iter();
-        let cert = match cert_iter.next() {
-            Some(cert) => cert,
-            None => X509::from_pem(pem)?,
-        };
-        for cert in cert_iter {
-            certs.push(cert)?;
-        }
-        // We build a PKCS #12 archive solely to have something to pass to
-        // `reqwest::Identity::from_pkcs12_der`, so the password and friendly
-        // name don't matter.
-        let pass = String::new();
-        let friendly_name = "";
-        let der = Pkcs12::builder()
-            .name(friendly_name)
-            .pkey(&pkey)
-            .cert(&cert)
-            .ca(certs)
-            .build2(&pass)?
-            .to_der()?;
-        Ok(Identity { der, pass })
+    pub fn from_pem(key: &[u8], cert: &[u8]) -> Result<Self, openssl::error::ErrorStack> {
+        let archive = pkcs12der_from_pem(key, cert)?;
+        Ok(Identity {
+            der: archive.der,
+            pass: archive.pass,
+        })
     }
 
     /// Wraps [`reqwest::Identity::from_pkcs12_der`].

--- a/src/ccsr/tests/client.rs
+++ b/src/ccsr/tests/client.rs
@@ -451,5 +451,5 @@ RxbPMjhEBdVZ5NxlxYer7yKN+h5OBJfrLswPku7y4vdFYK3x/lMuNQO61hb1VFHc
 T2BDTbF0QSlPxFsv18B9zg==
 -----END PRIVATE KEY-----
 x"#;
-    Identity::from_pem(certs.as_bytes()).unwrap_err();
+    Identity::from_pem(certs.as_bytes(), &[]).unwrap_err();
 }

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -21,7 +21,7 @@ derivative = "2.2.0"
 differential-dataflow = "0.12.0"
 fail = { version = "0.5.1", features = ["failpoints"] }
 itertools = { version = "0.10.5" }
-mysql_async = { version = "0.33.0", default-features = false, features = ["minimal"] }
+mysql_async = { version = "0.33.0", default-features = false, features = ["minimal", "native-tls-tls"] }
 mz-aws-util = { path = "../aws-util" }
 mz-ccsr = { path = "../ccsr" }
 mz-cloud-resources = { path = "../cloud-resources" }
@@ -43,6 +43,7 @@ mz-service = { path = "../service" }
 mz-ssh-util = { path = "../ssh-util" }
 mz-stash-types = { path = "../stash-types" }
 mz-timely-util = { path = "../timely-util" }
+mz-tls-util = { path = "../tls-util" }
 mz-tracing = { path = "../tracing" }
 native-tls = "0.2.11"
 num_enum = "0.5.7"

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -66,7 +66,7 @@ log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.8", features = ["net", "os-ext"] }
-mysql_async = { version = "0.33.0", default-features = false, features = ["binlog", "minimal", "tracing"] }
+mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "ecc4908e7c98ce1050fc536739c41ec444d03349", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
 mysql_common = { version = "0.31.0", default-features = false, features = ["binlog"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
@@ -181,7 +181,7 @@ log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.8", features = ["net", "os-ext"] }
-mysql_async = { version = "0.33.0", default-features = false, features = ["binlog", "minimal", "tracing"] }
+mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "ecc4908e7c98ce1050fc536739c41ec444d03349", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
 mysql_common = { version = "0.31.0", default-features = false, features = ["binlog"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }

--- a/test/mysql-cdc/15-create-connection-tls.td
+++ b/test/mysql-cdc/15-create-connection-tls.td
@@ -1,0 +1,158 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_mysql_source = true
+
+#
+# Validate MySQL server CA and client TLS/SSL client options
+#
+
+> CREATE SECRET ssl_ca AS '${arg.ssl-ca}'
+> CREATE SECRET ssl_client_cert AS '${arg.ssl-client-cert}'
+> CREATE SECRET ssl_client_key AS '${arg.ssl-client-key}'
+> CREATE SECRET ssl_wrong_ca AS '${arg.ssl-wrong-ca}'
+> CREATE SECRET ssl_wrong_client_cert AS '${arg.ssl-wrong-client-cert}'
+> CREATE SECRET ssl_wrong_client_key AS '${arg.ssl-wrong-client-key}'
+
+> CREATE SECRET mysqluserpass AS '${arg.mysql-user-password}'
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+CREATE USER 'norm_user' IDENTIFIED BY '${arg.mysql-user-password}';
+CREATE USER 'tls_user' IDENTIFIED BY '${arg.mysql-user-password}' REQUIRE SSL;
+CREATE USER 'tls_cert_user' IDENTIFIED BY '${arg.mysql-user-password}' REQUIRE X509;
+
+# Success: Disabled SSL Mode with normal user
+> CREATE CONNECTION mysq_tls TO MYSQL (
+    HOST mysql,
+    USER norm_user,
+    PASSWORD SECRET mysqluserpass,
+    SSL MODE disabled
+  )
+> DROP CONNECTION mysq_tls;
+
+# Error: Disabled SSL Mode with required TLS user
+! CREATE CONNECTION mysq_tls TO MYSQL (
+    HOST mysql,
+    USER tls_user,
+    PASSWORD SECRET mysqluserpass,
+    SSL MODE disabled
+  )
+contains:Access denied for user
+
+# Success: Required SSL mode with required TLS user
+> CREATE CONNECTION mysq_tls TO MYSQL (
+    HOST mysql,
+    USER tls_user,
+    PASSWORD SECRET mysqluserpass,
+    SSL MODE required
+  )
+> DROP CONNECTION mysq_tls;
+
+# Error: Required SSL mode with required x509 Cert user
+! CREATE CONNECTION mysq_tls TO MYSQL (
+    HOST mysql,
+    USER tls_cert_user,
+    PASSWORD SECRET mysqluserpass,
+    SSL MODE required
+  )
+contains:Access denied for user
+
+# Success: Required SSL mode + client cert with required x509 Cert user
+> CREATE CONNECTION mysq_tls TO MYSQL (
+    HOST mysql,
+    USER tls_cert_user,
+    PASSWORD SECRET mysqluserpass,
+    SSL MODE required,
+    SSL CERTIFICATE SECRET ssl_client_cert,
+    SSL KEY SECRET ssl_client_key
+  )
+> DROP CONNECTION mysq_tls;
+
+# Error: Required SSL mode + wrong client cert with required x509 Cert user
+! CREATE CONNECTION mysq_tls TO MYSQL (
+    HOST mysql,
+    USER tls_cert_user,
+    PASSWORD SECRET mysqluserpass,
+    SSL MODE required,
+    SSL CERTIFICATE SECRET ssl_wrong_client_cert,
+    SSL KEY SECRET ssl_wrong_client_key
+  )
+contains:Input/output error
+
+# Success: Verify_CA SSL mode
+> CREATE CONNECTION mysq_tls TO MYSQL (
+    HOST mysql,
+    USER tls_user,
+    PASSWORD SECRET mysqluserpass,
+    SSL MODE verify_ca,
+    SSL CERTIFICATE AUTHORITY SECRET ssl_ca
+  )
+> DROP CONNECTION mysq_tls;
+
+# Error: Verify_CA SSL mode without providing Server CA
+! CREATE CONNECTION mysq_tls TO MYSQL (
+    HOST mysql,
+    USER tls_user,
+    PASSWORD SECRET mysqluserpass,
+    SSL MODE verify_ca
+  )
+contains:TLS error
+
+# Error: Verify_CA SSL mode with wrong Server CA
+! CREATE CONNECTION mysq_tls TO MYSQL (
+    HOST mysql,
+    USER tls_user,
+    PASSWORD SECRET mysqluserpass,
+    SSL MODE verify_ca,
+    SSL CERTIFICATE AUTHORITY SECRET ssl_wrong_ca
+  )
+contains:TLS error
+
+# Error: Verify_CA SSL mode with required x509 Cert user and no client cert
+! CREATE CONNECTION mysq_tls TO MYSQL (
+    HOST mysql,
+    USER tls_cert_user,
+    PASSWORD SECRET mysqluserpass,
+    SSL MODE verify_ca,
+    SSL CERTIFICATE AUTHORITY SECRET ssl_ca
+  )
+contains:Access denied for user
+
+# Success: Verify_CA SSL mode with required x509 Cert user
+> CREATE CONNECTION mysq_tls TO MYSQL (
+    HOST mysql,
+    USER tls_cert_user,
+    PASSWORD SECRET mysqluserpass,
+    SSL MODE verify_ca,
+    SSL CERTIFICATE AUTHORITY SECRET ssl_ca,
+    SSL CERTIFICATE SECRET ssl_client_cert,
+    SSL KEY SECRET ssl_client_key
+  )
+> DROP CONNECTION mysq_tls;
+
+# Success: Verify_CA SSL mode with required x509 Cert user and wrong client cert
+! CREATE CONNECTION mysq_tls TO MYSQL (
+    HOST mysql,
+    USER tls_cert_user,
+    PASSWORD SECRET mysqluserpass,
+    SSL MODE verify_ca,
+    SSL CERTIFICATE AUTHORITY SECRET ssl_ca,
+    SSL CERTIFICATE SECRET ssl_wrong_client_cert,
+    SSL KEY SECRET ssl_wrong_client_key
+  )
+contains: Input/output error
+
+# TODO: Figure out how to test the Verify_Identity SSL Mode with the auto-generated certs
+# created by MySQL. They use an odd CN value in the CA cert:
+# https://dev.mysql.com/doc/refman/8.3/en/creating-ssl-rsa-files-using-mysql.html#creating-ssl-rsa-files-using-mysql-ssl-and-rsa-file-characteristics

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -10,13 +10,14 @@
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mysql import MySql
+from materialize.mzcompose.services.test_certs import TestCerts
 from materialize.mzcompose.services.testdrive import Testdrive
 
 SERVICES = [
     Materialized(
         additional_system_parameter_defaults={
             "log_filter": "mz_storage::source::mysql=trace,info"
-        }
+        },
     ),
     MySql(
         additional_args=[
@@ -27,7 +28,7 @@ SERVICES = [
             "--log-slave-updates",
             "--binlog-row-image=full",
             "--server-id=1",
-        ]
+        ],
     ),
     MySql(
         name="mysql-replica",
@@ -38,6 +39,7 @@ SERVICES = [
             "--server-id=2",
         ],
     ),
+    TestCerts(),
     Testdrive(default_timeout="60s"),
 ]
 
@@ -53,8 +55,39 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     c.up("materialized", "mysql")
 
+    # MySQL generates self-signed certificates for SSL connections on startup,
+    # for both the server and client:
+    # https://dev.mysql.com/doc/refman/8.3/en/creating-ssl-rsa-files-using-mysql.html
+    # Grab the correct Server CA and Client Key and Cert from the MySQL container
+    # (and strip the trailing null byte):
+    ssl_ca = c.exec("mysql", "cat", "/var/lib/mysql/ca.pem", capture=True).stdout.split(
+        "\x00", 1
+    )[0]
+    ssl_client_cert = c.exec(
+        "mysql", "cat", "/var/lib/mysql/client-cert.pem", capture=True
+    ).stdout.split("\x00", 1)[0]
+    ssl_client_key = c.exec(
+        "mysql", "cat", "/var/lib/mysql/client-key.pem", capture=True
+    ).stdout.split("\x00", 1)[0]
+
+    # Use the TestCert service to obtain a wrong CA and client cert/key:
+    ssl_wrong_ca = c.run("test-certs", "cat", "/secrets/ca.crt", capture=True).stdout
+    ssl_wrong_client_cert = c.run(
+        "test-certs", "cat", "/secrets/certuser.crt", capture=True
+    ).stdout
+    ssl_wrong_client_key = c.run(
+        "test-certs", "cat", "/secrets/certuser.key", capture=True
+    ).stdout
+
     c.run_testdrive_files(
+        f"--var=ssl-ca={ssl_ca}",
+        f"--var=ssl-client-cert={ssl_client_cert}",
+        f"--var=ssl-client-key={ssl_client_key}",
+        f"--var=ssl-wrong-ca={ssl_wrong_ca}",
+        f"--var=ssl-wrong-client-cert={ssl_wrong_client_cert}",
+        f"--var=ssl-wrong-client-key={ssl_wrong_client_key}",
         f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
+        "--var=mysql-user-password=us3rp4ssw0rd",
         *args.filter,
     )
 


### PR DESCRIPTION
Implements the TLS options for the MySQL Source in the `CREATE CONNECTION` command:
```
CREATE CONNECTION ... TO MYSQL
    [SSL MODE  <DISABLED|REQUIRED|VERIFY_CA|VERIFY_IDENTITY>]
    [SSL CERTIFICATE AUTHORITY <server ca>]
    [SSL CERTIFICATE <client cert>]
    [SSL KEY <client key>]
```

NOTE:
To implement this without having to temporarily create files for the CA cert and client cert/keys, I had to fork `mysql_async` to add support for providing the cert/key values directly: https://github.com/blackbeam/mysql_async/pull/288
That PR is now the latest on the `master` branch of our fork repo: https://github.com/MaterializeInc/mysql_async


### Motivation

Part of the work in https://github.com/MaterializeInc/materialize/issues/15901

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

There was a convenient function in `src/ccsr/src/tls.rs` for generating a PKCS12 archive from a pem-formatted client key/cert that I moved to `mz-tls-util`.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
