### PR TITLE
catalog-debug: Add ignore cmnd line args to dump

### DIFF
--- a/src/catalog/src/durable/debug.rs
+++ b/src/catalog/src/durable/debug.rs
@@ -61,7 +61,7 @@ pub trait Collection: Debug {
 ///
 /// The names of each variant are used to determine the labels of each [`CollectionTrace`] when
 /// dumping a [`Trace`].
-#[derive(Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CollectionType {
     AuditLog,


### PR DESCRIPTION
This commit adds the --ignore and --ignore-large-collections command line arguments to the dump command in the catalog debug tool. Often times when debugging, the user only cares about a handful of collections, and the other collections can be annoying noise. The --ignore flag allows the user to specify collections to ignore. The --ignore-large-collections flag is a convenience flag to ignore both audit_log and storage_usage, which are both extremely large and usually not helpful.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
