### PR TITLE
ci: Put QA Canary Load into its own pipeline

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1062,20 +1062,6 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: mz-e2e
 
-  - id: qa-canary-load
-    label: "QA Canary Environment Base Load"
-    artifact_paths: junit_*.xml
-    timeout_in_minutes: 360
-    concurrency: 1
-    concurrency_group: 'qa-canary-load'
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: canary-load
-          args: ["--runtime=18000"]
-    agents:
-      queue: linux-aarch64-small
-    branches: "main"
-
   - group: "Output consistency"
     key: output-consistency
     steps:

--- a/ci/qa-canary/pipeline.template.yml
+++ b/ci/qa-canary/pipeline.template.yml
@@ -1,0 +1,29 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+steps:
+  - id: build-aarch64
+    label: Build aarch64
+    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build aarch64
+    timeout_in_minutes: 60
+    agents:
+      queue: builder-linux-aarch64
+
+  - id: qa-canary-load
+    label: "QA Canary Environment Base Load"
+    artifact_paths: junit_*.xml
+    timeout_in_minutes: 1440 # 24 hours
+    concurrency: 1
+    concurrency_group: 'qa-canary-load'
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: canary-load
+          args: ["--runtime=82800"] # 23 hours
+    agents:
+      queue: linux-aarch64-small


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
