### PR TITLE
release-qualification pipeline: Against 0.87.2 and skip upgrade

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -170,9 +170,9 @@ steps:
     trigger: tests
     async: false
     build:
-      # TODO(def-): How to get the last release version here? For now v0.86.1
-      commit: "62f5f14cd7003570239508cc5ca9a2ede24ac044"
-      branch: "v0.86.1"
+      # TODO(def-): How to get the last release version here? For now v0.87.2
+      commit: "f79ca55f07854fa0f1c0f7bdba8001b615c822e6"
+      branch: "v0.87.2"
       env:
         CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
         CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 1
@@ -182,20 +182,21 @@ steps:
     trigger: tests
     async: false
     build:
-      # TODO(def-): How to get the last release version here? For now v0.86.1
-      commit: "62f5f14cd7003570239508cc5ca9a2ede24ac044"
-      branch: "v0.86.1"
+      # TODO(def-): How to get the last release version here? For now v0.87.2
+      commit: "f79ca55f07854fa0f1c0f7bdba8001b615c822e6"
+      branch: "v0.87.2"
       env:
         CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
         CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 0
+    skip: "Currently can't run pipeline two times at once, rollback is more interesting anyway"
   - id: nightlies-preflight-check-rollback
     label: Nightlies with preflight check and rollback
     trigger: nightlies
     async: false
     build:
-      # TODO(def-): How to get the last release version here? For now v0.86.1
-      commit: "62f5f14cd7003570239508cc5ca9a2ede24ac044"
-      branch: "v0.86.1"
+      # TODO(def-): How to get the last release version here? For now v0.87.2
+      commit: "f79ca55f07854fa0f1c0f7bdba8001b615c822e6"
+      branch: "v0.87.2"
       env:
         CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
         CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 1
@@ -205,12 +206,13 @@ steps:
     trigger: nightlies
     async: false
     build:
-      # TODO(def-): How to get the last release version here? For now v0.86.1
-      commit: "62f5f14cd7003570239508cc5ca9a2ede24ac044"
-      branch: "v0.86.1"
+      # TODO(def-): How to get the last release version here? For now v0.87.2
+      commit: "f79ca55f07854fa0f1c0f7bdba8001b615c822e6"
+      branch: "v0.87.2"
       env:
         CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
         CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 0
+    skip: "Currently can't run pipeline two times at once, rollback is more interesting anyway"
 
 
   - wait: ~


### PR DESCRIPTION
If this test turns out to be useful I think I have to automate this in mkpipeline.py

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
