### PR TITLE
Acquire precise read holds for `REFRESH AT`s

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1253,7 +1253,7 @@ pub struct Coordinator {
     ///
     /// Upon completing a transaction, this timestamp should be removed from the holds
     /// in `self.read_capability[id]`, using the `release_read_holds` method.
-    txn_read_holds: BTreeMap<ConnectionId, read_policy::ReadHolds<Timestamp>>,
+    txn_read_holds: BTreeMap<ConnectionId, Vec<read_policy::ReadHolds<Timestamp>>>,
 
     /// Access to the peek fields should be restricted to methods in the [`peek`] API.
     /// A map from pending peek ids to the queue into which responses are sent, and

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1253,6 +1253,8 @@ pub struct Coordinator {
     ///
     /// Upon completing a transaction, this timestamp should be removed from the holds
     /// in `self.read_capability[id]`, using the `release_read_holds` method.
+    ///
+    /// We use a Vec because `ReadHolds` doesn't have a way of tracking multiplicity.
     txn_read_holds: BTreeMap<ConnectionId, Vec<read_policy::ReadHolds<Timestamp>>>,
 
     /// Access to the peek fields should be restricted to methods in the [`peek`] API.

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -834,7 +834,8 @@ impl Coordinator {
             }
 
             if acquire_read_holds {
-                self.acquire_read_holds_auto_cleanup(session, timestamp, &ids);
+                self.acquire_read_holds_auto_cleanup(session, timestamp, &ids, false)
+                    .expect("precise==false, so acquiring read holds always succeeds");
             }
 
             Ok(Some(timestamp))

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -392,9 +392,9 @@ impl crate::coord::Coordinator {
     /// will acquire a read hold at the lowest possible time for that id.
     pub(crate) fn acquire_read_holds(
         &mut self,
-        time: mz_repr::Timestamp,
+        time: Timestamp,
         id_bundle: &CollectionIdBundle,
-    ) -> ReadHolds<mz_repr::Timestamp> {
+    ) -> ReadHolds<Timestamp> {
         let read_holds = self.initialize_read_holds(time, id_bundle);
         // Update STORAGE read policies.
         let mut policy_changes = Vec::new();
@@ -428,6 +428,39 @@ impl crate::coord::Coordinator {
     }
 
     /// Attempt to acquire read holds on the indicated collections at the indicated `time`.
+    /// This is similar to [Self::acquire_read_holds], but if it is unable to acquire read holds at precisely
+    /// the specified time, then it errors out rather than acquiring read holds at a later time.
+    ///
+    /// The returned error contains those collection sinces that were later than the specified time.
+    pub(crate) fn acquire_precise_read_holds(
+        &mut self,
+        requested_time: Timestamp,
+        id_bundle: &CollectionIdBundle,
+    ) -> Result<ReadHolds<Timestamp>, Vec<(Antichain<Timestamp>, CollectionIdBundle)>> {
+        let read_holds = self.acquire_read_holds(requested_time, id_bundle);
+        let too_late = read_holds
+            .holds
+            .iter()
+            .filter_map(|(antichain, ids)| {
+                if antichain
+                    .iter()
+                    .all(|hold_time| *hold_time == requested_time)
+                {
+                    None
+                } else {
+                    Some((antichain.clone(), ids.clone()))
+                }
+            })
+            .collect_vec();
+        if !too_late.is_empty() {
+            self.release_read_holds(read_holds);
+            Err(too_late)
+        } else {
+            Ok(read_holds)
+        }
+    }
+
+    /// Attempt to acquire read holds on the indicated collections at the indicated `time`.
     /// This is similar to [Self::acquire_read_holds], but instead of returning the read holds,
     /// it arranges for them to be automatically released at the end of the transaction.
     ///
@@ -444,6 +477,28 @@ impl crate::coord::Coordinator {
             .entry(session.conn_id().clone())
             .or_insert_with(Vec::new)
             .push(read_holds);
+    }
+
+    /// Attempt to acquire read holds on the indicated collections at the indicated `time`.
+    /// This is similar to [Self::acquire_precise_read_holds], but instead of returning the acquire
+    /// read holds, it arranges for them to be automatically released at the end of the transaction.
+    ///
+    /// Similarly to [Self::acquire_precise_read_holds], if it is unable to acquire read holds at
+    /// precisely the specified time, then it errors out.
+    ///
+    /// The returned error contains those collection sinces that were later than the specified time.
+    pub(crate) fn acquire_precise_read_holds_auto_cleanup(
+        &mut self,
+        session: &Session,
+        time: Timestamp,
+        id_bundle: &CollectionIdBundle,
+    ) -> Result<(), Vec<(Antichain<Timestamp>, CollectionIdBundle)>> {
+        let read_holds = self.acquire_precise_read_holds(time, id_bundle)?;
+        self.txn_read_holds
+            .entry(session.conn_id().clone())
+            .or_insert_with(Vec::new)
+            .push(read_holds);
+        Ok(())
     }
 
     /// Attempt to update the timestamp of the read holds on the indicated collections from the

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -436,8 +436,8 @@ impl crate::coord::Coordinator {
         let read_holds = self.acquire_read_holds(time, id_bundle);
         self.txn_read_holds
             .entry(session.conn_id().clone())
-            .or_insert_with(ReadHolds::new)
-            .extend(read_holds);
+            .or_insert_with(Vec::new)
+            .push(read_holds);
     }
 
     /// Attempt to update the timestamp of the read holds on the indicated collections from the

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -452,10 +452,10 @@ impl crate::coord::Coordinator {
     /// If we are unable to update a read hold at the provided `time` for a specific id, then we
     /// leave it unchanged.
     ///
-    /// This method relies on a previous call to `acquire_read_holds` with the same
-    /// `read_holds` argument or a previous call to `update_read_hold` that returned
+    /// This method relies on a previous call to
+    /// `initialize_read_holds`, `acquire_read_holds`, or `update_read_hold` that returned
     /// `read_holds`, and its behavior will be erratic if called on anything else.
-    pub(super) fn update_read_hold(
+    pub(super) fn update_read_holds(
         &mut self,
         read_holds: ReadHolds<mz_repr::Timestamp>,
         new_time: mz_repr::Timestamp,
@@ -553,13 +553,14 @@ impl crate::coord::Coordinator {
 
         new_read_holds
     }
-    /// Release read holds on the indicated collections at the indicated times.
+
+    /// Release the given read holds.
     ///
-    /// This method relies on a previous call to `acquire_read_holds` with the same
-    /// argument, or a previous call to `update_read_hold` that returned
+    /// This method relies on a previous call to
+    /// `initialize_read_holds`, `acquire_read_holds`, or `update_read_hold` that returned
     /// `read_holds`, and its behavior will be erratic if called on anything else,
     /// or if called more than once on the same bundle of read holds.
-    pub(super) fn release_read_hold(&mut self, read_holds: &ReadHolds<mz_repr::Timestamp>) {
+    pub(super) fn release_read_holds(&mut self, read_holds: ReadHolds<Timestamp>) {
         // Update STORAGE read policies.
         let mut policy_changes = Vec::new();
         for (time, id) in read_holds.storage_ids() {

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -254,11 +254,8 @@ impl Coordinator {
                     .index_oracle(*cluster_id)
                     .sufficient_collections(resolved_ids.0.iter());
                 for refresh_at_ts in &refresh_schedule.ats {
-                    match self.acquire_precise_read_holds_auto_cleanup(
-                        session,
-                        *refresh_at_ts,
-                        &ids,
-                    ) {
+                    match self.acquire_read_holds_auto_cleanup(session, *refresh_at_ts, &ids, true)
+                    {
                         Ok(()) => {}
                         Err(earliest_possible) => {
                             return Err(AdapterError::InputNotReadableAtRefreshAtTime(

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -1003,7 +1003,8 @@ impl Coordinator {
                 });
             }
         } else if let Some((timestamp, bundle)) = potential_read_holds {
-            self.acquire_read_holds_auto_cleanup(session, timestamp, bundle);
+            self.acquire_precise_read_holds_auto_cleanup(session, timestamp, bundle)
+                .expect("able to acquire read holds at the time that we just got from `determine_timestamp`");
         }
 
         // TODO: Checking for only `InTransaction` and not `Implied` (also `Started`?) seems

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -1003,7 +1003,7 @@ impl Coordinator {
                 });
             }
         } else if let Some((timestamp, bundle)) = potential_read_holds {
-            self.acquire_precise_read_holds_auto_cleanup(session, timestamp, bundle)
+            self.acquire_read_holds_auto_cleanup(session, timestamp, bundle, true)
                 .expect("able to acquire read holds at the time that we just got from `determine_timestamp`");
         }
 

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -984,6 +984,9 @@ impl Coordinator {
         // we must acquire read holds here so they are held until the off-thread work
         // returns to the coordinator.
         if let Some(txn_reads) = self.txn_read_holds.get(session.conn_id()) {
+            // Transactions involving peeks will acquire read holds at most once.
+            assert_eq!(txn_reads.len(), 1);
+            let txn_reads = &txn_reads[0];
             // Find referenced ids not in the read hold. A reference could be caused by a
             // user specifying an object in a different schema than the first query. An
             // index could be caused by a CREATE INDEX after the transaction started.

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -205,7 +205,9 @@ impl Coordinator {
 
         // Release this transaction's compaction hold on collections.
         if let Some(txn_reads) = self.txn_read_holds.remove(conn_id) {
-            self.release_read_hold(&txn_reads);
+            for hold in txn_reads {
+                self.release_read_hold(&hold);
+            }
         }
     }
 

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -206,7 +206,7 @@ impl Coordinator {
         // Release this transaction's compaction hold on collections.
         if let Some(txn_reads) = self.txn_read_holds.remove(conn_id) {
             for hold in txn_reads {
-                self.release_read_hold(&hold);
+                self.release_read_holds(hold);
             }
         }
     }

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -205,9 +205,7 @@ impl Coordinator {
 
         // Release this transaction's compaction hold on collections.
         if let Some(txn_reads) = self.txn_read_holds.remove(conn_id) {
-            for hold in txn_reads {
-                self.release_read_holds(hold);
-            }
+            self.release_read_holds(txn_reads);
         }
     }
 

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -723,7 +723,7 @@ impl Coordinator {
             };
             let read_ts = oracle.read_ts().await;
             if read_holds.times().any(|time| time.less_than(&read_ts)) {
-                read_holds = self.update_read_hold(read_holds, read_ts);
+                read_holds = self.update_read_holds(read_holds, read_ts);
             }
             self.global_timelines
                 .insert(timeline, TimelineState { oracle, read_holds });

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -313,10 +313,21 @@ impl AdapterError {
             ),
             AdapterError::InputNotReadableAtRefreshAtTime(oracle_read_ts, earliest_possible) => {
                 Some(format!(
-                    "the requested REFRESH AT time is {}, \
-                    while the following input collections are readable at no earlier than the following times: {:?}",
+                    "The requested REFRESH AT time is {}, \
+                    while the following input collections are readable at no earlier than the following times: [{}].",
                     oracle_read_ts,
-                    earliest_possible,
+                    earliest_possible.iter().map(|(antichain, id_bundle)|
+                        format!(
+                            "[{}]: {}",
+                            id_bundle.iter().map(|id| format!("{}", id)).join(", "),
+                            if antichain.len() == 1 {
+                                format!("{}", antichain.as_option().expect("antichain contains exactly 1 timestamp"))
+                            } else {
+                                // This can't occur currently
+                                format!("{:?}", antichain)
+                            }
+                        )
+                    ).join("; "),
                 ))
             }
             _ => None,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1314,7 +1314,11 @@ where
                 std::mem::swap(&mut collection.implied_capability, &mut new_read_capability);
                 update.extend(new_read_capability.iter().map(|time| (time.clone(), -1)));
                 if !update.is_empty() {
-                    read_capability_changes.insert(id, update);
+                    update.drain_into(
+                        read_capability_changes
+                            .entry(id)
+                            .or_insert_with(ChangeBatch::new),
+                    );
                 }
             }
 

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -975,7 +975,7 @@ statement ok
 SET transaction_isolation = 'strict serializable'
 
 ## MV that has refreshes only in the past
-query error db error: ERROR: all the specified refreshes of the materialized view would be too far in the past, and thus they would never happen
+query error db error: ERROR: REFRESH AT requested for a time where not all the inputs are readable
 CREATE MATERIALIZED VIEW mv_no_refresh
 WITH (REFRESH AT '2000-01-01 10:00')
 AS SELECT * FROM t2;
@@ -1039,3 +1039,41 @@ EXPLAIN SELECT * FROM mv5;
 
 statement ok
 EXPLAIN TIMESTAMP FOR SELECT * FROM mv5;
+
+## Stacked REFRESH MVs -- both have their first and only refresh in the future, at similar times
+statement ok
+CREATE MATERIALIZED VIEW mv6 WITH (REFRESH AT mz_now()::text::int8 + 3000) AS
+SELECT x-y+z from t2;
+
+statement ok
+CREATE MATERIALIZED VIEW mv7 WITH (REFRESH AT mz_now()::text::int8 + 3000) AS
+SELECT * from mv6;
+
+query I
+SELECT * FROM mv7
+----
+NULL
+NULL
+NULL
+2
+11
+30
+70
+100
+
+# We now insert something into the underlying table. This shouldn't be visible in mv6, because mv6's refresh shouldn't
+# be later than mv7's refresh.
+statement ok
+INSERT INTO t2 VALUES (0, 0, 0);
+
+query I
+SELECT * FROM mv6
+----
+NULL
+NULL
+NULL
+2
+11
+30
+70
+100


### PR DESCRIPTION
This makes the changes discussed [here](https://materializeinc.slack.com/archives/C02FWJ94HME/p1707767919719259?thread_ts=1707333434.781239&cid=C02FWJ94HME):

The main thing is that we'll try to acquire precise read holds for `REFRESH AT`, and error out the MV creation if this is not possible. This brings us closer to figuring out what is happening in https://github.com/MaterializeInc/materialize/issues/24288#issuecomment-1931856361, because if we'll now see this error instead of the one from sequencing, that means that the read hold acquisition is failing. (The other possibility is that we are somehow losing the read holds after successfully acquiring them.)

Additionally it fixes a bug where `acquire_read_holds_auto_cleanup` could previously leak read holds when duplicate read holds were involved.

In the huddle yesterday, we were thinking to maybe split `txn_read_holds` into two fields: one for peeks and for MV creations. I didn't do this in the end, because I felt that then we'd have too many of these `acquire_...` functions, so things wouldn't be any less confusing. But let me know if you'd prefer splitting.

### Motivation

  * This PR brings us closer to figuring out https://github.com/MaterializeInc/materialize/issues/24288#issuecomment-1931856361.

  * This PR fixes a previously unreported bug, see above.

### Tips for reviewer

Review the commits one-by-one.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
