### PR TITLE
compute:`JoinImplementation` can use `Attribute` non-mutably

### DIFF
--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -193,12 +193,12 @@ impl JoinImplementation {
                 input.visit(&mut attributes)?;
 
                 let cardinality = attributes
-                    .get_results_mut::<Cardinality>()
-                    .pop()
+                    .get_results::<Cardinality>()
+                    .last()
                     .expect("cardinality");
 
                 cardinality.collect_symbolics(&mut symbolics);
-                symbolic_cardinalities.push(cardinality);
+                symbolic_cardinalities.push(cardinality.clone());
             }
 
             let mut cardinality_stats = BTreeMap::new();


### PR DESCRIPTION
While trying to understand how difficult it would be to migrate away from the `Attribute` framework, I realized that `JoinImplementation` doesn't need to modify the attributes (at the price of a single `.clone()`.)

### Motivation

   * This PR refactors existing code.
   
Code used a mutable API when a by-reference API would have worked.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
