### PR TITLE
catalog: Fix persist data migration panics

### DIFF
--- a/src/catalog/src/durable/objects/serialization.rs
+++ b/src/catalog/src/durable/objects/serialization.rs
@@ -60,7 +60,7 @@ impl TryFrom<StateUpdateKindRaw> for proto::StateUpdateKind {
     type Error = String;
 
     fn try_from(value: StateUpdateKindRaw) -> Result<Self, Self::Error> {
-        Ok(value.to_serde::<Self>())
+        value.try_to_serde::<Self>().map_err(|err| err.to_string())
     }
 }
 


### PR DESCRIPTION
This commits fixes a panic that can happen in persist data migrations. Before running migrations the catalog attempts to read the epoch and config collection by calling `try_from` on the raw data to convert it into structured data. This should fail on un-migrated collections by returning an `Err`, not by panicking. However, the `try_from` implementation was calling a `to_serde` method that panics when it fails. This commit fixes the panic by adding a `try_to_serde` method that returns an `Err` which can be propagated to `try_from`.

### Motivation
 This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
