### PR TITLE
test: Fix storage usage test timestamp extraction

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1314,25 +1314,26 @@ fn test_storage_usage_collection_interval_timestamps() {
 
     // Retry because it may take some time for the initial snapshot to be taken.
     let rows = Retry::default()
-            .max_duration(Duration::from_secs(10))
-            .retry(|_| {
-                let rows = client
-                    .query(
-                        "SELECT EXTRACT(EPOCH FROM collection_timestamp)::integer, ARRAY_AGG(object_id) \
+        .max_duration(Duration::from_secs(10))
+        .retry(|_| {
+            let rows = client
+                .query(
+                    "SELECT EXTRACT(EPOCH FROM collection_timestamp), ARRAY_AGG(object_id) \
                 FROM mz_catalog.mz_storage_usage \
                 GROUP BY collection_timestamp \
                 ORDER BY collection_timestamp ASC;",
-                        &[],
-                    )
-                    .map_err(|e| e.to_string()).unwrap();
+                    &[],
+                )
+                .map_err(|e| e.to_string())
+                .unwrap();
 
-                if rows.is_empty() {
-                    Err("expected some timestamp, instead found None".to_string())
-                } else {
-                    Ok(rows)
-                }
-            })
-            .unwrap();
+            if rows.is_empty() {
+                Err("expected some timestamp, instead found None".to_string())
+            } else {
+                Ok(rows)
+            }
+        })
+        .unwrap();
 
     // The timestamp is selected after the storage usage is collected, so depending on how long
     // each collection takes, the timestamps can be arbitrarily close together or far apart. If


### PR DESCRIPTION
This commit cleans up the
test_storage_usage_collection_interval_timestamps test, by removing a cast to integer from a SQL query. Previously we were executing the query `SELECT EXTRACT(EPOCH FROM collection_timestamp)::integer ...`. `SELECT EXTRACT(EPOCH FROM <timestamp>)` returns a `float8` representing the epoch seconds. Casting to an integer would truncate the subsecond part of the epoch. This commit removes the cast which removes the truncation for more accuracy.

The cast may have caused false positives which is why the cast never led to test failures.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
