### PR TITLE
fivetran-destination: Order columns in describe, handle no-op alter tables

### DIFF
--- a/src/fivetran-destination/src/destination/ddl.rs
+++ b/src/fivetran-destination/src/destination/ddl.rs
@@ -7,14 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeMap;
+
 use mz_pgrepr::Type;
 use mz_sql_parser::ast::{Ident, UnresolvedItemName};
 use postgres_protocol::escape;
+use tokio_postgres::Client;
 
 use crate::destination::{config, FIVETRAN_SYSTEM_COLUMN_DELETE};
 use crate::error::{Context, OpError, OpErrorKind};
 use crate::fivetran_sdk::{
-    AlterTableRequest, Column, CreateTableRequest, DataType, DescribeTableRequest, Table,
+    AlterTableRequest, Column, CreateTableRequest, DataType, DecimalParams, DescribeTableRequest,
+    Table,
 };
 use crate::utils;
 
@@ -25,7 +29,15 @@ pub async fn handle_describe_table(
     request: DescribeTableRequest,
 ) -> Result<Option<Table>, OpError> {
     let (dbname, client) = config::connect(request.configuration).await?;
+    describe_table(&client, &dbname, &request.schema_name, &request.table_name).await
+}
 
+pub async fn describe_table(
+    client: &Client,
+    database: &str,
+    schema: &str,
+    table: &str,
+) -> Result<Option<Table>, OpError> {
     let table_id = {
         let rows = client
             .query(
@@ -35,7 +47,7 @@ pub async fn handle_describe_table(
                    JOIN mz_databases d ON d.id = s.database_id
                    WHERE d.name = $1 AND s.name = $2 AND t.name = $3
                 "#,
-                &[&dbname, &request.schema_name, &request.table_name],
+                &[&database, &schema, &table],
             )
             .await
             .context("fetching table ID")?;
@@ -61,7 +73,8 @@ pub async fn handle_describe_table(
                FROM mz_columns AS cols
                LEFT JOIN mz_internal.mz_comments AS coms
                ON cols.id = coms.id AND cols.position = coms.object_sub_id
-               WHERE cols.id = $2"#;
+               WHERE cols.id = $2
+               ORDER BY cols.position ASC"#;
 
         let rows = client
             .query(stmt, &[&PRIMARY_KEY_MAGIC_STRING, &table_id])
@@ -90,7 +103,7 @@ pub async fn handle_describe_table(
     };
 
     Ok(Some(Table {
-        name: request.table_name,
+        name: table.to_string(),
         columns,
     }))
 }
@@ -166,8 +179,64 @@ pub async fn handle_create_table(request: CreateTableRequest) -> Result<(), OpEr
     Ok(())
 }
 
-#[allow(clippy::unused_async)]
-pub async fn handle_alter_table(req: AlterTableRequest) -> Result<(), OpError> {
-    let error = format!("alter_table: {req:?}");
-    Err(OpErrorKind::Unsupported(error).into())
+pub async fn handle_alter_table(request: AlterTableRequest) -> Result<(), OpError> {
+    let (dbname, client) = config::connect(request.configuration).await?;
+
+    // Bail early if there isn't a table to alter.
+    let Some(request_table) = request.table else {
+        return Ok(());
+    };
+
+    let current_table = describe_table(&client, &dbname, &request.schema_name, &request_table.name)
+        .await
+        .context("alter table")?;
+    let Some(current_table) = current_table else {
+        return Err(OpErrorKind::UnknownTable {
+            database: dbname,
+            schema: request.schema_name,
+            table: request_table.name,
+        }
+        .into());
+    };
+
+    if columns_match(&request_table, &current_table) {
+        Ok(())
+    } else {
+        let error = format!("alter_table: {:?}", request_table);
+        Err(OpErrorKind::Unsupported(error).into())
+    }
+}
+
+// TODO(parkmycar): Implement some more complex diffing logic.
+fn columns_match(request: &Table, current: &Table) -> bool {
+    #[derive(Clone, Debug)]
+    struct ColumnMetadata {
+        ty: DataType,
+        primary_key: bool,
+        decimal: Option<DecimalParams>,
+    }
+
+    impl PartialEq<ColumnMetadata> for ColumnMetadata {
+        fn eq(&self, other: &ColumnMetadata) -> bool {
+            self.ty == other.ty
+                && self.primary_key == other.primary_key
+                && self.decimal.is_some() == other.decimal.is_some()
+        }
+    }
+
+    let map_columns = |col: &Column| {
+        let metadata = ColumnMetadata {
+            ty: col.r#type(),
+            primary_key: col.primary_key,
+            decimal: col.decimal.clone(),
+        };
+        (col.name.clone(), metadata)
+    };
+
+    // Sort the columns by name, and check if they're equal. Eventually we'll have some more
+    // complex logic here.
+    let request_cols: BTreeMap<_, _> = request.columns.iter().map(map_columns).collect();
+    let current_cols: BTreeMap<_, _> = current.columns.iter().map(map_columns).collect();
+
+    request_cols == current_cols
 }

--- a/src/fivetran-destination/src/destination/ddl.rs
+++ b/src/fivetran-destination/src/destination/ddl.rs
@@ -202,7 +202,10 @@ pub async fn handle_alter_table(request: AlterTableRequest) -> Result<(), OpErro
     if columns_match(&request_table, &current_table) {
         Ok(())
     } else {
-        let error = format!("alter_table: {:?}", request_table);
+        let error = format!(
+            "alter_table, request: {:?}, current: {:?}",
+            request_table, current_table
+        );
         Err(OpErrorKind::Unsupported(error).into())
     }
 }

--- a/src/fivetran-destination/src/destination/ddl.rs
+++ b/src/fivetran-destination/src/destination/ddl.rs
@@ -220,6 +220,7 @@ fn columns_match(request: &Table, current: &Table) -> bool {
         fn eq(&self, other: &ColumnMetadata) -> bool {
             self.ty == other.ty
                 && self.primary_key == other.primary_key
+                // TODO(parkmycar): Better comparison for decimals.
                 && self.decimal.is_some() == other.decimal.is_some()
         }
     }

--- a/src/fivetran-destination/src/error.rs
+++ b/src/fivetran-destination/src/error.rs
@@ -78,6 +78,12 @@ pub enum OpErrorKind {
     Unsupported(String),
     #[error("invalid identifier: {0:?}")]
     IdentError(#[from] mz_sql_parser::ast::IdentError),
+    #[error("unknown table: {database}.{schema}.{table}")]
+    UnknownTable {
+        database: String,
+        schema: String,
+        table: String,
+    },
     #[error("unknown request: {0}")]
     UnknownRequest(String),
 }
@@ -138,6 +144,7 @@ impl OpErrorKind {
             | Crypto(_)
             | Unsupported(_)
             | IdentError(_)
+            | UnknownTable { .. }
             | UnknownRequest(_) => false,
         }
     }

--- a/test/fivetran-destination/test-alter-table-no-op/00-README
+++ b/test/fivetran-destination/test-alter-table-no-op/00-README
@@ -1,0 +1,1 @@
+Tests that alter table returns success, if it's a no-op.

--- a/test/fivetran-destination/test-alter-table-no-op/01-in_order.json
+++ b/test/fivetran-destination/test-alter-table-no-op/01-in_order.json
@@ -1,0 +1,26 @@
+{
+    "create_table": {
+        "test_alter_table_in_order": {
+            "columns": {
+                "k": "STRING",
+                "v1": "INT",
+                "v2": "STRING"
+            },
+            "primary_keys": [
+                "k"
+            ]
+        }
+    },
+    "alter_table": {
+        "test_alter_table_in_order": {
+            "columns": {
+                "k": "STRING",
+                "v1": "INT",
+                "v2": "STRING"
+            },
+            "primary_keys": [
+                "k"
+            ]
+        }
+    }
+}

--- a/test/fivetran-destination/test-alter-table-no-op/02-out_of_order.json
+++ b/test/fivetran-destination/test-alter-table-no-op/02-out_of_order.json
@@ -1,0 +1,26 @@
+{
+    "create_table": {
+        "test_alter_table_out_of_order": {
+            "columns": {
+                "k": "STRING",
+                "v1": "INT",
+                "v2": "STRING"
+            },
+            "primary_keys": [
+                "k"
+            ]
+        }
+    },
+    "alter_table": {
+        "test_alter_table_out_of_order": {
+            "columns": {
+                "v1": "INT",
+                "k": "STRING",
+                "v2": "STRING"
+            },
+            "primary_keys": [
+                "k"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This PR changes `DescribeTableRequest`s to make sure the list of columns we return is in the order that they exist on the table itself. It also adds no-op support to `AlterTableRequest`.

### Motivation

When testing we found that Fivetran would send us `AlterTableRequest`s that appear to be a no-op. They're only supposed to send us an `AlterTableRequest` if the table returned from a `DescribeTableRequest` doesn't match their expected state. Our current describe table API doesn't sort the columns, and in at least one example returned a different ordering than what was provided in the `AlterTableRequest`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
