### PR TITLE
persist: Make number of threads in `IsolatedRuntime` configurable

### DIFF
--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -457,7 +457,7 @@ impl Service for TransactorService {
             Arc::new(UnreliableConsensus::new(consensus, unreliable));
 
         // Wire up the TransactorService.
-        let isolated_runtime = Arc::new(IsolatedRuntime::new());
+        let isolated_runtime = Arc::new(IsolatedRuntime::default());
         let pubsub_sender = PubSubClientConnection::noop().sender;
         let shared_states = Arc::new(StateCache::new(
             &config,

--- a/src/persist-cli/src/maelstrom/txn_list_append_single.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_single.rs
@@ -667,7 +667,7 @@ impl Service for TransactorService {
             Arc::new(UnreliableConsensus::new(consensus, unreliable));
 
         // Wire up the TransactorService.
-        let isolated_runtime = Arc::new(IsolatedRuntime::new());
+        let isolated_runtime = Arc::new(IsolatedRuntime::default());
         let pubsub_sender = PubSubClientConnection::noop().sender;
         let shared_states = Arc::new(StateCache::new(
             &config,

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -46,6 +46,7 @@ mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
 mz-timely-util = { path = "../timely-util" }
 mz-postgres-client = { path = "../postgres-client" }
+num_cpus = "1.14.0"
 once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/src/persist-client/benches/benches.rs
+++ b/src/persist-client/benches/benches.rs
@@ -106,7 +106,7 @@ fn create_mem_mem_client() -> Result<PersistClient, ExternalError> {
     let blob = Arc::new(MemBlob::open(MemBlobConfig::default()));
     let consensus = Arc::new(MemConsensus::default());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
-    let isolated_runtime = Arc::new(IsolatedRuntime::new());
+    let isolated_runtime = Arc::new(IsolatedRuntime::default());
     let pubsub_sender = PubSubClientConnection::noop().sender;
     let shared_states = Arc::new(StateCache::new(
         &cfg,
@@ -138,7 +138,7 @@ async fn create_file_pg_client(
     let postgres_consensus = Arc::new(PostgresConsensus::open(pg).await?);
     let consensus = Arc::clone(&postgres_consensus);
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
-    let isolated_runtime = Arc::new(IsolatedRuntime::new());
+    let isolated_runtime = Arc::new(IsolatedRuntime::default());
     let pubsub_sender = PubSubClientConnection::noop().sender;
     let shared_states = Arc::new(StateCache::new(
         &cfg,
@@ -173,7 +173,7 @@ async fn create_s3_pg_client(
     let postgres_consensus = Arc::new(PostgresConsensus::open(pg).await?);
     let consensus = Arc::clone(&postgres_consensus);
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
-    let isolated_runtime = Arc::new(IsolatedRuntime::new());
+    let isolated_runtime = Arc::new(IsolatedRuntime::default());
     let pubsub_sender = PubSubClientConnection::noop().sender;
     let shared_states = Arc::new(StateCache::new(
         &cfg,

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -83,13 +83,14 @@ impl PersistClientCache {
             Arc::clone(&state_cache),
             pubsub_client.receiver,
         );
+        let isolated_runtime = IsolatedRuntime::new(cfg.isolated_runtime_worker_threads);
 
         PersistClientCache {
             cfg,
             metrics,
             blob_by_uri: Mutex::new(BTreeMap::new()),
             consensus_by_uri: Mutex::new(BTreeMap::new()),
-            isolated_runtime: Arc::new(IsolatedRuntime::new()),
+            isolated_runtime: Arc::new(isolated_runtime),
             state_cache,
             pubsub_sender: pubsub_client.sender,
             _pubsub_receiver_task,

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -141,6 +141,9 @@ pub struct PersistConfig {
     pub pubsub_state_cache_shard_ref_channel_size: usize,
     /// Backoff after an established connection to Persist PubSub service fails.
     pub pubsub_reconnect_backoff: Duration,
+    /// Number of worker threads to create for the [`crate::IsolatedRuntime`], defaults to the
+    /// number of threads.
+    pub isolated_runtime_worker_threads: usize,
 }
 
 // Impl Deref to ConfigSet for convenience of accessing the dynamic configs.
@@ -195,6 +198,7 @@ impl PersistConfig {
             pubsub_server_connection_channel_size: 25,
             pubsub_state_cache_shard_ref_channel_size: 25,
             pubsub_reconnect_backoff: Duration::from_secs(5),
+            isolated_runtime_worker_threads: num_cpus::get(),
             // TODO: This doesn't work with the process orchestrator. Instead,
             // separate --log-prefix into --service-name and --enable-log-prefix
             // options, where the first is always provided and the second is

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -338,7 +338,7 @@ where
                 Arc::clone(&blob),
                 Arc::clone(&metrics),
                 Arc::clone(&machine.applier.shard_metrics),
-                Arc::new(IsolatedRuntime::new()),
+                Arc::new(IsolatedRuntime::default()),
                 req,
                 schemas,
             )
@@ -460,7 +460,7 @@ where
         state_versions,
         Arc::new(StateCache::new(cfg, metrics, Arc::new(NoopPubSubSender))),
         Arc::new(NoopPubSubSender),
-        Arc::new(IsolatedRuntime::new()),
+        Arc::new(IsolatedRuntime::default()),
         Diagnostics::from_purpose("admin"),
     )
     .await?;

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -572,7 +572,7 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
     let consensus =
         make_consensus(&cfg, &args.consensus_uri, NO_COMMIT, Arc::clone(&metrics)).await?;
     let blob = make_blob(&cfg, &args.blob_uri, NO_COMMIT, Arc::clone(&metrics)).await?;
-    let isolated_runtime = Arc::new(IsolatedRuntime::new());
+    let isolated_runtime = Arc::new(IsolatedRuntime::default());
     let state_cache = Arc::new(StateCache::new(
         &cfg,
         Arc::clone(&metrics),

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -1195,7 +1195,7 @@ mod tests {
             Arc::clone(&write.blob),
             Arc::clone(&write.metrics),
             write.metrics.shards.shard(&write.machine.shard_id(), ""),
-            Arc::new(IsolatedRuntime::new()),
+            Arc::new(IsolatedRuntime::default()),
             req.clone(),
             schemas,
         )
@@ -1277,7 +1277,7 @@ mod tests {
             Arc::clone(&write.blob),
             Arc::clone(&write.metrics),
             write.metrics.shards.shard(&write.machine.shard_id(), ""),
-            Arc::new(IsolatedRuntime::new()),
+            Arc::new(IsolatedRuntime::default()),
             req.clone(),
             schemas,
         )

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1614,7 +1614,7 @@ mod tests {
             blob,
             consensus,
             metrics,
-            Arc::new(IsolatedRuntime::new()),
+            Arc::new(IsolatedRuntime::default()),
             Arc::new(StateCache::new_no_metrics()),
             pubsub_sender,
         )


### PR DESCRIPTION
This PR makes the number of worker threads we create for an `IsolatedRuntime` configurable, with the default being the number of threads on a machine. Currently the only place we use a non-default value is in environmentd, which can be configured via a CLI argument.

The goal of this change is to prevent the `IsolatedRuntime` from starving other critical tasks if it gets a ton of work pushed onto it. For example, if `environmentd` is asked to do compaction work we don't want to pin its CPU to 100% and starve the Coordinator thread.

Note: this does not limit the number of threads the runtime will create for [blocking work](https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.max_blocking_threads). The `IsolatedRuntime` does not use `spawn_blocking`.

### Motivation

We saw an instance of environmentd's CPU getting pegged at 100% because of Persist compaction.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
