### PR TITLE
stash: Speed up large batch test

### DIFF
--- a/src/stash/src/transaction.rs
+++ b/src/stash/src/transaction.rs
@@ -43,7 +43,7 @@ pub const INSERT_BATCH_SPLIT_SIZE: usize = 2 * 1024 * 1024;
 /// [`tokio_postgres`] has a maximum number of arguments it supports when executing a query. This
 /// is the limit at which to split a batch to make sure we don't try to include too many elements
 /// in any one update.
-const MAX_INSERT_ARGUMENTS: u16 = u16::MAX / 4;
+pub(crate) const MAX_INSERT_ARGUMENTS: u16 = u16::MAX / 4;
 
 impl Stash {
     /// Transactionally executes closure `f`.


### PR DESCRIPTION
test_stash_batch_large_number_updates was added in dad4ed8c7124f5a5dd2e47f3597c7f98004407a0 to test the max number of args in a CRDB update statement. Previously, we were testing a number of updates that was order of magnitudes larger than the max number of args in a CRDB update statement. That caused the test to be slow and sometimes hang forever. This commit updates the test to lower the number of updates while still ensuring that we end up with more than the max number of args.

Works towards resolving #25003

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
