### PR TITLE
adapter: simplify subscribe cancelation

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -129,6 +129,7 @@ class FetchAction(Action):
             result.extend(
                 [
                     "does not exist",
+                    "subscribe has been terminated because underlying relation",
                 ]
             )
         return result

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -301,7 +301,7 @@ impl Coordinator {
                     self.sequence_subscribe(ctx, plan, target_cluster).await;
                 }
                 Plan::SideEffectingFunc(plan) => {
-                    ctx.retire(self.sequence_side_effecting_func(plan));
+                    self.sequence_side_effecting_func(ctx, plan).await;
                 }
                 Plan::ShowCreate(plan) => {
                     ctx.retire(Ok(Self::send_immediate_rows(vec![plan.row])));
@@ -442,7 +442,7 @@ impl Coordinator {
                 }
                 Plan::DiscardAll => {
                     let ret = if let TransactionStatus::Started(_) = ctx.session().transaction() {
-                        self.clear_transaction(ctx.session_mut());
+                        self.clear_transaction(ctx.session_mut()).await;
                         self.drop_temp_items(ctx.session().conn_id()).await;
                         ctx.session_mut().reset();
                         Ok(ExecuteResponse::DiscardedAll)

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -58,9 +58,7 @@ pub mod telemetry;
 pub mod webhook;
 
 pub use crate::client::{Client, Handle, SessionClient};
-pub use crate::command::{
-    Canceled, ExecuteResponse, ExecuteResponseKind, RowsFuture, StartupResponse,
-};
+pub use crate::command::{ExecuteResponse, ExecuteResponseKind, RowsFuture, StartupResponse};
 pub use crate::coord::id_bundle::CollectionIdBundle;
 pub use crate::coord::peek::PeekResponseUnary;
 pub use crate::coord::timeline::TimelineContext;

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -86,9 +86,6 @@ pub enum AdapterNotice {
         isolation_level: String,
     },
     StrongSessionSerializable,
-    DroppedSubscribe {
-        dropped_name: String,
-    },
     BadStartupSetting {
         name: String,
         reason: String,
@@ -173,7 +170,6 @@ impl AdapterNotice {
             AdapterNotice::QueryTrace { .. } => Severity::Notice,
             AdapterNotice::UnimplementedIsolationLevel { .. } => Severity::Notice,
             AdapterNotice::StrongSessionSerializable => Severity::Notice,
-            AdapterNotice::DroppedSubscribe { .. } => Severity::Notice,
             AdapterNotice::BadStartupSetting { .. } => Severity::Notice,
             AdapterNotice::RbacUserDisabled => Severity::Notice,
             AdapterNotice::RoleMembershipAlreadyExists { .. } => Severity::Notice,
@@ -264,7 +260,6 @@ impl AdapterNotice {
             AdapterNotice::QueryTrace { .. } => SqlState::WARNING,
             AdapterNotice::UnimplementedIsolationLevel { .. } => SqlState::WARNING,
             AdapterNotice::StrongSessionSerializable => SqlState::WARNING,
-            AdapterNotice::DroppedSubscribe { .. } => SqlState::WARNING,
             AdapterNotice::BadStartupSetting { .. } => SqlState::WARNING,
             AdapterNotice::RbacUserDisabled => SqlState::WARNING,
             AdapterNotice::RoleMembershipAlreadyExists { .. } => SqlState::WARNING,
@@ -370,12 +365,6 @@ impl fmt::Display for AdapterNotice {
                 write!(
                     f,
                     "The Strong Session Serializable isolation level may exhibit consistency violations when reading from catalog objects",
-                )
-            }
-            AdapterNotice::DroppedSubscribe { dropped_name } => {
-                write!(
-                    f,
-                    "subscribe has been terminated because underlying {dropped_name} was dropped"
                 )
             }
             AdapterNotice::BadStartupSetting { name, reason } => {

--- a/src/adapter/src/subscribe.rs
+++ b/src/adapter/src/subscribe.rs
@@ -15,7 +15,7 @@ use std::iter;
 
 use itertools::Itertools;
 use mz_adapter_types::connection::ConnectionId;
-use mz_compute_client::protocol::response::{SubscribeBatch, SubscribeResponse};
+use mz_compute_client::protocol::response::SubscribeBatch;
 use mz_controller_types::ClusterId;
 use mz_expr::compare_columns;
 use mz_ore::now::EpochMillis;
@@ -92,224 +92,214 @@ impl ActiveSubscribe {
     /// Process a subscribe response.
     ///
     /// Returns `true` if the subscribe is finished.
-    pub(crate) fn process_response(&mut self, response: SubscribeResponse) {
+    pub(crate) fn process_response(&mut self, batch: SubscribeBatch) {
         let mut row_buf = Row::default();
-        match response {
-            SubscribeResponse::Batch(SubscribeBatch {
-                lower: _,
-                upper,
-                updates,
-            }) => {
-                match updates {
-                    Ok(mut rows) => {
-                        // Sort results by time. We use stable sort here because it will produce deterministic
-                        // results since the cursor will always produce rows in the same order.
-                        // Compute doesn't guarantee that the results are sorted (#18936)
-                        match &self.output {
-                            SubscribeOutput::WithinTimestampOrderBy { order_by } => {
-                                let mut left_datum_vec = mz_repr::DatumVec::new();
-                                let mut right_datum_vec = mz_repr::DatumVec::new();
-                                rows.sort_by(|(left_time, left_row, left_diff), (right_time, right_row, right_diff)| {
-                                    left_time.cmp(right_time).then_with(|| {
-                                        let mut left_datums = left_datum_vec.borrow();
-                                        left_datums.extend(&[Datum::Int64(*left_diff)]);
-                                        left_datums.extend(left_row.iter());
-                                        let mut right_datums = right_datum_vec.borrow();
-                                        right_datums.extend(&[Datum::Int64(*right_diff)]);
-                                        right_datums.extend(right_row.iter());
-                                        compare_columns(order_by, &left_datums, &right_datums, || {
-                                            left_row.cmp(right_row).then(left_diff.cmp(right_diff))
-                                        })
+        match batch.updates {
+            Ok(mut rows) => {
+                // Sort results by time. We use stable sort here because it will produce deterministic
+                // results since the cursor will always produce rows in the same order.
+                // Compute doesn't guarantee that the results are sorted (#18936)
+                match &self.output {
+                    SubscribeOutput::WithinTimestampOrderBy { order_by } => {
+                        let mut left_datum_vec = mz_repr::DatumVec::new();
+                        let mut right_datum_vec = mz_repr::DatumVec::new();
+                        rows.sort_by(
+                            |(left_time, left_row, left_diff),
+                             (right_time, right_row, right_diff)| {
+                                left_time.cmp(right_time).then_with(|| {
+                                    let mut left_datums = left_datum_vec.borrow();
+                                    left_datums.extend(&[Datum::Int64(*left_diff)]);
+                                    left_datums.extend(left_row.iter());
+                                    let mut right_datums = right_datum_vec.borrow();
+                                    right_datums.extend(&[Datum::Int64(*right_diff)]);
+                                    right_datums.extend(right_row.iter());
+                                    compare_columns(order_by, &left_datums, &right_datums, || {
+                                        left_row.cmp(right_row).then(left_diff.cmp(right_diff))
                                     })
-                                });
-                            }
-                            SubscribeOutput::EnvelopeUpsert { order_by_keys }
-                            | SubscribeOutput::EnvelopeDebezium { order_by_keys } => {
-                                let debezium =
-                                    matches!(self.output, SubscribeOutput::EnvelopeDebezium { .. });
-                                let mut left_datum_vec = mz_repr::DatumVec::new();
-                                let mut right_datum_vec = mz_repr::DatumVec::new();
-                                rows.sort_by(|(left_time, left_row, left_diff), (right_time, right_row, right_diff)| {
-                                    left_time.cmp(right_time).then_with(|| {
-                                        let left_datums = left_datum_vec.borrow_with(left_row);
-                                        let right_datums = right_datum_vec.borrow_with(right_row);
-                                        compare_columns(order_by_keys, &left_datums, &right_datums, || left_diff.cmp(right_diff))
-                                    })
-                                });
+                                })
+                            },
+                        );
+                    }
+                    SubscribeOutput::EnvelopeUpsert { order_by_keys }
+                    | SubscribeOutput::EnvelopeDebezium { order_by_keys } => {
+                        let debezium =
+                            matches!(self.output, SubscribeOutput::EnvelopeDebezium { .. });
+                        let mut left_datum_vec = mz_repr::DatumVec::new();
+                        let mut right_datum_vec = mz_repr::DatumVec::new();
+                        rows.sort_by(
+                            |(left_time, left_row, left_diff),
+                             (right_time, right_row, right_diff)| {
+                                left_time.cmp(right_time).then_with(|| {
+                                    let left_datums = left_datum_vec.borrow_with(left_row);
+                                    let right_datums = right_datum_vec.borrow_with(right_row);
+                                    compare_columns(
+                                        order_by_keys,
+                                        &left_datums,
+                                        &right_datums,
+                                        || left_diff.cmp(right_diff),
+                                    )
+                                })
+                            },
+                        );
 
-                                let mut new_rows = Vec::new();
-                                let mut it = rows.iter();
-                                let mut datum_vec = mz_repr::DatumVec::new();
-                                let mut old_datum_vec = mz_repr::DatumVec::new();
-                                while let Some(start) = it.next() {
-                                    let group = iter::once(start)
-                                        .chain(it.take_while_ref(|row| {
-                                            let left_datums = left_datum_vec.borrow_with(&start.1);
-                                            let right_datums = right_datum_vec.borrow_with(&row.1);
-                                            start.0 == row.0
-                                                && compare_columns(
-                                                    order_by_keys,
-                                                    &left_datums,
-                                                    &right_datums,
-                                                    || Ordering::Equal,
-                                                ) == Ordering::Equal
-                                        }))
-                                        .collect_vec();
+                        let mut new_rows = Vec::new();
+                        let mut it = rows.iter();
+                        let mut datum_vec = mz_repr::DatumVec::new();
+                        let mut old_datum_vec = mz_repr::DatumVec::new();
+                        while let Some(start) = it.next() {
+                            let group = iter::once(start)
+                                .chain(it.take_while_ref(|row| {
+                                    let left_datums = left_datum_vec.borrow_with(&start.1);
+                                    let right_datums = right_datum_vec.borrow_with(&row.1);
+                                    start.0 == row.0
+                                        && compare_columns(
+                                            order_by_keys,
+                                            &left_datums,
+                                            &right_datums,
+                                            || Ordering::Equal,
+                                        ) == Ordering::Equal
+                                }))
+                                .collect_vec();
 
-                                    // Four cases:
-                                    // [(key, value, +1)] => ("insert", key, NULL, value)
-                                    // [(key, v1, -1), (key, v2, +1)] => ("upsert", key, v1, v2)
-                                    // [(key, value, -1)] => ("delete", key, value, NULL)
-                                    // everything else => ("key_violation", key, NULL, NULL)
-                                    let value_columns = self.arity - order_by_keys.len();
-                                    let mut packer = row_buf.packer();
-                                    new_rows.push(match &group[..] {
-                                        [(_, row, 1)] => {
-                                            packer.push(if debezium {
-                                                Datum::String("insert")
-                                            } else {
-                                                Datum::String("upsert")
-                                            });
-                                            let datums = datum_vec.borrow_with(row);
-                                            for column_order in order_by_keys {
-                                                packer.push(datums[column_order.column]);
-                                            }
-                                            if debezium {
-                                                for _ in 0..value_columns {
-                                                    packer.push(Datum::Null);
-                                                }
-                                            }
-                                            for idx in 0..self.arity {
-                                                if !order_by_keys.iter().any(|co| co.column == idx)
-                                                {
-                                                    packer.push(datums[idx]);
-                                                }
-                                            }
-                                            (start.0, row_buf.clone(), 0)
-                                        }
-                                        [(_, _, -1)] => {
-                                            packer.push(Datum::String("delete"));
-                                            let datums = datum_vec.borrow_with(&start.1);
-                                            for column_order in order_by_keys {
-                                                packer.push(datums[column_order.column]);
-                                            }
-                                            if debezium {
-                                                for idx in 0..self.arity {
-                                                    if !order_by_keys
-                                                        .iter()
-                                                        .any(|co| co.column == idx)
-                                                    {
-                                                        packer.push(datums[idx]);
-                                                    }
-                                                }
-                                            }
-                                            for _ in 0..self.arity - order_by_keys.len() {
-                                                packer.push(Datum::Null);
-                                            }
-                                            (start.0, row_buf.clone(), 0)
-                                        }
-                                        [(_, old_row, -1), (_, row, 1)] => {
-                                            packer.push(Datum::String("upsert"));
-                                            let datums = datum_vec.borrow_with(row);
-                                            let old_datums = old_datum_vec.borrow_with(old_row);
-
-                                            for column_order in order_by_keys {
-                                                packer.push(datums[column_order.column]);
-                                            }
-                                            if debezium {
-                                                for idx in 0..self.arity {
-                                                    if !order_by_keys
-                                                        .iter()
-                                                        .any(|co| co.column == idx)
-                                                    {
-                                                        packer.push(old_datums[idx]);
-                                                    }
-                                                }
-                                            }
-                                            for idx in 0..self.arity {
-                                                if !order_by_keys.iter().any(|co| co.column == idx)
-                                                {
-                                                    packer.push(datums[idx]);
-                                                }
-                                            }
-                                            (start.0, row_buf.clone(), 0)
-                                        }
-                                        _ => {
-                                            packer.push(Datum::String("key_violation"));
-                                            let datums = datum_vec.borrow_with(&start.1);
-                                            for column_order in order_by_keys {
-                                                packer.push(datums[column_order.column]);
-                                            }
-                                            if debezium {
-                                                for _ in 0..(self.arity - order_by_keys.len()) {
-                                                    packer.push(Datum::Null);
-                                                }
-                                            }
-                                            for _ in 0..(self.arity - order_by_keys.len()) {
-                                                packer.push(Datum::Null);
-                                            }
-                                            (start.0, row_buf.clone(), 0)
-                                        }
+                            // Four cases:
+                            // [(key, value, +1)] => ("insert", key, NULL, value)
+                            // [(key, v1, -1), (key, v2, +1)] => ("upsert", key, v1, v2)
+                            // [(key, value, -1)] => ("delete", key, value, NULL)
+                            // everything else => ("key_violation", key, NULL, NULL)
+                            let value_columns = self.arity - order_by_keys.len();
+                            let mut packer = row_buf.packer();
+                            new_rows.push(match &group[..] {
+                                [(_, row, 1)] => {
+                                    packer.push(if debezium {
+                                        Datum::String("insert")
+                                    } else {
+                                        Datum::String("upsert")
                                     });
+                                    let datums = datum_vec.borrow_with(row);
+                                    for column_order in order_by_keys {
+                                        packer.push(datums[column_order.column]);
+                                    }
+                                    if debezium {
+                                        for _ in 0..value_columns {
+                                            packer.push(Datum::Null);
+                                        }
+                                    }
+                                    for idx in 0..self.arity {
+                                        if !order_by_keys.iter().any(|co| co.column == idx) {
+                                            packer.push(datums[idx]);
+                                        }
+                                    }
+                                    (start.0, row_buf.clone(), 0)
                                 }
-                                rows = new_rows;
-                            }
-                            SubscribeOutput::Diffs => rows.sort_by_key(|(time, _, _)| *time),
+                                [(_, _, -1)] => {
+                                    packer.push(Datum::String("delete"));
+                                    let datums = datum_vec.borrow_with(&start.1);
+                                    for column_order in order_by_keys {
+                                        packer.push(datums[column_order.column]);
+                                    }
+                                    if debezium {
+                                        for idx in 0..self.arity {
+                                            if !order_by_keys.iter().any(|co| co.column == idx) {
+                                                packer.push(datums[idx]);
+                                            }
+                                        }
+                                    }
+                                    for _ in 0..self.arity - order_by_keys.len() {
+                                        packer.push(Datum::Null);
+                                    }
+                                    (start.0, row_buf.clone(), 0)
+                                }
+                                [(_, old_row, -1), (_, row, 1)] => {
+                                    packer.push(Datum::String("upsert"));
+                                    let datums = datum_vec.borrow_with(row);
+                                    let old_datums = old_datum_vec.borrow_with(old_row);
+
+                                    for column_order in order_by_keys {
+                                        packer.push(datums[column_order.column]);
+                                    }
+                                    if debezium {
+                                        for idx in 0..self.arity {
+                                            if !order_by_keys.iter().any(|co| co.column == idx) {
+                                                packer.push(old_datums[idx]);
+                                            }
+                                        }
+                                    }
+                                    for idx in 0..self.arity {
+                                        if !order_by_keys.iter().any(|co| co.column == idx) {
+                                            packer.push(datums[idx]);
+                                        }
+                                    }
+                                    (start.0, row_buf.clone(), 0)
+                                }
+                                _ => {
+                                    packer.push(Datum::String("key_violation"));
+                                    let datums = datum_vec.borrow_with(&start.1);
+                                    for column_order in order_by_keys {
+                                        packer.push(datums[column_order.column]);
+                                    }
+                                    if debezium {
+                                        for _ in 0..(self.arity - order_by_keys.len()) {
+                                            packer.push(Datum::Null);
+                                        }
+                                    }
+                                    for _ in 0..(self.arity - order_by_keys.len()) {
+                                        packer.push(Datum::Null);
+                                    }
+                                    (start.0, row_buf.clone(), 0)
+                                }
+                            });
+                        }
+                        rows = new_rows;
+                    }
+                    SubscribeOutput::Diffs => rows.sort_by_key(|(time, _, _)| *time),
+                }
+
+                let rows = rows
+                    .into_iter()
+                    .map(|(time, row, diff)| {
+                        assert!(self.as_of <= time);
+                        let mut packer = row_buf.packer();
+                        // TODO: Change to MzTimestamp.
+                        packer.push(Datum::from(numeric::Numeric::from(time)));
+                        if self.emit_progress {
+                            // When sinking with PROGRESS, the output
+                            // includes an additional column that
+                            // indicates whether a timestamp is
+                            // complete. For regular "data" updates this
+                            // is always `false`.
+                            packer.push(Datum::False);
                         }
 
-                        let rows = rows
-                            .into_iter()
-                            .map(|(time, row, diff)| {
-                                assert!(self.as_of <= time);
-                                let mut packer = row_buf.packer();
-                                // TODO: Change to MzTimestamp.
-                                packer.push(Datum::from(numeric::Numeric::from(time)));
-                                if self.emit_progress {
-                                    // When sinking with PROGRESS, the output
-                                    // includes an additional column that
-                                    // indicates whether a timestamp is
-                                    // complete. For regular "data" updates this
-                                    // is always `false`.
-                                    packer.push(Datum::False);
-                                }
+                        match &self.output {
+                            SubscribeOutput::EnvelopeUpsert { .. }
+                            | SubscribeOutput::EnvelopeDebezium { .. } => {}
+                            SubscribeOutput::Diffs
+                            | SubscribeOutput::WithinTimestampOrderBy { .. } => {
+                                packer.push(Datum::Int64(diff));
+                            }
+                        }
 
-                                match &self.output {
-                                    SubscribeOutput::EnvelopeUpsert { .. }
-                                    | SubscribeOutput::EnvelopeDebezium { .. } => {}
-                                    SubscribeOutput::Diffs
-                                    | SubscribeOutput::WithinTimestampOrderBy { .. } => {
-                                        packer.push(Datum::Int64(diff));
-                                    }
-                                }
+                        packer.extend_by_row(&row);
 
-                                packer.extend_by_row(&row);
-
-                                row_buf.clone()
-                            })
-                            .collect();
-                        self.send(PeekResponseUnary::Rows(rows));
-                    }
-                    Err(text) => {
-                        self.send(PeekResponseUnary::Error(text));
-                    }
-                }
-                // Emit progress message if requested. Don't emit progress for the first batch if the upper
-                // is exactly `as_of` (we're guaranteed it is not less than `as_of`, but it might be exactly
-                // `as_of`) as we've already emitted that progress message in `initialize`.
-                if !upper.less_equal(&self.as_of) {
-                    self.send_progress_message(&upper);
-                }
-                if upper.is_empty() {
-                    // The subscribe has completed. Drop the channel so that the
-                    // client knows there are no further responses coming.
-                    self.channel = None;
-                }
+                        row_buf.clone()
+                    })
+                    .collect();
+                self.send(PeekResponseUnary::Rows(rows));
             }
-            SubscribeResponse::DroppedAt(_) => {
-                // The subscribe has completed. Drop the channel so that the
-                // client knows there are no further responses coming.
-                self.channel = None;
+            Err(text) => {
+                self.send(PeekResponseUnary::Error(text));
             }
+        }
+        // Emit progress message if requested. Don't emit progress for the first batch if the upper
+        // is exactly `as_of` (we're guaranteed it is not less than `as_of`, but it might be exactly
+        // `as_of`) as we've already emitted that progress message in `initialize`.
+        if !batch.upper.less_equal(&self.as_of) {
+            self.send_progress_message(&batch.upper);
+        }
+        if batch.upper.is_empty() {
+            // The subscribe has completed. Drop the channel so that the
+            // client knows there are no further responses coming.
+            self.channel = None;
         }
     }
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -64,7 +64,7 @@ use crate::controller::replica::ReplicaConfig;
 use crate::logging::{LogVariant, LoggingConfig};
 use crate::metrics::ComputeControllerMetrics;
 use crate::protocol::command::{ComputeParameters, PeekTarget};
-use crate::protocol::response::{ComputeResponse, PeekResponse, SubscribeResponse};
+use crate::protocol::response::{ComputeResponse, PeekResponse, SubscribeBatch};
 use crate::service::{ComputeClient, ComputeGrpcClient};
 
 mod instance;
@@ -80,7 +80,7 @@ pub enum ComputeControllerResponse<T> {
     /// See [`ComputeResponse::PeekResponse`].
     PeekResponse(Uuid, PeekResponse, OpenTelemetryContext),
     /// See [`ComputeResponse::SubscribeResponse`].
-    SubscribeResponse(GlobalId, SubscribeResponse<T>),
+    SubscribeResponse(GlobalId, SubscribeBatch<T>),
     /// See [`ComputeResponse::FrontierUpper`]
     FrontierUpper { id: GlobalId, upper: Antichain<T> },
 }

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -351,7 +351,7 @@ impl Arbitrary for SubscribeResponse<mz_repr::Timestamp> {
 
 /// A batch of updates for the interval `[lower, upper)`.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct SubscribeBatch<T> {
+pub struct SubscribeBatch<T = mz_repr::Timestamp> {
     /// The lower frontier of the batch of updates.
     pub lower: Antichain<T>,
     /// The upper frontier of the batch of updates.

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -36,7 +36,7 @@ use mz_cluster_client::ReplicaId;
 use mz_compute_client::controller::{
     ActiveComputeController, ComputeController, ComputeControllerResponse,
 };
-use mz_compute_client::protocol::response::{PeekResponse, SubscribeResponse};
+use mz_compute_client::protocol::response::{PeekResponse, SubscribeBatch};
 use mz_compute_client::service::{ComputeClient, ComputeGrpcClient};
 use mz_orchestrator::{NamespacedOrchestrator, Orchestrator, ServiceProcessMetrics};
 use mz_ore::metrics::MetricsRegistry;
@@ -110,7 +110,7 @@ pub enum ControllerResponse<T = mz_repr::Timestamp> {
     /// done in compute!
     PeekResponse(Uuid, PeekResponse, OpenTelemetryContext),
     /// The worker's next response to a specified subscribe.
-    SubscribeResponse(GlobalId, SubscribeResponse<T>),
+    SubscribeResponse(GlobalId, SubscribeBatch<T>),
     /// Notification that new resource usage metrics are available for a given replica.
     ComputeReplicaMetrics(ReplicaId, Vec<ServiceProcessMetrics>),
     WatchSetFinished(Vec<Box<dyn Any>>),

--- a/test/cluster/cluster-drop-concurrent/run.td
+++ b/test/cluster/cluster-drop-concurrent/run.td
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> DROP CLUSTER drop CASCADE

--- a/test/cluster/cluster-drop-concurrent/setup.td
+++ b/test/cluster/cluster-drop-concurrent/setup.td
@@ -1,0 +1,22 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
+
+> DROP CLUSTER IF EXISTS drop CASCADE
+> CREATE CLUSTER drop REPLICAS (replica1 (
+  STORAGECTL ADDRESSES ['clusterd1:2100'],
+  STORAGE ADDRESSES ['clusterd1:2103'],
+  COMPUTECTL ADDRESSES ['clusterd1:2101'],
+  COMPUTE ADDRESSES ['clusterd1:2102'],
+  WORKERS 1))
+
+> DROP SOURCE IF EXISTS counter
+> CREATE SOURCE counter IN CLUSTER drop FROM LOAD GENERATOR COUNTER (TICK INTERVAL '10s');

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2997,7 +2997,8 @@ class PropagatingThread(Thread):
         super().join(timeout)
         if self.exc:
             raise self.exc
-        return self.ret
+        if hasattr(self, "ret"):
+            return self.ret
 
 
 def workflow_blue_green_deployment(
@@ -3053,7 +3054,10 @@ def workflow_blue_green_deployment(
                 cursor.execute("CLOSE subscribe")
             except DatabaseError as e:
                 # Expected
-                if "cached plan must not change result type" in str(e):
+                msg = str(e)
+                if ("cached plan must not change result type" in msg) or (
+                    "subscribe has been terminated because underlying relation" in msg
+                ):
                     continue
                 raise e
 
@@ -3194,3 +3198,58 @@ def workflow_test_compute_aggressive_readhold_downgrades_disabled(
                 """
             )
         )
+
+
+def workflow_cluster_drop_concurrent(
+    c: Composition, parser: WorkflowArgumentParser
+) -> None:
+    """
+    Test that dropping a cluster will close already running queries against
+    that cluster, both SELECTs and SUBSCRIBEs.
+    """
+    c.down(destroy_volumes=True)
+
+    def select():
+        with c.sql_cursor() as cursor:
+            # This should hang instantly as the timestamp is far in the future,
+            # until the cluster is dropped
+            cursor.execute("SELECT * FROM counter AS OF 18446744073709551615")
+
+    def subscribe():
+        cursor = c.sql_cursor()
+        cursor.execute("BEGIN")
+        cursor.execute("DECLARE subscribe CURSOR FOR SUBSCRIBE (SELECT * FROM counter)")
+        # This should hang until the cluster is dropped
+        cursor.execute("FETCH ALL subscribe")
+
+    with c.override(
+        Testdrive(
+            no_reset=True,
+        ),
+        Clusterd(name="clusterd1"),
+        Materialized(),
+    ):
+        c.up("materialized")
+        c.up("clusterd1")
+        c.run_testdrive_files("cluster-drop-concurrent/setup.td")
+        threads = [
+            PropagatingThread(target=fn, name=name)
+            for fn, name in ((select, "select"), (subscribe, "subscribe"))
+        ]
+
+        for thread in threads:
+            thread.start()
+        time.sleep(2)  # some time to make sure the queries are in progress
+        try:
+            c.run_testdrive_files("cluster-drop-concurrent/run.td")
+        finally:
+            for thread in threads:
+                try:
+                    thread.join(timeout=10)
+                except ProgrammingError as e:
+                    assert (
+                        e.args[0]["M"]
+                        == 'query could not complete because relation "materialize.public.counter" was dropped'
+                    ), e
+            for thread in threads:
+                assert not thread.is_alive(), f"Thread {thread.name} is still running"


### PR DESCRIPTION
This commit implements the simplification to subscribe lifecycle identified by @teskje in [0]. Highlights:

  * The adapter now immediately removes its state about a subscribe when it aborts a subscribe, thus eliminating the need for `ActiveSubscription::dropping`.

      * The logic for dropping subscribes is no longer semi-circular. The `drop_compute_sinks` method triggers a call to `drop_collections`, which triggers `SubscribeResponse::DroppedAt`, which does *not* cause another call to `drop_compute_sinks`. The only way that adapter and controller state gets cleaned up now is via a call to `drop_compute_sinks`.

  * The separate cancellation channel between the adapter and the protocol layers is no more. Cancellation is now *only* communicated via the peek and subscribe response protocol. This makes the protocol much easier to follow, with seemingly no loss of functionality or ability to send cancellation requests eagerly.

[0]: https://github.com/MaterializeInc/materialize/issues/21081#issuecomment-1903644620

Fix #16121.
Fix #21081.


### Motivation

   * This PR fixes outstanding bugs.
   * This PR refactors existing code.


### Tips for reviewer

Suppressing whitespace goes a long way.

@teskje please see line comments within; there's one piece I'm very not sure about.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
