### PR TITLE
persist-txn: use TxnsRead worker task in operator

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -89,7 +89,7 @@ mod rehydration;
 mod statistics;
 
 #[derive(Debug)]
-enum PersistTxns<T> {
+enum PersistTxns<T: Clone> {
     EnabledEager {
         txns_id: ShardId,
         txns_client: PersistClient,

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -27,7 +27,7 @@ use mz_persist_client::cfg::{PersistConfig, RetryParameters};
 use mz_persist_client::fetch::SerdeLeasedBatchPart;
 use mz_persist_client::fetch::{FetchedBlob, FetchedPart};
 use mz_persist_client::operators::shard_source::{shard_source, SnapshotMode};
-use mz_persist_txn::operator::txns_progress;
+use mz_persist_txn::operator::{txns_progress, TxnsContext};
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::Codec64;
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, RelationType, Row, RowArena, Timestamp};
@@ -217,10 +217,12 @@ where
     // system. This means the "logical" upper may be ahead of the "physical"
     // upper. Render a dataflow operator that passes through the input and
     // translates the progress frontiers as necessary.
+    let persist_txn_ctx = persist_clients.txn_ctx::<TxnsContext<G::Timestamp>>();
     let (stream, txns_tokens) = match metadata.txns_shard {
         Some(txns_shard) => txns_progress::<SourceData, (), Timestamp, i64, _, TxnsCodecRow, _, _>(
             stream,
             &source_id.to_string(),
+            (*persist_txn_ctx).clone(),
             move || {
                 let (c, l) = (
                     Arc::clone(&persist_clients),


### PR DESCRIPTION
Previously, each time the persist-txn operator was rendered, we'd crate
a (filtered) subscribe to the txns shard. This replaces it with a
process-singleton (unfiltered) subscribe.

There is a notable tradeoff here between N filtered vs 1 unfiltered
subscriptions. However, in my staging env when there was a bug that held
back the txns since, it caused a _very_ :nervous-laughter: and linearly
increasing amount of cpu, memory, and network use. Because of this, I
believe it's worth selecting the option that bounds the worst case over
the option that optimizes the case of a few tables.

We could later get the "optimizes the case of a few tables" back, if
necessary, with a decent amount of elbow grease: making TxnsRead more
sophisticated about quiescing as well as dynamically changing the set of
data_ids that it watches.

Touches #22173

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
