### PR TITLE
Enable missing-docs warning in compute crates

### DIFF
--- a/src/compute-client/build.rs
+++ b/src/compute-client/build.rs
@@ -13,7 +13,9 @@ fn main() {
     env::set_var("PROTOC", protobuf_src::protoc());
 
     let mut config = prost_build::Config::new();
-    config.btree_map(["."]);
+    config
+        .btree_map(["."])
+        .type_attribute(".", "#[allow(missing_docs)]");
 
     tonic_build::configure()
         // Enabling `emit_rerun_if_changed` will rerun the build script when

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -82,12 +82,18 @@ pub enum ComputeControllerResponse<T> {
     /// See [`ComputeResponse::SubscribeResponse`].
     SubscribeResponse(GlobalId, SubscribeResponse<T>),
     /// See [`ComputeResponse::FrontierUpper`]
-    FrontierUpper { id: GlobalId, upper: Antichain<T> },
+    FrontierUpper {
+        /// TODO(#25239): Add documentation.
+        id: GlobalId,
+        /// TODO(#25239): Add documentation.
+        upper: Antichain<T>,
+    },
 }
 
 /// Replica configuration
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ComputeReplicaConfig {
+    /// TODO(#25239): Add documentation.
     pub logging: ComputeReplicaLogging,
     /// The amount of effort to be spent on arrangement compaction during idle times.
     ///
@@ -188,6 +194,7 @@ impl<T: Timestamp> ComputeController<T> {
         }
     }
 
+    /// TODO(#25239): Add documentation.
     pub fn instance_exists(&self, id: ComputeInstanceId) -> bool {
         self.instances.contains_key(&id)
     }
@@ -223,6 +230,7 @@ impl<T: Timestamp> ComputeController<T> {
         Ok(collection)
     }
 
+    /// TODO(#25239): Add documentation.
     pub fn find_collection(
         &self,
         collection_id: GlobalId,
@@ -256,18 +264,22 @@ impl<T: Timestamp> ComputeController<T> {
             .collection_reverse_dependencies(id))
     }
 
+    /// TODO(#25239): Add documentation.
     pub fn set_default_idle_arrangement_merge_effort(&mut self, value: u32) {
         self.default_idle_arrangement_merge_effort = value;
     }
 
+    /// TODO(#25239): Add documentation.
     pub fn set_default_arrangement_exert_proportionality(&mut self, value: u32) {
         self.default_arrangement_exert_proportionality = value;
     }
 
+    /// TODO(#25239): Add documentation.
     pub fn enable_aggressive_readhold_downgrades(&self) -> bool {
         self.enable_aggressive_readhold_downgrades
     }
 
+    /// TODO(#25239): Add documentation.
     pub fn set_enable_aggressive_readhold_downgrades(&mut self, value: bool) {
         self.enable_aggressive_readhold_downgrades = value;
     }
@@ -443,6 +455,7 @@ pub struct ActiveComputeController<'a, T> {
 }
 
 impl<T: Timestamp> ActiveComputeController<'_, T> {
+    /// TODO(#25239): Add documentation.
     pub fn instance_exists(&self, id: ComputeInstanceId) -> bool {
         self.compute.instance_exists(id)
     }
@@ -822,6 +835,7 @@ impl<T: Timestamp> CollectionState<T> {
         }
     }
 
