### PR TITLE
auth: Add some tracing to help debug Frontegg issues

### DIFF
--- a/src/frontegg-auth/src/error.rs
+++ b/src/frontegg-auth/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     ReqwestError(Arc<reqwest::Error>),
     #[error("middleware programming error: {0}")]
     MiddlewareError(Arc<anyhow::Error>),
+    #[error("request to Frontegg failed: {0:?}")]
+    FronteggError(Arc<(reqwest::Error, String)>),
     #[error("authentication token expired")]
     TokenExpired,
     #[error("unauthorized organization")]

--- a/src/frontegg-mock/src/lib.rs
+++ b/src/frontegg-mock/src/lib.rs
@@ -141,6 +141,7 @@ impl FronteggMockServer {
         };
         let roles = context.roles.get(&email).cloned().unwrap_or_default();
         let refresh_token = Uuid::new_v4().to_string();
+        let trace_id = Uuid::new_v4().to_string();
         context
             .refresh_tokens
             .lock()
@@ -165,6 +166,7 @@ impl FronteggMockServer {
             expires_in: context.expires_in_secs,
             access_token,
             refresh_token,
+            frontegg_trace_id: Some(trace_id),
         };
         Ok(Response::new(Body::from(
             serde_json::to_vec(&resp).unwrap(),


### PR DESCRIPTION
This PR adds some additional tracing to our Frontegg auth code which should help us debug future issues.

### Motivation

Help debug issues

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
