### PR TITLE
storage/mysql: Ignore added columns to tables we're ingesting

### DIFF
--- a/test/mysql-cdc/25-schema-changes.td
+++ b/test/mysql-cdc/25-schema-changes.td
@@ -43,7 +43,40 @@ $ mysql-execute name=mysql
 ALTER TABLE add_columns ADD COLUMN f2 varchar(2);
 INSERT INTO add_columns VALUES (2, 'ab');
 
-! SELECT * FROM add_columns;
+> SELECT * FROM add_columns;
+1
+
+#
+# Now remove that added column
+#
+
+$ mysql-execute name=mysql
+ALTER TABLE add_columns DROP COLUMN f2;
+
+> SELECT * FROM add_columns;
+1
+
+> DROP SOURCE mz_source;
+
+
+#
+# ALTER TABLE <tbl> DROP COLUMN
+#
+
+$ mysql-execute name=mysql
+CREATE TABLE drop_columns (f1 INTEGER, f2 INTEGER);
+INSERT INTO drop_columns VALUES (1, 1);
+
+> CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (public.drop_columns);
+
+> SELECT * FROM drop_columns;
+1 1
+
+$ mysql-execute name=mysql
+ALTER TABLE drop_columns DROP COLUMN f2;
+
+! SELECT * FROM drop_columns;
 contains:incompatible schema change
 
 > DROP SOURCE mz_source;
@@ -88,6 +121,94 @@ ALTER TABLE public.alter_column_2 MODIFY f2 INT;
 INSERT INTO public.alter_column_2 VALUES (3, 23);
 
 ! SELECT * from alter_column_2;
+contains:incompatible schema change
+
+> DROP SOURCE mz_source;
+
+#
+# ALTER TABLE <tbl> MODIFY <col> TYPE NON NULLABLE
+# Adding a non-null constraint should be allowed
+#
+
+$ mysql-execute name=mysql
+USE public;
+CREATE TABLE alter_column_nullable (f1 INTEGER, f2 VARCHAR(2));
+INSERT INTO alter_column_nullable VALUES (2, '12');
+
+> CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (public.alter_column_nullable);
+
+$ mysql-execute name=mysql
+ALTER TABLE alter_column_nullable MODIFY f2 VARCHAR(2) NOT NULL;
+INSERT INTO alter_column_nullable VALUES (3, '23');
+
+> SELECT * from alter_column_nullable;
+2 12
+3 23
+
+> DROP SOURCE mz_source;
+
+#
+# ALTER TABLE <tbl> MODIFY <col> TYPE NULLABLE
+# Removing a non-null constraint should error
+#
+
+$ mysql-execute name=mysql
+CREATE TABLE alter_column_nullable_2 (f1 INTEGER, f2 VARCHAR(2) NOT NULL);
+INSERT INTO alter_column_nullable_2 VALUES (2, '12');
+
+> CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (public.alter_column_nullable_2);
+
+$ mysql-execute name=mysql
+ALTER TABLE alter_column_nullable_2 MODIFY f2 VARCHAR(2);
+INSERT INTO alter_column_nullable_2 VALUES (3, '23');
+
+! SELECT * from alter_column_nullable_2;
+contains:incompatible schema change
+
+> DROP SOURCE mz_source;
+
+#
+# ALTER TABLE <tbl> ADD CONSTRAINT <uq> UNIQUE (col);
+# Adding a new unique constraint should be allowed
+#
+
+$ mysql-execute name=mysql
+CREATE TABLE alter_column_uq (f1 INTEGER, f2 VARCHAR(2));
+INSERT INTO alter_column_uq VALUES (2, '12');
+
+> CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (public.alter_column_uq);
+
+$ mysql-execute name=mysql
+ALTER TABLE alter_column_uq ADD CONSTRAINT uq_f2 UNIQUE (f1);
+INSERT INTO alter_column_uq VALUES (3, '23');
+
+> SELECT * from alter_column_uq;
+2 12
+3 23
+
+> DROP SOURCE mz_source;
+
+#
+# ALTER TABLE <tbl> DROP INDEX <uq>;
+# Dropping new unique constraint should error
+#
+
+$ mysql-execute name=mysql
+CREATE TABLE alter_column_uq_2 (f1 INTEGER, f2 VARCHAR(2));
+ALTER TABLE alter_column_uq_2 ADD CONSTRAINT uq_f2 UNIQUE (f1);
+INSERT INTO alter_column_uq_2 VALUES (2, '12');
+
+> CREATE SOURCE mz_source FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (public.alter_column_uq_2);
+
+$ mysql-execute name=mysql
+ALTER TABLE alter_column_uq_2 DROP INDEX uq_f2;
+INSERT INTO alter_column_uq_2 VALUES (3, '23');
+
+! SELECT * from alter_column_uq_2;
 contains:incompatible schema change
 
 > DROP SOURCE mz_source;

--- a/test/mysql-cdc/schema-restart/before-restart.td
+++ b/test/mysql-cdc/schema-restart/before-restart.td
@@ -37,6 +37,6 @@ INSERT INTO other VALUES (1), (2), (3);
 # Now alter the dummy table
 $ mysql-execute name=mysql
 USE public;
-ALTER TABLE dummy ADD COLUMN f3 varchar(2);
+ALTER TABLE dummy DROP COLUMN f2;
 
 # Now restart MZ


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/materialize/issues/25072

This completes the above task by allowing compatible changes to occur without putting the source into an error state.

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Most of this logic is based on the same compatibility checks in the postgres source. We decided not to allow column renames, since it'll be impossible for us to differentiate between a re-order and a rename of the columns in a table.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
