### PR TITLE
ci: temporarily disable rqg-wmr

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1245,6 +1245,7 @@ steps:
 
     - id: rqg-wmr
       label: "RQG WMR workload"
+      skip: "flaky until #24904 is fixed"
       artifact_paths: junit_*.xml
       timeout_in_minutes: 45
       agents:


### PR DESCRIPTION
Disabling RQG WMR until https://github.com/MaterializeInc/materialize/issues/24904 is fixed.