### PR TITLE
adapter: general framework for off thread coordinator stages and spans

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -256,7 +256,7 @@ pub enum Message<T = mz_repr::Timestamp> {
     },
     CreateMaterializedViewStageReady {
         ctx: ExecuteContext,
-        otel_ctx: OpenTelemetryContext,
+        span: Span,
         stage: CreateMaterializedViewStage,
     },
     SubscribeStageReady {
@@ -608,30 +608,9 @@ pub struct ExplainPlanContext {
 
 #[derive(Debug)]
 pub enum CreateMaterializedViewStage {
-    Validate(CreateMaterializedViewValidate),
     Optimize(CreateMaterializedViewOptimize),
     Finish(CreateMaterializedViewFinish),
     Explain(CreateMaterializedViewExplain),
-}
-
-impl CreateMaterializedViewStage {
-    fn validity(&mut self) -> Option<&mut PlanValidity> {
-        match self {
-            Self::Validate(_) => None,
-            Self::Optimize(stage) => Some(&mut stage.validity),
-            Self::Finish(stage) => Some(&mut stage.validity),
-            Self::Explain(stage) => Some(&mut stage.validity),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct CreateMaterializedViewValidate {
-    plan: plan::CreateMaterializedViewPlan,
-    resolved_ids: ResolvedIds,
-    /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
-    explain_ctx: ExplainContext,
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -779,6 +779,7 @@ pub(crate) enum StageResult<T> {
 }
 
 /// Common functionality for [Coordinator::sequence_staged].
+#[async_trait::async_trait(?Send)]
 pub(crate) trait Staged: Send {
     fn validity(&mut self) -> &mut PlanValidity;
 

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -181,11 +181,10 @@ impl Coordinator {
                 }
                 Message::SubscribeStageReady {
                     ctx,
-                    otel_ctx,
+                    span,
                     stage,
                 } => {
-                    otel_ctx.attach_as_parent();
-                    self.sequence_subscribe_stage(ctx, stage, otel_ctx).await;
+                    self.sequence_staged(ctx, span, stage).await;
                 }
                 Message::DrainStatementLog => {
                     self.drain_statement_log().await;

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -158,11 +158,10 @@ impl Coordinator {
                 }
                 Message::CreateIndexStageReady {
                     ctx,
-                    otel_ctx,
+                    span,
                     stage,
                 } => {
-                    otel_ctx.attach_as_parent();
-                    self.execute_create_index_stage(ctx, stage, otel_ctx).await;
+                    self.sequence_staged(ctx, span, stage).await;
                 }
                 Message::CreateViewStageReady {
                     ctx,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -166,11 +166,10 @@ impl Coordinator {
                 }
                 Message::CreateViewStageReady {
                     ctx,
-                    otel_ctx,
+                    span,
                     stage,
                 } => {
-                    otel_ctx.attach_as_parent();
-                    self.sequence_create_view_stage(ctx, stage, otel_ctx).await;
+                    self.sequence_staged(ctx, span, stage).await;
                 }
                 Message::CreateMaterializedViewStageReady {
                     ctx,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -172,12 +172,10 @@ impl Coordinator {
                 }
                 Message::CreateMaterializedViewStageReady {
                     ctx,
-                    otel_ctx,
+                    span,
                     stage,
                 } => {
-                    otel_ctx.attach_as_parent();
-                    self.execute_create_materialized_view_stage(ctx, stage, otel_ctx)
-                        .await;
+                    self.sequence_staged(ctx, span, stage).await;
                 }
                 Message::SubscribeStageReady {
                     ctx,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -142,7 +142,7 @@ impl Coordinator {
     ) {
         return_if_err!(stage.validity().check(self.catalog()), ctx);
         let next = stage
-            .stage(self, ctx.session_mut())
+            .stage(self, &mut ctx)
             .instrument(parent_span.clone())
             .await;
         let stage = return_if_err!(next, ctx);

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -23,6 +23,7 @@ use mz_cloud_resources::VpcEndpointConfig;
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_expr::{CollectionPlan, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_ore::collections::{CollectionExt, HashSet};
+use mz_ore::task::spawn;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::vec::VecExt;
 use mz_ore::{soft_assert_or_log, task};
@@ -72,7 +73,7 @@ use mz_transform::notice::{OptimizerNoticeApi, OptimizerNoticeKind, RawOptimizer
 use mz_transform::EmptyStatisticsOracle;
 use timely::progress::Antichain;
 use tokio::sync::{oneshot, OwnedMutexGuard};
-use tracing::{instrument, warn, Span};
+use tracing::{instrument, warn, Instrument, Span};
 
 use crate::catalog::{self, Catalog, ConnCatalog, UpdatePrivilegeVariant};
 use crate::command::{ExecuteResponse, Response};
@@ -82,7 +83,7 @@ use crate::coord::timestamp_selection::{TimestampDetermination, TimestampSource}
 use crate::coord::{
     AlterConnectionValidationReady, Coordinator, CreateConnectionValidationReady, ExecuteContext,
     Message, PendingRead, PendingReadTxn, PendingTxn, PendingTxnResponse, PlanValidity,
-    RealTimeRecencyContext, TargetCluster,
+    RealTimeRecencyContext, StageResult, Staged, TargetCluster,
 };
 use crate::error::AdapterError;
 use crate::explain::explain_dataflow;
@@ -129,6 +130,45 @@ struct CreateSourceInner {
 }
 
 impl Coordinator {
+    /// Sequences the next staged of a [Staged] plan. This is designed for use with plans that
+    /// execute both on and off of the coordinator thread. Stages can either produce another stage
+    /// to execute or a final response. An explicit [Span] is passed to allow for convenient
+    /// tracing.
+    pub(crate) async fn sequence_staged<S: Staged + 'static>(
+        &mut self,
+        ctx: ExecuteContext,
+        parent_span: Span,
+        mut stage: S,
+    ) {
+        return_if_err!(stage.validity().check(self.catalog()), ctx);
+        let next = stage
+            .stage(self, ctx.session())
+            .instrument(parent_span.clone())
+            .await;
+        let stage = return_if_err!(next, ctx);
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
+        match stage {
+            StageResult::Handle(handle) => {
+                spawn(|| "sequence_staged", async move {
+                    let next = match handle.await {
+                        Ok(next) => return_if_err!(next, ctx),
+                        Err(err) => {
+                            tracing::error!("sequence_staged join error {err}");
+                            ctx.retire(Err(AdapterError::Internal(
+                                "sequence_staged join error".into(),
+                            )));
+                            return;
+                        }
+                    };
+                    let _ = internal_cmd_tx.send(next.message(ctx, parent_span));
+                });
+            }
+            StageResult::Response(resp) => {
+                ctx.retire(Ok(resp));
+            }
+        }
+    }
+
     async fn create_source_inner(
         &mut self,
         session: &Session,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -136,13 +136,13 @@ impl Coordinator {
     /// tracing.
     pub(crate) async fn sequence_staged<S: Staged + 'static>(
         &mut self,
-        ctx: ExecuteContext,
+        mut ctx: ExecuteContext,
         parent_span: Span,
         mut stage: S,
     ) {
         return_if_err!(stage.validity().check(self.catalog()), ctx);
         let next = stage
-            .stage(self, ctx.session())
+            .stage(self, ctx.session_mut())
             .instrument(parent_span.clone())
             .await;
         let stage = return_if_err!(next, ctx);

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -30,6 +30,7 @@ use crate::optimize::{self, Optimize, OverrideFrom};
 use crate::session::Session;
 use crate::{catalog, AdapterNotice, ExecuteContext, TimestampProvider};
 
+#[async_trait::async_trait(?Send)]
 impl Staged for CreateIndexStage {
     fn validity(&mut self) -> &mut PlanValidity {
         match self {

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -42,12 +42,14 @@ impl Staged for CreateIndexStage {
     async fn stage(
         self,
         coord: &mut Coordinator,
-        session: &mut Session,
+        ctx: &mut ExecuteContext,
     ) -> Result<StageResult<Box<Self>>, AdapterError> {
         match self {
             CreateIndexStage::Optimize(stage) => coord.create_index_optimize(stage).await,
-            CreateIndexStage::Finish(stage) => coord.create_index_finish(session, stage).await,
-            CreateIndexStage::Explain(stage) => coord.create_index_explain(session, stage),
+            CreateIndexStage::Finish(stage) => {
+                coord.create_index_finish(ctx.session_mut(), stage).await
+            }
+            CreateIndexStage::Explain(stage) => coord.create_index_explain(ctx.session(), stage),
         }
     }
 

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -11,18 +11,17 @@ use std::collections::BTreeSet;
 
 use maplit::btreemap;
 use mz_catalog::memory::objects::{CatalogItem, Index};
-use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan;
-use tracing::instrument;
+use tracing::{instrument, Span};
 
 use crate::command::ExecuteResponse;
 use crate::coord::sequencer::inner::return_if_err;
 use crate::coord::{
     Coordinator, CreateIndexExplain, CreateIndexFinish, CreateIndexOptimize, CreateIndexStage,
-    CreateIndexValidate, ExplainContext, ExplainPlanContext, Message, PlanValidity,
+    ExplainContext, ExplainPlanContext, Message, PlanValidity, StageResult, Staged,
 };
 use crate::error::AdapterError;
 use crate::explain::optimizer_trace::OptimizerTrace;
@@ -30,6 +29,36 @@ use crate::optimize::dataflows::dataflow_import_id_bundle;
 use crate::optimize::{self, Optimize, OverrideFrom};
 use crate::session::Session;
 use crate::{catalog, AdapterNotice, ExecuteContext, TimestampProvider};
+
+impl Staged for CreateIndexStage {
+    fn validity(&mut self) -> &mut PlanValidity {
+        match self {
+            Self::Optimize(stage) => &mut stage.validity,
+            Self::Finish(stage) => &mut stage.validity,
+            Self::Explain(stage) => &mut stage.validity,
+        }
+    }
+
+    async fn stage(
+        self,
+        coord: &mut Coordinator,
+        session: &mut Session,
+    ) -> Result<StageResult<Box<Self>>, AdapterError> {
+        match self {
+            CreateIndexStage::Optimize(stage) => coord.create_index_optimize(stage).await,
+            CreateIndexStage::Finish(stage) => coord.create_index_finish(session, stage).await,
+            CreateIndexStage::Explain(stage) => coord.create_index_explain(session, stage),
+        }
+    }
+
+    fn message(self, ctx: ExecuteContext, span: Span) -> Message {
+        Message::CreateIndexStageReady {
+            ctx,
+            span,
+            stage: self,
+        }
+    }
+}
 
 impl Coordinator {
     #[instrument(skip_all)]
@@ -39,16 +68,11 @@ impl Coordinator {
         plan: plan::CreateIndexPlan,
         resolved_ids: ResolvedIds,
     ) {
-        self.execute_create_index_stage(
-            ctx,
-            CreateIndexStage::Validate(CreateIndexValidate {
-                plan,
-                resolved_ids,
-                explain_ctx: ExplainContext::None,
-            }),
-            OpenTelemetryContext::obtain(),
-        )
-        .await;
+        let stage = return_if_err!(
+            self.create_index_validate(ctx.session(), plan, resolved_ids, ExplainContext::None),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
     }
 
     #[instrument(skip_all)]
@@ -80,27 +104,23 @@ impl Coordinator {
         // Not used in the EXPLAIN path so it's OK to generate a dummy value.
         let resolved_ids = ResolvedIds(Default::default());
 
-        self.execute_create_index_stage(
-            ctx,
-            CreateIndexStage::Validate(CreateIndexValidate {
-                plan,
-                resolved_ids,
-                explain_ctx: ExplainContext::Plan(ExplainPlanContext {
-                    broken,
-                    config,
-                    format,
-                    stage,
-                    replan: None,
-                    desc: None,
-                    optimizer_trace,
-                }),
-            }),
-            OpenTelemetryContext::obtain(),
-        )
-        .await;
+        let explain_ctx = ExplainContext::Plan(ExplainPlanContext {
+            broken,
+            config,
+            format,
+            stage,
+            replan: None,
+            desc: None,
+            optimizer_trace,
+        });
+        let stage = return_if_err!(
+            self.create_index_validate(ctx.session(), plan, resolved_ids, explain_ctx),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(crate) async fn explain_replan_index(
         &mut self,
         ctx: ExecuteContext,
@@ -134,78 +154,32 @@ impl Coordinator {
         // executing the optimizer pipeline.
         let optimizer_trace = OptimizerTrace::new(broken, stage.path());
 
-        self.execute_create_index_stage(
-            ctx,
-            CreateIndexStage::Validate(CreateIndexValidate {
-                plan,
-                resolved_ids,
-                explain_ctx: ExplainContext::Plan(ExplainPlanContext {
-                    broken,
-                    config,
-                    format,
-                    stage,
-                    replan: Some(id),
-                    desc: None,
-                    optimizer_trace,
-                }),
-            }),
-            OpenTelemetryContext::obtain(),
-        )
-        .await;
+        let explain_ctx = ExplainContext::Plan(ExplainPlanContext {
+            broken,
+            config,
+            format,
+            stage,
+            replan: Some(id),
+            desc: None,
+            optimizer_trace,
+        });
+        let stage = return_if_err!(
+            self.create_index_validate(ctx.session(), plan, resolved_ids, explain_ctx),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
     }
 
-    /// Processes as many `create index` stages as possible.
-    #[instrument(skip_all)]
-    pub(crate) async fn execute_create_index_stage(
-        &mut self,
-        mut ctx: ExecuteContext,
-        mut stage: CreateIndexStage,
-        otel_ctx: OpenTelemetryContext,
-    ) {
-        use CreateIndexStage::*;
-
-        // Process the current stage and allow for processing the next.
-        loop {
-            // Always verify plan validity. This is cheap, and prevents programming errors
-            // if we move any stages off thread.
-            if let Some(validity) = stage.validity() {
-                return_if_err!(validity.check(self.catalog()), ctx);
-            }
-
-            (ctx, stage) = match stage {
-                Validate(stage) => {
-                    let next =
-                        return_if_err!(self.create_index_validate(ctx.session(), stage), ctx);
-                    (ctx, CreateIndexStage::Optimize(next))
-                }
-                Optimize(stage) => {
-                    self.create_index_optimize(ctx, stage, otel_ctx).await;
-                    return;
-                }
-                Finish(stage) => {
-                    let result = self.create_index_finish(&mut ctx, stage).await;
-                    ctx.retire(result);
-                    return;
-                }
-                Explain(stage) => {
-                    let result = self.create_index_explain(&mut ctx, stage);
-                    ctx.retire(result);
-                    return;
-                }
-            }
-        }
-    }
-
+    // `explain_ctx` is an optional context set iff the state machine is initiated from
+    // sequencing an EXPALIN for this statement.
     #[instrument(skip_all)]
     fn create_index_validate(
         &mut self,
         session: &Session,
-        CreateIndexValidate {
-            plan,
-            resolved_ids,
-            explain_ctx,
-        }: CreateIndexValidate,
-    ) -> Result<CreateIndexOptimize, AdapterError> {
+        plan: plan::CreateIndexPlan,
+        resolved_ids: ResolvedIds,
+        explain_ctx: ExplainContext,
+    ) -> Result<CreateIndexStage, AdapterError> {
         let plan::CreateIndexPlan {
             index: plan::Index { on, cluster_id, .. },
             ..
@@ -219,43 +193,37 @@ impl Coordinator {
             role_metadata: session.role_metadata().clone(),
         };
 
-        Ok(CreateIndexOptimize {
+        Ok(CreateIndexStage::Optimize(CreateIndexOptimize {
             validity,
             plan,
             resolved_ids,
             explain_ctx,
-        })
+        }))
     }
 
     #[instrument(skip_all)]
     async fn create_index_optimize(
         &mut self,
-        ctx: ExecuteContext,
         CreateIndexOptimize {
             validity,
             plan,
             resolved_ids,
             explain_ctx,
         }: CreateIndexOptimize,
-        otel_ctx: OpenTelemetryContext,
-    ) {
+    ) -> Result<StageResult<Box<CreateIndexStage>>, AdapterError> {
         let plan::CreateIndexPlan {
             index: plan::Index { cluster_id, .. },
             ..
         } = &plan;
-
-        // Generate data structures that can be moved to another task where we will perform possibly
-        // expensive optimizations.
-        let internal_cmd_tx = self.internal_cmd_tx.clone();
 
         // Collect optimizer parameters.
         let compute_instance = self
             .instance_snapshot(*cluster_id)
             .expect("compute instance does not exist");
         let exported_index_id = if let ExplainContext::None = explain_ctx {
-            return_if_err!(self.catalog_mut().allocate_user_id().await, ctx)
+            self.catalog_mut().allocate_user_id().await?
         } else {
-            return_if_err!(self.allocate_transient_id(), ctx)
+            self.allocate_transient_id()?
         };
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
             .override_from(&explain_ctx);
@@ -267,11 +235,12 @@ impl Coordinator {
             exported_index_id,
             optimizer_config,
         );
-
-        mz_ore::task::spawn_blocking(
+        let span = Span::current();
+        Ok(StageResult::Handle(mz_ore::task::spawn_blocking(
             || "optimize create index",
             move || {
-                let mut pipeline = || -> Result<(
+                span.in_scope(|| {
+                    let mut pipeline = || -> Result<(
                     optimize::index::GlobalMirPlan,
                     optimize::index::GlobalLirPlan,
                 ), AdapterError> {
@@ -288,70 +257,64 @@ impl Coordinator {
                     Ok((global_mir_plan, global_lir_plan))
                 };
 
-                let stage = match pipeline() {
-                    Ok((global_mir_plan, global_lir_plan)) => {
-                        if let ExplainContext::Plan(explain_ctx) = explain_ctx {
-                            let (_, df_meta) = global_lir_plan.unapply();
-                            CreateIndexStage::Explain(CreateIndexExplain {
-                                validity,
-                                exported_index_id,
-                                plan,
-                                df_meta,
-                                explain_ctx,
-                            })
-                        } else {
-                            CreateIndexStage::Finish(CreateIndexFinish {
-                                validity,
-                                exported_index_id,
-                                plan,
-                                resolved_ids,
-                                global_mir_plan,
-                                global_lir_plan,
-                            })
+                    let stage = match pipeline() {
+                        Ok((global_mir_plan, global_lir_plan)) => {
+                            if let ExplainContext::Plan(explain_ctx) = explain_ctx {
+                                let (_, df_meta) = global_lir_plan.unapply();
+                                CreateIndexStage::Explain(CreateIndexExplain {
+                                    validity,
+                                    exported_index_id,
+                                    plan,
+                                    df_meta,
+                                    explain_ctx,
+                                })
+                            } else {
+                                CreateIndexStage::Finish(CreateIndexFinish {
+                                    validity,
+                                    exported_index_id,
+                                    plan,
+                                    resolved_ids,
+                                    global_mir_plan,
+                                    global_lir_plan,
+                                })
+                            }
                         }
-                    }
-                    // Internal optimizer errors are handled differently
-                    // depending on the caller.
-                    Err(err) => {
-                        let ExplainContext::Plan(explain_ctx) = explain_ctx else {
-                            // In `sequence_~` contexts, immediately retire the
-                            // execution with the error.
-                            return ctx.retire(Err(err.into()));
-                        };
+                        // Internal optimizer errors are handled differently
+                        // depending on the caller.
+                        Err(err) => {
+                            let ExplainContext::Plan(explain_ctx) = explain_ctx else {
+                                // In `sequence_~` contexts, immediately error.
+                                return Err(err.into());
+                            };
 
-                        if explain_ctx.broken {
-                            // In `EXPLAIN BROKEN` contexts, just log the error
-                            // and move to the next stage with default
-                            // parameters.
-                            tracing::error!("error while handling EXPLAIN statement: {}", err);
-                            CreateIndexStage::Explain(CreateIndexExplain {
-                                validity,
-                                exported_index_id,
-                                plan,
-                                df_meta: Default::default(),
-                                explain_ctx,
-                            })
-                        } else {
-                            // In regular `EXPLAIN` contexts, immediately retire
-                            // the execution with the error.
-                            return ctx.retire(Err(err.into()));
+                            if explain_ctx.broken {
+                                // In `EXPLAIN BROKEN` contexts, just log the error
+                                // and move to the next stage with default
+                                // parameters.
+                                tracing::error!("error while handling EXPLAIN statement: {}", err);
+                                CreateIndexStage::Explain(CreateIndexExplain {
+                                    validity,
+                                    exported_index_id,
+                                    plan,
+                                    df_meta: Default::default(),
+                                    explain_ctx,
+                                })
+                            } else {
+                                // In regular `EXPLAIN` contexts, immediately error.
+                                return Err(err.into());
+                            }
                         }
-                    }
-                };
-
-                let _ = internal_cmd_tx.send(Message::CreateIndexStageReady {
-                    ctx,
-                    otel_ctx,
-                    stage,
-                });
+                    };
+                    Ok(Box::new(stage))
+                })
             },
-        );
+        )))
     }
 
     #[instrument(skip_all)]
     async fn create_index_finish(
         &mut self,
-        ctx: &mut ExecuteContext,
+        session: &mut Session,
         CreateIndexFinish {
             exported_index_id,
             plan:
@@ -372,7 +335,7 @@ impl Coordinator {
             global_lir_plan,
             ..
         }: CreateIndexFinish,
-    ) -> Result<ExecuteResponse, AdapterError> {
+    ) -> Result<StageResult<Box<CreateIndexStage>>, AdapterError> {
         let ops = vec![catalog::Op::CreateItem {
             id: exported_index_id,
             oid: self.catalog_mut().allocate_oid()?,
@@ -396,7 +359,7 @@ impl Coordinator {
             .collect::<Result<Vec<_>, _>>()?;
 
         let transact_result = self
-            .catalog_transact_with_side_effects(Some(ctx.session()), ops, |coord| async {
+            .catalog_transact_with_side_effects(Some(session), ops, |coord| async {
                 // Save plan structures.
                 coord
                     .catalog_mut()
@@ -413,7 +376,7 @@ impl Coordinator {
                 df_desc.set_as_of(since);
 
                 // Emit notices.
-                coord.emit_optimizer_notices(ctx.session(), &df_meta.optimizer_notices);
+                coord.emit_optimizer_notices(session, &df_meta.optimizer_notices);
 
                 // Return a metainfo with rendered notices.
                 let df_meta =
@@ -457,17 +420,16 @@ impl Coordinator {
             .await;
 
         match transact_result {
-            Ok(_) => Ok(ExecuteResponse::CreatedIndex),
+            Ok(_) => Ok(StageResult::Response(ExecuteResponse::CreatedIndex)),
             Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
                 kind:
                     mz_catalog::memory::error::ErrorKind::Sql(CatalogError::ItemAlreadyExists(_, _)),
             })) if if_not_exists => {
-                ctx.session()
-                    .add_notice(AdapterNotice::ObjectAlreadyExists {
-                        name: name.item,
-                        ty: "index",
-                    });
-                Ok(ExecuteResponse::CreatedIndex)
+                session.add_notice(AdapterNotice::ObjectAlreadyExists {
+                    name: name.item,
+                    ty: "index",
+                });
+                Ok(StageResult::Response(ExecuteResponse::CreatedIndex))
             }
             Err(err) => Err(err),
         }
@@ -476,7 +438,7 @@ impl Coordinator {
     #[instrument(skip_all)]
     fn create_index_explain(
         &mut self,
-        ctx: &mut ExecuteContext,
+        session: &Session,
         CreateIndexExplain {
             exported_index_id,
             plan: plan::CreateIndexPlan { name, index, .. },
@@ -492,8 +454,8 @@ impl Coordinator {
                 },
             ..
         }: CreateIndexExplain,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        let session_catalog = self.catalog().for_session(ctx.session());
+    ) -> Result<StageResult<Box<CreateIndexStage>>, AdapterError> {
+        let session_catalog = self.catalog().for_session(session);
         let expr_humanizer = {
             let on_entry = self.catalog.get_entry(&index.on);
             let full_name = self.catalog.resolve_full_name(&name, on_entry.conn_id());
@@ -525,6 +487,6 @@ impl Coordinator {
             tracing_core::callsite::rebuild_interest_cache();
         }
 
-        Ok(Self::send_immediate_rows(rows))
+        Ok(StageResult::Response(Self::send_immediate_rows(rows)))
     }
 }

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -13,21 +13,20 @@ use mz_adapter_types::compaction::CompactionWindow;
 use mz_catalog::memory::objects::{CatalogItem, MaterializedView};
 use mz_expr::CollectionPlan;
 use mz_ore::soft_panic_or_log;
-use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::{ObjectId, ResolvedIds};
 use mz_sql::plan;
 use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};
 use timely::progress::Antichain;
-use tracing::instrument;
+use tracing::{instrument, Span};
 
 use crate::command::ExecuteResponse;
 use crate::coord::sequencer::inner::return_if_err;
 use crate::coord::{
     Coordinator, CreateMaterializedViewExplain, CreateMaterializedViewFinish,
-    CreateMaterializedViewOptimize, CreateMaterializedViewStage, CreateMaterializedViewValidate,
-    ExplainContext, ExplainPlanContext, Message, PlanValidity,
+    CreateMaterializedViewOptimize, CreateMaterializedViewStage, ExplainContext,
+    ExplainPlanContext, Message, PlanValidity, StageResult, Staged,
 };
 use crate::error::AdapterError;
 use crate::explain::optimizer_trace::OptimizerTrace;
@@ -37,6 +36,44 @@ use crate::session::Session;
 use crate::util::ResultExt;
 use crate::{catalog, AdapterNotice, ExecuteContext, TimestampProvider};
 
+impl Staged for CreateMaterializedViewStage {
+    fn validity(&mut self) -> &mut PlanValidity {
+        match self {
+            Self::Optimize(stage) => &mut stage.validity,
+            Self::Finish(stage) => &mut stage.validity,
+            Self::Explain(stage) => &mut stage.validity,
+        }
+    }
+
+    async fn stage(
+        self,
+        coord: &mut Coordinator,
+        ctx: &mut ExecuteContext,
+    ) -> Result<StageResult<Box<Self>>, AdapterError> {
+        match self {
+            CreateMaterializedViewStage::Optimize(stage) => {
+                coord.create_materialized_view_optimize(stage).await
+            }
+            CreateMaterializedViewStage::Finish(stage) => {
+                coord
+                    .create_materialized_view_finish(ctx.session(), stage)
+                    .await
+            }
+            CreateMaterializedViewStage::Explain(stage) => {
+                coord.create_materialized_view_explain(ctx.session(), stage)
+            }
+        }
+    }
+
+    fn message(self, ctx: ExecuteContext, span: Span) -> Message {
+        Message::CreateMaterializedViewStageReady {
+            ctx,
+            span,
+            stage: self,
+        }
+    }
+}
+
 impl Coordinator {
     #[instrument(skip_all)]
     pub(crate) async fn sequence_create_materialized_view(
@@ -45,16 +82,16 @@ impl Coordinator {
         plan: plan::CreateMaterializedViewPlan,
         resolved_ids: ResolvedIds,
     ) {
-        self.execute_create_materialized_view_stage(
-            ctx,
-            CreateMaterializedViewStage::Validate(CreateMaterializedViewValidate {
+        let stage = return_if_err!(
+            self.create_materialized_view_validate(
+                ctx.session(),
                 plan,
                 resolved_ids,
-                explain_ctx: ExplainContext::None,
-            }),
-            OpenTelemetryContext::obtain(),
-        )
-        .await;
+                ExplainContext::None
+            ),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
     }
 
     #[instrument(skip_all)]
@@ -86,27 +123,23 @@ impl Coordinator {
         // Not used in the EXPLAIN path so it's OK to generate a dummy value.
         let resolved_ids = ResolvedIds(Default::default());
 
-        self.execute_create_materialized_view_stage(
-            ctx,
-            CreateMaterializedViewStage::Validate(CreateMaterializedViewValidate {
-                plan,
-                resolved_ids,
-                explain_ctx: ExplainContext::Plan(ExplainPlanContext {
-                    broken,
-                    config,
-                    format,
-                    stage,
-                    replan: None,
-                    desc: None,
-                    optimizer_trace,
-                }),
-            }),
-            OpenTelemetryContext::obtain(),
-        )
-        .await;
+        let explain_ctx = ExplainContext::Plan(ExplainPlanContext {
+            broken,
+            config,
+            format,
+            stage,
+            replan: None,
+            desc: None,
+            optimizer_trace,
+        });
+        let stage = return_if_err!(
+            self.create_materialized_view_validate(ctx.session(), plan, resolved_ids, explain_ctx,),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[instrument(skip_all)]
     pub(crate) async fn explain_replan_materialized_view(
         &mut self,
         ctx: ExecuteContext,
@@ -140,81 +173,32 @@ impl Coordinator {
         // executing the optimizer pipeline.
         let optimizer_trace = OptimizerTrace::new(broken, stage.path());
 
-        self.execute_create_materialized_view_stage(
-            ctx,
-            CreateMaterializedViewStage::Validate(CreateMaterializedViewValidate {
-                plan,
-                resolved_ids,
-                explain_ctx: ExplainContext::Plan(ExplainPlanContext {
-                    broken,
-                    config,
-                    format,
-                    stage,
-                    replan: Some(id),
-                    desc: None,
-                    optimizer_trace,
-                }),
-            }),
-            OpenTelemetryContext::obtain(),
-        )
-        .await;
-    }
-
-    /// Processes as many `create materialized view` stages as possible.
-    #[instrument(skip_all)]
-    pub(crate) async fn execute_create_materialized_view_stage(
-        &mut self,
-        mut ctx: ExecuteContext,
-        mut stage: CreateMaterializedViewStage,
-        otel_ctx: OpenTelemetryContext,
-    ) {
-        use CreateMaterializedViewStage::*;
-
-        // Process the current stage and allow for processing the next.
-        loop {
-            // Always verify plan validity. This is cheap, and prevents programming errors
-            // if we move any stages off thread.
-            if let Some(validity) = stage.validity() {
-                return_if_err!(validity.check(self.catalog()), ctx);
-            }
-
-            (ctx, stage) = match stage {
-                Validate(stage) => {
-                    let next = return_if_err!(
-                        self.create_materialized_view_validate(ctx.session(), stage),
-                        ctx
-                    );
-                    (ctx, CreateMaterializedViewStage::Optimize(next))
-                }
-                Optimize(stage) => {
-                    self.create_materialized_view_optimize(ctx, stage, otel_ctx)
-                        .await;
-                    return;
-                }
-                Finish(stage) => {
-                    let result = self.create_materialized_view_finish(&mut ctx, stage).await;
-                    ctx.retire(result);
-                    return;
-                }
-                Explain(stage) => {
-                    let result = self.create_materialized_view_explain(&mut ctx, stage);
-                    ctx.retire(result);
-                    return;
-                }
-            }
-        }
+        let explain_ctx = ExplainContext::Plan(ExplainPlanContext {
+            broken,
+            config,
+            format,
+            stage,
+            replan: Some(id),
+            desc: None,
+            optimizer_trace,
+        });
+        let stage = return_if_err!(
+            self.create_materialized_view_validate(ctx.session(), plan, resolved_ids, explain_ctx,),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
     }
 
     #[instrument(skip_all)]
     fn create_materialized_view_validate(
         &mut self,
         session: &Session,
-        CreateMaterializedViewValidate {
-            plan,
-            resolved_ids,
-            explain_ctx,
-        }: CreateMaterializedViewValidate,
-    ) -> Result<CreateMaterializedViewOptimize, AdapterError> {
+        plan: plan::CreateMaterializedViewPlan,
+        resolved_ids: ResolvedIds,
+        // An optional context set iff the state machine is initiated from
+        // sequencing an EXPALIN for this statement.
+        explain_ctx: ExplainContext,
+    ) -> Result<CreateMaterializedViewStage, AdapterError> {
         let plan::CreateMaterializedViewPlan {
             materialized_view:
                 plan::MaterializedView {
@@ -255,26 +239,26 @@ impl Coordinator {
             role_metadata: session.role_metadata().clone(),
         };
 
-        Ok(CreateMaterializedViewOptimize {
-            validity,
-            plan,
-            resolved_ids,
-            explain_ctx,
-        })
+        Ok(CreateMaterializedViewStage::Optimize(
+            CreateMaterializedViewOptimize {
+                validity,
+                plan,
+                resolved_ids,
+                explain_ctx,
+            },
+        ))
     }
 
     #[instrument(skip_all)]
     async fn create_materialized_view_optimize(
         &mut self,
-        ctx: ExecuteContext,
         CreateMaterializedViewOptimize {
             validity,
             plan,
             resolved_ids,
             explain_ctx,
         }: CreateMaterializedViewOptimize,
-        otel_ctx: OpenTelemetryContext,
-    ) {
+    ) -> Result<StageResult<Box<CreateMaterializedViewStage>>, AdapterError> {
         let plan::CreateMaterializedViewPlan {
             name,
             materialized_view:
@@ -288,20 +272,16 @@ impl Coordinator {
             ..
         } = &plan;
 
-        // Generate data structures that can be moved to another task where we will perform possibly
-        // expensive optimizations.
-        let internal_cmd_tx = self.internal_cmd_tx.clone();
-
         // Collect optimizer parameters.
         let compute_instance = self
             .instance_snapshot(*cluster_id)
             .expect("compute instance does not exist");
         let exported_sink_id = if let ExplainContext::None = explain_ctx {
-            return_if_err!(self.catalog_mut().allocate_user_id().await, ctx)
+            self.catalog_mut().allocate_user_id().await?
         } else {
-            return_if_err!(self.allocate_transient_id(), ctx)
+            self.allocate_transient_id()?
         };
-        let internal_view_id = return_if_err!(self.allocate_transient_id(), ctx);
+        let internal_view_id = self.allocate_transient_id()?;
         let debug_name = self.catalog().resolve_full_name(name, None).to_string();
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
             .override_from(&explain_ctx);
@@ -319,10 +299,12 @@ impl Coordinator {
             optimizer_config,
         );
 
-        mz_ore::task::spawn_blocking(
+        let span = Span::current();
+        Ok(StageResult::Handle(mz_ore::task::spawn_blocking(
             || "optimize create materialized view",
             move || {
-                let mut pipeline = || -> Result<(
+                span.in_scope(|| {
+                    let mut pipeline = || -> Result<(
                     optimize::materialized_view::LocalMirPlan,
                     optimize::materialized_view::GlobalMirPlan,
                     optimize::materialized_view::GlobalLirPlan,
@@ -340,71 +322,70 @@ impl Coordinator {
                     Ok((local_mir_plan, global_mir_plan, global_lir_plan))
                 };
 
-                let stage = match pipeline() {
-                    Ok((local_mir_plan, global_mir_plan, global_lir_plan)) => {
-                        if let ExplainContext::Plan(explain_ctx) = explain_ctx {
-                            let (_, df_meta) = global_lir_plan.unapply();
-                            CreateMaterializedViewStage::Explain(CreateMaterializedViewExplain {
-                                validity,
-                                exported_sink_id,
-                                plan,
-                                df_meta,
-                                explain_ctx,
-                            })
-                        } else {
-                            CreateMaterializedViewStage::Finish(CreateMaterializedViewFinish {
-                                validity,
-                                exported_sink_id,
-                                plan,
-                                resolved_ids,
-                                local_mir_plan,
-                                global_mir_plan,
-                                global_lir_plan,
-                            })
+                    let stage = match pipeline() {
+                        Ok((local_mir_plan, global_mir_plan, global_lir_plan)) => {
+                            if let ExplainContext::Plan(explain_ctx) = explain_ctx {
+                                let (_, df_meta) = global_lir_plan.unapply();
+                                CreateMaterializedViewStage::Explain(
+                                    CreateMaterializedViewExplain {
+                                        validity,
+                                        exported_sink_id,
+                                        plan,
+                                        df_meta,
+                                        explain_ctx,
+                                    },
+                                )
+                            } else {
+                                CreateMaterializedViewStage::Finish(CreateMaterializedViewFinish {
+                                    validity,
+                                    exported_sink_id,
+                                    plan,
+                                    resolved_ids,
+                                    local_mir_plan,
+                                    global_mir_plan,
+                                    global_lir_plan,
+                                })
+                            }
                         }
-                    }
-                    // Internal optimizer errors are handled differently
-                    // depending on the caller.
-                    Err(err) => {
-                        let ExplainContext::Plan(explain_ctx) = explain_ctx else {
-                            // In `sequence_~` contexts, immediately retire the
-                            // execution with the error.
-                            return ctx.retire(Err(err.into()));
-                        };
+                        // Internal optimizer errors are handled differently
+                        // depending on the caller.
+                        Err(err) => {
+                            let ExplainContext::Plan(explain_ctx) = explain_ctx else {
+                                // In `sequence_~` contexts, immediately return the error.
+                                return Err(err.into());
+                            };
 
-                        if explain_ctx.broken {
-                            // In `EXPLAIN BROKEN` contexts, just log the error
-                            // and move to the next stage with default
-                            // parameters.
-                            tracing::error!("error while handling EXPLAIN statement: {}", err);
-                            CreateMaterializedViewStage::Explain(CreateMaterializedViewExplain {
-                                validity,
-                                exported_sink_id,
-                                plan,
-                                df_meta: Default::default(),
-                                explain_ctx,
-                            })
-                        } else {
-                            // In regular `EXPLAIN` contexts, immediately retire
-                            // the execution with the error.
-                            return ctx.retire(Err(err.into()));
+                            if explain_ctx.broken {
+                                // In `EXPLAIN BROKEN` contexts, just log the error
+                                // and move to the next stage with default
+                                // parameters.
+                                tracing::error!("error while handling EXPLAIN statement: {}", err);
+                                CreateMaterializedViewStage::Explain(
+                                    CreateMaterializedViewExplain {
+                                        validity,
+                                        exported_sink_id,
+                                        plan,
+                                        df_meta: Default::default(),
+                                        explain_ctx,
+                                    },
+                                )
+                            } else {
+                                // In regular `EXPLAIN` contexts, immediately return the error.
+                                return Err(err.into());
+                            }
                         }
-                    }
-                };
+                    };
 
-                let _ = internal_cmd_tx.send(Message::CreateMaterializedViewStageReady {
-                    ctx,
-                    otel_ctx,
-                    stage,
-                });
+                    Ok(Box::new(stage))
+                })
             },
-        );
+        )))
     }
 
     #[instrument(skip_all)]
     async fn create_materialized_view_finish(
         &mut self,
-        ctx: &mut ExecuteContext,
+        session: &Session,
         CreateMaterializedViewFinish {
             exported_sink_id,
             plan:
@@ -430,7 +411,7 @@ impl Coordinator {
             global_lir_plan,
             ..
         }: CreateMaterializedViewFinish,
-    ) -> Result<ExecuteResponse, AdapterError> {
+    ) -> Result<StageResult<Box<CreateMaterializedViewStage>>, AdapterError> {
         let ops = itertools::chain(
             drop_ids
                 .into_iter()
@@ -450,7 +431,7 @@ impl Coordinator {
                     custom_logical_compaction_window: compaction_window,
                     refresh_schedule: refresh_schedule.clone(),
                 }),
-                owner_id: *ctx.session().current_role_id(),
+                owner_id: *session.current_role_id(),
             }),
         )
         .collect::<Vec<_>>();
@@ -493,7 +474,7 @@ impl Coordinator {
             .collect::<Result<Vec<_>, _>>()?;
 
         let transact_result = self
-            .catalog_transact_with_side_effects(Some(ctx.session()), ops, |coord| async {
+            .catalog_transact_with_side_effects(Some(session), ops, |coord| async {
                 // Save plan structures.
                 coord
                     .catalog_mut()
@@ -512,7 +493,7 @@ impl Coordinator {
                 }
 
                 // Emit notices.
-                coord.emit_optimizer_notices(ctx.session(), &df_meta.optimizer_notices);
+                coord.emit_optimizer_notices(session, &df_meta.optimizer_notices);
 
                 // Return a metainfo with rendered notices.
                 let df_meta =
@@ -581,7 +562,7 @@ impl Coordinator {
                 kind:
                     mz_catalog::memory::error::ErrorKind::Sql(CatalogError::ItemAlreadyExists(_, _)),
             })) if if_not_exists => {
-                ctx.session()
+                session
                     .add_notice(AdapterNotice::ObjectAlreadyExists {
                         name: name.item,
                         ty: "materialized view",
@@ -590,12 +571,13 @@ impl Coordinator {
             }
             Err(err) => Err(err),
         }
+        .map(StageResult::Response)
     }
 
     #[instrument(skip_all)]
     fn create_materialized_view_explain(
         &mut self,
-        ctx: &mut ExecuteContext,
+        session: &Session,
         CreateMaterializedViewExplain {
             exported_sink_id,
             plan:
@@ -616,8 +598,8 @@ impl Coordinator {
                 },
             ..
         }: CreateMaterializedViewExplain,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        let session_catalog = self.catalog().for_session(ctx.session());
+    ) -> Result<StageResult<Box<CreateMaterializedViewStage>>, AdapterError> {
+        let session_catalog = self.catalog().for_session(session);
         let expr_humanizer = {
             let full_name = self.catalog().resolve_full_name(&name, None);
             let transient_items = btreemap! {
@@ -644,6 +626,6 @@ impl Coordinator {
             tracing_core::callsite::rebuild_interest_cache();
         }
 
-        Ok(Self::send_immediate_rows(rows))
+        Ok(StageResult::Response(Self::send_immediate_rows(rows)))
     }
 }

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -36,6 +36,7 @@ use crate::session::Session;
 use crate::util::ResultExt;
 use crate::{catalog, AdapterNotice, ExecuteContext, TimestampProvider};
 
+#[async_trait::async_trait(?Send)]
 impl Staged for CreateMaterializedViewStage {
     fn validity(&mut self) -> &mut PlanValidity {
         match self {

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -37,11 +37,11 @@ impl Staged for CreateViewStage {
     async fn stage(
         self,
         coord: &mut Coordinator,
-        session: &mut Session,
+        ctx: &mut ExecuteContext,
     ) -> Result<StageResult<Box<Self>>, AdapterError> {
         match self {
             CreateViewStage::Optimize(stage) => coord.create_view_optimize(stage).await,
-            CreateViewStage::Finish(stage) => coord.create_view_finish(session, stage).await,
+            CreateViewStage::Finish(stage) => coord.create_view_finish(ctx.session(), stage).await,
         }
     }
 

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -26,6 +26,7 @@ use crate::optimize::{self, Optimize};
 use crate::session::Session;
 use crate::{catalog, AdapterNotice, ExecuteContext};
 
+#[async_trait::async_trait(?Send)]
 impl Staged for CreateViewStage {
     fn validity(&mut self) -> &mut PlanValidity {
         match self {

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -37,7 +37,7 @@ impl Staged for CreateViewStage {
     async fn stage(
         self,
         coord: &mut Coordinator,
-        session: &Session,
+        session: &mut Session,
     ) -> Result<StageResult<Box<Self>>, AdapterError> {
         match self {
             CreateViewStage::Optimize(stage) => coord.create_view_optimize(stage).await,

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -25,6 +25,7 @@ use crate::subscribe::ActiveSubscribe;
 use crate::util::{ComputeSinkId, ResultExt};
 use crate::{optimize, AdapterNotice, ExecuteContext, TimelineContext};
 
+#[async_trait::async_trait(?Send)]
 impl Staged for SubscribeStage {
     fn validity(&mut self) -> &mut PlanValidity {
         match self {

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -7,16 +7,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_ore::tracing::OpenTelemetryContext;
 use mz_sql::plan::{self, QueryWhen};
 use timely::progress::Antichain;
 use tokio::sync::mpsc;
+use tracing::{instrument, Span};
 
 use crate::command::ExecuteResponse;
 use crate::coord::sequencer::inner::{check_log_reads, return_if_err};
 use crate::coord::{
-    Coordinator, Message, PlanValidity, SubscribeFinish, SubscribeOptimizeLir,
-    SubscribeOptimizeMir, SubscribeStage, SubscribeTimestamp, SubscribeValidate, TargetCluster,
+    Coordinator, Message, PlanValidity, StageResult, Staged, SubscribeFinish, SubscribeOptimizeMir,
+    SubscribeStage, SubscribeTimestampOptimizeLir, TargetCluster,
 };
 use crate::error::AdapterError;
 use crate::optimize::Optimize;
@@ -25,78 +25,62 @@ use crate::subscribe::ActiveSubscribe;
 use crate::util::{ComputeSinkId, ResultExt};
 use crate::{optimize, AdapterNotice, ExecuteContext, TimelineContext};
 
-impl Coordinator {
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub(crate) async fn sequence_subscribe(
-        &mut self,
-        ctx: ExecuteContext,
-        plan: plan::SubscribePlan,
-        target_cluster: TargetCluster,
-    ) {
-        self.sequence_subscribe_stage(
-            ctx,
-            SubscribeStage::Validate(SubscribeValidate {
-                plan,
-                target_cluster,
-            }),
-            OpenTelemetryContext::obtain(),
-        )
-        .await;
-    }
-
-    /// Processes as many `subscribe` stages as possible.
-    #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) async fn sequence_subscribe_stage(
-        &mut self,
-        mut ctx: ExecuteContext,
-        mut stage: SubscribeStage,
-        otel_ctx: OpenTelemetryContext,
-    ) {
-        use SubscribeStage::*;
-
-        // Process the current stage and allow for processing the next.
-        loop {
-            // Always verify plan validity. This is cheap, and prevents programming errors
-            // if we move any stages off thread.
-            if let Some(validity) = stage.validity() {
-                return_if_err!(validity.check(self.catalog()), ctx);
-            }
-
-            (ctx, stage) = match stage {
-                Validate(stage) => {
-                    let next =
-                        return_if_err!(self.subscribe_validate(ctx.session_mut(), stage), ctx);
-                    (ctx, SubscribeStage::OptimizeMir(next))
-                }
-                OptimizeMir(stage) => {
-                    self.subscribe_optimize_mir(ctx, stage, otel_ctx);
-                    return;
-                }
-                Timestamp(stage) => {
-                    let next = return_if_err!(self.subscribe_timestamp(&mut ctx, stage).await, ctx);
-                    (ctx, SubscribeStage::OptimizeLir(next))
-                }
-                OptimizeLir(stage) => {
-                    self.subscribe_optimize_lir(ctx, stage, otel_ctx);
-                    return;
-                }
-                Finish(stage) => {
-                    let result = self.subscribe_finish(&mut ctx, stage).await;
-                    ctx.retire(result);
-                    return;
-                }
-            }
+impl Staged for SubscribeStage {
+    fn validity(&mut self) -> &mut PlanValidity {
+        match self {
+            SubscribeStage::OptimizeMir(stage) => &mut stage.validity,
+            SubscribeStage::TimestampOptimizeLir(stage) => &mut stage.validity,
+            SubscribeStage::Finish(stage) => &mut stage.validity,
         }
     }
 
+    async fn stage(
+        self,
+        coord: &mut Coordinator,
+        ctx: &mut ExecuteContext,
+    ) -> Result<StageResult<Box<Self>>, AdapterError> {
+        match self {
+            SubscribeStage::OptimizeMir(stage) => {
+                coord.subscribe_optimize_mir(ctx.session(), stage)
+            }
+            SubscribeStage::TimestampOptimizeLir(stage) => {
+                coord.subscribe_timestamp_optimize_lir(ctx, stage).await
+            }
+            SubscribeStage::Finish(stage) => coord.subscribe_finish(ctx, stage).await,
+        }
+    }
+
+    fn message(self, ctx: ExecuteContext, span: Span) -> Message {
+        Message::SubscribeStageReady {
+            ctx,
+            span,
+            stage: self,
+        }
+    }
+}
+
+impl Coordinator {
+    #[instrument(skip_all)]
+    pub(crate) async fn sequence_subscribe(
+        &mut self,
+        mut ctx: ExecuteContext,
+        plan: plan::SubscribePlan,
+        target_cluster: TargetCluster,
+    ) {
+        let stage = return_if_err!(
+            self.subscribe_validate(ctx.session_mut(), plan, target_cluster),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
+    }
+
+    #[instrument(skip_all)]
     fn subscribe_validate(
         &mut self,
         session: &mut Session,
-        SubscribeValidate {
-            plan,
-            target_cluster,
-        }: SubscribeValidate,
-    ) -> Result<SubscribeOptimizeMir, AdapterError> {
+        plan: plan::SubscribePlan,
+        target_cluster: TargetCluster,
+    ) -> Result<SubscribeStage, AdapterError> {
         let plan::SubscribePlan { from, when, .. } = &plan;
 
         let cluster = self
@@ -153,50 +137,39 @@ impl Coordinator {
             role_metadata: session.role_metadata().clone(),
         };
 
-        Ok(SubscribeOptimizeMir {
+        Ok(SubscribeStage::OptimizeMir(SubscribeOptimizeMir {
             validity,
             plan,
             timeline,
-        })
+        }))
     }
 
+    #[instrument(skip_all)]
     fn subscribe_optimize_mir(
         &mut self,
-        mut ctx: ExecuteContext,
+        session: &Session,
         SubscribeOptimizeMir {
             validity,
             plan,
             timeline,
         }: SubscribeOptimizeMir,
-        otel_ctx: OpenTelemetryContext,
-    ) {
+    ) -> Result<StageResult<Box<SubscribeStage>>, AdapterError> {
         let plan::SubscribePlan {
             with_snapshot,
             up_to,
             ..
         } = &plan;
 
-        // Generate data structures that can be moved to another task where we will perform possibly
-        // expensive optimizations.
-        let internal_cmd_tx = self.internal_cmd_tx.clone();
-
         // Collect optimizer parameters.
         let compute_instance = self
             .instance_snapshot(validity.cluster_id.expect("cluser_id"))
             .expect("compute instance does not exist");
-        let id = return_if_err!(self.allocate_transient_id(), ctx);
-        let conn_id = ctx.session().conn_id().clone();
-        let up_to = return_if_err!(
-            up_to
-                .as_ref()
-                .map(|expr| Coordinator::evaluate_when(
-                    self.catalog().state(),
-                    expr.clone(),
-                    ctx.session_mut()
-                ))
-                .transpose(),
-            ctx
-        );
+        let id = self.allocate_transient_id()?;
+        let conn_id = session.conn_id().clone();
+        let up_to = up_to
+            .as_ref()
+            .map(|expr| Coordinator::evaluate_when(self.catalog().state(), expr.clone(), session))
+            .transpose()?;
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
 
         // Build an optimizer for this SUBSCRIBE.
@@ -210,50 +183,45 @@ impl Coordinator {
             optimizer_config,
         );
 
-        let span = tracing::debug_span!("optimize subscribe task (mir)");
-
-        mz_ore::task::spawn_blocking(
+        let span = Span::current();
+        Ok(StageResult::Handle(mz_ore::task::spawn_blocking(
             || "optimize subscribe (mir)",
             move || {
-                let _guard = span.enter();
+                span.in_scope(|| {
+                    // MIR ⇒ MIR optimization (global)
+                    let global_mir_plan = optimizer.catch_unwind_optimize(plan.from.clone())?;
 
-                // MIR ⇒ MIR optimization (global)
-                let global_mir_plan =
-                    return_if_err!(optimizer.catch_unwind_optimize(plan.from.clone()), ctx);
-
-                let stage = SubscribeStage::Timestamp(SubscribeTimestamp {
-                    validity,
-                    plan,
-                    timeline,
-                    optimizer,
-                    global_mir_plan,
-                });
-
-                let _ = internal_cmd_tx.send(Message::SubscribeStageReady {
-                    ctx,
-                    otel_ctx,
-                    stage,
-                });
+                    let stage =
+                        SubscribeStage::TimestampOptimizeLir(SubscribeTimestampOptimizeLir {
+                            validity,
+                            plan,
+                            timeline,
+                            optimizer,
+                            global_mir_plan,
+                        });
+                    Ok(Box::new(stage))
+                })
             },
-        );
+        )))
     }
 
-    async fn subscribe_timestamp(
+    #[instrument(skip_all)]
+    async fn subscribe_timestamp_optimize_lir(
         &mut self,
-        ctx: &mut ExecuteContext,
-        SubscribeTimestamp {
+        ctx: &ExecuteContext,
+        SubscribeTimestampOptimizeLir {
             validity,
             plan,
             timeline,
-            optimizer,
+            mut optimizer,
             global_mir_plan,
-        }: SubscribeTimestamp,
-    ) -> Result<SubscribeOptimizeLir, AdapterError> {
+        }: SubscribeTimestampOptimizeLir,
+    ) -> Result<StageResult<Box<SubscribeStage>>, AdapterError> {
         let plan::SubscribePlan { when, .. } = &plan;
 
         // Timestamp selection
-        let oracle_read_ts = self.oracle_read_ts(&ctx.session, &timeline, when).await;
-        let as_of = match self
+        let oracle_read_ts = self.oracle_read_ts(ctx.session(), &timeline, when).await;
+        let as_of = self
             .determine_timestamp(
                 ctx.session(),
                 &global_mir_plan.id_bundle(optimizer.cluster_id()),
@@ -263,75 +231,45 @@ impl Coordinator {
                 oracle_read_ts,
                 None,
             )
-            .await
-        {
-            Ok(v) => v.timestamp_context.timestamp_or_default(),
-            Err(e) => return Err(e),
-        };
+            .await?
+            .timestamp_context
+            .timestamp_or_default();
         if let Some(id) = ctx.extra().contents() {
             self.set_statement_execution_timestamp(id, as_of);
         }
         if let Some(up_to) = optimizer.up_to() {
             if as_of == up_to {
-                ctx.session_mut()
+                ctx.session()
                     .add_notice(AdapterNotice::EqualSubscribeBounds { bound: up_to });
             } else if as_of > up_to {
                 return Err(AdapterError::AbsurdSubscribeBounds { as_of, up_to });
             }
         }
+        let global_mir_plan = global_mir_plan.resolve(Antichain::from_elem(as_of));
 
-        Ok(SubscribeOptimizeLir {
-            validity,
-            plan,
-            optimizer,
-            global_mir_plan: global_mir_plan.resolve(Antichain::from_elem(as_of)),
-        })
-    }
-
-    fn subscribe_optimize_lir(
-        &mut self,
-        ctx: ExecuteContext,
-        SubscribeOptimizeLir {
-            validity,
-            plan,
-            mut optimizer,
-            global_mir_plan,
-        }: SubscribeOptimizeLir,
-        otel_ctx: OpenTelemetryContext,
-    ) {
-        // Generate data structures that can be moved to another task where we will perform possibly
-        // expensive optimizations.
-        let internal_cmd_tx = self.internal_cmd_tx.clone();
-
-        let span = tracing::debug_span!("optimize subscribe task (lir)");
-
-        mz_ore::task::spawn_blocking(
+        // Optimize LIR
+        let span = Span::current();
+        Ok(StageResult::Handle(mz_ore::task::spawn_blocking(
             || "optimize subscribe (lir)",
             move || {
-                let _guard = span.enter();
+                span.in_scope(|| {
+                    // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
+                    let global_lir_plan =
+                        optimizer.catch_unwind_optimize(global_mir_plan.clone())?;
 
-                // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                let global_lir_plan = return_if_err!(
-                    optimizer.catch_unwind_optimize(global_mir_plan.clone()),
-                    ctx
-                );
-
-                let stage = SubscribeStage::Finish(SubscribeFinish {
-                    validity,
-                    cluster_id: optimizer.cluster_id(),
-                    plan,
-                    global_lir_plan,
-                });
-
-                let _ = internal_cmd_tx.send(Message::SubscribeStageReady {
-                    ctx,
-                    otel_ctx,
-                    stage,
-                });
+                    let stage = SubscribeStage::Finish(SubscribeFinish {
+                        validity,
+                        cluster_id: optimizer.cluster_id(),
+                        plan,
+                        global_lir_plan,
+                    });
+                    Ok(Box::new(stage))
+                })
             },
-        );
+        )))
     }
 
+    #[instrument(skip_all)]
     async fn subscribe_finish(
         &mut self,
         ctx: &mut ExecuteContext,
@@ -347,7 +285,7 @@ impl Coordinator {
                 },
             global_lir_plan,
         }: SubscribeFinish,
-    ) -> Result<ExecuteResponse, AdapterError> {
+    ) -> Result<StageResult<Box<SubscribeStage>>, AdapterError> {
         let sink_id = global_lir_plan.sink_id();
 
         let (tx, rx) = mpsc::unbounded_channel();
@@ -401,12 +339,13 @@ impl Coordinator {
             rx,
             ctx_extra: std::mem::take(ctx.extra_mut()),
         };
-        match copy_to {
-            None => Ok(resp),
-            Some(format) => Ok(ExecuteResponse::CopyTo {
+        let resp = match copy_to {
+            None => resp,
+            Some(format) => ExecuteResponse::CopyTo {
                 format,
                 resp: Box::new(resp),
-            }),
-        }
+            },
+        };
+        Ok(StageResult::Response(resp))
     }
 }


### PR DESCRIPTION
Make a new requirement that all stages but the last must return a JoinHandle<Stage> or an ExecuteResponse. This allows us to remove the loop (since it will never trigger) currently in use in all of the sequence stage fns, and instead *only* have the final response or the next stage that can be sent as a message.

Because of this, we can now omit a lot of passing of the vars down through the various inner stage fns, and instead concentrate those in a common handling function.

Additionally, plumb through spans and easy tracing for nicely formatted trees.

Start with CREATE VIEW for now as the smallest possible demonstration.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a