### PR TITLE
ci: no second, superfluous junit.xml for SLT tests

### DIFF
--- a/misc/python/materialize/ci_util/__init__.py
+++ b/misc/python/materialize/ci_util/__init__.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import requests
 
-from materialize import ui
+from materialize import buildkite, ui
 
 
 def junit_report_filename(suite: str) -> Path:
@@ -45,7 +45,7 @@ def upload_junit_report(suite: str, junit_report: Path) -> None:
         suite: The identifier for the test suite in Buildkite Test Analytics.
         junit_report: The path to the JUnit XML-formatted report file.
     """
-    if "CI" not in os.environ:
+    if not buildkite.is_in_buildkite():
         return
     ui.header(f"Uploading report for suite {suite!r} to Buildkite Test Analytics")
     suite = suite.upper().replace("-", "_")
@@ -78,7 +78,7 @@ def upload_junit_report(suite: str, junit_report: Path) -> None:
 def get_artifacts() -> Any:
     """Get artifact informations from Buildkite. Outside of CI, this function does nothing."""
 
-    if "CI" not in os.environ:
+    if not buildkite.is_in_buildkite():
         return []
 
     ui.header("Getting artifact informations from Buildkite")

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -618,15 +618,22 @@ To see the available workflows, run:
             with composition.test_case(f"workflow-{args.workflow}"):
                 composition.workflow(args.workflow, *args.unknown_subargs[1:])
 
-            junit_suite = self.generate_junit_suite(composition)
-            junit_xml_file_path = self.write_junit_report_to_file(junit_suite)
-            ci_util.upload_junit_report("mzcompose", junit_xml_file_path)
+            if self.shall_generate_junit_report(args.find):
+                junit_suite = self.generate_junit_suite(composition)
+                junit_xml_file_path = self.write_junit_report_to_file(junit_suite)
+                ci_util.upload_junit_report("mzcompose", junit_xml_file_path)
 
             if any(
                 not result.is_successful()
                 for result in composition.test_results.values()
             ):
                 raise UIError("at least one test case failed")
+
+    def shall_generate_junit_report(self, composition: str) -> bool:
+        assert composition is not None
+
+        # sqllogictest already generates a proper junit.xml file
+        return composition != "sqllogictest"
 
     def generate_junit_suite(self, composition: Composition) -> junit_xml.TestSuite:
         buildkite_step_name = os.getenv("BUILDKITE_LABEL")


### PR DESCRIPTION
This closes https://github.com/MaterializeInc/materialize/issues/25233.