### PR TITLE
adapter: add a SessionMeta struct for off-thread work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,6 +2750,20 @@ checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -5577,6 +5600,7 @@ dependencies = [
  "globset",
  "hex",
  "http",
+ "im",
  "itertools",
  "maplit",
  "mysql_async",
@@ -7511,6 +7535,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8419,6 +8452,16 @@ name = "siphasher"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "skeptic"

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -20,6 +20,11 @@ who = "Matt Arthur <matthewleearthur@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.26.0"
 
+[[audits.bitmaps]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.1.0"
+
 [[audits.bitvec]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
@@ -74,6 +79,11 @@ version = "0.6.0"
 who = "Matt Jibson <matt.jibson@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.6.4"
+
+[[audits.im]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "15.1.0"
 
 [[audits.jsonwebtoken]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
@@ -135,6 +145,11 @@ who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.7.0"
 
+[[audits.rand_xoshiro]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.6.0"
+
 [[audits.raw-cpuid]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
@@ -174,6 +189,11 @@ delta = "0.16.20 -> 0.17.7"
 who = "Matt Jibson <matt.jibson@gmail.com>"
 criteria = "safe-to-deploy"
 version = "1.0.4"
+
+[[audits.sized-chunks]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.6.5"
 
 [[audits.spin]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"

--- a/src/adapter/src/active_compute_sink.rs
+++ b/src/adapter/src/active_compute_sink.rs
@@ -24,6 +24,7 @@ use mz_ore::now::EpochMillis;
 use mz_repr::adt::numeric;
 use mz_repr::{Datum, GlobalId, Row, Timestamp};
 use mz_sql::plan::SubscribeOutput;
+use mz_sql::session::metadata::SessionMetadata;
 use timely::progress::Antichain;
 use tokio::sync::mpsc;
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5347,7 +5347,7 @@ mod tests {
             .expect("must succeed");
         let prep_style = ExprPrepStyle::OneShot {
             logical_time: EvalTime::Time(Timestamp::MIN),
-            session: &session.meta(catalog.system_config()),
+            session: &session,
             catalog_state: &catalog.state,
         };
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use futures::Future;
 use itertools::Itertools;
 use mz_adapter_types::compaction::CompactionWindow;
+use mz_sql::session::metadata::SessionMetadata;
 use smallvec::SmallVec;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::MutexGuard;
@@ -371,32 +372,8 @@ impl ConnCatalog<'_> {
         &self,
         include_temp_schema: bool,
     ) -> Vec<(ResolvedDatabaseSpecifier, SchemaSpecifier)> {
-        let mut v = Vec::with_capacity(self.search_path.len() + 3);
-        // Temp schema is only included for relations and data types, not for functions and operators
-        let temp_schema = (
-            ResolvedDatabaseSpecifier::Ambient,
-            SchemaSpecifier::Temporary,
-        );
-        if include_temp_schema && !self.search_path.contains(&temp_schema) {
-            v.push(temp_schema);
-        }
-        let default_schemas = [
-            (
-                ResolvedDatabaseSpecifier::Ambient,
-                SchemaSpecifier::Id(self.state.get_mz_catalog_schema_id().clone()),
-            ),
-            (
-                ResolvedDatabaseSpecifier::Ambient,
-                SchemaSpecifier::Id(self.state.get_pg_catalog_schema_id().clone()),
-            ),
-        ];
-        for schema in default_schemas.into_iter() {
-            if !self.search_path.contains(&schema) {
-                v.push(schema);
-            }
-        }
-        v.extend_from_slice(&self.search_path);
-        v
+        self.state
+            .effective_search_path(&self.search_path, include_temp_schema)
     }
 }
 
@@ -5364,13 +5341,13 @@ mod tests {
             allow_windows: false,
         };
         let arena = RowArena::new();
-        let mut session = Session::dummy();
+        let mut session = Session::<Timestamp>::dummy();
         session
             .start_transaction(to_datetime(0), None, None)
             .expect("must succeed");
         let prep_style = ExprPrepStyle::OneShot {
             logical_time: EvalTime::Time(Timestamp::MIN),
-            session: &session,
+            session: &session.meta(catalog.system_config()),
             catalog_state: &catalog.state,
         };
 

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -33,6 +33,7 @@ use mz_repr::{GlobalId, Row, ScalarType};
 use mz_sql::ast::{Raw, Statement};
 use mz_sql::catalog::{EnvironmentId, SessionCatalog};
 use mz_sql::session::hint::ApplicationNameHint;
+use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::user::SUPPORT_USER;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::StatementKind;

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -21,6 +21,7 @@ use mz_ore::task;
 use mz_ore::vec::VecExt;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_sql::plan::Plan;
+use mz_sql::session::metadata::SessionMetadata;
 use mz_storage_client::client::TimestamplessUpdate;
 use mz_timestamp_oracle::WriteTimestamp;
 use tokio::sync::{oneshot, Notify, OwnedMutexGuard, OwnedSemaphorePermit, Semaphore};

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -11,6 +11,7 @@
 //! client via some external Materialize API (ex: HTTP and psql).
 
 use differential_dataflow::lattice::Lattice;
+use mz_sql::session::metadata::SessionMetadata;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
@@ -646,8 +647,7 @@ impl Coordinator {
                     // planning, which may require the use of some connections and secrets.
                     if let Err(e) = rbac::check_usage(
                         &catalog,
-                        ctx.session().role_metadata(),
-                        ctx.session().vars(),
+                        ctx.session(),
                         &resolved_ids,
                         &CREATE_ITEM_USAGE,
                     ) {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -36,6 +36,7 @@ use mz_repr::adt::numeric::Numeric;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::catalog::{CatalogCluster, CatalogSchema};
 use mz_sql::names::{ObjectId, ResolvedDatabaseSpecifier};
+use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::vars::{
     self, SystemVars, Var, MAX_AWS_PRIVATELINK_CONNECTIONS, MAX_CLUSTERS,
     MAX_CREDIT_CONSUMPTION_RATE, MAX_DATABASES, MAX_KAFKA_CONNECTIONS, MAX_MATERIALIZED_VIEWS,

--- a/src/adapter/src/coord/id_bundle.rs
+++ b/src/adapter/src/coord/id_bundle.rs
@@ -11,6 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use mz_compute_types::ComputeInstanceId;
 use mz_repr::GlobalId;
+use mz_sql::session::metadata::SessionMetadata;
 use serde::Deserialize;
 
 use crate::coord::Coordinator;

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -29,6 +29,7 @@ use mz_adapter_types::compaction::{CompactionWindow, ReadCapability};
 use mz_compute_types::ComputeInstanceId;
 use mz_ore::instrument;
 use mz_repr::{GlobalId, Timestamp};
+use mz_sql::session::metadata::SessionMetadata;
 use mz_storage_types::read_policy::ReadPolicy;
 use timely::progress::Antichain;
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -27,6 +27,7 @@ use mz_sql::plan::{
     FetchPlan, MutationKind, Params, Plan, PlanKind, QueryWhen, RaisePlan,
 };
 use mz_sql::rbac;
+use mz_sql::session::metadata::SessionMetadata;
 use mz_sql_parser::ast::{Raw, Statement};
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use std::sync::Arc;
@@ -120,8 +121,7 @@ impl Coordinator {
                         (conn_id.unhandled(), *conn_meta.authenticated_role_id())
                     })
                     .collect(),
-                ctx.session().role_metadata(),
-                ctx.session().vars(),
+                ctx.session(),
                 &plan,
                 target_cluster_id,
                 &resolved_ids,
@@ -711,7 +711,7 @@ impl Coordinator {
     }
 
     fn should_emit_rbac_notice(&self, session: &Session) -> Option<AdapterNotice> {
-        if !rbac::is_rbac_enabled_for_session(self.catalog.system_config(), session.vars()) {
+        if !rbac::is_rbac_enabled_for_session(self.catalog.system_config(), session) {
             Some(AdapterNotice::RbacUserDisabled)
         } else {
             None

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -29,6 +29,7 @@ use mz_sql::plan::{
     CreateClusterPlan, CreateClusterReplicaPlan, CreateClusterUnmanagedPlan, CreateClusterVariant,
     PlanClusterOption,
 };
+use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::vars::{SystemVars, Var, MAX_REPLICAS_PER_CLUSTER};
 
 use crate::catalog::Op;

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -16,6 +16,7 @@ use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan;
+use mz_sql::session::metadata::SessionMetadata;
 use tracing::Span;
 
 use crate::command::ExecuteResponse;

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -19,6 +19,7 @@ use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::{ObjectId, ResolvedIds};
 use mz_sql::plan;
+use mz_sql::session::metadata::SessionMetadata;
 use mz_sql_parser::ast;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -14,6 +14,7 @@ use mz_repr::RelationDesc;
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::{ObjectId, ResolvedIds};
 use mz_sql::plan::{self};
+use mz_sql::session::metadata::SessionMetadata;
 use tracing::Span;
 
 use crate::command::ExecuteResponse;

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -25,6 +25,7 @@ use mz_sql::catalog::CatalogCluster;
 use mz_catalog::memory::objects::CatalogItem;
 use mz_sql::plan::QueryWhen;
 use mz_sql::plan::{self, HirScalarExpr};
+use mz_sql::session::metadata::SessionMetadata;
 use mz_transform::EmptyStatisticsOracle;
 use tracing::Instrument;
 use tracing::{event, warn, Level};
@@ -99,7 +100,7 @@ impl Coordinator {
         let eval_uri = |to: HirScalarExpr| -> Result<Uri, AdapterError> {
             let style = ExprPrepStyle::OneShot {
                 logical_time: EvalTime::NotAvailable,
-                session: ctx.session(),
+                session: &ctx.session().meta(self.catalog().system_config()),
                 catalog_state: self.catalog().state(),
             };
             let mut to = to.lower_uncorrelated()?;
@@ -526,6 +527,7 @@ impl Coordinator {
             )
             .await
             .unwrap_or_else(|_| Box::new(EmptyStatisticsOracle));
+        let session = ctx.session().meta(self.catalog().system_config());
 
         mz_ore::task::spawn_blocking(
             || "optimize peek",
@@ -541,7 +543,7 @@ impl Coordinator {
                             // HIR ⇒ MIR lowering and MIR optimization (local)
                             let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
                             // Attach resolved context required to continue the pipeline.
-                            let local_mir_plan = local_mir_plan.resolve(timestamp_context, ctx.session(), stats);
+                            let local_mir_plan = local_mir_plan.resolve(timestamp_context, &session, stats);
                             // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global)
                             let global_lir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
 
@@ -552,7 +554,7 @@ impl Coordinator {
                             // HIR ⇒ MIR lowering and MIR optimization (local and global)
                             let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
                             // Attach resolved context required to continue the pipeline.
-                            let local_mir_plan = local_mir_plan.resolve(timestamp_context, ctx.session(), stats);
+                            let local_mir_plan = local_mir_plan.resolve(timestamp_context, &session, stats);
                             // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global)
                             let global_lir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
 

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -100,7 +100,7 @@ impl Coordinator {
         let eval_uri = |to: HirScalarExpr| -> Result<Uri, AdapterError> {
             let style = ExprPrepStyle::OneShot {
                 logical_time: EvalTime::NotAvailable,
-                session: &ctx.session().meta(self.catalog().system_config()),
+                session: ctx.session(),
                 catalog_state: self.catalog().state(),
             };
             let mut to = to.lower_uncorrelated()?;
@@ -527,7 +527,7 @@ impl Coordinator {
             )
             .await
             .unwrap_or_else(|_| Box::new(EmptyStatisticsOracle));
-        let session = ctx.session().meta(self.catalog().system_config());
+        let session = ctx.session().meta();
 
         mz_ore::task::spawn_blocking(
             || "optimize peek",

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -9,6 +9,7 @@
 
 use mz_ore::instrument;
 use mz_sql::plan::{self, QueryWhen};
+use mz_sql::session::metadata::SessionMetadata;
 use timely::progress::Antichain;
 use tokio::sync::mpsc;
 use tracing::Span;

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -15,6 +15,7 @@ use mz_ore::now::EpochMillis;
 use mz_repr::{GlobalId, ScalarType};
 use mz_sql::names::{Aug, ResolvedIds};
 use mz_sql::plan::{Params, StatementDesc};
+use mz_sql::session::metadata::SessionMetadata;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{Raw, Statement, StatementKind};
 

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -19,6 +19,7 @@ use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::timestamp::TimestampLike;
 use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
 use mz_sql::plan::Params;
+use mz_sql::session::metadata::SessionMetadata;
 use mz_sql_parser::ast::{statement_kind_label_value, StatementKind};
 use mz_storage_client::controller::IntrospectionType;
 use qcell::QCell;

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -20,6 +20,7 @@ use mz_ore::cast::CastLossy;
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::{GlobalId, RowArena, ScalarType, Timestamp, TimestampManipulation};
 use mz_sql::plan::QueryWhen;
+use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::vars::IsolationLevel;
 use mz_storage_types::sources::Timeline;
 use serde::{Deserialize, Serialize};

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -21,6 +21,7 @@ use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
 use mz_repr::explain::trace_plan;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::plan::HirRelationExpr;
+use mz_sql::session::metadata::SessionMetadata;
 use mz_storage_types::connections::Connection;
 use mz_storage_types::sinks::S3UploadInfo;
 use mz_transform::dataflow::DataflowMetainfo;
@@ -40,7 +41,6 @@ use crate::optimize::{
     optimize_mir_local, trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize,
     OptimizeMode, OptimizerConfig, OptimizerError,
 };
-use crate::session::SessionMeta;
 use crate::TimestampContext;
 
 pub struct Optimizer {
@@ -111,7 +111,7 @@ pub struct LocalMirPlan<T = Unresolved> {
 pub struct Resolved<'s> {
     timestamp_ctx: TimestampContext<Timestamp>,
     stats: Box<dyn StatisticsOracle>,
-    session: &'s SessionMeta,
+    session: &'s dyn SessionMetadata,
 }
 
 /// The (final) result after
@@ -163,7 +163,7 @@ impl LocalMirPlan<Unresolved> {
     pub fn resolve(
         self,
         timestamp_ctx: TimestampContext<Timestamp>,
-        session: &SessionMeta,
+        session: &dyn SessionMetadata,
         stats: Box<dyn StatisticsOracle>,
     ) -> LocalMirPlan<Resolved> {
         LocalMirPlan {

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -40,7 +40,7 @@ use crate::optimize::{
     optimize_mir_local, trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize,
     OptimizeMode, OptimizerConfig, OptimizerError,
 };
-use crate::session::Session;
+use crate::session::SessionMeta;
 use crate::TimestampContext;
 
 pub struct Optimizer {
@@ -111,7 +111,7 @@ pub struct LocalMirPlan<T = Unresolved> {
 pub struct Resolved<'s> {
     timestamp_ctx: TimestampContext<Timestamp>,
     stats: Box<dyn StatisticsOracle>,
-    session: &'s Session,
+    session: &'s SessionMeta,
 }
 
 /// The (final) result after
@@ -163,7 +163,7 @@ impl LocalMirPlan<Unresolved> {
     pub fn resolve(
         self,
         timestamp_ctx: TimestampContext<Timestamp>,
-        session: &Session,
+        session: &SessionMeta,
         stats: Box<dyn StatisticsOracle>,
     ) -> LocalMirPlan<Resolved> {
         LocalMirPlan {

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -36,7 +36,7 @@ use crate::optimize::{
     optimize_mir_local, trace_plan, MirDataflowDescription, Optimize, OptimizeMode,
     OptimizerConfig, OptimizerError,
 };
-use crate::session::Session;
+use crate::session::SessionMeta;
 use crate::TimestampContext;
 
 pub struct Optimizer {
@@ -123,7 +123,7 @@ pub struct LocalMirPlan<T = Unresolved> {
 pub struct Resolved<'s> {
     timestamp_ctx: TimestampContext<Timestamp>,
     stats: Box<dyn StatisticsOracle>,
-    session: &'s Session,
+    session: &'s SessionMeta,
 }
 
 /// The (final) result after
@@ -171,7 +171,7 @@ impl LocalMirPlan<Unresolved> {
     pub fn resolve(
         self,
         timestamp_ctx: TimestampContext<Timestamp>,
-        session: &Session,
+        session: &SessionMeta,
         stats: Box<dyn StatisticsOracle>,
     ) -> LocalMirPlan<Resolved> {
         LocalMirPlan {

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -19,6 +19,7 @@ use mz_expr::{MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFi
 use mz_repr::explain::trace_plan;
 use mz_repr::{GlobalId, RelationType, Timestamp};
 use mz_sql::plan::HirRelationExpr;
+use mz_sql::session::metadata::SessionMetadata;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::normalize_lets::normalize_lets;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
@@ -36,7 +37,6 @@ use crate::optimize::{
     optimize_mir_local, trace_plan, MirDataflowDescription, Optimize, OptimizeMode,
     OptimizerConfig, OptimizerError,
 };
-use crate::session::SessionMeta;
 use crate::TimestampContext;
 
 pub struct Optimizer {
@@ -123,7 +123,7 @@ pub struct LocalMirPlan<T = Unresolved> {
 pub struct Resolved<'s> {
     timestamp_ctx: TimestampContext<Timestamp>,
     stats: Box<dyn StatisticsOracle>,
-    session: &'s SessionMeta,
+    session: &'s dyn SessionMetadata,
 }
 
 /// The (final) result after
@@ -171,7 +171,7 @@ impl LocalMirPlan<Unresolved> {
     pub fn resolve(
         self,
         timestamp_ctx: TimestampContext<Timestamp>,
-        session: &SessionMeta,
+        session: &dyn SessionMetadata,
         stats: Box<dyn StatisticsOracle>,
     ) -> LocalMirPlan<Resolved> {
         LocalMirPlan {

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -19,7 +19,7 @@ use mz_ore::{halt, soft_assert_no_log};
 use mz_repr::{RelationDesc, ScalarType};
 use mz_sql::names::FullItemName;
 use mz_sql::plan::StatementDesc;
-use mz_sql::session::vars::Var;
+use mz_sql::session::metadata::SessionMetadata;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
     CreateIndexStatement, FetchStatement, Ident, Raw, RawClusterName, RawItemName, Statement,
@@ -29,7 +29,7 @@ use mz_transform::TransformError;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 
-use crate::catalog::{Catalog, CatalogState};
+use crate::catalog::Catalog;
 use crate::command::{Command, Response};
 use crate::coord::{Message, PendingTxnResponse};
 use crate::error::AdapterError;
@@ -411,19 +411,4 @@ impl ShouldHalt for InstanceMissing {
     fn should_halt(&self) -> bool {
         false
     }
-}
-
-/// Returns the viewable session and system variables.
-pub(crate) fn viewable_variables<'a>(
-    catalog: &'a CatalogState,
-    session: &'a Session,
-) -> impl Iterator<Item = &'a dyn Var> {
-    session
-        .vars()
-        .iter()
-        .chain(catalog.system_config().iter())
-        .filter(|v| {
-            v.visible(session.user(), Some(catalog.system_config()))
-                .is_ok()
-        })
 }

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -47,6 +47,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::str::StrExt;
 use mz_repr::user::ExternalUserMetadata;
 use mz_server_core::{ConnectionHandler, Server};
+use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::user::{HTTP_DEFAULT_USER, SUPPORT_USER_NAME, SYSTEM_USER_NAME};
 use mz_sql::session::vars::{
     ConnectionCounter, DropConnection, Value, Var, VarInput, WELCOME_MESSAGE,

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -38,6 +38,7 @@ use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{Raw, Statement, StatementKind};
 use mz_sql::parse::StatementParseResult;
 use mz_sql::plan::Plan;
+use mz_sql::session::metadata::SessionMetadata;
 use serde::{Deserialize, Serialize};
 use tokio::{select, time};
 use tokio_postgres::error::SqlState;

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -41,6 +41,7 @@ use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{FetchDirection, Ident, Raw, Statement};
 use mz_sql::parse::StatementParseResult;
 use mz_sql::plan::{CopyFormat, ExecuteTimeout, StatementDesc};
+use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::user::INTERNAL_USER_NAMES;
 use mz_sql::session::vars::{ConnectionCounter, DropConnection, Var, VarInput, MAX_COPY_FROM_SIZE};
 use postgres::error::SqlState;

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -25,6 +25,7 @@ fail = { version = "0.5.1", features = ["failpoints"] }
 globset = "0.4.9"
 hex = "0.4.3"
 http = "0.2.8"
+im = "15.1.0"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 maplit = "1.0.2"

--- a/src/sql/src/session.rs
+++ b/src/sql/src/session.rs
@@ -14,5 +14,6 @@
 //! should be revisited with more intention in the future.
 
 pub mod hint;
+pub mod metadata;
 pub mod user;
 pub mod vars;

--- a/src/sql/src/session/metadata.rs
+++ b/src/sql/src/session/metadata.rs
@@ -11,39 +11,55 @@ use std::fmt::Debug;
 
 use mz_adapter_types::connection::ConnectionId;
 use mz_repr::role_id::RoleId;
-use mz_sql_parser::ast::Ident;
 
 use crate::plan::PlanContext;
 use crate::session::user::{RoleMetadata, User};
+use crate::session::vars::SessionVars;
 
 pub trait SessionMetadata: Debug + Sync {
-    /// Returns the user who owns this session.
-    fn user(&self) -> &User;
-    /// Returns the database session variable.
-    fn database(&self) -> &str;
-    /// Returns the search path session variable.
-    fn search_path(&self) -> &[Ident];
+    /// Returns the session vars for this session.
+    fn vars(&self) -> &SessionVars;
     /// Returns the connection ID associated with the session.
     fn conn_id(&self) -> &ConnectionId;
     /// Returns the current transaction's PlanContext. Panics if there is not a
     /// current transaction.
     fn pcx(&self) -> &PlanContext;
+    /// Returns the role metadata for this session.
+    fn role_metadata(&self) -> &RoleMetadata;
+
     /// Returns the session's current role ID.
     ///
     /// # Panics
     /// If the session has not connected successfully.
-    fn current_role_id(&self) -> &RoleId;
+    fn current_role_id(&self) -> &RoleId {
+        &self.role_metadata().current_role
+    }
+
     /// Returns the session's session role ID.
     ///
     /// # Panics
     /// If the session has not connected successfully.
-    fn session_role_id(&self) -> &RoleId;
-    /// Whether the current session is a superuser.
-    fn is_superuser(&self) -> bool;
-    fn enable_session_rbac_checks(&self) -> bool;
-    /// Returns the session's role metadata.
-    ///
-    /// # Panics
-    /// If the session has not connected successfully.
-    fn role_metadata(&self) -> &RoleMetadata;
+    fn session_role_id(&self) -> &RoleId {
+        &self.role_metadata().session_role
+    }
+
+    fn user(&self) -> &User {
+        self.vars().user()
+    }
+
+    fn database(&self) -> &str {
+        self.vars().database()
+    }
+
+    fn search_path(&self) -> &[mz_sql_parser::ast::Ident] {
+        self.vars().search_path()
+    }
+
+    fn is_superuser(&self) -> bool {
+        self.vars().is_superuser()
+    }
+
+    fn enable_session_rbac_checks(&self) -> bool {
+        self.vars().enable_session_rbac_checks()
+    }
 }

--- a/src/sql/src/session/metadata.rs
+++ b/src/sql/src/session/metadata.rs
@@ -1,0 +1,49 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::Debug;
+
+use mz_adapter_types::connection::ConnectionId;
+use mz_repr::role_id::RoleId;
+use mz_sql_parser::ast::Ident;
+
+use crate::plan::PlanContext;
+use crate::session::user::{RoleMetadata, User};
+
+pub trait SessionMetadata: Debug + Sync {
+    /// Returns the user who owns this session.
+    fn user(&self) -> &User;
+    /// Returns the database session variable.
+    fn database(&self) -> &str;
+    /// Returns the search path session variable.
+    fn search_path(&self) -> &[Ident];
+    /// Returns the connection ID associated with the session.
+    fn conn_id(&self) -> &ConnectionId;
+    /// Returns the current transaction's PlanContext. Panics if there is not a
+    /// current transaction.
+    fn pcx(&self) -> &PlanContext;
+    /// Returns the session's current role ID.
+    ///
+    /// # Panics
+    /// If the session has not connected successfully.
+    fn current_role_id(&self) -> &RoleId;
+    /// Returns the session's session role ID.
+    ///
+    /// # Panics
+    /// If the session has not connected successfully.
+    fn session_role_id(&self) -> &RoleId;
+    /// Whether the current session is a superuser.
+    fn is_superuser(&self) -> bool;
+    fn enable_session_rbac_checks(&self) -> bool;
+    /// Returns the session's role metadata.
+    ///
+    /// # Panics
+    /// If the session has not connected successfully.
+    fn role_metadata(&self) -> &RoleMetadata;
+}


### PR DESCRIPTION
An upcoming refactor will move the ctx ownership during peeks out of the individual stages, making it not possible to share the session across tasks. The optimizer was designed to work across tasks, but we were breaking that abstraction boundary by passing sessions by reference instead of some object fully owned by the task.

Teach sessions how to generate a snapshot of their needed data for `fn eval_unmaterializable_func` called a `SessionMeta`, a reference-less struct containing mostly cheap data copies. It does have one exception to thas, which is that `Var`s must allocate a new btree and value strings because `Var` is not `Clone` (and is hard to make so), so isn't easily shareable. Overall we believe this var snapshotting, even though it is done on every request, is still cheaper than any other option we considered.

Abstract this new struct and the old Session with a common trait and use that in places where it's supported. Due to vars being tricky some things do require a SessionMeta, but we hope an upcoming `Var` refactor will allow this restriction to be lifted.

Our goal is to make the coord thread is un-contested as possible, and thus move work into off-thread tasks. If we did not make the current change, we would have to do something like split up the optimize stage into two stages, and in between them walk the expr and apply eval_unmaterializable_func to it on the main coord thread (since it owns the Session). This seems like it'd be at least as much CPU time as it takes to allocate a new btree and some Strings.

Other options we considered and rejected were:
- share the session with an `Arc` (bad because during ctx.retire and other operations we'd have to wait an unknown amount of time to be the only strong reference holder and confuses ownership responsibilities)
- use some immutable map data structure for session vars that has cheap snapshotting/cloning (not possible because values need to be `Clone`, and `Var` is not)
- change the sequence_staged API to pass around ctx by owner instead of reference (bad because its current API allows for regular `?` returns, thus not needing to wrap errors in `return_if_err!`, and has a single owner of ctx with really clear responsibilities about which component needs to retire it)

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a