### PR TITLE
fivetran-destination: Fix issues we found in dogfooding

### DIFF
--- a/src/fivetran-destination/src/destination/config.rs
+++ b/src/fivetran-destination/src/destination/config.rs
@@ -93,7 +93,7 @@ async fn test_permissions(config: BTreeMap<String, String>) -> Result<(), OpErro
     let (dbname, client) = connect(config).await?;
     let row = client
         .query_one(
-            "SELECT has_database_privilege($1, 'CREATE') AS has_create",
+            "SELECT has_database_privilege($1, 'CREATE') OR mz_is_superuser() AS has_create",
             &[&dbname],
         )
         .await


### PR DESCRIPTION
We set up our Fivetran destination for the first time and found a few small issues, which this PR addresses.

1. The permissions check did not consider superuser status.
2. `TruncateRequest`s can occur even if the table hasn't been created yet, so we need to no-op in that scenario.
3. The `_fivetran_deleted` column is always required, but not always provided, so we make sure to include it when missing.

Also if we ever get an `AlterTableRequest` we make sure to include the debug representation in the error message, so it's easier to debug.

Note: I tried to add tests for these scenarios but it's not possible at the moment. The tester seemed to ignore truncate requests for tables that didn't exist and the tester always provides the `_fivetran_deleted` columns I couldn't exercise either of these situations.

### Motivation

Fixes issues we found when debugging: https://materializeinc.slack.com/archives/C043QH7C0VB/p1707427816936459

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes issues in the Fivetran destination.