### PR TITLE
storage: refactor upsert code

### DIFF
--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -355,6 +355,119 @@ fn stage_input<T, O>(
     }
 }
 
+/// Helper method for `upsert_inner` used to stage `data` updates
+/// from the input timely edge.
+async fn drain_staged_input<S, G, T, O, E>(
+    stash: &mut Vec<(T, UpsertKey, Reverse<O>, Option<UpsertValue>)>,
+    commands_state: &mut indexmap::IndexMap<UpsertKey, types::UpsertValueAndSize>,
+    output_updates: &mut Vec<(Result<Row, UpsertError>, T, Diff)>,
+    multi_get_scratch: &mut Vec<UpsertKey>,
+    upper: &Antichain<T>,
+    error_emitter: &mut E,
+    state: &mut UpsertState<'_, S>,
+) where
+    S: UpsertStateBackend,
+    G: Scope,
+    T: PartialOrder + Ord + Clone,
+    O: Ord,
+    E: UpsertErrorEmitter<G>,
+{
+    stash.sort_unstable();
+
+    // Find the prefix that we can emit
+    let idx = stash.partition_point(|(ts, _, _, _)| !upper.less_equal(ts));
+
+    // Read the previous values _per key_ out of `state`, recording it
+    // along with the value with the _latest timestamp for that key_.
+    commands_state.clear();
+    for (_, key, _, _) in stash.iter().take(idx) {
+        commands_state.entry(*key).or_default();
+    }
+
+    // These iterators iterate in the same order because `commands_state`
+    // is an `IndexMap`.
+    multi_get_scratch.clear();
+    multi_get_scratch.extend(commands_state.iter().map(|(k, _)| *k));
+    match state
+        .multi_get(multi_get_scratch.drain(..), commands_state.values_mut())
+        .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            error_emitter
+                .emit("Failed to fetch records from state".to_string(), e)
+                .await;
+        }
+    }
+
+    // From the prefix that can be emitted we can deduplicate based on (ts, key) in
+    // order to only process the command with the maximum order within the (ts,
+    // key) group. This is achieved by wrapping order in `Reverse(order)` above.;
+    let mut commands = stash.drain(..idx).dedup_by(|a, b| {
+        let ((a_ts, a_key, _, _), (b_ts, b_key, _, _)) = (a, b);
+        a_ts == b_ts && a_key == b_key
+    });
+
+    let bincode_opts = types::upsert_bincode_opts();
+    // Upsert the values into `commands_state`, by recording the latest
+    // value (or deletion). These will be synced at the end to the `state`.
+    //
+    // Note that we are effectively doing "mini-upsert" here, using
+    // `command_state`. This "mini-upsert" is seeded with data from `state`, using
+    // a single `multi_get` above, and the final state is written out into
+    // `state` using a single `multi_put`. This simplifies `UpsertStateBackend`
+    // implementations, and reduces the number of reads and write we need to do.
+    //
+    // This "mini-upsert" technique is actually useful in `UpsertState`'s
+    // `merge_snapshot_chunk` implementation, minimizing gets and puts on
+    // the `UpsertStateBackend` implementations. In some sense, its "upsert all the way down".
+    while let Some((ts, key, _, value)) = commands.next() {
+        let command_state = commands_state
+            .get_mut(&key)
+            .expect("key missing from commands_state");
+
+        if let Some(cs) = command_state.value.as_mut() {
+            cs.ensure_decoded(bincode_opts);
+        }
+
+        match value {
+            Some(value) => {
+                if let Some(old_value) = command_state.value.replace(value.clone().into()) {
+                    output_updates.push((old_value.to_decoded(), ts.clone(), -1));
+                }
+                output_updates.push((value, ts, 1));
+            }
+            None => {
+                if let Some(old_value) = command_state.value.take() {
+                    output_updates.push((old_value.to_decoded(), ts, -1));
+                }
+            }
+        }
+    }
+
+    match state
+        .multi_put(commands_state.drain(..).map(|(k, cv)| {
+            (
+                k,
+                types::PutValue {
+                    value: cv.value.map(|cv| cv.to_decoded()),
+                    previous_persisted_size: cv
+                        .size
+                        .map(|v| v.try_into().expect("less than i64 size")),
+                },
+            )
+        }))
+        .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            error_emitter
+                .emit("Failed to update records in state".to_string(), e)
+                .await;
+        }
+    }
+}
+
 // Created a struct to hold the configs for upserts.
 // So that new configs don't require a new method parameter.
 struct UpsertConfig {
@@ -433,6 +546,8 @@ where
         let mut stash = vec![];
         let mut input_upper = Antichain::from_elem(Timestamp::minimum());
         let mut legacy_errors_to_correct = vec![];
+
+        let mut error_emitter = (&mut health_output, &health_cap);
 
         while !PartialOrder::less_equal(&resume_upper, &snapshot_upper)
             || (upsert_config.wait_for_input_resumption
@@ -533,11 +648,10 @@ where
                     }
                 }
                 Err(e) => {
-                    process_upsert_state_error::<G>(
+                    UpsertErrorEmitter::<G>::emit(
+                        &mut error_emitter,
                         "Failed to rehydrate state".to_string(),
                         e,
-                        &mut health_output,
-                        &health_cap,
                     )
                     .await;
                 }
@@ -634,110 +748,17 @@ where
                     if PartialOrder::less_than(&upper, &resume_upper) {
                         continue;
                     }
-                    stash.sort_unstable();
 
-                    // Find the prefix that we can emit
-                    let idx = stash.partition_point(|(ts, _, _, _)| !upper.less_equal(ts));
-
-                    // Read the previous values _per key_ out of `state`, recording it
-                    // along with the value with the _latest timestamp for that key_.
-                    commands_state.clear();
-                    for (_, key, _, _) in stash.iter().take(idx) {
-                        commands_state.entry(*key).or_default();
-                    }
-
-                    // These iterators iterate in the same order because `commands_state`
-                    // is an `IndexMap`.
-                    multi_get_scratch.clear();
-                    multi_get_scratch.extend(commands_state.iter().map(|(k, _)| *k));
-                    match state
-                        .multi_get(multi_get_scratch.drain(..), commands_state.values_mut())
-                        .await
-                    {
-                        Ok(_) => {}
-                        Err(e) => {
-                            process_upsert_state_error::<G>(
-                                "Failed to fetch records from state".to_string(),
-                                e,
-                                &mut health_output,
-                                &health_cap,
-                            )
-                            .await;
-                        }
-                    }
-
-                    // From the prefix that can be emitted we can deduplicate based on (ts, key) in
-                    // order to only process the command with the maximum order within the (ts,
-                    // key) group. This is achieved by wrapping order in `Reverse(order)` above.
-                    let mut commands = stash.drain(..idx).dedup_by(|a, b| {
-                        let ((a_ts, a_key, _, _), (b_ts, b_key, _, _)) = (a, b);
-                        a_ts == b_ts && a_key == b_key
-                    });
-
-                    let bincode_opts = types::upsert_bincode_opts();
-                    // Upsert the values into `commands_state`, by recording the latest
-                    // value (or deletion). These will be synced at the end to the `state`.
-                    //
-                    // Note that we are effectively doing "mini-upsert" here, using
-                    // `command_state`. This "mini-upsert" is seeded with data from `state`, using
-                    // a single `multi_get` above, and the final state is written out into
-                    // `state` using a single `multi_put`. This simplifies `UpsertStateBackend`
-                    // implementations, and reduces the number of reads and write we need to do.
-                    //
-                    // This "mini-upsert" technique is actually useful in `UpsertState`'s
-                    // `merge_snapshot_chunk` implementation, minimizing gets and puts on
-                    // the `UpsertStateBackend` implementations. In some sense, its "upsert all the way down".
-                    while let Some((ts, key, _, value)) = commands.next() {
-                        let command_state = commands_state
-                            .get_mut(&key)
-                            .expect("key missing from commands_state");
-
-                        if let Some(cs) = command_state.value.as_mut() {
-                            cs.ensure_decoded(bincode_opts);
-                        }
-
-                        match value {
-                            Some(value) => {
-                                if let Some(old_value) =
-                                    command_state.value.replace(value.clone().into())
-                                {
-                                    output_updates.push((old_value.to_decoded(), ts.clone(), -1));
-                                }
-                                output_updates.push((value, ts, 1));
-                            }
-                            None => {
-                                if let Some(old_value) = command_state.value.take() {
-                                    output_updates.push((old_value.to_decoded(), ts, -1));
-                                }
-                            }
-                        }
-                    }
-
-                    match state
-                        .multi_put(commands_state.drain(..).map(|(k, cv)| {
-                            (
-                                k,
-                                types::PutValue {
-                                    value: cv.value.map(|cv| cv.to_decoded()),
-                                    previous_persisted_size: cv
-                                        .size
-                                        .map(|v| v.try_into().expect("less than i64 size")),
-                                },
-                            )
-                        }))
-                        .await
-                    {
-                        Ok(_) => {}
-                        Err(e) => {
-                            process_upsert_state_error::<G>(
-                                "Failed to update records in state".to_string(),
-                                e,
-                                &mut health_output,
-                                &health_cap,
-                            )
-                            .await;
-                        }
-                    }
+                    drain_staged_input::<_, G, _, _, _>(
+                        &mut stash,
+                        &mut commands_state,
+                        &mut output_updates,
+                        &mut multi_get_scratch,
+                        &upper,
+                        &mut error_emitter,
+                        &mut state,
+                    )
+                    .await;
 
                     // Emit the _consolidated_ changes to the output.
                     output_handle
@@ -760,6 +781,27 @@ where
         health_stream,
         shutdown_button.press_on_drop(),
     )
