### PR TITLE
pgtz: allow errant punctuation as delimiters when tokenizing timezones

### DIFF
--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -91,6 +91,10 @@ CREATE TABLE "таблица" ("колона" TEXT);
 ALTER TABLE "таблица" REPLICA IDENTITY FULL;
 INSERT INTO "таблица" VALUES ('стойност');
 
+CREATE TABLE tstzrange_table (a TSTZRANGE);
+ALTER TABLE tstzrange_table REPLICA IDENTITY FULL;
+INSERT INTO tstzrange_table VALUES ('["2024-02-13 17:01:58.37848+00!?!",)');
+
 CREATE TABLE """literal_quotes""" (a TEXT);
 ALTER TABLE """literal_quotes""" REPLICA IDENTITY FULL;
 INSERT INTO """literal_quotes""" VALUES ('v');
@@ -292,7 +296,8 @@ detail:referenced items: no_replica_identity
     conflict_schema.conflict_table AS public.conflict_table,
     "space table",
     """literal_quotes""",
-    "create"
+    "create",
+    tstzrange_table
   );
 
 > SHOW SOURCES
@@ -311,6 +316,7 @@ pk_table              subsource <null>  <null>
 trailing_space_nopk   subsource <null>  <null>
 trailing_space_pk     subsource <null>  <null>
 "\"literal_quotes\""  subsource <null>  <null>
+tstzrange_table       subsource <null>  <null>
 types_table           subsource <null>  <null>
 utf8_table            subsource <null>  <null>
 таблица               subsource <null>  <null>
@@ -403,6 +409,9 @@ v
 
 > SELECT * FROM "create"
 v
+
+> SELECT * FROM tstzrange_table
+"[2024-02-13 17:01:58.378480 UTC,)"
 
 #
 # Confirm that the new sources can be used to build upon
@@ -575,6 +584,7 @@ DELETE FROM nulls_table;
 DELETE FROM utf8_table;
 DELETE FROM "таблица";
 DELETE FROM conflict_schema.conflict_table;
+DELETE FROM tstzrange_table;
 
 #
 # Check that all data sources empty out on the Materialize side
@@ -611,6 +621,9 @@ DELETE FROM conflict_schema.conflict_table;
 0
 
 > SELECT COUNT(*) FROM conflict_table;
+0
+
+> SELECT COUNT(*) FROM tstzrange_table;
 0
 
 #

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1256,8 +1256,65 @@ SELECT '"2020!03-17 #?~T~02:36:56#"'::timestamp;
 ----
 2020-03-17 02:36:56
 
+query T
+SELECT '"2020!03-17 #?~T~02:36:56#+00"'::timestamp;
+----
+2020-03-17 02:36:56
+
 query error invalid input syntax for type timestamp: have unprocessed tokens 56
 select TIMESTAMP '"2020-03-17 ~02:36:~56~"';
+
+query T
+SELECT '"2020!03-17 #?~T~02:36:56#+00~"'::timestamp with time zone;
+----
+2020-03-17 02:36:56+00
+
+query T
+SELECT '"2020!03-17 #?~T~02:36:56# +   00   '::timestamp with time zone;
+----
+2020-03-17 02:36:56+00
+
+query T
+SELECT '"2020!03-17 #?~T~02:36:56# +   00 ?  '::timestamp with time zone;
+----
+2020-03-17 02:36:56+00
+
+query T
+SELECT '"2020!03-17 #?~T~02:36:56# # +   00 ?  '::timestamp with time zone;
+----
+2020-03-17 02:36:56+00
+
+query T
+SELECT '"2020!03-17 #?~T~02:36:56# # +   00 ?#'::timestamp with time zone;
+----
+2020-03-17 02:36:56+00
+
+query T
+SELECT '\"\"2024-02-13 17:01:58.37848+00\"\"\"'::timestamp with time zone;
+----
+2024-02-13 17:01:58.37848+00
+
+# : is not prohibited
+query T
+SELECT '"?!?2024-02-13 17:01:58.37848 ?+  00  : '::timestamp with time zone;
+----
+2024-02-13 17:01:58.37848+00
+
+# + is prohibited after numerals
+query error db error: ERROR: invalid input syntax for type timestamp with time zone: have unprocessed tokens \+  0: "\\"\?!\?2024\-02\-13 17:01:58\.37848 \?\+  00  \+ "
+SELECT '"?!?2024-02-13 17:01:58.37848 ?+  00  + '::timestamp with time zone;
+
+# - is prohibited after numerals
+query error db error: ERROR: invalid input syntax for type timestamp with time zone: have unprocessed tokens \+  0: "\\"\?!\?2024\-02\-13 17:01:58\.37848 \?\+  00  \+ "
+SELECT '"?!?2024-02-13 17:01:58.37848 ?+  00  + '::timestamp with time zone;
+
+# no space between numerals
+query error db error: ERROR: invalid input syntax for type timestamp with time zone: Cannot parse timezone offset \+  0 0: "\\"\?!\?2024\-02\-13 17:01:58\.37848\+  0 0"
+SELECT '"?!?2024-02-13 17:01:58.37848+  0 0'::timestamp with time zone;
+
+# no non-space characters between + or - and the numerals
+query error db error: ERROR: invalid input syntax for type timestamp with time zone: Cannot parse timezone offset \+ \? 00: "\\"\?!\?2024\-02\-13 17:01:58\.37848\+ \? 00"
+SELECT '"?!?2024-02-13 17:01:58.37848+ ? 00'::timestamp with time zone;
 
 # Regression for #6272. These match postgres.
 query TTT

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -7307,6 +7307,16 @@ SELECT '[1970-01-01 00:00:01,]'::tstzrange;
 ----
 ["1970-01-01 00:00:01+00",)
 
+query T
+SELECT '["2024-02-13 17:01:58.37848+00",)'::tstzrange;
+----
+["2024-02-13 17:01:58.37848+00",)
+
+query T
+SELECT '["?!?2024-02-13 17:01:58.37848+00!?!",)'::tstzrange;
+----
+["2024-02-13 17:01:58.37848+00",)
+
 # Range bound errors
 query error range lower bound must be less than or equal to range upper bound
 SELECT '[1970-01-01 00:00:01,1969-12-31 11:59:59]'::tstzrange;


### PR DESCRIPTION
PG allows errant punctuation marks in the timezone field, just as it allows them in the timestamp string itself. We didn't support that, it turns out.

### Motivation

This PR fixes a recognized bug. Discovered by a customer ([Slack](https://materializeinc.slack.com/archives/C03REC5MEKU/p1707857381021219)).

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix a bug that potentially prevented `timestamp with timezone data` from being correctly parsed when ingested through PostgreSQL sources.
