### PR TITLE
misc: disable .psqlrc in python-invoked psql

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -353,7 +353,7 @@ def _cargo_command(args: argparse.Namespace, subcommand: str) -> list[str]:
 
 def _run_sql(url: str, sql: str) -> None:
     try:
-        spawn.runv(["psql", "-At", url, "-c", sql])
+        spawn.runv(["psql", "-AtX", url, "-c", sql])
     except Exception as e:
         raise UIError(
             f"unable to execute postgres statement: {e}",


### PR DESCRIPTION
This is needed when run.py does the --reset stuff into cockroachdb, where some of the .psqlrc commands might not apply cleanly and leave lots of useless error messages in the console.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a