### PR TITLE
platform-checks: Set higher statement_timeout

### DIFF
--- a/misc/python/materialize/checks/all_checks/array_type.py
+++ b/misc/python/materialize/checks/all_checks/array_type.py
@@ -40,8 +40,6 @@ class ArrayType(Check):
                   array_col, ARRAY[ARRAY[1,2], ARRAY[NULL, 4]]
                   FROM array_type_table;
 
-                > SET statement_timeout = '120s';
-
                 > INSERT INTO array_type_table SELECT * FROM array_type_table LIMIT 1;
                 """,
                 """
@@ -50,8 +48,6 @@ class ArrayType(Check):
                   text_col, array_fill('foo'::text, ARRAY[2]) AS array_fill2,
                   array_col, ARRAY[ARRAY[1,2], ARRAY[NULL, 4]]
                   FROM array_type_table;
-
-                > SET statement_timeout = '120s';
 
                 > INSERT INTO array_type_table SELECT * FROM array_type_table LIMIT 1;
                 """,

--- a/misc/python/materialize/checks/all_checks/boolean_type.py
+++ b/misc/python/materialize/checks/all_checks/boolean_type.py
@@ -28,8 +28,6 @@ class BooleanType(Check):
             Testdrive(dedent(s))
             for s in [
                 """
-                > SET statement_timeout = '240s';
-
                 > CREATE MATERIALIZED VIEW boolean_type_view1 AS
                   SELECT boolean_col, 'TRUE'::boolean AS true_col, 'FALSE'::boolean AS false_col
                   FROM boolean_type_table
@@ -38,7 +36,6 @@ class BooleanType(Check):
                 > INSERT INTO boolean_type_table SELECT * FROM boolean_type_table;
                 """,
                 """
-                > SET statement_timeout = '240s';
                 > CREATE MATERIALIZED VIEW boolean_type_view2 AS
                   SELECT boolean_col, 'TRUE'::boolean AS true_col, 'FALSE'::boolean AS false_col
                   FROM boolean_type_table

--- a/misc/python/materialize/checks/all_checks/create_table.py
+++ b/misc/python/materialize/checks/all_checks/create_table.py
@@ -70,7 +70,6 @@ class CreateTable(Check):
                 > SELECT f2 FROM create_table1 WHERE f2 = 1234;
                 1234
 
-                > SET statement_timeout = '120s'
                 > DELETE FROM create_table1 WHERE f1 = 999;
 
                 > SHOW CREATE TABLE create_table2;

