### PR TITLE
persist: use lgalloc to back data fetched from s3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,6 +4901,7 @@ dependencies = [
  "futures-util",
  "md-5",
  "mz-aws-util",
+ "mz-dyncfg",
  "mz-ore",
  "mz-persist-types",
  "mz-postgres-client",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -50,6 +50,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_next_listen_batch_retryer_fixed_sleep": "1200ms",
     # -----
     # Persist internals changes: advance coverage
+    "persist_enable_s3_lgalloc_noncc_sizes": "true",
     "persist_streaming_compaction_enabled": "true",
     "persist_streaming_snapshot_and_fetch_enabled": "true",
     # -----

--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -141,6 +141,10 @@ struct Args {
     #[clap(long)]
     announce_memory_limit: Option<usize>,
 
+    /// Whether the cluster is using a v2 (cc/C) size or not.
+    #[clap(long)]
+    is_cluster_size_v2: bool,
+
     /// Set core affinity for Timely workers.
     ///
     /// This flag should only be set if the process is provided with exclusive access to its
@@ -262,7 +266,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         configs = mz_persist_txn::all_dyn_configs(configs);
         configs
     }
-    let persist_cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), all_dyn_configs());
+    let mut persist_cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), all_dyn_configs());
+    persist_cfg.is_cc_active = args.is_cluster_size_v2;
     let persist_clients = Arc::new(PersistClientCache::new(
         persist_cfg,
         &metrics_registry,

--- a/src/controller-types/src/lib.rs
+++ b/src/controller-types/src/lib.rs
@@ -16,3 +16,9 @@ pub type ClusterId = mz_compute_types::ComputeInstanceId;
 pub type ReplicaId = mz_cluster_client::ReplicaId;
 
 pub use mz_compute_types::DEFAULT_COMPUTE_REPLICA_LOGGING_INTERVAL as DEFAULT_REPLICA_LOGGING_INTERVAL;
+
+/// Reports whether a given size name is a "v2" cluster size--i.e., a cluster
+/// size that ends in "cc" or "C".
+pub fn is_cluster_size_v2(size: &str) -> bool {
+    size.ends_with("cc") || size.ends_with('C')
+}

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -22,7 +22,7 @@ use mz_compute_client::controller::{ComputeReplicaConfig, ComputeReplicaLogging}
 use mz_compute_client::logging::LogVariant;
 use mz_compute_client::service::{ComputeClient, ComputeGrpcClient};
 use mz_compute_types::ComputeInstanceId;
-use mz_controller_types::{ClusterId, ReplicaId};
+use mz_controller_types::{is_cluster_size_v2, ClusterId, ReplicaId};
 use mz_orchestrator::{
     CpuLimit, DiskLimit, LabelSelectionLogic, LabelSelector, MemoryLimit, Service, ServiceConfig,
     ServiceEvent, ServicePort,
@@ -662,6 +662,9 @@ where
                         }
                         if location.allocation.cpu_exclusive && enable_worker_core_affinity {
                             args.push("--worker-core-affinity".into());
+                        }
+                        if is_cluster_size_v2(&location.size) {
+                            args.push("--is-cluster-size-v2".into());
                         }
 
                         args.extend(secrets_args.clone());

--- a/src/ore/src/bytes.rs
+++ b/src/ore/src/bytes.rs
@@ -26,6 +26,8 @@ use bytes::{Buf, Bytes};
 use internal::SegmentedReader;
 use smallvec::SmallVec;
 
+use crate::lgbytes::LgBytes;
+
 /// A cheaply clonable collection of possibly non-contiguous bytes.
 ///
 /// `Vec<u8>` or `Bytes` are contiguous chunks of memory, which are fast (e.g. better cache
@@ -41,9 +43,79 @@ use smallvec::SmallVec;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SegmentedBytes<const N: usize = 1> {
     /// Collection of non-contiguous segments.
-    segments: SmallVec<[Bytes; N]>,
+    segments: SmallVec<[MaybeLgBytes; N]>,
     /// Pre-computed length of all the segments.
     len: usize,
+}
+
+/// A [Bytes] or an [LgBytes].
+///
+/// TODO: Once we've validated the persist s3 usage of LgBytes, change the CYA
+/// fallback path to be a heap allocated LgBytes. Then we can make this not pub.
+#[derive(Clone, Debug)]
+pub enum MaybeLgBytes {
+    /// A [Bytes], always heap allocated, untracked by metrics.
+    Bytes(Bytes),
+    /// An [LgBytes], possibly heap allocated, but always tracked by metrics.
+    LgBytes(LgBytes),
+}
+
+impl PartialEq for MaybeLgBytes {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl Eq for MaybeLgBytes {}
+
+impl AsRef<[u8]> for MaybeLgBytes {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            MaybeLgBytes::Bytes(x) => x.as_ref(),
+            MaybeLgBytes::LgBytes(x) => x.as_ref(),
+        }
+    }
+}
+
+impl MaybeLgBytes {
+    /// Returns the number of bytes contained in this `MaybeLgBytes`.
+    pub fn len(&self) -> usize {
+        match self {
+            MaybeLgBytes::Bytes(x) => x.len(),
+            MaybeLgBytes::LgBytes(x) => x.len(),
+        }
+    }
+
+    /// Returns true if the `MaybeLgBytes` has a length of 0.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            MaybeLgBytes::Bytes(x) => x.is_empty(),
+            MaybeLgBytes::LgBytes(x) => x.is_empty(),
+        }
+    }
+}
+
+impl Buf for MaybeLgBytes {
+    fn remaining(&self) -> usize {
+        match self {
+            MaybeLgBytes::Bytes(x) => x.remaining(),
+            MaybeLgBytes::LgBytes(x) => x.remaining(),
+        }
+    }
+
+    fn chunk(&self) -> &[u8] {
+        match self {
+            MaybeLgBytes::Bytes(x) => x.chunk(),
+            MaybeLgBytes::LgBytes(x) => x.chunk(),
+        }
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        match self {
+            MaybeLgBytes::Bytes(x) => x.advance(cnt),
+            MaybeLgBytes::LgBytes(x) => x.advance(cnt),
+        }
+    }
 }
 
 impl Default for SegmentedBytes {
@@ -80,7 +152,7 @@ impl<const N: usize> SegmentedBytes<N> {
 
     /// Consumes `self` returning an [`Iterator`] over all of the non-contiguous segments
     /// that make up this buffer.
-    pub fn into_segments(self) -> impl Iterator<Item = Bytes> {
+    pub fn into_segments(self) -> impl Iterator<Item = MaybeLgBytes> {
         self.segments.into_iter()
     }
 
@@ -92,7 +164,7 @@ impl<const N: usize> SegmentedBytes<N> {
     /// Extends the buffer by one more segment of [`Bytes`]
     pub fn push(&mut self, b: Bytes) {
         self.len += b.len();
-        self.segments.push(b);
+        self.segments.push(MaybeLgBytes::Bytes(b));
     }
 
     /// Consumes `self` returning a type that implements [`io::Read`] and [`io::Seek`].
@@ -146,14 +218,24 @@ impl From<Bytes> for SegmentedBytes {
     fn from(value: Bytes) -> Self {
         let len = value.len();
         let mut segments = SmallVec::new();
+        segments.push(MaybeLgBytes::Bytes(value));
+
+        SegmentedBytes { segments, len }
+    }
+}
+
+impl From<MaybeLgBytes> for SegmentedBytes {
+    fn from(value: MaybeLgBytes) -> Self {
+        let len = value.len();
+        let mut segments = SmallVec::new();
         segments.push(value);
 
         SegmentedBytes { segments, len }
     }
 }
 
-impl From<Vec<Bytes>> for SegmentedBytes {
-    fn from(value: Vec<Bytes>) -> Self {
+impl From<Vec<MaybeLgBytes>> for SegmentedBytes {
+    fn from(value: Vec<MaybeLgBytes>) -> Self {
         let mut len = 0;
         let mut segments = SmallVec::with_capacity(value.len());
 
@@ -168,8 +250,7 @@ impl From<Vec<Bytes>> for SegmentedBytes {
 
 impl From<Vec<u8>> for SegmentedBytes {
     fn from(value: Vec<u8>) -> Self {
-        let bytes = Bytes::from(value);
-        SegmentedBytes::from(bytes)
+        SegmentedBytes::from(MaybeLgBytes::Bytes(Bytes::from(value)))
     }
 }
 
@@ -180,7 +261,7 @@ impl<const N: usize> FromIterator<Bytes> for SegmentedBytes<N> {
 
         for segment in iter {
             len += segment.len();
-            segments.push(segment);
+            segments.push(MaybeLgBytes::Bytes(segment));
         }
 
         SegmentedBytes { segments, len }
@@ -198,20 +279,19 @@ mod internal {
     use std::io;
     use std::ops::Bound;
 
-    use bytes::Bytes;
-
+    use crate::bytes::MaybeLgBytes;
     use crate::cast::CastFrom;
 
     /// Provides efficient reading and seeking across a collection of segmented bytes.
     #[derive(Debug)]
     pub struct SegmentedReader {
-        segments: BTreeMap<usize, Bytes>,
+        segments: BTreeMap<usize, MaybeLgBytes>,
         len: usize,
         pointer: u64,
     }
 
     impl SegmentedReader {
-        pub fn new(segments: impl IntoIterator<Item = Bytes>) -> Self {
+        pub fn new(segments: impl IntoIterator<Item = MaybeLgBytes>) -> Self {
             let mut map = BTreeMap::new();
             let mut total_len = 0;
 
@@ -264,7 +344,11 @@ mod internal {
                 // How many bytes we'll read.
                 let len = core::cmp::min(remaining_len, buf.len());
                 // Copy bytes from the current segment into the buffer.
-                buf[..len].copy_from_slice(&segment[segment_pos..segment_pos + len]);
+                let segment_buf = match segment {
+                    MaybeLgBytes::Bytes(x) => x.as_ref(),
+                    MaybeLgBytes::LgBytes(x) => x.as_ref(),
+                };
+                buf[..len].copy_from_slice(&segment_buf[segment_pos..segment_pos + len]);
                 // Advance our pointer.
                 self.pointer += u64::cast_from(len);
 

--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -383,6 +383,7 @@ impl Service for TransactorService {
                     blob_uri,
                     Box::new(config.clone()),
                     metrics.s3_blob.clone(),
+                    config.configs.clone(),
                 )
                 .await
                 .expect("blob_uri should be valid");

--- a/src/persist-cli/src/maelstrom/txn_list_append_single.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_single.rs
@@ -615,6 +615,7 @@ impl Service for TransactorService {
                     blob_uri,
                     Box::new(config.clone()),
                     metrics.s3_blob.clone(),
+                    config.configs.clone(),
                 )
                 .await
                 .expect("blob_uri should be valid");

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -207,6 +207,7 @@ impl PersistClientCache {
                     x.key(),
                     Box::new(self.cfg.clone()),
                     self.metrics.s3_blob.clone(),
+                    self.cfg.configs.clone(),
                 )
                 .await?;
                 let blob = retry_external(&self.metrics.retries.external.blob_open, || {

--- a/src/persist-client/src/cli/args.rs
+++ b/src/persist-client/src/cli/args.rs
@@ -147,8 +147,13 @@ pub(super) async fn make_blob(
     commit: bool,
     metrics: Arc<Metrics>,
 ) -> anyhow::Result<Arc<dyn Blob + Send + Sync>> {
-    let blob =
-        BlobConfig::try_from(blob_uri, Box::new(cfg.clone()), metrics.s3_blob.clone()).await?;
+    let blob = BlobConfig::try_from(
+        blob_uri,
+        Box::new(cfg.clone()),
+        metrics.s3_blob.clone(),
+        cfg.configs.clone(),
+    )
+    .await?;
     let blob = blob.clone().open().await?;
     let blob = if commit {
         blob

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -39,7 +39,8 @@ futures-util = "0.3.25"
 once_cell = "1.16.0"
 md-5 = "0.10.5"
 mz-aws-util = { path = "../aws-util", features = ["s3"] }
-mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes_"] }
+mz-dyncfg = { path = "../dyncfg" }
+mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes_", "region"] }
 mz-persist-types = { path = "../persist-types" }
 mz-postgres-client = { path = "../postgres-client" }
 mz-proto = { path = "../proto" }

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::anyhow;
+use mz_dyncfg::ConfigSet;
 use tracing::warn;
 use url::Url;
 
@@ -49,6 +50,8 @@ pub trait BlobKnobs: std::fmt::Debug + Send + Sync {
     fn connect_timeout(&self) -> Duration;
     /// Maximum time to wait to read the first byte of a response, including connection time.
     fn read_timeout(&self) -> Duration;
+    /// Whether this is running in a "cc" sized cluster.
+    fn is_cc_active(&self) -> bool;
 }
 
 impl BlobConfig {
@@ -68,6 +71,7 @@ impl BlobConfig {
         value: &str,
         knobs: Box<dyn BlobKnobs>,
         metrics: S3BlobMetrics,
+        cfg: ConfigSet,
     ) -> Result<Self, ExternalError> {
         let url = Url::parse(value)
             .map_err(|err| anyhow!("failed to parse blob location {} as a url: {}", &value, err))?;
@@ -109,6 +113,7 @@ impl BlobConfig {
                     credentials,
                     knobs,
                     metrics,
+                    cfg,
                 )
                 .await?;
 

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -101,11 +101,11 @@ struct MemBlobCore {
 }
 
 impl MemBlobCore {
-    fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
+    fn get(&self, key: &str) -> Result<Option<Bytes>, ExternalError> {
         Ok(self
             .dataz
             .get(key)
-            .and_then(|(x, exists)| exists.then(|| x.to_vec())))
+            .and_then(|(x, exists)| exists.then(|| Bytes::clone(x))))
     }
 
     fn set(&mut self, key: &str, value: Bytes) -> Result<(), ExternalError> {

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -9,6 +9,7 @@
 
 //! Implementation-specific metrics for persist blobs and consensus
 
+use mz_ore::lgbytes::LgBytesMetrics;
 use mz_ore::metric;
 use mz_ore::metrics::{IntCounter, MetricsRegistry};
 use prometheus::IntCounterVec;
@@ -28,6 +29,7 @@ pub struct S3BlobMetrics {
     pub(crate) delete_head: IntCounter,
     pub(crate) delete_object: IntCounter,
     pub(crate) list_objects: IntCounter,
+    pub(crate) lgbytes: LgBytesMetrics,
 }
 
 impl S3BlobMetrics {
@@ -63,6 +65,7 @@ impl S3BlobMetrics {
             delete_head: operations.with_label_values(&["delete_head"]),
             delete_object: operations.with_label_values(&["delete_object"]),
             list_objects: operations.with_label_values(&["list_objects"]),
+            lgbytes: LgBytesMetrics::new(registry),
         }
     }
 }

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -30,6 +30,7 @@ use aws_types::region::Region;
 use bytes::Bytes;
 use futures_util::stream::FuturesOrdered;
 use futures_util::{FutureExt, StreamExt};
+use mz_dyncfg::{Config, ConfigSet};
 use mz_ore::bytes::{MaybeLgBytes, SegmentedBytes};
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
@@ -50,6 +51,8 @@ pub struct S3BlobConfig {
     client: S3Client,
     bucket: String,
     prefix: String,
+    cfg: ConfigSet,
+    is_cc_active: bool,
 }
 
 // There is no simple way to hook into the S3 client to capture when its various timeouts
@@ -119,7 +122,9 @@ impl S3BlobConfig {
         credentials: Option<(String, String)>,
         knobs: Box<dyn BlobKnobs>,
         metrics: S3BlobMetrics,
+        cfg: ConfigSet,
     ) -> Result<Self, Error> {
+        let is_cc_active = knobs.is_cc_active();
         let mut loader = mz_aws_util::defaults();
 
         if let Some(region) = region {
@@ -172,6 +177,8 @@ impl S3BlobConfig {
             client,
             bucket,
             prefix,
+            cfg,
+            is_cc_active,
         })
     }
 
@@ -244,6 +251,10 @@ impl S3BlobConfig {
             fn read_timeout(&self) -> Duration {
                 READ_TIMEOUT_MARKER
             }
+
+            fn is_cc_active(&self) -> bool {
+                false
+            }
         }
 
         // Give each test a unique prefix so they don't conflict. We don't have
@@ -261,6 +272,9 @@ impl S3BlobConfig {
             None,
             Box::new(TestBlobKnobs),
             metrics,
+            ConfigSet::default()
+                .add(&ENABLE_S3_LGALLOC_CC_SIZES)
+                .add(&ENABLE_S3_LGALLOC_NONCC_SIZES),
         )
         .await?;
         Ok(Some(config))
@@ -286,6 +300,8 @@ pub struct S3Blob {
     // Defaults to 1000 which is the current AWS max.
     max_keys: i32,
     multipart_config: MultipartConfig,
+    cfg: ConfigSet,
+    is_cc_active: bool,
 }
 
 impl S3Blob {
@@ -298,6 +314,8 @@ impl S3Blob {
             prefix: config.prefix,
             max_keys: 1_000,
             multipart_config: MultipartConfig::default(),
+            cfg: config.cfg,
+            is_cc_active: config.is_cc_active,
         };
         // Connect before returning success. We don't particularly care about
         // what's stored in this blob (nothing writes to it, so presumably it's
@@ -310,6 +328,20 @@ impl S3Blob {
         format!("{}/{}", self.prefix, key)
     }
 }
+
+/// The `persist_enable_s3_lgalloc_cc_sizes` config.
+pub const ENABLE_S3_LGALLOC_CC_SIZES: Config<bool> = Config::new(
+    "persist_enable_s3_lgalloc_cc_sizes",
+    true,
+    "An incident flag to disable copying fetched s3 data into lgalloc on cc sized clusters.",
+);
+
+/// The `persist_enable_s3_lgalloc_noncc_sizes` config.
+pub const ENABLE_S3_LGALLOC_NONCC_SIZES: Config<bool> = Config::new(
+    "persist_enable_s3_lgalloc_noncc_sizes",
+    false,
+    "A feature flag to enable copying fetched s3 data into lgalloc on non-cc sized clusters.",
+);
 
 #[async_trait]
 impl Blob for S3Blob {
@@ -408,7 +440,7 @@ impl Blob for S3Blob {
             let request_future = async move {
                 // Fetch the headers of the rest of the parts. (Using the existing headers
                 // for part 1.
-                let object = match first_part {
+                let mut object = match first_part {
                     Some(first_part) => {
                         assert_eq!(part_num, 1, "only the first part should be prefetched");
                         first_part
@@ -436,11 +468,32 @@ impl Blob for S3Blob {
 
                 // Request the body.
                 let body_start = Instant::now();
-                let body = object
-                    .body
-                    .collect()
-                    .await
-                    .map_err(|err| Error::from(format!("s3 get body err: {}", err)))?;
+                let mut body = Vec::new();
+                while let Some(data) = object.body.next().await {
+                    let data =
+                        data.map_err(|err| Error::from(format!("s3 get body err: {}", err)))?;
+                    // Get the data into lgalloc at the absolute earliest
+                    // possible point without (yet) having to fork the s3 client
+                    // library.
+                    let enable_s3_lgalloc = if self.is_cc_active {
+                        ENABLE_S3_LGALLOC_CC_SIZES.get(&self.cfg)
+                    } else {
+                        ENABLE_S3_LGALLOC_NONCC_SIZES.get(&self.cfg)
+                    };
+                    let data = if enable_s3_lgalloc {
+                        MaybeLgBytes::LgBytes(self.metrics.lgbytes.try_mmap(&data))
+                    } else {
+                        // In the CYA fallback case, make sure we skip the
+                        // memcpy to preserve the previous behavior as closely
+                        // as possible.
+                        //
+                        // TODO: Once we've validated the LgBytes path, change
+                        // this fallback path to be a heap allocated LgBytes.
+                        // Then we can remove the pub from MaybeLgBytes.
+                        MaybeLgBytes::Bytes(data)
+                    };
+                    body.push(data)
+                }
                 let body_elapsed = body_start.elapsed();
                 min_body_elapsed.observe(body_elapsed, "s3 download part body");
 
@@ -453,12 +506,12 @@ impl Blob for S3Blob {
         // Await on all of our parts requests.
         let mut segments = vec![];
         while let Some(result) = body_futures.next().await {
-            let part_body = result
+            let mut part_body = result
                 // Download failure, we failed to fetch the body from S3.
                 .map_err(|err| Error::from(format!("s3 get body err: {}", err)))?;
 
             // Collect all of our segments.
-            segments.extend(part_body.into_segments().map(MaybeLgBytes::Bytes));
+            segments.append(&mut part_body);
         }
 
         debug!(
@@ -1001,6 +1054,10 @@ mod tests {
                     client: config.client.clone(),
                     bucket: config.bucket.clone(),
                     prefix: format!("{}/s3_blob_impl_test/{}", config.prefix, path),
+                    cfg: ConfigSet::default()
+                        .add(&ENABLE_S3_LGALLOC_CC_SIZES)
+                        .add(&ENABLE_S3_LGALLOC_NONCC_SIZES),
+                    is_cc_active: true,
                 };
                 let mut blob = S3Blob::open(config).await?;
                 blob.max_keys = 2;

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -30,7 +30,7 @@ use aws_types::region::Region;
 use bytes::Bytes;
 use futures_util::stream::FuturesOrdered;
 use futures_util::{FutureExt, StreamExt};
-use mz_ore::bytes::SegmentedBytes;
+use mz_ore::bytes::{MaybeLgBytes, SegmentedBytes};
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::task::RuntimeExt;
@@ -458,7 +458,7 @@ impl Blob for S3Blob {
                 .map_err(|err| Error::from(format!("s3 get body err: {}", err)))?;
 
             // Collect all of our segments.
-            segments.extend(part_body.into_segments());
+            segments.extend(part_body.into_segments().map(MaybeLgBytes::Bytes));
         }
 
         debug!(

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -19,7 +19,9 @@ use std::time::Duration;
 
 use itertools::{Either, Itertools};
 use mz_adapter_types::compaction::CompactionWindow;
-use mz_controller_types::{ClusterId, ReplicaId, DEFAULT_REPLICA_LOGGING_INTERVAL};
+use mz_controller_types::{
+    is_cluster_size_v2, ClusterId, ReplicaId, DEFAULT_REPLICA_LOGGING_INTERVAL,
+};
 use mz_expr::refresh_schedule::{RefreshEvery, RefreshSchedule};
 use mz_expr::{CollectionPlan, UnmaterializableFunc};
 use mz_interchange::avro::{AvroSchemaGenerator, AvroSchemaOptions, DocTarget};
@@ -5699,8 +5701,4 @@ fn ensure_cluster_is_not_managed(
     } else {
         Ok(())
     }
-}
-
-fn is_cluster_size_v2(size: &str) -> bool {
-    size.ends_with("cc") || size.ends_with('C')
 }


### PR DESCRIPTION
This will reduce rehydration memory spikes by moving the data fetched
from s3 into file-backed mapped allocations.

Ideally, we'd read directly from the network into these allocs, but that
requires maintaining a fork of our s3 client library and/or hyper. We
appear to get a meaningful improvement by moving the data in at the very
first place it touches mz code, and that's a much easier place to start.
It would probably be more lgalloc-friendly to copy in a full s3 blob at
the end of the fetch, but initial testing on a staging env indicates
this is measurably worse than moving in each s3 multipart as it comes
in.

On its own, this seems to be sufficient to make parquet allocations the
limiting factor in rehydration spikes in practice. However, we may want
to supplement it with a semaphore around s3 fetching to get a hard upper
bound on how much data may have arrived from s3 but not yet been moved
into lgalloc. (This semaphore has the deficit of being similar in spirit
to the persist_source "physical backpressure" that we're trying to move
away from, but it has the benefit of working cross-persist_source, so it
may be worth doing in the short-term, anyway.)

Touches #23332

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Should be easy to go commit-by-commit. The first three are other PRs and will be rebased out once they merge.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
