### PR TITLE
storage/mysql: Fix snapshot consistency issue by doing an explicit consistent read rather than relying on 'WITH CONSISTENT SNAPSHOT'

### DIFF
--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+from textwrap import dedent
+
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mysql import MySql
@@ -119,3 +121,74 @@ def workflow_schema_change_restart(c: Composition) -> None:
             f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
             "schema-restart/after-restart.td",
         )
+
+
+def workflow_many_inserts(c: Composition, parser: WorkflowArgumentParser) -> None:
+    """
+    Tests a scenario that caused a consistency issue in the past. We insert a large
+    number of rows into a table, and then create a source for that table. We then
+    insert more rows into the table while the source is snapshotting the table, and
+    verify that the correct count of rows is captured by the source.
+
+    In earlier incarnations of the MySQL source, the source would snapshot inside
+    a transaction using REPEATABLE READ 'WITH CONSISTENT SNAPSHOT' semantics, which
+    we assumed would produce a consistent read from the point that the transaction started at.
+    However this test would fail because the snapshot would capture some of the
+    rows inserted after the transaction started and they would not be correctly rewound.
+
+    We replaced the 'WITH CONSISTENT SNAPSHOT' with a SELECT count(*) FROM {table}
+    to trigger a consistent read inside the snapshot transaction to fix the issue.
+    """
+    c.up("materialized", "mysql")
+    c.up("testdrive", persistent=True)
+
+    n = 100000
+
+    insertions = "\n".join(
+        [
+            f"""
+            SET @i:=0;
+            INSERT INTO t1 (f2) SELECT @i:=@i+1 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT {round(n/1000)};
+            """
+            for i in range(0, 1000)
+        ]
+    )
+
+    c.testdrive(
+        dedent(
+            f"""
+            $ postgres-execute connection=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
+            ALTER SYSTEM SET enable_mysql_source = true
+
+            $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+
+            > CREATE SECRET IF NOT EXISTS mysqlpass AS '{MySql.DEFAULT_ROOT_PASSWORD}'
+            > CREATE CONNECTION IF NOT EXISTS mysql_conn TO MYSQL (HOST mysql, USER root, PASSWORD SECRET mysqlpass)
+
+            $ mysql-execute name=mysql
+            DROP DATABASE IF EXISTS public;
+            CREATE DATABASE public;
+            USE public;
+            DROP TABLE IF EXISTS t1;
+            CREATE TABLE t1 (pk SERIAL PRIMARY KEY, f2 BIGINT);
+
+            {insertions}
+            {insertions}
+
+            > DROP SOURCE IF EXISTS s1;
+
+            $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+
+            > CREATE SOURCE s1
+                FROM MYSQL CONNECTION mysql_conn
+                FOR TABLES (public.t1);
+
+            $ mysql-execute name=mysql
+            USE public;
+            {insertions}
+
+            > SELECT count(*) FROM t1
+            {n*3}
+            """
+        )
+    )


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug. Fixes: https://github.com/MaterializeInc/materialize/issues/25124


<!--
Which of the following best describes the motivation behind this PR?



    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Context for this PR is in the attached issue

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
