### PR TITLE
Revert "ci: reenable MySqlStreaming"

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -29,7 +29,7 @@ from materialize.version_list import (
 # so we need to explicitly add this directory to the Python module search path
 sys.path.append(os.path.dirname(__file__))
 from scenarios import *  # noqa: F401 F403
-from scenarios import Scenario
+from scenarios import MySqlStreaming, Scenario
 from scenarios_concurrency import *  # noqa: F401 F403
 from scenarios_customer import *  # noqa: F401 F403
 from scenarios_optbench import *  # noqa: F401 F403
@@ -375,6 +375,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             [s for s in all_subclasses(root_scenario) if not s.__subclasses__()],
             key=repr,
         )
+
+        # TODO: #25124 (correctness issue with streaming)
+        selected_scenarios.remove(MySqlStreaming)
     else:
         selected_scenarios = [root_scenario]
 


### PR DESCRIPTION
This reverts commit 5cff5a64e75434a0d736c19c46afd6dd9e35dc21.

https://github.com/MaterializeInc/materialize/issues/25124 was observed again on `main` in [builds/6429](https://buildkite.com/materialize/nightlies/builds/6429#018da79c-1476-4cd9-928a-a4971a8b29ce) since enabling it with https://github.com/MaterializeInc/materialize/pull/25180.