### PR TITLE
adapter: Add metrics for Coord message processing

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2497,10 +2497,13 @@ impl Coordinator {
                     // https://docs.rs/tokio/1.8.0/tokio/sync/mpsc/struct.Receiver.html#cancel-safety
                     timer = idle_rx.recv() => {
                         timer.expect("does not drop").observe_duration();
+                        self.metrics.messages_processed.inc();
+                        self.metrics.watchdog_messages_processed.inc();
                         continue;
                     }
                 };
 
+                self.metrics.messages_processed.inc();
                 // All message processing functions trace. Start a parent span
                 // for them to make it easy to find slow messages.
                 let msg_kind = msg.kind();

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -22,6 +22,8 @@ pub struct Metrics {
     pub active_subscribes: IntGaugeVec,
     pub active_copy_tos: IntGaugeVec,
     pub queue_busy_seconds: HistogramVec,
+    pub messages_processed: IntCounter,
+    pub watchdog_messages_processed: IntCounter,
     pub determine_timestamp: IntCounterVec,
     pub timestamp_difference_for_strict_serializable_ms: HistogramVec,
     pub commands: IntCounterVec,
@@ -66,6 +68,14 @@ impl Metrics {
                 name: "mz_coord_queue_busy_seconds",
                 help: "The number of seconds the coord queue was processing before it was empty. This is a sampled metric and does not measure the full coord queue wait/idle times.",
                 buckets: histogram_seconds_buckets(0.000_128, 32.0)
+            )),
+            messages_processed: registry.register(metric!(
+                name: "mz_coord_messages_processed",
+                help: "The total number of messages processed by the coord.",
+            )),
+            watchdog_messages_processed: registry.register(metric!(
+                name: "mz_coord_watchdog_messages_processed",
+                help: "The total number of watchdog messages processed by the coord.",
             )),
             determine_timestamp: registry.register(metric!(
                 name: "mz_determine_timestamp",


### PR DESCRIPTION
This commit adds a metric for the total number of messages processed by the Coordinator and the total number of watchdog messages processed by the Coordinator. These are helpful for determining when the Coordinator is stuck.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
