### PR TITLE
[persist/explain] Explain pushdown

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -325,10 +325,9 @@ impl Coordinator {
                 Plan::ExplainPlan(plan) => {
                     self.sequence_explain_plan(ctx, plan, target_cluster).await;
                 }
-                Plan::ExplainPushdown(_plan) => {
-                    ctx.retire(Err(AdapterError::Unsupported(
-                        "EXPLAIN FILTER PUSHDOWN queries",
-                    )));
+                Plan::ExplainPushdown(plan) => {
+                    self.sequence_explain_pushdown(ctx, plan, target_cluster)
+                        .await;
                 }
                 Plan::ExplainSinkSchema(plan) => {
                     let result = self.sequence_explain_schema(plan);

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1919,7 +1919,7 @@ impl Coordinator {
             }
             _ => {
                 ctx.retire(Err(AdapterError::Unsupported(
-                    "EXPLAIN FILTER PUSHDOWN queries for this query type",
+                    "EXPLAIN FILTER PUSHDOWN queries for this explainee type",
                 )));
             }
         };

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -22,6 +22,7 @@ use mz_adapter_types::compaction::CompactionWindow;
 use mz_cloud_resources::VpcEndpointConfig;
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_expr::{CollectionPlan, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing};
+
 use mz_ore::collections::{CollectionExt, HashSet};
 use mz_ore::task::spawn;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -50,9 +51,9 @@ use mz_catalog::memory::objects::{
 };
 use mz_ore::instrument;
 use mz_sql::plan::{
-    AlterConnectionAction, AlterConnectionPlan, ExplainSinkSchemaPlan, IndexOption, MutationKind,
-    Params, Plan, PlannedAlterRoleOption, PlannedRoleVariable, QueryWhen, SideEffectingFunc,
-    UpdatePrivilege, VariableValue,
+    AlterConnectionAction, AlterConnectionPlan, ExplainSinkSchemaPlan, Explainee,
+    ExplaineeStatement, IndexOption, MutationKind, Params, Plan, PlannedAlterRoleOption,
+    PlannedRoleVariable, QueryWhen, SideEffectingFunc, UpdatePrivilege, VariableValue,
 };
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::user::UserKind;
@@ -84,8 +85,8 @@ use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::timestamp_selection::{TimestampDetermination, TimestampSource};
 use crate::coord::{
     AlterConnectionValidationReady, Coordinator, CreateConnectionValidationReady, ExecuteContext,
-    Message, PendingRead, PendingReadTxn, PendingTxn, PendingTxnResponse, PlanValidity,
-    RealTimeRecencyContext, StageResult, Staged, TargetCluster,
+    ExplainContext, Message, PeekStage, PeekStageValidate, PendingRead, PendingReadTxn, PendingTxn,
+    PendingTxnResponse, PlanValidity, RealTimeRecencyContext, StageResult, Staged, TargetCluster,
 };
 use crate::error::AdapterError;
 use crate::notice::{AdapterNotice, DroppedInUseIndex};
@@ -1888,6 +1889,38 @@ impl Coordinator {
             }
             plan::Explainee::ReplanIndex(_) => {
                 self.explain_replan_index(ctx, plan).await;
+            }
+        };
+    }
+
+    pub(super) async fn sequence_explain_pushdown(
+        &mut self,
+        ctx: ExecuteContext,
+        plan: plan::ExplainPushdownPlan,
+        target_cluster: TargetCluster,
+    ) {
+        match plan.explainee {
+            Explainee::Statement(ExplaineeStatement::Select {
+                broken: false,
+                plan,
+                desc: _,
+            }) => {
+                self.execute_peek_stage(
+                    ctx,
+                    OpenTelemetryContext::obtain(),
+                    PeekStage::Validate(PeekStageValidate {
+                        plan,
+                        target_cluster,
+                        copy_to_ctx: None,
+                        explain_ctx: ExplainContext::Pushdown,
+                    }),
+                )
+                .await;
+            }
+            _ => {
+                ctx.retire(Err(AdapterError::Unsupported(
+                    "EXPLAIN FILTER PUSHDOWN queries for this query type",
+                )));
             }
         };
     }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -26,7 +26,7 @@ use differential_dataflow::lattice::Lattice;
 use mz_cluster_client::client::ClusterReplicaLocation;
 use mz_cluster_client::ReplicaId;
 use mz_persist_client::read::{Cursor, ReadHandle};
