### PR TITLE
test/cluster: unflake test-compute-controller-metrics

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -68,12 +68,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     for i, name in enumerate(c.workflows):
         # incident-70 requires more memory, runs in separate CI step
         # concurrent-connections is too flaky
-        # TODO: Reenable test-compute-controller-metrics when #25214 is fixed
         if name in (
             "default",
             "test-incident-70",
             "test-concurrent-connections",
-            "test-compute-controller-metrics",
         ):
             continue
         if buildkite.accepted_by_shard(i):
@@ -2426,6 +2424,9 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
 
     index_id = c.sql_query("SELECT id FROM mz_indexes WHERE name = 'idx'")[0][0]
     mv_id = c.sql_query("SELECT id FROM mz_materialized_views WHERE name = 'mv'")[0][0]
+
+    # Wait a bit to let the controller refresh its metrics.
+    time.sleep(2)
 
     # Check that expected metrics exist and have sensible values.
     metrics = fetch_metrics()


### PR DESCRIPTION
The compute controller now only refreshed its metrics once per second, which makes it more likely that test-compute-controller-metrics, which runs some SQL and then checks for that to be reflected in the metrics, gets to see outdated values.

The only way we can solve this is by sleeping before querying the metrics. Given the 1s refresh interval, sleeping for 2s should be enough.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/25214

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A