+    /// TODO(#25239): Add documentation.
     pub fn new_log_collection() -> Self {
         let since = Antichain::from_elem(Timestamp::minimum());
         let mut state = Self::new(since, Vec::new(), Vec::new());

--- a/src/compute-client/src/controller/error.rs
+++ b/src/compute-client/src/controller/error.rs
@@ -41,8 +41,10 @@ pub struct CollectionMissing(pub GlobalId);
 /// Errors arising during compute collection lookup.
 #[derive(Error, Debug)]
 pub enum CollectionLookupError {
+    /// TODO(#25239): Add documentation.
     #[error("instance does not exist: {0}")]
     InstanceMissing(ComputeInstanceId),
+    /// TODO(#25239): Add documentation.
     #[error("collection does not exist: {0}")]
     CollectionMissing(GlobalId),
 }
@@ -62,10 +64,13 @@ impl From<CollectionMissing> for CollectionLookupError {
 /// Errors arising during compute replica creation.
 #[derive(Error, Debug)]
 pub enum ReplicaCreationError {
+    /// TODO(#25239): Add documentation.
     #[error("instance does not exist: {0}")]
     InstanceMissing(ComputeInstanceId),
+    /// TODO(#25239): Add documentation.
     #[error("replica exists already: {0}")]
     ReplicaExists(ReplicaId),
+    /// TODO(#25239): Add documentation.
     #[error("collection does not exist: {0}")]
     CollectionMissing(GlobalId),
 }
@@ -91,8 +96,10 @@ impl From<CollectionMissing> for ReplicaCreationError {
 /// Errors arising during compute replica removal.
 #[derive(Error, Debug)]
 pub enum ReplicaDropError {
+    /// TODO(#25239): Add documentation.
     #[error("instance does not exist: {0}")]
     InstanceMissing(ComputeInstanceId),
+    /// TODO(#25239): Add documentation.
     #[error("replica does not exist: {0}")]
     ReplicaMissing(ReplicaId),
 }
@@ -112,12 +119,16 @@ impl From<instance::ReplicaMissing> for ReplicaDropError {
 /// Errors arising during dataflow creation.
 #[derive(Error, Debug)]
 pub enum DataflowCreationError {
+    /// TODO(#25239): Add documentation.
     #[error("instance does not exist: {0}")]
     InstanceMissing(ComputeInstanceId),
+    /// TODO(#25239): Add documentation.
     #[error("collection does not exist: {0}")]
     CollectionMissing(GlobalId),
+    /// TODO(#25239): Add documentation.
     #[error("dataflow definition lacks an as_of value")]
     MissingAsOf,
+    /// TODO(#25239): Add documentation.
     #[error("dataflow has an as_of not beyond the since of collection: {0}")]
     SinceViolation(GlobalId),
 }
@@ -142,12 +153,16 @@ impl From<instance::DataflowCreationError> for DataflowCreationError {
 /// Errors arising during peek processing.
 #[derive(Error, Debug)]
 pub enum PeekError {
+    /// TODO(#25239): Add documentation.
     #[error("instance does not exist: {0}")]
     InstanceMissing(ComputeInstanceId),
+    /// TODO(#25239): Add documentation.
     #[error("collection does not exist: {0}")]
     CollectionMissing(GlobalId),
+    /// TODO(#25239): Add documentation.
     #[error("replica does not exist: {0}")]
     ReplicaMissing(ReplicaId),
+    /// TODO(#25239): Add documentation.
     #[error("peek timestamp is not beyond the since of collection: {0}")]
     SinceViolation(GlobalId),
 }
@@ -172,8 +187,10 @@ impl From<instance::PeekError> for PeekError {
 /// Errors arising during collection updates.
 #[derive(Error, Debug)]
 pub enum CollectionUpdateError {
+    /// TODO(#25239): Add documentation.
     #[error("instance does not exist: {0}")]
     InstanceMissing(ComputeInstanceId),
+    /// TODO(#25239): Add documentation.
     #[error("collection does not exist: {0}")]
     CollectionMissing(GlobalId),
 }
@@ -193,10 +210,13 @@ impl From<CollectionMissing> for CollectionUpdateError {
 /// Errors arising during collection read policy assignment.
 #[derive(Error, Debug)]
 pub enum ReadPolicyError {
+    /// TODO(#25239): Add documentation.
     #[error("instance does not exist: {0}")]
     InstanceMissing(ComputeInstanceId),
+    /// TODO(#25239): Add documentation.
     #[error("collection does not exist: {0}")]
     CollectionMissing(GlobalId),
+    /// TODO(#25239): Add documentation.
     #[error("collection is write-only: {0}")]
     WriteOnlyCollection(GlobalId),
 }
@@ -217,15 +237,19 @@ impl From<instance::ReadPolicyError> for ReadPolicyError {
     }
 }
 
-// Errors arising during subscribe target assignment.
+/// Errors arising during subscribe target assignment.
 #[derive(Error, Debug)]
 pub enum SubscribeTargetError {
+    /// TODO(#25239): Add documentation.
     #[error("instance does not exist: {0}")]
     InstanceMissing(ComputeInstanceId),
+    /// TODO(#25239): Add documentation.
     #[error("subscribe does not exist: {0}")]
     SubscribeMissing(GlobalId),
+    /// TODO(#25239): Add documentation.
     #[error("replica does not exist: {0}")]
     ReplicaMissing(ReplicaId),
+    /// TODO(#25239): Add documentation.
     #[error("subscribe has already produced output")]
     SubscribeAlreadyStarted,
 }
@@ -250,6 +274,7 @@ impl From<instance::SubscribeTargetError> for SubscribeTargetError {
 /// Errors arising during orphan removal.
 #[derive(Error, Debug)]
 pub enum RemoveOrphansError {
+    /// TODO(#25239): Add documentation.
     #[error("orchestrator error: {0}")]
     OrchestratorError(anyhow::Error),
 }

--- a/src/compute-client/src/lib.rs
+++ b/src/compute-client/src/lib.rs
@@ -7,9 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// This appears to be defective at the moment, with false positives
-// for each variant of the `Command` enum, each of which are documented.
-// #![warn(missing_docs)]
+#![warn(missing_docs)]
 
 //! The public API for the compute layer.
 

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -101,12 +101,16 @@ impl ProtoMapEntry<LogVariant, GlobalId> for ProtoIndexLog {
     }
 }
 
+/// TODO(#25239): Add documentation.
 #[derive(
     Arbitrary, Hash, Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Copy, Serialize, Deserialize,
 )]
 pub enum LogVariant {
+    /// TODO(#25239): Add documentation.
     Timely(TimelyLog),
+    /// TODO(#25239): Add documentation.
     Differential(DifferentialLog),
+    /// TODO(#25239): Add documentation.
     Compute(ComputeLog),
 }
 
@@ -151,20 +155,32 @@ impl RustType<ProtoLogVariant> for LogVariant {
     }
 }
 
+/// TODO(#25239): Add documentation.
 #[derive(
     Arbitrary, Hash, Eq, Ord, PartialEq, PartialOrd, Debug, Clone, Copy, Serialize, Deserialize,
 )]
 pub enum TimelyLog {
+    /// TODO(#25239): Add documentation.
     Operates,
+    /// TODO(#25239): Add documentation.
     Channels,
+    /// TODO(#25239): Add documentation.
     Elapsed,
+    /// TODO(#25239): Add documentation.
     Histogram,
+    /// TODO(#25239): Add documentation.
     Addresses,
+    /// TODO(#25239): Add documentation.
     Parks,
+    /// TODO(#25239): Add documentation.
     MessagesSent,
+    /// TODO(#25239): Add documentation.
     MessagesReceived,
+    /// TODO(#25239): Add documentation.
     Reachability,
+    /// TODO(#25239): Add documentation.
     BatchesSent,
+    /// TODO(#25239): Add documentation.
     BatchesReceived,
 }
 
@@ -207,16 +223,24 @@ impl RustType<ProtoTimelyLog> for TimelyLog {
     }
 }
 
