### PR TITLE
compute: rename s3_oneshot sink to copy_to_s3_oneshot

### DIFF
--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -14,7 +14,9 @@ use std::sync::Arc;
 
 use http::Uri;
 use mz_compute_types::plan::Plan;
-use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, S3OneshotSinkConnection};
+use mz_compute_types::sinks::{
+    ComputeSinkConnection, ComputeSinkDesc, CopyToS3OneshotSinkConnection,
+};
 use mz_compute_types::ComputeInstanceId;
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
 use mz_pgcopy::CopyFormatParams;
@@ -223,7 +225,7 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
         // sinks, which should be set here depending upon the url scheme.
         let connection = match &self.copy_to_connection {
             Connection::Aws(aws_connection) => {
-                ComputeSinkConnection::S3Oneshot(S3OneshotSinkConnection {
+                ComputeSinkConnection::CopyToS3Oneshot(CopyToS3OneshotSinkConnection {
                     aws_connection: aws_connection.clone(),
                     prefix: self.copy_to_uri.to_string(),
                 })

--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -41,6 +41,8 @@ breaking:
     - compute-types/src/dataflows.proto
     # reason: does currently not require backward-compatibility
     - compute-types/src/plan.proto
+    # reason: does not currently require backward-compatibility
+    - compute-types/src/sinks.proto
     # reason: Ignore because plans are currently not persisted.
     - expr/src/relation.proto
     # reason: still under active development

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -81,14 +81,14 @@ pub enum ComputeControllerResponse<T> {
     PeekResponse(Uuid, PeekResponse, OpenTelemetryContext),
     /// See [`ComputeResponse::SubscribeResponse`].
     SubscribeResponse(GlobalId, SubscribeBatch<T>),
-    /// The response from a dataflow containing an `S3Oneshot` sink.
+    /// The response from a dataflow containing an `CopyToS3Oneshot` sink.
     ///
     /// The `GlobalId` identifies the sink. The `Result` is the response from
     /// the sink, where an `Ok(n)` indicates that `n` rows were successfully
     /// copied to S3 and an `Err` indicates that an error was encountered
     /// during the copy operation.
     ///
-    /// For a given `S3Oneshot` sink, there will be at most one `CopyToResponse`
+    /// For a given `CopyToS3Oneshot` sink, there will be at most one `CopyToResponse`
     /// produced. (The sink may produce no responses if its dataflow is dropped
     /// before completion.)
     CopyToResponse(GlobalId, Result<u64, anyhow::Error>),

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -990,7 +990,9 @@ where
                     ComputeSinkConnection::Persist(conn)
                 }
                 ComputeSinkConnection::Subscribe(conn) => ComputeSinkConnection::Subscribe(conn),
-                ComputeSinkConnection::S3Oneshot(conn) => ComputeSinkConnection::S3Oneshot(conn),
+                ComputeSinkConnection::CopyToS3Oneshot(conn) => {
+                    ComputeSinkConnection::CopyToS3Oneshot(conn)
+                }
             };
             let desc = ComputeSinkDesc {
                 from: se.from,

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -324,7 +324,7 @@ where
         self.sink_exports
             .iter()
             .filter_map(|(id, desc)| match desc.connection {
-                ComputeSinkConnection::S3Oneshot(_) => Some(*id),
+                ComputeSinkConnection::CopyToS3Oneshot(_) => Some(*id),
                 _ => None,
             })
     }

--- a/src/compute-types/src/sinks.proto
+++ b/src/compute-types/src/sinks.proto
@@ -36,7 +36,7 @@ message ProtoComputeSinkConnection {
     oneof kind {
         google.protobuf.Empty subscribe = 1;
         ProtoPersistSinkConnection persist = 2;
-        ProtoS3OneshotSinkConnection copy_to_s3_oneshot = 3;
+        ProtoCopyToS3OneshotSinkConnection copy_to_s3_oneshot = 3;
     }
 }
 
@@ -45,7 +45,7 @@ message ProtoPersistSinkConnection {
     mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 2;
 }
 
-message ProtoS3OneshotSinkConnection {
+message ProtoCopyToS3OneshotSinkConnection {
     string prefix = 1;
     mz_storage_types.connections.aws.ProtoAwsConnection aws_connection = 2;
 }

--- a/src/compute-types/src/sinks.proto
+++ b/src/compute-types/src/sinks.proto
@@ -6,6 +6,9 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+
+// buf breaking: ignore (does not currently require backward-compatibility)
+
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -33,7 +36,7 @@ message ProtoComputeSinkConnection {
     oneof kind {
         google.protobuf.Empty subscribe = 1;
         ProtoPersistSinkConnection persist = 2;
-        ProtoS3OneshotSinkConnection s3_oneshot = 3;
+        ProtoS3OneshotSinkConnection copy_to_s3_oneshot = 3;
     }
 }
 

--- a/src/compute-types/src/sinks.rs
+++ b/src/compute-types/src/sinks.rs
@@ -117,8 +117,8 @@ pub enum ComputeSinkConnection<S: 'static = ()> {
     Subscribe(SubscribeSinkConnection),
     /// TODO(#25239): Add documentation.
     Persist(PersistSinkConnection<S>),
-    /// TODO(#25239): Add documentation.
-    S3Oneshot(S3OneshotSinkConnection),
+    /// A compute sink to do a oneshot copy to s3.
+    CopyToS3Oneshot(CopyToS3OneshotSinkConnection),
 }
 
 impl<S> ComputeSinkConnection<S> {
@@ -127,7 +127,7 @@ impl<S> ComputeSinkConnection<S> {
         match self {
             ComputeSinkConnection::Subscribe(_) => "subscribe",
             ComputeSinkConnection::Persist(_) => "persist",
-            ComputeSinkConnection::S3Oneshot(_) => "s3",
+            ComputeSinkConnection::CopyToS3Oneshot(_) => "copy_to_s3_oneshot",
         }
     }
 
@@ -148,7 +148,9 @@ impl RustType<ProtoComputeSinkConnection> for ComputeSinkConnection<CollectionMe
             kind: Some(match self {
                 ComputeSinkConnection::Subscribe(_) => Kind::Subscribe(()),
                 ComputeSinkConnection::Persist(persist) => Kind::Persist(persist.into_proto()),
-                ComputeSinkConnection::S3Oneshot(s3) => Kind::S3Oneshot(s3.into_proto()),
+                ComputeSinkConnection::CopyToS3Oneshot(s3) => {
+                    Kind::CopyToS3Oneshot(s3.into_proto())
+                }
             }),
         }
     }
@@ -161,7 +163,7 @@ impl RustType<ProtoComputeSinkConnection> for ComputeSinkConnection<CollectionMe
         Ok(match kind {
             Kind::Subscribe(_) => ComputeSinkConnection::Subscribe(SubscribeSinkConnection {}),
             Kind::Persist(persist) => ComputeSinkConnection::Persist(persist.into_rust()?),
-            Kind::S3Oneshot(s3) => ComputeSinkConnection::S3Oneshot(s3.into_rust()?),
+            Kind::CopyToS3Oneshot(s3) => ComputeSinkConnection::CopyToS3Oneshot(s3.into_rust()?),
         })
     }
 }
