### PR TITLE
storage: SSH Tunnel & PrivateLink support for MySQL connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4697,6 +4697,7 @@ dependencies = [
  "indexmap 1.9.1",
  "itertools",
  "mysql_async",
+ "mz-cloud-resources",
  "mz-ore",
  "mz-proto",
  "mz-repr",

--- a/src/ccsr/src/tls.rs
+++ b/src/ccsr/src/tls.rs
@@ -23,9 +23,7 @@ pub struct Identity {
 }
 
 impl Identity {
-    /// Reimplements [`reqwest::Certificate::from_pem`] in terms of OpenSSL.
-    ///
-    /// The implementation in reqwest requires rustls.
+    /// Constructs an identity from a PEM-formatted key and certificate using OpenSSL.
     pub fn from_pem(key: &[u8], cert: &[u8]) -> Result<Self, openssl::error::ErrorStack> {
         let archive = pkcs12der_from_pem(key, cert)?;
         Ok(Identity {

--- a/src/mysql-util/Cargo.toml
+++ b/src/mysql-util/Cargo.toml
@@ -11,18 +11,19 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
-mysql_async = { version = "0.33.0", default-features = false, features = ["minimal", "tracing"] }
-mz-proto = { path = "../proto" }
-mz-ssh-util = { path = "../ssh-util" }
-mz-repr = { path = "../repr" }
-mz-ore = { path = "../ore", features = ["async"] }
-thiserror = "1.0.37"
-itertools = "0.10.5"
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
+itertools = "0.10.5"
+mz-cloud-resources = { path = "../cloud-resources" }
+mz-ore = { path = "../ore", features = ["async"] }
+mz-proto = { path = "../proto" }
+mz-repr = { path = "../repr" }
+mz-ssh-util = { path = "../ssh-util" }
+mysql_async = { version = "0.33.0", default-features = false, features = ["minimal", "tracing"] }
+once_cell = "1.16.0"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
-once_cell = "1.16.0"
 serde = { version = "1.0.152", features = ["derive"] }
+thiserror = "1.0.37"
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -10,7 +10,7 @@
 //! MySQL utility library.
 
 mod tunnel;
-pub use tunnel::{Config, TunnelConfig};
+pub use tunnel::{Config, MySqlConn, TunnelConfig};
 
 mod desc;
 pub use desc::{
@@ -29,6 +29,8 @@ pub use schemas::{schema_info, SchemaRequest};
 
 #[derive(Debug, thiserror::Error)]
 pub enum MySqlError {
+    #[error("error setting up ssh: {0}")]
+    Ssh(#[source] anyhow::Error),
     #[error("unsupported data type: '{column_type}' for '{qualified_table_name}.{column_name}'.")]
     UnsupportedDataType {
         column_type: String,

--- a/src/tls-util/src/lib.rs
+++ b/src/tls-util/src/lib.rs
@@ -103,9 +103,7 @@ pub struct Pkcs12Archive {
     pub pass: String,
 }
 
-/// Reimplements `reqwest::Certificate::from_pem` in terms of OpenSSL.
-///
-/// The implementation in reqwest requires rustls.
+/// Constructs an identity from a PEM-formatted key and certificate using OpenSSL.
 pub fn pkcs12der_from_pem(
     key: &[u8],
     cert: &[u8],

--- a/test/ssh-connection/mysql-source-after-ssh-failure.td
+++ b/test/ssh-connection/mysql-source-after-ssh-failure.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This test script runs after the SSH bastion host has been terminated.
+
+> SELECT status FROM mz_internal.mz_source_statuses st
+  JOIN mz_sources s ON st.id = s.id
+  WHERE s.name = 'mysql_source' AND error LIKE '%ssh:%'
+stalled

--- a/test/ssh-connection/mysql-source-after-ssh-restart.td
+++ b/test/ssh-connection/mysql-source-after-ssh-restart.td
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Ensure that the source becomes healthy again once the SSH tunnel is restarted.
+# We specifically make sure that new data written to the Kafka topic is visible
+# in the source, as that is the true measure of health, vs what is reported in
+# the mz_source_statuses relation.
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+USE dummyschema;
+INSERT INTO dummy VALUES (4);
+
+> SELECT f1 FROM dummy ORDER BY f1 ASC;
+1
+2
+3
+4
+
+> SELECT bool_and(error IS NULL)
+  FROM mz_internal.mz_source_statuses
+  WHERE
+      name
+      IN (
+      SELECT name FROM (SHOW SUBSOURCES ON mysql_source WHERE type = 'subsource')
+      );
+true

--- a/test/ssh-connection/mysql-source.td
+++ b/test/ssh-connection/mysql-source.td
@@ -1,0 +1,46 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test creating a MySQL source using SSH
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_mysql_source = true
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+> CREATE CONNECTION mysql TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass,
+    SSH TUNNEL thancred
+  );
+
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS dummyschema;
+CREATE DATABASE dummyschema;
+USE dummyschema;
+CREATE TABLE dummy (f1 INTEGER);
+INSERT INTO dummy VALUES (1), (2);
+COMMIT;
+
+> CREATE SOURCE mysql_source FROM MYSQL CONNECTION mysql FOR ALL TABLES;
+
+> SELECT COUNT(*) FROM dummy;
+2
+
+$ mysql-execute name=mysql
+INSERT INTO dummy VALUES (3);
+
+> SELECT * FROM dummy;
+1
+2
+3


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/24923 and https://github.com/MaterializeInc/materialize/issues/25027


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I added some tests to validate SSH tunnel connections, but for PrivateLink we've decided to punt on adding automated tests until after Private Preview (prioritized behind other more important tasks) ([discusson](https://www.notion.so/MySQL-Source-Prototype-8838b49eb2124e3580a4e9922761d423?d=afa0c42c2a61400180cdb82ce90874a1&pvs=4#5ab6ed833c5244739c2aa280c918c379)).

You'll also notice that I had to create a wrapper `MySqlConn` around `mysql_async::Conn` so that we can maintain a reference to the handle of a possible SSH tunnel associated with the connection. This seemed more elegant than spawning a tokio task to keep the handle alive in the background (which is what postgres does, but it also needs the task to await its connection future), and since it turns out `mysql_async` doesn't actually expose a public method on the `Conn` object to know if it's still connected. 

Also, I've punted on trying to figure out how to allow for the `VERIFY_IDENTITY` SSL MODE when using an SSH or PrivateLink tunnel. This would involve being able to create/modify the TLS connector used by `mysql_async` to allow changing the TLS host to something other than the connection host. `tokio-postgres` allows this via a `connect_raw` method but unfortunately `mysql_async` does not yet have a way to do this. 

Lastly - once https://github.com/MaterializeInc/materialize/pull/25021 merges then we can add tests to validate SSH tunnel + SSL support.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
