### PR TITLE
Update lgalloc and enable eager memory reclamation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3112,8 +3112,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 [[package]]
 name = "lgalloc"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e3de70c23cbcf5613858a870f9c02185e6c337ebcd076453383a24fde8f64a"
+source = "git+https://github.com/antiguru/rust-lgalloc?branch=eager_return#c584bc1b0829e8ec8f44706c9f5c11e02b676ff3"
 dependencies = [
  "crossbeam-deque",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,8 @@ debug = 2
 # merged), after which point it becomes impossible to build that historical
 # version of Materialize.
 [patch.crates-io]
+lgalloc = { git = "https://github.com/antiguru/rust-lgalloc", branch = "eager_return" }
+
 # Projects that do not reliably release to crates.io.
 timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
 timely_bytes = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -39,6 +39,7 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
         enable_mz_join_core: Some(config.enable_mz_join_core()),
         enable_jemalloc_profiling: Some(config.enable_jemalloc_profiling()),
         enable_columnation_lgalloc: Some(config.enable_columnation_lgalloc()),
+        enable_lgalloc_eager_reclamation: Some(config.enable_columnation_lgalloc()),
         persist: persist_config(config),
         tracing: tracing_config(config),
         grpc_client: grpc_client_config(config),

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -85,6 +85,7 @@ message ProtoComputeParameters {
     optional bool enable_jemalloc_profiling = 7;
     mz_compute_types.dataflows.ProtoYieldSpec linear_join_yielding = 9;
     optional bool enable_columnation_lgalloc = 10;
+    optional bool enable_lgalloc_eager_reclamation = 11;
 }
 
 message ProtoComputeMaxInflightBytesConfig {

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -383,6 +383,8 @@ pub struct ComputeParameters {
     pub enable_jemalloc_profiling: Option<bool>,
     /// Enable lgalloc for columnation.
     pub enable_columnation_lgalloc: Option<bool>,
+    /// Enable lgalloc's eager memory return/reclamation feature.
+    pub enable_lgalloc_eager_reclamation: Option<bool>,
     /// Persist client configuration.
     pub persist: PersistParameters,
     /// Tracing configuration.
@@ -401,6 +403,7 @@ impl ComputeParameters {
             enable_mz_join_core,
             enable_jemalloc_profiling,
             enable_columnation_lgalloc,
+            enable_lgalloc_eager_reclamation,
             persist,
             tracing,
             grpc_client,
@@ -423,6 +426,9 @@ impl ComputeParameters {
         }
         if enable_columnation_lgalloc.is_some() {
             self.enable_columnation_lgalloc = enable_columnation_lgalloc;
+        }
+        if enable_lgalloc_eager_reclamation.is_some() {
+            self.enable_lgalloc_eager_reclamation = enable_lgalloc_eager_reclamation;
         }
 
         self.persist.update(persist);
@@ -449,6 +455,7 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
             enable_mz_join_core: self.enable_mz_join_core.into_proto(),
             enable_jemalloc_profiling: self.enable_jemalloc_profiling.into_proto(),
             enable_columnation_lgalloc: self.enable_columnation_lgalloc.into_proto(),
+            enable_lgalloc_eager_reclamation: self.enable_lgalloc_eager_reclamation.into_proto(),
             persist: Some(self.persist.into_proto()),
             tracing: Some(self.tracing.into_proto()),
             grpc_client: Some(self.grpc_client.into_proto()),
@@ -466,6 +473,7 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
             enable_mz_join_core: proto.enable_mz_join_core.into_rust()?,
             enable_jemalloc_profiling: proto.enable_jemalloc_profiling.into_rust()?,
             enable_columnation_lgalloc: proto.enable_columnation_lgalloc.into_rust()?,
+            enable_lgalloc_eager_reclamation: proto.enable_lgalloc_eager_reclamation.into_rust()?,
             persist: proto
                 .persist
                 .into_rust_if_some("ProtoComputeParameters::persist")?,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -255,6 +255,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                     lgalloc::lgalloc_set_config(
                         lgalloc::LgAlloc::new()
                             .enable()
+                            .eager_return(true)
                             .with_path(path.clone())
                             .with_background_config(lgalloc::BackgroundWorkerConfig {
                                 interval: Duration::from_secs(1),

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1503,6 +1503,13 @@ pub const ENABLE_COLUMNATION_LGALLOC: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
+pub const ENABLE_LGALLOC_EAGER_RECLAMATION: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_lgalloc_eager_reclamation"),
+    value: true,
+    description: "Enable lgalloc's eager return behavior.",
+    internal: true,
+};
+
 pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("enable_statement_lifecycle_logging"),
     value: false,
@@ -2980,6 +2987,7 @@ impl SystemVars {
             .with_var(&PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE)
             .with_var(&WEBHOOK_CONCURRENT_REQUEST_LIMIT)
             .with_var(&ENABLE_COLUMNATION_LGALLOC)
+            .with_var(&ENABLE_LGALLOC_EAGER_RECLAMATION)
             .with_var(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
             .with_var(&ENABLE_DEPENDENCY_READ_HOLD_ASSERTS)
             .with_var(&TIMESTAMP_ORACLE_IMPL)
@@ -3849,6 +3857,11 @@ impl SystemVars {
     /// Returns the `enable_columnation_lgalloc` configuration parameter.
     pub fn enable_columnation_lgalloc(&self) -> bool {
         *self.expect_value(&ENABLE_COLUMNATION_LGALLOC)
+    }
+
+    /// Returns the `enable_lgalloc_eager_reclamation` configuration parameter.
+    pub fn enable_lgalloc_eager_reclamation(&self) -> bool {
+        *self.expect_value(&ENABLE_LGALLOC_EAGER_RECLAMATION)
     }
 
     pub fn enable_statement_lifecycle_logging(&self) -> bool {
@@ -5505,6 +5518,7 @@ impl SystemVars {
             || name == ENABLE_MZ_JOIN_CORE.name()
             || name == ENABLE_JEMALLOC_PROFILING.name()
             || name == ENABLE_COLUMNATION_LGALLOC.name()
+            || name == ENABLE_LGALLOC_EAGER_RECLAMATION.name()
             || self.is_persist_config_var(name)
             || is_tracing_var(name)
     }


### PR DESCRIPTION
Experiment with eager memory reclamation in lgalloc.


### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
