### PR TITLE
fivetran-destination: Deflake recently added test

### DIFF
--- a/test/fivetran-destination/test-multi-table/02-verify.td
+++ b/test/fivetran-destination/test-multi-table/02-verify.td
@@ -14,16 +14,8 @@ k   v1       v2             _fivetran_deleted
 2   "foo"    "bar"          true
 3   "bing!"  "whomp whomp"  false
 
-> SELECT COUNT(DISTINCT(_fivetran_synced)) FROM test.tester.green
-3
-
 > SELECT a, b, c, _fivetran_deleted FROM test.tester.blue
 a     b       c             _fivetran_deleted
 ---------------------------------------------
 100   "eek!"  "haw"        true
 200   "vice"  "versa"      true
-
-# Truncate does not update the _fivetran_synced column, so we have two unique _fivetran_synced
-# values from the other operations.
-> SELECT COUNT(DISTINCT(_fivetran_synced)) FROM test.tester.blue
-2


### PR DESCRIPTION
Turns out the value passed to `_fivetran_synced` to different operations but within a single test run could be the same, which breaks some current assertions.

### Motivation

Fix main

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