+}
+
+#[async_trait::async_trait(?Send)]
+trait UpsertErrorEmitter<G> {
+    async fn emit(&mut self, context: String, e: anyhow::Error);
+}
+
+#[async_trait::async_trait(?Send)]
+impl<G: Scope> UpsertErrorEmitter<G>
+    for (
+        &mut AsyncOutputHandle<
+            <G as ScopeParent>::Timestamp,
+            Vec<(OutputIndex, HealthStatusUpdate)>,
+            TeeCore<<G as ScopeParent>::Timestamp, Vec<(OutputIndex, HealthStatusUpdate)>>,
+        >,
+        &Capability<<G as ScopeParent>::Timestamp>,
+    )
+{
+    async fn emit(&mut self, context: String, e: anyhow::Error) {
+        process_upsert_state_error::<G>(context, e, self.0, self.1).await
+    }
 }
 
 /// Emit the given error, and stall till the dataflow is restarted.

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -41,12 +41,13 @@ use timely::progress::{Antichain, Timestamp};
 use crate::healthcheck::HealthStatusUpdate;
 use crate::metrics::upsert::UpsertMetrics;
 use crate::render::sources::OutputIndex;
-use crate::render::upsert::types::{
-    upsert_bincode_opts, AutoSpillBackend, InMemoryHashMap, RocksDBParams, UpsertState,
-    UpsertStateBackend,
-};
+use crate::render::upsert::autospill::{AutoSpillBackend, RocksDBParams};
+use crate::render::upsert::memory::InMemoryHashMap;
+use crate::render::upsert::types::{upsert_bincode_opts, UpsertState, UpsertStateBackend};
 use crate::storage_state::StorageInstanceContext;
 
