### PR TITLE
persist: use lgalloc to back data decoded from arrow/parquet

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -50,6 +50,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_next_listen_batch_retryer_fixed_sleep": "1200ms",
     # -----
     # Persist internals changes: advance coverage
+    "persist_enable_arrow_lgalloc_noncc_sizes": "true",
     "persist_enable_s3_lgalloc_noncc_sizes": "true",
     "persist_streaming_compaction_enabled": "true",
     "persist_streaming_snapshot_and_fetch_enabled": "true",

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -710,7 +710,10 @@ where
         if updates.is_empty() {
             self.key_buf.clear();
             self.val_buf.clear();
-            return (vec![], ColumnarRecordsBuilder::default().finish());
+            return (
+                vec![],
+                ColumnarRecordsBuilder::default().finish(&self.metrics.columnar),
+            );
         }
 
         let ((mut key_lower, _), _, _) = &updates[0];
@@ -737,7 +740,7 @@ where
         }
         let key_lower = truncate_bytes(key_lower, TRUNCATE_LEN, TruncateBound::Lower)
             .expect("lower bound always exists");
-        let columnar = builder.finish();
+        let columnar = builder.finish(&self.metrics.columnar);
 
         self.batch_write_metrics
             .step_columnar_encoding

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -277,7 +277,7 @@ pub(crate) const MiB: usize = 1024 * 1024;
 /// something like the `ctor` or `inventory` crate. This would involve managing
 /// the footgun of a Config being linked into one binary but not the other.
 pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
-    configs
+    mz_persist::cfg::all_dyn_configs(configs)
         .add(&crate::batch::BATCH_DELETE_ENABLED)
         .add(&crate::batch::BLOB_TARGET_SIZE)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL_STAGGER)
@@ -306,8 +306,6 @@ pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::stats::STATS_UNTRIMMABLE_COLUMNS_EQUALS)
         .add(&crate::stats::STATS_UNTRIMMABLE_COLUMNS_PREFIX)
         .add(&crate::stats::STATS_UNTRIMMABLE_COLUMNS_SUFFIX)