--- a/misc/python/materialize/checks/all_checks/error.py
+++ b/misc/python/materialize/checks/all_checks/error.py
@@ -99,13 +99,11 @@ class DataflowErrorRetraction(Check):
             for s in [
                 dedent(
                     """
-                > SET statement_timeout = '60s'
                 > DELETE FROM dataflow_error_retraction_table WHERE f1 = 'abc'
                 """
                 ),
                 dedent(
                     """
-                > SET statement_timeout = '60s'
                 > DELETE FROM dataflow_error_retraction_table WHERE f1 = 'klm'
                 """
                 ),

--- a/misc/python/materialize/checks/all_checks/float_types.py
+++ b/misc/python/materialize/checks/all_checks/float_types.py
@@ -37,7 +37,6 @@ class DoubleType(Check):
                   OR double_col IN ('+Inf', '-Inf', 'NaN')
                   OR double_col IS NULL;
 
-                > SET statement_timeout = '60s'
                 > INSERT INTO double_type_table SELECT * FROM double_type_table;
                 """,
                 """
@@ -49,7 +48,6 @@ class DoubleType(Check):
                   OR double_col IN ('+Inf', '-Inf', 'NaN')
                   OR double_col IS NULL
 
-                > SET statement_timeout = '60s'
                 > INSERT INTO double_type_table SELECT * FROM double_type_table;
                 """,
             ]

--- a/misc/python/materialize/checks/all_checks/insert_select.py
+++ b/misc/python/materialize/checks/all_checks/insert_select.py
@@ -30,15 +30,11 @@ class InsertSelect(Check):
             Testdrive(dedent(s))
             for s in [
                 """
-                > SET statement_timeout = '240s'
-
                 > INSERT INTO insert_select_source_table SELECT 'T2' || generate_series FROM generate_series(1, 10000);
 
                 > INSERT INTO insert_select_destination SELECT * FROM insert_select_source_table;
                 """,
                 """
-                > SET statement_timeout = '240s'
-
                 > INSERT INTO insert_select_source_table SELECT 'T3' || generate_series FROM generate_series(1, 10000);
 
                 > INSERT INTO insert_select_destination SELECT * FROM insert_select_source_table;

--- a/misc/python/materialize/checks/all_checks/jsonb_type.py
+++ b/misc/python/materialize/checks/all_checks/jsonb_type.py
@@ -44,7 +44,6 @@ class JsonbType(Check):
                       jsonb_col <@ '{"boolean_element": true}' AS c11,
                       jsonb_col ? 'number_element' AS c12
                     FROM jsonb_type_table, cte;
-                > SET statement_timeout = '120s'
                 > INSERT INTO jsonb_type_table SELECT * FROM jsonb_type_table LIMIT 1;
                 """,
                 """
@@ -64,7 +63,6 @@ class JsonbType(Check):
                       jsonb_col <@ '{"boolean_element": true}' AS c11,
                       jsonb_col ? 'number_element' AS c12
                     FROM jsonb_type_table, cte;
-                > SET statement_timeout = '120s'
                 > INSERT INTO jsonb_type_table SELECT * FROM jsonb_type_table LIMIT 1;
                 """,
             ]

--- a/misc/python/materialize/checks/all_checks/large_tables.py
+++ b/misc/python/materialize/checks/all_checks/large_tables.py
@@ -56,7 +56,6 @@ class ManyRows(Check):
                 """
                 > CREATE TABLE many_rows (f1 TEXT);
                 > CREATE DEFAULT INDEX ON many_rows;
-                > SET statement_timeout = '120s';
                 > INSERT INTO many_rows SELECT 'a' || generate_series FROM generate_series(1, 1000000);
                 """
             )
@@ -67,11 +66,9 @@ class ManyRows(Check):
             Testdrive(dedent(s))
             for s in [
                 """
-                > SET statement_timeout = '120s';
                 > INSERT INTO many_rows SELECT 'b' || generate_series FROM generate_series(1, 1000000);
                 """,
                 """
-                > SET statement_timeout = '120s';
                 > INSERT INTO many_rows SELECT * FROM many_rows;
                 """,
             ]

--- a/misc/python/materialize/checks/all_checks/nested_types.py
+++ b/misc/python/materialize/checks/all_checks/nested_types.py
@@ -42,7 +42,6 @@ class NestedTypes(Check):
                   array_col, ARRAY[ARRAY['a', 'b'], ARRAY['c', 'd']]
                   FROM nested_types_table;
 
-                > SET statement_timeout = '120s'
                 > INSERT INTO nested_types_table SELECT * FROM nested_types_table LIMIT 1;
                 """,
                 """
@@ -53,7 +52,6 @@ class NestedTypes(Check):
                   array_col, ARRAY[ARRAY['a', 'b'], ARRAY['c', 'd']]
                   FROM nested_types_table;
 
-                > SET statement_timeout = '120s'
                 > INSERT INTO nested_types_table SELECT * FROM nested_types_table LIMIT 1;
                 """,
             ]

--- a/misc/python/materialize/checks/all_checks/peek_persist.py
+++ b/misc/python/materialize/checks/all_checks/peek_persist.py
@@ -28,12 +28,10 @@ class PeekPersist(Check):
             for s in [
                 """
                 > INSERT INTO peek_persist VALUES (NULL), (1), (2), (3);
-                > SET statement_timeout = '60s'
                 > UPDATE peek_persist SET f1 = f1 + 1;
             """,
                 """
                 > INSERT INTO peek_persist VALUES (3), (NULL), (1), (2);
-                > SET statement_timeout = '60s'
                 > DELETE FROM peek_persist WHERE f1 = 4;
             """,
             ]

