### PR TITLE
tables: Finalize shards after a table is dropped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5924,6 +5924,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "derivative",
  "differential-dataflow",
  "futures",
  "itertools",

--- a/src/persist-txn/src/txns.rs
+++ b/src/persist-txn/src/txns.rs
@@ -396,8 +396,10 @@ where
                 }
             }
 
-            self.datas.data_write.remove(&data_id);
+            // Note: Ordering here matters, we want to generate the Tidy work _before_ removing the
+            // handle because the work will create a handle to the shard.
             let tidy = self.apply_le(&forget_ts).await;
+            self.datas.data_write.remove(&data_id);
 
             Ok(tidy)
         })

--- a/src/storage-controller/Cargo.toml
+++ b/src/storage-controller/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.66"
 async-trait = "0.1.68"
 bytes = "1.3.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
+derivative = "2.2.0"
 differential-dataflow = "0.12.0"
 futures = "0.3.25"
 itertools = { version = "0.10.5" }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2939,6 +2939,7 @@ where
                                     return Ok(());
                                 }
                             }
+                            write_handle.expire().await;
 
                             persist_client
                                 .finalize_shard::<SourceData, (), T, Diff>(

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -378,3 +378,24 @@ name nullable type
 -----------------------
 b    true     integer
 a    true     integer
+
+
+# Test that the underlying Persist shard gets cleaned up on DROP.
+> CREATE TABLE shard_drop_test (a int, b text);
+
+> INSERT INTO shard_drop_test VALUES (1, 'hello');
+
+$ set-from-sql var=shard-drop-test-id
+SELECT id FROM mz_tables WHERE name = 'shard_drop_test';
+
+> CREATE TABLE shard_drop_test_empty (a int, b text);
+
+$ set-from-sql var=shard-drop-test-empty-id
+SELECT id FROM mz_tables WHERE name = 'shard_drop_test_empty';
+
+> DROP TABLE shard_drop_test;
+
+> DROP TABLE shard_drop_test_empty;
+
+> SELECT COUNT(*) FROM mz_internal.mz_storage_shards WHERE object_id IN ('$shard-drop-test-id', '$shard-drop-test-empty-id');
+0


### PR DESCRIPTION
This PR finalizes the Persist shard for a table, after the table gets dropped.

Previously when dropping a table we would leak the shard, and only during a restart of environmentd would we notice the shard has been leaked and schedule it for finalization. Now after a table gets dropped we do the following:

1. Wait for the since of the shard to get downgraded to the empty Antichain, which is triggered by the Coordinator when the table is dropped.
2. Ask and wait for `PersistTxn` to forget the handle.
3. Emit a `DroppedIds` event which triggers shard finalization.

Note: I wrote a consistency check that would check for leak shards and automatically run after a testdrive test. I wanted to include this but unfortunately subsources also leak their shards, and fixing that is non-trivial, so we'll have to wait to merge that.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/25246

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
