### PR TITLE
bin: add an environmentd-debug-zip command

### DIFF
--- a/bin/environmentd-debug-zip
+++ b/bin/environmentd-debug-zip
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# environmentd-debug-zip — gather local environment's state into a zip file.
+
+set -euo pipefail
+
+postgres=${MZDEV_POSTGRES:-postgres://root@localhost:26257/materialize}
+
+echo "Shutting down running environmentd and clusterd (if any)"
+killall -q environmentd clusterd || true
+
+mkdir -p mzdata/pgdump
+for i in consensus.consensus storage.collections storage.data storage.fence storage.sinces storage.uppers tsoracle.timestamp_oracle adapter.collections adapter.data adapter.fence adapter.sinces adapter.uppers; do
+  echo "Exporting ${i} from CockroachDB"
+  psql "${postgres}" -q --csv -c "select * from ${i}" > mzdata/pgdump/"${i}.csv"
+done
+
+zip -qr mzdata/debug.zip mzdata --exclude debug.zip
+
+echo "Bundled environmentd debug data into ./mzdata/debug.zip"


### PR DESCRIPTION
This slurps up everything necessary to recreate the state of a local bin/environmentd. Hopefully will be helpful if someone has a sticky repro of a rare bug.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
