### PR TITLE
ci: release qualification: feature benchmark should compare against the previous release

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -130,7 +130,7 @@ steps:
             args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=100000, --max-execution-time=8h]
 
   - id: feature-benchmark-scale-plus-one
-    label: "Feature benchmark against 'latest' with --scale=+1 %N"
+    label: "Feature benchmark against 'common-ancestor' with --scale=+1 %N"
     timeout_in_minutes: 2880
     parallelism: 8
     agents:
@@ -138,7 +138,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: feature-benchmark
-          args: [--other-tag=latest, --scale=+1]
+          args: [--other-tag=common-ancestor, --scale=+1]
 
   - group: SQLsmith
     key: sqlsmith


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/release-qualification/builds/428#018daf74-d96d-4583-92c0-04c7db281b1f.

The feature benchmark compared `v0.88.0 (ea142299b)` against `latest`, which is the same version. It should compare against the previous release, which can be achieved by specifying `common-ancestor`. When in CI and on a release branch, `common-ancestor` will return the preceding major release.

```
_bk;t=1708047244247The version of the 'THIS' Mz instance is: environmentd v0.88.0 (ea142299b)
[...]
_bk;t=1708045896008The version of the 'OTHER' Mz instance is: environmentd v0.88.0 (ea142299b)
```