### PR TITLE
test: Use persist catalog in legacy upgrade tests

### DIFF
--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -18,7 +18,6 @@ from materialize.mzcompose.composition import Composition, WorkflowArgumentParse
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.minio import Minio
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.test_certs import TestCerts
@@ -43,7 +42,6 @@ SERVICES = [
         options=list(mz_options.values()),
         volumes_extra=["secrets:/share/secrets"],
         external_cockroach=True,
-        external_minio=True,
         catalog_store="shadow",
     ),
     # N.B.: we need to use `validate_catalog_store=None` because testdrive uses
@@ -59,11 +57,9 @@ SERVICES = [
     # testdrive commands.
     Testdrive(
         external_cockroach=True,
-        external_minio=True,
         validate_catalog_store=None,
         volumes_extra=["secrets:/share/secrets", "mzdata:/mzdata"],
     ),
-    Minio(setup_materialize=True),
 ]
 
 
@@ -153,7 +149,6 @@ def test_upgrade_from_version(
             ],
             volumes_extra=["secrets:/share/secrets"],
             external_cockroach=True,
-            external_minio=True,
             catalog_store=catalog_store,
         )
         with c.override(mz_from):
@@ -184,7 +179,6 @@ def test_upgrade_from_version(
         options=list(mz_options.values()),
         volumes_extra=["secrets:/share/secrets"],
         external_cockroach=True,
-        external_minio=True,
         catalog_store=catalog_store,
     )
     with c.override(mz_to):
@@ -199,7 +193,6 @@ def test_upgrade_from_version(
             Testdrive(
                 postgres_stash="cockroach",
                 external_cockroach=True,
-                external_minio=True,
                 validate_catalog_store=catalog_store,
                 volumes_extra=["secrets:/share/secrets", "mzdata:/mzdata"],
             )

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -42,7 +42,7 @@ SERVICES = [
         options=list(mz_options.values()),
         volumes_extra=["secrets:/share/secrets"],
         external_cockroach=True,
-        catalog_store="shadow",
+        catalog_store="persist",
     ),
     # N.B.: we need to use `validate_catalog_store=None` because testdrive uses
     # HEAD to load the catalog from disk but does *not* run migrations. There
@@ -133,7 +133,7 @@ def test_upgrade_from_version(
     c.up("zookeeper", "kafka", "schema-registry", "postgres")
 
     catalog_store = (
-        "shadow"
+        "persist"
         if from_version == "current_source"
         or MzVersion.parse_mz(from_version) >= MzVersion.parse_mz("v0.82.0-dev")
         else "stash"

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -18,6 +18,7 @@ from materialize.mzcompose.composition import Composition, WorkflowArgumentParse
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.minio import Minio
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.test_certs import TestCerts
@@ -42,6 +43,7 @@ SERVICES = [
         options=list(mz_options.values()),
         volumes_extra=["secrets:/share/secrets"],
         external_cockroach=True,
+        external_minio=True,
         catalog_store="shadow",
     ),
     # N.B.: we need to use `validate_catalog_store=None` because testdrive uses
@@ -57,9 +59,11 @@ SERVICES = [
     # testdrive commands.
     Testdrive(
         external_cockroach=True,
+        external_minio=True,
         validate_catalog_store=None,
         volumes_extra=["secrets:/share/secrets", "mzdata:/mzdata"],
     ),
+    Minio(setup_materialize=True),
 ]
 
 
@@ -149,6 +153,7 @@ def test_upgrade_from_version(
             ],
             volumes_extra=["secrets:/share/secrets"],
             external_cockroach=True,
+            external_minio=True,
             catalog_store=catalog_store,
         )
         with c.override(mz_from):
@@ -179,6 +184,7 @@ def test_upgrade_from_version(
         options=list(mz_options.values()),
         volumes_extra=["secrets:/share/secrets"],
         external_cockroach=True,
+        external_minio=True,
         catalog_store=catalog_store,
     )
     with c.override(mz_to):
@@ -193,6 +199,7 @@ def test_upgrade_from_version(
             Testdrive(
                 postgres_stash="cockroach",
                 external_cockroach=True,
+                external_minio=True,
                 validate_catalog_store=catalog_store,
                 volumes_extra=["secrets:/share/secrets", "mzdata:/mzdata"],
             )


### PR DESCRIPTION
This commit updates the legacy upgrade tests to use the persist catalog when possible instead of the stash catalog.

Works towards resolving #24218

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
