### PR TITLE
sql: Make mz_schema_oid more robust

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -935,11 +935,7 @@
       description: >-
         Reports whether the role with the specified role name or OID has the privilege on
         the schema with the specified schema name or OID. If the role is omitted then
-        the `current_role` is assumed. This function has the following
-        limitations around schema resolution: 1) none of the schema names can have
-        database qualifiers (e.g., `has_schema_privilege('materialize.public', 'SELECT')`
-        will not work properly); 2) the name lookup does not consider the
-        active database.
+        the `current_role` is assumed.
     - signature: 'has_role([user: name or oid,] role: text or oid, privilege: text) -> bool'
       description: >-
         Reports whether the `user` has the privilege for `role`. `privilege` can either be `MEMBER`

--- a/src/pgrepr-consts/src/oid.rs
+++ b/src/pgrepr-consts/src/oid.rs
@@ -374,3 +374,4 @@ pub const FUNC_SECRET_OID_OID: u32 = 16_651;
 pub const FUNC_MAP_BUILD: u32 = 16_652;
 pub const FUNC_MAP_AGG: u32 = 16_653;
 pub const FUNC_UNNEST_MAP_OID: u32 = 16_654;
+pub const FUNC_MZ_NORMALIZE_SCHEMA_NAME: u32 = 16_655;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -4134,30 +4134,21 @@ pub static MZ_INTERNAL_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(
                 mz_unsafe.mz_error_if_null(
                     (
                         SELECT
-                            CASE
-                                -- Schema names should only have 2 components, so error if there's
-                                -- three.
-                                WHEN n[1] IS NOT NULL THEN
-                                    mz_unsafe.mz_error_if_null(
-                                        NULL,
-                                        'invalid schema \"' || $1 || '\"'
-                                    )::oid
-                            ELSE
-                                (
-                                    SELECT s.oid
-                                    FROM mz_schemas AS s
-                                    LEFT JOIN mz_databases AS d ON s.database_id = d.id
-                                    WHERE
-                                        (
-                                            -- Filter to only schemas in the named database or the
-                                            -- current database if no database was specified.
-                                            d.name = COALESCE(n[2], pg_catalog.current_database())
-                                            -- Always include all ambient schemas.
-                                            OR s.database_id IS NULL
-                                        ) AND s.name = n[3]
-                                )
-                            END
-                        FROM mz_internal.mz_normalize_object_name($1) AS n
+                            (
+                                SELECT s.oid
+                                FROM mz_schemas AS s
+                                LEFT JOIN mz_databases AS d ON s.database_id = d.id
+                                WHERE
+                                    (
+                                        -- Filter to only schemas in the named database or the
+                                        -- current database if no database was specified.
+                                        d.name = COALESCE(n[1], pg_catalog.current_database())
+                                        -- Always include all ambient schemas.
+                                        OR s.database_id IS NULL
+                                    )
+                                    AND s.name = n[2]
+                            )
+                        FROM mz_internal.mz_normalize_schema_name($1) AS n
                     ),
                     'schema \"' || $1 || '\" does not exist'
                 )

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -4081,6 +4081,30 @@ pub static MZ_INTERNAL_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(
                 ) AS i
             )") => ScalarType::Array(Box::new(ScalarType::String)), oid::FUNC_MZ_NORMALIZE_OBJECT_NAME;
         },
