### PR TITLE
kafka-resumption test: Add workflow with large amount of data

### DIFF
--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -125,3 +125,31 @@ def find_source_resume_upper(c: Composition, partition_id: str) -> int | None:
                 return int(value)
 
     return None
+
+
+def workflow_sink_queue_full(c: Composition) -> None:
+    """Similar to the sink-networking workflow, but with 11 million rows (more then the 11 million defined as queue.buffering.max.messages) and only creating the sink after these rows are ingested into Mz. Triggers #24936"""
+    seed = random.getrandbits(16)
+    c.up("zookeeper", "kafka", "schema-registry", "materialized", "toxiproxy")
+    for i, failure_mode in enumerate(
+        [
+            "toxiproxy-close-connection.td",
+            "toxiproxy-limit-connection.td",
+            "toxiproxy-timeout.td",
+            "toxiproxy-timeout-hold.td",
+        ]
+    ):
+        c.up("toxiproxy")
+        c.run_testdrive_files(
+            "--no-reset",
+            "--max-errors=1",
+            f"--seed={seed}{i}",
+            f"--temp-dir=/share/tmp/kafka-resumption-{seed}{i}",
+            "sink-queue-full/setup.td",
+            f"sink-queue-full/{failure_mode}",
+            "sink-queue-full/during.td",
+            "sink-queue-full/toxiproxy-restore-connection.td",
+            "sink-queue-full/verify-success.td",
+            "sink-queue-full/cleanup.td",
+        )
+        c.kill("toxiproxy")

--- a/test/kafka-resumption/sink-queue-full/cleanup.td
+++ b/test/kafka-resumption/sink-queue-full/cleanup.td
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> DROP SINK output CASCADE;
+
+> DROP SOURCE largeinput CASCADE;
+
+$ http-request method=DELETE url=http://toxiproxy:8474/proxies/kafka content-type=application/json

--- a/test/kafka-resumption/sink-queue-full/during.td
+++ b/test/kafka-resumption/sink-queue-full/during.td
@@ -1,0 +1,23 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-ingest topic=largeinput format=bytes repeat=11000000
+A,B,0
+
+# Long enough to ingest all the data
+> SELECT mz_unsafe.mz_sleep(60);
+<null>
+
+> SELECT count(*) FROM largeinput
+11000001
+
+> CREATE SINK output FROM largeinput
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-byo-sink-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM

--- a/test/kafka-resumption/sink-queue-full/setup.td
+++ b/test/kafka-resumption/sink-queue-full/setup.td
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
+{
+  "name": "kafka",
+  "listen": "0.0.0.0:9093",
+  "upstream": "kafka:9092"
+}
+
+$ kafka-create-topic topic=largeinput
+$ kafka-ingest topic=largeinput format=bytes
+A,B,0
+
+> CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+# The source intentionally does not go through toxiproxy.
+> CREATE SOURCE largeinput (city, state, zip)
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-largeinput-${testdrive.seed}')
+  FORMAT CSV WITH 3 COLUMNS
+  INCLUDE OFFSET
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );

--- a/test/kafka-resumption/sink-queue-full/toxiproxy-close-connection.td
+++ b/test/kafka-resumption/sink-queue-full/toxiproxy-close-connection.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies/kafka/toxics content-type=application/json
+{
+  "name": "kafka",
+  "type": "limit_data",
+  "attributes": { "bytes": 0 }
+}

--- a/test/kafka-resumption/sink-queue-full/toxiproxy-limit-connection.td
+++ b/test/kafka-resumption/sink-queue-full/toxiproxy-limit-connection.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies/kafka/toxics content-type=application/json
+{
+  "name": "kafka",
+  "type": "limit_data",
+  "attributes": { "bytes": 16 }
+}

--- a/test/kafka-resumption/sink-queue-full/toxiproxy-restore-connection.td
+++ b/test/kafka-resumption/sink-queue-full/toxiproxy-restore-connection.td
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=DELETE url=http://toxiproxy:8474/proxies/kafka/toxics/kafka content-type=application/json

--- a/test/kafka-resumption/sink-queue-full/toxiproxy-timeout-hold.td
+++ b/test/kafka-resumption/sink-queue-full/toxiproxy-timeout-hold.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies/kafka/toxics content-type=application/json
+{
+  "name": "kafka",
+  "type": "timeout",
+  "attributes": { "timeout": 0 }
+}

--- a/test/kafka-resumption/sink-queue-full/toxiproxy-timeout.td
+++ b/test/kafka-resumption/sink-queue-full/toxiproxy-timeout.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies/kafka/toxics content-type=application/json
+{
+  "name": "kafka",
+  "type": "timeout",
+  "attributes": { "timeout": 30000 }
+}

--- a/test/kafka-resumption/sink-queue-full/verify-success.td
+++ b/test/kafka-resumption/sink-queue-full/verify-success.td
@@ -1,0 +1,13 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT status FROM mz_internal.mz_sink_statuses
+running
+
+> SELECT * FROM mz_internal.mz_sink_status_history WHERE status = 'stalled'


### PR DESCRIPTION
To trigger queue full in sink

Verified on top of #24360 that this would have caught the error

Fixes: #24936

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
