### PR TITLE
tracing: Don't trace the whole catalog

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -833,7 +833,7 @@ impl CatalogState {
     }
 
     /// Parses the given SQL string into a pair of [`Plan`] and a [`ResolvedIds)`.
-    #[tracing::instrument(level = "info", skip(self, pcx, catalog))]
+    #[tracing::instrument(skip_all)]
     pub(crate) fn parse_plan(
         &self,
         id: GlobalId,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -822,25 +822,15 @@ impl CatalogState {
             .with_planning_id(id)
             .with_ignore_if_exists_errors(force_if_exists_skip);
         let mut session_catalog = self.for_system_session();
-        self.parse_plan(
-            id,
-            create_sql,
-            Some(&pcx),
-            false,
-            None,
-            &mut session_catalog,
-        )
+        self.parse_plan(create_sql, Some(&pcx), &mut session_catalog)
     }
 
     /// Parses the given SQL string into a pair of [`Plan`] and a [`ResolvedIds)`.
     #[tracing::instrument(skip_all)]
     pub(crate) fn parse_plan(
         &self,
-        id: GlobalId,
         create_sql: String,
         pcx: Option<&PlanContext>,
-        is_retained_metrics_object: bool,
-        custom_logical_compaction_window: Option<CompactionWindow>,
         catalog: &mut ConnCatalog,
     ) -> Result<(Plan, ResolvedIds), AdapterError> {
         // Enable catalog features that might be required during planning in
@@ -885,14 +875,7 @@ impl CatalogState {
     ) -> Result<CatalogItem, AdapterError> {
         let mut session_catalog = self.for_system_session();
 
-        let (plan, resolved_ids) = self.parse_plan(
-            id,
-            create_sql,
-            pcx,
-            is_retained_metrics_object,
-            custom_logical_compaction_window,
-            &mut session_catalog,
-        )?;
+        let (plan, resolved_ids) = self.parse_plan(create_sql, pcx, &mut session_catalog)?;
 
         Ok(match plan {
             Plan::CreateTable(CreateTablePlan { table, .. }) => CatalogItem::Table(Table {

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -833,7 +833,7 @@ impl CatalogState {
     }
 
     /// Parses the given SQL string into a pair of [`Plan`] and a [`ResolvedIds)`.
-    #[tracing::instrument(level = "info", skip(self, pcx))]
+    #[tracing::instrument(level = "info", skip(self, pcx, catalog))]
     pub(crate) fn parse_plan(
         &self,
         id: GlobalId,


### PR DESCRIPTION
I turned on debug logging locally and it was immediately unusable because we end up tracing the whole catalog when calling `parse_plan`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
