### PR TITLE
test: Change default catalog to persist

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -52,7 +52,7 @@ SERVICES = [
         propagate_crashes=False,
         external_cockroach=True,
         # Kills make the shadow catalog not work properly
-        catalog_store="stash",
+        catalog_store="persist",
     ),
     Redpanda(),
     Toxiproxy(),

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -217,7 +217,7 @@ def create_mz_service(
         external_cockroach=True,
         external_minio=True,
         sanity_restart=False,
-        catalog_store="stash",
+        catalog_store="persist",
     )
 
 

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -71,7 +71,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     complexity = Complexity(args.complexity)
 
     if scenario in (Scenario.Kill, Scenario.BackupRestore, Scenario.TogglePersistTxn):
-        catalog_store = "stash"
+        catalog_store = "persist"
         sanity_restart = False
     else:
         catalog_store = "shadow"

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -94,7 +94,7 @@ SERVICES = [
         external_minio=True,
         sanity_restart=False,
         volumes_extra=["secrets:/share/secrets"],
-        catalog_store="stash",
+        catalog_store="persist",
     ),
     TestdriveService(
         default_timeout=TESTDRIVE_DEFAULT_TIMEOUT,

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -63,7 +63,7 @@ SERVICES = [
     Materialized(
         image="materialize/materialized:latest",
         sanity_restart=False,
-        catalog_store="stash",
+        catalog_store="persist",
     ),
     Postgres(),
     Balancerd(),

--- a/test/upgrade-matrix/mzcompose.py
+++ b/test/upgrade-matrix/mzcompose.py
@@ -61,7 +61,7 @@ SERVICES = [
     Debezium(redpanda=True),
     Minio(setup_materialize=True),
     Materialized(
-        external_minio=True, catalog_store="stash"
+        external_minio=True, catalog_store="persist"
     ),  # Overriden inside Platform Checks
     TestdriveService(
         default_timeout="300s",


### PR DESCRIPTION
There are some tests that cannot use the shadow catalog for various
reasons. Previously, those tests defaulted to using the stash catalog,
because that is the catalog used in production. We are actively working
on switching the stash catalog to the persist catalog in production,
and we're not changing the stash catalog at all. Therefore, we'd prefer
to test the persist catalog over the stash catalog.

Works towards resolving #24218

### Motivation
Update tests

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
