### PR TITLE
ci: improve panic matching

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -324,7 +324,6 @@ def get_error_logs(log_files: list[str]) -> list[ErrorLog]:
                             )
             assert not open_panics, f"Panic log never finished: {open_panics}"
 
-    # TODO: Only report multiple errors once?
     return error_logs
 
 

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -64,8 +64,12 @@ ERROR_RE = re.compile(
 # Panics are multiline and our log lines of multiple services are interleaved,
 # making them complex to handle in regular expressions, thus handle them
 # separately.
-PANIC_START_RE = re.compile(rb"^(?P<service>[^ ]*) *\| thread '.*' panicked at ")
-SERVICES_LOG_LINE_RE = re.compile(rb"^(?P<service>[^ ]*) *\| (?P<msg>.*)$")
+# Example 1: launchdarkly-materialized-1  | thread 'coordinator' panicked at [...]
+# Example 2: [pod/environmentd-0/environmentd] thread 'coordinator' panicked at [...]
+PANIC_START_RE = re.compile(rb"^(\[)?(?P<service>[^ ]*)(\s*\||\]) thread '.*' panicked at ")
+# Example 1: launchdarkly-materialized-1  | global timestamp must always go up
+# Example 2: [pod/environmentd-0/environmentd] Unknown collection identifier u2082
+SERVICES_LOG_LINE_RE = re.compile(rb"^(\[)?(?P<service>[^ ]*)(\s*\||\]) (?P<msg>.*)$")
 
 # Expected failures, don't report them
 IGNORE_RE = re.compile(


### PR DESCRIPTION
### Before

Only panics with this layout are matched:

```
launchdarkly-materialized-1  | thread 'coordinator' panicked at src/catalog/src/durable/impls/stash.rs:1201:13:
launchdarkly-materialized-1  | global timestamp must always go up
```

### After

Additionally supported layouts:

```
[pod/environmentd-0/environmentd] thread 'coordinator' panicked at /var/lib/buildkite-agent/builds/buildkite-builders-aarch64-585fc7f-i-04d4e39675bda911c-1/materialize/tests/src/storage-controller/src/lib.rs:1468:17:
[pod/environmentd-0/environmentd] Unknown collection identifier u2082
```

(seen in `kubectl-get-logs-previous.log` of [builds/6376](https://buildkite.com/materialize/nightlies/builds/6376#018d8df9-aa16-429d-9801-67a596dfdf8f))

and

```
thread 'coordinator' panicked at 'forced panic', src/expr/src/scalar/func/impls/string.rs:1060:9
stack backtrace:
   0: rust_begin_unwind
[...]
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
forced panic[2m2023-10-05T00:36:41.262358Z[0m [31mERROR[0m [2mmz_adapter::coord::sequencer::inner[0m[2m:[0m error while handling EXPLAIN statement: internal error: panic at the `local` optimization stage
```

(seen in `run.log` of [builds/65204](https://buildkite.com/materialize/tests/builds/65204#018afd3e-c4c8-4c18-9b02-06e1da4f8eee))