### PR TITLE
ci: allow overriding common-ancestor with COMMON_ANCESTOR_OVERRIDE

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -209,6 +209,7 @@ case "$cmd" in
             --env CI_FINAL_PREFLIGHT_CHECK_ROLLBACK
             --env CI_TEST_SELECTION
             --env CLOUDTEST_CLUSTER_DEFINITION_FILE
+            --env COMMON_ANCESTOR_OVERRIDE
             --env CONFLUENT_CLOUD_DEVEX_KAFKA_PASSWORD
             --env CONFLUENT_CLOUD_DEVEX_KAFKA_USERNAME
             --env GITHUB_TOKEN


### PR DESCRIPTION
Demo: https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Aci%2Foverride-common-ancestor (supposed to run the scalability framework against `v0.85.0`)