### PR TITLE
Use extend_from_slice to copy rows

### DIFF
--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -211,7 +211,7 @@ mod container {
         /// or does not and returns false.
         fn try_push(&mut self, slice: &[u8]) -> bool {
             if self.storage.len() + slice.len() <= self.storage.capacity() {
-                self.storage.extend(slice.iter().cloned());
+                self.storage.extend_from_slice(slice);
                 self.offsets.push(self.storage.len());
                 true
             } else {


### PR DESCRIPTION
This avoids a common performance problem where `extend_from_slice` is faster than `extend` and passing a slice iterator. I don't have measurements to back this up, and we're not CPU-bound, but it's good habit to use the more specific `extend_from_slice` API.

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
