### PR TITLE
Test for a HTML file being served from the envd proxy instead of CSS.

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1994,10 +1994,6 @@ async fn test_concurrent_id_reuse() {
     client.batch_execute("SELECT 1").await.unwrap();
 }
 
-// TODO: re-enable once we figure out how to do this test without
-// relying on internal resources:
-// <https://github.com/MaterializeInc/materialize/issues/25294>
-#[ignore]
 #[mz_ore::test]
 fn test_internal_console_proxy() {
     let server = test_util::TestHarness::default().start_blocking();
@@ -2007,7 +2003,7 @@ fn test_internal_console_proxy() {
         .unwrap()
         .get(
             Url::parse(&format!(
-                "http://{}/internal-console/styles.css",
+                "http://{}/internal-console/",
                 server.inner().internal_http_local_addr()
             ))
             .unwrap(),
@@ -2018,7 +2014,7 @@ fn test_internal_console_proxy() {
     assert_eq!(res.status().is_success(), true);
     assert_contains!(
         res.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap(),
-        "text/css"
+        "text/html"
     );
 }
 


### PR DESCRIPTION


<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug

The filename `styles.css` is not part of Console's external-facing contract. Instead, let's test for an HTML response from the base internal path.

Fixes #25294 
<!--
Which of the following best describes the motivation behind this PR?



    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

:+1:

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
