### PR TITLE
platform-checks: Increase timeout in peek_persist

### DIFF
--- a/misc/python/materialize/checks/all_checks/peek_persist.py
+++ b/misc/python/materialize/checks/all_checks/peek_persist.py
@@ -28,10 +28,12 @@ class PeekPersist(Check):
             for s in [
                 """
                 > INSERT INTO peek_persist VALUES (NULL), (1), (2), (3);
+                > SET statement_timeout = '60s'
                 > UPDATE peek_persist SET f1 = f1 + 1;
             """,
                 """
                 > INSERT INTO peek_persist VALUES (3), (NULL), (1), (2);
+                > SET statement_timeout = '60s'
                 > DELETE FROM peek_persist WHERE f1 = 4;
             """,
             ]


### PR DESCRIPTION
Seen in migration in https://buildkite.com/materialize/nightlies/builds/6361#018d89fc-ed03-4181-8f76-b7d5075c90f7

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
