### PR TITLE
adapter: only do a single pass with ExprPrepStyle

### DIFF
--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -130,8 +130,6 @@ pub enum ExprPrepStyle<'a> {
 #[derive(Clone, Copy, Debug)]
 pub enum EvalTime {
     Time(mz_repr::Timestamp),
-    /// Skips mz_now() calls.
-    Deferred,
     /// Errors on mz_now() calls.
     NotAvailable,
 }
@@ -635,7 +633,6 @@ fn eval_unmaterializable_func(
         UnmaterializableFunc::MzIsSuperuser => pack(Datum::from(session.is_superuser())),
         UnmaterializableFunc::MzNow => match logical_time {
             EvalTime::Time(logical_time) => pack(Datum::MzTimestamp(logical_time)),
-            EvalTime::Deferred => Ok(MirScalarExpr::CallUnmaterializable(f.clone())),
             EvalTime::NotAvailable => Err(OptimizerError::UncallableFunction {
                 func: UnmaterializableFunc::MzNow,
                 context: "this",


### PR DESCRIPTION
This was a remnant from when the optimizer was in two steps and the timestamp was determined between them. Now that we always have it, only do a single unmat fn resolution.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a