### PR TITLE
Fix error message for ALTER SOURCE on non-postgres sources

### DIFF
--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1304,7 +1304,7 @@ async fn purify_alter_source(
         match desc.connection {
             GenericSourceConnection::Postgres(pg_connection) => pg_connection,
             _ => sql_bail!(
-                "{} is a {} source, which does not support ALTER TABLE...ADD SUBSOURCES",
+                "{} is a {} source, which does not support ALTER SOURCE...ADD SUBSOURCES",
                 scx.catalog.minimal_qualification(item.name()),
                 desc.connection.name()
             ),

--- a/test/testdrive/kafka-alter-source.td
+++ b/test/testdrive/kafka-alter-source.td
@@ -25,7 +25,7 @@ one
 one
 
 !ALTER SOURCE data ADD SUBSOURCE t;
-contains:data is a kafka source, which does not support ALTER TABLE...ADD SUBSOURCES
+contains:data is a kafka source, which does not support ALTER SOURCE...ADD SUBSOURCES
 
 !ALTER SOURCE data DROP SUBSOURCE t;
 contains:unknown catalog item 't'


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->


### Motivation

  * This PR fixes a recognized bug. Fixes: https://github.com/MaterializeInc/materialize/issues/25124

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
