### PR TITLE
storage: disallow `JSON ARRAY` format in sources

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1908,7 +1908,8 @@ impl<'a> Parser<'a> {
             };
             Format::Csv { columns, delimiter }
         } else if self.parse_keyword(JSON) {
-            Format::Json { array: false }
+            let array = self.parse_keyword(ARRAY);
+            Format::Json { array }
         } else if self.parse_keyword(TEXT) {
             Format::Text
         } else if self.parse_keyword(BYTES) {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1905,7 +1905,8 @@ fn get_encoding_inner(
                     .map_err(|_| sql_err!("CSV delimiter must be an ASCII character"))?,
             })
         }
-        Format::Json { .. } => DataEncodingInner::Json,
+        Format::Json { array: false } => DataEncodingInner::Json,
+        Format::Json { array: true } => bail_unsupported!("JSON ARRAY format in sources"),
         Format::Text => DataEncodingInner::Text,
     }))
 }
@@ -2833,7 +2834,8 @@ fn kafka_sink_builder(
                 csr_connection,
             }
         }
-        Some(Format::Json { .. }) => KafkaSinkFormat::Json,
+        Some(Format::Json { array: false }) => KafkaSinkFormat::Json,
+        Some(Format::Json { array: true }) => bail_unsupported!("JSON ARRAY format in sinks"),
         Some(format) => bail_unsupported!(format!("sink format {:?}", format)),
         None => bail_unsupported!("sink without format"),
     };

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -17,6 +17,15 @@
   );
 
 > CREATE CLUSTER simple_view_sink_cluster SIZE '${arg.default-storage-size}';
+
+! CREATE SINK simple_view_sink
+  IN CLUSTER simple_view_sink_cluster
+  FROM simple_view
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'unnamed-cols-sink-${testdrive.seed}')
+  FORMAT JSON ARRAY
+  ENVELOPE DEBEZIUM
+contains:JSON ARRAY format in sinks not yet supported
+
 > CREATE SINK simple_view_sink
   IN CLUSTER simple_view_sink_cluster
   FROM simple_view

--- a/test/testdrive/source-format-json.td
+++ b/test/testdrive/source-format-json.td
@@ -16,6 +16,12 @@ $ kafka-ingest format=bytes topic=data
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
+! CREATE SOURCE data
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FORMAT JSON ARRAY;
+contains:JSON ARRAY format in sources not yet supported
+
 > CREATE SOURCE data
   IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This type of format was added for webhook sources but the planner accidentally accepts it for sources and sinks even though it is ignored. This PR changes the planner to error on these statements so that when we eventually support it it's not a breaking change. 
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
