### PR TITLE
cargo: remove mz-avro-derive from src/interchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4563,7 +4563,6 @@ dependencies = [
  "itertools",
  "maplit",
  "mz-avro",
- "mz-avro-derive",
  "mz-ccsr",
  "mz-ore",
  "mz-repr",

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -24,7 +24,6 @@ itertools = "0.10.5"
 once_cell = "1.16.0"
 maplit = "1.0.2"
 mz-avro = { path = "../avro", features = ["snappy"] }
-mz-avro-derive = { path = "../avro-derive" }
 mz-ccsr = { path = "../ccsr" }
 mz-ore = { path = "../ore", features = ["network"] }
 mz-repr = { path = "../repr" }


### PR DESCRIPTION
Reported in [builds/6448](https://buildkite.com/materialize/nightlies/builds/6448#018daa2c-f023-46a4-988d-74331dd5e7c5).