### PR TITLE
sql: Fix float parsing of zero

### DIFF
--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -265,8 +265,9 @@ where
     // If fast_float returns zero and the input was not an explicitly-specified
     // zero, then we know underflow occurred.
 
-    // Matches `0`, `-0`, `+0`, `000000.00000`, `0.0e10`, et al.
-    static ZERO_RE: Lazy<Regex> = Lazy::new(|| Regex::new("(?i-u)^[-+]?0+(\\.0+)?(e|$)").unwrap());
+    // Matches `0`, `-0`, `+0`, `000000.00000`, `0.0e10`, 0., .0, et al.
+    static ZERO_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r#"(?i-u)^[-+]?(0+(\.0*)?|\.0+)(e|$)"#).unwrap());
     // Matches `inf`, `-inf`, `+inf`, `infinity`, et al.
     static INF_RE: Lazy<Regex> = Lazy::new(|| Regex::new("(?i-u)^[-+]?inf").unwrap());
 

--- a/test/sqllogictest/float.slt
+++ b/test/sqllogictest/float.slt
@@ -42,7 +42,7 @@ SELECT '.0'::float::text
 query T
 SELECT '-.0'::float::text
 ----
-0
+-0
 
 query T
 SELECT '+.0'::float::text
@@ -57,7 +57,7 @@ SELECT '+0.'::float::text
 query T
 SELECT '-0.'::float::text
 ----
-0
+-0
 
 query error invalid input syntax
 SELECT '++0'::float::text

--- a/test/sqllogictest/float.slt
+++ b/test/sqllogictest/float.slt
@@ -14,6 +14,31 @@ SELECT '-0'::float::text
 ----
 -0
 
+query T
+SELECT '+0'::float::text
+----
+0
+
+query T
+SELECT '000000.00000'::float::text
+----
+0
+
+query T
+SELECT '0.0e10'::float::text
+----
+0
+
+query T
+SELECT '0.'::float::text
+----
+0
+
+query T
+SELECT '.0'::float::text
+----
+0
+
 query TTTTT
 SELECT 'Inf'::float::text, 'Infinity'::float::text, 'inFinIty'::float::text, '+inf'::float::text, '+infinity'::float::text
 ----
@@ -106,3 +131,12 @@ query T
 SELECT MIN(f1+f2)-SUM(f1) FROM t1
 ----
 20282409603651670423947251286016.000
+
+query error invalid input syntax
+SELECT ''::float::text
+
+query error invalid input syntax
+SELECT 'e'::float::text
+
+query error invalid input syntax
+SELECT 'e10'::float::text

--- a/test/sqllogictest/float.slt
+++ b/test/sqllogictest/float.slt
@@ -39,6 +39,32 @@ SELECT '.0'::float::text
 ----
 0
 
+query T
+SELECT '-.0'::float::text
+----
+0
+
+query T
+SELECT '+.0'::float::text
+----
+0
+
+query T
+SELECT '+0.'::float::text
+----
+0
+
+query T
+SELECT '-0.'::float::text
+----
+0
+
+query error invalid input syntax
+SELECT '++0'::float::text
+
+query error invalid input syntax
+SELECT '--0'::float::text
+
 query TTTTT
 SELECT 'Inf'::float::text, 'Infinity'::float::text, 'inFinIty'::float::text, '+inf'::float::text, '+infinity'::float::text
 ----


### PR DESCRIPTION
This commit fixes float parsing of zero so that `0.` and `.0` are valid.

Fixes #22748

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix float parsing of certain zero values such as `0.` and `.0`.
