### PR TITLE
adapter: minor refactorings to compute sink cleanup

### DIFF
--- a/src/adapter/src/active_compute_sink.rs
+++ b/src/adapter/src/active_compute_sink.rs
@@ -167,209 +167,206 @@ impl ActiveSubscribe {
     ///
     /// Returns `true` if the subscribe is finished.
     pub fn process_response(&mut self, batch: SubscribeBatch) -> bool {
+        let mut rows = match batch.updates {
+            Ok(rows) => rows,
+            Err(s) => {
+                self.send(PeekResponseUnary::Error(s));
+                return true;
+            }
+        };
+
+        // Sort results by time. We use stable sort here because it will produce
+        // deterministic results since the cursor will always produce rows in
+        // the same order. Compute doesn't guarantee that the results are sorted
+        // (#18936)
         let mut row_buf = Row::default();
-        match batch.updates {
-            Ok(mut rows) => {
-                // Sort results by time. We use stable sort here because it will produce deterministic
-                // results since the cursor will always produce rows in the same order.
-                // Compute doesn't guarantee that the results are sorted (#18936)
-                match &self.output {
-                    SubscribeOutput::WithinTimestampOrderBy { order_by } => {
-                        let mut left_datum_vec = mz_repr::DatumVec::new();
-                        let mut right_datum_vec = mz_repr::DatumVec::new();
-                        rows.sort_by(
-                            |(left_time, left_row, left_diff),
-                             (right_time, right_row, right_diff)| {
-                                left_time.cmp(right_time).then_with(|| {
-                                    let mut left_datums = left_datum_vec.borrow();
-                                    left_datums.extend(&[Datum::Int64(*left_diff)]);
-                                    left_datums.extend(left_row.iter());
-                                    let mut right_datums = right_datum_vec.borrow();
-                                    right_datums.extend(&[Datum::Int64(*right_diff)]);
-                                    right_datums.extend(right_row.iter());
-                                    compare_columns(order_by, &left_datums, &right_datums, || {
-                                        left_row.cmp(right_row).then(left_diff.cmp(right_diff))
-                                    })
-                                })
-                            },
-                        );
-                    }
-                    SubscribeOutput::EnvelopeUpsert { order_by_keys }
-                    | SubscribeOutput::EnvelopeDebezium { order_by_keys } => {
-                        let debezium =
-                            matches!(self.output, SubscribeOutput::EnvelopeDebezium { .. });
-                        let mut left_datum_vec = mz_repr::DatumVec::new();
-                        let mut right_datum_vec = mz_repr::DatumVec::new();
-                        rows.sort_by(
-                            |(left_time, left_row, left_diff),
-                             (right_time, right_row, right_diff)| {
-                                left_time.cmp(right_time).then_with(|| {
-                                    let left_datums = left_datum_vec.borrow_with(left_row);
-                                    let right_datums = right_datum_vec.borrow_with(right_row);
-                                    compare_columns(
-                                        order_by_keys,
-                                        &left_datums,
-                                        &right_datums,
-                                        || left_diff.cmp(right_diff),
-                                    )
-                                })
-                            },
-                        );
+        match &self.output {
+            SubscribeOutput::WithinTimestampOrderBy { order_by } => {
+                let mut left_datum_vec = mz_repr::DatumVec::new();
+                let mut right_datum_vec = mz_repr::DatumVec::new();
+                rows.sort_by(
+                    |(left_time, left_row, left_diff), (right_time, right_row, right_diff)| {
+                        left_time.cmp(right_time).then_with(|| {
+                            let mut left_datums = left_datum_vec.borrow();
+                            left_datums.extend(&[Datum::Int64(*left_diff)]);
+                            left_datums.extend(left_row.iter());
+                            let mut right_datums = right_datum_vec.borrow();
+                            right_datums.extend(&[Datum::Int64(*right_diff)]);
+                            right_datums.extend(right_row.iter());
+                            compare_columns(order_by, &left_datums, &right_datums, || {
+                                left_row.cmp(right_row).then(left_diff.cmp(right_diff))
+                            })
+                        })
+                    },
+                );
+            }
+            SubscribeOutput::EnvelopeUpsert { order_by_keys }
+            | SubscribeOutput::EnvelopeDebezium { order_by_keys } => {
+                let debezium = matches!(self.output, SubscribeOutput::EnvelopeDebezium { .. });
+                let mut left_datum_vec = mz_repr::DatumVec::new();
+                let mut right_datum_vec = mz_repr::DatumVec::new();
+                rows.sort_by(
+                    |(left_time, left_row, left_diff), (right_time, right_row, right_diff)| {
+                        left_time.cmp(right_time).then_with(|| {
+                            let left_datums = left_datum_vec.borrow_with(left_row);
+                            let right_datums = right_datum_vec.borrow_with(right_row);
+                            compare_columns(order_by_keys, &left_datums, &right_datums, || {
+                                left_diff.cmp(right_diff)
+                            })
+                        })
+                    },
+                );
 
-                        let mut new_rows = Vec::new();
-                        let mut it = rows.iter();
-                        let mut datum_vec = mz_repr::DatumVec::new();
-                        let mut old_datum_vec = mz_repr::DatumVec::new();
-                        while let Some(start) = it.next() {
-                            let group = iter::once(start)
-                                .chain(it.take_while_ref(|row| {
-                                    let left_datums = left_datum_vec.borrow_with(&start.1);
-                                    let right_datums = right_datum_vec.borrow_with(&row.1);
-                                    start.0 == row.0
-                                        && compare_columns(
-                                            order_by_keys,
-                                            &left_datums,
-                                            &right_datums,
-                                            || Ordering::Equal,
-                                        ) == Ordering::Equal
-                                }))
-                                .collect_vec();
+                let mut new_rows = Vec::new();
+                let mut it = rows.iter();
+                let mut datum_vec = mz_repr::DatumVec::new();
+                let mut old_datum_vec = mz_repr::DatumVec::new();
+                while let Some(start) = it.next() {
+                    let group = iter::once(start)
+                        .chain(it.take_while_ref(|row| {
+                            let left_datums = left_datum_vec.borrow_with(&start.1);
+                            let right_datums = right_datum_vec.borrow_with(&row.1);
+                            start.0 == row.0
+                                && compare_columns(
+                                    order_by_keys,
+                                    &left_datums,
+                                    &right_datums,
+                                    || Ordering::Equal,
+                                ) == Ordering::Equal
+                        }))
+                        .collect_vec();
 
-                            // Four cases:
-                            // [(key, value, +1)] => ("insert", key, NULL, value)
-                            // [(key, v1, -1), (key, v2, +1)] => ("upsert", key, v1, v2)
-                            // [(key, value, -1)] => ("delete", key, value, NULL)
-                            // everything else => ("key_violation", key, NULL, NULL)
-                            let value_columns = self.arity - order_by_keys.len();
-                            let mut packer = row_buf.packer();
-                            new_rows.push(match &group[..] {
-                                [(_, row, 1)] => {
-                                    packer.push(if debezium {
-                                        Datum::String("insert")
-                                    } else {
-                                        Datum::String("upsert")
-                                    });
-                                    let datums = datum_vec.borrow_with(row);
-                                    for column_order in order_by_keys {
-                                        packer.push(datums[column_order.column]);
-                                    }
-                                    if debezium {
-                                        for _ in 0..value_columns {
-                                            packer.push(Datum::Null);
-                                        }
-                                    }
-                                    for idx in 0..self.arity {
-                                        if !order_by_keys.iter().any(|co| co.column == idx) {
-                                            packer.push(datums[idx]);
-                                        }
-                                    }
-                                    (start.0, row_buf.clone(), 0)
-                                }
-                                [(_, _, -1)] => {
-                                    packer.push(Datum::String("delete"));
-                                    let datums = datum_vec.borrow_with(&start.1);
-                                    for column_order in order_by_keys {
-                                        packer.push(datums[column_order.column]);
-                                    }
-                                    if debezium {
-                                        for idx in 0..self.arity {
-                                            if !order_by_keys.iter().any(|co| co.column == idx) {
-                                                packer.push(datums[idx]);
-                                            }
-                                        }
-                                    }
-                                    for _ in 0..self.arity - order_by_keys.len() {
-                                        packer.push(Datum::Null);
-                                    }
-                                    (start.0, row_buf.clone(), 0)
-                                }
-                                [(_, old_row, -1), (_, row, 1)] => {
-                                    packer.push(Datum::String("upsert"));
-                                    let datums = datum_vec.borrow_with(row);
-                                    let old_datums = old_datum_vec.borrow_with(old_row);
-
-                                    for column_order in order_by_keys {
-                                        packer.push(datums[column_order.column]);
-                                    }
-                                    if debezium {
-                                        for idx in 0..self.arity {
-                                            if !order_by_keys.iter().any(|co| co.column == idx) {
-                                                packer.push(old_datums[idx]);
-                                            }
-                                        }
-                                    }
-                                    for idx in 0..self.arity {
-                                        if !order_by_keys.iter().any(|co| co.column == idx) {
-                                            packer.push(datums[idx]);
-                                        }
-                                    }
-                                    (start.0, row_buf.clone(), 0)
-                                }
-                                _ => {
-                                    packer.push(Datum::String("key_violation"));
-                                    let datums = datum_vec.borrow_with(&start.1);
-                                    for column_order in order_by_keys {
-                                        packer.push(datums[column_order.column]);
-                                    }
-                                    if debezium {
-                                        for _ in 0..(self.arity - order_by_keys.len()) {
-                                            packer.push(Datum::Null);
-                                        }
-                                    }
-                                    for _ in 0..(self.arity - order_by_keys.len()) {
-                                        packer.push(Datum::Null);
-                                    }
-                                    (start.0, row_buf.clone(), 0)
-                                }
+                    // Four cases:
+                    // [(key, value, +1)] => ("insert", key, NULL, value)
+                    // [(key, v1, -1), (key, v2, +1)] => ("upsert", key, v1, v2)
+                    // [(key, value, -1)] => ("delete", key, value, NULL)
+                    // everything else => ("key_violation", key, NULL, NULL)
+                    let value_columns = self.arity - order_by_keys.len();
+                    let mut packer = row_buf.packer();
+                    new_rows.push(match &group[..] {
+                        [(_, row, 1)] => {
+                            packer.push(if debezium {
+                                Datum::String("insert")
+                            } else {
+                                Datum::String("upsert")
                             });
+                            let datums = datum_vec.borrow_with(row);
+                            for column_order in order_by_keys {
+                                packer.push(datums[column_order.column]);
+                            }
+                            if debezium {
+                                for _ in 0..value_columns {
+                                    packer.push(Datum::Null);
+                                }
+                            }
+                            for idx in 0..self.arity {
+                                if !order_by_keys.iter().any(|co| co.column == idx) {
+                                    packer.push(datums[idx]);
+                                }
+                            }
+                            (start.0, row_buf.clone(), 0)
                         }
-                        rows = new_rows;
-                    }
-                    SubscribeOutput::Diffs => rows.sort_by_key(|(time, _, _)| *time),
+                        [(_, _, -1)] => {
+                            packer.push(Datum::String("delete"));
+                            let datums = datum_vec.borrow_with(&start.1);
+                            for column_order in order_by_keys {
+                                packer.push(datums[column_order.column]);
+                            }
+                            if debezium {
+                                for idx in 0..self.arity {
+                                    if !order_by_keys.iter().any(|co| co.column == idx) {
+                                        packer.push(datums[idx]);
+                                    }
+                                }
+                            }
+                            for _ in 0..self.arity - order_by_keys.len() {
+                                packer.push(Datum::Null);
+                            }
+                            (start.0, row_buf.clone(), 0)
+                        }
+                        [(_, old_row, -1), (_, row, 1)] => {
+                            packer.push(Datum::String("upsert"));
+                            let datums = datum_vec.borrow_with(row);
+                            let old_datums = old_datum_vec.borrow_with(old_row);
+
+                            for column_order in order_by_keys {
+                                packer.push(datums[column_order.column]);
+                            }
+                            if debezium {
+                                for idx in 0..self.arity {
+                                    if !order_by_keys.iter().any(|co| co.column == idx) {
+                                        packer.push(old_datums[idx]);
+                                    }
+                                }
+                            }
+                            for idx in 0..self.arity {
+                                if !order_by_keys.iter().any(|co| co.column == idx) {
+                                    packer.push(datums[idx]);
+                                }
+                            }
+                            (start.0, row_buf.clone(), 0)
+                        }
+                        _ => {
+                            packer.push(Datum::String("key_violation"));
+                            let datums = datum_vec.borrow_with(&start.1);
+                            for column_order in order_by_keys {
+                                packer.push(datums[column_order.column]);
+                            }
+                            if debezium {
+                                for _ in 0..(self.arity - order_by_keys.len()) {
+                                    packer.push(Datum::Null);
+                                }
+                            }
+                            for _ in 0..(self.arity - order_by_keys.len()) {
+                                packer.push(Datum::Null);
+                            }
+                            (start.0, row_buf.clone(), 0)
+                        }
+                    });
+                }
+                rows = new_rows;
+            }
+            SubscribeOutput::Diffs => rows.sort_by_key(|(time, _, _)| *time),
+        }
+
+        let rows = rows
+            .into_iter()
+            .map(|(time, row, diff)| {
+                assert!(self.as_of <= time);
+                let mut packer = row_buf.packer();
+                // TODO: Change to MzTimestamp.
+                packer.push(Datum::from(numeric::Numeric::from(time)));
+                if self.emit_progress {
+                    // When sinking with PROGRESS, the output includes an
+                    // additional column that indicates whether a timestamp is
+                    // complete. For regular "data" updates this is always
+                    // `false`.
+                    packer.push(Datum::False);
                 }
 
-                let rows = rows
-                    .into_iter()
-                    .map(|(time, row, diff)| {
-                        assert!(self.as_of <= time);
-                        let mut packer = row_buf.packer();
-                        // TODO: Change to MzTimestamp.
-                        packer.push(Datum::from(numeric::Numeric::from(time)));
-                        if self.emit_progress {
-                            // When sinking with PROGRESS, the output
-                            // includes an additional column that
-                            // indicates whether a timestamp is
-                            // complete. For regular "data" updates this
-                            // is always `false`.
-                            packer.push(Datum::False);
-                        }
+                match &self.output {
+                    SubscribeOutput::EnvelopeUpsert { .. }
+                    | SubscribeOutput::EnvelopeDebezium { .. } => {}
+                    SubscribeOutput::Diffs | SubscribeOutput::WithinTimestampOrderBy { .. } => {
+                        packer.push(Datum::Int64(diff));
+                    }
+                }
 
-                        match &self.output {
-                            SubscribeOutput::EnvelopeUpsert { .. }
-                            | SubscribeOutput::EnvelopeDebezium { .. } => {}
-                            SubscribeOutput::Diffs
-                            | SubscribeOutput::WithinTimestampOrderBy { .. } => {
-                                packer.push(Datum::Int64(diff));
-                            }
-                        }
+                packer.extend_by_row(&row);
 
-                        packer.extend_by_row(&row);
+                row_buf.clone()
+            })
+            .collect();
+        self.send(PeekResponseUnary::Rows(rows));
 
-                        row_buf.clone()
-                    })
-                    .collect();
-                self.send(PeekResponseUnary::Rows(rows));
-            }
-            Err(text) => {
-                self.send(PeekResponseUnary::Error(text));
-            }
-        }
-        // Emit progress message if requested. Don't emit progress for the first batch if the upper
-        // is exactly `as_of` (we're guaranteed it is not less than `as_of`, but it might be exactly
-        // `as_of`) as we've already emitted that progress message in `initialize`.
+        // Emit progress message if requested. Don't emit progress for the first
+        // batch if the upper is exactly `as_of` (we're guaranteed it is not
+        // less than `as_of`, but it might be exactly `as_of`) as we've already
+        // emitted that progress message in `initialize`.
         if !batch.upper.less_equal(&self.as_of) {
             self.send_progress_message(&batch.upper);
         }
+
         batch.upper.is_empty()
     }
 

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -929,7 +929,7 @@ impl Coordinator {
         }
 
         self.cancel_pending_peeks(&conn_id);
-        self.cancel_active_compute_sinks(&conn_id).await;
+        self.cancel_compute_sinks_for_conn(&conn_id).await;
     }
 
     /// Handle termination of a client session.

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -44,13 +44,12 @@ use mz_sql::session::vars::{
 use mz_storage_client::controller::ExportDescription;
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::controller::StorageError;
-use mz_storage_types::instances::StorageInstanceId;
 use mz_storage_types::read_policy::ReadPolicy;
 use mz_storage_types::sources::GenericSourceConnection;
 use serde_json::json;
 use tracing::{event, info_span, instrument, warn, Instrument, Level};
 
-use crate::active_compute_sink::ActiveComputeSinkRetireReason;
+use crate::active_compute_sink::{ActiveComputeSink, ActiveComputeSinkRetireReason};
 use crate::catalog::{CatalogState, Op, TransactionResult};
 use crate::coord::appends::BuiltinTableAppendNotify;
 use crate::coord::timeline::{TimelineContext, TimelineState};
@@ -225,7 +224,7 @@ impl Coordinator {
         let mut vpc_endpoints_to_drop = vec![];
         let mut clusters_to_drop = vec![];
         let mut cluster_replicas_to_drop = vec![];
-        let mut compute_sinks_to_drop = vec![];
+        let mut compute_sinks_to_drop = BTreeMap::new();
         let mut peeks_to_drop = vec![];
         let mut update_tracing_config = false;
         let mut update_compute_config = false;
@@ -418,22 +417,22 @@ impl Coordinator {
                     .catalog()
                     .resolve_full_name(entry.name(), Some(conn_id))
                     .to_string();
-                compute_sinks_to_drop.push((
+                compute_sinks_to_drop.insert(
                     *sink_id,
                     ActiveComputeSinkRetireReason::DependencyDropped(format!(
                         "relation {}",
                         name.quoted()
                     )),
-                ));
+                );
             } else if clusters_to_drop.contains(&cluster_id) {
                 let name = self.catalog().get_cluster(cluster_id).name();
-                compute_sinks_to_drop.push((
+                compute_sinks_to_drop.insert(
                     *sink_id,
                     ActiveComputeSinkRetireReason::DependencyDropped(format!(
                         "cluster {}",
                         name.quoted()
                     )),
-                ));
+                );
             }
         }
 
@@ -558,8 +557,7 @@ impl Coordinator {
                 self.drop_storage_sinks(storage_sinks_to_drop);
             }
             if !compute_sinks_to_drop.is_empty() {
-                self.drop_compute_sinks_with_reason(compute_sinks_to_drop)
-                    .await;
+                self.retire_compute_sinks(compute_sinks_to_drop).await;
             }
             if !peeks_to_drop.is_empty() {
                 for (dropped_name, uuid) in peeks_to_drop {
@@ -740,17 +738,39 @@ impl Coordinator {
         }
     }
 
-    /// This method drops the compute sink, by calling `compute.drop_collections`.
-    /// This should only be called after removing the corresponding sink entry from
-    /// `self.active_compute_sinks`.
-    pub(crate) fn drop_compute_sinks(
+    /// Like `drop_compute_sinks`, but for a single compute sink.
+    ///
+    /// Returns the controller's state for the compute sink if the identified
+    /// sink was known to the controller. It is the caller's responsibility to
+    /// retire the returned sink. Consider using `retire_compute_sinks` instead.
+    #[must_use]
+    pub async fn drop_compute_sink(&mut self, sink_id: GlobalId) -> Option<ActiveComputeSink> {
+        self.drop_compute_sinks([sink_id]).await.remove(&sink_id)
+    }
+
+    /// Drops a batch of compute sinks.
+    ///
+    /// For each sink that exists, the coordinator and controller's state
+    /// associated with the sink is removed.
+    ///
+    /// Returns a map containing the controller's state for each sink that was
+    /// removed. It is the caller's responsibility to retire the returned sinks.
+    /// Consider using `retire_compute_sinks` instead.
+    #[must_use]
+    pub async fn drop_compute_sinks(
         &mut self,
-        sink_and_cluster_ids: impl IntoIterator<Item = (GlobalId, StorageInstanceId)>,
-    ) {
+        sink_ids: impl IntoIterator<Item = GlobalId>,
+    ) -> BTreeMap<GlobalId, ActiveComputeSink> {
+        let mut by_id = BTreeMap::new();
         let mut by_cluster: BTreeMap<_, Vec<_>> = BTreeMap::new();
-        for (sink_id, cluster_id) in sink_and_cluster_ids {
-            // The active sink should have already been removed from the state
-            assert!(!self.active_compute_sinks.contains_key(&sink_id));
+        for sink_id in sink_ids {
+            let sink = match self.remove_active_compute_sink(sink_id).await {
+                None => {
+                    tracing::error!(%sink_id, "drop_compute_sinks called on nonexistent sink");
+                    continue;
+                }
+                Some(sink) => sink,
+            };
 
             if !self
                 .controller
@@ -765,7 +785,11 @@ impl Coordinator {
                 }
             }
 
-            by_cluster.entry(cluster_id).or_default().push(sink_id);
+            by_cluster
+                .entry(sink.cluster_id())
+                .or_default()
+                .push(sink_id);
+            by_id.insert(sink_id, sink);
         }
         let mut compute = self.controller.active_compute();
         for (cluster_id, ids) in by_cluster {
@@ -776,25 +800,24 @@ impl Coordinator {
                     .unwrap_or_terminate("cannot fail to drop collections");
             }
         }
+        by_id
     }
 
-    /// Drops active compute sinks and might send appropriate response back
-    /// depending upon the reason.
-    pub(crate) async fn drop_compute_sinks_with_reason(
+    /// Retires a batch of sinks with disparate reasons for retirement.
+    ///
+    /// Each sink identified in `reasons` is dropped (see `drop_compute_sinks`),
+    /// then retired with its corresponding reason.
+    pub async fn retire_compute_sinks(
         &mut self,
-        sinks: impl IntoIterator<Item = (GlobalId, ActiveComputeSinkRetireReason)>,
+        mut reasons: BTreeMap<GlobalId, ActiveComputeSinkRetireReason>,
     ) {
-        let mut sink_cluster_id_map = BTreeMap::new();
-        for (sink_id, reason) in sinks {
-            if let Some(sink) = self.remove_active_compute_sink(sink_id).await {
-                sink_cluster_id_map.insert(sink_id, sink.cluster_id());
-                sink.retire(reason);
-            } else {
-                tracing::error!(%sink_id, "drop_compute_sinks called on nonexistent sink");
-                continue;
-            }
+        let sink_ids = reasons.keys().cloned();
+        for (id, sink) in self.drop_compute_sinks(sink_ids).await {
+            let reason = reasons
+                .remove(&id)
+                .expect("all returned IDs are in `reasons`");
+            sink.retire(reason);
         }
-        self.drop_compute_sinks(sink_cluster_id_map.into_iter());
     }
 
     /// Cancels all active compute sinks for the identified connection.
@@ -819,8 +842,8 @@ impl Coordinator {
             .drop_sinks
             .iter()
             .map(|sink_id| (*sink_id, reason.clone()))
-            .collect::<Vec<_>>();
-        self.drop_compute_sinks_with_reason(drop_sinks).await;
+            .collect();
+        self.retire_compute_sinks(drop_sinks).await;
     }
 
     pub(crate) fn drop_storage_sinks(&mut self, sinks: Vec<GlobalId>) {

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -18,7 +18,6 @@ use futures::FutureExt;
 use mz_adapter_types::connection::ConnectionId;
 use mz_controller::clusters::ClusterEvent;
 use mz_controller::ControllerResponse;
-use mz_ore::cast::CastFrom;
 use mz_ore::now::EpochMillis;
 use mz_ore::task;
 use mz_persist_client::usage::ShardsUsageReferenced;
@@ -31,7 +30,7 @@ use rand::{rngs, Rng, SeedableRng};
 use tracing::{event, warn, Instrument, Level};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::active_compute_sink::{ActiveComputeSink, ComputeSinkRemovalReason};
+use crate::active_compute_sink::{ActiveComputeSink, ActiveComputeSinkRetireReason};
 use crate::command::Command;
 use crate::coord::appends::Deferred;
 use crate::coord::statement_logging::StatementLoggingId;
@@ -43,7 +42,7 @@ use crate::coord::{
 use crate::session::Session;
 use crate::statement_logging::StatementLifecycleEvent;
 use crate::util::ResultExt;
-use crate::{catalog, AdapterError, AdapterNotice, ExecuteResponse, TimestampContext};
+use crate::{catalog, AdapterNotice, TimestampContext};
 
 impl Coordinator {
     /// BOXED FUTURE: As of Nov 2023 the returned Future from this function was 74KB. This would
@@ -351,7 +350,7 @@ impl Coordinator {
                         if finished {
                             self.drop_compute_sinks_with_reason([(
                                 sink_id,
-                                ComputeSinkRemovalReason::Finished,
+                                ActiveComputeSinkRetireReason::Finished,
                             )])
                             .await;
                         }
@@ -362,14 +361,10 @@ impl Coordinator {
                 }
             }
             ControllerResponse::CopyToResponse(sink_id, response) => {
-                match self.remove_active_sink(sink_id).await {
+                match self.remove_active_compute_sink(sink_id).await {
                     Some(ActiveComputeSink::CopyTo(active_copy_to)) => {
-                        let response = match response {
-                            Ok(n) => Ok(ExecuteResponse::Copied(usize::cast_from(n))),
-                            Err(error) => Err(AdapterError::Unstructured(error)),
-                        };
                         let sink_and_cluster_id = (sink_id, active_copy_to.cluster_id);
-                        active_copy_to.process_response(response);
+                        active_copy_to.retire_with_response(response);
                         self.drop_compute_sinks([sink_and_cluster_id]);
                     }
                     _ => {

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -291,7 +291,6 @@ impl Coordinator {
 
         let (tx, rx) = mpsc::unbounded_channel();
         let active_subscribe = ActiveSubscribe {
-            user: ctx.session().user().clone(),
             conn_id: ctx.session().conn_id().clone(),
             channel: tx,
             emit_progress,

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -218,7 +218,8 @@ impl Coordinator {
         id: GlobalId,
         active_sink: ActiveComputeSink,
     ) -> BuiltinTableAppendNotify {
-        let session_type = metrics::session_type_label_value(active_sink.user());
+        let user = self.active_conns()[active_sink.connection_id()].user();
+        let session_type = metrics::session_type_label_value(user);
 
         self.active_conns
             .get_mut(active_sink.connection_id())
@@ -263,7 +264,8 @@ impl Coordinator {
         id: GlobalId,
     ) -> Option<ActiveComputeSink> {
         if let Some(sink) = self.active_compute_sinks.remove(&id) {
-            let session_type = metrics::session_type_label_value(sink.user());
+            let user = self.active_conns()[sink.connection_id()].user();
+            let session_type = metrics::session_type_label_value(user);
 
             self.active_conns
                 .get_mut(sink.connection_id())


### PR DESCRIPTION
This is a minor follow up to the `COPY ... TO` response protocol implementation PRs (#25179, #25042, and #25311) that attempts to leave the compute sink cleanup code in the best state possible.

Details are in the individual commit messages, but the gist is that functions are now named and documented as consistently as possible, and subscribe and copy to are handled as symmetrically as possible.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Go commit by commit and suppress whitespace. The diff isn't actually that large, and is mostly code movement!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
