### PR TITLE
compute-client: fix replica write frontier initialization

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1277,6 +1277,10 @@ where
             }
         }
 
+        // Prune empty changes. We might end up with empty changes for dependencies that have been
+        // dropped already, which is fine but might be confusing if we reported them.
+        storage_read_capability_changes.retain(|_key, update| !update.is_empty());
+
         if !storage_read_capability_changes.is_empty() {
             self.storage_controller
                 .update_read_capabilities(&mut storage_read_capability_changes);


### PR DESCRIPTION
When installing write frontiers for a new replica, we should not attempt to install empty read holds for dataflow dependencies with the storage controller. If a collection has advanced to the empty frontier, this means we don't have read holds on its inputs anymore, so the storage controller has been free to drop these input collections. If we try to update the storage read capabilities for an object the storage controller doesn't know about, it panics, so we must avoid that.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/25366

### Tips for reviewer

I don't think we can write a reliable regression test for #25366. The panic only happens when the various cleanup steps happen in a specific order (shard finalization, replica creation, compute collection cleanup) and we have no way to control that order without changing the code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A