### PR TITLE
adapter: eagerly remove finished subscribes

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -159,7 +159,7 @@ use crate::optimize::{self, Optimize, OptimizerConfig};
 use crate::session::{EndTransactionAction, Session};
 use crate::statement_logging::StatementEndedExecutionReason;
 use crate::subscribe::ActiveSubscribe;
-use crate::util::{ClientTransmitter, CompletedClientTransmitter, ComputeSinkId, ResultExt};
+use crate::util::{ClientTransmitter, CompletedClientTransmitter, ResultExt};
 use crate::webhook::{WebhookAppenderInvalidator, WebhookConcurrencyLimiter};
 use crate::{flags, AdapterNotice, TimestampProvider};
 use mz_catalog::builtin::BUILTINS;
@@ -852,7 +852,7 @@ pub struct ConnMeta {
 
     /// Sinks that will need to be dropped when the current transaction, if
     /// any, is cleared.
-    drop_sinks: BTreeSet<ComputeSinkId>,
+    drop_sinks: BTreeSet<GlobalId>,
 
     /// Channel on which to send notices to a session.
     notice_tx: mpsc::UnboundedSender<AdapterNotice>,

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -293,7 +293,7 @@ impl Coordinator {
         let active_subscribe = ActiveSubscribe {
             user: ctx.session().user().clone(),
             conn_id: ctx.session().conn_id().clone(),
-            channel: Some(tx),
+            channel: tx,
             emit_progress,
             as_of: global_lir_plan
                 .as_of()

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -23,7 +23,7 @@ use crate::coord::appends::BuiltinTableAppendNotify;
 use crate::coord::Coordinator;
 use crate::session::{Session, TransactionStatus};
 use crate::subscribe::{ActiveSubscribe, SubscribeRemovalReason};
-use crate::util::{describe, ComputeSinkId};
+use crate::util::describe;
 use crate::{metrics, AdapterError, ExecuteContext, ExecuteResponse, PeekResponseUnary};
 
 impl Coordinator {
@@ -232,10 +232,7 @@ impl Coordinator {
             .get_mut(&active_subscribe.conn_id)
             .expect("must exist for active sessions")
             .drop_sinks
-            .insert(ComputeSinkId {
-                cluster_id: active_subscribe.cluster_id,
-                global_id: id,
-            });
+            .insert(id);
 
         self.active_subscribes.insert(id, active_subscribe);
 
@@ -292,10 +289,7 @@ impl Coordinator {
                 .get_mut(&active_subscribe.conn_id)
                 .expect("must exist for active subscribe")
                 .drop_sinks
-                .remove(&ComputeSinkId {
-                    cluster_id: active_subscribe.cluster_id,
-                    global_id: id,
-                });
+                .remove(&id);
 
             let message = match reason {
                 SubscribeRemovalReason::Finished => return,

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -16,7 +16,7 @@ use mz_compute_client::controller::error::{
 use mz_controller_types::ClusterId;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{halt, soft_assert_no_log};
-use mz_repr::{GlobalId, RelationDesc, ScalarType};
+use mz_repr::{RelationDesc, ScalarType};
 use mz_sql::names::FullItemName;
 use mz_sql::plan::StatementDesc;
 use mz_sql::session::vars::Var;
@@ -257,13 +257,6 @@ pub fn describe(
             )?)
         }
     }
-}
-
-/// Type identifying a sink maintained by a cluster.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ComputeSinkId {
-    pub cluster_id: ClusterId,
-    pub global_id: GlobalId,
 }
 
 pub trait ResultExt<T> {


### PR DESCRIPTION
**DO NOT MERGE. Merging is blocked on https://github.com/MaterializeInc/materialize/pull/25042#issuecomment-1945460455!**

I didn't realize while working on #25179, but @teskje's simplification to the compute controller's subscribe response handling (c42b42f65) means that we can eagerly drop any finished subscribes.

The rationale: the adapter will never see a response for a subscribe that's already been dropped. So we don't need to worry about the race that existed previously, where dropping a subscribe while observing a SubscribeResponse could "double drop" if said subscribe had been cancelled.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
