### PR TITLE
postgres consistency: add ignore for #25228 (date parsing)

### DIFF
--- a/misc/python/materialize/output_consistency/input_data/operations/generic_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/generic_operations_provider.py
@@ -34,6 +34,8 @@ from materialize.output_consistency.operation.operation import (
 
 GENERIC_OPERATION_TYPES: list[DbOperationOrFunction] = []
 
+TAG_CASTING = "casting"
+
 GENERIC_OPERATION_TYPES.append(
     DbFunction(
         "greatest",
@@ -96,6 +98,6 @@ GENERIC_OPERATION_TYPES.append(
             all_data_types_enum_constant_operation_param(must_be_pg_compatible=True),
         ],
         OtherReturnTypeSpec(),
-        is_pg_compatible=True,
+        tags={TAG_CASTING},
     )
 )

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -42,6 +42,9 @@ from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter im
 from materialize.output_consistency.ignore_filter.param_matchers import (
     index_of_param_by_type,
 )
+from materialize.output_consistency.input_data.operations.generic_operations_provider import (
+    TAG_CASTING,
+)
 from materialize.output_consistency.input_data.operations.jsonb_operations_provider import (
     TAG_JSONB_TO_TEXT,
 )
@@ -111,6 +114,12 @@ class PgPreExecutionInconsistencyIgnoreFilter(
             True,
         ):
             return YesIgnore("Consequence of #23571")
+
+        if operation.is_tagged(TAG_CASTING) and expression.matches(
+            partial(matches_fun_by_name, function_name_in_lower_case="to_char"),
+            True,
+        ):
+            return YesIgnore("#25228: date format that cannot be parsed")
 
         return super()._matches_problematic_operation_or_function_invocation(
             expression, operation, _all_involved_characteristics


### PR DESCRIPTION
This was reported by @teskje in https://buildkite.com/materialize/nightlies/builds/6418#018da6e2-e722-4573-9a9a-ba7c4341b15e.

Identified issue: https://github.com/MaterializeInc/materialize/issues/25228 (no regression)