### PR TITLE
feature benchmark: add ignore for persist-txn message count change

### DIFF
--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -58,10 +58,13 @@ _MIN_ANCESTOR_MZ_VERSION_PER_COMMIT_TO_ACCOUNT_FOR_PERFORMANCE_AND_SCALABILITY_R
     str, MzVersion
 ] = {
     # insert newer commits at the top
+    # PR#24918 (persist-txn: switch to a new operator protocol for lazy) increased number of messages against v0.86.1
+    "b648576b52b8ba9bb3a4732f7022ab5c06ebed32": MzVersion.parse_mz("v0.87.0"),
     # PR#23659 (persist-txn: enable in CI with "eager uppers") introduces regressions against v0.79.0
     "c4f520a57a3046e5074939d2ea345d1c72be7079": MzVersion.parse_mz("v0.80.0"),
     # PR#23421 (coord: smorgasbord of improvements for the crdb-backed timestamp oracle) introduces regressions against 0.78.13
     "5179ebd39aea4867622357a832aaddcde951b411": MzVersion.parse_mz("v0.79.0"),
+    # insert newer commits at the top
 }
 
 """


### PR DESCRIPTION
This adds an ignore to the feature benchmark for https://github.com/MaterializeInc/materialize/pull/24918.

Needed on main once https://github.com/MaterializeInc/materialize/pull/25104 lands.