### PR TITLE
Fix `set_read_policy` also in the Compute controller

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1195,10 +1195,11 @@ where
             let old_capability = &collection.implied_capability;
             let new_capability = new_policy.frontier(collection.write_frontier.borrow());
             if PartialOrder::less_than(old_capability, &new_capability) {
-                let mut update = ChangeBatch::new();
-                update.extend(old_capability.iter().map(|t| (t.clone(), -1)));
-                update.extend(new_capability.iter().map(|t| (t.clone(), 1)));
-                read_capability_changes.insert(id, update);
+                let entry = read_capability_changes
+                    .entry(id)
+                    .or_insert_with(ChangeBatch::new);
+                entry.extend(old_capability.iter().map(|t| (t.clone(), -1)));
+                entry.extend(new_capability.iter().map(|t| (t.clone(), 1)));
                 collection.implied_capability = new_capability;
             }
 


### PR DESCRIPTION
Turns out that the Compute controller has the same bug that d3feba8c6f3403be78f251a4d4a9ee6dd50b8da1 fixed in the Storage controller.

### Motivation

  * This PR fixes a previously unreported bug: See commit msg of d3feba8c6f3403be78f251a4d4a9ee6dd50b8da1

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
