### PR TITLE
Support `EXPLAIN REPLAN [INDEX | MATERIALIZED VIEW]`

### DIFF
--- a/misc/python/materialize/mzexplore/common.py
+++ b/misc/python/materialize/mzexplore/common.py
@@ -72,6 +72,8 @@ class ExplainFlag(Enum):
     HUMANIZED_EXPRS = auto()
     # Enable outer join lowering implemented in #22343.
     ENABLE_NEW_OUTER_JOIN_LOWERING = auto()
+    # Enable eager delta joins implemented in #23318.
+    ENABLE_EAGER_DELTA_JOINS = auto()
 
     def __str__(self):
         return self.name.lower()

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -633,6 +633,7 @@ pub struct ExplainContext {
     pub config: ExplainConfig,
     pub format: ExplainFormat,
     pub stage: ExplainStage,
+    pub replan: Option<GlobalId>,
     pub desc: Option<RelationDesc>,
     pub optimizer_trace: OptimizerTrace,
 }

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -87,7 +87,7 @@ impl DataflowBuilder<'_> {
         self.catalog
             .get_indexes_on(id, self.compute.instance_id())
             .filter(|(idx_id, _idx)| self.compute.contains_collection(idx_id))
-            .filter(|(idx_id, _idx)| !self.ignored_indexes.contains(idx_id))
+            .filter(|(idx_id, _idx)| self.replan.map_or(true, |id| idx_id < &id))
     }
 }
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1821,12 +1821,10 @@ impl Coordinator {
                 ctx.retire(result);
             }
             plan::Explainee::ReplanMaterializedView(_) => {
-                let msg = "EXPLAIN REPLAN MATERIALIZED VIEW is currently not supported";
-                ctx.retire(Err(AdapterError::Unsupported(msg)));
+                self.explain_replan_materialized_view(ctx, plan).await;
             }
             plan::Explainee::ReplanIndex(_) => {
-                let msg = "EXPLAIN REPLAN INDEX is currently not supported";
-                ctx.retire(Err(AdapterError::Unsupported(msg)));
+                self.explain_replan_index(ctx, plan).await;
             }
         };
     }

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -89,6 +89,7 @@ impl Coordinator {
                     config,
                     format,
                     stage,
+                    replan: None,
                     desc: None,
                     optimizer_trace,
                 }),