@@ -170,16 +172,16 @@ impl RustType<ProtoComputeSinkConnection> for ComputeSinkConnection<CollectionMe
 #[derive(Arbitrary, Default, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct SubscribeSinkConnection {}
 
-/// TODO(#25239): Add documentation.
+/// Connection attributes required to do a oneshot copy to s3.
 #[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct S3OneshotSinkConnection {
-    /// TODO(#25239): Add documentation.
+pub struct CopyToS3OneshotSinkConnection {
+    /// The s3 prefix path to write the data to.
     pub prefix: String,
-    /// TODO(#25239): Add documentation.
+    /// The AWS connection information to do the writes.
     pub aws_connection: mz_storage_types::connections::aws::AwsConnection,
 }
 
-impl RustType<ProtoS3OneshotSinkConnection> for S3OneshotSinkConnection {
+impl RustType<ProtoS3OneshotSinkConnection> for CopyToS3OneshotSinkConnection {
     fn into_proto(&self) -> ProtoS3OneshotSinkConnection {
         ProtoS3OneshotSinkConnection {
             prefix: self.prefix.clone(),
@@ -188,7 +190,7 @@ impl RustType<ProtoS3OneshotSinkConnection> for S3OneshotSinkConnection {
     }
 
     fn from_proto(proto: ProtoS3OneshotSinkConnection) -> Result<Self, TryFromProtoError> {
-        Ok(S3OneshotSinkConnection {
+        Ok(CopyToS3OneshotSinkConnection {
             prefix: proto.prefix,
             aws_connection: proto
                 .aws_connection

--- a/src/compute-types/src/sinks.rs
+++ b/src/compute-types/src/sinks.rs
@@ -181,20 +181,20 @@ pub struct CopyToS3OneshotSinkConnection {
     pub aws_connection: mz_storage_types::connections::aws::AwsConnection,
 }
 
-impl RustType<ProtoS3OneshotSinkConnection> for CopyToS3OneshotSinkConnection {
-    fn into_proto(&self) -> ProtoS3OneshotSinkConnection {
-        ProtoS3OneshotSinkConnection {
+impl RustType<ProtoCopyToS3OneshotSinkConnection> for CopyToS3OneshotSinkConnection {
+    fn into_proto(&self) -> ProtoCopyToS3OneshotSinkConnection {
+        ProtoCopyToS3OneshotSinkConnection {
             prefix: self.prefix.clone(),
             aws_connection: Some(self.aws_connection.into_proto()),
         }
     }
 
-    fn from_proto(proto: ProtoS3OneshotSinkConnection) -> Result<Self, TryFromProtoError> {
+    fn from_proto(proto: ProtoCopyToS3OneshotSinkConnection) -> Result<Self, TryFromProtoError> {
         Ok(CopyToS3OneshotSinkConnection {
             prefix: proto.prefix,
             aws_connection: proto
                 .aws_connection
-                .into_rust_if_some("ProtoS3OneshotSinkConnection::aws_connection")?,
+                .into_rust_if_some("ProtoCopyToS3OneshotSinkConnection::aws_connection")?,
         })
     }
 }

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -118,7 +118,7 @@ where
         let region_name = match sink.connection {
             ComputeSinkConnection::Subscribe(_) => format!("SubscribeSink({:?})", sink_id),
             ComputeSinkConnection::Persist(_) => format!("PersistSink({:?})", sink_id),
-            ComputeSinkConnection::S3Oneshot(_) => format!("S3Sink({:?})", sink_id),
+            ComputeSinkConnection::CopyToS3Oneshot(_) => format!("S3Sink({:?})", sink_id),
         };
         self.scope
             .parent
@@ -172,6 +172,6 @@ where
     match connection {
         ComputeSinkConnection::Subscribe(connection) => Box::new(connection.clone()),
         ComputeSinkConnection::Persist(connection) => Box::new(connection.clone()),
-        ComputeSinkConnection::S3Oneshot(connection) => Box::new(connection.clone()),
+        ComputeSinkConnection::CopyToS3Oneshot(connection) => Box::new(connection.clone()),
     }
 }

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -118,7 +118,9 @@ where
         let region_name = match sink.connection {
             ComputeSinkConnection::Subscribe(_) => format!("SubscribeSink({:?})", sink_id),
             ComputeSinkConnection::Persist(_) => format!("PersistSink({:?})", sink_id),
-            ComputeSinkConnection::CopyToS3Oneshot(_) => format!("S3Sink({:?})", sink_id),
+            ComputeSinkConnection::CopyToS3Oneshot(_) => {
+                format!("CopyToS3OneshotSink({:?})", sink_id)
+            }
         };
         self.scope
             .parent

--- a/src/compute/src/sink/copy_to_s3_oneshot.rs
+++ b/src/compute/src/sink/copy_to_s3_oneshot.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 
 use differential_dataflow::Collection;
 use mz_compute_client::protocol::response::CopyToResponse;
-use mz_compute_types::sinks::{ComputeSinkDesc, S3OneshotSinkConnection};
+use mz_compute_types::sinks::{ComputeSinkDesc, CopyToS3OneshotSinkConnection};
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
@@ -26,7 +26,7 @@ use timely::PartialOrder;
 
 use crate::render::sinks::SinkRender;
 
-impl<G> SinkRender<G> for S3OneshotSinkConnection
+impl<G> SinkRender<G> for CopyToS3OneshotSinkConnection
 where
     G: Scope<Timestamp = Timestamp>,
 {

--- a/src/compute/src/sink/mod.rs
+++ b/src/compute/src/sink/mod.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod copy_to_s3_oneshot;
 mod persist_sink;
 mod refresh;
-mod s3_oneshot;
 mod subscribe;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Follow up from https://github.com/MaterializeInc/materialize/pull/25042, renaming the `s3_oneshot` sink to `copy_to_s3_oneshot` to make the naming consistent with `CopyTo` prefix used elsewhere.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->

cc @teskje 