### PR TITLE
storage/source/mysql: fix snapshot transaction

### DIFF
--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use itertools::Itertools;
 
 use mysql_async::prelude::{FromRow, Queryable};
-use mysql_async::{Conn, FromRowError, Row};
+use mysql_async::{FromRowError, Row};
 
 use mz_repr::adt::char::CharLength;
 use mz_repr::adt::numeric::{NumericMaxScale, NUMERIC_DATUM_MAX_PRECISION};
@@ -78,10 +78,13 @@ pub enum SchemaRequest<'a> {
 }
 
 /// Retrieve the tables and column descriptions for tables in the given schemas.
-pub async fn schema_info<'a>(
-    conn: &mut Conn,
+pub async fn schema_info<'a, Q>(
+    conn: &mut Q,
     schema_request: &SchemaRequest<'a>,
-) -> Result<Vec<MySqlTableDesc>, MySqlError> {
+) -> Result<Vec<MySqlTableDesc>, MySqlError>
+where
+    Q: Queryable,
+{
     let table_rows: Vec<(String, String)> = match schema_request {
         SchemaRequest::All => {
             // Get all tables in non-system schemas.

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -974,7 +974,7 @@ async fn purify_create_source(
             };
 
             // Retrieve schemas for all requested tables
-            let tables = mz_mysql_util::schema_info(&mut conn, &table_schema_request)
+            let tables = mz_mysql_util::schema_info(&mut *conn, &table_schema_request)
                 .await
                 .map_err(|err| match err {
                     // TODO: Refactor schema_info to return all unsupported columns rather than

--- a/src/storage/src/source/mysql/replication/events.rs
+++ b/src/storage/src/source/mysql/replication/events.rs
@@ -96,7 +96,7 @@ pub(super) async fn handle_query_event(
                         &config.config.connection_context.ssh_tunnel_manager,
                     )
                     .await?;
-                if let Some((err_table, err)) = verify_schemas(&mut conn, &[(&table, table_desc)])
+                if let Some((err_table, err)) = verify_schemas(&mut *conn, &[(&table, table_desc)])
                     .await?
                     .drain(..)
                     .next()
@@ -125,7 +125,7 @@ pub(super) async fn handle_query_event(
                 .filter(|(t, _)| !errored_tables.contains(t))
                 .map(|(t, d)| (t, &d.1))
                 .collect::<Vec<_>>();
-            let schema_errors = verify_schemas(&mut conn, &expected).await?;
+            let schema_errors = verify_schemas(&mut *conn, &expected).await?;
             for (dropped_table, err) in schema_errors {
                 if table_info.contains_key(dropped_table) && !errored_tables.contains(dropped_table)
                 {

--- a/src/storage/src/source/mysql/schemas.rs
+++ b/src/storage/src/source/mysql/schemas.rs
@@ -9,7 +9,8 @@
 
 use std::collections::BTreeMap;
 
-use mz_mysql_util::{schema_info, MySqlConn, MySqlError, MySqlTableDesc, SchemaRequest};
+use mysql_async::prelude::Queryable;
+use mz_mysql_util::{schema_info, MySqlError, MySqlTableDesc, SchemaRequest};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::UnresolvedItemName;
 
@@ -19,10 +20,13 @@ use super::{table_name, DefiniteError};
 /// and verify they are compatible with the expected schema.
 ///
 /// Returns a vec of tables that have incompatible schema changes.
-pub(super) async fn verify_schemas<'a>(
-    conn: &mut MySqlConn,
+pub(super) async fn verify_schemas<'a, Q>(
+    conn: &mut Q,
     expected: &[(&'a UnresolvedItemName, &MySqlTableDesc)],
-) -> Result<Vec<(&'a UnresolvedItemName, DefiniteError)>, MySqlError> {
+) -> Result<Vec<(&'a UnresolvedItemName, DefiniteError)>, MySqlError>
+where
+    Q: Queryable,
+{
     // Get the current schema for each requested table from mysql
     let cur_schemas: BTreeMap<_, _> = schema_info(
         conn,

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -90,7 +90,7 @@ use std::rc::Rc;
 use differential_dataflow::{AsCollection, Collection};
 use futures::TryStreamExt;
 use mysql_async::prelude::Queryable;
-use mysql_async::{Conn, IsolationLevel, Row as MySqlRow, TxOpts};
+use mysql_async::{IsolationLevel, Row as MySqlRow, TxOpts};
 use mz_timely_util::antichain::AntichainExt;
 use timely::dataflow::operators::{CapabilitySet, Concat, Map};
 use timely::dataflow::{Scope, Stream};
@@ -295,13 +295,12 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                     .with_isolation_level(IsolationLevel::RepeatableRead)
                     .with_consistent_snapshot(true)
                     .with_readonly(true);
-                conn.start_transaction(tx_opts).await?;
+                let mut tx = conn.start_transaction(tx_opts).await?;
                 // Set the session time zone to UTC so that we can read TIMESTAMP columns as UTC
                 // From https://dev.mysql.com/doc/refman/8.0/en/datetime.html: "MySQL converts TIMESTAMP values
                 // from the current time zone to UTC for storage, and back from UTC to the current time zone
                 // for retrieval. (This does not occur for other types such as DATETIME.)"
-                conn.query_drop("set @@session.time_zone = '+00:00'")
-                    .await?;
+                tx.query_drop("set @@session.time_zone = '+00:00'").await?;
 
                 // We have started our transaction so we can unlock the tables.
                 lock_conn.query_drop("UNLOCK TABLES").await?;
@@ -311,7 +310,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
 
                 // Verify the schemas of the tables we are snapshotting
                 let errored_tables = verify_schemas(
-                    &mut conn,
+                    &mut tx,
                     &reader_snapshot_table_info
                         .iter()
                         .map(|(table, (_, desc))| (table, desc))
@@ -356,7 +355,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                 *rewind_cap_set = CapabilitySet::new();
 
                 record_table_sizes(
-                    &mut conn,
+                    &mut tx,
                     metrics,
                     reader_snapshot_table_info
                         .values()
@@ -377,7 +376,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                     let query = format!("SELECT * FROM {}", table.to_ast_string());
                     trace!(%id, "timely-{worker_id} reading snapshot from \
                                  table '{table}':\n{table_desc:?}");
-                    let mut results = conn.exec_stream(query, ()).await?;
+                    let mut results = tx.exec_stream(query, ()).await?;
                     while let Some(row) = results.try_next().await? {
                         let row: MySqlRow = row;
                         match pack_mysql_row(&mut final_row, row, &table_desc)? {
@@ -427,12 +426,15 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
 }
 
 /// Record the sizes of the tables being snapshotted in `MySqlSnapshotMetrics`.
-async fn record_table_sizes(
-    conn: &mut Conn,
+async fn record_table_sizes<Q>(
+    conn: &mut Q,
     metrics: MySqlSnapshotMetrics,
     // Tables and their schemas.
     tables: Vec<(String, String)>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), anyhow::Error>
+where
+    Q: Queryable,
+{
     for (table, schema) in tables {
         let stats = collect_table_statistics(conn, &table, &schema).await?;
         if let Some(estimate) = stats.estimate_count {
@@ -463,11 +465,14 @@ struct TableStatistics {
     estimate_count: Option<u64>,
 }
 
-async fn collect_table_statistics(
-    conn: &mut Conn,
+async fn collect_table_statistics<Q>(
+    conn: &mut Q,
     table: &str,
     schema: &str,
-) -> Result<TableStatistics, anyhow::Error> {
+) -> Result<TableStatistics, anyhow::Error>
+where
+    Q: Queryable,
+{
     let mut stats = TableStatistics::default();
 
     let estimate_row: Option<u64> = conn

--- a/test/mysql-cdc/15-create-source.td
+++ b/test/mysql-cdc/15-create-source.td
@@ -24,9 +24,9 @@ ALTER SYSTEM SET enable_mysql_source = true
 $ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
-DROP DATABASE IF EXISTS dummyschema;
-CREATE DATABASE dummyschema;
-USE dummyschema;
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
 CREATE TABLE dummy (f1 INTEGER PRIMARY KEY, id VARCHAR(128));
 COMMIT;
 
@@ -50,6 +50,7 @@ dummy    subsource
 
 $ mysql-execute name=mysql
 DROP DATABASE IF EXISTS public;
+
 CREATE DATABASE public;
 USE public;
 CREATE TABLE t1 (f1 INTEGER);

--- a/test/mysql-cdc/20-source-replication.td
+++ b/test/mysql-cdc/20-source-replication.td
@@ -21,9 +21,9 @@ ALTER SYSTEM SET enable_mysql_source = true
 $ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
-DROP DATABASE IF EXISTS dummyschema;
-CREATE DATABASE dummyschema;
-USE dummyschema;
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
 CREATE TABLE dummy (f1 INTEGER PRIMARY KEY, id VARCHAR(128));
 INSERT INTO dummy VALUES (123, "dummy data");
 INSERT INTO dummy VALUES (234, "moar dummy");
@@ -35,7 +35,7 @@ COMMIT;
 234 "moar dummy"
 
 $ mysql-execute name=mysql
-USE dummyschema;
+USE public;
 INSERT INTO dummy VALUES (145, "next row");
 COMMIT;
 

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -197,7 +197,6 @@ def workflow_many_inserts(c: Composition) -> None:
             {concurrent_sql}
             """
         )
-        print(x)
         c.testdrive(args=["--no-reset"], input=x)
 
     insert_thread = threading.Thread(target=do_inserts, args=(c,))

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import threading
+from textwrap import dedent
+
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mysql import MySql
@@ -119,3 +122,107 @@ def workflow_schema_change_restart(c: Composition) -> None:
             f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
             "schema-restart/after-restart.td",
         )
+
+
+def _make_inserts(*, txns: int, txn_size: int) -> tuple[str, int]:
+    sql = "\n".join(
+        [
+            f"""
+            SET @i:=0;
+            INSERT INTO many_inserts (f2) SELECT @i:=@i+1 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT {txn_size};
+            """
+            for i in range(0, txns)
+        ]
+    )
+    records = txns * txn_size
+    return (sql, records)
+
+
+def workflow_many_inserts(c: Composition) -> None:
+    """
+    Tests a scenario that caused a consistency issue in the past. We insert a
+    large number of rows into a table, then create a source for that table while
+    simultaneously inserting many more rows into the table in a background
+    thread, then finally verify that the correct count of rows is captured by
+    the source.
+
+    In earlier incarnations of the MySQL source, the source accidentally failed
+    to snapshot inside of a repeatable read transaction.
+    """
+    c.up("materialized", "mysql")
+    c.up("testdrive", persistent=True)
+
+    # Records to before creating the source.
+    (initial_sql, initial_records) = _make_inserts(txns=1, txn_size=1_000_000)
+
+    # Records to insert concurrently with creating the source.
+    (concurrent_sql, concurrent_records) = _make_inserts(txns=1000, txn_size=100)
+
+    # Set up the MySQL server with the initial records, set up the connection to
+    # the MySQL server in Materialize.
+    c.testdrive(
+        dedent(
+            f"""
+            $ postgres-execute connection=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
+            ALTER SYSTEM SET enable_mysql_source = true
+
+            $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+
+            > CREATE SECRET IF NOT EXISTS mysqlpass AS '{MySql.DEFAULT_ROOT_PASSWORD}'
+            > CREATE CONNECTION IF NOT EXISTS mysql_conn TO MYSQL (HOST mysql, USER root, PASSWORD SECRET mysqlpass)
+
+            $ mysql-execute name=mysql
+            DROP DATABASE IF EXISTS public;
+            CREATE DATABASE public;
+            USE public;
+            DROP TABLE IF EXISTS many_inserts;
+            CREATE TABLE many_inserts (pk SERIAL PRIMARY KEY, f2 BIGINT);
+
+            {initial_sql}
+
+            > DROP SOURCE IF EXISTS s1;
+            """
+        )
+    )
+
+    # Start inserting in the background.
+
+    def do_inserts(c: Composition):
+        x = dedent(
+            f"""
+            $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+
+            $ mysql-execute name=mysql
+            USE public;
+            {concurrent_sql}
+            """
+        )
+        print(x)
+        c.testdrive(args=["--no-reset"], input=x)
+
+    insert_thread = threading.Thread(target=do_inserts, args=(c,))
+    insert_thread.start()
+
+    # Create the source.
+    c.testdrive(
+        args=["--no-reset"],
+        input=dedent(
+            """
+            > CREATE SOURCE s1
+                FROM MYSQL CONNECTION mysql_conn
+                FOR TABLES (public.many_inserts);
+            """
+        ),
+    )
+
+    # Ensure the source eventually sees the right number of records.
+    insert_thread.join()
+    c.testdrive(
+        args=["--no-reset"],
+        input=dedent(
+            f"""
+            > SELECT count(*) FROM many_inserts
+            {initial_records + concurrent_records}
+            """
+        ),
+    )

--- a/test/mysql-cdc/override/10-replica-connection.td
+++ b/test/mysql-cdc/override/10-replica-connection.td
@@ -20,9 +20,14 @@ $ mysql-connect name=mysql-replica url=mysql://root@mysql-replica password=${arg
 
 #
 # Create some data on the primary
+# and use RESET MASTER to clear any previous state
+# from the binlogs that may slow down the replication
+# process on the replica and cause us to be in an unknown
+# state when we create our source.
 #
 $ mysql-execute name=mysql
 DROP DATABASE IF EXISTS public;
+RESET MASTER;
 CREATE DATABASE public;
 USE public;
 CREATE TABLE t1 (f1 INTEGER);

--- a/test/mysql-cdc/schema-restart/after-restart.td
+++ b/test/mysql-cdc/schema-restart/after-restart.td
@@ -31,7 +31,7 @@ true
 $ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
-USE dummyschema
+USE public
 INSERT INTO other VALUES (4), (5);
 
 > SELECT count(*) FROM OTHER;

--- a/test/mysql-cdc/schema-restart/before-restart.td
+++ b/test/mysql-cdc/schema-restart/before-restart.td
@@ -23,9 +23,9 @@ $ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-pass
 # Create some test tables
 # Insert a bunch of rows one of the tables so the snapshot doesn't complete before we restart MZ
 $ mysql-execute name=mysql
-DROP DATABASE IF EXISTS dummyschema;
-CREATE DATABASE dummyschema;
-USE dummyschema;
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
 CREATE TABLE dummy (f1 INTEGER, f2 INTEGER);
 SET @i:=0;
 INSERT INTO dummy (f1, f2) SELECT @i:=@i+1, FLOOR(RAND()*10000) FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 50000;
@@ -36,7 +36,7 @@ INSERT INTO other VALUES (1), (2), (3);
 
 # Now alter the dummy table
 $ mysql-execute name=mysql
-USE dummyschema;
+USE public;
 ALTER TABLE dummy ADD COLUMN f3 varchar(2);
 
 # Now restart MZ


### PR DESCRIPTION
The source snapshot code was inadvertently dropping the transaction it intended to use on the floor, leading to the correctness issue observed in #25124.

Specifically, the SELECT query to load the table's snapshot was running outside of any transaction. This allowed it to observe the handful of transactions that committed *after* the snapshot's consistent point was constructed but before the SELECT query began executing. The replication stream (correctly) did not rewind this data, resulting in the data from that handful of transactions getting ingested into Materialize twice.

As far as I can tell, the code's approach to locking is (now) sound, so we don't need any of the changes to the locking scheme proposed in #25300. In particular, FLUSH TABLES only seems relevant if you need the data to be flushed to disk--e.g., so that you can reach into MySQL's data directory and tar up the files for export to another machine. Since we export the data using a SELECT statement, it seems to me that using LOCK should be sufficient [0].

The test enclosed in this PR is based on @rjobanp's test in #25300, but modified to insert data in parallel with creating the source in Materialize. The original test only failed sporadically on current main, but the modified test failed reliably--i.e., in 100% of the 4-5 times I ran it. The modified test also reliably passes with the fix in this commit.

Closes #25300.
Fixes #25124.

[0]: Confirming that statement in the MySQL documentation is left as an exercise to the reader.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
