### PR TITLE
sql-parser: teach join constraints about AS OF

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -6872,10 +6872,7 @@ impl<'a> Parser<'a> {
             Ok(JoinConstraint::On(constraint))
         } else if self.parse_keyword(USING) {
             let columns = self.parse_parenthesized_column_list(Mandatory)?;
-            let alias = self
-                .parse_keyword(AS)
-                .then(|| self.parse_identifier())
-                .transpose()?;
+            let alias = self.parse_optional_alias(Keyword::is_reserved_in_table_alias)?;
 
             Ok(JoinConstraint::Using { columns, alias })
         } else {

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -935,7 +935,7 @@ Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { 
 parse-statement
 SELECT * FROM t1 JOIN t2 USING (c1) AS
 ----
-error: Expected identifier, found EOF
+error: Expected an identifier after AS, found EOF
 SELECT * FROM t1 JOIN t2 USING (c1) AS
                                       ^
 
@@ -1695,3 +1695,32 @@ select count(distinct s) from y
 SELECT count(DISTINCT s) FROM y
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: Name(UnresolvedItemName([Ident("count")])), args: Args { args: [Identifier([Ident("s")])], order_by: [] }, filter: None, over: None, distinct: true }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("y")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT * FROM t JOIN t USING (a) AS OF 1234
+----
+SELECT * FROM t JOIN t USING (a) AS OF 1234
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, join_operator: Inner(Using { columns: [Ident("a")], alias: None }) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Value(Number("1234")))) })
+
+parse-statement
+SELECT * FROM t JOIN t USING (a) AS b AS OF 1234
+----
+SELECT * FROM t JOIN t USING (a) AS b AS OF 1234
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [Join { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, join_operator: Inner(Using { columns: [Ident("a")], alias: Some(Ident("b")) }) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Value(Number("1234")))) })
+
+
+parse-statement
+SELECT * FROM t JOIN t USING (a) AS OF 1234 AS 123
+----
+error: Expected end of statement, found AS
+SELECT * FROM t JOIN t USING (a) AS OF 1234 AS 123
+                                            ^
+
+parse-statement
+SELECT * FROM t JOIN t USING (a) AS OF
+----
+error: Expected a timestamp value after 'AS OF', found EOF
+SELECT * FROM t JOIN t USING (a) AS OF
+                                      ^


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a