### PR TITLE
storage: report an error when observing a legacy error

### DIFF
--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -680,6 +680,12 @@ where
         upsert_metrics
             .legacy_value_errors
             .set(u64::cast_from(legacy_errors_to_correct.len()));
+        if !legacy_errors_to_correct.is_empty() {
+            tracing::error!(
+                "unexpected legacy error representation. Found {} occurences",
+                legacy_errors_to_correct.len()
+            );
+        }
         consolidation::consolidate(&mut legacy_errors_to_correct);
         for (mut error, diff) in legacy_errors_to_correct {
             assert!(


### PR DESCRIPTION
A few months ago we accidentally shipped a protobuf incompatible change which was persisted in various collection shards. In order to handle this we shipped a version of MZ[1] that automatically detects the incompatible protobufs and heals the shards by retracting the incompatible representation and inserting the correct one. The idea was that eventually shard compaction would lead to the incompatible protobufs getting deleted. As part of that work we also added metrics tha tracked the occurances of legacy errors with the expection of that metric dropping to zero after enough time had passed.

The metrics for the legacy representation of errors have indeed dropped to zero for all environments in production. While this could be considered enough evidence to finally remove the healing code I would like to first get a release out that raises a sentry error if a legacy representation is observed. If our metrics are accurate then this error should not fire and in the release after that one we'll be free to remove all this code.

[1] https://github.com/MaterializeInc/materialize/pull/21887

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
