### PR TITLE
catalog: Speed up stash batches

### DIFF
--- a/src/catalog/src/durable/impls/stash.rs
+++ b/src/catalog/src/durable/impls/stash.rs
@@ -925,9 +925,12 @@ impl DurableCatalogState for Connection {
                 collection.id
             );
             let mut batch = collection.make_batch_tx(tx).await?;
-            for (k, v, diff) in changes {
-                collection.append_to_batch(&mut batch, k, v, *diff);
-            }
+            collection.extend_batch(
+                &mut batch,
+                changes
+                    .into_iter()
+                    .map(|(key, value, diff)| (key, value, *diff)),
+            );
             batches.push(batch);
             Ok(())
         }

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -170,9 +170,22 @@ where
 {
     /// Append `key`, `value`, `diff` to `batch`.
     pub fn append_to_batch(&self, batch: &mut AppendBatch, key: &K, value: &V, diff: Diff) {
-        let key = key.encode_to_vec();
-        let val = value.encode_to_vec();
-        batch.entries.push(((key, val), batch.timestamp, diff));
+        self.extend_batch(batch, [(key, value, diff)])
+    }
+
+    /// Extend `batch`, with the keys, values, and diffs in `iter`.
+    pub fn extend_batch<'a>(
+        &'a self,
+        batch: &'a mut AppendBatch,
+        iter: impl IntoIterator<Item = (&'a K, &'a V, Diff)>,
+    ) {
+        batch
+            .entries
+            .extend(iter.into_iter().map(|(key, value, diff)| {
+                let key = key.encode_to_vec();
+                let val = value.encode_to_vec();
+                ((key, val), batch.timestamp, diff)
+            }))
     }
 }
 

--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -570,7 +570,7 @@ async fn test_stash_batch_large_number_updates() {
     Stash::with_debug_stash(|mut stash| async move {
         let col = collection::<i64, i64>(&mut stash, "c1").await.unwrap();
         let mut batch = make_batch(&col, &mut stash).await.unwrap();
-        let batches: Vec<_> = (0..500_000r).map(|i| (i, (i + 1), 1)).collect();
+        let batches: Vec<_> = (0..500_0000).map(|i| (i, (i + 1), 1)).collect();
         col.extend_batch(
             &mut batch,
             batches.iter().map(|(key, value, diff)| (key, value, *diff)),

--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -570,7 +570,7 @@ async fn test_stash_batch_large_number_updates() {
     Stash::with_debug_stash(|mut stash| async move {
         let col = collection::<i64, i64>(&mut stash, "c1").await.unwrap();
         let mut batch = make_batch(&col, &mut stash).await.unwrap();
-        let batches: Vec<_> = (0..500_00).map(|i| (i, (i + 1), 1)).collect();
+        let batches: Vec<_> = (0..500_000r).map(|i| (i, (i + 1), 1)).collect();
         col.extend_batch(
             &mut batch,
             batches.iter().map(|(key, value, diff)| (key, value, *diff)),

--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -570,9 +570,11 @@ async fn test_stash_batch_large_number_updates() {
     Stash::with_debug_stash(|mut stash| async move {
         let col = collection::<i64, i64>(&mut stash, "c1").await.unwrap();
         let mut batch = make_batch(&col, &mut stash).await.unwrap();
-        for i in 0..500_000 {
-            col.append_to_batch(&mut batch, &i, &(i + 1), 1);
-        }
+        let batches: Vec<_> = (0..500_00).map(|i| (i, (i + 1), 1)).collect();
+        col.extend_batch(
+            &mut batch,
+            batches.iter().map(|(key, value, diff)| (key, value, *diff)),
+        );
         append(&mut stash, vec![batch]).await.unwrap();
     })
     .await

--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -570,7 +570,7 @@ async fn test_stash_batch_large_number_updates() {
     Stash::with_debug_stash(|mut stash| async move {
         let col = collection::<i64, i64>(&mut stash, "c1").await.unwrap();
         let mut batch = make_batch(&col, &mut stash).await.unwrap();
-        let batches: Vec<_> = (0..500_0000).map(|i| (i, (i + 1), 1)).collect();
+        let batches: Vec<_> = (0..500_000).map(|i| (i, (i + 1), 1)).collect();
         col.extend_batch(
             &mut batch,
             batches.iter().map(|(key, value, diff)| (key, value, *diff)),


### PR DESCRIPTION
Works towards resolving #25003

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
