### PR TITLE
ci: fix junit.xml exclude for SLT tests

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -629,9 +629,7 @@ To see the available workflows, run:
             ):
                 raise UIError("at least one test case failed")
 
-    def shall_generate_junit_report(self, composition: str) -> bool:
-        assert composition is not None
-
+    def shall_generate_junit_report(self, composition: str | None) -> bool:
         # sqllogictest already generates a proper junit.xml file
         return composition != "sqllogictest"
 


### PR DESCRIPTION
`args.find` is not set if you invoke tests like this:
```
cd test/canary-environment
./mzcompose run test
```