### PR TITLE
adapter: simplify `peek` and `copy_to` sequencing and optimization

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -386,8 +386,7 @@ pub enum PeekStage {
     LinearizeTimestamp(PeekStageLinearizeTimestamp),
     RealTimeRecency(PeekStageRealTimeRecency),
     TimestampReadHold(PeekStageTimestampReadHold),
-    OptimizeMir(PeekStageOptimizeMir),
-    OptimizeLir(PeekStageOptimizeLir),
+    Optimize(PeekStageOptimize),
     Finish(PeekStageFinish),
     CopyTo(PeekStageCopyTo),
     Explain(PeekStageExplain),
@@ -400,8 +399,7 @@ impl PeekStage {
             PeekStage::LinearizeTimestamp(PeekStageLinearizeTimestamp { validity, .. })
             | PeekStage::RealTimeRecency(PeekStageRealTimeRecency { validity, .. })
             | PeekStage::TimestampReadHold(PeekStageTimestampReadHold { validity, .. })
-            | PeekStage::OptimizeMir(PeekStageOptimizeMir { validity, .. })
-            | PeekStage::OptimizeLir(PeekStageOptimizeLir { validity, .. })
+            | PeekStage::Optimize(PeekStageOptimize { validity, .. })
             | PeekStage::Finish(PeekStageFinish { validity, .. })
             | PeekStage::CopyTo(PeekStageCopyTo { validity, .. })
             | PeekStage::Explain(PeekStageExplain { validity, .. }) => Some(validity),
@@ -475,7 +473,7 @@ pub struct PeekStageTimestampReadHold {
 }
 
 #[derive(Debug)]
-pub struct PeekStageOptimizeMir {
+pub struct PeekStageOptimize {
     validity: PlanValidity,
     plan: mz_sql::plan::SelectPlan,
     source_ids: BTreeSet<GlobalId>,
@@ -483,21 +481,6 @@ pub struct PeekStageOptimizeMir {
     target_replica: Option<ReplicaId>,
     determination: TimestampDetermination<mz_repr::Timestamp>,
     optimizer: Either<optimize::peek::Optimizer, optimize::copy_to::Optimizer>,
-    /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
-    explain_ctx: Option<ExplainContext>,
-}
-
-#[derive(Debug)]
-pub struct PeekStageOptimizeLir {
-    validity: PlanValidity,
-    plan: mz_sql::plan::SelectPlan,
-    id_bundle: CollectionIdBundle,
-    target_replica: Option<ReplicaId>,
-    determination: TimestampDetermination<mz_repr::Timestamp>,
-    source_ids: BTreeSet<GlobalId>,
-    optimizer: Either<optimize::peek::Optimizer, optimize::copy_to::Optimizer>,
-    global_mir_plan: Either<optimize::peek::GlobalMirPlan, optimize::copy_to::GlobalMirPlan>,
     /// An optional context set iff the state machine is initiated from
     /// sequencing an EXPALIN for this statement.
     explain_ctx: Option<ExplainContext>,

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -284,8 +284,6 @@ impl Coordinator {
                         None
                     };
 
-                    let _span_guard = tracing::debug_span!(target: "optimizer", "optimize").entered();
-
                     let index_plan =
                         optimize::index::Index::new(&plan.name, &plan.index.on, &plan.index.keys);
 

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -22,7 +22,7 @@ use crate::command::ExecuteResponse;
 use crate::coord::sequencer::inner::return_if_err;
 use crate::coord::{
     Coordinator, CreateIndexExplain, CreateIndexFinish, CreateIndexOptimize, CreateIndexStage,
-    CreateIndexValidate, ExplainContext, Message, PlanValidity,
+    CreateIndexValidate, ExplainContext, ExplainPlanContext, Message, PlanValidity,
 };
 use crate::error::AdapterError;
 use crate::explain::optimizer_trace::OptimizerTrace;
@@ -44,7 +44,7 @@ impl Coordinator {
             CreateIndexStage::Validate(CreateIndexValidate {
                 plan,
                 resolved_ids,
-                explain_ctx: None,
+                explain_ctx: ExplainContext::None,
             }),
             OpenTelemetryContext::obtain(),
         )
@@ -85,7 +85,7 @@ impl Coordinator {
             CreateIndexStage::Validate(CreateIndexValidate {
                 plan,
                 resolved_ids,
-                explain_ctx: Some(ExplainContext {
+                explain_ctx: ExplainContext::Plan(ExplainPlanContext {
                     broken,
                     config,
                     format,
@@ -139,7 +139,7 @@ impl Coordinator {
             CreateIndexStage::Validate(CreateIndexValidate {
                 plan,
                 resolved_ids,
-                explain_ctx: Some(ExplainContext {
+                explain_ctx: ExplainContext::Plan(ExplainPlanContext {
                     broken,
                     config,
                     format,
@@ -252,10 +252,10 @@ impl Coordinator {
         let compute_instance = self
             .instance_snapshot(*cluster_id)
             .expect("compute instance does not exist");
-        let exported_index_id = if explain_ctx.is_some() {
-            return_if_err!(self.allocate_transient_id(), ctx)
-        } else {
+        let exported_index_id = if let ExplainContext::None = explain_ctx {
             return_if_err!(self.catalog_mut().allocate_user_id().await, ctx)
+        } else {
+            return_if_err!(self.allocate_transient_id(), ctx)
         };
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
             .override_from(&explain_ctx);
@@ -275,14 +275,7 @@ impl Coordinator {
                     optimize::index::GlobalMirPlan,
                     optimize::index::GlobalLirPlan,
                 ), AdapterError> {
-                    // In `explain_~` contexts, set the trace-derived dispatch
-                    // as default while optimizing.
-                    let _dispatch_guard = if let Some(explain_ctx) = explain_ctx.as_ref() {
-                        let dispatch = tracing::Dispatch::from(&explain_ctx.optimizer_trace);
-                        Some(tracing::dispatcher::set_default(&dispatch))
-                    } else {
-                        None
-                    };
+                    let _dispatch_guard = explain_ctx.dispatch_guard();
 
                     let index_plan =
                         optimize::index::Index::new(&plan.name, &plan.index.on, &plan.index.keys);
@@ -297,7 +290,7 @@ impl Coordinator {
 
                 let stage = match pipeline() {
                     Ok((global_mir_plan, global_lir_plan)) => {
-                        if let Some(explain_ctx) = explain_ctx {
+                        if let ExplainContext::Plan(explain_ctx) = explain_ctx {
                             let (_, df_meta) = global_lir_plan.unapply();
                             CreateIndexStage::Explain(CreateIndexExplain {
                                 validity,
@@ -320,7 +313,7 @@ impl Coordinator {
                     // Internal optimizer errors are handled differently
                     // depending on the caller.
                     Err(err) => {
-                        let Some(explain_ctx) = explain_ctx else {
+                        let ExplainContext::Plan(explain_ctx) = explain_ctx else {
                             // In `sequence_~` contexts, immediately retire the
                             // execution with the error.
                             return ctx.retire(Err(err.into()));
@@ -489,7 +482,7 @@ impl Coordinator {
             plan: plan::CreateIndexPlan { name, index, .. },
             df_meta,
             explain_ctx:
-                ExplainContext {
+                ExplainPlanContext {
                     broken,
                     config,
                     format,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -27,7 +27,7 @@ use crate::coord::sequencer::inner::return_if_err;
 use crate::coord::{
     Coordinator, CreateMaterializedViewExplain, CreateMaterializedViewFinish,
     CreateMaterializedViewOptimize, CreateMaterializedViewStage, CreateMaterializedViewValidate,
-    ExplainContext, Message, PlanValidity,
+    ExplainContext, ExplainPlanContext, Message, PlanValidity,
 };
 use crate::error::AdapterError;
 use crate::explain::optimizer_trace::OptimizerTrace;
@@ -50,7 +50,7 @@ impl Coordinator {
             CreateMaterializedViewStage::Validate(CreateMaterializedViewValidate {
                 plan,
                 resolved_ids,
-                explain_ctx: None,
+                explain_ctx: ExplainContext::None,
             }),
             OpenTelemetryContext::obtain(),
         )
@@ -91,7 +91,7 @@ impl Coordinator {
             CreateMaterializedViewStage::Validate(CreateMaterializedViewValidate {
                 plan,
                 resolved_ids,
-                explain_ctx: Some(ExplainContext {
+                explain_ctx: ExplainContext::Plan(ExplainPlanContext {
                     broken,
                     config,
                     format,
@@ -145,7 +145,7 @@ impl Coordinator {
             CreateMaterializedViewStage::Validate(CreateMaterializedViewValidate {
                 plan,
                 resolved_ids,
-                explain_ctx: Some(ExplainContext {
+                explain_ctx: ExplainContext::Plan(ExplainPlanContext {
                     broken,
                     config,
                     format,
@@ -296,10 +296,10 @@ impl Coordinator {
         let compute_instance = self
             .instance_snapshot(*cluster_id)
             .expect("compute instance does not exist");
-        let exported_sink_id = if explain_ctx.is_some() {
-            return_if_err!(self.allocate_transient_id(), ctx)
-        } else {
+        let exported_sink_id = if let ExplainContext::None = explain_ctx {
             return_if_err!(self.catalog_mut().allocate_user_id().await, ctx)
+        } else {
+            return_if_err!(self.allocate_transient_id(), ctx)
         };
         let internal_view_id = return_if_err!(self.allocate_transient_id(), ctx);
         let debug_name = self.catalog().resolve_full_name(name, None).to_string();
@@ -327,14 +327,7 @@ impl Coordinator {
                     optimize::materialized_view::GlobalMirPlan,
                     optimize::materialized_view::GlobalLirPlan,
                 ), AdapterError> {
-                    // In `explain_~` contexts, set the trace-derived dispatch
-                    // as default while optimizing.
-                    let _dispatch_guard = if let Some(explain_ctx) = explain_ctx.as_ref() {
-                        let dispatch = tracing::Dispatch::from(&explain_ctx.optimizer_trace);
-                        Some(tracing::dispatcher::set_default(&dispatch))
-                    } else {
-                        None
-                    };
+                    let _dispatch_guard = explain_ctx.dispatch_guard();
 
                     let raw_expr = plan.materialized_view.expr.clone();
 
@@ -349,7 +342,7 @@ impl Coordinator {
 
                 let stage = match pipeline() {
                     Ok((local_mir_plan, global_mir_plan, global_lir_plan)) => {
-                        if let Some(explain_ctx) = explain_ctx {
+                        if let ExplainContext::Plan(explain_ctx) = explain_ctx {
                             let (_, df_meta) = global_lir_plan.unapply();
                             CreateMaterializedViewStage::Explain(CreateMaterializedViewExplain {
                                 validity,
@@ -373,7 +366,7 @@ impl Coordinator {
                     // Internal optimizer errors are handled differently
                     // depending on the caller.
                     Err(err) => {
-                        let Some(explain_ctx) = explain_ctx else {
+                        let ExplainContext::Plan(explain_ctx) = explain_ctx else {
                             // In `sequence_~` contexts, immediately retire the
                             // execution with the error.
                             return ctx.retire(Err(err.into()));
@@ -613,7 +606,7 @@ impl Coordinator {
                 },
             df_meta,
             explain_ctx:
-                ExplainContext {
+                ExplainPlanContext {
                     broken,
                     config,
                     format,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -336,25 +336,15 @@ impl Coordinator {
                         None
                     };
 
-                    let _span_guard =
-                        tracing::debug_span!(target: "optimizer", "optimize").entered();
-
                     let raw_expr = plan.materialized_view.expr.clone();
 
                     // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local and global)
                     let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
-                    let global_mir_plan =
-                        optimizer.catch_unwind_optimize(local_mir_plan.clone())?;
-
+                    let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan.clone())?;
                     // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                    let global_lir_plan =
-                        optimizer.catch_unwind_optimize(global_mir_plan.clone())?;
+                    let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan.clone())?;
 
-                    Ok((
-                        local_mir_plan,
-                        global_mir_plan,
-                        global_lir_plan,
-                    ))
+                    Ok((local_mir_plan, global_mir_plan, global_lir_plan))
                 };
 
                 let stage = match pipeline() {

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -563,23 +563,23 @@ impl Coordinator {
                     match optimizer.as_mut() {
                         // Optimize SELECT statement.
                         Either::Left(optimizer) => {
-                            // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local and global)
+                            // HIR ⇒ MIR lowering and MIR optimization (local)
                             let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
+                            // Attach resolved context required to continue the pipeline.
                             let local_mir_plan = local_mir_plan.resolve(timestamp_context, ctx.session(), stats);
-                            let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
-                            // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                            let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan)?;
+                            // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global)
+                            let global_lir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
 
                             Ok(Either::Left(global_lir_plan))
                         }
                         // Optimize COPY TO statement.
                         Either::Right(optimizer) => {
-                            // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local and global)
+                            // HIR ⇒ MIR lowering and MIR optimization (local and global)
                             let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
+                            // Attach resolved context required to continue the pipeline.
                             let local_mir_plan = local_mir_plan.resolve(timestamp_context, ctx.session(), stats);
-                            let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
-                            // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                            let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan)?;
+                            // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global)
+                            let global_lir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
 
                             Ok(Either::Right(global_lir_plan))
                         }

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -565,10 +565,9 @@ impl Coordinator {
                         Either::Left(optimizer) => {
                             // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local and global)
                             let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
-                            let local_mir_plan = local_mir_plan.resolve(ctx.session(), stats);
+                            let local_mir_plan = local_mir_plan.resolve(timestamp_context, ctx.session(), stats);
                             let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
                             // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                            let global_mir_plan = global_mir_plan.resolve(timestamp_context.clone(), ctx.session_mut());
                             let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan)?;
 
                             Ok(Either::Left(global_lir_plan))

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -514,7 +514,7 @@ impl Coordinator {
     #[tracing::instrument(level = "debug", skip_all)]
     async fn peek_stage_optimize(
         &mut self,
-        mut ctx: ExecuteContext,
+        ctx: ExecuteContext,
         root_otel_ctx: OpenTelemetryContext,
         PeekStageOptimize {
             validity,
@@ -576,10 +576,9 @@ impl Coordinator {
                         Either::Right(optimizer) => {
                             // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local and global)
                             let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
-                            let local_mir_plan = local_mir_plan.resolve(ctx.session(), stats);
+                            let local_mir_plan = local_mir_plan.resolve(timestamp_context, ctx.session(), stats);
                             let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
                             // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                            let global_mir_plan = global_mir_plan.resolve(timestamp_context.clone(), ctx.session_mut())?;
                             let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan)?;
 
                             Ok(Either::Right(global_lir_plan))

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -555,9 +555,6 @@ impl Coordinator {
                         None
                     };
 
-                    let _span_guard =
-                        tracing::debug_span!(target: "optimizer", "optimize").entered();
-
                     let raw_expr = plan.source.clone();
 
                     match optimizer.as_mut() {

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Optimizer implementation for `SELECT` statements.
+//! Optimizer implementation for `COPY TO` statements.
 
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -110,8 +110,8 @@ impl Debug for Optimizer {
     }
 }
 
-/// Marker type for [`LocalMirPlan`] and [`GlobalMirPlan`] structs representing
-/// an optimization result without context.
+/// Marker type for [`LocalMirPlan`] representing an optimization result without
+/// context.
 pub struct Unresolved;
 
 /// The (sealed intermediate) result after HIR ⇒ MIR lowering and decorrelation
@@ -124,7 +124,8 @@ pub struct LocalMirPlan<T = Unresolved> {
 
 /// Marker type for [`LocalMirPlan`] structs representing an optimization result
 /// with attached environment context required for the next optimization stage.
-pub struct ResolvedLocal<'s> {
+pub struct Resolved<'s> {
+    timestamp_ctx: TimestampContext<Timestamp>,
     stats: Box<dyn StatisticsOracle>,
     session: &'s Session,
 }
@@ -132,33 +133,13 @@ pub struct ResolvedLocal<'s> {
 /// The (sealed intermediate) result after:
 ///
 /// 1. embedding a [`LocalMirPlan`] into a [`MirDataflowDescription`],
-/// 2. transitively inlining referenced views, and
-/// 3. jointly optimizing the `MIR` plans in the [`MirDataflowDescription`].
+/// 2. transitively inlining referenced views,
+/// 3. timestamp resolution, and
+/// 4. jointly optimizing the `MIR` plans in the [`MirDataflowDescription`].
 #[derive(Clone)]
-pub struct GlobalMirPlan<T = Unresolved> {
+pub struct GlobalMirPlan {
     df_desc: MirDataflowDescription,
     df_meta: DataflowMetainfo,
-    context: T,
-}
-
-impl Debug for GlobalMirPlan<Unresolved> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GlobalMirPlan")
-            .field("df_desc", &self.df_desc)
-            .field("df_meta", &self.df_meta)
-            .finish()
-    }
-}
-
-/// Marker type for [`GlobalMirPlan`] structs representing an optimization
-/// result with with a resolved timestamp and attached environment context
-/// required for the next optimization stage.
-///
-/// The actual timestamp value is set in the [`MirDataflowDescription`] of the
-/// surrounding [`GlobalMirPlan`] when we call `resolve()`.
-#[derive(Clone)]
-pub struct ResolvedGlobal<'s> {
-    session: &'s Session,
 }
 
 /// The (final) result after MIR ⇒ LIR lowering and optimizing the resulting
@@ -200,30 +181,37 @@ impl Optimize<HirRelationExpr> for Optimizer {
 }
 
 impl LocalMirPlan<Unresolved> {
-    /// Produces the [`LocalMirPlan`] with [`ResolvedLocal`] contextual
-    /// information required for the next stage.
+    /// Produces the [`LocalMirPlan`] with [`Resolved`] contextual information
+    /// required for the next stage.
     pub fn resolve(
         self,
+        timestamp_ctx: TimestampContext<Timestamp>,
         session: &Session,
         stats: Box<dyn StatisticsOracle>,
-    ) -> LocalMirPlan<ResolvedLocal> {
+    ) -> LocalMirPlan<Resolved> {
         LocalMirPlan {
             expr: self.expr,
-            context: ResolvedLocal { session, stats },
+            context: Resolved {
+                timestamp_ctx,
+                session,
+                stats,
+            },
         }
     }
 }
 
-impl<'s> Optimize<LocalMirPlan<ResolvedLocal<'s>>> for Optimizer {
-    type To = GlobalMirPlan<Unresolved>;
+impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
+    type To = GlobalMirPlan;
 
-    fn optimize(
-        &mut self,
-        plan: LocalMirPlan<ResolvedLocal<'s>>,
-    ) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, plan: LocalMirPlan<Resolved<'s>>) -> Result<Self::To, OptimizerError> {
         let LocalMirPlan {
             expr,
-            context: ResolvedLocal { stats, session },
+            context:
+                Resolved {
+                    timestamp_ctx,
+                    stats,
+                    session,
+                },
         } = plan;
 
         let expr = OptimizedMirRelationExpr(expr);
@@ -284,6 +272,28 @@ impl<'s> Optimize<LocalMirPlan<ResolvedLocal<'s>>> for Optimizer {
             |s| prep_scalar_expr(s, style),
         )?;
 
+        // Set the `as_of` and `until` timestamps for the dataflow.
+        df_desc.set_as_of(timestamp_ctx.antichain());
+
+        // Use the the opportunity to name an `until` frontier that will prevent
+        // work we needn't perform. By default, `until` will be
+        // `Antichain::new()`, which prevents no updates and is safe.
+        //
+        // If `timestamp_ctx.antichain()` is empty, `timestamp_ctx.timestamp()`
+        // will return `None` and we use the default (empty) `until`. Otherwise,
+        // we expect to be able to set `until = as_of + 1` without an overflow.
+        if let Some(as_of) = timestamp_ctx.timestamp() {
+            if let Some(until) = as_of.checked_add(1) {
+                df_desc.until = Antichain::from_elem(until);
+                // Also updating the sink up_to
+                for (_, sink) in &mut df_desc.sink_exports {
+                    sink.up_to = df_desc.until.clone();
+                }
+            } else {
+                warn!(as_of = %as_of, "as_of + 1 overflow");
+            }
+        }
+
         let df_meta = mz_transform::optimize_dataflow(
             &mut df_desc,
             &df_builder,
@@ -297,67 +307,17 @@ impl<'s> Optimize<LocalMirPlan<ResolvedLocal<'s>>> for Optimizer {
         }
 
         // Return the (sealed) plan at the end of this optimization step.
-        Ok(GlobalMirPlan {
-            df_desc,
-            df_meta,
-            context: Unresolved,
-        })
+        Ok(GlobalMirPlan { df_desc, df_meta })
     }
 }
 
-impl GlobalMirPlan<Unresolved> {
-    /// Produces the [`GlobalMirPlan`] with [`ResolvedGlobal`] contextual
-    /// information required for the next stage.
-    ///
-    /// We need to resolve timestamps before the `GlobalMirPlan ⇒ GlobalLirPlan`
-    /// optimization stage in order to profit from possible single-time
-    /// optimizations in the `Plan::finalize_dataflow` call.
-    pub fn resolve(
-        mut self,
-        timestamp_ctx: TimestampContext<Timestamp>,
-        session: &Session,
-    ) -> Result<GlobalMirPlan<ResolvedGlobal>, OptimizerError> {
-        // Set the `as_of` and `until` timestamps for the dataflow.
-        self.df_desc.set_as_of(timestamp_ctx.antichain());
-
-        // Use the the opportunity to name an `until` frontier that will prevent
-        // work we needn't perform. By default, `until` will be
-        // `Antichain::new()`, which prevents no updates and is safe.
-        //
-        // If `timestamp_ctx.antichain()` is empty, `timestamp_ctx.timestamp()`
-        // will return `None` and we use the default (empty) `until`. Otherwise,
-        // we expect to be able to set `until = as_of + 1` without an overflow.
-        if let Some(as_of) = timestamp_ctx.timestamp() {
-            if let Some(until) = as_of.checked_add(1) {
-                self.df_desc.until = Antichain::from_elem(until);
-                // Also updating the sink up_to
-                for (_, sink) in &mut self.df_desc.sink_exports {
-                    sink.up_to = self.df_desc.until.clone();
-                }
-            } else {
-                warn!(as_of = %as_of, "as_of + 1 overflow");
-            }
-        }
-
-        Ok(GlobalMirPlan {
-            df_desc: self.df_desc,
-            df_meta: self.df_meta,
-            context: ResolvedGlobal { session },
-        })
-    }
-}
-
-impl<'s> Optimize<GlobalMirPlan<ResolvedGlobal<'s>>> for Optimizer {
+impl Optimize<GlobalMirPlan> for Optimizer {
     type To = GlobalLirPlan;
 
-    fn optimize(
-        &mut self,
-        plan: GlobalMirPlan<ResolvedGlobal<'s>>,
-    ) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, plan: GlobalMirPlan) -> Result<Self::To, OptimizerError> {
         let GlobalMirPlan {
             mut df_desc,
             df_meta,
-            context: ResolvedGlobal { session },
         } = plan;
 
         // Get the single timestamp representing the `as_of` time.

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -38,17 +38,15 @@ use mz_sql::plan::HirRelationExpr;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::normalize_lets::normalize_lets;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
-use mz_transform::Optimizer as TransformOptimizer;
 use timely::progress::Antichain;
-use tracing::debug_span;
 
 use crate::catalog::Catalog;
 use crate::optimize::dataflows::{
     prep_relation_expr, ComputeInstanceSnapshot, DataflowBuilder, ExprPrepStyle,
 };
 use crate::optimize::{
-    trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize, OptimizeMode,
-    OptimizerConfig, OptimizerError,
+    optimize_mir_local, trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize,
+    OptimizeMode, OptimizerConfig, OptimizerError,
 };
 
 pub struct Optimizer {
@@ -161,16 +159,7 @@ impl Optimize<HirRelationExpr> for Optimizer {
         let expr = expr.lower(&self.config)?;
 
         // MIR ⇒ MIR optimization (local)
-        let expr = debug_span!(target: "optimizer", "local").in_scope(|| {
-            #[allow(deprecated)]
-            let optimizer = TransformOptimizer::logical_optimizer(&self.typecheck_ctx);
-            let expr = optimizer.optimize(expr)?.into_inner();
-
-            // Trace the result of this phase.
-            trace_plan(&expr);
-
-            Ok::<_, OptimizerError>(expr)
-        })?;
+        let expr = optimize_mir_local(expr, &self.typecheck_ctx)?.into_inner();
 
         // Return the (sealed) plan at the end of this optimization step.
         Ok(LocalMirPlan { expr })

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -115,6 +115,7 @@ where
     /// Like [`Self::optimize`], but additionally ensures that panics occurring
     /// in the [`Self::optimize`] call are caught and demoted to an
     /// [`OptimizerError::Internal`] error.
+    #[tracing::instrument(target = "optimizer", level = "debug", name = "optimize", skip_all)]
     fn catch_unwind_optimize(&mut self, plan: From) -> Result<Self::To, OptimizerError> {
         match mz_ore::panic::catch_unwind(AssertUnwindSafe(|| self.optimize(plan))) {
             Ok(result) => {

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -215,22 +215,13 @@ pub trait OverrideFrom<T> {
     fn override_from(self, layer: &T) -> Self;
 }
 
-/// Blanket implementation for optional layers.
-impl<S, T> OverrideFrom<Option<T>> for S
-where
-    S: OverrideFrom<T>,
-{
-    fn override_from(self, layer: &Option<T>) -> Self {
-        match layer.as_ref() {
-            Some(layer) => self.override_from(layer),
-            None => self,
-        }
-    }
-}
-
 /// [`OptimizerConfig`] overrides coming from an [`ExplainContext`].
 impl OverrideFrom<ExplainContext> for OptimizerConfig {
     fn override_from(mut self, ctx: &ExplainContext) -> Self {
+        let ExplainContext::Plan(ctx) = ctx else {
+            return self; // Return immediately for all other contexts.
+        };
+
         // Override general parameters.
         self.mode = OptimizeMode::Explain;
         self.replan = ctx.replan;

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -64,13 +64,27 @@ use std::panic::AssertUnwindSafe;
 
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::Plan;
-use mz_expr::{EvalError, OptimizedMirRelationExpr, UnmaterializableFunc};
+use mz_expr::{EvalError, MirRelationExpr, OptimizedMirRelationExpr, UnmaterializableFunc};
 use mz_ore::stack::RecursionLimitError;
 use mz_repr::adt::timestamp::TimestampError;
 use mz_repr::GlobalId;
 use mz_sql::plan::PlanError;
 use mz_sql::session::vars::SystemVars;
+use mz_transform::typecheck::SharedContext as TypecheckContext;
 use mz_transform::TransformError;
+
+// Alias types
+// -----------
+
+/// A type for a [`DataflowDescription`] backed by `Mir~` plans. Used internally
+/// by the optimizer implementations.
+type MirDataflowDescription = DataflowDescription<OptimizedMirRelationExpr>;
+/// A type for a [`DataflowDescription`] backed by `Lir~` plans. Used internally
+/// by the optimizer implementations.
+type LirDataflowDescription = DataflowDescription<Plan>;
+
+// Core API
+// --------
 
 /// A trait that represents an optimization stage.
 ///
@@ -132,6 +146,9 @@ where
         }
     }
 }
+
+// Optimizer configuration
+// -----------------------
 
 // Feature flags for the optimizer.
 #[derive(Clone, Debug)]
@@ -239,12 +256,8 @@ impl From<&OptimizerConfig> for mz_sql::plan::HirToMirConfig {
     }
 }
 
-/// A type for a [`DataflowDescription`] backed by `Mir~` plans. Used internally
-/// by the optimizer implementations.
-type MirDataflowDescription = DataflowDescription<OptimizedMirRelationExpr>;
-/// A type for a [`DataflowDescription`] backed by `Lir~` plans. Used internally
-/// by the optimizer implementations.
-type LirDataflowDescription = DataflowDescription<Plan>;
+// OptimizerError
+// ===============
 
 /// Error types that can be generated during optimization.
 #[derive(Debug, thiserror::Error)]
@@ -298,6 +311,24 @@ impl From<anyhow::Error> for OptimizerError {
     fn from(value: anyhow::Error) -> Self {
         OptimizerError::Internal(value.to_string())
     }
+}
+
+// Tracing helpers
+// ---------------
+
+#[tracing::instrument(target = "optimizer", level = "debug", name = "local", skip_all)]
+fn optimize_mir_local(
+    expr: MirRelationExpr,
+    typecheck_ctx: &TypecheckContext,
+) -> Result<OptimizedMirRelationExpr, OptimizerError> {
+    #[allow(deprecated)]
+    let optimizer = mz_transform::Optimizer::logical_optimizer(typecheck_ctx);
+    let expr = optimizer.optimize(expr)?;
+
+    // Trace the result of this phase.
+    mz_repr::explain::trace_plan(expr.as_inner());
+
+    Ok::<_, OptimizerError>(expr)
 }
 
 macro_rules! trace_plan {

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -101,7 +101,7 @@ impl Debug for Optimizer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OptimizePeek")
             .field("config", &self.config)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -125,20 +125,16 @@ pub struct Resolved<'s> {
     session: &'s Session,
 }
 
-/// The (sealed intermediate) result after:
+/// The (final) result after
 ///
-/// 1. embedding a [`LocalMirPlan`] into a [`MirDataflowDescription`],
+/// 1. embedding a [`LocalMirPlan`] into a `DataflowDescription`,
 /// 2. transitively inlining referenced views,
-/// 3. timestamp resolution, and
-/// 4. jointly optimizing the `MIR` plans in the [`MirDataflowDescription`].
-#[derive(Clone)]
-pub struct GlobalMirPlan {
-    df_desc: MirDataflowDescription,
-    df_meta: DataflowMetainfo,
-    typ: RelationType, // TODO: read this from the index_exports.
-}
-
-/// The (final) result after MIR ⇒ LIR lowering and optimizing the resulting
+/// 3. timestamp resolution,
+/// 4. optimizing the resulting `DataflowDescription` with `MIR` plans.
+/// 5. MIR ⇒ LIR lowering, and
+/// 6. optimizing the resulting `DataflowDescription` with `LIR` plans.
+///
+///  MIR ⇒ LIR lowering and optimizing the resulting
 /// `DataflowDescription` with `LIR` plans.
 #[derive(Debug)]
 pub struct GlobalLirPlan {
@@ -198,7 +194,7 @@ impl LocalMirPlan<Unresolved> {
 }
 
 impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
-    type To = GlobalMirPlan;
+    type To = GlobalLirPlan;
 
     fn optimize(&mut self, plan: LocalMirPlan<Resolved<'s>>) -> Result<Self::To, OptimizerError> {
         let LocalMirPlan {
@@ -291,25 +287,6 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
             // Collect the list of indexes used by the dataflow at this point.
             trace_plan!(at: "global", &df_meta.used_indexes(&df_desc));
         }
-
-        // Return the (sealed) plan at the end of this optimization step.
-        Ok(GlobalMirPlan {
-            df_desc,
-            df_meta,
-            typ,
-        })
-    }
-}
-
-impl Optimize<GlobalMirPlan> for Optimizer {
-    type To = GlobalLirPlan;
-
-    fn optimize(&mut self, plan: GlobalMirPlan) -> Result<Self::To, OptimizerError> {
-        let GlobalMirPlan {
-            mut df_desc,
-            df_meta,
-            typ,
-        } = plan;
 
         // Get the single timestamp representing the `as_of` time.
         let as_of = df_desc

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -22,7 +22,7 @@ use mz_sql::plan::HirRelationExpr;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::normalize_lets::normalize_lets;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
-use mz_transform::{Optimizer as TransformOptimizer, StatisticsOracle};
+use mz_transform::StatisticsOracle;
 use timely::progress::Antichain;
 use tracing::{debug_span, warn};
 
@@ -33,7 +33,8 @@ use crate::optimize::dataflows::{
     ExprPrepStyle,
 };
 use crate::optimize::{
-    trace_plan, MirDataflowDescription, Optimize, OptimizeMode, OptimizerConfig, OptimizerError,
+    optimize_mir_local, trace_plan, MirDataflowDescription, Optimize, OptimizeMode,
+    OptimizerConfig, OptimizerError,
 };
 use crate::session::Session;
 use crate::TimestampContext;
@@ -154,16 +155,7 @@ impl Optimize<HirRelationExpr> for Optimizer {
         let expr = expr.lower(&self.config)?;
 
         // MIR ⇒ MIR optimization (local)
-        let expr = debug_span!(target: "optimizer", "local").in_scope(|| {
-            #[allow(deprecated)]
-            let optimizer = TransformOptimizer::logical_optimizer(&self.typecheck_ctx);
-            let expr = optimizer.optimize(expr)?.into_inner();
-
-            // Trace the result of this phase.
-            trace_plan(&expr);
-
-            Ok::<_, OptimizerError>(expr)
-        })?;
+        let expr = optimize_mir_local(expr, &self.typecheck_ctx)?.into_inner();
 
         // Return the (sealed) plan at the end of this optimization step.
         Ok(LocalMirPlan {

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -105,8 +105,8 @@ impl Debug for Optimizer {
     }
 }
 
-/// Marker type for [`LocalMirPlan`] and [`GlobalMirPlan`] structs representing
-/// an optimization result without context.
+/// Marker type for [`LocalMirPlan`] representing an optimization result without
+/// context.
 pub struct Unresolved;
 
 /// The (sealed intermediate) result after HIR ⇒ MIR lowering and decorrelation
@@ -119,7 +119,8 @@ pub struct LocalMirPlan<T = Unresolved> {
 
 /// Marker type for [`LocalMirPlan`] structs representing an optimization result
 /// with attached environment context required for the next optimization stage.
-pub struct ResolvedLocal<'s> {
+pub struct Resolved<'s> {
+    timestamp_ctx: TimestampContext<Timestamp>,
     stats: Box<dyn StatisticsOracle>,
     session: &'s Session,
 }
@@ -127,35 +128,14 @@ pub struct ResolvedLocal<'s> {
 /// The (sealed intermediate) result after:
 ///
 /// 1. embedding a [`LocalMirPlan`] into a [`MirDataflowDescription`],
-/// 2. transitively inlining referenced views, and
-/// 3. jointly optimizing the `MIR` plans in the [`MirDataflowDescription`].
+/// 2. transitively inlining referenced views,
+/// 3. timestamp resolution, and
+/// 4. jointly optimizing the `MIR` plans in the [`MirDataflowDescription`].
 #[derive(Clone)]
-pub struct GlobalMirPlan<T = Unresolved> {
+pub struct GlobalMirPlan {
     df_desc: MirDataflowDescription,
     df_meta: DataflowMetainfo,
     typ: RelationType, // TODO: read this from the index_exports.
-    context: T,
-}
-
-impl Debug for GlobalMirPlan<Unresolved> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GlobalMirPlan")
-            .field("df_desc", &self.df_desc)
-            .field("df_meta", &self.df_meta)
-            .field("typ", &self.typ)
-            .finish()
-    }
-}
-
-/// Marker type for [`GlobalMirPlan`] structs representing an optimization
-/// result with with a resolved timestamp and attached environment context
-/// required for the next optimization stage.
-///
-/// The actual timestamp value is set in the [`MirDataflowDescription`] of the
-/// surrounding [`GlobalMirPlan`] when we call `resolve()`.
-#[derive(Clone)]
-pub struct ResolvedGlobal<'s> {
-    session: &'s Session,
 }
 
 /// The (final) result after MIR ⇒ LIR lowering and optimizing the resulting
@@ -198,30 +178,37 @@ impl Optimize<HirRelationExpr> for Optimizer {
 }
 
 impl LocalMirPlan<Unresolved> {
-    /// Produces the [`LocalMirPlan`] with [`ResolvedLocal`] contextual
-    /// information required for the next stage.
+    /// Produces the [`LocalMirPlan`] with [`Resolved`] contextual information
+    /// required for the next stage.
     pub fn resolve(
         self,
+        timestamp_ctx: TimestampContext<Timestamp>,
         session: &Session,
         stats: Box<dyn StatisticsOracle>,
-    ) -> LocalMirPlan<ResolvedLocal> {
+    ) -> LocalMirPlan<Resolved> {
         LocalMirPlan {
             expr: self.expr,
-            context: ResolvedLocal { session, stats },
+            context: Resolved {
+                timestamp_ctx,
+                session,
+                stats,
+            },
         }
     }
 }
 
-impl<'s> Optimize<LocalMirPlan<ResolvedLocal<'s>>> for Optimizer {
-    type To = GlobalMirPlan<Unresolved>;
+impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
+    type To = GlobalMirPlan;
 
-    fn optimize(
-        &mut self,
-        plan: LocalMirPlan<ResolvedLocal<'s>>,
-    ) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, plan: LocalMirPlan<Resolved<'s>>) -> Result<Self::To, OptimizerError> {
         let LocalMirPlan {
             expr,
-            context: ResolvedLocal { stats, session },
+            context:
+                Resolved {
+                    timestamp_ctx,
+                    stats,
+                    session,
+                },
         } = plan;
 
         let expr = OptimizedMirRelationExpr(expr);
@@ -275,6 +262,24 @@ impl<'s> Optimize<LocalMirPlan<ResolvedLocal<'s>>> for Optimizer {
             );
         }
 
+        // Set the `as_of` and `until` timestamps for the dataflow.
+        df_desc.set_as_of(timestamp_ctx.antichain());
+
+        // Use the the opportunity to name an `until` frontier that will prevent
+        // work we needn't perform. By default, `until` will be
+        // `Antichain::new()`, which prevents no updates and is safe.
+        //
+        // If `timestamp_ctx.antichain()` is empty, `timestamp_ctx.timestamp()`
+        // will return `None` and we use the default (empty) `until`. Otherwise,
+        // we expect to be able to set `until = as_of + 1` without an overflow.
+        if let Some(as_of) = timestamp_ctx.timestamp() {
+            if let Some(until) = as_of.checked_add(1) {
+                df_desc.until = Antichain::from_elem(until);
+            } else {
+                warn!(as_of = %as_of, "as_of + 1 overflow");
+            }
+        }
+
         let df_meta = mz_transform::optimize_dataflow(
             &mut df_desc,
             &df_builder,
@@ -292,62 +297,18 @@ impl<'s> Optimize<LocalMirPlan<ResolvedLocal<'s>>> for Optimizer {
             df_desc,
             df_meta,
             typ,
-            context: Unresolved,
         })
     }
 }
 
-impl GlobalMirPlan<Unresolved> {
-    /// Produces the [`GlobalMirPlan`] with [`ResolvedGlobal`] contextual
-    /// information required for the next stage.
-    ///
-    /// We need to resolve timestamps before the `GlobalMirPlan ⇒ GlobalLirPlan`
-    /// optimization stage in order to profit from possible single-time
-    /// optimizations in the `Plan::finalize_dataflow` call.
-    pub fn resolve(
-        mut self,
-        timestamp_ctx: TimestampContext<Timestamp>,
-        session: &Session,
-    ) -> GlobalMirPlan<ResolvedGlobal> {
-        // Set the `as_of` and `until` timestamps for the dataflow.
-        self.df_desc.set_as_of(timestamp_ctx.antichain());
-
-        // Use the the opportunity to name an `until` frontier that will prevent
-        // work we needn't perform. By default, `until` will be
-        // `Antichain::new()`, which prevents no updates and is safe.
-        //
-        // If `timestamp_ctx.antichain()` is empty, `timestamp_ctx.timestamp()`
-        // will return `None` and we use the default (empty) `until`. Otherwise,
-        // we expect to be able to set `until = as_of + 1` without an overflow.
-        if let Some(as_of) = timestamp_ctx.timestamp() {
-            if let Some(until) = as_of.checked_add(1) {
-                self.df_desc.until = Antichain::from_elem(until);
-            } else {
-                warn!(as_of = %as_of, "as_of + 1 overflow");
-            }
-        }
-
-        GlobalMirPlan {
-            df_desc: self.df_desc,
-            df_meta: self.df_meta,
-            typ: self.typ,
-            context: ResolvedGlobal { session },
-        }
-    }
-}
-
-impl<'s> Optimize<GlobalMirPlan<ResolvedGlobal<'s>>> for Optimizer {
+impl Optimize<GlobalMirPlan> for Optimizer {
     type To = GlobalLirPlan;
 
-    fn optimize(
-        &mut self,
-        plan: GlobalMirPlan<ResolvedGlobal<'s>>,
-    ) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, plan: GlobalMirPlan) -> Result<Self::To, OptimizerError> {
         let GlobalMirPlan {
             mut df_desc,
             df_meta,
             typ,
-            context: ResolvedGlobal { session },
         } = plan;
 
         // Get the single timestamp representing the `as_of` time.

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -19,23 +19,20 @@ use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, SubscribeS
 use mz_compute_types::ComputeInstanceId;
 use mz_ore::collections::CollectionExt;
 use mz_ore::soft_assert_or_log;
-use mz_repr::explain::trace_plan;
 use mz_repr::{GlobalId, RelationDesc, Timestamp};
 use mz_sql::plan::SubscribeFrom;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::normalize_lets::normalize_lets;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
-use mz_transform::Optimizer as TransformOptimizer;
 use timely::progress::Antichain;
-use tracing::debug_span;
 
 use crate::catalog::Catalog;
 use crate::optimize::dataflows::{
     dataflow_import_id_bundle, ComputeInstanceSnapshot, DataflowBuilder,
 };
 use crate::optimize::{
-    trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize, OptimizeMode,
-    OptimizerConfig, OptimizerError,
+    optimize_mir_local, trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize,
+    OptimizeMode, OptimizerConfig, OptimizerError,
 };
 use crate::CollectionIdBundle;
 
@@ -212,16 +209,7 @@ impl Optimize<SubscribeFrom> for Optimizer {
                 // let expr = expr.lower(&self.config)?;
 
                 // MIR ⇒ MIR optimization (local)
-                let expr = debug_span!(target: "optimizer", "local").in_scope(|| {
-                    #[allow(deprecated)]
-                    let optimizer = TransformOptimizer::logical_optimizer(&self.typecheck_ctx);
-                    let expr = optimizer.optimize(expr)?;
-
-                    // Trace the result of this phase.
-                    trace_plan(&expr);
-
-                    Ok::<_, OptimizerError>(expr)
-                })?;
+                let expr = optimize_mir_local(expr, &self.typecheck_ctx)?;
 
                 let from_desc = RelationDesc::new(expr.typ(), desc.iter_names());
                 let from_id = self.transient_id;

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -67,7 +67,7 @@ impl std::fmt::Debug for Optimizer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Optimizer")
             .field("config", &self.config)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1390,11 +1390,11 @@ pub enum RequireLinearization {
     NotRequired,
 }
 
-impl From<&Option<ExplainContext>> for RequireLinearization {
-    fn from(ctx: &Option<ExplainContext>) -> Self {
+impl From<&ExplainContext> for RequireLinearization {
+    fn from(ctx: &ExplainContext) -> Self {
         match ctx {
-            None => RequireLinearization::Required,
-            Some(..) => RequireLinearization::NotRequired,
+            ExplainContext::None => RequireLinearization::Required,
+            _ => RequireLinearization::NotRequired,
         }
     }
 }


### PR DESCRIPTION
Simplify `coord::sequencer::inner::peek`, `optimize::peek`, and `optimize::copy_to`.

### Motivation

   * This PR refactors existing code.

Simplify various code bits unblocked by the reorganization of the `PeekStage` variant in #24567. More specifically, this PR achieves he following:

1. Fuse the adjacent `PeekStageOptimizeMir` and `PeekStageOptimizeMir` stages into a single stage `PeekStageOptimize` that runs the entire optimizer pipeline for `COPY TO` and `SELECT` statements off-thread.
2. Move timestamp resolution earlier in the `peek` and `copy_to` optimizer pipelines (after `LocalMirPlan` creation). ~In particular, this entails that `prep_relation_expr` and `prep_scalar_expr` need to be called only once~ (reverted the last bit for now because of `*.slt` failures).
3. Fuse the adjacent `LocalMirPlan ⇒ GlobalMirPlan` and `GlobalMirPlan ⇒ GlobalLirPlan` stages in `peek` and `copy_to` into one.
4. I also used the occasion to cherry-pick a refactor from @bkirwi's [`EXPLAIN PUSHDOWN` PR](25028) and another minor which ensures that the only instrumentation of an off-thread closure neede for `EXPLAIN PLAN`-ready now is adding the following line:
    ```rust
    let _dispatch_guard = explain_ctx.dispatch_guard();
    ```  

### Tips for reviewer

- @mjibson - review the `adapter:` commits.
- @teskje - review the `optimize:` commits.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
