### PR TITLE
ci: Bump redpanda versions

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/redpanda.py
+++ b/misc/python/materialize/cloudtest/k8s/redpanda.py
@@ -31,7 +31,7 @@ class RedpandaDeployment(K8sDeployment):
         super().__init__(namespace)
         container = V1Container(
             name="redpanda",
-            image="vectorized/redpanda:v23.1.9",
+            image="vectorized/redpanda:v23.3.5",
             command=[
                 "/usr/bin/rpk",
                 "redpanda",

--- a/misc/python/materialize/mzcompose/services/redpanda.py
+++ b/misc/python/materialize/mzcompose/services/redpanda.py
@@ -18,7 +18,7 @@ class Redpanda(Service):
     def __init__(
         self,
         name: str = "redpanda",
-        version: str = "v23.1.9",
+        version: str = "v23.3.5",
         auto_create_topics: bool = False,
         image: str | None = None,
         aliases: list[str] | None = None,

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -16,7 +16,7 @@ from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
 
-REDPANDA_VERSIONS = ["v22.3.25", "v23.1.21", "v23.2.23", "v23.3.3"]
+REDPANDA_VERSIONS = ["v22.3.25", "v23.1.21", "v23.2.25", "v23.3.5"]
 
 CONFLUENT_PLATFORM_VERSIONS = [
     "6.2.14",


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
