### PR TITLE
catalog-debug: Remove hard coded replica sizes

### DIFF
--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -405,7 +405,8 @@ async fn upgrade_check(
         .open_savepoint(
             now(),
             &BootstrapArgs {
-                default_cluster_replica_size: "1".into(),
+                default_cluster_replica_size:
+                    "DEFAULT CLUSTER REPLICA SIZE IS ONLY USED FOR NEW ENVIRONMENTS".into(),
                 bootstrap_role: None,
             },
             None,
@@ -417,6 +418,15 @@ async fn upgrade_check(
     // debugging/testing/inspecting.
     let previous_ts = now().into();
 
+    // If this upgrade has new builtin replicas, then we need to assign some size to it. It doesn't
+    // really matter what size since it's not persisted, so we pick a random valid one.
+    let builtin_cluster_replica_size = cluster_replica_sizes
+        .0
+        .first_key_value()
+        .expect("we must have at least a single valid replica size")
+        .0
+        .clone();
+
     let (_catalog, _, _, last_catalog_version) = Catalog::initialize_state(
         StateConfig {
             unsafe_mode: true,
@@ -426,7 +436,7 @@ async fn upgrade_check(
             now,
             skip_migrations: false,
             cluster_replica_sizes,
-            builtin_cluster_replica_size: "1".into(),
+            builtin_cluster_replica_size,
             system_parameter_defaults: Default::default(),
             remote_system_parameters: None,
             availability_zones: vec![],


### PR DESCRIPTION
Previously, the catalog-debug tool would hard-code replica sizes of `1` in multiple places for the upgrade checker. This isn't always valid because the size `1` is not valid for all environments (really for any prod environments). This commit removes these hard coded values and replaces them with more sensible values.

`default_cluster_replica_size` is only used for initializing new environments. Specifically it is used for the size of the `quickstart` cluster. The upgrade checker should never be used in non-existent environments. So this commit replaces the size with the string "DEFAULT CLUSTER REPLICA SIZE IS ONLY USED FOR NEW ENVIRONMENTS", so that we'll get a meaningful error message if the value is ever used in the upgrade checker.

`builtin_cluster_replica_size` is used as the size for new builtin replicas, which is a valid scenario for an upgrade. This commit replaces the size with some random valid size, so it doesn't fail. The actual size doesn't matter because it's never persisted.

### Motivation
This PR fixes a previously unreported bug.

### Tips for reviewer
For context, see: https://materializeinc.slack.com/archives/CTESPM7FU/p1707497185646239.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
