### PR TITLE
Enable warm up of REFRESH materialized views (warmup capabilities)

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1241,10 +1241,11 @@ impl Coordinator {
                                 // problem, so we don't want a notice.
                                 !ids_set.contains(&ObjectId::Item(**dependant_id))
                             })
-                            .map(|dependant_id| {
-                                humanizer
-                                    .humanize_id(*dependant_id)
-                                    .unwrap_or(id.to_string())
+                            .flat_map(|dependant_id| {
+                                // If we are not able to find a name for this ID it probably means
+                                // we have already dropped the compute collection, in which case we
+                                // can ignore it.
+                                humanizer.humanize_id(*dependant_id)
                             })
                             .collect_vec();
                         if !dependants.is_empty() {

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -207,7 +207,7 @@ impl<T: Timestamp> Controller<T> {
 
 impl<T> Controller<T>
 where
-    T: Timestamp + Lattice,
+    T: TimestampManipulation,
     ComputeGrpcClient: ComputeClient<T>,
 {
     pub fn update_orchestrator_scheduling_config(

--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -247,6 +247,26 @@ true
   WHERE m.name = 'mv7' AND t.name = 't4'
 true
 
+# Test that the warmup optimization works, i.e. a REFRESH MV can hydrate prior
+# to the next refresh time.
+
+> CREATE TABLE t5 (x int)
+> CREATE MATERIALIZED VIEW mv8
+  IN CLUSTER refresh_cluster
+  WITH (REFRESH AT CREATION, REFRESH AT mz_now()::string::int8 + 1000000)
+  AS SELECT * FROM t5
+> SELECT * FROM mv8
+
+> ALTER CLUSTER refresh_cluster SET (REPLICATION FACTOR 2)
+
+> SELECT r.name, h.hydrated
+  FROM mz_internal.mz_hydration_statuses h
+  JOIN mz_materialized_views m ON (m.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  WHERE m.name = 'mv8'
+r1 true
+r2 true
+
 ######## Cleanup ########
 > DROP DATABASE materialized_view_refresh_options CASCADE;
 > DROP CLUSTER refresh_cluster CASCADE;


### PR DESCRIPTION
This PR introduces warmup capabilities held by the controller for compute collections. These capabilities hold back their collections' read frontiers, and therefore the as-ofs of new dataflows installed for collections, to a time that is immediately available in all inputs.

This is done to enable warming up dataflows, particularly REFRESH materialized views that have their next refresh time in the future. By holding back the as-ofs of dataflows we ensure that they can begin hydration immediately and don't have to wait for a future time (like the next refresh time) to do so.

This solves the same issue as https://github.com/MaterializeInc/materialize/pull/24979 and https://github.com/MaterializeInc/materialize/pull/25019, but with the benefit that we don't need to introduce a notion of "current time" to the compute controller and we don't need to assume that all collections move on the same timeline.

### Motivation

  * This PR adds a known-desirable feature.

Closes https://github.com/MaterializeInc/materialize/issues/24966

### Tips for reviewer

Look at the commits and their descriptions separately!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
