### PR TITLE
sql: remove enable_cc_cluster_sizes feature flag

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -61,7 +61,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "disk_cluster_replicas_default": "true",
     "enable_alter_swap": "true",
     "enable_assert_not_null": "true",
-    "enable_cc_cluster_sizes": "true",
     "enable_columnation_lgalloc": "true",
     "enable_comment": "true",
     "enable_disk_cluster_replicas": "true",

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2125,13 +2125,6 @@ feature_flags!(
         enable_for_item_parsing: false,
     },
     {
-        name: enable_cc_cluster_sizes,
-        desc: "use of 'cc' cluster sizes",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_off_thread_optimization,
         desc: "use off-thread optimization in `CREATE` statements",
         default: true,

--- a/test/testdrive/cc_cluster_sizes.td
+++ b/test/testdrive/cc_cluster_sizes.td
@@ -8,36 +8,36 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_cc_cluster_sizes = false;
+ALTER SYSTEM SET allowed_cluster_replica_sizes = "1";
 ALTER SYSTEM SET disk_cluster_replicas_default = false;
 
 # Cannot create clusters with cc cluster size naming schemes
 ! CREATE CLUSTER c SIZE '1cc';
-contains:use of 'cc' cluster sizes is not supported
+contains:unknown cluster replica size 1cc
 
 ! CREATE CLUSTER c SIZE '512C';
-contains:use of 'cc' cluster sizes is not supported
+contains:unknown cluster replica size 512C
 
 # Nor can we create an unmanaged replica directly
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
 
 ! CREATE CLUSTER c REPLICAS (r1 (SIZE '1cc'))
-contains:use of 'cc' cluster sizes is not supported
+contains:unknown cluster replica size 1cc
 
 # The existing cluster names are fine
 > CREATE CLUSTER c SIZE '1';
 
 # But ensure we cannot ALTER our way to a cc name either
 ! ALTER CLUSTER c SET (SIZE '1cc');
-contains:use of 'cc' cluster sizes is not supported
+contains:unknown cluster replica size 1cc
 
 > DROP CLUSTER c
 
 # Now flip the flag and test that we can create clusters
 # with this naming scheme.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_cc_cluster_sizes = true
+ALTER SYSTEM RESET allowed_cluster_replica_sizes;
 
 > CREATE CLUSTER c SIZE '1cc';
 > SELECT disk FROM mz_clusters WHERE name = 'c'


### PR DESCRIPTION
Turns out it was redundant with the existing allowed_cluster_replica_sizes feature flag.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
