### PR TITLE
storage/mysql: Allow SSL MODE verify_identity with SSH and Privatelink tunnels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "mysql_async"
 version = "0.33.0"
-source = "git+https://github.com/MaterializeInc/mysql_async.git?rev=ecc4908e7c98ce1050fc536739c41ec444d03349#ecc4908e7c98ce1050fc536739c41ec444d03349"
+source = "git+https://github.com/MaterializeInc/mysql_async.git?rev=5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc#5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc"
 dependencies = [
  "bytes",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,8 +172,9 @@ postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres" }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
 
-# Waiting on https://github.com/blackbeam/mysql_async/pull/288
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "ecc4908e7c98ce1050fc536739c41ec444d03349" }
+# Waiting on https://github.com/blackbeam/mysql_async/pull/288 and
+# https://github.com/blackbeam/mysql_async/pull/289
+mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc" }
 
 # Waiting on https://github.com/MaterializeInc/serde-value/pull/35.
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }

--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -425,21 +425,6 @@ impl ConnectionOptionExtracted {
                 }
                 let tunnel = scx.build_tunnel_definition(self.ssh_tunnel, self.aws_privatelink)?;
 
-                // TODO: Implement proper host verification when using an SSH or PrivateLink tunnel. This
-                // requires a way to modify the TLS configuration created within mysql_async.
-                if matches!(
-                    (&tls_mode, &tunnel),
-                    (
-                        &MySqlSslMode::VerifyIdentity,
-                        &Tunnel::Ssh(_) | &Tunnel::AwsPrivatelink(_)
-                    )
-                ) {
-                    sql_bail!(
-                        "invalid CONNECTION: VERIFY_IDENTITY SSL MODE is not currently \
-                        supported with SSH TUNNEL or AWS PRIVATELINK"
-                    );
-                }
-
                 Connection::MySql(MySqlConnection {
                     password: self.password.map(|password| password.into()),
                     host: self

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -66,7 +66,7 @@ log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.8", features = ["net", "os-ext"] }
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "ecc4908e7c98ce1050fc536739c41ec444d03349", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
+mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
 mysql_common = { version = "0.31.0", default-features = false, features = ["binlog"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
@@ -181,7 +181,7 @@ log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.8", features = ["net", "os-ext"] }
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "ecc4908e7c98ce1050fc536739c41ec444d03349", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
+mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
 mysql_common = { version = "0.31.0", default-features = false, features = ["binlog"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }

--- a/test/ssh-connection/mysql-source-ssl.td
+++ b/test/ssh-connection/mysql-source-ssl.td
@@ -1,0 +1,58 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test creating a MySQL source using SSH and SSL options
+# More comprehensive SSL option tests are in
+# `test/mysql-cdc/15-create-connection-tls.td`
+
+> CREATE SECRET ssl_ca AS '${arg.ssl-ca}'
+> CREATE SECRET ssl_client_cert AS '${arg.ssl-client-cert}'
+> CREATE SECRET ssl_client_key AS '${arg.ssl-client-key}'
+
+# Basic TLS
+> CREATE CONNECTION mysql_ssl TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass,
+    SSH TUNNEL thancred,
+    SSL MODE required
+  );
+> DROP CONNECTION mysql_ssl;
+
+# TLS with CA verification and a client cert
+> CREATE CONNECTION mysql_ssl TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass,
+    SSL MODE verify_ca,
+    SSL CERTIFICATE AUTHORITY SECRET ssl_ca,
+    SSL CERTIFICATE SECRET ssl_client_cert,
+    SSL KEY SECRET ssl_client_key
+  );
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS tls_schema;
+CREATE DATABASE tls_schema;
+USE tls_schema;
+CREATE TABLE tls_data (f1 INTEGER);
+INSERT INTO tls_data VALUES (1), (2);
+COMMIT;
+
+> CREATE SOURCE mysql_source_ssl FROM MYSQL
+  CONNECTION mysql_ssl
+  FOR TABLES (tls_schema.tls_data);
+
+> SELECT COUNT(*) FROM tls_data;
+2
+
+# TODO: Figure out how to test the Verify_Identity SSL Mode with the auto-generated certs
+# created by MySQL. They use an odd CN value in the CA cert:
+# https://dev.mysql.com/doc/refman/8.3/en/creating-ssl-rsa-files-using-mysql.html#creating-ssl-rsa-files-using-mysql-ssl-and-rsa-file-characteristics

--- a/test/ssh-connection/mzcompose.py
+++ b/test/ssh-connection/mzcompose.py
@@ -160,13 +160,30 @@ def workflow_mysql(c: Composition) -> None:
         "mysql-source-after-ssh-restart.td",
     )
 
-    # TODO(roshan): Enable this when TLS/SSL options for MySQL are supported
+    # MySQL generates self-signed certificates for SSL connections on startup,
+    # for both the server and client:
+    # https://dev.mysql.com/doc/refman/8.3/en/creating-ssl-rsa-files-using-mysql.html
+    # Grab the correct Server CA and Client Key and Cert from the MySQL container
+    # (and strip the trailing null byte):
+    ssl_ca = c.exec("mysql", "cat", "/var/lib/mysql/ca.pem", capture=True).stdout.split(
+        "\x00", 1
+    )[0]
+    ssl_client_cert = c.exec(
+        "mysql", "cat", "/var/lib/mysql/client-cert.pem", capture=True
+    ).stdout.split("\x00", 1)[0]
+    ssl_client_key = c.exec(
+        "mysql", "cat", "/var/lib/mysql/client-key.pem", capture=True
+    ).stdout.split("\x00", 1)[0]
+
     # Validate SSL/TLS connections over SSH tunnel
-    # c.run_testdrive_files(
-    #     "--no-reset",
-    #     f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
-    #     "mysql-source-ssl.td",
-    # )
+    c.run_testdrive_files(
+        "--no-reset",
+        f"--var=ssl-ca={ssl_ca}",
+        f"--var=ssl-client-cert={ssl_client_cert}",
+        f"--var=ssl-client-key={ssl_client_key}",
+        f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
+        "mysql-source-ssl.td",
+    )
 
 
 def workflow_kafka(c: Composition, redpanda: bool = False) -> None:


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/25048

This is now possible since I made the corresponding change to our fork of `mysql-async` - the upstream PR is here: https://github.com/blackbeam/mysql_async/pull/289

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I did add tests to validate SSL when using an SSH tunnel, but I still couldn't get the verify_identity test to work with the auto-generated mysql certs. At some point I'll probably switch to generating the certs ourselves and then make that test to work.



<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
