### PR TITLE
storage/mysql: Fix correctness issue when snapshot is interrupted

### DIFF
--- a/src/storage-types/src/sources/mysql.proto
+++ b/src/storage-types/src/sources/mysql.proto
@@ -23,4 +23,5 @@ message ProtoMySqlSourceConnection {
 
 message ProtoMySqlSourceDetails {
     repeated mz_mysql_util.ProtoMySqlTableDesc tables = 1;
+    string initial_gtid_set = 2;
 }

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -178,10 +178,29 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
 
             trace!(%id, "timely-{worker_id} replication binlog frontier: {binlog_frontier:?}");
 
-            // Calculate the minimum frontier across all subsources, which represents the point which
+            // Calculate the lowest frontier across all subsources, which represents the point which
             // we should start replication from.
             let resume_upper =
-                Antichain::from_iter(subsource_resume_uppers.into_values().flatten());
+                match Antichain::from_iter(subsource_resume_uppers.into_values().flatten()) {
+                    upper if upper == Antichain::from_elem(GtidPartition::minimum()) => {
+                        // If any subsource is at the minimum frontier then we are either starting
+                        // from scratch or at least one table has to complete its initial snapshot.
+                        //
+                        // In either case, we need to ensure that the resumption point is
+                        // deterministic and consistent across all tables, so that a user can't
+                        // observe an MZ timestamp that may contain different snapshots for
+                        // different tables.
+                        // We've chosen the frontier beyond the GTID Set recorded
+                        // during purification as this consistent resume point.
+                        //
+                        // Tables may still be snapshot at a future GTID Set but as long as we can
+                        // resume the replication stream from this consistent point all updates
+                        // will be rewound appropriately, such that the effective snapshot point
+                        // is consistent across all tables.
+                        gtid_set_frontier(&connection.details.initial_gtid_set)?
+                    }
+                    upper => upper,
+                };
 
             // Validate that we can actually resume from this upper.
             if !PartialOrder::less_equal(&binlog_frontier, &resume_upper) {
@@ -224,7 +243,10 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                             )
                             .await);
                         };
-                        rewinds.insert(req.table.clone(), (caps.clone(), req));
+                        // If the snapshot point is the same as the resume point then we don't need to rewind
+                        if resume_upper != req.snapshot_upper {
+                            rewinds.insert(req.table.clone(), (caps.clone(), req));
+                        }
                     }
                 }
             }
@@ -300,7 +322,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                             upper_cap_set.downgrade(&*new_upper);
 
                             rewinds.retain(|_, (_, req)| {
-                                !PartialOrder::less_equal(&req.snapshot_upper, &new_upper)
+                                !PartialOrder::less_than(&req.snapshot_upper, &new_upper)
                             });
 
                             trace!(%id, "timely-{worker_id} pending rewinds after \
@@ -429,7 +451,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                         upper_cap_set.downgrade(&*new_upper);
 
                         rewinds.retain(|_, (_, req)| {
-                            !PartialOrder::less_equal(&req.snapshot_upper, &new_upper)
+                            !PartialOrder::less_than(&req.snapshot_upper, &new_upper)
                         });
                         trace!(%id, "timely-{worker_id} pending rewinds \
                                      after filtering: {rewinds:?}");


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/24982

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

See the attached issue for a description of the correctness bug. @petrosagg I _think_ this addresses the issue but I may have missed something important so would appreciate your close eye!

I'm also not sure how to test this but all the existing mysql source tests pass, so we can at least confirm it didn't break the nominal case.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
