### PR TITLE
doc/user: add shortcodes for in-progress rollouts

### DIFF
--- a/doc/user/README.md
+++ b/doc/user/README.md
@@ -19,38 +19,87 @@ For help contributing to the docs, see [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ## Tasks
 
-### (Temporary) Updating LTS Docs
+### Making changes
 
-As we start to break apart the binary, we have to work through a temporary phase where users of `v0.26 LTS` (or lower) shouldn't be exposed to documentation changes related to the new features landing in `main`, to avoid confusion. #11795 updated the docs deployment process to use two different branches:
+Shipping changes to the user-facing documentation is designed to be as
+lightweight and painless as possible to encourage contributions.
 
-* `lts-docs`: capturing the state of the docs at `v0.26 LTS`, deploying to `https://materialize.com/docs/`
-* `main`: ongoing development branch, deploying to `https://materialize.com/docs/unstable/`
+Merging to the `main` branch will immediately deploy the updated documentation
+to https://materialize.com/docs.
 
-#### Shipping updates to Unstable Docs
+### Adjusting documentation for existing features
 
-PRs to `materialize/main` will trigger new builds of materialize.com/docs/unstable/. Deploy docs updates to unstable if:
+If you're correcting errors or adding documentation for features that are
+already deployed to production, put up a PR with your changes and wait for a
+review. The changes will (correctly) go live as soon as your PR is merged.
 
-1. The change applies to both LTS and Unstable _(e.g. if you're correcting a typo on the Postgres source page)_
-2. The change only applies to Unstable
+### Adding documentation for new features
 
-#### Shipping updates to LTS Docs
+If documenting a *new* feature of Materialize that has not yet rolled out to
+production, use the `warn-if-unreleased` shortcode to indicate in what version
+the feature will become available:
 
-To update `materialize.com/docs`, you need to merge a PR to the `lts-docs` branch (typically, following a PR to `main`) to backport the changes, in which case the process is:
+```
+{{< warn-if-unreleased v0.86 >}}
+```
 
-1. Create a new branch on your fork that references `lts-docs`.
-   ```
-   git checkout -b my-branch-name lts-docs
-   ```
-2. Cherry-pick the commit from `main` with the changes you need, or just make the necessary changes as you would normally.
-   ```
-   git cherry-pick COMMIT-SHA-FROM-MAIN
-   ```
-4. Push your branch.
-   ```
-   git push
-   ```
-5. Open a PR - if this was a cherry-picked commit that has already been reviewed, approved and merged to `main`, you can just merge it once CI turns green. If it has conflicts or it is a unique PR for `lts-docs`, then you'll need a review.
+This will add a large warning that indicates to users that the change is not
+yet available:
 
+<img src="https://github.com/MaterializeInc/materialize/assets/882976/97b33d8d-de45-4fd4-ac1c-3080c4c07773">
+
+The warning will automatically disappear when the version is deployed to
+production.
+
+You can use the `warn-if-unreleased-inline` shortcode for a smaller warning that
+can appear inline in a paragraph, table, or list:
+
+```
+{{< warn-if-unreleased-inline v0.86 >}}
+```
+
+For new SQL functions, add a `version-added` field to the function's definition:
+
+```yml:
+    - signature: 'my_new_function() -> int'
+      description: A new function shipping in the next release.
+      version-added: v0.86
+```
+
+This will render the same warning next to the function's description until the
+version containing the function is deployed to production.
+
+#### Rationale
+
+Using these shortcodes allows developers to merge the documentation for a change
+in the same PR that adds the implementation of the change. This greatly improves
+the odds that developers will adjust the docs when making a change.
+
+In the past, we instead asked developers to open a separate docs PR for each
+change, then wait to merge the docs PR until that change was deployed to
+production. This was enough overhead that they would often skip writing docs
+entirely.
+
+#### Special cases
+
+If necessary, you can use `if-released` and `if-unreleased` to render
+different content depending on whether a given release:
+
+```
+{{< if-released v0.86 >}}
+This block is shown only if v0.86 is released.
+{{< /if-released >}}
+
+{{< if-unreleased v0.86 >}}
+This block is shown only if v0.86 is *not* released.
+{{< /if-unreleased >}}
+```
+
+Exercise caution with these shortcodes! It is easy to have typos or rendering
+glitches in an `if-released` block that slip through review because they are not
+visible when the PR is previewed during review. To preview an `if-released`
+block while developing the docs locally, toggle the `released` parameter in
+/releases/vX.Y.md.
 
 ### Updating CSS
 

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -523,7 +523,7 @@ p+p {
     .public-preview {
         box-sizing: border-box;
         margin: 1.6rem 0;
-        padding: 1.6rem 1.6rem 1.6rem 9.6rem;
+        padding: 1.6rem 1.6rem 1.6rem 10.4rem;
         position: relative;
         border-radius: 1.2rem;
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -126,6 +126,7 @@
         first of which is `text`. In the face of duplicate keys, `map_build` retains
         value from the record in the latest positition. This function is
         purpose-built to process [Kafka headers](/sql/create-source/kafka/#headers).
+      version-added: v0.86
     - signature: 'map_agg(keys: text, values: T) -> map[text=>T]'
       description: Aggregate keys and values (including nulls) as a map. ([docs](/sql/functions/map_agg))
 

--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -1,4 +1,10 @@
 {{/*  Converts data/sql_funcs.yml into table. */}}
+
+{{$releasedVersions := dict}}
+{{range (where $.Site.RegularPages "Section" "releases")}}
+  {{$releasedVersions = merge $releasedVersions (dict .File.ContentBaseName .) }}
+{{end}}
+
 {{ range $.Site.Data.sql_funcs }}
 
 {{ if not (isset $.Params 0) }}
@@ -45,6 +51,18 @@
 
       {{ if .side_effecting }}
         <br><br><b>Note:</b> This function is <a href="#side-effecting-functions">side-effecting</a>.
+      {{ end }}
+
+      {{ $versionAdded := index . "version-added" }}
+      {{ if $versionAdded }}
+        {{ $releasePage := index $releasedVersions $versionAdded }}
+        {{ if not $releasePage.Params.released }}
+          <br><br>
+          <b>Unreleased: </b> This function will be released in
+          <a href="{{ printf "/releases/%s" $versionAdded | relURL }}"><strong>{{$versionAdded}}</strong></a>.
+          It may not be available in your region yet.
+          The release is scheduled to complete by <strong>{{dateFormat "January 2, 2006" $releasePage.Params.date}}</strong>.
+        {{ end }}
       {{ end }}
     </td>
   </tr>

--- a/doc/user/layouts/shortcodes/if-released.html
+++ b/doc/user/layouts/shortcodes/if-released.html
@@ -1,0 +1,9 @@
+{{$version := .Get 0}}
+{{$releasePages := where $.Site.RegularPages "Section" "releases"}}
+{{$releasePage := (index (where $releasePages ".File.ContentBaseName" $version) 0)}}
+{{$isReleased := $releasePage.Params.released}}
+{{$releaseDate := $releasePage.Params.date}}
+
+{{if $isReleased}}
+{{.Inner | .Page.RenderString}}
+{{end}}

--- a/doc/user/layouts/shortcodes/if-unreleased.html
+++ b/doc/user/layouts/shortcodes/if-unreleased.html
@@ -1,0 +1,9 @@
+{{$version := .Get 0}}
+{{$releasePages := where $.Site.RegularPages "Section" "releases"}}
+{{$releasePage := (index (where $releasePages ".File.ContentBaseName" $version) 0)}}
+{{$isReleased := $releasePage.Params.released}}
+{{$releaseDate := $releasePage.Params.date}}
+
+{{if not $isReleased}}
+{{.Inner | .Page.RenderString}}
+{{end}}

--- a/doc/user/layouts/shortcodes/warn-if-unreleased-inline.html
+++ b/doc/user/layouts/shortcodes/warn-if-unreleased-inline.html
@@ -1,0 +1,12 @@
+{{$version := .Get 0}}
+{{$releasePages := where $.Site.RegularPages "Section" "releases"}}
+{{$releasePage := (index (where $releasePages ".File.ContentBaseName" $version) 0)}}
+{{$isReleased := $releasePage.Params.released}}
+{{$releaseDate := $releasePage.Params.date}}
+
+{{if not $isReleased}}
+<strong>Unreleased: </strong>This feature will be released in
+<a href="{{$releasePage.RelPermalink}}"><strong>{{$version}}</strong></a>.
+It may not be available in your region yet.
+The release is scheduled to complete by <strong>{{dateFormat "January 2, 2006" $releaseDate}}</strong>.
+{{end}}

--- a/doc/user/layouts/shortcodes/warn-if-unreleased.html
+++ b/doc/user/layouts/shortcodes/warn-if-unreleased.html
@@ -1,0 +1,15 @@
+{{$version := .Get 0}}
+{{$releasePages := where $.Site.RegularPages "Section" "releases"}}
+{{$releasePage := (index (where $releasePages ".File.ContentBaseName" $version) 0)}}
+{{$isReleased := $releasePage.Params.released}}
+{{$releaseDate := $releasePage.Params.date}}
+
+{{if not $isReleased}}
+  <div class="warning">
+    <strong class="gutter">Unreleased</strong>
+    This feature will be released in
+    <a href="{{$releasePage.RelPermalink}}"><strong>{{$version}}</strong></a>.
+    It may not be available in your region yet.
+    The release is scheduled to complete by <strong>{{dateFormat "January 2, 2006" $releaseDate}}</strong>.
+  </div>
+{{end}}


### PR DESCRIPTION
We've had a lot of trouble lately with folks either:

  1. Not writing documentation for their changes.
  2. Writing documentation for their changes, but merging it in the PR that implements that change, before the change has rolled out to production.

Attempt to solve both of those problems by introducing new rollout shortcodes. These shortcodes add a user-visible warning that indicates a feature may not yet be available. The warning automatically disappears when the version containing the feature is marked as released.

This will "bless" the approach of updating docs for a change in the same PR that implements the change. This hopefully encourages developers to write more documentation, without confusing end users with documentation for features that do not yet exist.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR improves the process of writing documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