-        .add(&mz_persist::s3::ENABLE_S3_LGALLOC_CC_SIZES)
-        .add(&mz_persist::s3::ENABLE_S3_LGALLOC_NONCC_SIZES)
 }
 
 impl PersistConfig {

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -329,7 +329,7 @@ pub async fn blob_batch_part(
 ) -> Result<impl serde::Serialize, anyhow::Error> {
     let cfg = PersistConfig::new_default_configs(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
-    let blob = make_blob(&cfg, blob_uri, NO_COMMIT, metrics).await?;
+    let blob = make_blob(&cfg, blob_uri, NO_COMMIT, Arc::clone(&metrics)).await?;
 
     let key = PartialBatchKey(partial_key).complete(&shard_id);
     let part = blob
@@ -337,7 +337,7 @@ pub async fn blob_batch_part(
         .await
         .expect("blob exists")
         .expect("part exists");
-    let part = BlobTraceBatchPart::<u64>::decode(&part).expect("decodable");
+    let part = BlobTraceBatchPart::<u64>::decode(&part, &metrics.columnar).expect("decodable");
     let desc = part.desc.clone();
 
     let encoded_part = EncodedPart::new(&*key, part.desc.clone(), part);

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -282,7 +282,7 @@ where
         let part = metrics
             .codecs
             .batch
-            .decode(|| BlobTraceBatchPart::decode(value))
+            .decode(|| BlobTraceBatchPart::decode(value, &metrics.columnar))
             .map_err(|err| anyhow!("couldn't decode batch at key {}: {}", key, err))
             // We received a State that we couldn't decode. This could happen if
             // persist messes up backward/forward compatibility, if the durable

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -1209,6 +1209,7 @@ mod tests {
         let (part, updates) = expect_fetch_part(
             write.blob.as_ref(),
             &part.key.complete(&write.machine.shard_id()),
+            &write.metrics,
         )
         .await;
         assert_eq!(part.desc, res.output.desc);
@@ -1291,6 +1292,7 @@ mod tests {
         let (part, updates) = expect_fetch_part(
             write.blob.as_ref(),
             &part.key.complete(&write.machine.shard_id()),
+            &write.metrics,
         )
         .await;
         assert_eq!(part.desc, res.output.desc);

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -909,6 +909,7 @@ mod tests {
     pub async fn expect_fetch_part<K, V, T, D>(
         blob: &(dyn Blob + Send + Sync),
         key: &BlobKey,
+        metrics: &Metrics,
     ) -> (
         BlobTraceBatchPart<T>,
         Vec<((Result<K, String>, Result<V, String>), T, D)>,
@@ -924,7 +925,8 @@ mod tests {
             .await
             .expect("failed to fetch part")
             .expect("missing part");
-        let part = BlobTraceBatchPart::decode(&value).expect("failed to decode part");
+        let part =
+            BlobTraceBatchPart::decode(&value, &metrics.columnar).expect("failed to decode part");
         let mut updates = Vec::new();
         for chunk in part.updates.iter() {
             for ((k, v), t, d) in chunk.iter() {

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -28,6 +28,15 @@ use crate::metrics::S3BlobMetrics;
 use crate::postgres::{PostgresConsensus, PostgresConsensusConfig};
 use crate::s3::{S3Blob, S3BlobConfig};
 
+/// Adds the full set of all mz_persist `Config`s.
+pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
+    configs
+        .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_CC_SIZES)
+        .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_NONCC_SIZES)
+        .add(&crate::s3::ENABLE_S3_LGALLOC_CC_SIZES)
+        .add(&crate::s3::ENABLE_S3_LGALLOC_NONCC_SIZES)
+}
+
 /// Config for an implementation of [Blob].
 #[derive(Debug, Clone)]
 pub enum BlobConfig {

--- a/src/persist/src/indexed/columnar/arrow.rs
+++ b/src/persist/src/indexed/columnar/arrow.rs
@@ -20,6 +20,8 @@ use arrow2::datatypes::{DataType, Field, Schema};
 use arrow2::io::ipc::read::{read_file_metadata, FileMetadata, FileReader};
 use arrow2::io::ipc::write::{FileWriter, WriteOptions};
 use differential_dataflow::trace::Description;
+use mz_dyncfg::Config;
+use mz_ore::lgbytes::MetricsRegion;
 use mz_persist_types::Codec64;
 use once_cell::sync::Lazy;
 use timely::progress::{Antichain, Timestamp};
@@ -30,6 +32,7 @@ use crate::indexed::columnar::ColumnarRecords;
 use crate::indexed::encoding::{
     decode_trace_inline_meta, encode_trace_inline_meta, BlobTraceBatchPart,
 };
+use crate::metrics::ColumnarMetrics;
 
 /// The Arrow schema we use to encode ((K, V), T, D) tuples.
 ///
@@ -106,6 +109,7 @@ pub fn encode_trace_arrow<W: Write, T: Timestamp + Codec64>(
 /// for the local cache and so we can easily compare arrow vs parquet.
 pub fn decode_trace_arrow<R: Read + Seek, T: Timestamp + Codec64>(
     r: &mut R,
+    metrics: &ColumnarMetrics,
 ) -> Result<BlobTraceBatchPart<T>, Error> {
     let file_meta = read_file_metadata(r)?;
     let (format, meta) =
@@ -113,7 +117,7 @@ pub fn decode_trace_arrow<R: Read + Seek, T: Timestamp + Codec64>(
 
     let updates = match format {
         ProtoBatchFormat::Unknown => return Err("unknown format".into()),
-        ProtoBatchFormat::ArrowKvtd => decode_arrow_file_kvtd(r, file_meta)?,
+        ProtoBatchFormat::ArrowKvtd => decode_arrow_file_kvtd(r, file_meta, metrics)?,
         ProtoBatchFormat::ParquetKvtd => {
             return Err("ParquetKvtd format not supported in arrow".into())
         }
@@ -140,6 +144,7 @@ pub fn decode_trace_arrow<R: Read + Seek, T: Timestamp + Codec64>(
 fn decode_arrow_file_kvtd<R: Read + Seek>(
     r: &mut R,
     file_meta: FileMetadata,
+    metrics: &ColumnarMetrics,
 ) -> Result<Vec<ColumnarRecords>, Error> {
     let projection = None;
     let file_reader = FileReader::new(r, file_meta, projection, None);
@@ -156,7 +161,7 @@ fn decode_arrow_file_kvtd<R: Read + Seek>(
 
     let mut ret = Vec::new();
     for chunk in file_reader {
-        ret.push(decode_arrow_batch_kvtd(&chunk?)?);
+        ret.push(decode_arrow_batch_kvtd(&chunk?, metrics)?);
     }
     Ok(ret)
 }
@@ -166,28 +171,67 @@ pub fn encode_arrow_batch_kvtd(x: &ColumnarRecords) -> Chunk<Box<dyn Array>> {
     Chunk::try_new(vec![
         convert::identity::<Box<dyn Array>>(Box::new(BinaryArray::new(
             DataType::Binary,
-            x.key_offsets.clone(),
-            x.key_data.clone(),
+            (*x.key_offsets)
+                .as_ref()
+                .to_vec()
+                .try_into()
+                .expect("valid offsets"),
+            (*x.key_data).as_ref().to_vec().into(),
             None,
         ))),
         Box::new(BinaryArray::new(
             DataType::Binary,
-            x.val_offsets.clone(),
-            x.val_data.clone(),
+            (*x.val_offsets)
+                .as_ref()
+                .to_vec()
+                .try_into()
+                .expect("valid offsets"),
+            (*x.val_data).as_ref().to_vec().into(),
             None,
         )),
         Box::new(PrimitiveArray::new(
             DataType::Int64,
-            x.timestamps.clone(),
+            (*x.timestamps).as_ref().to_vec().into(),
             None,
         )),
-        Box::new(PrimitiveArray::new(DataType::Int64, x.diffs.clone(), None)),
+        Box::new(PrimitiveArray::new(
+            DataType::Int64,
+            (*x.diffs).as_ref().to_vec().into(),
+            None,
+        )),
     ])
     .expect("schema matches fields")
 }
 
+pub(crate) const ENABLE_ARROW_LGALLOC_CC_SIZES: Config<bool> = Config::new(
+    "persist_enable_arrow_lgalloc_cc_sizes",
+    true,
+    "An incident flag to disable copying decoded arrow data into lgalloc on cc sized clusters.",
+);
+
+pub(crate) const ENABLE_ARROW_LGALLOC_NONCC_SIZES: Config<bool> = Config::new(
+    "persist_enable_arrow_lgalloc_noncc_sizes",
+    false,
+    "A feature flag to enable copying decoded arrow data into lgalloc on non-cc sized clusters.",
+);
+
 /// Converts an arrow [(K, V, T, D)] Chunk into a ColumnarRecords.
-pub fn decode_arrow_batch_kvtd(x: &Chunk<Box<dyn Array>>) -> Result<ColumnarRecords, String> {
+pub fn decode_arrow_batch_kvtd(
+    x: &Chunk<Box<dyn Array>>,
+    metrics: &ColumnarMetrics,
+) -> Result<ColumnarRecords, String> {
+    fn to_region<T: Copy>(buf: &[T], metrics: &ColumnarMetrics) -> Arc<MetricsRegion<T>> {
+        let use_lgbytes_mmap = if metrics.is_cc_active {
+            ENABLE_ARROW_LGALLOC_CC_SIZES.get(&metrics.cfg)
+        } else {
+            ENABLE_ARROW_LGALLOC_NONCC_SIZES.get(&metrics.cfg)
+        };
+        if use_lgbytes_mmap {
+            Arc::new(metrics.lgbytes_arrow.try_mmap_region(buf))
+        } else {
+            Arc::new(metrics.lgbytes_arrow.heap_region(buf.to_owned()))
+        }
+    }
     let columns = x.columns();
     if columns.len() != 4 {
         return Err(format!("expected 4 fields got {}", columns.len()));
@@ -202,27 +246,27 @@ pub fn decode_arrow_batch_kvtd(x: &Chunk<Box<dyn Array>>) -> Result<ColumnarReco
         .downcast_ref::<BinaryArray<i32>>()
         .ok_or_else(|| "column 0 doesn't match schema".to_string())?
         .clone();
-    let key_offsets = key_array.offsets().clone();
-    let key_data = key_array.values().clone();
+    let key_offsets = to_region(key_array.offsets().as_slice(), metrics);
+    let key_data = to_region(key_array.values().as_slice(), metrics);
     let val_array = val_col
         .as_any()
         .downcast_ref::<BinaryArray<i32>>()
         .ok_or_else(|| "column 1 doesn't match schema".to_string())?
         .clone();
-    let val_offsets = val_array.offsets().clone();
-    let val_data = val_array.values().clone();
+    let val_offsets = to_region(val_array.offsets().as_slice(), metrics);
+    let val_data = to_region(val_array.values().as_slice(), metrics);
     let timestamps = ts_col
         .as_any()
         .downcast_ref::<PrimitiveArray<i64>>()
         .ok_or_else(|| "column 2 doesn't match schema".to_string())?
-        .values()
-        .clone();
+        .values();
+    let timestamps = to_region(timestamps.as_slice(), metrics);
     let diffs = diff_col
         .as_any()
         .downcast_ref::<PrimitiveArray<i64>>()
         .ok_or_else(|| "column 3 doesn't match schema".to_string())?
-        .values()
-        .clone();
+        .values();
+    let diffs = to_region(diffs.as_slice(), metrics);
 
     let len = x.len();
     let ret = ColumnarRecords {

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -9,7 +9,8 @@
 
 //! Implementation-specific metrics for persist blobs and consensus
 
-use mz_ore::lgbytes::LgBytesMetrics;
+use mz_dyncfg::ConfigSet;
+use mz_ore::lgbytes::{LgBytesMetrics, LgBytesOpMetrics};
 use mz_ore::metric;
 use mz_ore::metrics::{IntCounter, MetricsRegistry};
 use prometheus::IntCounterVec;
@@ -29,7 +30,11 @@ pub struct S3BlobMetrics {
     pub(crate) delete_head: IntCounter,
     pub(crate) delete_object: IntCounter,
     pub(crate) list_objects: IntCounter,
-    pub(crate) lgbytes: LgBytesMetrics,
+
+    /// Metrics for all usages of LgBytes. Exposed as public for convenience in
+    /// persist boot, we'll have to pull this out and do the plumbing
+    /// differently if mz gains a non-persist user of LgBytes.
+    pub lgbytes: LgBytesMetrics,
 }
 
 impl S3BlobMetrics {
@@ -67,5 +72,35 @@ impl S3BlobMetrics {
             list_objects: operations.with_label_values(&["list_objects"]),
             lgbytes: LgBytesMetrics::new(registry),
         }
+    }
+}
+
+/// Metrics for `ColumnarRecords`.
+#[derive(Debug)]
+pub struct ColumnarMetrics {
+    pub(crate) lgbytes_arrow: LgBytesOpMetrics,
+    // TODO: Having these two here isn't quite the right thing to do, but it
+    // saves a LOT of plumbing.
+    pub(crate) cfg: ConfigSet,
+    pub(crate) is_cc_active: bool,
+}
+
+impl ColumnarMetrics {
+    /// Returns a new [ColumnarMetrics].
+    pub fn new(lgbytes: &LgBytesMetrics, cfg: ConfigSet, is_cc_active: bool) -> Self {
+        ColumnarMetrics {
+            lgbytes_arrow: lgbytes.persist_arrow.clone(),
+            cfg,
+            is_cc_active,
+        }
+    }
+
+    /// Returns a [ColumnarMetrics] disconnected from any metrics registry.
+    ///
+    /// Exposed for testing.
+    pub fn disconnected() -> Self {
+        let lgbytes = LgBytesMetrics::new(&MetricsRegistry::new());
+        let cfg = crate::cfg::all_dyn_configs(ConfigSet::default());
+        Self::new(&lgbytes, cfg, false)
     }
 }

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -329,15 +329,13 @@ impl S3Blob {
     }
 }
 
-/// The `persist_enable_s3_lgalloc_cc_sizes` config.
-pub const ENABLE_S3_LGALLOC_CC_SIZES: Config<bool> = Config::new(
+pub(crate) const ENABLE_S3_LGALLOC_CC_SIZES: Config<bool> = Config::new(
     "persist_enable_s3_lgalloc_cc_sizes",
     true,
     "An incident flag to disable copying fetched s3 data into lgalloc on cc sized clusters.",
 );
 
-/// The `persist_enable_s3_lgalloc_noncc_sizes` config.
-pub const ENABLE_S3_LGALLOC_NONCC_SIZES: Config<bool> = Config::new(
+pub(crate) const ENABLE_S3_LGALLOC_NONCC_SIZES: Config<bool> = Config::new(
     "persist_enable_s3_lgalloc_noncc_sizes",
     false,
     "A feature flag to enable copying fetched s3 data into lgalloc on non-cc sized clusters.",
@@ -481,7 +479,7 @@ impl Blob for S3Blob {
                         ENABLE_S3_LGALLOC_NONCC_SIZES.get(&self.cfg)
                     };
                     let data = if enable_s3_lgalloc {
-                        MaybeLgBytes::LgBytes(self.metrics.lgbytes.try_mmap(&data))
+                        MaybeLgBytes::LgBytes(self.metrics.lgbytes.persist_s3.try_mmap(&data))
                     } else {
                         // In the CYA fallback case, make sure we skip the
                         // memcpy to preserve the previous behavior as closely

--- a/src/persist/src/workload.rs
+++ b/src/persist/src/workload.rs
@@ -18,6 +18,7 @@ use mz_ore::cast::CastFrom;
 use mz_persist_types::Codec64;
 
 use crate::indexed::columnar::{ColumnarRecords, ColumnarRecordsBuilder};
+use crate::metrics::ColumnarMetrics;
 
 /// A configurable data generator for benchmarking.
 #[derive(Clone, Debug)]
@@ -171,7 +172,7 @@ impl DataGenerator {
                 "generator exceeded batch size; smaller batches needed"
             );
         }
-        Some(batch.finish())
+        Some(batch.finish(&ColumnarMetrics::disconnected()))
     }
 
     fn gen_record(&mut self, record_idx: usize) -> ((&[u8], &[u8]), u64, i64) {

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -12,6 +12,7 @@ use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsBuilder};
+use mz_persist::metrics::ColumnarMetrics;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::columnar::{PartDecoder, PartEncoder};
 use mz_persist_types::part::{Part, PartBuilder};
@@ -255,7 +256,7 @@ fn encode_legacy(rows: &[Row]) -> ColumnarRecords {
         row.encode(&mut key_buf);
         assert!(buf.push(((&key_buf, &[]), 1i64.to_le_bytes(), 1i64.to_le_bytes())));
     }
-    buf.finish()
+    buf.finish(&ColumnarMetrics::disconnected())
 }
 
 fn decode_legacy(part: &ColumnarRecords) -> Vec<Row> {

--- a/src/storage/examples/upsert_open_loop/workload.rs
+++ b/src/storage/examples/upsert_open_loop/workload.rs
@@ -17,6 +17,7 @@ use std::mem::size_of;
 
 use mz_ore::cast::CastFrom;
 use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsBuilder};
+use mz_persist::metrics::ColumnarMetrics;
 use mz_persist_types::Codec64;
 
 /// A configurable data generator for benchmarking.
@@ -224,7 +225,7 @@ impl DataGenerator {
                 "generator exceeded batch size; smaller batches needed"
             );
         }
-        Some(batch.finish())
+        Some(batch.finish(&ColumnarMetrics::disconnected()))
     }
 
     fn gen_record(&mut self, record_idx: usize) -> ((&[u8], &[u8]), u64, i64) {


### PR DESCRIPTION
This will reduce rehydration memory spikes by moving the data decoded
from arrow/parquet into file-backed mapped allocations.

Ideally, we'd read decode into these allocs, but that
requires maintaining a fork of our arrow client library. We
appear to get a meaningful improvement by moving the data in at the very
first place it touches mz code, and that's a much easier place to start.

Mechanically, this is accomplished by replacing the arrow2-provided
`*Buffer` structs (morally an `Arc<Vec<T>>`) with lgalloc-backed
`Regions`. On the decode path, we attempt to use `Region::Mmap` (only on
cc clusters). On the encode path, we assume the data will shortly be
encoded and don't bother, instead just using `Region::Heap`. This diff
is pretty small, most of the PR is generalizing `MetricsRegion` to any
`T: Copy` as well as plumbing the configs and metrics.

Along with #25097, this is sufficient to allow the TPCH (sf=1) queries
as indexes to rehydrate on a 3xsmall (4 GiB, modified with bonus disk).
That represents ~40 GiB of input data fetched from s3.

Touches #23332

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