--- a/misc/python/materialize/checks/all_checks/ranges.py
+++ b/misc/python/materialize/checks/all_checks/ranges.py
@@ -109,8 +109,6 @@ class Range(Check):
                     (SELECT partition FROM range_source_progress LIMIT 1) AS progress_range
                   FROM range_table;
 
-                > SET statement_timeout = '120s';
-
                 > INSERT INTO range_table SELECT * FROM range_table WHERE index = 1;
             """
 

--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -222,7 +222,6 @@ class SinkTables(Check):
                 > CREATE TABLE sink_large_transaction_table (f1 INTEGER, f2 TEXT, PRIMARY KEY (f1));
                 > CREATE DEFAULT INDEX ON sink_large_transaction_table;
 
-                > SET statement_timeout = '120s';
                 > INSERT INTO sink_large_transaction_table SELECT generate_series, REPEAT('x', 1024) FROM generate_series(1, 100000);
 
                 > CREATE MATERIALIZED VIEW sink_large_transaction_view AS SELECT f1 - 1 AS f1 , f2 FROM sink_large_transaction_table;
@@ -288,8 +287,6 @@ class SinkTables(Check):
                     SELECT (before).f2, -COUNT(*) AS c  FROM sink_large_transaction_source GROUP BY (before).f2
                   )
                   GROUP BY f2
-
-                > SET statement_timeout = '120s'
 
                 > SELECT * FROM sink_large_transaction_view2
                 500000 200000 100000 0 99999

--- a/misc/python/materialize/checks/all_checks/text_bytea_types.py
+++ b/misc/python/materialize/checks/all_checks/text_bytea_types.py
@@ -33,7 +33,6 @@ class TextByteaTypes(Check):
                   FROM text_bytea_types_table
                   WHERE text_col >= ''::TEXT AND bytea_col >= ''::BYTEA;
 
-                > SET statement_timeout = '60s';
                 > INSERT INTO text_bytea_types_table SELECT DISTINCT text_col, bytea_col FROM text_bytea_types_table;
                 """,
                 """
@@ -42,7 +41,6 @@ class TextByteaTypes(Check):
                   FROM text_bytea_types_table
                   WHERE text_col >= ''::TEXT AND bytea_col >= ''::BYTEA;
 
-                > SET statement_timeout = '60s';
                 > INSERT INTO text_bytea_types_table SELECT DISTINCT text_col, bytea_col FROM text_bytea_types_table;
                 """,
             ]

--- a/misc/python/materialize/checks/all_checks/top_k.py
+++ b/misc/python/materialize/checks/all_checks/top_k.py
@@ -45,11 +45,9 @@ class BasicTopK(Check):
                 """
                 > INSERT INTO basic_topk_table SELECT * FROM basic_topk_table
                 > CREATE MATERIALIZED VIEW basic_topk_view1 AS SELECT f1, COUNT(f1) FROM basic_topk_table GROUP BY f1 ORDER BY f1 DESC NULLS LAST LIMIT 2;
-                > SET statement_timeout = '120s'
                 > INSERT INTO basic_topk_table SELECT * FROM basic_topk_table;
                 """,
                 """
-                > SET statement_timeout = '120s'
                 > INSERT INTO basic_topk_table SELECT * FROM basic_topk_table;
                 > CREATE MATERIALIZED VIEW basic_topk_view2 AS SELECT f1, COUNT(f1) FROM basic_topk_table GROUP BY f1 ORDER BY f1 ASC NULLS FIRST LIMIT 2;
                 > INSERT INTO basic_topk_table SELECT * FROM basic_topk_table;

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -98,6 +98,7 @@ SERVICES = [
     ),
     TestdriveService(
         default_timeout=TESTDRIVE_DEFAULT_TIMEOUT,
+        materialize_params={"statement_timeout": f"'{TESTDRIVE_DEFAULT_TIMEOUT}'"},
         no_reset=True,
         seed=1,
         entrypoint_extra=[


### PR DESCRIPTION
Mostly for migration tests, see for example https://buildkite.com/materialize/nightlies/builds/6417#018da273-ec60-42c9-bb85-449500a48acd

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
