### PR TITLE
Fix the stepping back in `downgrade_warmup_capabilities`

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1729,9 +1729,7 @@ where
             let mut new_capability = Antichain::new();
             for frontier in compute_frontiers.chain(storage_frontiers) {
                 for time in frontier.iter() {
-                    if let Some(time) = time.step_back() {
-                        new_capability.insert(time);
-                    }
+                    new_capability.insert(time.step_back().unwrap_or(time.clone()));
                 }
             }
 

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1,4 +1,4 @@
-# Copyright Materialize, Inc. and contributors. All rights resemved.
+# Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
 # included in the LICENSE file at the root of this repository.


### PR DESCRIPTION
`downgrade_warmup_capabilities` was calling `step_back()` on each input collection's write frontier, and ignoring the case when `step_back()` returned None (which happens when the given timestamp is 0). This meant that if all input collection's write frontier was still at 0 (which can happen for a short time after the creation of a Storage collection, or even not for a not so short time, when the cluster that's feeding a Storage collection doesn't have any replicas), then we didn't keep a warmup capability.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
