### PR TITLE
storage: subsource input indexes

### DIFF
--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -418,14 +418,16 @@ impl DataSourceDesc {
         let source_exports = ingestion
             .subsource_exports
             .iter()
-            // By convention the first output corresponds to the main source object
-            .chain(std::iter::once((&id, &0)))
-            .map(|(id, output_index)| {
-                let export = SourceExport {
-                    output_index: *output_index,
-                    storage_metadata: (),
-                };
-                (*id, export)
+            .map(|(id, input_index)| (*id, Some(*input_index)))
+            .chain(std::iter::once((id, None)))
+            .map(|(id, input_index)| {
+                (
+                    id,
+                    SourceExport {
+                        input_index,
+                        storage_metadata: (),
+                    },
+                )
             })
             .collect();
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1254,6 +1254,8 @@ pub enum DataSourceDesc {
 pub struct Ingestion {
     pub desc: SourceDesc<ReferencedConnection>,
     pub source_imports: BTreeSet<GlobalId>,
+    /// Correlates GlobalIds to the objects in the external source that this
+    /// outputs.
     pub subsource_exports: BTreeMap<GlobalId, usize>,
     pub progress_subsource: GlobalId,
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -938,7 +938,7 @@ pub fn plan_create_source(
 
                     column_casts.push(mir_cast);
                 }
-                let r = table_casts.insert(i + 1, column_casts);
+                let r = table_casts.insert(i, column_casts);
                 assert!(r.is_none(), "cannot have table defined multiple times");
 
                 let name = FullItemName {
@@ -947,10 +947,7 @@ pub fn plan_create_source(
                     item: table.name.clone(),
                 };
 
-                // The zero-th output is the main output
-                // TODO(petrosagg): these plus ones are an accident waiting to happen. Find a way
-                // to handle the main source and the subsources uniformly
-                available_subsources.insert(name, i + 1);
+                available_subsources.insert(name, i);
             }
 
             let publication_details = PostgresSourcePublicationDetails::from_proto(details)
@@ -1003,10 +1000,7 @@ pub fn plan_create_source(
                     schema: table.schema_name.clone(),
                     item: table.name.clone(),
                 };
-                // The zero-th output is the main output
-                // TODO(petrosagg): these plus ones are an accident waiting to happen. Find a way
-                // to handle the main source and the subsources uniformly
-                available_subsources.insert(name, index + 1);
+                available_subsources.insert(name, index);
             }
 
             let connection =
@@ -1607,10 +1601,7 @@ pub(crate) fn load_generator_ast_to_generator(
             },
             item: name.to_string(),
         };
-        // The zero-th output is the main output
-        // TODO(petrosagg): these plus ones are an accident waiting to happen. Find a way
-        // to handle the main source and the subsources uniformly
-        available_subsources.insert(name, (i + 1, desc.clone()));
+        available_subsources.insert(name, (i, desc.clone()));
     }
     let available_subsources = if available_subsources.is_empty() {
         None

--- a/src/sql/src/pure/mysql.rs
+++ b/src/sql/src/pure/mysql.rs
@@ -42,7 +42,7 @@ pub(super) fn mysql_upstream_name(
 
 pub(super) fn derive_catalog_from_tables<'a>(
     tables: &'a [MySqlTableDesc],
-) -> Result<SubsourceCatalog<&'a MySqlTableDesc>, PlanError> {
+) -> Result<SubsourceCatalog<MySqlTableDesc>, PlanError> {
     // An index from table name -> schema name -> MySqlTableDesc
     let mut tables_by_name = BTreeMap::new();
     for table in tables.iter() {
@@ -52,7 +52,7 @@ pub(super) fn derive_catalog_from_tables<'a>(
             .entry(table.schema_name.clone())
             .or_insert_with(BTreeMap::new)
             .entry(MYSQL_DATABASE_FAKE_NAME.to_string())
-            .or_insert(table);
+            .or_insert(table.clone());
     }
 
     Ok(SubsourceCatalog(tables_by_name))

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -34,7 +34,7 @@ use super::RequestedSubsource;
 pub(super) fn derive_catalog_from_publication_tables<'a>(
     database: &'a str,
     publication_tables: &'a [PostgresTableDesc],
-) -> Result<SubsourceCatalog<&'a PostgresTableDesc>, PlanError> {
+) -> Result<SubsourceCatalog<PostgresTableDesc>, PlanError> {
     // An index from table name -> schema name -> database name -> PostgresTableDesc
     let mut tables_by_name = BTreeMap::new();
     for table in publication_tables.iter() {
@@ -44,7 +44,7 @@ pub(super) fn derive_catalog_from_publication_tables<'a>(
             .entry(table.namespace.clone())
             .or_insert_with(BTreeMap::new)
             .entry(database.to_string())
-            .or_insert(table);
+            .or_insert(table.clone());
     }
 
     Ok(SubsourceCatalog(tables_by_name))
@@ -82,7 +82,7 @@ pub(super) async fn validate_requested_subsources_privileges(
 }
 
 pub(super) fn generate_text_columns(
-    publication_catalog: &SubsourceCatalog<&PostgresTableDesc>,
+    publication_catalog: &SubsourceCatalog<PostgresTableDesc>,
     text_columns: &mut [UnresolvedItemName],
     option_name: &str,
 ) -> Result<BTreeMap<u32, BTreeSet<String>>, PlanError> {

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -3110,7 +3110,7 @@ where
                 id,
                 SourceExport {
                     storage_metadata,
-                    output_index: export.output_index,
+                    input_index: export.input_index,
                 },
             );
         }

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -78,9 +78,10 @@ message ProtoIngestionDescription {
         mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 2;
     }
     message ProtoSourceExport {
+        reserved 2;
         mz_repr.global_id.ProtoGlobalId id = 1;
-        uint64 output_index = 2;
         mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 3;
+        optional uint64 input_index = 4;
     }
     repeated ProtoSourceImport source_imports = 1;
     repeated ProtoSourceExport source_exports = 2;

--- a/src/storage-types/src/sources/load_generator.rs
+++ b/src/storage-types/src/sources/load_generator.rs
@@ -16,7 +16,7 @@ use mz_repr::{ColumnType, GlobalId, RelationDesc, Row, ScalarType};
 use once_cell::sync::Lazy;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use timely::dataflow::operators::to_stream::Event;
 
 use crate::connections::inline::ConnectionAccess;
@@ -382,6 +382,7 @@ pub trait Generator {
         now: NowFn,
         seed: Option<u64>,
         resume_offset: MzOffset,
+        inputs_to_outputs: BTreeMap<usize, usize>,
     ) -> Box<dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>>;
 }
 

