### PR TITLE
Add [soft-panic] to soft panic logs and find them in CI

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -55,6 +55,7 @@ ERROR_RE = re.compile(
     | error:\ Found\ argument\ '.*'\ which\ wasn't\ expected,\ or\ isn't\ valid\ in\ this\ context
     | environmentd .* unrecognized\ configuration\ parameter
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
+    | soft-panic
     )
     .* $
     """,

--- a/src/compute/src/render/errors.rs
+++ b/src/compute/src/render/errors.rs
@@ -129,7 +129,7 @@ impl ErrorLogger {
     pub fn soft_panic_or_log(&self, message: &'static str, details: &str) {
         tracing::warn!(
             dataflow = self.dataflow_name,
-            "[customer-data] {message} ({details})"
+            "[customer-data] [soft-panic] {message} ({details})"
         );
         mz_ore::soft_panic_or_log!("{}", message);
     }


### PR DESCRIPTION
Thoughts? My main motivation is that it might make sense to find all soft-panics which happen in CI and are logged, and currently there doesn't seem to be a way.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
