### PR TITLE
storage: remove unused source_imports on IngestionDescription

### DIFF
--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -409,12 +409,6 @@ impl DataSourceDesc {
         ingestion: PlanIngestion,
         instance_id: ClusterId,
     ) -> DataSourceDesc {
-        let source_imports = ingestion
-            .source_imports
-            .iter()
-            .map(|id| (*id, ()))
-            .collect();
-
         let source_exports = ingestion
             .subsource_exports
             .iter()
@@ -432,7 +426,6 @@ impl DataSourceDesc {
         DataSourceDesc::Ingestion(IngestionDescription {
             desc: ingestion.desc.clone(),
             ingestion_metadata: (),
-            source_imports,
             source_exports,
             instance_id,
             remap_collection_id: ingestion.progress_subsource,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1258,7 +1258,6 @@ pub enum DataSourceDesc {
 #[derive(Clone, Debug)]
 pub struct Ingestion {
     pub desc: SourceDesc<ReferencedConnection>,
-    pub source_imports: BTreeSet<GlobalId>,
     pub subsource_exports: BTreeMap<GlobalId, usize>,
     pub progress_subsource: GlobalId,
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1363,8 +1363,6 @@ pub fn plan_create_source(
         create_sql,
         data_source: DataSourceDesc::Ingestion(Ingestion {
             desc: source_desc,
-            // Currently no source reads from another source
-            source_imports: BTreeSet::new(),
             subsource_exports,
             progress_subsource,
         }),

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -3087,16 +3087,6 @@ where
         id: GlobalId,
         ingestion: IngestionDescription,
     ) -> Result<IngestionDescription<CollectionMetadata>, StorageError> {
-        // Each ingestion is augmented with the collection metadata.
-        let mut source_imports = BTreeMap::new();
-        for (id, _) in ingestion.source_imports {
-            // This _requires_ that the sub-source collection (with
-            // `DataSource::Other`) was registered BEFORE we process this, the
-            // top-level collection.
-            let metadata = self.collection(id)?.collection_metadata.clone();
-            source_imports.insert(id, metadata);
-        }
-
         // The ingestion metadata is simply the collection metadata of the collection with
         // the associated ingestion
         let ingestion_metadata = self.collection(id)?.collection_metadata.clone();
@@ -3116,7 +3106,6 @@ where
         }
 
         Ok(IngestionDescription {
-            source_imports,
             source_exports,
             ingestion_metadata,
             // The rest of the fields are identical

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -82,7 +82,10 @@ message ProtoIngestionDescription {
         uint64 output_index = 2;
         mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 3;
     }
-    repeated ProtoSourceImport source_imports = 1;
+
+    reserved 1;
+    reserved "source_imports";
+    // repeated ProtoSourceImport source_imports = 1;
     repeated ProtoSourceExport source_exports = 2;
     mz_storage_types.controller.ProtoCollectionMetadata ingestion_metadata = 3;
     ProtoSourceDesc desc = 4;

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -229,8 +229,6 @@ where
                             desc: desc.clone(),
                             ingestion_metadata: collection_metadata,
                             source_exports,
-                            // Only used for Debezium
-                            source_imports: BTreeMap::new(),
                             instance_id: mz_storage_types::instances::StorageInstanceId::User(100),
                             // This id is only used to fill in the
                             // collection metadata, which we're filling in


### PR DESCRIPTION
This `source_imports` field on `IngestionDescription` was unused––it occasionally confuses me (and maybe others), so remove it for the time being.

Note that this does not preclude this concept from being reintroduced as we e.g. unify the description of how storage dataflows run with compute.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
