### PR TITLE
Update dependency on timely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8820,12 +8820,11 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#de20aa88cc6df3de910e9befbe68408d31e287be"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#9208396d1d86becbcc91c76e780ffe61fd51e65e"
 dependencies = [
  "abomonation",
  "abomonation_derive",
  "crossbeam-channel",
- "futures-util",
  "getopts",
  "serde",
  "serde_derive",
@@ -8838,12 +8837,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#de20aa88cc6df3de910e9befbe68408d31e287be"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#9208396d1d86becbcc91c76e780ffe61fd51e65e"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#de20aa88cc6df3de910e9befbe68408d31e287be"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#9208396d1d86becbcc91c76e780ffe61fd51e65e"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -8859,7 +8858,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#de20aa88cc6df3de910e9befbe68408d31e287be"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#9208396d1d86becbcc91c76e780ffe61fd51e65e"
 dependencies = [
  "columnation",
  "serde",
@@ -8868,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#de20aa88cc6df3de910e9befbe68408d31e287be"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#9208396d1d86becbcc91c76e780ffe61fd51e65e"
 
 [[package]]
 name = "tiny-keccak"

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -183,27 +183,22 @@ delta = "3.8.0 -> 3.8.1"
 [[audits.timely]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:de20aa88cc6df3de910e9befbe68408d31e287be"
-
-[[audits.timely]]
-who = "Moritz Hoffmann <mh@materialize.com>"
-criteria = "safe-to-deploy"
-version = "0.12.0@git:de20aa88cc6df3de910e9befbe68408d31e287be"
+version = "0.12.0@git:9208396d1d86becbcc91c76e780ffe61fd51e65e"
 
 [[audits.timely_bytes]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:de20aa88cc6df3de910e9befbe68408d31e287be"
+version = "0.12.0@git:9208396d1d86becbcc91c76e780ffe61fd51e65e"
 
 [[audits.timely_communication]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:de20aa88cc6df3de910e9befbe68408d31e287be"
+version = "0.12.0@git:9208396d1d86becbcc91c76e780ffe61fd51e65e"
 
 [[audits.timely_logging]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:de20aa88cc6df3de910e9befbe68408d31e287be"
+version = "0.12.0@git:9208396d1d86becbcc91c76e780ffe61fd51e65e"
 
 [[audits.tracing-log]]
 who = "Gus Wynn <gus@materialize.com>"

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -217,8 +217,7 @@ where
 
 /// Data and progress events of a shard subscription.
 ///
-/// TODO: Unify this with [timely::dataflow::operators::to_stream::Event] or
-/// [timely::dataflow::operators::capture::event::Event].
+/// TODO: Unify this with [timely::dataflow::operators::capture::event::Event].
 #[derive(Debug, PartialEq)]
 pub enum ListenEvent<T, D> {
     /// Progress of the shard.

--- a/src/storage-types/src/sources/load_generator.rs
+++ b/src/storage-types/src/sources/load_generator.rs
@@ -17,7 +17,6 @@ use once_cell::sync::Lazy;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
-use timely::dataflow::operators::to_stream::Event;
 
 use crate::sources::{MzOffset, SourceConnection};
 
@@ -25,6 +24,14 @@ include!(concat!(
     env!("OUT_DIR"),
     "/mz_storage_types.sources.load_generator.rs"
 ));
+
+/// Data and progress events of the native stream.
+pub enum Event<F: IntoIterator, D> {
+    /// Indicates that timestamps have advanced to frontier F
+    Progress(F),
+    /// Indicates that event D happened at time T
+    Message(F::Item, D),
+}
 
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct LoadGeneratorSourceConnection {

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -14,11 +14,10 @@ use differential_dataflow::{AsCollection, Collection};
 use futures::StreamExt;
 use mz_repr::{Diff, Row};
 use mz_storage_types::sources::load_generator::{
-    Generator, LoadGenerator, LoadGeneratorSourceConnection,
+    Event, Generator, LoadGenerator, LoadGeneratorSourceConnection,
 };
 use mz_storage_types::sources::{MzOffset, SourceTimestamp};
 use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
-use timely::dataflow::operators::to_stream::Event;
 use timely::dataflow::operators::ToStream;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;

--- a/src/storage/src/source/generator/auction.rs
+++ b/src/storage/src/source/generator/auction.rs
@@ -12,12 +12,11 @@ use std::iter;
 
 use mz_ore::now::{to_datetime, NowFn};
 use mz_repr::{Datum, Row};
-use mz_storage_types::sources::load_generator::Generator;
+use mz_storage_types::sources::load_generator::{Event, Generator};
 use mz_storage_types::sources::MzOffset;
 use rand::prelude::{Rng, SmallRng};
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
-use timely::dataflow::operators::to_stream::Event;
 
 /// CREATE TABLE organizations
 ///   (

--- a/src/storage/src/source/generator/counter.rs
+++ b/src/storage/src/source/generator/counter.rs
@@ -9,9 +9,8 @@
 
 use mz_ore::now::NowFn;
 use mz_repr::{Datum, Row};
-use mz_storage_types::sources::load_generator::Generator;
+use mz_storage_types::sources::load_generator::{Event, Generator};
 use mz_storage_types::sources::MzOffset;
-use timely::dataflow::operators::to_stream::Event;
 
 pub struct Counter {
     /// How many values will be emitted before old ones are retracted,

--- a/src/storage/src/source/generator/datums.rs
+++ b/src/storage/src/source/generator/datums.rs
@@ -11,9 +11,8 @@ use std::iter;
 
 use mz_ore::now::NowFn;
 use mz_repr::{Datum, Row, ScalarType};
-use mz_storage_types::sources::load_generator::Generator;
+use mz_storage_types::sources::load_generator::{Event, Generator};
 use mz_storage_types::sources::MzOffset;
-use timely::dataflow::operators::to_stream::Event;
 
 pub struct Datums {}
 

--- a/src/storage/src/source/generator/marketing.rs
+++ b/src/storage/src/source/generator/marketing.rs
@@ -14,10 +14,9 @@ use std::{
 
 use mz_ore::now::to_datetime;
 use mz_repr::{Datum, Row};
-use mz_storage_types::sources::load_generator::Generator;
+use mz_storage_types::sources::load_generator::{Event, Generator};
 use mz_storage_types::sources::MzOffset;
 use rand::{distributions::Standard, rngs::SmallRng, Rng, SeedableRng};
-use timely::dataflow::operators::to_stream::Event;
 
 const CUSTOMERS_OUTPUT: usize = 1;
 const IMPRESSIONS_OUTPUT: usize = 2;

--- a/src/storage/src/source/generator/tpch.rs
+++ b/src/storage/src/source/generator/tpch.rs
@@ -19,14 +19,13 @@ use mz_ore::now::NowFn;
 use mz_repr::adt::date::Date;
 use mz_repr::adt::numeric::{self, DecimalLike, Numeric};
 use mz_repr::{Datum, Row};
-use mz_storage_types::sources::load_generator::Generator;
+use mz_storage_types::sources::load_generator::{Event, Generator};
 use mz_storage_types::sources::MzOffset;
 use once_cell::sync::Lazy;
 use rand::distributions::{Alphanumeric, DistString};
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
-use timely::dataflow::operators::to_stream::Event;
 
 #[derive(Clone, Debug)]
 pub struct Tpch {


### PR DESCRIPTION
Update our timely dependency. This includes a change to remove the async operator builder, which causes a bunch of changes around the now-missing `Event` struct. All changes in https://github.com/MaterializeInc/timely-dataflow/commit/9208396d1d86becbcc91c76e780ffe61fd51e65e.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
