### PR TITLE
catalog: Clean up boot_ts usage in open

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -615,7 +615,7 @@ impl Catalog {
             stash_config,
         ));
         let storage = openable_storage
-            .open_read_only(now(), &test_bootstrap_args())
+            .open_read_only(&test_bootstrap_args())
             .await?;
         Self::open_debug_catalog_inner(storage, now, environment_id).await
     }
@@ -637,7 +637,7 @@ impl Catalog {
             .await,
         );
         let storage = openable_storage
-            .open_read_only(now(), &test_bootstrap_args())
+            .open_read_only(&test_bootstrap_args())
             .await?;
         Self::open_debug_catalog_inner(storage, now, Some(environment_id)).await
     }
@@ -661,7 +661,7 @@ impl Catalog {
             .await,
         );
         let storage = openable_storage
-            .open_read_only(now(), &test_bootstrap_args())
+            .open_read_only(&test_bootstrap_args())
             .await?;
         Self::open_debug_catalog_inner(storage, now, Some(environment_id)).await
     }

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -101,9 +101,11 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// Will return an error in the following scenarios:
     ///   - Catalog initialization fails.
     ///   - Catalog migrations fail.
+    ///
+    /// `initial_ts` is used as the initial timestamp for new environments.
     async fn open_savepoint(
         mut self: Box<Self>,
-        boot_ts: EpochMillis,
+        initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
         epoch_lower_bound: Option<Epoch>,
@@ -116,7 +118,6 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// it will fail to open in read only mode.
     async fn open_read_only(
         mut self: Box<Self>,
-        boot_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError>;
 
@@ -124,11 +125,12 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// catalog, if it has not been initialized, and perform any migrations
     /// needed.
     ///
+    /// `initial_ts` is used as the initial timestamp for new environments.
     /// `epoch_lower_bound` is used as a lower bound for the epoch that is used by the returned
     /// catalog.
     async fn open(
         mut self: Box<Self>,
-        boot_ts: EpochMillis,
+        initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
         epoch_lower_bound: Option<Epoch>,

--- a/src/catalog/src/durable/impls/persist/tests.rs
+++ b/src/catalog/src/durable/impls/persist/tests.rs
@@ -99,7 +99,7 @@ async fn test_upgrade_shard() {
     .await
     .expect("failed to create persist catalog");
     let _persist_state = Box::new(persist_openable_state)
-        .open_read_only(NOW_ZERO(), &test_bootstrap_args())
+        .open_read_only(&test_bootstrap_args())
         .await
         .expect("failed to open readonly persist catalog");
 

--- a/src/catalog/src/durable/impls/shadow.rs
+++ b/src/catalog/src/durable/impls/shadow.rs
@@ -80,19 +80,19 @@ where
 {
     async fn open_savepoint(
         self: Box<Self>,
-        boot_ts: EpochMillis,
+        initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
         epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         let stash = self.stash.open_savepoint(
-            boot_ts.clone(),
+            initial_ts.clone(),
             bootstrap_args,
             deploy_generation.clone(),
             epoch_lower_bound,
         );
         let persist = self.persist.open_savepoint(
-            boot_ts,
+            initial_ts,
             bootstrap_args,
             deploy_generation,
             epoch_lower_bound,
@@ -110,11 +110,10 @@ where
 
     async fn open_read_only(
         self: Box<Self>,
-        boot_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
-        let stash = self.stash.open_read_only(boot_ts.clone(), bootstrap_args);
-        let persist = self.persist.open_read_only(boot_ts, bootstrap_args);
+        let stash = self.stash.open_read_only(bootstrap_args);
+        let persist = self.persist.open_read_only(bootstrap_args);
         let (stash, persist) = futures::future::join(stash, persist).await;
         soft_assert_eq_or_log!(
             stash.is_ok(),
@@ -128,19 +127,19 @@ where
 
     async fn open(
         self: Box<Self>,
-        boot_ts: EpochMillis,
+        initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
         epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         let stash = self.stash.open(
-            boot_ts.clone(),
+            initial_ts.clone(),
             bootstrap_args,
             deploy_generation.clone(),
             epoch_lower_bound,
         );
         let persist = self.persist.open(
-            boot_ts,
+            initial_ts,
             bootstrap_args,
             deploy_generation,
             epoch_lower_bound,

--- a/src/catalog/src/durable/impls/stash.rs
+++ b/src/catalog/src/durable/impls/stash.rs
@@ -207,38 +207,37 @@ impl OpenableDurableCatalogState for OpenableConnection {
     #[tracing::instrument(name = "storage::open_check", level = "info", skip_all)]
     async fn open_savepoint(
         mut self: Box<Self>,
-        boot_ts: EpochMillis,
+        initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
         epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         self.open_stash_savepoint(epoch_lower_bound).await?;
         let stash = self.stash.take().expect("opened above");
-        retry_open(stash, boot_ts, bootstrap_args, deploy_generation).await
+        retry_open(stash, initial_ts, bootstrap_args, deploy_generation).await
     }
 
     #[tracing::instrument(name = "storage::open_read_only", level = "info", skip_all)]
     async fn open_read_only(
         mut self: Box<Self>,
-        boot_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         self.open_stash_read_only().await?;
         let stash = self.stash.take().expect("opened above");
-        retry_open(stash, boot_ts, bootstrap_args, None).await
+        retry_open(stash, EpochMillis::MIN, bootstrap_args, None).await
     }
 
     #[tracing::instrument(name = "storage::open", level = "info", skip_all)]
     async fn open(
         mut self: Box<Self>,
-        boot_ts: EpochMillis,
+        initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
         epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         self.open_stash(epoch_lower_bound).await?;
         let stash = self.stash.take().expect("opened above");
-        retry_open(stash, boot_ts, bootstrap_args, deploy_generation).await
+        retry_open(stash, initial_ts, bootstrap_args, deploy_generation).await
     }
 
     #[tracing::instrument(name = "storage::open_debug", level = "info", skip_all)]
@@ -451,7 +450,7 @@ impl OpenableDurableCatalogState for OpenableConnection {
 /// If the inner stash has not been opened.
 async fn retry_open(
     mut stash: Stash,
-    boot_ts: EpochMillis,
+    initial_ts: EpochMillis,
     bootstrap_args: &BootstrapArgs,
     deploy_generation: Option<u64>,
 ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
@@ -462,7 +461,7 @@ async fn retry_open(
     let mut retry = pin::pin!(retry);
 
     loop {
-        match open_inner(stash, boot_ts.clone(), bootstrap_args, deploy_generation).await {
+        match open_inner(stash, initial_ts.clone(), bootstrap_args, deploy_generation).await {
             Ok(conn) => {
                 return Ok(conn);
             }
@@ -480,7 +479,7 @@ async fn retry_open(
 #[tracing::instrument(name = "storage::open_inner", level = "info", skip_all)]
 async fn open_inner(
     mut stash: Stash,
-    boot_ts: EpochMillis,
+    initial_ts: EpochMillis,
     bootstrap_args: &BootstrapArgs,
     deploy_generation: Option<u64>,
 ) -> Result<Box<Connection>, (Stash, CatalogError)> {
@@ -499,7 +498,7 @@ async fn open_inner(
             Ok(txn) => txn,
             Err(e) => return Err((conn.stash, e)),
         };
-        match initialize::initialize(&mut tx, &args, boot_ts, deploy_generation).await {
+        match initialize::initialize(&mut tx, &args, initial_ts, deploy_generation).await {
             Ok(()) => {}
             Err(e) => return Err((conn.stash, e)),
         }
@@ -1313,14 +1312,14 @@ impl TestOpenableConnection<'_> {
 impl OpenableDurableCatalogState for TestOpenableConnection<'_> {
     async fn open_savepoint(
         mut self: Box<Self>,
-        boot_ts: EpochMillis,
+        initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
         epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         self.openable_connection
             .open_savepoint(
-                boot_ts,
+                initial_ts,
                 bootstrap_args,
                 deploy_generation,
                 epoch_lower_bound,
@@ -1330,24 +1329,23 @@ impl OpenableDurableCatalogState for TestOpenableConnection<'_> {
 
     async fn open_read_only(
         mut self: Box<Self>,
-        boot_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         self.openable_connection
-            .open_read_only(boot_ts, bootstrap_args)
+            .open_read_only(bootstrap_args)
             .await
     }
 
     async fn open(
         mut self: Box<Self>,
-        boot_ts: EpochMillis,
+        initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
         epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         self.openable_connection
             .open(
-                boot_ts,
+                initial_ts,
                 bootstrap_args,
                 deploy_generation,
                 epoch_lower_bound,

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -87,14 +87,14 @@ const DEFAULT_ALLOCATOR_ID: u64 = 1;
 pub async fn initialize(
     tx: &mut Transaction<'_>,
     options: &BootstrapArgs,
-    now: EpochMillis,
+    initial_ts: EpochMillis,
     deploy_generation: Option<u64>,
 ) -> Result<(), CatalogError> {
     // Collect audit events so we can commit them once at the very end.
     let mut audit_events = vec![];
 
     // First thing we need to do is persist the timestamp we're booting with.
-    tx.insert_timestamp(Timeline::EpochMilliseconds, now.into())?;
+    tx.insert_timestamp(Timeline::EpochMilliseconds, initial_ts.into())?;
 
     for (name, next_id) in [
         (USER_ID_ALLOC_KEY.to_string(), DEFAULT_ALLOCATOR_ID),
@@ -597,7 +597,7 @@ pub async fn initialize(
             object_type,
             details,
             user: None,
-            occurred_at: now,
+            occurred_at: initial_ts,
         }));
     }
 

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -361,7 +361,7 @@ async fn test_open_read_only(
 ) {
     // Can't open a read-only catalog until it's been initialized.
     let err = Box::new(openable_state1)
-        .open_read_only(SYSTEM_TIME(), &test_bootstrap_args())
+        .open_read_only(&test_bootstrap_args())
         .await
         .unwrap_err();
     match err {
@@ -377,7 +377,7 @@ async fn test_open_read_only(
     assert_eq!(state.epoch(), Epoch::new(2).expect("known to be non-zero"));
 
     let mut read_only_state = Box::new(openable_state3)
-        .open_read_only(SYSTEM_TIME(), &test_bootstrap_args())
+        .open_read_only(&test_bootstrap_args())
         .await
         .unwrap();
     // Read-only catalogs do not increment the epoch.


### PR DESCRIPTION
This commit renames the `boot_ts` parameter of the open family of method in `OpenableDurableCatalogState` to `initial_ts`. `initial_ts` is more accurate because the timestamp is only used to initialize the catalog if it's a new environment. Additionally, `boot_ts` is used in other places and is linearized against the timestamp oracle. In the open family of methods, `boot_ts` wasn't linearized, so the name may have mistakenly led people to people that this `boot_ts` was also linearized.

Additionally, `initial_ts` is removed as a parameter from `open_readonly`, because `open_readonly` cannot initialize a new environment, so it doesn't make sense to require a `initial_ts`.

### Motivation
This PR refactors existing code.


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
