### PR TITLE
Update lgalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,13 +3111,14 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lgalloc"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e800ee9a186dfd634b56aac0814ab6281f87c962bc63087361fa73442e30e1"
+checksum = "06e3de70c23cbcf5613858a870f9c02185e6c337ebcd076453383a24fde8f64a"
 dependencies = [
  "crossbeam-deque",
  "libc",
  "memmap2",
+ "page_size",
  "tempfile",
  "thiserror",
 ]
@@ -6688,6 +6689,16 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "papergrid"

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -763,7 +763,7 @@ version = "1.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.lgalloc]]
-version = "0.1.6"
+version = "0.1.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
@@ -960,6 +960,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.outref]]
 version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.page_size]]
+version = "0.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.papergrid]]

--- a/src/ore/src/region.rs
+++ b/src/ore/src/region.rs
@@ -245,7 +245,7 @@ impl<T> Region<T> {
     /// The capacity of the returned region must be at least as large as the requested capacity,
     /// but can be larger if the implementation requires it.
     ///
-    /// Returns a [`Region::MMapRegion`] if possible, and falls back to [`Region::Heap`] otherwise.
+    /// Returns a [`Region::MMap`] if possible, and falls back to [`Region::Heap`] otherwise.
     #[must_use]
     pub fn new_auto(capacity: usize) -> Region<T> {
         match Region::new_mmap(capacity) {

--- a/src/ore/src/region.rs
+++ b/src/ore/src/region.rs
@@ -323,7 +323,7 @@ impl<T> Region<T> {
     ///
     /// Unsafe because the caller has to make sure that the vector will not reallocate.
     #[inline]
-    pub unsafe fn as_mut_vec(&mut self) -> &mut Vec<T> {
+    unsafe fn as_mut_vec(&mut self) -> &mut Vec<T> {
         match self {
             Region::Heap(vec) => vec,
             Region::MMap(inner) => &mut inner.inner,

--- a/src/ore/src/region.rs
+++ b/src/ore/src/region.rs
@@ -16,6 +16,8 @@
 //! Region-allocated data utilities.
 
 use std::fmt::{Debug, Formatter};
+use std::mem::ManuallyDrop;
+use std::ops::{Deref, DerefMut};
 
 /// A region allocator which holds items at stable memory locations.
 ///
@@ -28,9 +30,9 @@ use std::fmt::{Debug, Formatter};
 /// fixed memory locations.
 pub struct LgAllocRegion<T> {
     /// The active allocation into which we are writing.
-    local: lgalloc::Region<T>,
+    local: Region<T>,
     /// All previously active allocations.
-    stash: Vec<lgalloc::Region<T>>,
+    stash: Vec<Region<T>>,
     /// The maximum allocation size
     limit: usize,
 }
@@ -110,7 +112,7 @@ impl<T> LgAllocRegion<T> {
             let mut next_len = (self.local.capacity() + 1).next_power_of_two();
             next_len = std::cmp::min(next_len, self.limit);
             next_len = std::cmp::max(count, next_len);
-            let new_local = lgalloc::Region::new_auto(next_len);
+            let new_local = Region::new_auto(next_len);
             if !self.local.is_empty() {
                 self.stash.push(std::mem::take(&mut self.local));
             }
@@ -146,5 +148,221 @@ impl<T> LgAllocRegion<T> {
         for stash in &self.stash {
             callback(stash.len() * size_of_t, stash.capacity() * size_of_t);
         }
+    }
+}
+
+/// An abstraction over different kinds of allocated regions.
+#[derive(Debug)]
+pub enum Region<T> {
+    /// A possibly empty heap-allocated region, represented as a vector.
+    Heap(Vec<T>),
+    /// A mmaped region, represented by a vector and its backing memory mapping.
+    MMap(MMapRegion<T>),
+}
+
+/// Type encapsulating private data for memory-mapped regions.
+pub struct MMapRegion<T> {
+    /// Vector-representation of the underlying memory. Must not be dropped.
+    inner: ManuallyDrop<Vec<T>>,
+    /// Opaque handle to lgalloc.
+    handle: Option<lgalloc::Handle>,
+}
+
+impl<T> MMapRegion<T> {
+    /// Clear the contents of this region without dropping elements.
+    unsafe fn clear(&mut self) {
+        self.inner.set_len(0);
+    }
+}
+
+impl<T: Debug> Debug for MMapRegion<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MMapRegion")
+            .field("inner", &self.inner)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> Deref for MMapRegion<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> Default for Region<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new_empty()
+    }
+}
+
+impl<T> Region<T> {
+    /// Create a new empty region.
+    #[inline]
+    #[must_use]
+    pub fn new_empty() -> Region<T> {
+        Region::Heap(Vec::new())
+    }
+
+    /// Create a new heap-allocated region of a specific capacity.
+    #[inline]
+    #[must_use]
+    pub fn new_heap(capacity: usize) -> Region<T> {
+        Region::Heap(Vec::with_capacity(capacity))
+    }
+
+    /// Create a new file-based mapped region of a specific capacity. The capacity of the
+    /// returned region can be larger than requested to accommodate page sizes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the memory allocation fails.
+    #[inline(always)]
+    pub fn new_mmap(capacity: usize) -> Result<Region<T>, lgalloc::AllocError> {
+        lgalloc::allocate(capacity).map(|(ptr, capacity, handle)| {
+            // SAFETY: memory points to suitable memory.
+            let inner =
+                ManuallyDrop::new(unsafe { Vec::from_raw_parts(ptr.as_ptr(), 0, capacity) });
+            let handle = Some(handle);
+            Region::MMap(MMapRegion { inner, handle })
+        })
+    }
+
+    /// Create a region depending on the capacity.
+    ///
+    /// The capacity of the returned region must be at least as large as the requested capacity,
+    /// but can be larger if the implementation requires it.
+    ///
+    /// Returns a [`Region::MMapRegion`] if possible, and falls back to [`Region::Heap`] otherwise.
+    #[must_use]
+    pub fn new_auto(capacity: usize) -> Region<T> {
+        match Region::new_mmap(capacity) {
+            Ok(r) => return r,
+            Err(lgalloc::AllocError::Disabled) | Err(lgalloc::AllocError::InvalidSizeClass(_)) => {}
+            Err(e) => {
+                eprintln!("lgalloc error: {e}, falling back to heap");
+            }
+        }
+        // Fall-through
+        Region::new_heap(capacity)
+    }
+
+    /// Clears the contents of the region, without dropping its elements.
+    ///
+    /// # Safety
+    ///
+    /// Discards all contends. Elements are not dropped.
+    #[inline]
+    pub unsafe fn clear(&mut self) {
+        match self {
+            Region::Heap(vec) => vec.set_len(0),
+            Region::MMap(inner) => inner.clear(),
+        }
+    }
+
+    /// Returns the capacity of the underlying allocation.
+    #[inline]
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        match self {
+            Region::Heap(vec) => vec.capacity(),
+            Region::MMap(inner) => inner.inner.capacity(),
+        }
+    }
+
+    /// Returns the number of elements in the allocation.
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match self {
+            Region::Heap(vec) => vec.len(),
+            Region::MMap(inner) => inner.len(),
+        }
+    }
+
+    /// Returns true if the region does not contain any elements.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Region::Heap(vec) => vec.is_empty(),
+            Region::MMap(inner) => inner.is_empty(),
+        }
+    }
+
+    /// Dereference to the contained vector
+    #[inline]
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<T> {
+        match self {
+            Region::Heap(vec) => vec,
+            Region::MMap(inner) => &inner.inner,
+        }
+    }
+
+    /// Extend the underlying region from the iterator.
+    ///
+    /// Care must be taken to not re-allocate the inner vector representation.
+    #[inline]
+    pub fn extend<I: IntoIterator<Item = T> + ExactSizeIterator>(&mut self, iter: I) {
+        debug_assert!(self.capacity() - self.len() >= iter.len());
+        self.as_mut_vec().extend(iter);
+    }
+
+    /// Obtain a mutable reference to the inner vector representation.
+    #[inline]
+    pub fn as_mut_vec(&mut self) -> &mut Vec<T> {
+        match self {
+            Region::Heap(vec) => vec,
+            Region::MMap(inner) => &mut inner.inner,
+        }
+    }
+}
+
+impl<T: Clone> Region<T> {
+    /// Extend the region from a slice.
+    #[inline]
+    pub fn extend_from_slice(&mut self, slice: &[T]) {
+        debug_assert!(self.capacity() - self.len() >= slice.len());
+        self.as_mut_vec().extend_from_slice(slice);
+    }
+}
+
+impl<T> Deref for Region<T> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_vec()
+    }
+}
+
+impl<T> DerefMut for Region<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_vec()
+    }
+}
+
+impl<T> Drop for Region<T> {
+    #[inline]
+    fn drop(&mut self) {
+        match self {
+            Region::Heap(vec) => {
+                // SAFETY: Don't drop the elements, drop the vec.
+                unsafe { vec.set_len(0) }
+            }
+            Region::MMap(_) => {}
+        }
+    }
+}
+
+impl<T> Drop for MMapRegion<T> {
+    fn drop(&mut self) {
+        // Forget reasoning: The vector points to the mapped region, which frees the
+        // allocation. Don't drop elements, don't drop vec.
+        lgalloc::deallocate(self.handle.take().unwrap());
     }
 }


### PR DESCRIPTION
### Motivation

This PR updates our lgalloc dependency and move the `Region` implementation into Materialize. I'm planning on eventually removing it from `lgalloc` because it seems like an odd fit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