-use mz_persist_client::stats::SnapshotStats;
+use mz_persist_client::stats::{SnapshotPartsStats, SnapshotStats};
 use mz_persist_types::Codec64;
 use mz_repr::{Diff, GlobalId, RelationDesc, Row};
 use mz_storage_types::configuration::StorageConfiguration;
@@ -399,6 +399,14 @@ pub trait StorageController: Debug {
         id: GlobalId,
         as_of: Antichain<Self::Timestamp>,
     ) -> Result<SnapshotStats, StorageError>;
+
+    /// Returns aggregate statistics about the contents of the local input named
+    /// `id` at `as_of`.
+    async fn snapshot_parts_stats(
+        &self,
+        id: GlobalId,
+        as_of: Antichain<Self::Timestamp>,
+    ) -> Result<SnapshotPartsStats, StorageError>;
 
     /// Assigns a read policy to specific identifiers.
     ///

--- a/test/sqllogictest/explain-pushdown.slt
+++ b/test/sqllogictest/explain-pushdown.slt
@@ -9,7 +9,7 @@
 
 mode cockroach
 
-# Check that EXPLAIN FILTER PUSHDOWN statements parse, though they're not yet supported
+# EXPLAIN FILTER PUSHDOWN statements are blocked by a feature flag
 statement ok
 CREATE TABLE numbers (
     value int
@@ -30,7 +30,7 @@ EOF
 query error db error: ERROR: EXPLAIN FILTER PUSHDOWN is not supported
 EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM numbers where value > 10;
 
-# Even when the feature flag is enabled, the feature is blocked in adapter
+# Even when the feature flag is enabled, the feature is blocked in adapter for most queries
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_explain_pushdown = true
@@ -39,6 +39,28 @@ COMPLETE 0
 
 query error db error: ERROR: EXPLAIN FILTER PUSHDOWN queries for this query type are not supported
 EXPLAIN FILTER PUSHDOWN FOR CREATE MATERIALIZED VIEW foo AS SELECT * FROM numbers where value > 10;
+
+# However, EXPLAIN FILTER PUSHDOWN FOR SELECT is now supported
+
+query TIIII
+EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM numbers where value > 10;
+----
+materialize.public.numbers  0  0  0  0
+
+statement ok
+INSERT INTO numbers VALUES (1), (2), (3);
+
+# The next two queries may be slightly brittle, since they depend on part sizes.
+# Feel free to --rewrite-results or delete them if they prove difficult to maintain.
+query TIIII
+EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM numbers where value > 10;
+----
+materialize.public.numbers  1039  0  1  0
+
+query TIIII
+EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM numbers where value < 10;
+----
+materialize.public.numbers  1039  1039  1  1
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_explain_pushdown = false

--- a/test/sqllogictest/explain-pushdown.slt
+++ b/test/sqllogictest/explain-pushdown.slt
@@ -37,7 +37,7 @@ ALTER SYSTEM SET enable_explain_pushdown = true
 ----
 COMPLETE 0
 
-query error db error: ERROR: EXPLAIN FILTER PUSHDOWN queries for this query type are not supported
+query error db error: ERROR: EXPLAIN FILTER PUSHDOWN queries for this explainee type are not supported
 EXPLAIN FILTER PUSHDOWN FOR CREATE MATERIALIZED VIEW foo AS SELECT * FROM numbers where value > 10;
 
 # However, EXPLAIN FILTER PUSHDOWN FOR SELECT is now supported

--- a/test/sqllogictest/explain-pushdown.slt
+++ b/test/sqllogictest/explain-pushdown.slt
@@ -37,8 +37,8 @@ ALTER SYSTEM SET enable_explain_pushdown = true
 ----
 COMPLETE 0
 
-query error db error: ERROR: EXPLAIN FILTER PUSHDOWN queries are not supported
-EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM numbers where value > 10;
+query error db error: ERROR: EXPLAIN FILTER PUSHDOWN queries for this query type are not supported
+EXPLAIN FILTER PUSHDOWN FOR CREATE MATERIALIZED VIEW foo AS SELECT * FROM numbers where value > 10;
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_explain_pushdown = false


### PR DESCRIPTION
Implements an initial version of the explain-pushdown feature.

### Motivation

#24498 

### Tips for reviewer

For example, querying against the auction house load generator:

```
materialize=> explain filter pushdown for select * from bids where bid_time + '300 seconds' > mz_now();
         Source          | Total Bytes | Selected Bytes | Total Parts | Selected Parts 
-------------------------+-------------+----------------+-------------+----------------
 materialize.public.bids | 605556      | 27374          | 19          | 13
(1 row)
```

This is still behind a flag; I may ask to take larger requests or extensions as followup PRs.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
