### PR TITLE
.github: Fix external user notification workflow

### DIFF
--- a/.github/workflows/slack_notify_opened.yml
+++ b/.github/workflows/slack_notify_opened.yml
@@ -39,11 +39,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Push to Slack
         if: |
-          steps.is_organization_member.outputs.result == false
+          ${{ steps.is_organization_member.outputs.result == 'false' }}
         uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
-          channel: devex
+          channel: product
           custom_payload: |
             {
               "blocks": [


### PR DESCRIPTION
We have a workflow to detect issues opened by external users that...doesn't work. It turns out that there's [some subtleties around how GH Actions handles booleans](https://github.com/actions/runner/issues/1483).

Didn't notice until now because there was a parallel workflow running via Zapier.