### PR TITLE
test: Fix legacy upgrade tests catalog impl

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -282,7 +282,6 @@ steps:
 
   - id: legacy-upgrade
     label: Legacy upgrade tests (last version from docs)
-    skip: "failing, to be addressed with #25321"
     depends_on: build-aarch64
     timeout_in_minutes: 60
     artifact_paths: junit_*.xml

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -42,7 +42,11 @@ SERVICES = [
         options=list(mz_options.values()),
         volumes_extra=["secrets:/share/secrets"],
         external_cockroach=True,
-        catalog_store="stash",
+        # This test will skip versions when testing certain upgrade paths. The persist catalog
+        # will panic if a version is skipped when upgrading. Even when using the stash
+        # implementation we open the persist catalog, which will cause the panic. To avoid this, we
+        # use the emergency-stash, which doesn't even attempt to open the persist catalog.
+        catalog_store="emergency-stash",
     ),
     # N.B.: we need to use `validate_catalog_store=None` because testdrive uses
     # HEAD to load the catalog from disk but does *not* run migrations. There
@@ -141,7 +145,7 @@ def test_upgrade_from_version(
             ],
             volumes_extra=["secrets:/share/secrets"],
             external_cockroach=True,
-            catalog_store="stash",
+            catalog_store="emergency-stash",
         )
         with c.override(mz_from):
             c.up("materialized")
@@ -178,7 +182,7 @@ def test_upgrade_from_version(
     with c.override(
         Testdrive(
             postgres_stash="cockroach",
-            validate_catalog_store="stash",
+            validate_catalog_store="emergency-stash",
             volumes_extra=["secrets:/share/secrets"],
         )
     ):

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -182,7 +182,7 @@ def test_upgrade_from_version(
     with c.override(
         Testdrive(
             postgres_stash="cockroach",
-            validate_catalog_store="emergency-stash",
+            validate_catalog_store="stash",
             volumes_extra=["secrets:/share/secrets"],
         )
     ):


### PR DESCRIPTION
This legacy upgrade test will skip versions when testing certain upgrade paths. The persist catalog will panic if a version is skipped when upgrading. Even when using the stash catalog implementation we open the persist catalog during boot, which will cause the panic. To avoid this, this commit uses the emergency-stash catalog implementation, which doesn't even attempt to open the persist catalog.

Fixes #25321

### Motivation
This PR fixes a known bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
