### PR TITLE
sql-parser: allow using `row` in expressions

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -573,7 +573,9 @@ impl<'a> Parser<'a> {
             Token::Keyword(NOT) => Ok(Expr::Not {
                 expr: Box::new(self.parse_subexpr(Precedence::PrefixNot)?),
             }),
-            Token::Keyword(ROW) => self.parse_row_expr(),
+            Token::Keyword(ROW) if self.peek_token() == Some(Token::LParen) => {
+                self.parse_row_expr()
+            }
             Token::Keyword(TRIM) => self.parse_trim_expr(),
             Token::Keyword(POSITION) if self.peek_token() == Some(Token::LParen) => {
                 self.parse_position_expr()

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -193,6 +193,16 @@ SELECT ROW(1, 2)
 ----
 SELECT ROW(1, 2)
 
+parse-statement roundtrip
+SELECT ROW
+----
+SELECT row
+
+parse-statement roundtrip
+SELECT ROW + 1
+----
+SELECT row + 1
+
 parse-statement
 SELECT id, fname, lname FROM customer WHERE id = 1 LIMIT 5
 ----


### PR DESCRIPTION
Unless it is followed by a `(` token, in which case it is an explicit row constructor. The new behavior matches PostgreSQL.

Fix #23827.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow using `row` in scalar expression contexts outside of explicit row constructors.
