### PR TITLE
storage/mysql: Detect schema changes before performing snapshot and put subsource into error state

### DIFF
--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -221,6 +221,10 @@ pub enum TransientError {
 /// A definite error that always ends up in the collection of a specific table.
 #[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error)]
 pub enum DefiniteError {
+    #[error("table was dropped")]
+    TableDropped,
+    #[error("incompatible schema change: {0}")]
+    IncompatibleSchema(String),
     #[error("received a gtid set from the server that violates our requirements: {0}")]
     UnsupportedGtidState(String),
     #[error("received out of order gtids for source {0} at transaction-id {1}")]

--- a/test/mysql-cdc/schema-restart/after-restart.td
+++ b/test/mysql-cdc/schema-restart/after-restart.td
@@ -1,0 +1,43 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+# Primary source is starting because of snapshot error in one subsource
+> SELECT true
+    FROM mz_internal.mz_source_statuses
+    WHERE
+        name = 'schema_test' AND status = 'starting';
+true
+
+# dummy subsource is put into error state
+> SELECT true
+    FROM mz_internal.mz_source_statuses
+    WHERE
+        name = 'dummy' AND status = 'ceased'
+            AND
+        error ILIKE 'incompatible schema change%';
+true
+
+# other table still has data
+> SELECT count(*) FROM other;
+3
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+USE dummyschema
+INSERT INTO other VALUES (4), (5);
+
+> SELECT count(*) FROM OTHER;
+5
+
+# Drop the source + subsources because some tests expect
+# all remaining sources at the end of the test to be
+# healthy.
+> DROP SOURCE schema_test;

--- a/test/mysql-cdc/schema-restart/before-restart.td
+++ b/test/mysql-cdc/schema-restart/before-restart.td
@@ -1,0 +1,42 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_mysql_source = true
+
+> CREATE CONNECTION mysq TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+# Create some test tables
+# Insert a bunch of rows one of the tables so the snapshot doesn't complete before we restart MZ
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS dummyschema;
+CREATE DATABASE dummyschema;
+USE dummyschema;
+CREATE TABLE dummy (f1 INTEGER, f2 INTEGER);
+SET @i:=0;
+INSERT INTO dummy (f1, f2) SELECT @i:=@i+1, FLOOR(RAND()*10000) FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 50000;
+CREATE TABLE other (d1 INTEGER);
+INSERT INTO other VALUES (1), (2), (3);
+
+> CREATE SOURCE schema_test FROM MYSQL CONNECTION mysq FOR ALL TABLES;
+
+# Now alter the dummy table
+$ mysql-execute name=mysql
+USE dummyschema;
+ALTER TABLE dummy ADD COLUMN f3 varchar(2);
+
+# Now restart MZ


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature. Fixes #25091 

This is a basic check to validate the mysql table schemas remain consistent between purification and snapshot time in the source.


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I expect the test will be refactored once we also detect DDL changes in the replication stream (my next task).

We also plan to implement a check to detect backwards-compatible schema changes and avoid erroring (in `verify_schema`), but I wanted to implement that logic at a future time. 

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
