### PR TITLE
Validate replicas of unmanaged clusters for internal/billing

### DIFF
--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -291,6 +291,15 @@ impl Coordinator {
                     internal,
                     size,
                 } => {
+                    // Only internal users have access to INTERNAL and BILLED AS
+                    if !session.user().is_internal() && (internal || billed_as.is_some()) {
+                        coord_bail!("cannot specify INTERNAL or BILLED AS as non-internal user")
+                    }
+                    // BILLED AS implies the INTERNAL flag.
+                    if billed_as.is_some() && !internal {
+                        coord_bail!("must specify INTERNAL when specifying BILLED AS");
+                    }
+
                     let location = mz_catalog::durable::ReplicaLocation::Managed {
                         availability_zone,
                         billed_as,

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -805,4 +805,33 @@ DROP CLUSTER REPLICA t1.r1;
 statement ok
 DROP CLUSTER t1
 
+# Test unmanaged clusters with internal/billed as.
+
+statement error db error: ERROR: cannot specify INTERNAL or BILLED AS as non\-internal user
+CREATE CLUSTER t1 (REPLICAS (r1 (SIZE '1', INTERNAL, BILLED AS 'free')));
+
+statement error db error: ERROR: cannot specify INTERNAL or BILLED AS as non\-internal user
+CREATE CLUSTER t1 (REPLICAS (internal_r1 (SIZE '1', INTERNAL, BILLED AS 'free')));
+
+statement error db error: ERROR: cannot specify INTERNAL or BILLED AS as non\-internal user
+CREATE CLUSTER t1 (REPLICAS (internal_r1 (SIZE '1', BILLED AS 'free')));
+
+statement error db error: ERROR: cannot specify INTERNAL or BILLED AS as non\-internal user
+CREATE CLUSTER t1 (REPLICAS (internal_r1 (SIZE '1', INTERNAL)));
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER t1 (REPLICAS (internal_r1 (SIZE '1', BILLED AS 'free')));
+----
+db error: ERROR: must specify INTERNAL when specifying BILLED AS
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER t1 (REPLICAS (internal_r1 (SIZE '1', INTERNAL, BILLED AS 'free')));
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP CLUSTER t1
+----
+COMPLETE 0
+
 reset-server


### PR DESCRIPTION
This adds a check that users cannot create replicas overriding the internal and billed-as properties.

Fixes https://github.com/MaterializeInc/accounts/issues/50


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
