### PR TITLE
ci: Bump timeouts

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -395,7 +395,7 @@ steps:
       - id: fivetran-destination-tests
         label: Fivetran Destination tests
         depends_on: build-aarch64
-        timeout_in_minutes: 10
+        timeout_in_minutes: 30
         inputs: [test/fivetran-destination]
         artifact_paths: junit_*.xml
         plugins:
@@ -591,7 +591,7 @@ steps:
   - id: metabase-demo
     label: Metabase smoke test
     depends_on: build-aarch64
-    timeout_in_minutes: 10
+    timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -603,7 +603,7 @@ steps:
   - id: dbt-materialize
     label: dbt-materialize tests
     depends_on: build-aarch64
-    timeout_in_minutes: 20
+    timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -625,7 +625,7 @@ steps:
   - id: tracing
     label: "Tracing Fast Path"
     depends_on: build-aarch64
-    timeout_in_minutes: 10
+    timeout_in_minutes: 30
     inputs: [test/tracing]
     artifact_paths: junit_*.xml
     plugins:

--- a/misc/python/materialize/checks/all_checks/error.py
+++ b/misc/python/materialize/checks/all_checks/error.py
@@ -97,8 +97,18 @@ class DataflowErrorRetraction(Check):
         return [
             Testdrive(s)
             for s in [
-                "> DELETE FROM dataflow_error_retraction_table WHERE f1 = 'abc'",
-                "> DELETE FROM dataflow_error_retraction_table WHERE f1 = 'klm'",
+                dedent(
+                    """
+                > SET statement_timeout = '60s'
+                > DELETE FROM dataflow_error_retraction_table WHERE f1 = 'abc'
+                """
+                ),
+                dedent(
+                    """
+                > SET statement_timeout = '60s'
+                > DELETE FROM dataflow_error_retraction_table WHERE f1 = 'klm'
+                """
+                ),
             ]
         ]
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/tests/builds/75317, docker seems to be slower at fetching today

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