+mod autospill;
+mod memory;
 mod rocksdb;
 mod types;
 

--- a/src/storage/src/render/upsert/autospill.rs
+++ b/src/storage/src/render/upsert/autospill.rs
@@ -1,0 +1,148 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use mz_ore::metrics::DeleteOnDropGauge;
+use mz_rocksdb::RocksDBConfig;
+use prometheus::core::AtomicU64;
+
+use super::upsert_bincode_opts;
+use crate::render::upsert::memory::InMemoryHashMap;
+use crate::render::upsert::rocksdb::RocksDB;
+use crate::render::upsert::types::{
+    GetStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize,
+};
+use crate::render::upsert::UpsertKey;
+
+pub enum BackendType {
+    InMemory(InMemoryHashMap),
+    RocksDb(RocksDB),
+}
+/// Params required to create rocksdb instance
+pub(crate) struct RocksDBParams {
+    pub(crate) instance_path: PathBuf,
+    pub(crate) legacy_instance_path: PathBuf,
+    pub(crate) env: rocksdb::Env,
+    pub(crate) tuning_config: RocksDBConfig,
+    pub(crate) shared_metrics: Arc<mz_rocksdb::RocksDBSharedMetrics>,
+    pub(crate) instance_metrics: Arc<mz_rocksdb::RocksDBInstanceMetrics>,
+}
+
+pub struct AutoSpillBackend {
+    backend_type: BackendType,
+    rockdsdb_params: RocksDBParams,
+    auto_spill_threshold_bytes: usize,
+    rocksdb_autospill_in_use: Arc<DeleteOnDropGauge<'static, AtomicU64, Vec<String>>>,
+}
+
+impl AutoSpillBackend {
+    pub(crate) fn new(
+        rockdsdb_params: RocksDBParams,
+        auto_spill_threshold_bytes: usize,
+        rocksdb_autospill_in_use: Arc<DeleteOnDropGauge<'static, AtomicU64, Vec<String>>>,
+    ) -> Self {
+        // Initializing the metric to 0, to reflect in memory hash map is being used
+        rocksdb_autospill_in_use.set(0);
+        Self {
+            backend_type: BackendType::InMemory(InMemoryHashMap::default()),
+            rockdsdb_params,
+            auto_spill_threshold_bytes,
+            rocksdb_autospill_in_use,
+        }
+    }
+
+    async fn init_rocksdb(rocksdb_params: &RocksDBParams) -> RocksDB {
+        let RocksDBParams {
+            instance_path,
+            legacy_instance_path,
+            env,
+            tuning_config,
+            shared_metrics,
+            instance_metrics,
+        } = rocksdb_params;
+        tracing::info!("spilling to disk for upsert at {:?}", instance_path);
+
+        RocksDB::new(
+            mz_rocksdb::RocksDBInstance::new(
+                instance_path,
+                legacy_instance_path,
+                mz_rocksdb::InstanceOptions::defaults_with_env(env.clone()),
+                tuning_config.clone(),
+                Arc::clone(shared_metrics),
+                Arc::clone(instance_metrics),
+                upsert_bincode_opts(),
+            )
+            .await
+            .unwrap(),
+        )
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl UpsertStateBackend for AutoSpillBackend {
+    async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
+    where
+        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue>)>,
+    {
+        match &mut self.backend_type {
+            BackendType::InMemory(map) => {
+                let mut put_stats = map.multi_put(puts).await?;
+                let in_memory_size: usize = map
+                    .current_size()
+                    .try_into()
+                    .expect("unexpected error while casting");
+                if in_memory_size > self.auto_spill_threshold_bytes {
+                    let mut rocksdb_backend =
+                        AutoSpillBackend::init_rocksdb(&self.rockdsdb_params).await;
+
+                    let (last_known_size, new_puts) = map.drain();
+                    let new_puts = new_puts.map(|(k, v)| {
+                        (
+                            k,
+                            PutValue {
+                                value: Some(v),
+                                previous_persisted_size: None,
+                            },
+                        )
+                    });
+
+                    let rocksdb_stats = rocksdb_backend.multi_put(new_puts).await?;
+                    // Adjusting the sizes as the value sizes in rocksdb could be different than in memory
+                    put_stats.size_diff += rocksdb_stats.size_diff;
+                    put_stats.size_diff -= last_known_size;
+                    // Setting backend to rocksdb
+                    self.backend_type = BackendType::RocksDb(rocksdb_backend);
+                    // Switching metric to 1 for rocksdb
+                    self.rocksdb_autospill_in_use.set(1);
+                }
+                Ok(put_stats)
+            }
+            BackendType::RocksDb(rocks_db) => rocks_db.multi_put(puts).await,
+        }
+    }
+
+    async fn multi_get<'r, G, R>(
+        &mut self,
+        gets: G,
+        results_out: R,
+    ) -> Result<GetStats, anyhow::Error>
+    where
+        G: IntoIterator<Item = UpsertKey>,
+        R: IntoIterator<Item = &'r mut UpsertValueAndSize>,
+    {
+        match &mut self.backend_type {
+            BackendType::InMemory(in_memory_hash_map) => {
+                in_memory_hash_map.multi_get(gets, results_out).await
+            }
+            BackendType::RocksDb(rocks_db) => rocks_db.multi_get(gets, results_out).await,
+        }
+    }
+}

