### PR TITLE
ci: Group builds in nightly pipeline

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -8,26 +8,29 @@
 # by the Apache License, Version 2.0.
 
 steps:
-  - id: build-x86_64
-    label: Build x86_64
-    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build x86_64
-    timeout_in_minutes: 60
-    # For releases we trigger nightly from the test job directly, no need to build again
-    branches: "!v*.*"
-    agents:
-      queue: builder-linux-x86_64
+  - group: Builds
+    key: builds
+    steps:
+    - id: build-x86_64
+      label: Build x86_64
+      command: bin/ci-builder run stable bin/pyactivate -m ci.test.build x86_64
+      timeout_in_minutes: 60
+      # For releases we trigger nightly from the test job directly, no need to build again
+      branches: "!v*.*"
+      agents:
+        queue: builder-linux-x86_64
 
-  - id: build-aarch64
-    label: Build aarch64
-    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build aarch64
-    timeout_in_minutes: 60
-    # For releases we trigger nightly from the test job directly, no need to build again
-    branches: "!v*.*"
-    agents:
-      queue: builder-linux-aarch64
-    # TODO(def-) Remove automatic retry when #24818 is fixed
-    retry:
-      automatic: true
+    - id: build-aarch64
+      label: Build aarch64
+      command: bin/ci-builder run stable bin/pyactivate -m ci.test.build aarch64
+      timeout_in_minutes: 60
+      # For releases we trigger nightly from the test job directly, no need to build again
+      branches: "!v*.*"
+      agents:
+        queue: builder-linux-aarch64
+      # TODO(def-) Remove automatic retry when #24818 is fixed
+      retry:
+        automatic: true
 
   - wait: ~
 


### PR DESCRIPTION
Since we currently have x86-64 and aarch64 (unfortunately)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
