### PR TITLE
compute-client: avoid regressing global write frontier

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1322,13 +1322,13 @@ where
         for (id, new_upper) in updates {
             let collection = self.compute.expect_collection_mut(*id);
 
-            let old_upper = std::mem::replace(&mut collection.write_frontier, new_upper.clone());
-            let old_since = &collection.implied_capability;
-
-            if !PartialOrder::less_than(&old_upper, new_upper) {
+            if !PartialOrder::less_than(&collection.write_frontier, new_upper) {
                 continue; // frontier has not advanced
             }
 
+            collection.write_frontier = new_upper.clone();
+
+            let old_since = &collection.implied_capability;
             let new_since = match &collection.read_policy {
                 Some(read_policy) => {
                     // For readable collections the read frontier is determined by applying the


### PR DESCRIPTION
This PR fixes a bug in the compute controller where global write frontiers could regress by being overwritten with the write frontiers of lagging replicas.

The `maybe_update_global_write_frontiers` method did contain a check to ensure that frontier regressions are ignored. However, this check was applied only _after_ `CollectionState::write_frontier` was already unconditionally updated to the new frontier, making it quite useless.

The fix is of course to check for regressions before updating the collection state.

The bug was introduced in #25005 which changed `update_global_write_frontiers` from panicking on regressions to handling them gracefully (by ignoring them). The previous code was correct because the regression in `ComputeState::write_frontier` didn't matter when the processed panicked immediately afterwards.

### Motivation

  * This PR fixes a recognized bug.

Fixes #25157

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
