### PR TITLE
feature benchmark: update ignore entry to account for PR#24918 being reverted in 0.87.1

### DIFF
--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -58,7 +58,9 @@ _MIN_ANCESTOR_MZ_VERSION_PER_COMMIT_TO_ACCOUNT_FOR_PERFORMANCE_REGRESSIONS: dict
     str, MzVersion
 ] = {
     # insert newer commits at the top
-    # PR#24918 (persist-txn: switch to a new operator protocol for lazy) increased number of messages against v0.86.1
+    # first commit after 0.77.x / first commit of v0.88.0-dev to account for PR#24918 being reverted in 0.77.1
+    "dd16e12e8c045e1060cef868c17b5b40d031a5fe": MzVersion.parse_mz("v0.88.0"),
+    # PR#24918 (persist-txn: switch to a new operator protocol for lazy) increased number of messages against v0.86.1 (but got reverted in 0.87.1)
     "b648576b52b8ba9bb3a4732f7022ab5c06ebed32": MzVersion.parse_mz("v0.87.0"),
     # PR#23659 (persist-txn: enable in CI with "eager uppers") introduces regressions against v0.79.0
     "c4f520a57a3046e5074939d2ea345d1c72be7079": MzVersion.parse_mz("v0.80.0"),


### PR DESCRIPTION
Assuming the following is correct:
> ["persist-txn: switch to a new operator protocol for lazy"](https://github.com/MaterializeInc/materialize/pull/24918)
> * was introduced in 0.87.0 with [b648576b](https://github.com/MaterializeInc/materialize/commit/b648576b52b8ba9bb3a4732f7022ab5c06ebed32)
> * was reverted in 0.87.1 with [c0384b20](https://github.com/MaterializeInc/materialize/commit/c0384b20a40f6c406c38a4722db6ea88e8e28430)
> * was not reverted on main
> * so that 0.88.0 will be the first version shipping this functionality

(https://materializeinc.slack.com/archives/C01LKF361MZ/p1707744548965469?thread_ts=1707727135.871749&cid=C01LKF361MZ)