### PR TITLE
feature benchmark: enable MySqlStreaming

### DIFF
--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -1495,9 +1495,7 @@ class MySqlStreaming(MySqlCdc):
 
     @classmethod
     def can_run(cls, version: MzVersion) -> bool:
-        # TODO: #25124 (correctness issue)
-        # return version >= MzVersion.parse_mz("...")
-        return False
+        return version >= MzVersion.parse_mz("v0.88.0-dev")
 
     def shared(self) -> Action:
         return TdAction(


### PR DESCRIPTION
Nightly: https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Abenchmark%2Fenable-mysql-streaming
with `COMMON_ANCESTOR_OVERRIDE="v0.88.0-dev"`

✅ Running `v0.89.0-dev` (`v0.88.0-dev` was no longer available) and `v0.88.1` succeeded.