### PR TITLE
platform-checks: No shadow catalog in persit-txn restart tests

### DIFF
--- a/misc/python/materialize/checks/scenarios_persist_txn.py
+++ b/misc/python/materialize/checks/scenarios_persist_txn.py
@@ -19,30 +19,37 @@ class PersistTxnToggle(Scenario):
     def actions(self) -> list[Action]:
         return [
             StartMz(
-                self, additional_system_parameter_defaults={"persist_txn_tables": "off"}
+                self,
+                additional_system_parameter_defaults={"persist_txn_tables": "off"},
+                catalog_store="persist",
             ),
             Initialize(self),
             KillMz(capture_logs=True),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"persist_txn_tables": "eager"},
+                catalog_store="persist",
             ),
             Manipulate(self, phase=1),
             KillMz(capture_logs=True),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"persist_txn_tables": "lazy"},
+                catalog_store="persist",
             ),
             Manipulate(self, phase=2),
             KillMz(capture_logs=True),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"persist_txn_tables": "eager"},
+                catalog_store="persist",
             ),
             Validate(self),
             KillMz(capture_logs=True),
             StartMz(
-                self, additional_system_parameter_defaults={"persist_txn_tables": "off"}
+                self,
+                additional_system_parameter_defaults={"persist_txn_tables": "off"},
+                catalog_store="persist",
             ),
             Validate(self),
         ]
@@ -60,12 +67,14 @@ class PersistTxnFencing(Scenario):
                 self,
                 additional_system_parameter_defaults={"persist_txn_tables": "off"},
                 mz_service="mz_txn_tables_off",
+                catalog_store="persist",
             ),
             Manipulate(self, phase=1, mz_service="mz_txn_tables_off"),
             StartMz(
                 self,
                 additional_system_parameter_defaults={"persist_txn_tables": "eager"},
                 mz_service="mz_txn_tables_eager",
+                catalog_store="persist",
             ),
             Manipulate(self, phase=2, mz_service="mz_txn_tables_eager"),
             Validate(self, mz_service="mz_txn_tables_eager"),
@@ -73,6 +82,7 @@ class PersistTxnFencing(Scenario):
                 self,
                 additional_system_parameter_defaults={"persist_txn_tables": "lazy"},
                 mz_service="mz_txn_tables_lazy",
+                catalog_store="persist",
             ),
             Validate(self, mz_service="mz_txn_tables_lazy"),
             # Since we are creating Mz instances with a non-default name,


### PR DESCRIPTION
Fixes: #25112

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