--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -415,6 +415,7 @@ pub fn render_decode_delimited<G: Scope, FromTime: Timestamp>(
     debug_name: String,
     metrics: DecodeMetricDefs,
     storage_configuration: StorageConfiguration,
+    health_output: usize,
 ) -> (
     Collection<G, DecodeResult<FromTime>, Diff>,
     Stream<G, HealthStatusMessage>,
@@ -525,10 +526,10 @@ pub fn render_decode_delimited<G: Scope, FromTime: Timestamp>(
         })
     });
 
-    let health = transient_errors.map(|err: Rc<CsrConnectError>| {
+    let health = transient_errors.map(move |err: Rc<CsrConnectError>| {
         let halt_status = HealthStatusUpdate::halting(err.display_with_causes().to_string(), None);
         HealthStatusMessage {
-            index: 0,
+            index: health_output,
             namespace: if matches!(&*err, CsrConnectError::Ssh(_)) {
                 StatusNamespace::Ssh
             } else {

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -252,14 +252,23 @@ where
                     }),
                     empty(scope),
                 ),
-                (key_encoding, value_encoding) => render_decode_delimited(
-                    &ok_source,
-                    key_encoding,
-                    value_encoding,
-                    dataflow_debug_name.clone(),
-                    storage_state.metrics.decode_defs.clone(),
-                    storage_state.storage_configuration.clone(),
-                ),
+                (key_encoding, value_encoding) => {
+                    let primary_source_idx = description
+                        .source_exports
+                        .keys()
+                        .position(|export_id| *export_id == id)
+                        .expect("primary source must be in exports");
+
+                    render_decode_delimited(
+                        &ok_source,
+                        key_encoding,
+                        value_encoding,
+                        dataflow_debug_name.clone(),
+                        storage_state.metrics.decode_defs.clone(),
+                        storage_state.storage_configuration.clone(),
+                        primary_source_idx,
+                    )
+                }
             };
 
             // render envelopes

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -88,6 +88,12 @@ impl SourceRender for LoadGeneratorSourceConnection {
 
         let (mut data_output, stream) = builder.new_output();
 
+        let primary_source_idx = config
+            .source_exports
+            .keys()
+            .position(|export_id| export_id == &config.id)
+            .expect("primary source must be included in exports");
+
         let button = builder.build(move |caps| async move {
             let mut cap = caps.into_element();
 
@@ -149,7 +155,7 @@ impl SourceRender for LoadGeneratorSourceConnection {
         });
 
         let status = [HealthStatusMessage {
-            index: 0,
+            index: primary_source_idx,
             namespace: Self::STATUS_NAMESPACE.clone(),
             update: HealthStatusUpdate::running(),
         }]

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -111,10 +111,20 @@ impl SourceRender for LoadGeneratorSourceConnection {
                 return;
             };
 
+            let inputs_to_outputs = config
+                .source_exports
+                .iter()
+                .enumerate()
+                .filter_map(|(output_idx, (_, export))| {
+                    export.input_index.map(|input_idx| (input_idx, output_idx))
+                })
+                .collect();
+
             let mut rows = as_generator(&self.load_generator, self.tick_micros).by_seed(
                 mz_ore::now::SYSTEM_TIME.clone(),
                 None,
                 resume_offset,
+                inputs_to_outputs,
             );
 
             let tick = Duration::from_micros(self.tick_micros.unwrap_or(1_000_000));

--- a/src/storage/src/source/generator/counter.rs
+++ b/src/storage/src/source/generator/counter.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeMap;
+
 use mz_ore::now::NowFn;
 use mz_repr::{Datum, Row};
 use mz_storage_types::sources::load_generator::Generator;
@@ -28,7 +30,13 @@ impl Generator for Counter {
         _now: NowFn,
         _seed: Option<u64>,
         resume_offset: MzOffset,
+        inputs_to_outputs: BTreeMap<usize, usize>,
     ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
+        mz_ore::soft_assert_no_log!(
+            inputs_to_outputs.is_empty(),
+            "Counter generator only outputs to primary source",
+        );
+
         let max_cardinality = self.max_cardinality;
 
         Box::new(

--- a/src/storage/src/source/generator/datums.rs
+++ b/src/storage/src/source/generator/datums.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeMap;
 use std::iter;
 
 use mz_ore::now::NowFn;
@@ -26,7 +27,13 @@ impl Generator for Datums {
         _: NowFn,
         _seed: Option<u64>,
         _resume_offset: MzOffset,
+        inputs_to_outputs: BTreeMap<usize, usize>,
     ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
+        mz_ore::soft_assert_no_log!(
+            inputs_to_outputs.is_empty(),
+            "Datums generator only outputs to primary source",
+        );
+
         let typs = ScalarType::enumerate();
         let mut datums: Vec<Vec<Datum>> = typs
             .iter()

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -85,6 +85,17 @@ pub struct RawSourceCreationConfig {
     /// The ID of this instantiation of this source.
     pub id: GlobalId,
     /// The details of the outputs from this ingestion.
+    ///
+    /// ## Notes:
+    /// - The iteration order of this field determines the output indexes used
+    ///   to demux an ingestion's single output into multiple persist shards.
+    ///   Because of this, you must be sure to iterate over all of its elements
+    ///   when determining output indexes. e.g. if the source supports
+    ///   subsources, ensure you _do not_ skip over the primary source when
+    ///   deriving output indices.
+    /// - This collection does _not_ include the remap collection, which is
+    ///   tracked in its own field. It's best to think of the remap collection
+    ///   as something other than export.
     pub source_exports: BTreeMap<GlobalId, SourceExport<CollectionMetadata>>,
     /// The ID of the worker on which this operator is executing
     pub worker_id: usize,
@@ -801,14 +812,7 @@ where
     // We use the output index from the source export to route values to its ok and err streams. We
     // do this obliquely by generating as many partitions as there are output indices and then
     // dropping all unused partitions.
-    let partition_count = u64::cast_from(
-        source_exports
-            .iter()
-            .map(|(_, SourceExport { output_index, .. })| *output_index)
-            .max()
-            .unwrap_or_default()
-            + 1,
-    );
+    let partition_count = u64::cast_from(source_exports.len());
 
     let ok_streams: Vec<_> = ok_muxed_stream
         .partition(partition_count, |((output, data), time, diff)| {

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -192,7 +192,7 @@ where
                 id,
                 mz_storage_types::sources::SourceExport {
                     storage_metadata: collection_metadata.clone(),
-                    output_index: 0,
+                    input_index: None,
                 },
             )]);
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1737,7 +1737,7 @@ def workflow_pg_snapshot_partial_failure(c: Composition) -> None:
         Postgres(),
         Testdrive(no_reset=True),
         Clusterd(
-            name="storage", environment_extra=["FAILPOINTS=pg_snapshot_pause=return(2)"]
+            name="storage", environment_extra=["FAILPOINTS=pg_snapshot_pause=return(1)"]
         ),
     ):
         c.up("materialized", "postgres", "storage")

--- a/test/pg-cdc/alter-table-irrelevant.td
+++ b/test/pg-cdc/alter-table-irrelevant.td
@@ -100,3 +100,9 @@ INSERT INTO irrelevant_table VALUES ('gh');
 > SELECT * FROM base_table;
 1
 2
+
+! SELECT * FROM irrelevant_table;
+contains: incompatible schema change
+
+# Drop broken table because mzcompose expects all healthy sources
+> ALTER SOURCE mz_source DROP SUBSOURCE irrelevant_table;


### PR DESCRIPTION
To support sources that produce multiple streams of data (i.e. sources w/ subsources), the source produces a stream of updates, the data of which contains a `usize` we refer to as the `output_index`. When ingesting data, data for the primary sources goes to `output_index` 0, and each subsource produces data to a distinct `output_index`. In rendering, we then partition (demux) the source's output among all `output_index`es, and then correlate the data's `output_index` with one of the source exports (i.e. the primary source at `output_index` 0, followed by all of its subsources, each of which explicitly identifies its output index)––this is the mapping between upstream objects and persist shards.

```
                                                                        persist_shard_0
                                                                       ↗                                      
[source]-->(output_index, events)-->partition(max(output_index), input)→ persist_shard_1
                                                                       ↘
                                                                        persist_shard_n
```

To accomplish this mapping, we current determine the `output_index` during planning using an algorithm approximated with the following pseudocode:

```rust
vec![primary_source].extend(upstream_subsource_descriptions)
```

Fusing together the indexes of the upstream subsource descriptions and the subsources themselves means that there was no way to have any 1 upstream subsource object demuxed into multiple subsources/persist shards **using different schemas**. Additionally, this structure required us to add 1 to indexes in a few places to retain the offset of the primary source at index 0.

To pave the way for demuxing a single upstream table into multiple persist shards **with different schemas**, I propose we changed `output_index` in `SourceExprort` to `input_index` whose type is `Option<usize>`. This lets us keep the same simple semantics for finding which upstream object the subsource refers (i.e. what was the `output_index` in some places just becomes the `input_index`, except that the primary source's `input_index` is `None`). Then, to determine the output index, we rely on the iteration order of the source exports, i.e.

```rust
struct Source {
  exports: BTreeMap<GlobalId, SourceExport>
}
...
    for (output_idx, (id, source)) in source.exports.iter().enumerate() {
...
```

I find this de-coupling of choosing what to ingest from choosing where to put it more intuitive--hope others are similarly convinced.

Note that this PR doesn't actually introduce demuxing a single upstream object into multiple collections; it only makes it possible to do!

### Motivation

 This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
