### PR TITLE
platform-checks: Increase timeout for migration test

### DIFF
--- a/misc/python/materialize/checks/all_checks/create_table.py
+++ b/misc/python/materialize/checks/all_checks/create_table.py
@@ -70,6 +70,7 @@ class CreateTable(Check):
                 > SELECT f2 FROM create_table1 WHERE f2 = 1234;
                 1234
 
+                > SET statement_timeout = '120s'
                 > DELETE FROM create_table1 WHERE f1 = 999;
 
                 > SHOW CREATE TABLE create_table2;


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/6354#018d8802-fd33-4d90-abdc-6d905929f57a

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
