### PR TITLE
builds: Enable lld, optimize linking more, faster cargo-test build

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -13,8 +13,9 @@
 # Sync: This target-cpu and list of features should be kept in sync with the ones in ci-builder and
 # xcompile.
 rustflags = [
-    "-C",
-    "link-arg=-Wl,--compress-debug-sections=zlib-gabi",
+    "-Clink-arg=-Wl,--compress-debug-sections=zlib",
+    "-Clink-arg=-Wl,-O2",
+    "-Clink-arg=-fuse-ld=lld",
     "-Csymbol-mangling-version=v0",
     "-Ctarget-cpu=x86-64-v3",
     "-Ctarget-feature=+aes",
@@ -31,8 +32,9 @@ rustflags = [
 # xcompile.
 [target."aarch64-unknown-linux-gnu"]
 rustflags = [
-    "-C",
-    "link-arg=-Wl,--compress-debug-sections=zlib-gabi",
+    "-Clink-arg=-Wl,--compress-debug-sections=zlib",
+    "-Clink-arg=-Wl,-O2",
+    "-Clink-arg=-fuse-ld=lld",
     "-Csymbol-mangling-version=v0",
     "-Ctarget-cpu=neoverse-n1",
     "-Ctarget-feature=+aes,+sha2",
@@ -43,3 +45,7 @@ rustflags = [
 # Always reserve at least one core so Cargo doesn't pin our CPU
 jobs = -1
 rustflags = ["--cfg=tokio_unstable"]
+
+[profile.ci]
+inherits = "dev"
+debug = "line-tables-only"

--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -122,6 +122,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     "build",
                     "--bin",
                     "clusterd",
+                    "--profile=ci",
                 ],
                 env=env,
             )
@@ -138,6 +139,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     "nextest",
                     "run",
                     "--profile=ci",
+                    "--cargo-profile=ci",
                     f"--partition=count:{partition}/{total}",
                     # Most tests don't use 100% of a CPU core, so run two tests per CPU.
                     # TODO(def-): Reenable when #19931 is fixed

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -195,6 +195,7 @@ steps:
         artifact_paths: [junit_*.xml, target/nextest/ci/junit_cargo-test.xml]
         inputs:
           - Cargo.lock
+          - ".config/nextest.toml"
           - "**/Cargo.toml"
           - "**/*.rs"
           - "**/*.proto"

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -16,6 +16,7 @@ you'll need a working C and C++ toolchain. You'll also need to install:
 * The [CMake] build system
 * libclang
 * PostgreSQL
+* lld (on Linux, or set a custom `RUSTFLAGS`)
 
 On macOS, if you install [Homebrew], you'll be guided through the process of
 installing Apple's developer tools, which includes a C compiler and libclang.
@@ -29,7 +30,7 @@ On Debian-based Linux variants, it's even easier:
 
 ```shell
 sudo apt update
-sudo apt install build-essential cmake postgresql-client libclang-dev
+sudo apt install build-essential cmake postgresql-client libclang-dev lld
 ```
 
 On other platforms, you'll have to figure out how to get these tools yourself.


### PR DESCRIPTION
Seems to be ~10% faster for cargo-test.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
