### PR TITLE
persist: patch in arrow2 iterative next impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,8 +123,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4c5b03335bc1cb0fd9f5297f8fd3bbfd6fb04f3cb0bc7d6c91b7128cb8336a"
+source = "git+https://github.com/MaterializeInc/arrow2.git?branch=parquet_binary_next_iter#61e271a3f70bc993f8b7854b73e8fee099803d1c"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,9 @@ openssh = { git = "https://github.com/MaterializeInc/openssh.git" }
 reqwest-middleware = { git = "https://github.com/MaterializeInc/reqwest-middleware.git" }
 reqwest-retry = { git = "https://github.com/MaterializeInc/reqwest-middleware.git" }
 
+# To pick up https://github.com/MaterializeInc/arrow2/commit/61e271a3f70bc993f8b7854b73e8fee099803d1c
+arrow2 = { git = "https://github.com/MaterializeInc/arrow2.git", branch = "parquet_binary_next_iter" }
+
 [patch."https://github.com/frankmcsherry/columnation"]
 # Projects that do not reliably release to crates.io.
 columnation = { git = "https://github.com/MaterializeInc/columnation.git" }


### PR DESCRIPTION
There is a cap of 128 frames in our jemalloc profiling, so switching this impl from recursive to iterative _greatly_ increases the usefulness of PolarSignals memory profiles for looking at where parquet allocations are coming from.

Example (not directly comparable):
- [before](https://pprof.me/39589b07486ad05625193a74ed8a2a02)
- [after](https://pprof.me/314438fae57a108439222bbfc23254eb)

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