+        "mz_normalize_schema_name" => Scalar {
+            params!(String) => sql_impl_func("
+             (
+                SELECT
+                    CASE
+                        WHEN $1 IS NULL THEN NULL
+                        WHEN pg_catalog.array_length(ident, 1) > 2
+                            THEN mz_unsafe.mz_error_if_null(
+                                NULL::pg_catalog.text[],
+                                'improper schema name (too many dotted names): ' || $1
+                            )
+                        ELSE pg_catalog.array_cat(
+                            pg_catalog.array_fill(
+                                CAST(NULL AS pg_catalog.text),
+                                ARRAY[2 - pg_catalog.array_length(ident, 1)]
+                            ),
+                            ident
+                        )
+                    END
+                FROM (
+                    SELECT pg_catalog.parse_ident($1) AS ident
+                ) AS i
+            )") => ScalarType::Array(Box::new(ScalarType::String)), oid::FUNC_MZ_NORMALIZE_SCHEMA_NAME;
+        },
         "mz_render_typmod" => Scalar {
             params!(Oid, Int32) => BinaryFunc::MzRenderTypmod => String, oid::FUNC_MZ_RENDER_TYPMOD_OID;
         },

--- a/test/sqllogictest/mz_schema_oid.slt
+++ b/test/sqllogictest/mz_schema_oid.slt
@@ -32,7 +32,6 @@ SELECT mz_internal.mz_schema_oid(NULL) IS NULL
 ----
 true
 
-
 statement OK
 CREATE DATABASE db
 
@@ -60,7 +59,7 @@ SELECT mz_internal.mz_schema_oid('db.s') = (SELECT s.oid FROM mz_schemas s JOIN 
 ----
 true
 
-query error improper schema name (too many dotted names): db.s.i
+query error improper schema name \(too many dotted names\): db\.s\.i
 SELECT mz_internal.mz_schema_oid('db.s.i')
 
 query error schema "schmutz" does not exist

--- a/test/sqllogictest/mz_schema_oid.slt
+++ b/test/sqllogictest/mz_schema_oid.slt
@@ -60,7 +60,7 @@ SELECT mz_internal.mz_schema_oid('db.s') = (SELECT s.oid FROM mz_schemas s JOIN 
 ----
 true
 
-query error improper schema name (too many dotted names): "db.s.i"
+query error improper schema name (too many dotted names): db.s.i
 SELECT mz_internal.mz_schema_oid('db.s.i')
 
 query error schema "schmutz" does not exist

--- a/test/sqllogictest/mz_schema_oid.slt
+++ b/test/sqllogictest/mz_schema_oid.slt
@@ -1,0 +1,78 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+reset-server
+
+statement OK
+CREATE SCHEMA s
+
+query T
+SELECT mz_internal.mz_schema_oid('s') = (SELECT oid FROM mz_schemas WHERE name = 's')
+----
+true
+
+query T
+SELECT mz_internal.mz_schema_oid('materialize.s') = (SELECT oid FROM mz_schemas WHERE name = 's')
+----
+true
+
+query T
+SELECT mz_internal.mz_schema_oid('mz_catalog') = (SELECT oid FROM mz_schemas WHERE name = 'mz_catalog')
+----
+true
+
+query T
+SELECT mz_internal.mz_schema_oid(NULL) IS NULL
+----
+true
+
+
+statement OK
+CREATE DATABASE db
+
+statement OK
+CREATE SCHEMA db.sc
+
+query error schema "sc" does not exist
+SELECT mz_internal.mz_schema_oid('sc')
+
+query T
+SELECT mz_internal.mz_schema_oid('db.sc') = (SELECT oid FROM mz_schemas WHERE name = 'sc')
+----
+true
+
+statement OK
+CREATE SCHEMA db.s
+
+query T
+SELECT mz_internal.mz_schema_oid('s') = (SELECT s.oid FROM mz_schemas s JOIN mz_databases d ON s.database_id = d.id WHERE s.name = 's' AND d.name = 'materialize')
+----
+true
+
+query T
+SELECT mz_internal.mz_schema_oid('db.s') = (SELECT s.oid FROM mz_schemas s JOIN mz_databases d ON s.database_id = d.id WHERE s.name = 's' AND d.name = 'db')
+----
+true
+
+query error invalid schema "db.s.i"
+SELECT mz_internal.mz_schema_oid('db.s.i')
+
+query error schema "schmutz" does not exist
+SELECT mz_internal.mz_schema_oid('schmutz')
+
+statement OK
+SET database TO ''
+
+query T
+SELECT mz_internal.mz_schema_oid('mz_catalog') = (SELECT oid FROM mz_schemas WHERE name = 'mz_catalog')
+----
+true
+
+query error schema "s" does not exist
+SELECT mz_internal.mz_schema_oid('s')

--- a/test/sqllogictest/mz_schema_oid.slt
+++ b/test/sqllogictest/mz_schema_oid.slt
@@ -60,7 +60,7 @@ SELECT mz_internal.mz_schema_oid('db.s') = (SELECT s.oid FROM mz_schemas s JOIN 
 ----
 true
 
-query error invalid schema "db.s.i"
+query error improper schema name (too many dotted names): "db.s.i"
 SELECT mz_internal.mz_schema_oid('db.s.i')
 
 query error schema "schmutz" does not exist

--- a/test/sqllogictest/parse_ident.slt
+++ b/test/sqllogictest/parse_ident.slt
@@ -333,7 +333,7 @@ SELECT mz_internal.mz_normalize_schema_name('"SchemaX"')::text;
 query error db error: ERROR: improper schema name \(too many dotted names\): Dbz\.Schemax\.Tabley
 SELECT mz_internal.mz_normalize_schema_name('Dbz.Schemax.Tabley')::text;
 
-query error db error: ERROR: improper relation name \(too many dotted names\): "Dbz"\."SchemaX"\."TableY"
+query error db error: ERROR: improper schema name \(too many dotted names\): "Dbz"\."SchemaX"\."TableY"
 SELECT mz_internal.mz_normalize_schema_name('"Dbz"."SchemaX"."TableY"')::text;
 
 query error string is not a valid identifier: ""

--- a/test/sqllogictest/parse_ident.slt
+++ b/test/sqllogictest/parse_ident.slt
@@ -308,6 +308,71 @@ SELECT mz_internal.mz_normalize_object_name('🌍.🌍.🌍');
 query error db error: ERROR: improper relation name \(too many dotted names\): 🌍\.🌍\.🌍\.🌍
 SELECT mz_internal.mz_normalize_object_name('🌍.🌍.🌍.🌍');
 
+# normalizing schema names; this is largely built on top of parse_ident
+
+query T
+SELECT mz_internal.mz_normalize_schema_name('Dbz.Schemax')::text;
+----
+{dbz,schemax}
+
+query T
+SELECT mz_internal.mz_normalize_schema_name('"Dbz"."SchemaX"')::text;
+----
+{Dbz,SchemaX}
+
+query T
+SELECT mz_internal.mz_normalize_schema_name('Schemax')::text;
+----
+{NULL,schemax}
+
+query T
+SELECT mz_internal.mz_normalize_schema_name('"SchemaX"')::text;
+----
+{NULL,SchemaX}
+
+query error db error: ERROR: improper schema name \(too many dotted names\): Dbz\.Schemax\.Tabley
+SELECT mz_internal.mz_normalize_schema_name('Dbz.Schemax.Tabley')::text;
+
+query error db error: ERROR: improper relation name \(too many dotted names\): "Dbz"\."SchemaX"\."TableY"
+SELECT mz_internal.mz_normalize_schema_name('"Dbz"."SchemaX"."TableY"')::text;
+
+query error string is not a valid identifier: ""
+SELECT mz_internal.mz_normalize_schema_name('');
+
+query error string is not a valid identifier: " "
+SELECT mz_internal.mz_normalize_schema_name(' ');
+
+query error string is not a valid identifier: "1020"
+SELECT mz_internal.mz_normalize_schema_name('1020');
+
+query T
+SELECT mz_internal.mz_normalize_schema_name('"$abc"');
+----
+{NULL,$abc}
+
+query T
+SELECT mz_internal.mz_normalize_schema_name('a$.d$');
+----
+{a$,d$}
+
+query T
+SELECT mz_internal.mz_normalize_schema_name('"🌍"');
+----
+{NULL,🌍}
+
+query T
+SELECT mz_internal.mz_normalize_schema_name('"🌍"."🌍"');
+----
+{🌍,🌍}
+
+query T
+SELECT mz_internal.mz_normalize_schema_name('🌍.🌍');
+----
+{🌍,🌍}
+
+query error db error: ERROR: improper schema name \(too many dotted names\): 🌍\.🌍\.🌍
+SELECT mz_internal.mz_normalize_schema_name('🌍.🌍.🌍');
+
 statement ok
 DROP TABLE IF EXISTS t;
 

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -4153,12 +4153,12 @@ false
 ## Schemas
 
 query B
-SELECT has_schema_privilege('s1', 'CREATE')
+SELECT has_schema_privilege('d1.s1', 'CREATE')
 ----
 false
 
 query B
-SELECT has_schema_privilege('s2', 'CREATE')
+SELECT has_schema_privilege('d2.s2', 'CREATE')
 ----
 false
 
@@ -4168,12 +4168,12 @@ GRANT CREATE ON ALL SCHEMAS IN DATABASE d1, d2 TO materialize;
 COMPLETE 0
 
 query B
-SELECT has_schema_privilege('s1', 'CREATE')
+SELECT has_schema_privilege('d1.s1', 'CREATE')
 ----
 true
 
 query B
-SELECT has_schema_privilege('s2', 'CREATE')
+SELECT has_schema_privilege('d2.s2', 'CREATE')
 ----
 true
 
@@ -4183,12 +4183,12 @@ REVOKE CREATE ON ALL SCHEMAS IN DATABASE d1, d2 FROM materialize;
 COMPLETE 0
 
 query B
-SELECT has_schema_privilege('s1', 'CREATE')
+SELECT has_schema_privilege('d1.s1', 'CREATE')
 ----
 false
 
 query B
-SELECT has_schema_privilege('s2', 'CREATE')
+SELECT has_schema_privilege('d2.s2', 'CREATE')
 ----
 false
 
@@ -4495,12 +4495,12 @@ false
 ## Schemas
 
 query B
-SELECT has_schema_privilege('s1', 'CREATE')
+SELECT has_schema_privilege('d1.s1', 'CREATE')
 ----
 false
 
 query B
-SELECT has_schema_privilege('s2', 'CREATE')
+SELECT has_schema_privilege('d2.s2', 'CREATE')
 ----
 false
 
@@ -4510,12 +4510,12 @@ GRANT CREATE ON ALL SCHEMAS TO materialize;
 COMPLETE 0
 
 query B
-SELECT has_schema_privilege('s1', 'CREATE')
+SELECT has_schema_privilege('d1.s1', 'CREATE')
 ----
 true
 
 query B
-SELECT has_schema_privilege('s2', 'CREATE')
+SELECT has_schema_privilege('d2.s2', 'CREATE')
 ----
 true
 
@@ -4525,12 +4525,12 @@ REVOKE CREATE ON ALL SCHEMAS FROM materialize;
 COMPLETE 0
 
 query B
-SELECT has_schema_privilege('s1', 'CREATE')
+SELECT has_schema_privilege('d1.s1', 'CREATE')
 ----
 false
 
 query B
-SELECT has_schema_privilege('s2', 'CREATE')
+SELECT has_schema_privilege('d2.s2', 'CREATE')
 ----
 false
 

--- a/test/sqllogictest/regclass.slt
+++ b/test/sqllogictest/regclass.slt
@@ -35,12 +35,12 @@ CREATE MATERIALIZED VIEW s.m AS SELECT * FROM s.t;
 query T
 SELECT 't'::regclass::oid::int
 ----
-20696
+20697
 
 query T
 SELECT 's.t'::regclass::oid::int
 ----
-20697
+20698
 
 query T
 SELECT 't'::regclass = 's.t'::regclass
@@ -73,7 +73,7 @@ t
 query T
 SELECT 't'::regclass::oid::int
 ----
-20697
+20698
 
 query T
 SELECT 'public.t'::regclass::text;
@@ -101,12 +101,12 @@ d.public.t
 query T
 SELECT 'm'::regclass::oid::int
 ----
-20701
+20702
 
 query T
 SELECT 's.m'::regclass::oid::int
 ----
-20702
+20703
 
 query T
 SELECT 'm'::regclass = 's.m'::regclass
@@ -296,7 +296,7 @@ true
 query T
 SELECT 'materialize.public.t'::regclass::oid::int
 ----
-20696
+20697
 
 query error db error: ERROR: relation "t" does not exist
 SELECT 't'::regclass::oid::int

--- a/test/sqllogictest/regtype.slt
+++ b/test/sqllogictest/regtype.slt
@@ -142,12 +142,12 @@ CREATE TYPE d.public.t AS LIST (ELEMENT TYPE = int4);
 query T
 SELECT 't'::regtype::oid::int
 ----
-20697
+20698
 
 query T
 SELECT 's.t'::regtype::oid::int
 ----
-20698
+20699
 
 query T
 SELECT 't'::regtype = 's.t'::regtype


### PR DESCRIPTION
This commit makes mz_schema_oid more robust by only searching for schemas in the current database of the session when a database is not explicitly specified. Additionally, this commit allows callers to specify the database of a schema when calling mz_schema_oid. As a result other functions that call mz_schema_oid, such as has_schema_privilege, also are more robust.

Fixes #21490

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Make has_schema_privileges more robust by taking into account the current database and any specified database.
