### PR TITLE
ci: Only upload heap profiles when requested via CI_HEAP_PROFILES=1

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -106,16 +106,18 @@ upload_artifact() {
     fi
 }
 
-rm -rf prof
-mkdir prof
-(while true; do
-    sleep 10
-    for cservice in $(mzcompose --mz-quiet ps --services); do
-        artifact=$(date "+prof/$cservice-%Y-%m-%d_%H:%M:%S.pb.gz")
-        upload_artifact "$cservice" "$artifact" &
+if [ -n "${CI_HEAP_PROFILES:-}" ]; then
+    rm -rf prof
+    mkdir prof
+    (while true; do
+        sleep 10
+        for cservice in $(mzcompose --mz-quiet ps --services); do
+            artifact=$(date "+prof/$cservice-%Y-%m-%d_%H:%M:%S.pb.gz")
+            upload_artifact "$cservice" "$artifact" &
+        done
     done
-done
-) &
+    ) &
+fi
 
 ci_uncollapsed_heading ":docker: Running \`bin/mzcompose --find \"$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION\" run ${run_args[*]}\`"
 


### PR DESCRIPTION
Otherwise we spam too many files

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