--- a/src/storage/src/render/upsert/memory.rs
+++ b/src/storage/src/render/upsert/memory.rs
@@ -1,0 +1,115 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Allow usage of `std::collections::HashMap`.
+//! We need to iterate through all the values in the map, so we can't use `mz_ore` wrapper.
+//! Also, we don't need any ordering for the values fetched, so using std HashMap.
+#![allow(clippy::disallowed_types)]
+
+use std::collections::hash_map::Drain;
+use std::collections::HashMap;
+
+use itertools::Itertools;
+
+use crate::render::upsert::types::{
+    GetStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize,
+};
+use crate::render::upsert::UpsertKey;
+
+/// A `HashMap` tracking its total size
+pub struct InMemoryHashMap {
+    state: HashMap<UpsertKey, StateValue>,
+    total_size: i64,
+}
+
+impl InMemoryHashMap {
+    /// Drain the map, returning the last total size as well.
+    pub fn drain(&mut self) -> (i64, Drain<'_, UpsertKey, StateValue>) {
+        let last_size = self.total_size;
+        self.total_size = 0;
+
+        (last_size, self.state.drain())
+    }
+
+    /// Get the current size of the map. Note that after `drain`-ing, this is 0.
+    pub fn current_size(&self) -> i64 {
+        self.total_size
+    }
+}
+
+impl Default for InMemoryHashMap {
+    fn default() -> Self {
+        Self {
+            state: HashMap::new(),
+            total_size: 0,
+        }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl UpsertStateBackend for InMemoryHashMap {
+    async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
+    where
+        P: IntoIterator<Item = (UpsertKey, PutValue<StateValue>)>,
+    {
+        let mut stats = PutStats::default();
+        for (key, p_value) in puts {
+            stats.processed_puts += 1;
+            match p_value.value {
+                Some(value) => {
+                    let size: i64 = value.memory_size().try_into().expect("less than i64 size");
+                    match p_value.previous_persisted_size {
+                        Some(previous_size) => {
+                            stats.size_diff -= previous_size;
+                            stats.size_diff += size;
+                            stats.updates += 1;
+                        }
+                        None => {
+                            stats.values_diff += 1;
+                            stats.size_diff += size;
+                            stats.inserts += 1;
+                        }
+                    }
+                    self.state.insert(key, value);
+                }
+                None => {
+                    if let Some(previous_size) = p_value.previous_persisted_size {
+                        stats.size_diff -= previous_size;
+                        stats.values_diff -= 1;
+                        stats.deletes += 1;
+                    }
+                    self.state.remove(&key);
+                }
+            }
+        }
+        self.total_size += stats.size_diff;
+        Ok(stats)
+    }
+
+    async fn multi_get<'r, G, R>(
+        &mut self,
+        gets: G,
+        results_out: R,
+    ) -> Result<GetStats, anyhow::Error>
+    where
+        G: IntoIterator<Item = UpsertKey>,
+        R: IntoIterator<Item = &'r mut UpsertValueAndSize>,
+    {
+        let mut stats = GetStats::default();
+        for (key, result_out) in gets.into_iter().zip_eq(results_out) {
+            stats.processed_gets += 1;
+            let value = self.state.get(&key).cloned();
+            let size = value.as_ref().map(|v| v.memory_size());
+            stats.processed_gets_size += size.unwrap_or(0);
+            stats.returned_gets += size.map(|_| 1).unwrap_or(0);
+            *result_out = UpsertValueAndSize { value, size };
+        }
+        Ok(stats)
+    }
+}


### PR DESCRIPTION
- fix rustfmt
- move autospill/memory impls into their own files
- break things into functions

broken out from: https://github.com/MaterializeInc/materialize/pull/24663

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
