### PR TITLE
persist-txn: use real timestamp oracle in maelstrom tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6810,6 +6810,8 @@ dependencies = [
  "mz-persist-client",
  "mz-persist-txn",
  "mz-persist-types",
+ "mz-repr",
+ "mz-timestamp-oracle",
  "num_cpus",
  "num_enum",
  "prometheus",
@@ -6818,6 +6820,7 @@ dependencies = [
  "timely",
  "tokio",
  "tracing",
+ "url",
  "uuid",
  "workspace-hack",
 ]

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -32,6 +32,8 @@ mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-txn = { path = "../persist-txn" }
 mz-persist-types = { path = "../persist-types" }
+mz-repr = { path = "../repr" }
+mz-timestamp-oracle = { path = "../timestamp-oracle" }
 num_cpus = "1.14.0"
 num_enum = "0.5.7"
 prometheus = { version = "0.13.3", default-features = false }
@@ -40,6 +42,7 @@ serde_json = "1.0.89"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.32.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
+url = "2.3.1"
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/timestamp-oracle/src/lib.rs
+++ b/src/timestamp-oracle/src/lib.rs
@@ -86,7 +86,7 @@ pub trait TimestampOracle<T> {
 /// in-memory/backed-by-catalog TimestampOracle around. Once we remove that we can
 /// make [`TimestampOracle`] shareable.
 #[async_trait]
-pub trait ShareableTimestampOracle<T> {
+pub trait ShareableTimestampOracle<T>: std::fmt::Debug {
     /// Acquire a new timestamp for writing.
     ///
     /// This timestamp will be strictly greater than all prior values of


### PR DESCRIPTION
This hooks up the production impl of ShareableTimestampOracle to the persist-txn maelstrom tests. It also adds an in-mem impl of that trait for convenience when running a single-node test.

It should be possible to also make the MaelstromOracle implement this trait (I think I have it working locally) but it's just tricky enough that I didn't feel great about it and seems like that doesn't need to hold up this PR (we just lose the fancy graphs).

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