+/// TODO(#25239): Add documentation.
 #[derive(
     Arbitrary, Hash, Eq, Ord, PartialEq, PartialOrd, Debug, Clone, Copy, Serialize, Deserialize,
 )]
 pub enum DifferentialLog {
+    /// TODO(#25239): Add documentation.
     ArrangementBatches,
+    /// TODO(#25239): Add documentation.
     ArrangementRecords,
+    /// TODO(#25239): Add documentation.
     Sharing,
+    /// TODO(#25239): Add documentation.
     BatcherRecords,
+    /// TODO(#25239): Add documentation.
     BatcherSize,
+    /// TODO(#25239): Add documentation.
     BatcherCapacity,
+    /// TODO(#25239): Add documentation.
     BatcherAllocations,
 }
 
@@ -253,20 +277,32 @@ impl RustType<ProtoDifferentialLog> for DifferentialLog {
     }
 }
 
+/// TODO(#25239): Add documentation.
 #[derive(
     Arbitrary, Hash, Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Copy, Serialize, Deserialize,
 )]
 pub enum ComputeLog {
+    /// TODO(#25239): Add documentation.
     DataflowCurrent,
+    /// TODO(#25239): Add documentation.
     FrontierCurrent,
+    /// TODO(#25239): Add documentation.
     PeekCurrent,
+    /// TODO(#25239): Add documentation.
     PeekDuration,
+    /// TODO(#25239): Add documentation.
     FrontierDelay,
+    /// TODO(#25239): Add documentation.
     ImportFrontierCurrent,
+    /// TODO(#25239): Add documentation.
     ArrangementHeapSize,
+    /// TODO(#25239): Add documentation.
     ArrangementHeapCapacity,
+    /// TODO(#25239): Add documentation.
     ArrangementHeapAllocations,
+    /// TODO(#25239): Add documentation.
     ShutdownDuration,
+    /// TODO(#25239): Add documentation.
     ErrorCount,
 }
 
