### PR TITLE
Fix visitation in `HirRelationExpr::contains_temporal`

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2297,7 +2297,7 @@ impl Coordinator {
                     }
                 };
 
-                if plan.values.contains_temporal() {
+                if return_if_err!(plan.values.contains_temporal(), ctx) {
                     ctx.retire(Err(AdapterError::Unsupported(
                         "calls to mz_now in write statements",
                     )));

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -336,7 +336,7 @@ impl Coordinator {
         let source_ids = plan.source.depends_on();
         let mut timeline_context = self.validate_timeline_context(source_ids.clone())?;
         if matches!(timeline_context, TimelineContext::TimestampIndependent)
-            && plan.source.contains_temporal()
+            && plan.source.contains_temporal()?
         {
             // If the source IDs are timestamp independent but the query contains temporal functions,
             // then the timeline context needs to be upgraded to timestamp dependent. This is

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1924,10 +1924,14 @@ impl HirRelationExpr {
     }
 
     /// Whether the expression contains an [`UnmaterializableFunc::MzNow`] call.
-    pub fn contains_temporal(&self) -> bool {
+    pub fn contains_temporal(&self) -> Result<bool, RecursionLimitError> {
         let mut contains = false;
-        self.visit_children(|expr: &HirScalarExpr| contains = contains || expr.contains_temporal());
-        contains
+        self.visit_post(&mut |expr| {
+            expr.visit_children(|expr: &HirScalarExpr| {
+                contains = contains || expr.contains_temporal()
+            })
+        })?;
+        Ok(contains)
     }
 }
 

--- a/test/sqllogictest/temporal.slt
+++ b/test/sqllogictest/temporal.slt
@@ -212,3 +212,24 @@ ORDER BY day DESC;
 2023-12-03␠00:00:00  1  fy2023
 2023-12-02␠00:00:00  1  fy2023
 2023-12-01␠00:00:00  1  fy2023
+
+# Constant queries should have a timestamp near the current time (instead of, e.g., u64::MAX)
+query B
+select mz_now() < '3000-01-01';
+----
+true
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/25339
+query B
+with v as (select mz_now() < '3000-01-01') select * from v;
+----
+true
+
+# Make sure that we find temporal expressions also in referenced views.
+statement ok
+create view v as select mz_now() as x;
+
+query B
+select x < '3000-01-01' from v;
+----
+true


### PR DESCRIPTION
The problem was that `contains_temporal` was just calling `visit_children`, which doesn't do a visitation in the entire subtree, but merely visits the scalar expressions in the top-level relation expr node. This PR changes `contains_temporal` to do a visitation of all relation expr nodes, and for each of them do what we were doing before for just the top-level node.

The issue description mentions that we should be able to find temporal expressions also in referenced view definitions. This already works: `peek_stage_validate` calls `validate_timeline_context`, which calls `get_timeline_contexts`, which transitively visits view definitions and calls `MirRelationExpr::contains_temporal()` on their optimized expressions.

### Motivation

  * This PR partially fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/25339
    * It doesn't fix it for `could_run_expensive_function`.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
