### PR TITLE
[persist] Track the actual upper in validations

### DIFF
--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -1085,6 +1085,9 @@ impl<T: Timestamp + Lattice + Codec64> ReferencedBlobValidator<T> {
             }
         });
 
+        // Check that the sets of batches overall cover the same pTVC.
+        // Partial ordering means we can't just take the first and last batches; instead compute
+        // bounds using the lattice operations.
         fn overall_desc<'a, T: Timestamp + Lattice>(
             iter: impl Iterator<Item = &'a Description<T>>,
         ) -> (Antichain<T>, Antichain<T>) {
@@ -1101,6 +1104,7 @@ impl<T: Timestamp + Lattice + Codec64> ReferencedBlobValidator<T> {
         assert_eq!(inc_lower, full_lower);
         assert_eq!(inc_upper, full_upper);
 
+        // Check that the overall set of parts contained in both representations is the same.
         let inc_parts: HashSet<_> = self
             .inc_batches
             .iter()
@@ -1115,6 +1119,7 @@ impl<T: Timestamp + Lattice + Codec64> ReferencedBlobValidator<T> {
             .collect();
         assert_eq!(inc_parts, full_parts);
 
+        // Check that both representations have the same rollups.
         assert_eq!(self.inc_rollups, self.full_rollups);
     }
 }

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -29,6 +29,7 @@ use mz_persist_types::{Codec, Codec64};
 use mz_proto::RustType;
 use prost::Message;
 use timely::progress::{Antichain, Timestamp};
+use timely::PartialOrder;
 use tracing::{debug, debug_span, trace, warn, Instrument};
 
 use crate::error::{CodecMismatch, CodecMismatchT};
@@ -1090,19 +1091,26 @@ impl<T: Timestamp + Lattice + Codec64> ReferencedBlobValidator<T> {
         // bounds using the lattice operations.
         fn overall_desc<'a, T: Timestamp + Lattice>(
             iter: impl Iterator<Item = &'a Description<T>>,
-        ) -> (Antichain<T>, Antichain<T>) {
+        ) -> (Antichain<T>, Antichain<T>, Antichain<T>) {
             let mut lower = Antichain::new();
             let mut upper = Antichain::from_elem(T::minimum());
+            let mut since = Antichain::from_elem(T::minimum());
             for desc in iter {
                 lower.meet_assign(desc.lower());
                 upper.join_assign(desc.upper());
+                since.join_assign(desc.since());
             }
-            (lower, upper)
+            (lower, upper, since)
         }
-        let (inc_lower, inc_upper) = overall_desc(self.inc_batches.iter().map(|a| &a.desc));
-        let (full_lower, full_upper) = overall_desc(self.full_batches.iter().map(|a| &a.desc));
+        let (inc_lower, inc_upper, inc_since) =
+            overall_desc(self.inc_batches.iter().map(|a| &a.desc));
+        let (full_lower, full_upper, full_since) =
+            overall_desc(self.full_batches.iter().map(|a| &a.desc));
         assert_eq!(inc_lower, full_lower);
         assert_eq!(inc_upper, full_upper);
+        // Unsure if we can strengthen this to an equality check; sticking with the
+        // inequality from the original code for now.
+        assert!(PartialOrder::less_equal(&full_since, &inc_since));
 
         // Check that the overall set of parts contained in both representations is the same.
         let inc_parts: HashSet<_> = self


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/materialize/issues/25015

I'm not confident that this is actually the issue from that ticket, but I have low enough confidence in the old assertions that I don't feel like they're especially indicative of a bug, so I think it's worth updating them regardless.

- The empty antichain is sorted lower than any other antichain, not higher as you'd expect. (The lower is never the empty antichain, but this can happen for the upper.)
- The second block of tests would look at the upper of the largest batch, which is not guaranteed to be the batch with the largest upper. (Particularly given the above!)

Additionally, the result of the `PartialOrder` call in these tests was unused. It was unclear to me what the intent of those calls was; I've removed them here.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
