### PR TITLE
sql: support parameters in LIMIT expressions

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -29,16 +29,19 @@ use postgres_array::{Array, Dimension};
 use tokio::sync::mpsc;
 
 #[mz_ore::test]
-#[ignore]
 fn test_bind_params() {
     let server = test_util::TestHarness::default()
         .unsafe_mode()
         .start_blocking();
+    server.enable_feature_flags(&["enable_expressions_in_limit_syntax"]);
     let mut client = server.connect(postgres::NoTls).unwrap();
 
     match client.query("SELECT ROW(1, 2) = $1", &[&"(1,2)"]) {
         Ok(_) => panic!("query with invalid parameters executed successfully"),
-        Err(err) => assert!(err.to_string().contains("no overload")),
+        Err(err) => assert!(
+            err.to_string().contains("operator does not exist"),
+            "unexpected error: {err}"
+        ),
     }
 
     assert!(client
@@ -76,6 +79,32 @@ fn test_bind_params() {
             .unwrap();
         let val: Numeric = client.query_one(&stmt, &[&num]).unwrap().get(0);
         assert_eq!(val.to_string(), "3.57");
+    }
+
+    // Ensure that parameters in a `SELECT .. LIMIT` clause are supported.
+    {
+        let stmt = client
+            .prepare("SELECT generate_series(1, 3) LIMIT $1")
+            .unwrap();
+        let vals = client
+            .query(&stmt, &[&2_i64])
+            .unwrap()
+            .iter()
+            .map(|r| r.get(0))
+            .collect::<Vec<i32>>();
+        assert_eq!(vals, &[1, 2]);
+    }
+
+    // Ensure that parameters in a `VALUES .. LIMIT` clause are supported.
+    {
+        let stmt = client.prepare("VALUES (1), (2), (3) LIMIT $1").unwrap();
+        let vals = client
+            .query(&stmt, &[&2_i64])
+            .unwrap()
+            .iter()
+            .map(|r| r.get(0))
+            .collect::<Vec<i32>>();
+        assert_eq!(vals, &[1, 2]);
     }
 
     // A `CREATE` statement with parameters should be rejected.

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2974,11 +2974,11 @@ impl JoinInputCharacteristics {
 /// multisets. But as it turns out, the same idea can be used to optimize
 /// trivial peeks.
 #[derive(Arbitrary, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RowSetFinishing {
+pub struct RowSetFinishing<L = NonNeg<i64>> {
     /// Order rows by the given columns.
     pub order_by: Vec<ColumnOrder>,
     /// Include only as many rows (after offset).
-    pub limit: Option<NonNeg<i64>>,
+    pub limit: Option<L>,
     /// Omit as many rows.
     pub offset: usize,
     /// Include only given columns.
@@ -3005,9 +3005,9 @@ impl RustType<ProtoRowSetFinishing> for RowSetFinishing {
     }
 }
 
-impl RowSetFinishing {
+impl<L> RowSetFinishing<L> {
     /// Returns a trivial finishing, i.e., that does nothing to the result set.
-    pub fn trivial(arity: usize) -> RowSetFinishing {
+    pub fn trivial(arity: usize) -> RowSetFinishing<L> {
         RowSetFinishing {
             order_by: Vec::new(),
             limit: None,
@@ -3022,6 +3022,9 @@ impl RowSetFinishing {
             && self.offset == 0
             && self.project.iter().copied().eq(0..arity)
     }
+}
+
+impl RowSetFinishing {
     /// Determines the index of the (Row, count) pair, and the
     /// index into the count within that pair, corresponding to a particular offset.
     ///

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1852,7 +1852,7 @@ impl HirRelationExpr {
     /// finishing into a trivial finishing.
     pub fn finish_maintained(
         &mut self,
-        finishing: &mut RowSetFinishing,
+        finishing: &mut RowSetFinishing<HirScalarExpr>,
         group_size_hints: GroupSizeHints,
     ) {
         if !finishing.is_trivial(self.arity()) {
@@ -1868,9 +1868,7 @@ impl HirRelationExpr {
                 ),
                 vec![],
                 old_finishing.order_by,
-                old_finishing
-                    .limit
-                    .map(|l| HirScalarExpr::literal(Datum::Int64(*l), ScalarType::Int64)),
+                old_finishing.limit,
                 old_finishing.offset,
                 group_size_hints.limit_input_group_size,
             )

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -42,9 +42,7 @@ use itertools::Itertools;
 use mz_expr::virtual_syntax::AlgExcept;
 use mz_expr::{func as expr_func, Id, LetRecLimit, LocalId, MirScalarExpr, RowSetFinishing};
 use mz_ore::collections::CollectionExt;
-use mz_ore::num::NonNeg;
 use mz_ore::option::FallibleMapExt;
-use mz_ore::soft_panic_or_log;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 use mz_ore::str::StrExt;
 use mz_repr::adt::char::CharLength;
@@ -99,7 +97,7 @@ use crate::session::vars::{self, FeatureFlag};
 pub struct PlannedRootQuery<E> {
     pub expr: E,
     pub desc: RelationDesc,
-    pub finishing: RowSetFinishing,
+    pub finishing: RowSetFinishing<HirScalarExpr>,
     pub scope: Scope,
 }
 
@@ -128,24 +126,6 @@ pub fn plan_root_query(
         project,
         group_size_hints,
     } = plan_query(&mut qcx, &query)?;
-
-    // A top-level limit cannot be data dependent so eagerly evaluate it.
-    let limit = match limit {
-        None => None,
-        Some(limit) => {
-            let Some(limit) = limit.as_literal() else {
-                sql_bail!("Top-level LIMIT must be a constant expression")
-            };
-            match limit {
-                Datum::Null => None,
-                Datum::Int64(v) if v >= 0 => NonNeg::<i64>::try_from(v).ok(),
-                _ => {
-                    soft_panic_or_log!("Valid literal limit must be asserted in `plan_query`");
-                    sql_bail!("LIMIT must be a non negative INT or NULL")
-                }
-            }
-        }
-    };
 
     let mut finishing = RowSetFinishing {
         limit,


### PR DESCRIPTION
When the `enable_expressions_in_limit_syntax` feature flag is enabled, this commit teaches Materialize to allow parameters in LIMIT expressions.

The trick is to allow a `RowSetFinishing` to be generic over the type of the limit, so that the planner can hold the finishing's limit as an `HirScalarExpr` long enough to call `bind_parameters` on it.

Fix https://github.com/MaterializeInc/materialize/issues/24893.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow `LIMIT` expressions to contain parameters.