@@ -200,7 +201,7 @@ impl Coordinator {
             return_if_err!(self.catalog_mut().allocate_user_id().await, ctx)
         };
         let optimizer_config = if let Some(explain_ctx) = explain_ctx.as_ref() {
-            optimize::OptimizerConfig::from((self.catalog().system_config(), &explain_ctx.config))
+            optimize::OptimizerConfig::from((self.catalog().system_config(), explain_ctx))
         } else {
             optimize::OptimizerConfig::from(self.catalog().system_config())
         };

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -26,7 +26,7 @@ use crate::coord::{
 use crate::error::AdapterError;
 use crate::explain::optimizer_trace::OptimizerTrace;
 use crate::optimize::dataflows::dataflow_import_id_bundle;
-use crate::optimize::{self, Optimize};
+use crate::optimize::{self, Optimize, OverrideFrom};
 use crate::session::Session;
 use crate::{catalog, AdapterNotice, ExecuteContext, TimestampProvider};
 
@@ -200,11 +200,8 @@ impl Coordinator {
         } else {
             return_if_err!(self.catalog_mut().allocate_user_id().await, ctx)
         };
-        let optimizer_config = if let Some(explain_ctx) = explain_ctx.as_ref() {
-            optimize::OptimizerConfig::from((self.catalog().system_config(), explain_ctx))
-        } else {
-            optimize::OptimizerConfig::from(self.catalog().system_config())
-        };
+        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
+            .override_from(&explain_ctx);
 
         // Build an optimizer for this INDEX.
         let mut optimizer = optimize::index::Optimizer::new(

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -95,6 +95,7 @@ impl Coordinator {
                     config,
                     format,
                     stage,
+                    replan: None,
                     desc: None,
                     optimizer_trace,
                 }),
@@ -246,7 +247,7 @@ impl Coordinator {
         let internal_view_id = return_if_err!(self.allocate_transient_id(), ctx);
         let debug_name = self.catalog().resolve_full_name(name, None).to_string();
         let optimizer_config = if let Some(explain_ctx) = explain_ctx.as_ref() {
-            optimize::OptimizerConfig::from((self.catalog().system_config(), &explain_ctx.config))
+            optimize::OptimizerConfig::from((self.catalog().system_config(), explain_ctx))
         } else {
             optimize::OptimizerConfig::from(self.catalog().system_config())
         };

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -105,6 +105,60 @@ impl Coordinator {
         .await;
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) async fn explain_replan_materialized_view(
+        &mut self,
+        ctx: ExecuteContext,
+        plan::ExplainPlanPlan {
+            stage,
+            format,
+            config,
+            explainee,
+        }: plan::ExplainPlanPlan,
+    ) {
+        let plan::Explainee::ReplanMaterializedView(id) = explainee else {
+            unreachable!() // Asserted in `sequence_explain_plan`.
+        };
+        let CatalogItem::MaterializedView(item) = self.catalog().get_entry(&id).item() else {
+            unreachable!() // Asserted in `plan_explain_plan`.
+        };
+
+        let state = self.catalog().state();
+        let plan_result = state.deserialize_plan(id, item.create_sql.clone(), true);
+        let (plan, resolved_ids) = return_if_err!(plan_result, ctx);
+
+        let plan::Plan::CreateMaterializedView(plan) = plan else {
+            unreachable!() // We are parsing the `create_sql` of a `MaterializedView` item.
+        };
+
+        // It is safe to assume that query optimization will always succeed, so
+        // for now we statically assume `broken = false`.
+        let broken = false;
+
+        // Create an OptimizerTrace instance to collect plans emitted when
+        // executing the optimizer pipeline.
+        let optimizer_trace = OptimizerTrace::new(broken, stage.path());
+
+        self.execute_create_materialized_view_stage(
+            ctx,
+            CreateMaterializedViewStage::Validate(CreateMaterializedViewValidate {
+                plan,
+                resolved_ids,
+                explain_ctx: Some(ExplainContext {
+                    broken,
+                    config,
+                    format,
+                    stage,
+                    replan: Some(id),
+                    desc: None,
+                    optimizer_trace,
+                }),
+            }),
+            OpenTelemetryContext::obtain(),
+        )
+        .await;
+    }
+
     /// Processes as many `create materialized view` stages as possible.
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn execute_create_materialized_view_stage(

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -179,6 +179,7 @@ impl Coordinator {
                     config,
                     format,
                     stage,
+                    replan: None,
                     desc: Some(desc),
                     optimizer_trace,
                 }),
@@ -285,7 +286,7 @@ impl Coordinator {
             .expect("compute instance does not exist");
         let view_id = self.allocate_transient_id()?;
         let optimizer_config = if let Some(explain_ctx) = explain_ctx.as_ref() {
-            optimize::OptimizerConfig::from((self.catalog().system_config(), &explain_ctx.config))
+            optimize::OptimizerConfig::from((self.catalog().system_config(), explain_ctx))
         } else {
             optimize::OptimizerConfig::from(self.catalog().system_config())
         };
@@ -1007,6 +1008,7 @@ impl Coordinator {
                     stage,
                     desc,
                     optimizer_trace,
+                    ..
                 },
             ..
         }: PeekStageExplain,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -48,7 +48,7 @@ use crate::error::AdapterError;
 use crate::explain::optimizer_trace::OptimizerTrace;
 use crate::notice::AdapterNotice;
 use crate::optimize::dataflows::{prep_scalar_expr, EvalTime, ExprPrepStyle};
-use crate::optimize::{self, Optimize};
+use crate::optimize::{self, Optimize, OverrideFrom};
 use crate::session::{RequireLinearization, Session, TransactionOps, TransactionStatus};
 use crate::statement_logging::StatementLifecycleEvent;
 use crate::util::ResultExt;
@@ -285,11 +285,8 @@ impl Coordinator {
             .instance_snapshot(cluster.id())
             .expect("compute instance does not exist");
         let view_id = self.allocate_transient_id()?;
-        let optimizer_config = if let Some(explain_ctx) = explain_ctx.as_ref() {
-            optimize::OptimizerConfig::from((self.catalog().system_config(), explain_ctx))
-        } else {
-            optimize::OptimizerConfig::from(self.catalog().system_config())
-        };
+        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
+            .override_from(&explain_ctx);
 
         let optimizer = match copy_to_ctx {
             None => {

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -233,9 +233,12 @@ impl<'s> Optimize<LocalMirPlan<ResolvedLocal<'s>>> for Optimizer {
 
         let expr = OptimizedMirRelationExpr(expr);
 
-        // The assembled dataflow contains a view and an index of that view.
-        let mut df_builder =
-            DataflowBuilder::new(self.catalog.state(), self.compute_instance.clone());
+        // The assembled dataflow contains a view and a sink on that view.
+        let mut df_builder = {
+            let catalog = self.catalog.state();
+            let compute = self.compute_instance.clone();
+            DataflowBuilder::new(catalog, compute).with_config(&self.config)
+        };
 
         let debug_name = format!("oneshot-select-{}", self.select_id);
         let mut df_desc = MirDataflowDescription::new(debug_name.to_string());

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -143,7 +143,11 @@ impl Optimize<Index> for Optimizer {
             .desc(&full_name)
             .expect("can only create indexes on items with a valid description");
 
-        let mut df_builder = DataflowBuilder::new(state, self.compute_instance.clone());
+        let mut df_builder = {
+            let catalog = self.catalog.state();
+            let compute = self.compute_instance.clone();
+            DataflowBuilder::new(catalog, compute).with_config(&self.config)
+        };
         let mut df_desc = MirDataflowDescription::new(full_name.to_string());
 
         df_builder.import_into_dataflow(&index.on, &mut df_desc)?;

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -206,8 +206,11 @@ impl Optimize<LocalMirPlan> for Optimizer {
         }
         let rel_desc = RelationDesc::new(rel_typ, self.column_names.clone());
 
-        let mut df_builder =
-            DataflowBuilder::new(self.catalog.state(), self.compute_instance.clone());
+        let mut df_builder = {
+            let catalog = self.catalog.state();
+            let compute = self.compute_instance.clone();
+            DataflowBuilder::new(catalog, compute).with_config(&self.config)
+        };
         let mut df_desc = MirDataflowDescription::new(self.debug_name.clone());
 
         df_builder.import_view_into_dataflow(&self.internal_view_id, &expr, &mut df_desc)?;

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -158,13 +158,11 @@ pub struct OptimizerConfig {
     /// Persist fast-path peek. Required by the `create_fast_path_plan` call in
     /// [`peek::Optimizer`].
     pub persist_fast_path_limit: usize,
-    /// Enable outer join lowering implemented in #22343.
+    /// Bound from [`SystemVars::enable_new_outer_join_lowering`].
     pub enable_new_outer_join_lowering: bool,
-    /// Enable eager delta joins.
+    /// Bound from [`SystemVars::enable_eager_delta_joins`].
     pub enable_eager_delta_joins: bool,
-    /// Enable fusion of MFPs in reductions.
-    ///
-    /// The fusion happens in MIR ⇒ LIR lowering.
+    /// Bound from [`SystemVars::enable_reduce_mfp_fusion`].
     pub enable_reduce_mfp_fusion: bool,
 }
 

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -222,6 +222,9 @@ impl OverrideFrom<ExplainContext> for OptimizerConfig {
         if let Some(explain_flag) = ctx.config.enable_new_outer_join_lowering {
             self.enable_new_outer_join_lowering = explain_flag;
         }
+        if let Some(explain_flag) = ctx.config.enable_eager_delta_joins {
+            self.enable_eager_delta_joins = explain_flag;
+        }
 
         // Return final result.
         self

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -237,8 +237,11 @@ impl<'s> Optimize<LocalMirPlan<ResolvedLocal<'s>>> for Optimizer {
             .collect();
 
         // The assembled dataflow contains a view and an index of that view.
-        let mut df_builder =
-            DataflowBuilder::new(self.catalog.state(), self.compute_instance.clone());
+        let mut df_builder = {
+            let catalog = self.catalog.state();
+            let compute = self.compute_instance.clone();
+            DataflowBuilder::new(catalog, compute).with_config(&self.config)
+        };
 
         let debug_name = format!("oneshot-select-{}", self.select_id);
         let mut df_desc = MirDataflowDescription::new(debug_name.to_string());

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -193,8 +193,11 @@ impl Optimize<SubscribeFrom> for Optimizer {
                     refresh_schedule: None,
                 };
 
-                let mut df_builder =
-                    DataflowBuilder::new(self.catalog.state(), self.compute_instance.clone());
+                let mut df_builder = {
+                    let catalog = self.catalog.state();
+                    let compute = self.compute_instance.clone();
+                    DataflowBuilder::new(catalog, compute).with_config(&self.config)
+                };
 
                 let (df_desc, df_meta) =
                     df_builder.build_sink_dataflow(sink_name, sink_id, sink_desc)?;
@@ -236,8 +239,11 @@ impl Optimize<SubscribeFrom> for Optimizer {
                     refresh_schedule: None,
                 };
 
-                let mut df_builder =
-                    DataflowBuilder::new(self.catalog.state(), self.compute_instance.clone());
+                let mut df_builder = {
+                    let catalog = self.catalog.state();
+                    let compute = self.compute_instance.clone();
+                    DataflowBuilder::new(catalog, compute).with_config(&self.config)
+                };
 
                 let mut df_desc = MirDataflowDescription::new(sink_name);
 

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -197,6 +197,8 @@ pub struct ExplainConfig {
     // -------------
     /// Enable outer join lowering implemented in #22347 and #22348.
     pub enable_new_outer_join_lowering: Option<bool>,
+    /// Enable the eager delta join planning implemented in #23318.
+    pub enable_eager_delta_joins: Option<bool>,
 }
 
 impl Default for ExplainConfig {
@@ -222,6 +224,7 @@ impl Default for ExplainConfig {
             timing: false,
             types: false,
             enable_new_outer_join_lowering: None,
+            enable_eager_delta_joins: None,
         }
     }
 }
@@ -270,6 +273,7 @@ impl TryFrom<BTreeSet<String>> for ExplainConfig {
             timing: flags.remove("timing"),
             types: flags.remove("types"),
             enable_new_outer_join_lowering: parse_flag(&mut flags, "new_outer_join_lowering")?,
+            enable_eager_delta_joins: parse_flag(&mut flags, "eager_delta_joins")?,
         };
         if flags.is_empty() {
             Ok(result)
@@ -961,6 +965,7 @@ mod tests {
             timing: true,
             types: false,
             enable_new_outer_join_lowering: None,
+            enable_eager_delta_joins: None,
         };
         let context = ExplainContext {
             env,

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -309,6 +309,7 @@ Registry
 Rename
 Repeatable
 Replace
+Replan
 Replica
 Replicas
 Replication

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3540,6 +3540,9 @@ pub enum Explainee<T: AstInfo> {
     View(T::ItemName),
     MaterializedView(T::ItemName),
     Index(T::ItemName),
+    ReplanView(T::ItemName),
+    ReplanMaterializedView(T::ItemName),
+    ReplanIndex(T::ItemName),
     Select(Box<SelectStatement<T>>, bool),
     CreateMaterializedView(Box<CreateMaterializedViewStatement<T>>, bool),
     CreateIndex(Box<CreateIndexStatement<T>>, bool),
@@ -3558,6 +3561,18 @@ impl<T: AstInfo> AstDisplay for Explainee<T> {
             }
             Self::Index(name) => {
                 f.write_str("INDEX ");
+                f.write_node(name);
+            }
+            Self::ReplanView(name) => {
+                f.write_str("REPLAN VIEW ");
+                f.write_node(name);
+            }
+            Self::ReplanMaterializedView(name) => {
+                f.write_str("REPLAN MATERIALIZED VIEW ");
+                f.write_node(name);
+            }
+            Self::ReplanIndex(name) => {
+                f.write_str("REPLAN INDEX ");
                 f.write_node(name);
             }
             Self::Select(select, broken) => {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -7291,6 +7291,15 @@ impl<'a> Parser<'a> {
         } else if self.parse_keyword(INDEX) {
             // Parse: `INDEX name`
             Explainee::Index(self.parse_raw_name()?)
+        } else if self.parse_keywords(&[REPLAN, VIEW]) {
+            // Parse: `REPLAN VIEW name`
+            Explainee::ReplanView(self.parse_raw_name()?)
+        } else if self.parse_keywords(&[REPLAN, MATERIALIZED, VIEW]) {
+            // Parse: `REPLAN MATERIALIZED VIEW name`
+            Explainee::ReplanMaterializedView(self.parse_raw_name()?)
+        } else if self.parse_keywords(&[REPLAN, INDEX]) {
+            // Parse: `REPLAN INDEX name`
+            Explainee::ReplanIndex(self.parse_raw_name()?)
         } else {
             let broken = self.parse_keyword(BROKEN);
 

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -82,6 +82,27 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR INDEX foo
 ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: Index(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
+EXPLAIN OPTIMIZED PLAN FOR REPLAN VIEW foo
+----
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR REPLAN VIEW foo
+=>
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: ReplanView(Name(UnresolvedItemName([Ident("foo")]))) })
+
+parse-statement
+EXPLAIN OPTIMIZED PLAN FOR REPLAN MATERIALIZED VIEW foo
+----
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR REPLAN MATERIALIZED VIEW foo
+=>
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: ReplanMaterializedView(Name(UnresolvedItemName([Ident("foo")]))) })
+
+parse-statement
+EXPLAIN OPTIMIZED PLAN FOR REPLAN INDEX foo
+----
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR REPLAN INDEX foo
+=>
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: ReplanIndex(Name(UnresolvedItemName([Ident("foo")]))) })
+
+parse-statement
 EXPLAIN OPTIMIZED PLAN WITH(types) FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN WITH(types) AS TEXT FOR VIEW foo

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1574,6 +1574,7 @@ impl Params {
 pub struct PlanContext {
     pub wall_time: DateTime<Utc>,
     pub planning_id: Option<GlobalId>,
+    pub ignore_if_exists_errors: bool,
 }
 
 impl PlanContext {
@@ -1581,6 +1582,7 @@ impl PlanContext {
         Self {
             wall_time,
             planning_id: None,
+            ignore_if_exists_errors: false,
         }
     }
 
@@ -1591,10 +1593,17 @@ impl PlanContext {
         PlanContext {
             wall_time: now::to_datetime(NOW_ZERO()),
             planning_id: None,
+            ignore_if_exists_errors: false,
         }
     }
 
-    pub fn set_planning_id(&mut self, id: GlobalId) {
+    pub fn with_planning_id(mut self, id: GlobalId) -> Self {
         self.planning_id = Some(id);
+        self
+    }
+
+    pub fn with_ignore_if_exists_errors(mut self, value: bool) -> Self {
+        self.ignore_if_exists_errors = value;
+        self
     }
 }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -813,10 +813,14 @@ pub struct ExplainPlanPlan {
 /// The type of object to be explained
 #[derive(Clone, Debug)]
 pub enum Explainee {
-    /// An existing materialized view.
+    /// Lookup and explain a plan saved for an existing materialized view.
     MaterializedView(GlobalId),
-    /// An existing index.
+    /// Lookup and explain a plan saved for an existing index.
     Index(GlobalId),
+    /// Replan an existing materialized view.
+    ReplanMaterializedView(GlobalId),
+    /// Replan an existing index.
+    ReplanIndex(GlobalId),
     /// A SQL statement.
     Statement(ExplaineeStatement),
 }

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -766,7 +766,10 @@ fn generate_rbac_requirements(
             explainee,
         }) => RbacRequirements {
             privileges: match explainee {
-                Explainee::MaterializedView(id) | Explainee::Index(id) => {
+                Explainee::MaterializedView(id)
+                | Explainee::Index(id)
+                | Explainee::ReplanMaterializedView(id)
+                | Explainee::ReplanIndex(id) => {
                     let item = catalog.get_item(id);
                     let schema_id: ObjectId = item.name().qualifiers.clone().into();
                     vec![(SystemObjectId::Object(schema_id), AclMode::USAGE, role_id)]
@@ -782,7 +785,10 @@ fn generate_rbac_requirements(
                     .collect(),
             },
             item_usage: match explainee {
-                Explainee::MaterializedView(_) | Explainee::Index(_) => &EMPTY_ITEM_USAGE,
+                Explainee::MaterializedView(..)
+                | Explainee::Index(..)
+                | Explainee::ReplanMaterializedView(..)
+                | Explainee::ReplanIndex(..) => &EMPTY_ITEM_USAGE,
                 Explainee::Statement(_) => &DEFAULT_ITEM_USAGE,
             },
             ..Default::default()

--- a/test/sqllogictest/explain/enable_eager_delta_joins.slt
+++ b/test/sqllogictest/explain/enable_eager_delta_joins.slt
@@ -1,0 +1,269 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test the ability to catch plan changes using the `enable_eager_delta_joins`
+# config flag in EXPLAIN. This test can be deleted when the feature flag is
+# removed.
+
+mode cockroach
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_eager_delta_joins TO false;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE t1 (
+  x int,
+  y int
+);
+
+statement ok
+CREATE TABLE t2 (
+  x int,
+  y int
+);
+
+statement ok
+CREATE TABLE t3 (
+  x int,
+  y int
+);
+
+# Test materialized views
+# -----------------------
+
+# A query that will produce different plans depending on the value of the
+# `enable_eager_delta_joins` feature flag.
+statement ok
+CREATE MATERIALIZED VIEW mv AS
+SELECT
+  t1.y as c1,
+  t2.y as c2,
+  t3.y as c3
+FROM
+  t1, t2, t3
+where
+  t1.x = t2.x AND
+  t2.y = t3.y;
+
+# EXPLAIN and EXPLAIN REPLAN should coincide.
+query T multiline
+EXPLAIN WITH(join_impls)
+MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Project (#1, #3, #3)
+    Join on=(#0 = #2 AND #3 = #4) type=differential
+      implementation
+        %0:t1[#0]K » %1:t2[#0]K » %2:t3[#0]K
+      ArrangeBy keys=[[#0]]
+        Filter (#0) IS NOT NULL
+          ReadStorage materialize.public.t1
+      ArrangeBy keys=[[#0]]
+        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+          ReadStorage materialize.public.t2
+      ArrangeBy keys=[[#0]]
+        Project (#1)
+          Filter (#1) IS NOT NULL
+            ReadStorage materialize.public.t3
+
+Source materialize.public.t1
+  filter=((#0) IS NOT NULL)
+Source materialize.public.t2
+  filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+Source materialize.public.t3
+  filter=((#1) IS NOT NULL)
+
+EOF
+
+# EXPLAIN and EXPLAIN REPLAN should coincide.
+query T multiline
+EXPLAIN WITH(join_impls)
+REPLAN MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Project (#1, #3, #3)
+    Join on=(#0 = #2 AND #3 = #4) type=differential
+      implementation
+        %0:t1[#0]K » %1:t2[#0]K » %2:t3[#0]K
+      ArrangeBy keys=[[#0]]
+        Filter (#0) IS NOT NULL
+          ReadStorage materialize.public.t1
+      ArrangeBy keys=[[#0]]
+        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+          ReadStorage materialize.public.t2
+      ArrangeBy keys=[[#0]]
+        Project (#1)
+          Filter (#1) IS NOT NULL
+            ReadStorage materialize.public.t3
+
+Source materialize.public.t1
+  filter=((#0) IS NOT NULL)
+Source materialize.public.t2
+  filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+Source materialize.public.t3
+  filter=((#1) IS NOT NULL)
+
+EOF
+
+# EXPLAIN REPLAN WITH(enable_eager_delta_joins) should differ.
+query T multiline
+EXPLAIN WITH(join_impls, enable_eager_delta_joins)
+REPLAN MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Project (#1, #3, #3)
+    Join on=(#0 = #2 AND #3 = #4) type=delta
+      implementation
+        %0:t1 » %1:t2[#0]K » %2:t3[#0]K
+        %1:t2 » %0:t1[#0]K » %2:t3[#0]K
+        %2:t3 » %1:t2[#1]K » %0:t1[#0]K
+      ArrangeBy keys=[[#0]]
+        Filter (#0) IS NOT NULL
+          ReadStorage materialize.public.t1
+      ArrangeBy keys=[[#0], [#1]]
+        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+          ReadStorage materialize.public.t2
+      ArrangeBy keys=[[#0]]
+        Project (#1)
+          Filter (#1) IS NOT NULL
+            ReadStorage materialize.public.t3
+
+Source materialize.public.t1
+  filter=((#0) IS NOT NULL)
+Source materialize.public.t2
+  filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+Source materialize.public.t3
+  filter=((#1) IS NOT NULL)
+
+EOF
+
+# Test indexed views
+# ------------------
+
+# Same as above, but as an indexed view.
+statement ok
+CREATE VIEW v AS
+SELECT
+  t1.y as c1,
+  t2.y as c2,
+  t3.y as c3
+FROM
+  t1, t2, t3
+where
+  t1.x = t2.x AND
+  t2.y = t3.y;
+
+statement ok
+CREATE INDEX v_idx ON v(c1);
+
+# EXPLAIN and EXPLAIN REPLAN should coincide.
+query T multiline
+EXPLAIN WITH(join_impls)
+INDEX v_idx;
+----
+materialize.public.v_idx:
+  ArrangeBy keys=[[#0]]
+    ReadGlobalFromSameDataflow materialize.public.v
+
+materialize.public.v:
+  Project (#1, #3, #3)
+    Join on=(#0 = #2 AND #3 = #4) type=differential
+      implementation
+        %0:t1[#0]K » %1:t2[#0]K » %2:t3[#0]K
+      ArrangeBy keys=[[#0]]
+        Filter (#0) IS NOT NULL
+          ReadStorage materialize.public.t1
+      ArrangeBy keys=[[#0]]
+        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+          ReadStorage materialize.public.t2
+      ArrangeBy keys=[[#0]]
+        Project (#1)
+          Filter (#1) IS NOT NULL
+            ReadStorage materialize.public.t3
+
+Source materialize.public.t1
+  filter=((#0) IS NOT NULL)
+Source materialize.public.t2
+  filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+Source materialize.public.t3
+  filter=((#1) IS NOT NULL)
+
+EOF
+
+# EXPLAIN and EXPLAIN REPLAN should coincide.
+query T multiline
+EXPLAIN WITH(join_impls)
+REPLAN INDEX v_idx;
+----
+materialize.public.v_idx:
+  ArrangeBy keys=[[#0]]
+    ReadGlobalFromSameDataflow materialize.public.v
+
+materialize.public.v:
+  Project (#1, #3, #3)
+    Join on=(#0 = #2 AND #3 = #4) type=differential
+      implementation
+        %0:t1[#0]K » %1:t2[#0]K » %2:t3[#0]K
+      ArrangeBy keys=[[#0]]
+        Filter (#0) IS NOT NULL
+          ReadStorage materialize.public.t1
+      ArrangeBy keys=[[#0]]
+        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+          ReadStorage materialize.public.t2
+      ArrangeBy keys=[[#0]]
+        Project (#1)
+          Filter (#1) IS NOT NULL
+            ReadStorage materialize.public.t3
+
+Source materialize.public.t1
+  filter=((#0) IS NOT NULL)
+Source materialize.public.t2
+  filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+Source materialize.public.t3
+  filter=((#1) IS NOT NULL)
+
+EOF
+
+# EXPLAIN REPLAN WITH(enable_eager_delta_joins) should differ.
+query T multiline
+EXPLAIN WITH(join_impls, enable_eager_delta_joins)
+REPLAN INDEX v_idx;
+----
+materialize.public.v_idx:
+  ArrangeBy keys=[[#0]]
+    ReadGlobalFromSameDataflow materialize.public.v
+
+materialize.public.v:
+  Project (#1, #3, #3)
+    Join on=(#0 = #2 AND #3 = #4) type=delta
+      implementation
+        %0:t1 » %1:t2[#0]K » %2:t3[#0]K
+        %1:t2 » %0:t1[#0]K » %2:t3[#0]K
+        %2:t3 » %1:t2[#1]K » %0:t1[#0]K
+      ArrangeBy keys=[[#0]]
+        Filter (#0) IS NOT NULL
+          ReadStorage materialize.public.t1
+      ArrangeBy keys=[[#0], [#1]]
+        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+          ReadStorage materialize.public.t2
+      ArrangeBy keys=[[#0]]
+        Project (#1)
+          Filter (#1) IS NOT NULL
+            ReadStorage materialize.public.t3
+
+Source materialize.public.t1
+  filter=((#0) IS NOT NULL)
+Source materialize.public.t2
+  filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+Source materialize.public.t3
+  filter=((#1) IS NOT NULL)
+
+EOF

--- a/test/sqllogictest/explain/replan_catalog_items.slt
+++ b/test/sqllogictest/explain/replan_catalog_items.slt
@@ -1,0 +1,178 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE t1 (
+  x int,
+  y int
+);
+
+statement ok
+CREATE TABLE t2 (
+  y int,
+  z int
+);
+
+statement ok
+CREATE VIEW v AS SELECT x, sum(z) FROM t1 JOIN t2 USING(y) GROUP BY x
+
+statement ok
+CREATE MATERIALIZED VIEW mv AS SELECT x, sum(z) FROM t1 JOIN t2 USING(y) GROUP BY x
+
+statement ok
+CREATE INDEX ON t1(y);
+
+# EXPLAIN and EXPLAIN REPLAN should coincide.
+query T multiline
+EXPLAIN
+MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Reduce group_by=[#0] aggregates=[sum(#1)]
+    Project (#0, #3)
+      Join on=(#1 = #2) type=differential
+        ArrangeBy keys=[[#1]]
+          Filter (#1) IS NOT NULL
+            ReadStorage materialize.public.t1
+        ArrangeBy keys=[[#0]]
+          Filter (#0) IS NOT NULL
+            ReadStorage materialize.public.t2
+
+Source materialize.public.t1
+  filter=((#1) IS NOT NULL)
+Source materialize.public.t2
+  filter=((#0) IS NOT NULL)
+
+EOF
+
+# EXPLAIN and EXPLAIN REPLAN should coincide.
+query T multiline
+EXPLAIN
+REPLAN MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Reduce group_by=[#0] aggregates=[sum(#1)]
+    Project (#0, #3)
+      Join on=(#1 = #2) type=differential
+        ArrangeBy keys=[[#1]]
+          Filter (#1) IS NOT NULL
+            ReadStorage materialize.public.t1
+        ArrangeBy keys=[[#0]]
+          Filter (#0) IS NOT NULL
+            ReadStorage materialize.public.t2
+
+Source materialize.public.t1
+  filter=((#1) IS NOT NULL)
+Source materialize.public.t2
+  filter=((#0) IS NOT NULL)
+
+EOF
+
+# EXPLAIN CREATE should differ from the above two.
+query T multiline
+EXPLAIN
+CREATE MATERIALIZED VIEW mv AS SELECT x, sum(z) FROM t1 JOIN t2 USING(y) GROUP BY x;
+----
+materialize.public.mv:
+  Reduce group_by=[#0] aggregates=[sum(#1)]
+    Project (#0, #3)
+      Filter (#1) IS NOT NULL
+        Join on=(#1 = #2) type=differential
+          ArrangeBy keys=[[#1]]
+            ReadIndex on=t1 t1_y_idx=[differential join]
+          ArrangeBy keys=[[#0]]
+            Filter (#0) IS NOT NULL
+              ReadStorage materialize.public.t2
+
+Source materialize.public.t2
+  filter=((#0) IS NOT NULL)
+
+Used Indexes:
+  - materialize.public.t1_y_idx (differential join)
+
+EOF
+
+statement ok
+CREATE INDEX v_idx ON v(x);
+
+# EXPLAIN and EXPLAIN REPLAN should coincide.
+query T multiline
+EXPLAIN
+INDEX v_idx;
+----
+materialize.public.v_idx:
+  ArrangeBy keys=[[#0]]
+    ReadGlobalFromSameDataflow materialize.public.v
+
+materialize.public.v:
+  Reduce group_by=[#0] aggregates=[sum(#1)]
+    Project (#0, #3)
+      Filter (#1) IS NOT NULL
+        Join on=(#1 = #2) type=differential
+          ArrangeBy keys=[[#1]]
+            ReadIndex on=t1 t1_y_idx=[differential join]
+          ArrangeBy keys=[[#0]]
+            Filter (#0) IS NOT NULL
+              ReadStorage materialize.public.t2
+
+Source materialize.public.t2
+  filter=((#0) IS NOT NULL)
+
+Used Indexes:
+  - materialize.public.t1_y_idx (differential join)
+
+EOF
+
+# EXPLAIN and EXPLAIN REPLAN should coincide.
+query T multiline
+EXPLAIN
+REPLAN INDEX v_idx;
+----
+materialize.public.v_idx:
+  ArrangeBy keys=[[#0]]
+    ReadGlobalFromSameDataflow materialize.public.v
+
+materialize.public.v:
+  Reduce group_by=[#0] aggregates=[sum(#1)]
+    Project (#0, #3)
+      Filter (#1) IS NOT NULL
+        Join on=(#1 = #2) type=differential
+          ArrangeBy keys=[[#1]]
+            ReadIndex on=t1 t1_y_idx=[differential join]
+          ArrangeBy keys=[[#0]]
+            Filter (#0) IS NOT NULL
+              ReadStorage materialize.public.t2
+
+Source materialize.public.t2
+  filter=((#0) IS NOT NULL)
+
+Used Indexes:
+  - materialize.public.t1_y_idx (differential join)
+
+EOF
+
+# EXPLAIN CREATE should differ from the above two.
+query T multiline
+EXPLAIN
+CREATE INDEX ON v(x);
+----
+materialize.public.v_x_idx:
+  ArrangeBy keys=[[#0]]
+    ReadIndex on=v v_idx=[plan root (no new arrangement)]
+
+Used Indexes:
+  - materialize.public.v_idx (plan root (no new arrangement), index export)
+
+Notices:
+  - Notice: The current index is identical to materialize.public.v_idx, which is also defined on v(x).
+    Hint: Please drop all indexes except the first index created on v(x) and recreate all dependent objects.
+
+EOF


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

I don't think we have an issue for that, but currently there is no way to inspect how a plan would differ if we enable an optimizer feature flag and then restart `environmentd`. A naive solution might be to lookup the `CREATE` statement for a catalog item from the catalog and then run

```sql
EXPLAIN CREATE <catalog item>
```

However, this doesn't work because:

1. The catalog state considered when we run `EXPLAIN CREATE <catalog item>` might be different from the catalog state available when re-planning during `bootstrap`.
2. Our external tooling soon won't be able to lookup valid `CREATE` statements for all catalog items because they are not redacted (and the redacted versions are not valid SQL).

To solve both issues we introduce new (for now undocumented) syntax:

```sql
EXPLAIN REPLAN CATALOG ITEM <name>;
EXPLAIN REPLAN INDEX <name>;
```

That can be used in conjunction with optimizer feature flags passed with `EXPLAIN WITH(...)` to inspect a catalog for plan regressions and plan improvements before rolling out a change.

### Tips for reviewer

It's best to review one commit at a time.

- @MaterializeInc/adapter prease review `sql:` and `adapter:` commits.
- @ggevay please review `optimize:` commits.

Besides the obvious syntax changes, mechanically the main difference between running an optimizer pipeline for
```sql
EXPLAIN CREATE <catalog item ddl>
```
and
```sql
EXPLAIN REPLAN <catalog item name>
```
is that the latter uses a slightly modified `DataflowBuilder` where the `IndexOracle` implementation doesn't report indexes that are higher or equal than the `GlobalId` of the optimized catalog item.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
