### PR TITLE
storage/mysql: Add mysql support for date, time, datetime, timestamp data types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3480,6 +3480,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "cc",
+ "chrono",
  "cmake",
  "crc32fast",
  "flate2",

--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -182,7 +182,7 @@ where
                     // this is bounds-checked in the TryFrom impl
                     precision: info
                         .datetime_precision
-                        .and_then(|precision| Some(TimestampPrecision::try_from(precision)))
+                        .map(TimestampPrecision::try_from)
                         .transpose()
                         .map_err(|_| MySqlError::UnsupportedDataType {
                             column_type: info.column_type,

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -35,7 +35,7 @@ indexmap = { version = "2.0.0", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
 maplit = "1.0.2"
 mysql_async = { version = "0.33.0", default-features = false, features = ["minimal", "binlog"] }
-mysql_common = { version = "0.31.0", default-features = false }
+mysql_common = { version = "0.31.0", default-features = false, features = ["chrono"] }
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util", features = ["s3"] }
 mz-build-info = { path = "../build-info" }

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -58,7 +58,7 @@ use std::rc::Rc;
 use differential_dataflow::Collection;
 use itertools::{EitherOrBoth, Itertools};
 use mysql_async::Row as MySqlRow;
-use mysql_common::value::convert::from_value;
+use mysql_common::value::convert::from_value_opt;
 use mysql_common::Value;
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pushers::TeeCore;
@@ -69,9 +69,12 @@ use uuid::Uuid;
 
 use mz_mysql_util::{
     ensure_full_row_binlog_format, ensure_gtid_consistency, ensure_replication_commit_order,
-    MySqlError, MySqlTableDesc,
+    MySqlColumnDesc, MySqlError, MySqlTableDesc,
 };
+use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
+use mz_repr::adt::date::Date;
+use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::{Datum, Diff, Row, ScalarType};
 use mz_sql_parser::ast::{Ident, UnresolvedItemName};
 use mz_storage_types::errors::SourceErrorDetails;
@@ -207,6 +210,8 @@ pub enum ReplicationError {
 pub enum TransientError {
     #[error("issue when decoding")]
     DecodeError(String),
+    #[error("error decoding value for column {0} in {1}: {2}")]
+    ValueDecodeError(String, String, String),
     #[error("couldn't decode binlog row")]
     BinlogRowDecodeError(#[from] mysql_async::binlog::row::BinlogRowToRowError),
     #[error("stream ended prematurely")]
@@ -238,8 +243,6 @@ pub enum DefiniteError {
     UnsupportedGtidState(String),
     #[error("received out of order gtids for source {0} at transaction-id {1}")]
     BinlogGtidMonotonicityViolation(String, GtidState),
-    #[error("received a null value in a non-null column: {0}")]
-    NullValueInNonNullColumn(String),
     #[error("mysql server does not have the binlog available at the requested gtid set")]
     BinlogNotAvailable,
     #[error("mysql server binlog frontier at {0} is beyond required frontier {1}")]
@@ -306,55 +309,123 @@ pub(crate) fn pack_mysql_row(
                 )))?
             }
         };
-        let datum = match value {
-            Value::NULL => {
-                if col_desc.column_type.nullable {
-                    Datum::Null
-                } else {
-                    // produce definite error and stop ingesting this table
-                    return Ok(Err(DefiniteError::NullValueInNonNullColumn(
-                        col_desc.name.clone(),
-                    )));
-                }
-            }
-            value => match &col_desc.column_type.scalar_type {
-                ScalarType::Bool => Datum::from(from_value::<bool>(value)),
-                ScalarType::UInt16 => Datum::from(from_value::<u16>(value)),
-                ScalarType::Int16 => Datum::from(from_value::<i16>(value)),
-                ScalarType::UInt32 => Datum::from(from_value::<u32>(value)),
-                ScalarType::Int32 => Datum::from(from_value::<i32>(value)),
-                ScalarType::UInt64 => Datum::from(from_value::<u64>(value)),
-                ScalarType::Int64 => Datum::from(from_value::<i64>(value)),
-                ScalarType::Float32 => Datum::from(from_value::<f32>(value)),
-                ScalarType::Float64 => Datum::from(from_value::<f64>(value)),
-                ScalarType::Char { length: _ } => {
-                    temp_strs.push(from_value::<String>(value));
-                    Datum::from(temp_strs.last().unwrap().as_str())
-                }
-                ScalarType::VarChar { max_length: _ } => {
-                    temp_strs.push(from_value::<String>(value));
-                    Datum::from(temp_strs.last().unwrap().as_str())
-                }
-                ScalarType::String => {
-                    temp_strs.push(from_value::<String>(value));
-                    Datum::from(temp_strs.last().unwrap().as_str())
-                }
-                ScalarType::Bytes => {
-                    let data = from_value::<Vec<u8>>(value);
-                    temp_bytes.push(data);
-                    Datum::from(temp_bytes.last().unwrap().as_slice())
-                }
-                // TODO(roshan): IMPLEMENT OTHER TYPES
-                data_type => Err(TransientError::UnsupportedDataType(format!(
-                    "{:?}",
-                    data_type
-                )))?,
-            },
+        let datum = match mysql_val_to_datum(value, col_desc, &mut temp_strs, &mut temp_bytes) {
+            Err(err) => Err(TransientError::ValueDecodeError(
+                col_desc.name.clone(),
+                format!("{}.{}", table_desc.schema_name, table_desc.name),
+                err.to_string(),
+            ))?,
+            Ok(datum) => datum,
         };
         packer.push(datum);
     }
 
     Ok(Ok(row_container.clone()))
+}
+
+fn mysql_val_to_datum<'a>(
+    value: Value,
+    col_desc: &MySqlColumnDesc,
+    temp_strs: &'a mut Vec<String>,
+    temp_bytes: &'a mut Vec<Vec<u8>>,
+) -> Result<Datum<'a>, anyhow::Error> {
+    Ok(match value {
+        Value::NULL => {
+            if col_desc.column_type.nullable {
+                Datum::Null
+            } else {
+                Err(anyhow::anyhow!(
+                    "received a null value in a non-null column".to_string(),
+                ))?
+            }
+        }
+        value => match &col_desc.column_type.scalar_type {
+            ScalarType::Bool => Datum::from(from_value_opt::<bool>(value)?),
+            ScalarType::UInt16 => Datum::from(from_value_opt::<u16>(value)?),
+            ScalarType::Int16 => Datum::from(from_value_opt::<i16>(value)?),
+            ScalarType::UInt32 => Datum::from(from_value_opt::<u32>(value)?),
+            ScalarType::Int32 => Datum::from(from_value_opt::<i32>(value)?),
+            ScalarType::UInt64 => Datum::from(from_value_opt::<u64>(value)?),
+            ScalarType::Int64 => Datum::from(from_value_opt::<i64>(value)?),
+            ScalarType::Float32 => Datum::from(from_value_opt::<f32>(value)?),
+            ScalarType::Float64 => Datum::from(from_value_opt::<f64>(value)?),
+            ScalarType::Char { length } => {
+                let val = from_value_opt::<String>(value)?;
+                check_char_length(length.map(|l| l.into_u32()), &val, col_desc)?;
+                temp_strs.push(val);
+                Datum::from(temp_strs.last().unwrap().as_str())
+            }
+            ScalarType::VarChar { max_length } => {
+                let val = from_value_opt::<String>(value)?;
+                check_char_length(max_length.map(|l| l.into_u32()), &val, col_desc)?;
+                temp_strs.push(val);
+                Datum::from(temp_strs.last().unwrap().as_str())
+            }
+            ScalarType::String => {
+                temp_strs.push(from_value_opt::<String>(value)?);
+                Datum::from(temp_strs.last().unwrap().as_str())
+            }
+            ScalarType::Bytes => {
+                let data = from_value_opt::<Vec<u8>>(value)?;
+                temp_bytes.push(data);
+                Datum::from(temp_bytes.last().unwrap().as_slice())
+            }
+            ScalarType::Date => {
+                let date = Date::try_from(from_value_opt::<chrono::NaiveDate>(value)?)?;
+                Datum::from(date)
+            }
+            ScalarType::Timestamp { precision: _ } => {
+                // Timestamps are encoded as different mysql_common::Value types depending on
+                // whether they are from a binlog event or a query, and depending on which
+                // mysql timestamp version is used. We handle those cases here
+                // https://github.com/blackbeam/rust_mysql_common/blob/v0.31.0/src/binlog/value.rs#L87-L155
+                // https://github.com/blackbeam/rust_mysql_common/blob/v0.31.0/src/value/mod.rs#L332
+                let chrono_timestamp = match value {
+                    Value::Date(..) => from_value_opt::<chrono::NaiveDateTime>(value)?,
+                    // old temporal format from before MySQL 5.6; didn't support fractional seconds
+                    Value::Int(val) => chrono::NaiveDateTime::from_timestamp_opt(val, 0)
+                        .ok_or(anyhow::anyhow!("received invalid timestamp value: {}", val))?,
+                    Value::Bytes(data) => {
+                        let data = std::str::from_utf8(&data)?;
+                        if data.contains('.') {
+                            chrono::NaiveDateTime::parse_from_str(data, "%s%.6f")?
+                        } else {
+                            chrono::NaiveDateTime::parse_from_str(data, "%s")?
+                        }
+                    }
+                    _ => Err(anyhow::anyhow!(
+                        "received unexpected value for timestamp type: {:?}",
+                        value
+                    ))?,
+                };
+                Datum::try_from(CheckedTimestamp::try_from(chrono_timestamp)?)?
+            }
+            ScalarType::Time => Datum::from(from_value_opt::<chrono::NaiveTime>(value)?),
+            // TODO(roshan): IMPLEMENT OTHER TYPES
+            data_type => Err(TransientError::UnsupportedDataType(format!(
+                "{:?}",
+                data_type
+            )))?,
+        },
+    })
+}
+
+fn check_char_length(
+    length: Option<u32>,
+    val: &str,
+    col_desc: &MySqlColumnDesc,
+) -> Result<(), anyhow::Error> {
+    if let Some(length) = length {
+        if let Some(_) = val.char_indices().nth(usize::cast_from(length)) {
+            Err(anyhow::anyhow!(
+                "received string value of length {} for column {} which has a max length of {}",
+                val.len(),
+                col_desc.name,
+                length
+            ))?
+        }
+    }
+    Ok(())
 }
 
 async fn return_definite_error(

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -67,7 +67,7 @@ memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.8", features = ["net", "os-ext"] }
 mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
-mysql_common = { version = "0.31.0", default-features = false, features = ["binlog"] }
+mysql_common = { version = "0.31.0", default-features = false, features = ["binlog", "chrono"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
@@ -182,7 +182,7 @@ memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.8", features = ["net", "os-ext"] }
 mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
-mysql_common = { version = "0.31.0", default-features = false, features = ["binlog"] }
+mysql_common = { version = "0.31.0", default-features = false, features = ["binlog", "chrono"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -38,12 +38,17 @@ SERVICES = [
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    for name in c.workflows:
-        if name == "default":
-            continue
+    # If args were passed then we are running the main CDC workflow
+    if parser.args:
+        workflow_cdc(c, parser)
+    else:
+        # Otherwise we are running all workflows
+        for name in c.workflows:
+            if name == "default":
+                continue
 
-        with c.test_case(name):
-            c.workflow(name)
+            with c.test_case(name):
+                c.workflow(name)
 
 
 def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:

--- a/test/mysql-cdc/types-temporal.td
+++ b/test/mysql-cdc/types-temporal.td
@@ -1,0 +1,51 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test mysql temporal data types (DATE, DATETIME, TIME, TIMESTAMP)
+#
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_mysql_source = true
+
+> CREATE CONNECTION mysqc TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+# Insert data pre-snapshot
+# We insert values with both default precision (0) and a value of 6 where allowed
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+CREATE TABLE t1 ( date_col DATE, time_col TIME(6), time_trunc_col TIME, datetime_col DATETIME(6), datetime_trunc_col DATETIME, timestamp_col TIMESTAMP(6), timestamp_trunc_col TIMESTAMP);
+
+INSERT INTO t1 VALUES ('2011-11-11', '11:11:11.123456', '11:11:11.123456', '2011-11-11 11:11:11.123456', '2011-11-11 11:11:11.123456', '2011-11-11 11:11:11.123456', '2011-11-11 11:11:11.123456');
+
+> CREATE SOURCE da FROM MYSQL CONNECTION mysqc FOR TABLES (public.t1);
+
+> SELECT * FROM t1;
+2011-11-11 11:11:11.123456 11:11:11 "2011-11-11 11:11:11.123456" "2011-11-11 11:11:11" "2011-11-11 11:11:11.123456" "2011-11-11 11:11:11"
+
+# Insert the same data post-snapshot
+$ mysql-execute name=mysql
+INSERT INTO t1 SELECT * FROM t1;
+
+> SELECT pg_typeof(date_col), pg_typeof(datetime_col), pg_typeof(time_col), pg_typeof(timestamp_col) FROM t1 LIMIT 1;
+date "timestamp without time zone" time "timestamp without time zone"
+
+> SELECT * FROM t1;
+2011-11-11 11:11:11.123456 11:11:11 "2011-11-11 11:11:11.123456" "2011-11-11 11:11:11" "2011-11-11 11:11:11.123456" "2011-11-11 11:11:11"
+2011-11-11 11:11:11.123456 11:11:11 "2011-11-11 11:11:11.123456" "2011-11-11 11:11:11" "2011-11-11 11:11:11.123456" "2011-11-11 11:11:11"


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/25149


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Relevant MySQL docs:
- https://dev.mysql.com/doc/refman/8.0/en/datetime.html
- https://dev.mysql.com/blog-archive/mysql-8-0-removing-support-for-old-temporal-datatypes/

The tests validate the decoding in both the snapshot and replication operators (since one is based on query results, and the other is based on decoding binlog events). I stole this idea from the pg-cdc type tests and it helped catch that the encoding for `timestamp` is different between query/binlog in `rust-mysql-common`!

I also switched all the decoding to using the fallible `from_value_opt` method from `mysql-async` rather than panicking on a failure, which seems better :)

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
