### PR TITLE
controller: remove empty watch sets

### DIFF
--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -350,6 +350,7 @@ where
     ) -> Option<ControllerResponse<T>> {
         let mut finished = vec![];
         for (id, antichain) in updates {
+            let mut remove = None;
             if let Some(x) = self.watch_sets.get_mut(id) {
                 let mut i = 0;
                 while i < x.len() {
@@ -361,6 +362,12 @@ where
                         i += 1;
                     }
                 }
+                if x.is_empty() {
+                    remove = Some(id);
+                }
+            }
+            if let Some(id) = remove {
+                self.watch_sets.remove(id);
             }
         }
         (!(finished.is_empty())).then(|| ControllerResponse::WatchSetFinished(finished))


### PR DESCRIPTION
Otherwise they could stay around forever.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a