@@ -309,6 +345,7 @@ impl RustType<ProtoComputeLog> for ComputeLog {
     }
 }
 
+/// TODO(#25239): Add documentation.
 pub static DEFAULT_LOG_VARIANTS: Lazy<Vec<LogVariant>> = Lazy::new(|| {
     let default_logs = vec![
         LogVariant::Timely(TimelyLog::Operates),
@@ -350,6 +387,7 @@ impl LogVariant {
             .unwrap_or_else(|| (0..arity).collect())
     }
 
+    /// TODO(#25239): Add documentation.
     pub fn desc(&self) -> RelationDesc {
         match self {
             LogVariant::Timely(TimelyLog::Operates) => RelationDesc::empty()

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -31,6 +31,7 @@ use crate::protocol::response::{PeekResponse, ProtoComputeResponse};
 
 type IntCounter = DeleteOnDropCounter<'static, AtomicU64, Vec<String>>;
 type Gauge = DeleteOnDropGauge<'static, AtomicF64, Vec<String>>;
+/// TODO(#25239): Add documentation.
 pub type UIntGauge = DeleteOnDropGauge<'static, AtomicU64, Vec<String>>;
 type Histogram = DeleteOnDropHistogram<'static, Vec<String>>;
 
@@ -64,6 +65,7 @@ pub struct ComputeControllerMetrics {
 }
 
 impl ComputeControllerMetrics {
+    /// TODO(#25239): Add documentation.
     pub fn new(metrics_registry: MetricsRegistry) -> Self {
         ComputeControllerMetrics {
             commands_total: metrics_registry.register(metric!(
@@ -145,6 +147,7 @@ impl ComputeControllerMetrics {
         }
     }
 
+    /// TODO(#25239): Add documentation.
     pub fn for_instance(&self, instance_id: ComputeInstanceId) -> InstanceMetrics {
         let labels = vec![instance_id.to_string()];
         let replica_count = self.replica_count.get_delete_on_drop_gauge(labels.clone());
@@ -193,17 +196,26 @@ pub struct InstanceMetrics {
     instance_id: ComputeInstanceId,
     metrics: ComputeControllerMetrics,
 
+    /// TODO(#25239): Add documentation.
     pub replica_count: UIntGauge,
+    /// TODO(#25239): Add documentation.
     pub collection_count: UIntGauge,
+    /// TODO(#25239): Add documentation.
     pub peek_count: UIntGauge,
+    /// TODO(#25239): Add documentation.
     pub subscribe_count: UIntGauge,
+    /// TODO(#25239): Add documentation.
     pub history_command_count: CommandMetrics<UIntGauge>,
+    /// TODO(#25239): Add documentation.
     pub history_dataflow_count: UIntGauge,
+    /// TODO(#25239): Add documentation.
     pub peeks_total: PeekMetrics<IntCounter>,
+    /// TODO(#25239): Add documentation.
     pub peek_duration_seconds: PeekMetrics<Histogram>,
 }
 
 impl InstanceMetrics {
+    /// TODO(#25239): Add documentation.
     pub fn for_replica(&self, replica_id: ReplicaId) -> ReplicaMetrics {
         let labels = vec![self.instance_id.to_string(), replica_id.to_string()];
         let extended_labels = |extra: &str| {
@@ -263,6 +275,7 @@ impl InstanceMetrics {
         }
     }
 
+    /// TODO(#25239): Add documentation.
     pub fn for_history(&self) -> HistoryMetrics<UIntGauge> {
         let labels = vec![self.instance_id.to_string()];
         let command_counts = CommandMetrics::build(|typ| {
@@ -298,9 +311,11 @@ pub struct ReplicaMetrics {
     replica_id: ReplicaId,
     metrics: ComputeControllerMetrics,
 
+    /// TODO(#25239): Add documentation.
     pub inner: Arc<ReplicaMetricsInner>,
 }
 
+/// TODO(#25239): Add documentation.
 #[derive(Debug)]
 pub struct ReplicaMetricsInner {
     commands_total: CommandMetrics<IntCounter>,
@@ -308,7 +323,9 @@ pub struct ReplicaMetricsInner {
     responses_total: ResponseMetrics<IntCounter>,
     response_message_bytes_total: ResponseMetrics<IntCounter>,
 
+    /// TODO(#25239): Add documentation.
     pub command_queue_size: UIntGauge,
+    /// TODO(#25239): Add documentation.
     pub response_queue_size: UIntGauge,
 }
 
@@ -363,23 +380,33 @@ impl StatsCollector<ProtoComputeCommand, ProtoComputeResponse> for ReplicaMetric
 /// Per-replica-and-collection metrics.
 #[derive(Debug)]
 pub(crate) struct ReplicaCollectionMetrics {
+    /// TODO(#25239): Add documentation.
     pub initial_output_duration_seconds: Gauge,
 }
 
 /// Metrics keyed by `ComputeCommand` type.
 #[derive(Debug)]
 pub struct CommandMetrics<M> {
+    /// TODO(#25239): Add documentation.
     pub create_timely: M,
+    /// TODO(#25239): Add documentation.
     pub create_instance: M,
+    /// TODO(#25239): Add documentation.
     pub create_dataflow: M,
+    /// TODO(#25239): Add documentation.
     pub allow_compaction: M,
+    /// TODO(#25239): Add documentation.
     pub peek: M,
+    /// TODO(#25239): Add documentation.
     pub cancel_peek: M,
+    /// TODO(#25239): Add documentation.
     pub initialization_complete: M,
+    /// TODO(#25239): Add documentation.
     pub update_configuration: M,
 }
 
 impl<M> CommandMetrics<M> {
+    /// TODO(#25239): Add documentation.
     pub fn build<F>(build_metric: F) -> Self
     where
         F: Fn(&str) -> M,
@@ -410,6 +437,7 @@ impl<M> CommandMetrics<M> {
         f(&self.cancel_peek);
     }
 
+    /// TODO(#25239): Add documentation.
     pub fn for_command<T>(&self, command: &ComputeCommand<T>) -> &M {
         use ComputeCommand::*;
 

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -59,7 +59,9 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// use the `epoch` to ensure that their individual processes agree on which protocol iteration
     /// they are in.
     CreateTimely {
+        /// TODO(#25239): Add documentation.
         config: TimelyConfig,
+        /// TODO(#25239): Add documentation.
         epoch: ClusterStartupEpoch,
     },
 
@@ -173,7 +175,9 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// [`FrontierUpper`]: super::response::ComputeResponse::FrontierUpper
     /// [#16275]: https://github.com/MaterializeInc/materialize/issues/16275
     AllowCompaction {
+        /// TODO(#25239): Add documentation.
         id: GlobalId,
+        /// TODO(#25239): Add documentation.
         frontier: Antichain<T>,
     },
 
@@ -328,6 +332,7 @@ impl Arbitrary for ComputeCommand<mz_repr::Timestamp> {
 /// for anything in this struct.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct InstanceConfig {
+    /// TODO(#25239): Add documentation.
     pub logging: LoggingConfig,
 }
 
@@ -493,6 +498,7 @@ pub enum PeekTarget {
 }
 
 impl PeekTarget {
+    /// TODO(#25239): Add documentation.
     pub fn id(&self) -> GlobalId {
         match self {
             PeekTarget::Index { id, .. } => *id,

--- a/src/compute-client/src/protocol/history.rs
+++ b/src/compute-client/src/protocol/history.rs
@@ -19,6 +19,7 @@ use timely::progress::Antichain;
 use crate::metrics::HistoryMetrics;
 use crate::protocol::command::{ComputeCommand, ComputeParameters, Peek};
 
+/// TODO(#25239): Add documentation.
 #[derive(Debug)]
 pub struct ComputeCommandHistory<M, T = mz_repr::Timestamp> {
     /// The number of commands at the last time we compacted the history.
@@ -38,6 +39,7 @@ where
     M: Borrow<UIntGauge>,
     T: timely::progress::Timestamp,
 {
+    /// TODO(#25239): Add documentation.
     pub fn new(metrics: HistoryMetrics<M>) -> Self {
         metrics.reset();
 

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -74,7 +74,12 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// [`CreateDataflow` command]: super::command::ComputeCommand::CreateDataflow
     /// [`CreateInstance` command]: super::command::ComputeCommand::CreateInstance
     /// [#16275]: https://github.com/MaterializeInc/materialize/issues/16275
-    FrontierUpper { id: GlobalId, upper: Antichain<T> },
+    FrontierUpper {
+        /// TODO(#25239): Add documentation.
+        id: GlobalId,
+        /// TODO(#25239): Add documentation.
+        upper: Antichain<T>,
+    },
 
     /// `PeekResponse` reports the result of a previous [`Peek` command]. The peek is identified by
     /// a `Uuid` that matches the command's [`Peek::uuid`].
@@ -217,6 +222,7 @@ pub enum PeekResponse {
 }
 
 impl PeekResponse {
+    /// TODO(#25239): Add documentation.
     pub fn unwrap_rows(self) -> Vec<(Row, NonZeroUsize)> {
         match self {
             PeekResponse::Rows(rows) => rows,

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -57,6 +57,7 @@ impl<T: Send> GenericClient<ComputeCommand<T>, ComputeResponse<T>> for Box<dyn C
     }
 }
 
+/// TODO(#25239): Add documentation.
 #[derive(Debug, Clone)]
 pub enum ComputeProtoServiceTypes {}
 
@@ -67,6 +68,7 @@ impl ProtoServiceTypes for ComputeProtoServiceTypes {
     const URL: &'static str = "/mz_compute_client.service.ProtoCompute/CommandResponseStream";
 }
 
+/// TODO(#25239): Add documentation.
 pub type ComputeGrpcClient = GrpcClient<ComputeProtoServiceTypes>;
 
 #[async_trait]

--- a/src/compute-types/build.rs
+++ b/src/compute-types/build.rs
@@ -13,7 +13,9 @@ fn main() {
     env::set_var("PROTOC", protobuf_src::protoc());
 
     let mut config = prost_build::Config::new();
-    config.btree_map(["."]);
+    config
+        .btree_map(["."])
+        .type_attribute(".", "#[allow(missing_docs)]");
 
     tonic_build::configure()
         // Enabling `emit_rerun_if_changed` will rerun the build script when

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -692,7 +692,9 @@ pub struct IndexImport {
 /// An association of a global identifier to an expression.
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BuildDesc<P> {
+    /// TODO(#25239): Add documentation.
     pub id: GlobalId,
+    /// TODO(#25239): Add documentation.
     pub plan: P,
 }
 

--- a/src/compute-types/src/explain/mod.rs
+++ b/src/compute-types/src/explain/mod.rs
@@ -151,6 +151,7 @@ impl<'a> DataflowDescription<OptimizedMirRelationExpr> {
     }
 }
 
+/// TODO(#25239): Add documentation.
 pub fn export_ids_for<P, S, T>(dd: &DataflowDescription<P, S, T>) -> BTreeMap<GlobalId, GlobalId> {
     let mut map = BTreeMap::<GlobalId, GlobalId>::default();
 

--- a/src/compute-types/src/lib.rs
+++ b/src/compute-types/src/lib.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![warn(missing_docs)]
+
 //! Shared types for the `mz-compute*` crates
 
 use std::time::Duration;

--- a/src/compute-types/src/plan/interpret/api.rs
+++ b/src/compute-types/src/plan/interpret/api.rs
@@ -48,14 +48,17 @@ use crate::plan::{AvailableCollections, GetPlan, Plan};
 ///
 /// TODO(#24943): align this with the `Plan` structure
 pub trait Interpreter<T = mz_repr::Timestamp> {
+    /// TODO(#25239): Add documentation.
     type Domain: Debug + Sized;
 
+    /// TODO(#25239): Add documentation.
     fn constant(
         &self,
         ctx: &Context<Self::Domain>,
         rows: &Result<Vec<(Row, T, Diff)>, EvalError>,
     ) -> Self::Domain;
 
+    /// TODO(#25239): Add documentation.
     fn get(
         &self,
         ctx: &Context<Self::Domain>,
@@ -64,6 +67,7 @@ pub trait Interpreter<T = mz_repr::Timestamp> {
         plan: &GetPlan,
     ) -> Self::Domain;
 
+    /// TODO(#25239): Add documentation.
     fn mfp(
         &self,
         ctx: &Context<Self::Domain>,
@@ -72,6 +76,7 @@ pub trait Interpreter<T = mz_repr::Timestamp> {
         input_key_val: &Option<(Vec<MirScalarExpr>, Option<Row>)>,
     ) -> Self::Domain;
 
+    /// TODO(#25239): Add documentation.
     fn flat_map(
         &self,
         ctx: &Context<Self::Domain>,
@@ -82,6 +87,7 @@ pub trait Interpreter<T = mz_repr::Timestamp> {
         input_key: &Option<Vec<MirScalarExpr>>,
     ) -> Self::Domain;
 
+    /// TODO(#25239): Add documentation.
     fn join(
         &self,
         ctx: &Context<Self::Domain>,
@@ -89,6 +95,7 @@ pub trait Interpreter<T = mz_repr::Timestamp> {
         plan: &JoinPlan,
     ) -> Self::Domain;
 
+    /// TODO(#25239): Add documentation.
     fn reduce(
         &self,
         ctx: &Context<Self::Domain>,
@@ -99,6 +106,7 @@ pub trait Interpreter<T = mz_repr::Timestamp> {
         mfp_after: &MapFilterProject,
     ) -> Self::Domain;
 
+    /// TODO(#25239): Add documentation.
     fn top_k(
         &self,
         ctx: &Context<Self::Domain>,
@@ -106,8 +114,10 @@ pub trait Interpreter<T = mz_repr::Timestamp> {
         top_k_plan: &TopKPlan,
     ) -> Self::Domain;
 
+    /// TODO(#25239): Add documentation.
     fn negate(&self, ctx: &Context<Self::Domain>, input: Self::Domain) -> Self::Domain;
 
+    /// TODO(#25239): Add documentation.
     fn threshold(
         &self,
         ctx: &Context<Self::Domain>,
@@ -115,6 +125,7 @@ pub trait Interpreter<T = mz_repr::Timestamp> {
         threshold_plan: &ThresholdPlan,
     ) -> Self::Domain;
 
+    /// TODO(#25239): Add documentation.
     fn union(
         &self,
         ctx: &Context<Self::Domain>,
@@ -122,6 +133,7 @@ pub trait Interpreter<T = mz_repr::Timestamp> {
         consolidate_output: bool,
     ) -> Self::Domain;
 
+    /// TODO(#25239): Add documentation.
     fn arrange_by(
         &self,
         ctx: &Context<Self::Domain>,
@@ -140,6 +152,8 @@ pub struct InterpreterContext<Domain> {
     /// Is the context recursive (i.e., is one of our ancestors a `LetRec` binding) or not.
     pub is_rec: bool,
 }
+
+/// TODO(#25239): Add documentation.
 pub type Context<Domain> = InterpreterContext<Domain>;
 
 impl<Domain> Default for InterpreterContext<Domain> {
@@ -211,6 +225,7 @@ where
     I: Interpreter<T>,
     I::Domain: BoundedLattice + Clone,
 {
+    /// TODO(#25239): Add documentation.
     pub fn new(interpreter: I) -> Self {
         Self {
             interpret: interpreter,
@@ -485,6 +500,7 @@ where
     I::Domain: BoundedLattice + Clone,
     A: FnMut(&mut Plan<T>, &I::Domain, &[I::Domain]),
 {
+    /// TODO(#25239): Add documentation.
     pub fn new(interpreter: I, action: A) -> Self {
         Self {
             interpret: interpreter,

--- a/src/compute-types/src/plan/join/mod.rs
+++ b/src/compute-types/src/plan/join/mod.rs
@@ -84,7 +84,9 @@ impl RustType<ProtoJoinPlan> for JoinPlan {
 /// this with a Rust closure (glorious battle was waged, but ultimately lost).
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct JoinClosure {
+    /// TODO(#25239): Add documentation.
     pub ready_equivalences: Vec<Vec<MirScalarExpr>>,
+    /// TODO(#25239): Add documentation.
     pub before: mz_expr::SafeMfpPlan,
 }
 

--- a/src/compute-types/src/plan/transform/api.rs
+++ b/src/compute-types/src/plan/transform/api.rs
@@ -21,11 +21,13 @@ use crate::plan::Plan;
 /// as an immutable reference.
 #[derive(Debug)]
 pub struct TransformConfig {
+    /// TODO(#25239): Add documentation.
     pub monotonic_ids: BTreeSet<GlobalId>,
 }
 
 /// A transform for [crate::plan::Plan] nodes.
 pub trait Transform<T = mz_repr::Timestamp> {
+    /// TODO(#25239): Add documentation.
     fn name(&self) -> &'static str;
 
     /// Transform a [Plan] using the given [TransformConfig].
@@ -56,6 +58,7 @@ pub trait Transform<T = mz_repr::Timestamp> {
     ) -> Result<(), RecursionLimitError>;
 }
 
+/// TODO(#25239): Add documentation.
 pub trait BottomUpTransform<T = mz_repr::Timestamp> {
     /// A type representing analysis information to be associated with each
     /// sub-term and exposed to the transformation action callback.

--- a/src/compute-types/src/plan/transform/relax_must_consolidate.rs
+++ b/src/compute-types/src/plan/transform/relax_must_consolidate.rs
@@ -27,6 +27,7 @@ pub struct RelaxMustConsolidate<T = mz_repr::Timestamp> {
 }
 
 impl<T> RelaxMustConsolidate<T> {
+    /// TODO(#25239): Add documentation.
     pub fn new() -> Self {
         RelaxMustConsolidate {
             _phantom: Default::default(),

--- a/src/compute-types/src/sinks.rs
+++ b/src/compute-types/src/sinks.rs
@@ -23,12 +23,19 @@ include!(concat!(env!("OUT_DIR"), "/mz_compute_types.sinks.rs"));
 /// A sink for updates to a relational collection.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ComputeSinkDesc<S: 'static = (), T = Timestamp> {
+    /// TODO(#25239): Add documentation.
     pub from: GlobalId,
+    /// TODO(#25239): Add documentation.
     pub from_desc: RelationDesc,
+    /// TODO(#25239): Add documentation.
     pub connection: ComputeSinkConnection<S>,
+    /// TODO(#25239): Add documentation.
     pub with_snapshot: bool,
+    /// TODO(#25239): Add documentation.
     pub up_to: Antichain<T>,
+    /// TODO(#25239): Add documentation.
     pub non_null_assertions: Vec<usize>,
+    /// TODO(#25239): Add documentation.
     pub refresh_schedule: Option<RefreshSchedule>,
 }
 
@@ -103,10 +110,14 @@ impl RustType<ProtoComputeSinkDesc> for ComputeSinkDesc<CollectionMetadata, Time
     }
 }
 
+/// TODO(#25239): Add documentation.
 #[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum ComputeSinkConnection<S: 'static = ()> {
+    /// TODO(#25239): Add documentation.
     Subscribe(SubscribeSinkConnection),
+    /// TODO(#25239): Add documentation.
     Persist(PersistSinkConnection<S>),
+    /// TODO(#25239): Add documentation.
     S3Oneshot(S3OneshotSinkConnection),
 }
 
@@ -155,12 +166,16 @@ impl RustType<ProtoComputeSinkConnection> for ComputeSinkConnection<CollectionMe
     }
 }
 
+/// TODO(#25239): Add documentation.
 #[derive(Arbitrary, Default, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct SubscribeSinkConnection {}
 
+/// TODO(#25239): Add documentation.
 #[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct S3OneshotSinkConnection {
+    /// TODO(#25239): Add documentation.
     pub prefix: String,
+    /// TODO(#25239): Add documentation.
     pub aws_connection: mz_storage_types::connections::aws::AwsConnection,
 }
 
@@ -182,9 +197,12 @@ impl RustType<ProtoS3OneshotSinkConnection> for S3OneshotSinkConnection {
     }
 }
 
+/// TODO(#25239): Add documentation.
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PersistSinkConnection<S> {
+    /// TODO(#25239): Add documentation.
     pub value_desc: RelationDesc,
+    /// TODO(#25239): Add documentation.
     pub storage_metadata: S,
 }
 

--- a/src/compute/src/extensions/mod.rs
+++ b/src/compute/src/extensions/mod.rs
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![warn(missing_docs)]
-
 //! Operator extensions to Timely and Differential
 
 pub(crate) mod arrange;


### PR DESCRIPTION
This enables the `missing_docs` warning in compute crates and adds a placeholder documentation for all undocumented items. We can document these later.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
