### PR TITLE
sql: Update reg* casting to support invalid DBs

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3932,8 +3932,7 @@ pub static MZ_INTERNAL_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(
                         -- If the provided database does not exist, add a row for it so that it
                         -- can still join against ambient schemas.
                         UNION ALL
-                        SELECT '', $1
-                        WHERE (SELECT $1 NOT IN (SELECT name FROM mz_catalog.mz_databases))
+                        SELECT '', $1 WHERE $1 NOT IN (SELECT name FROM mz_catalog.mz_databases)
                     ) AS d
                     ON d.id = COALESCE(s.database_id, d.id)
             WHERE d.name = CAST($1 AS pg_catalog.text);

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3932,7 +3932,7 @@ pub static MZ_INTERNAL_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(
                         -- If the provided database does not exist, add a row for it so that it
                         -- can still join against ambient schemas.
                         UNION ALL
-                        SELECT NULL, $1
+                        SELECT '', $1
                         WHERE (SELECT $1 NOT IN (SELECT name FROM mz_catalog.mz_databases))
                     ) AS d
                     ON d.id = COALESCE(s.database_id, d.id)

--- a/test/sqllogictest/regclass.slt
+++ b/test/sqllogictest/regclass.slt
@@ -292,3 +292,11 @@ query T
 SELECT 'mz_internal.mz_activity_log'::regclass = (SELECT oid FROM mz_objects WHERE name = 'mz_activity_log')
 ----
 true
+
+query T
+SELECT 'materialize.public.t'::regclass::oid::int
+----
+20696
+
+query error db error: ERROR: relation "t" does not exist
+SELECT 't'::regclass::oid::int

--- a/test/sqllogictest/regclass.slt
+++ b/test/sqllogictest/regclass.slt
@@ -277,3 +277,18 @@ NULL
 # ensure that all existing types can be cast to their respective names
 statement OK
 select oid, oid::regclass::text from (select oid from pg_catalog.pg_class)
+
+# ensure that catalog items can be resolved if the active database is invalid
+
+statement OK
+SET database TO ''
+
+query T
+SELECT 'mz_tables'::regclass = (SELECT oid FROM mz_objects WHERE name = 'mz_tables')
+----
+true
+
+query T
+SELECT 'mz_internal.mz_activity_log'::regclass = (SELECT oid FROM mz_objects WHERE name = 'mz_activity_log')
+----
+true

--- a/test/sqllogictest/regproc.slt
+++ b/test/sqllogictest/regproc.slt
@@ -191,3 +191,13 @@ true
 true
 true
 true
+
+# ensure that catalog functions can be resolved if the active database is invalid
+
+statement OK
+SET database TO ''
+
+query T
+SELECT 'array_in'::regproc
+----
+750


### PR DESCRIPTION
This commit fixes text to reg* casting (such as text to regclass) so that items in a system schema can be correctly resolved when the active database is invalid.

Fixes #25080

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow users to cast text to `reg*` types (such as `regclass`) for items in system schemas when the active database is invalid. This also fixes any function that uses `reg*` casting such as access privilege inquiry functions.