### PR TITLE
Revert "Use more robust row batch sizing (#24330)"

### DIFF
--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -103,8 +103,6 @@ mod container {
     /// A slice container with four bytes overhead per slice.
     pub struct DatumContainer {
         batches: Vec<DatumBatch>,
-        /// Stored out of line from batches to allow more effective binary search.
-        offsets: Vec<usize>,
     }
 
     impl DatumContainer {
@@ -115,10 +113,6 @@ mod container {
             callback(
                 self.batches.len() * std::mem::size_of::<DatumBatch>(),
                 self.batches.capacity() * std::mem::size_of::<DatumBatch>(),
-            );
-            callback(
-                self.offsets.len() * std::mem::size_of::<usize>(),
-                self.offsets.capacity() * std::mem::size_of::<usize>(),
             );
             for batch in self.batches.iter() {
                 use crate::extensions::arrange;
@@ -135,66 +129,57 @@ mod container {
         fn copy(&mut self, item: Self::ReadItem<'_>) {
             if let Some(batch) = self.batches.last_mut() {
                 let success = batch.try_push(item.bytes);
-                if success {
-                    return;
+                if !success {
+                    // double the lengths from `batch`.
+                    let item_cap = 2 * batch.offsets.len();
+                    let byte_cap = std::cmp::max(2 * batch.storage.capacity(), item.bytes.len());
+                    let mut new_batch = DatumBatch::with_capacities(item_cap, byte_cap);
+                    assert!(new_batch.try_push(item.bytes));
+                    self.batches.push(new_batch);
                 }
             }
-
-            // By default, we use zero capacities if we have no batches already present.
-            let (mut item_cap, mut byte_cap) = self
-                .batches
-                .last()
-                .map(|b| (b.offsets.len(), b.storage.capacity()))
-                .unwrap_or((0, 0));
-            // Double the previous "capacities" hoping that these track likely use.
-            // The byte capacity should be great because it drives `copy` acceptance,
-            // but the item capacity is a bit of a guess and there may be resizing.
-            item_cap = 2 * item_cap;
-            byte_cap = 2 * byte_cap;
-            // New byte capacity should be in the range 2MB - 128MB, and at least the item length.
-            byte_cap = std::cmp::max(byte_cap, 2 << 20);
-            byte_cap = std::cmp::min(byte_cap, 128 << 20);
-            byte_cap = std::cmp::max(byte_cap, item.bytes.len());
-            let mut new_batch = DatumBatch::with_capacities(item_cap, byte_cap);
-            assert!(new_batch.try_push(item.bytes));
-            self.offsets.push(self.len());
-            self.batches.push(new_batch);
         }
 
-        fn with_capacity(_size: usize) -> Self {
-            // This structure starts at a reasonable capacity and never resized its allocations.
-            // We judged it relatively harmless to restart at that capacity and grow, rather than
-            // navigate the two different capacities (items and bytes) and some glitchy start-up
-            // logic around mis-sized capacities (if the first copy would fail).
+        fn with_capacity(size: usize) -> Self {
             Self {
-                batches: Vec::new(),
-                offsets: Vec::new(),
+                batches: vec![DatumBatch::with_capacities(size, size)],
             }
         }
 
-        fn merge_capacity(_cont1: &Self, _cont2: &Self) -> Self {
-            // Same explanation as `with_capacity`: we believe the default behavior is good enough.
-            Self::with_capacity(0)
+        fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
+            let mut item_cap = 1;
+            let mut byte_cap = 0;
+            for batch in cont1.batches.iter() {
+                item_cap += batch.offsets.len() - 1;
+                byte_cap += batch.storage.len();
+            }
+            for batch in cont2.batches.iter() {
+                item_cap += batch.offsets.len() - 1;
+                byte_cap += batch.storage.len();
+            }
+            Self {
+                batches: vec![DatumBatch::with_capacities(item_cap, byte_cap)],
+            }
         }
 
-        fn index(&self, index: usize) -> Self::ReadItem<'_> {
-            // Determine which batch the index belongs to.
-            // Binary search gives different answers based on whether it finds
-            // the result or not, and we need to tidy up those results to point
-            // at the first batch for which the offset is less or equal to `index`.
-            let batch_idx = match self.offsets.binary_search(&index) {
-                Ok(x) => x,
-                Err(x) => x - 1,
-            };
-
-            DatumSeq {
-                bytes: self.batches[batch_idx].index(index - self.offsets[batch_idx]),
+        fn index(&self, mut index: usize) -> Self::ReadItem<'_> {
+            for batch in self.batches.iter() {
+                if index < batch.len() {
+                    return DatumSeq {
+                        bytes: batch.index(index),
+                    };
+                }
+                index -= batch.len();
             }
+            panic!("Index out of bounds");
         }
 
         fn len(&self) -> usize {
-            self.offsets.last().map(|x| *x).unwrap_or(0)
-                + self.batches.last().map(|x| x.len()).unwrap_or(0)
+            let mut result = 0;
+            for batch in self.batches.iter() {
+                result += batch.len();
+            }
+            result
         }
     }
 

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -275,7 +275,7 @@ true true true
 
 > CREATE DEFAULT INDEX ii_empty ON t3
 
-> SELECT records, batches, size < 16 * 1024, capacity > 0, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_empty'
+> SELECT records, batches, size < 16 * 1024, capacity < 16 * 1024, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_empty'
 0 32 true true true
 
 # Tests that arrangement sizes are approximate
@@ -286,7 +286,7 @@ true true true
 
 # We have 16 workers, and only want to ensure that the sizes are not egregious.
 
-> SELECT records, batches, size < 16 * 1024, capacity > 0, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+> SELECT records, batches, size < 16 * 1024, capacity < 16 * 1024, allocations < 512 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
 0 32 true true true
 
 > INSERT INTO t4 SELECT 1
@@ -354,10 +354,11 @@ true true true true true
     size > 0,
     size < 4 * 130 * 1000,
     capacity > 0,
+    capacity < 4 * 130 * 1000,
     allocations > 0
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%c1%';
-true true true true true true
+true true true true true true true
 
 > SELECT
     records > 1000,
@@ -365,10 +366,11 @@ true true true true true true
     size > 0,
     size < 4 * 100 * 1024,
     capacity > 0,
+    capacity < 4 * 100 * 1024,
     allocations > 100
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%c2%';
-true true true true true true
+true true true true true true true
 
 # For coverage, we also include a recursive materialized view to account for dynamic timestamps.
 > CREATE MATERIALIZED VIEW rec AS
@@ -393,10 +395,11 @@ true true true true true true
     size > 0,
     size < 4 * 1000 * 1000,
     capacity > 0,
+    capacity < 4 * 1000 * 1000,
     allocations > 0
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%rec%';
-true true true true true true
+true true true true true true true
 
 > DROP TABLE ten CASCADE;
 
@@ -426,10 +429,11 @@ true true true true true true
     size > 0,
     size < 4 * 200 * 1000,
     capacity > 0,
+    capacity < 4 * 200 * 1000,
     allocations > 100
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%m_minmax%';
-true true true true true true
+true true true true true true true
 
 > SELECT
     records >= 2 * 1000,
@@ -437,10 +441,11 @@ true true true true true true
     size > 0,
     size < 4 * 172 * 1000,
     capacity > 0,
+    capacity < 4 * 172 * 1000,
     allocations > 100
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%m_top1%';
-true true true true true true
+true true true true true true true
 
 > DROP SOURCE counter CASCADE;
 


### PR DESCRIPTION
This PR reverts https://github.com/MaterializeInc/materialize/pull/24330 because there is some evidence that it regresses memory usage.

We observed a large memory regression (from ~4.8 to ~8 GiB) in one cluster in our canary environments, going from version 0.86 to 0.87. We identified #24330 as the most likely cause of the regression from among the PRs merged in 0.87.

I attempted to reproduce the memory regression on staging and was partially successful. The increased memory usage is visible, although the difference is not nearly as big as what we see on that canary cluster.

![Screenshot 2024-02-14 at 12 13 42](https://github.com/MaterializeInc/materialize/assets/4521314/ab2085fe-b459-4491-8b08-003d65048ae8)
![Screenshot 2024-02-14 at 12 13 58](https://github.com/MaterializeInc/materialize/assets/4521314/f47c7ab0-97c1-4bb0-b012-3f8f4584a6a3)

(The lines are, in order: v0.86.1, v0.87.1, v0.87.1 with this revert applied.)

We also have ~~some suspicion~~ [pretty good evidence](https://github.com/MaterializeInc/materialize/issues/25153#issuecomment-1943661451) that #24330 causes #25153.

### Motivation

  * This PR fixes a recognized bug.

Fixes #25153

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
