### PR TITLE
adapter: improve various tracing

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -22,7 +22,7 @@ use mz_adapter_types::compaction::CompactionWindow;
 use smallvec::SmallVec;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::MutexGuard;
-use tracing::{info, trace};
+use tracing::{info, instrument, trace};
 use uuid::Uuid;
 
 use mz_adapter_types::connection::ConnectionId;
@@ -1177,7 +1177,7 @@ impl Catalog {
         }
     }
 
-    #[tracing::instrument(name = "catalog::transact", level = "debug", skip_all)]
+    #[instrument(name = "catalog::transact", skip_all)]
     pub async fn transact<F, R>(
         &mut self,
         oracle_write_ts: mz_repr::Timestamp,
@@ -1265,7 +1265,7 @@ impl Catalog {
         })
     }
 
-    #[tracing::instrument(name = "catalog::transact_inner", level = "debug", skip_all)]
+    #[instrument(name = "catalog::transact_inner", skip_all)]
     fn transact_inner(
         oracle_write_ts: mz_repr::Timestamp,
         session: Option<&ConnMeta>,

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -17,7 +17,7 @@ use futures::future::{BoxFuture, FutureExt};
 use mz_adapter_types::compaction::CompactionWindow;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use tracing::{info, warn, Instrument};
+use tracing::{info, instrument, warn, Instrument};
 use uuid::Uuid;
 
 use mz_catalog::builtin::{
@@ -853,6 +853,7 @@ impl Catalog {
     /// BOXED FUTURE: As of Nov 2023 the returned Future from this function was 17KB. This would
     /// get stored on the stack which is bad for runtime performance, and blow up our stack usage.
     /// Because of that we purposefully move this Future onto the heap (i.e. Box it).
+    #[instrument(name = "catalog::open", skip_all)]
     pub fn open(
         config: Config<'_>,
         previous_ts: mz_repr::Timestamp,

--- a/src/adapter/src/coord/consistency.rs
+++ b/src/adapter/src/coord/consistency.rs
@@ -14,6 +14,7 @@ use crate::catalog::consistency::CatalogInconsistencies;
 use mz_catalog::memory::objects::{CatalogItem, DataSourceDesc, Source};
 use mz_repr::GlobalId;
 use serde::Serialize;
+use tracing::instrument;
 
 #[derive(Debug, Default, Serialize, PartialEq)]
 pub struct CoordinatorInconsistencies {
@@ -35,6 +36,7 @@ impl CoordinatorInconsistencies {
 
 impl Coordinator {
     /// Checks the [`Coordinator`] to make sure we're internally consistent.
+    #[instrument(name = "coord::check_consistency")]
     pub fn check_consistency(&self) -> Result<(), CoordinatorInconsistencies> {
         let mut inconsistencies = CoordinatorInconsistencies::default();
 

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -30,6 +30,7 @@ use mz_compute_types::ComputeInstanceId;
 use mz_repr::{GlobalId, Timestamp};
 use mz_storage_types::read_policy::ReadPolicy;
 use timely::progress::Antichain;
+use tracing::instrument;
 
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::timeline::{TimelineContext, TimelineState};
@@ -188,7 +189,7 @@ impl crate::coord::Coordinator {
     /// This should be called only after a collection is created, and
     /// ideally very soon afterwards. The collection is otherwise initialized
     /// with a read policy that allows no compaction.
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[instrument(name = "coord::initialize_read_policies", skip_all)]
     pub(crate) async fn initialize_read_policies(
         &mut self,
         id_bundle: &CollectionIdBundle,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -72,7 +72,7 @@ use mz_transform::notice::{OptimizerNoticeApi, OptimizerNoticeKind, RawOptimizer
 use mz_transform::EmptyStatisticsOracle;
 use timely::progress::Antichain;
 use tokio::sync::{oneshot, OwnedMutexGuard};
-use tracing::{warn, Span};
+use tracing::{instrument, warn, Span};
 
 use crate::catalog::{self, Catalog, ConnCatalog, UpdatePrivilegeVariant};
 use crate::command::{ExecuteResponse, Response};
@@ -214,7 +214,7 @@ impl Coordinator {
         })
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(super) async fn sequence_create_source(
         &mut self,
         session: &mut Session,
@@ -319,7 +319,7 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(super) async fn sequence_create_connection(
         &mut self,
         mut ctx: ExecuteContext,
@@ -407,7 +407,7 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(crate) async fn sequence_create_connection_stage_finish(
         &mut self,
         session: &mut Session,
@@ -467,7 +467,7 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(super) async fn sequence_create_database(
         &mut self,
         session: &mut Session,
@@ -494,7 +494,7 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(super) async fn sequence_create_schema(
         &mut self,
         session: &mut Session,
@@ -522,7 +522,7 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(super) async fn sequence_create_role(
         &mut self,
         conn_id: Option<&ConnectionId>,
@@ -539,7 +539,7 @@ impl Coordinator {
             .map(|_| ExecuteResponse::CreatedRole)
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(super) async fn sequence_create_table(
         &mut self,
         ctx: &mut ExecuteContext,
@@ -624,7 +624,7 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(super) async fn sequence_create_secret(
         &mut self,
         session: &mut Session,
@@ -678,7 +678,7 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self, ctx))]
+    #[instrument(skip_all)]
     pub(super) async fn sequence_create_sink(
         &mut self,
         ctx: ExecuteContext,
@@ -814,7 +814,7 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(super) async fn sequence_create_type(
         &mut self,
         session: &Session,
@@ -846,6 +846,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_comment_on(
         &mut self,
         session: &Session,
@@ -860,6 +861,7 @@ impl Coordinator {
         Ok(ExecuteResponse::Comment)
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_drop_objects(
         &mut self,
         session: &Session,
@@ -1081,6 +1083,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_drop_owned(
         &mut self,
         session: &Session,
@@ -1438,6 +1441,7 @@ impl Coordinator {
         Ok(Self::send_immediate_rows(vec![row]))
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_inspect_shard(
         &self,
         session: &Session,
@@ -1461,6 +1465,7 @@ impl Coordinator {
         Ok(Self::send_immediate_rows(vec![jsonb.into_row()]))
     }
 
+    #[instrument(skip_all)]
     pub(super) fn sequence_set_variable(
         &self,
         session: &mut Session,
@@ -1589,7 +1594,7 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub(super) async fn sequence_end_transaction(
         &mut self,
         mut ctx: ExecuteContext,
@@ -1701,7 +1706,7 @@ impl Coordinator {
         ctx.retire(response);
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn sequence_end_transaction_inner(
         &mut self,
         session: &mut Session,
@@ -1796,6 +1801,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_explain_plan(
         &mut self,
         ctx: ExecuteContext,
@@ -1953,6 +1959,7 @@ impl Coordinator {
         Ok(Self::send_immediate_rows(rows))
     }
 
+    #[instrument(skip_all)]
     pub async fn sequence_explain_timestamp(
         &mut self,
         mut ctx: ExecuteContext,
@@ -2123,6 +2130,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_explain_timestamp_finish_inner(
         &mut self,
         session: &mut Session,
@@ -2169,6 +2177,7 @@ impl Coordinator {
         Ok(Self::send_immediate_rows(rows))
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_insert(
         &mut self,
         mut ctx: ExecuteContext,
@@ -2271,6 +2280,7 @@ impl Coordinator {
     /// read. This works by doing a Peek then queuing a SendDiffs. No writes
     /// or read-then-writes can occur between the Peek and SendDiff otherwise a
     /// serializability violation could occur.
+    #[instrument(skip_all)]
     pub(super) async fn sequence_read_then_write(
         &mut self,
         mut ctx: ExecuteContext,
@@ -2616,6 +2626,7 @@ impl Coordinator {
         });
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_alter_item_rename(
         &mut self,
         session: &mut Session,
@@ -2635,6 +2646,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_alter_schema_rename(
         &mut self,
         session: &mut Session,
@@ -2656,6 +2668,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_alter_schema_swap(
         &mut self,
         session: &mut Session,
@@ -2711,6 +2724,7 @@ impl Coordinator {
         Ok(ExecuteResponse::AlteredObject(ObjectType::Index))
     }
 
+    #[instrument(skip_all)]
     pub(super) fn sequence_alter_index_reset_options(
         &mut self,
         plan: plan::AlterIndexResetOptionsPlan,
@@ -2725,6 +2739,7 @@ impl Coordinator {
         Ok(ExecuteResponse::AlteredObject(ObjectType::Index))
     }
 
+    #[instrument(skip_all)]
     pub(super) fn set_index_compaction_window(
         &mut self,
         id: GlobalId,
@@ -2741,6 +2756,7 @@ impl Coordinator {
         Ok(())
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_alter_role(
         &mut self,
         session: &Session,
@@ -2822,6 +2838,7 @@ impl Coordinator {
         Ok(response)
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_alter_secret(
         &mut self,
         session: &Session,
@@ -2836,6 +2853,7 @@ impl Coordinator {
         Ok(ExecuteResponse::AlteredObject(ObjectType::Secret))
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_alter_connection(
         &mut self,
         ctx: ExecuteContext,
@@ -2857,6 +2875,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     async fn sequence_rotate_keys(
         &mut self,
         session: &Session,
@@ -2881,6 +2900,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     async fn sequence_alter_connection_options(
         &mut self,
         mut ctx: ExecuteContext,
@@ -3022,7 +3042,7 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(crate) async fn sequence_alter_connection_stage_finish(
         &mut self,
         session: &mut Session,
@@ -3129,6 +3149,7 @@ impl Coordinator {
         Ok(ExecuteResponse::AlteredObject(ObjectType::Connection))
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_alter_source(
         &mut self,
         session: &Session,
@@ -3684,6 +3705,7 @@ impl Coordinator {
         Ok(Vec::from(payload))
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_alter_system_set(
         &mut self,
         session: &Session,
@@ -3708,6 +3730,7 @@ impl Coordinator {
         Ok(ExecuteResponse::AlteredSystemConfiguration)
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_alter_system_reset(
         &mut self,
         session: &Session,
@@ -3723,6 +3746,7 @@ impl Coordinator {
         Ok(ExecuteResponse::AlteredSystemConfiguration)
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_alter_system_reset_all(
         &mut self,
         session: &Session,
@@ -3778,6 +3802,7 @@ impl Coordinator {
     }
 
     // Returns the name of the portal to execute.
+    #[instrument(skip_all)]
     pub(super) fn sequence_execute(
         &mut self,
         session: &mut Session,
@@ -3795,6 +3820,7 @@ impl Coordinator {
         session.create_new_portal(stmt, logging, desc, plan.params, Vec::new(), revision)
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_grant_privileges(
         &mut self,
         session: &Session,
@@ -3812,6 +3838,7 @@ impl Coordinator {
         .await
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_revoke_privileges(
         &mut self,
         session: &Session,
@@ -3829,6 +3856,7 @@ impl Coordinator {
         .await
     }
 
+    #[instrument(skip_all)]
     async fn sequence_update_privileges(
         &mut self,
         session: &Session,
@@ -3937,6 +3965,7 @@ impl Coordinator {
         res
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_alter_default_privileges(
         &mut self,
         session: &Session,
@@ -3983,6 +4012,7 @@ impl Coordinator {
         Ok(ExecuteResponse::AlteredDefaultPrivileges)
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_grant_role(
         &mut self,
         session: &Session,
@@ -4027,6 +4057,7 @@ impl Coordinator {
             .map(|_| ExecuteResponse::GrantedRole)
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_revoke_role(
         &mut self,
         session: &Session,
@@ -4071,6 +4102,7 @@ impl Coordinator {
             .map(|_| ExecuteResponse::RevokedRole)
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_alter_owner(
         &mut self,
         session: &Session,
@@ -4139,6 +4171,7 @@ impl Coordinator {
             .map(|_| ExecuteResponse::AlteredObject(object_type))
     }
 
+    #[instrument(skip_all)]
     pub(super) async fn sequence_reassign_owned(
         &mut self,
         session: &Session,

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -16,6 +16,7 @@ use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan;
+use tracing::instrument;
 
 use crate::command::ExecuteResponse;
 use crate::coord::sequencer::inner::return_if_err;
@@ -31,7 +32,7 @@ use crate::session::Session;
 use crate::{catalog, AdapterNotice, ExecuteContext, TimestampProvider};
 
 impl Coordinator {
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(crate) async fn sequence_create_index(
         &mut self,
         ctx: ExecuteContext,
@@ -50,7 +51,7 @@ impl Coordinator {
         .await;
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(crate) async fn explain_create_index(
         &mut self,
         ctx: ExecuteContext,
@@ -154,7 +155,7 @@ impl Coordinator {
     }
 
     /// Processes as many `create index` stages as possible.
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub(crate) async fn execute_create_index_stage(
         &mut self,
         mut ctx: ExecuteContext,
@@ -195,6 +196,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     fn create_index_validate(
         &mut self,
         session: &Session,
@@ -225,6 +227,7 @@ impl Coordinator {
         })
     }
 
+    #[instrument(skip_all)]
     async fn create_index_optimize(
         &mut self,
         ctx: ExecuteContext,
@@ -354,6 +357,7 @@ impl Coordinator {
         );
     }
 
+    #[instrument(skip_all)]
     async fn create_index_finish(
         &mut self,
         ctx: &mut ExecuteContext,
@@ -478,6 +482,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     fn create_index_explain(
         &mut self,
         ctx: &mut ExecuteContext,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -20,6 +20,7 @@ use mz_sql::names::{ObjectId, ResolvedIds};
 use mz_sql::plan;
 use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};
 use timely::progress::Antichain;
+use tracing::instrument;
 
 use crate::command::ExecuteResponse;
 use crate::coord::sequencer::inner::return_if_err;
@@ -37,7 +38,7 @@ use crate::util::ResultExt;
 use crate::{catalog, AdapterNotice, ExecuteContext, TimestampProvider};
 
 impl Coordinator {
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(crate) async fn sequence_create_materialized_view(
         &mut self,
         ctx: ExecuteContext,
@@ -56,7 +57,7 @@ impl Coordinator {
         .await;
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(crate) async fn explain_create_materialized_view(
         &mut self,
         ctx: ExecuteContext,
@@ -160,7 +161,7 @@ impl Coordinator {
     }
 
     /// Processes as many `create materialized view` stages as possible.
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub(crate) async fn execute_create_materialized_view_stage(
         &mut self,
         mut ctx: ExecuteContext,
@@ -204,6 +205,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     fn create_materialized_view_validate(
         &mut self,
         session: &Session,
@@ -261,6 +263,7 @@ impl Coordinator {
         })
     }
 
+    #[instrument(skip_all)]
     async fn create_materialized_view_optimize(
         &mut self,
         ctx: ExecuteContext,
@@ -415,6 +418,7 @@ impl Coordinator {
         );
     }
 
+    #[instrument(skip_all)]
     async fn create_materialized_view_finish(
         &mut self,
         ctx: &mut ExecuteContext,
@@ -605,6 +609,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     fn create_materialized_view_explain(
         &mut self,
         ctx: &mut ExecuteContext,

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -14,6 +14,7 @@ use mz_repr::RelationDesc;
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::{ObjectId, ResolvedIds};
 use mz_sql::plan::{self};
+use tracing::instrument;
 
 use crate::command::ExecuteResponse;
 use crate::coord::sequencer::inner::return_if_err;
@@ -27,7 +28,6 @@ use crate::session::Session;
 use crate::{catalog, AdapterNotice, ExecuteContext};
 
 impl Coordinator {
-    #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn sequence_create_view(
         &mut self,
         ctx: ExecuteContext,
@@ -43,7 +43,7 @@ impl Coordinator {
     }
 
     /// Processes as many `create view` stages as possible.
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub(crate) async fn sequence_create_view_stage(
         &mut self,
         mut ctx: ExecuteContext,
@@ -78,6 +78,7 @@ impl Coordinator {
         }
     }
 
+    #[instrument(skip_all)]
     fn create_view_validate(
         &mut self,
         session: &Session,
@@ -112,6 +113,7 @@ impl Coordinator {
         })
     }
 
+    #[instrument(skip_all)]
     async fn create_view_optimize(
         &mut self,
         ctx: ExecuteContext,
@@ -162,6 +164,7 @@ impl Coordinator {
         );
     }
 
+    #[instrument(skip_all)]
     async fn create_view_finish(
         &mut self,
         ctx: &mut ExecuteContext,

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -35,7 +35,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use timely::progress::Timestamp;
-use tracing::{error, warn};
+use tracing::{error, instrument, warn};
 
 use crate::Controller;
 
@@ -506,6 +506,7 @@ where
     }
 
     /// Remove orphaned replicas.
+    #[instrument(skip_all)]
     pub async fn remove_orphaned_replicas(
         &mut self,
         next_user_replica_id: u64,

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -62,6 +62,7 @@ use timely::progress::{Antichain, Timestamp};
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::time::{self, Duration, Interval, MissedTickBehavior};
 use tokio_stream::wrappers::UnboundedReceiverStream;
+use tracing::instrument;
 use uuid::Uuid;
 
 pub mod clusters;
@@ -406,6 +407,7 @@ where
     T: Into<mz_repr::Timestamp>,
 {
     /// Creates a new controller.
+    #[instrument(name = "controller::new", skip_all)]
     pub async fn new(
         config: ControllerConfig,
         envd_epoch: NonZeroI64,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -52,7 +52,7 @@ use mz_storage_types::controller::PersistTxnTablesImpl;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::RecvError;
 use tower_http::cors::AllowOrigin;
-use tracing::info;
+use tracing::{info, info_span, Instrument};
 
 use crate::http::{HttpConfig, HttpServer, InternalHttpConfig, InternalHttpServer};
 
@@ -609,6 +609,7 @@ impl Listeners {
             http_host_name: config.http_host_name,
             tracing_handle: config.tracing_handle,
         })
+        .instrument(info_span!(parent: None, "adapter::serve"))
         .await?;
 
         // Install an adapter client in the internal HTTP server.


### PR DESCRIPTION
Move to some new standards:

- `tracing::instrument` -> `instrument`
- omit `level = "info"` as it's the default
- improve names

Add INFO tracing to most queries. Plans that spawn tasks (create source, select, create index/mv) partially work. They will be hooked up to their parent in a later PR.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a