### PR TITLE
feature benchmark: enable MySqlInitialLoad

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -39,7 +39,6 @@ from materialize.feature_benchmark.filter import Filter, FilterFirst, NoFilter
 from materialize.feature_benchmark.measurement import MeasurementType
 from materialize.feature_benchmark.scenarios.benchmark_main import *  # noqa: F401 F403
 from materialize.feature_benchmark.scenarios.benchmark_main import (
-    MySqlInitialLoad,
     Scenario,
 )
 from materialize.feature_benchmark.scenarios.concurrency import *  # noqa: F401 F403
@@ -389,9 +388,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             [s for s in all_subclasses(root_scenario) if not s.__subclasses__()],
             key=repr,
         )
-        # TODO: Re-enable -- was failing spuriously when testing release qual:
-        # https://github.com/MaterializeInc/materialize/issues/25323
-        selected_scenarios.remove(MySqlInitialLoad)
     else:
         selected_scenarios = [root_scenario]
 


### PR DESCRIPTION
Nightly: https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Abenchmark%2Fenable-mysql-initial-load
with `COMMON_ANCESTOR_OVERRIDE="v0.88.0-dev"`

✅ Running `v0.89.0-dev` (`v0.88.0-dev` was no longer available) and `v0.88.1` succeeded. Not sure if this means that #25323 is no longer an issue or whether the seen failure was a flake. We will see that in the coming CI runs.