### PR TITLE
storage/format/json: encode nested arrays correctly

### DIFF
--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -252,7 +252,7 @@ table:
 
 SQL type                     | Conversion
 -----------------------------|-------------------------------------
-[`array`][`arrays`]          | Values are converted to JSON arrays. Multidimensional arrays are flattened into a single dimension following row-major order.
+[`array`][`arrays`]          | Values are converted to JSON arrays.
 [`bigint`]                   | Values are converted to JSON numbers.
 [`boolean`]                  | Values are converted to `true` or `false`.
 [`integer`]                  | Values are converted to JSON numbers.

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1994,6 +1994,10 @@ async fn test_concurrent_id_reuse() {
     client.batch_execute("SELECT 1").await.unwrap();
 }
 
+// TODO: re-enable once we figure out how to do this test without
+// relying on internal resources:
+// <https://github.com/MaterializeInc/materialize/issues/25294>
+#[ignore]
 #[mz_ore::test]
 fn test_internal_console_proxy() {
     let server = test_util::TestHarness::default().start_blocking();

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -25,7 +25,7 @@ once_cell = "1.16.0"
 maplit = "1.0.2"
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-ccsr = { path = "../ccsr" }
-mz-ore = { path = "../ore", features = ["network"] }
+mz-ore = { path = "../ore", features = ["network", "cli"] }
 mz-repr = { path = "../repr" }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -126,13 +126,19 @@ contains:column "a" specified more than once
 
 > CREATE TYPE int4_map_map AS MAP (KEY TYPE = text, VALUE TYPE = int4_map);
 
+# We do this dance here to work around #25282
+$ set-from-sql var=int4_id
+SELECT id FROM mz_objects WHERE name = '_int4';
+$ set-from-sql var=text_id
+SELECT id FROM mz_objects WHERE name = '_text';
+
 > CREATE MATERIALIZED VIEW complex_type_view AS
   SELECT
     '{{1,2},{3,4}}'::int4_list_list c1,
     '{a=>{b=>1, c=>2}, d=> {e=>3, f=>4}}'::int4_map_map c2,
-    ARRAY[ARRAY[1, 2], ARRAY[3, 4], ARRAY[5, 6]] c3,
-    ARRAY[]::int[] c4,
-    ARRAY[ARRAY[ARRAY['a'], ARRAY['b']], ARRAY[ARRAY['c'], ARRAY['d']]] c5;
+    ARRAY[ARRAY[1, 2], ARRAY[3, 4], ARRAY[5, 6]]::[${int4_id} AS "pg_catalog"."_int4"] c3,
+    ARRAY[]::[${int4_id} AS "pg_catalog"."_int4"] c4,
+    ARRAY[ARRAY[ARRAY['a'], ARRAY['b']], ARRAY[ARRAY['c'], ARRAY['d']]]::[${text_id} AS "pg_catalog"."_text"] c5;
 
 > CREATE CLUSTER complex_type_sink_cluster SIZE '${arg.default-storage-size}';
 > CREATE SINK complex_type_sink

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -126,7 +126,13 @@ contains:column "a" specified more than once
 
 > CREATE TYPE int4_map_map AS MAP (KEY TYPE = text, VALUE TYPE = int4_map);
 
-> CREATE MATERIALIZED VIEW complex_type_view AS SELECT '{{1,2},{3,4}}'::int4_list_list c1, '{a=>{b=>1, c=>2}, d=> {e=>3, f=>4}}'::int4_map_map c2;
+> CREATE MATERIALIZED VIEW complex_type_view AS
+  SELECT
+    '{{1,2},{3,4}}'::int4_list_list c1,
+    '{a=>{b=>1, c=>2}, d=> {e=>3, f=>4}}'::int4_map_map c2,
+    ARRAY[ARRAY[1, 2], ARRAY[3, 4], ARRAY[5, 6]] c3,
+    ARRAY[]::int[] c4,
+    ARRAY[ARRAY[ARRAY['a'], ARRAY['b']], ARRAY[ARRAY['c'], ARRAY['d']]] c5;
 
 > CREATE CLUSTER complex_type_sink_cluster SIZE '${arg.default-storage-size}';
 > CREATE SINK complex_type_sink
@@ -137,7 +143,7 @@ contains:column "a" specified more than once
   ENVELOPE DEBEZIUM
 
 $ kafka-verify-data format=json sink=materialize.public.complex_type_sink key=false
-{"before": null, "after": {"c1": [[1,2],[3,4]], "c2": {"a":{"b":1, "c":2}, "d": {"e":3, "f":4}}}}
+{"before": null, "after": {"c1": [[1,2],[3,4]], "c2": {"a":{"b":1, "c":2}, "d": {"e":3, "f":4}}, "c3": [[1, 2], [3, 4], [5,6]], "c4": [], "c5": [[["a"], ["b"]], [["c"], ["d"]]]}}
 
 # testdrive will not automatically clean up types, so we need to do that ourselves
 


### PR DESCRIPTION
Fixes #25148

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
