### PR TITLE
Add readiness query to blue/green docs.

### DIFF
--- a/doc/user/content/manage/blue-green.md
+++ b/doc/user/content/manage/blue-green.md
@@ -125,7 +125,7 @@ it is safe to cut over. The following example checks for the presence of pending
         EXCEPT
         SELECT id FROM ready_dataflows
     )
-  SELECT * FROM pending_dataflows
+    SELECT * FROM pending_dataflows
     ```
 
 3. Use the `SWAP` operation to atomically rename your objects in a way that is


### PR DESCRIPTION
- Added cluster ready query check to blue/green workflow docs. From: https://github.com/MaterializeInc/materialize/blob/0bae996f82cb89eca7aa6b8addb71c33dd972f2b/test/cluster/blue-green-deployment/setup.td#L69C1-L101C34
- Preview: https://preview.materialize.com/materialize/25121/manage/blue-green/



### Tips for reviewer
- Should we provide an example with macros?
- Should we add a source/sink check as well? See: https://materializeinc.slack.com/archives/C05SLRXKNGN/p1706780532813009?thread_ts=1706729350.801729&cid=C05SLRXKNGN

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
