### PR TITLE
environmentd: assert tracing spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4380,6 +4380,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-core",
+ "tracing-fluent-assertions",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tungstenite",
@@ -4863,6 +4864,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "derivative",
  "futures-core",
  "http",
  "humantime",
@@ -4876,6 +4878,7 @@ dependencies = [
  "opentelemetry_sdk",
  "sentry-tracing",
  "tracing",
+ "tracing-fluent-assertions",
  "tracing-subscriber",
  "workspace-hack",
 ]
@@ -4894,6 +4897,7 @@ dependencies = [
  "console-subscriber",
  "criterion",
  "ctor",
+ "derivative",
  "either",
  "futures",
  "hibitset",
@@ -4928,6 +4932,7 @@ dependencies = [
  "tokio-test",
  "tonic",
  "tracing",
+ "tracing-fluent-assertions",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
@@ -9405,6 +9410,17 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-fluent-assertions"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12de1a8c6bcfee614305e836308b596bbac831137a04c61f7e5b0b0bf2cfeaf6"
+dependencies = [
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -240,6 +240,11 @@ who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.12.0@git:9208396d1d86becbcc91c76e780ffe61fd51e65e"
 
+[[audits.tracing-fluent-assertions]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+
 [[audits.tracing-log]]
 who = "Gus Wynn <gus@materialize.com>"
 criteria = "maintained-and-necessary"

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -17,8 +17,8 @@ use itertools::Either;
 use maplit::btreemap;
 use mz_controller_types::ClusterId;
 use mz_expr::{CollectionPlan, ResultSpec};
-use mz_ore::task;
 use mz_ore::tracing::OpenTelemetryContext;
+use mz_ore::{instrument, task};
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_repr::optimize::OverrideFrom;
 use mz_repr::{Datum, GlobalId, Row, RowArena, Timestamp};
@@ -65,7 +65,7 @@ impl Coordinator {
     /// deploying the most efficient evaluation plan. The peek could evaluate to a constant,
     /// be a simple read out of an existing arrangement, or required a new dataflow to build
     /// the results to return.
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     pub(crate) async fn sequence_peek(
         &mut self,
         ctx: ExecuteContext,
@@ -87,7 +87,7 @@ impl Coordinator {
         .await;
     }
 
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     pub(crate) async fn sequence_copy_to(
         &mut self,
         ctx: ExecuteContext,
@@ -149,7 +149,7 @@ impl Coordinator {
         .await;
     }
 
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     pub(crate) async fn explain_peek(
         &mut self,
         ctx: ExecuteContext,
@@ -198,7 +198,7 @@ impl Coordinator {
     }
 
     /// Processes as many `peek` stages as possible.
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     pub(crate) async fn execute_peek_stage(
         &mut self,
         mut ctx: ExecuteContext,
@@ -275,7 +275,7 @@ impl Coordinator {
     }
 
     /// Do some simple validation. We must defer most of it until after any off-thread work.
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     fn peek_stage_validate(
         &mut self,
         session: &Session,
@@ -386,7 +386,7 @@ impl Coordinator {
     }
 
     /// Possibly linearize a timestamp from a `TimestampOracle`.
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     async fn peek_stage_linearize_timestamp(
         &mut self,
         ctx: ExecuteContext,
@@ -453,7 +453,7 @@ impl Coordinator {
     }
 
     /// Determine a read timestamp and create appropriate read holds.
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     async fn peek_stage_timestamp_read_hold(
         &mut self,
         session: &mut Session,
@@ -507,7 +507,7 @@ impl Coordinator {
         })
     }
 
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     async fn peek_stage_optimize(
         &mut self,
         ctx: ExecuteContext,
@@ -670,7 +670,7 @@ impl Coordinator {
         );
     }
 
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     fn peek_stage_real_time_recency(
         &mut self,
         ctx: ExecuteContext,
@@ -735,7 +735,7 @@ impl Coordinator {
         }
     }
 
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     async fn peek_stage_finish(
         &mut self,
         ctx: &mut ExecuteContext,
@@ -841,7 +841,7 @@ impl Coordinator {
         }
     }
 
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     async fn peek_stage_copy_to_dataflow(
         &mut self,
         ctx: ExecuteContext,
@@ -874,6 +874,7 @@ impl Coordinator {
         self.ship_dataflow(df_desc, cluster_id).await;
     }
 
+    #[instrument]
     fn peek_stage_explain_plan(
         &mut self,
         ctx: &mut ExecuteContext,
@@ -931,6 +932,7 @@ impl Coordinator {
         Ok(Self::send_immediate_rows(rows))
     }
 
+    #[instrument]
     async fn peek_stage_explain_pushdown(
         &mut self,
         ctx: &mut ExecuteContext,
@@ -1021,7 +1023,7 @@ impl Coordinator {
 
     /// Determines the query timestamp and acquires read holds on dependent sources
     /// if necessary.
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     pub(super) async fn sequence_peek_timestamp(
         &mut self,
         session: &mut Session,

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -113,6 +113,7 @@ tower = { version = "0.4.13", features = ["buffer", "limit", "load-shed"] }
 tower-http = { version = "0.4.2", features = ["cors"] }
 tracing = "0.1.37"
 tracing-core = "0.1.30"
+tracing-fluent-assertions = { version = "0.3.0", optional = true }
 tracing-opentelemetry = { version = "0.22.0" }
 tracing-subscriber = "0.3.16"
 tungstenite = { version = "0.20.0" }
@@ -139,10 +140,10 @@ postgres_array = { version = "0.11.0" }
 predicates = "2.1.4"
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 rdkafka = { version = "0.29.0", features = [
-    "cmake-build",
-    "ssl-vendored",
-    "libz-static",
-    "zstd",
+  "cmake-build",
+  "ssl-vendored",
+  "libz-static",
+  "zstd",
 ] }
 reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.89"
@@ -174,6 +175,8 @@ test = [
   "postgres-openssl",
   "mz-tracing",
   "mz-frontegg-mock",
+  "tracing-fluent-assertions",
+  "mz-orchestrator-tracing/fluent-assertions",
 ]
 tokio-console = [
   "mz-ore/tokio-console",

--- a/src/environmentd/tests/tracing.rs
+++ b/src/environmentd/tests/tracing.rs
@@ -1,0 +1,66 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use mz_environmentd::test_util;
+use tracing_fluent_assertions::AssertionRegistry;
+
+// Test that expected spans are generated for various queries.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)] // allow(test-attribute)
+#[cfg_attr(miri, ignore)] // too slow
+async fn test_expected_spans() {
+    let registry = AssertionRegistry::default();
+    // Sets of expected span names and SQL statements that should produce that span.
+    let tests = vec![
+        // TODO: Tests that call create_collections have a race condition.
+        // ("sequence_create_table", "CREATE TABLE t (i INT)"),
+        // ("sequence_insert", "INSERT INTO t VALUES (1)"),
+        // (
+        //     "create_materialized_view_finish",
+        //     "CREATE MATERIALIZED VIEW MV AS SELECT 1",
+        // ),
+        ("create_view_finish", "CREATE VIEW V AS SELECT 1"),
+        ("create_index_finish", "CREATE DEFAULT INDEX i ON v"),
+        ("subscribe_finish", "SUBSCRIBE (SELECT 1)"),
+        ("peek_stage_finish", "SELECT 1"),
+        ("peek_stage_explain_plan", "EXPLAIN SELECT 1"),
+    ];
+    let asserts = tests
+        .iter()
+        .map(|(name, _)| {
+            (
+                *name,
+                registry
+                    .build()
+                    .with_name(*name)
+                    .was_closed_exactly(1)
+                    .finalize(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let server = test_util::TestHarness::default()
+        .with_enable_tracing(true)
+        .with_fluent_assertions(registry)
+        .with_system_parameter_default("opentelemetry_filter".to_string(), "info".to_string())
+        .start()
+        .await;
+    let client = server.connect().await.unwrap();
+
+    for (_, sql) in tests {
+        client.batch_execute(sql).await.unwrap();
+    }
+    for (name, assert) in asserts {
+        if !assert.try_assert() {
+            // Try one more time and print the name. Use .assert here because it prints a deeper
+            // cause than try_assert.
+            println!("assert failed for {name}");
+            assert.assert();
+        }
+    }
+}

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anyhow = "1.0.66"
 async-trait = "0.1.68"
 clap = { version = "3.2.24", features = ["env", "derive"] }
+derivative = "2.2.0"
 futures-core = "0.3.21"
 http = "0.2.8"
 humantime = { version = "2.1.0", optional = true }
@@ -24,6 +25,7 @@ mz-service = { path = "../service" }
 mz-tracing = { path = "../tracing" }
 sentry-tracing = { version = "0.29.1" }
 tracing = { version = "0.1.37" }
+tracing-fluent-assertions = { version = "0.3.0", optional = true }
 tracing-subscriber = { version = "0.3.16", default-features = false }
 opentelemetry = { version = "0.21.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.21.2", features = ["rt-tokio"] }
@@ -35,6 +37,7 @@ mz-ore = { path = "../ore", features = ["network", "test"] }
 [features]
 default = ["tokio-console"]
 tokio-console = ["mz-ore/tokio-console", "mz-repr", "humantime"]
+fluent-assertions = ["tracing-fluent-assertions", "mz-ore/fluent-assertions"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use clap::{FromArgMatches, IntoApp};
+use derivative::Derivative;
 use futures_core::stream::BoxStream;
 use http::header::{HeaderName, HeaderValue};
 use mz_build_info::BuildInfo;
@@ -50,7 +51,8 @@ use opentelemetry_sdk::resource::Resource;
 /// This logic is separated from `mz_ore::tracing` because the details of how
 /// these command-line arguments are parsed and unparsed is specific to
 /// orchestrators and does not belong in a foundational crate like `mz_ore`.
-#[derive(Debug, Clone, clap::Parser)]
+#[derive(Derivative, Clone, clap::Parser)]
+#[derivative(Debug)]
 pub struct TracingCliArgs {
     /// Which tracing events to log to stderr.
     ///
@@ -192,6 +194,11 @@ pub struct TracingCliArgs {
         use_value_delimiter = true
     )]
     pub sentry_tag: Vec<KeyValueArg<String, String>>,
+    /// Test-only feature to enable tracing assertions.
+    #[cfg(feature = "fluent-assertions")]
+    #[derivative(Debug = "ignore")]
+    #[clap(skip)]
+    pub fluent_assertions: Option<tracing_fluent_assertions::AssertionRegistry>,
 }
 
 impl Default for TracingCliArgs {
@@ -263,6 +270,8 @@ impl TracingCliArgs {
             build_sha: build_info.sha,
             build_time: build_info.time,
             registry,
+            #[cfg(feature = "fluent-assertions")]
+            fluent_assertions: self.fluent_assertions.clone(),
         })
         .await
     }
@@ -352,6 +361,8 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
                 sentry_dsn,
                 sentry_environment,
                 sentry_tag,
+                #[cfg(feature = "fluent-assertions")]
+                    fluent_assertions: _,
             } = &self.tracing_args;
             args.push(format!("--startup-log-filter={startup_log_filter}"));
             args.push(format!("--log-format={log_format}"));

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -26,6 +26,7 @@ chrono = { version = "0.4.23", default-features = false, features = [
 clap = { version = "3.2.24", features = ["env"], optional = true }
 compact_bytes = { version = "0.1.1", optional = true }
 ctor = { version = "0.1.26", optional = true }
+derivative = { version = "2.2.0", optional = true }
 either = "1.8.0"
 futures = { version = "0.3.25", optional = true }
 hibitset = { version = "0.6.4", optional = true }
@@ -54,6 +55,7 @@ tokio = { version = "1.32.0", features = [
   "time",
 ], optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
+tracing-fluent-assertions = { version = "0.3.0", optional = true }
 # TODO(guswynn): determine, when, if ever, we can remove `tracing-log`
 # The `tracing-log` feature here is load-bearing: While our busiest-logging dependency (`rdkafka`) is now hooked-up
 # to use `tracing`, we cannot remove this feature until we guarantee no dependencies log using the `log` crate, for
@@ -141,9 +143,10 @@ tracing_ = [
 tokio-console = ["console-subscriber", "tokio", "tokio/tracing", "network"]
 cli = ["clap"]
 stack = ["stacker"]
-test = ["anyhow", "ctor", "tracing-subscriber"]
+test = ["anyhow", "ctor", "tracing-subscriber", "derivative"]
 metrics = ["prometheus"]
 id_gen = ["hibitset", "rand", "uuid"]
+fluent-assertions = ["tracing-fluent-assertions"]
 
 [[test]]
 name = "future"


### PR DESCRIPTION
Add a capturing tracing layer during tests that can be used to assert various things about spans. Use this to verify that expected finishing spans are created during some queries. This is useful because we have at many times in the past broken tracing during refactors.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a