### PR TITLE
test: Verify that skipping versions fails

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -114,7 +114,7 @@ IGNORE_RE = re.compile(
     # For persist-catalog-migration ignore failpoint panics
     | persist-catalog-migration-materialized.* \| .* failpoint\ .* panic
     # For tests we purposely trigger this error
-    | persist-catalog-migration-materialized.* \| .* incompatible persist version \d+\.\d+\.\d+(-dev)?, current: \d+\.\d+\.\d+(-dev)?, make sure to upgrade the catalog one version at a time
+    | persist-catalog-migration-materialized.* \| .* incompatible\ persist\ version\ \d+\.\d+\.\d+(-dev)?,\ current:\ \d+\.\d+\.\d+(-dev)?,\ make\ sure\ to\ upgrade\ the\ catalog\ one\ version\ at\ a\ time
     )
     """,
     re.VERBOSE | re.MULTILINE,

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -113,6 +113,8 @@ IGNORE_RE = re.compile(
     | internal\ error:\ no\ AWS\ external\ ID\ prefix\ configured
     # For persist-catalog-migration ignore failpoint panics
     | persist-catalog-migration-materialized.* \| .* failpoint\ .* panic
+    # For tests we purposely trigger this error
+    | persist-catalog-migration-materialized.* \| incompatible persist version \d+\.\d+\.\d+(-dev)?, current: \d+\.\d+\.\d+(-dev)?, make sure to upgrade the catalog one version at a time
     )
     """,
     re.VERBOSE | re.MULTILINE,

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -114,7 +114,7 @@ IGNORE_RE = re.compile(
     # For persist-catalog-migration ignore failpoint panics
     | persist-catalog-migration-materialized.* \| .* failpoint\ .* panic
     # For tests we purposely trigger this error
-    | persist-catalog-migration-materialized.* \| incompatible persist version \d+\.\d+\.\d+(-dev)?, current: \d+\.\d+\.\d+(-dev)?, make sure to upgrade the catalog one version at a time
+    | persist-catalog-migration-materialized.* \| .* incompatible persist version \d+\.\d+\.\d+(-dev)?, current: \d+\.\d+\.\d+(-dev)?, make sure to upgrade the catalog one version at a time
     )
     """,
     re.VERBOSE | re.MULTILINE,


### PR DESCRIPTION
This commit adds a test to assert that upgrading by skipping versions will fail.

Works toward resolving #24218

### Motivation
Adds a test.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
