### PR TITLE
Change MV bootstrapping to enable REFRESH warmup

### DIFF
--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -478,6 +478,16 @@ pub trait TimestampProvider {
         since
     }
 
+    /// Returns `least_valid_write` - 1, i.e., each time in `least_valid_write` stepped back in a
+    /// saturating way.
+    fn greatest_available_read(&self, id_bundle: &CollectionIdBundle) -> Antichain<Timestamp> {
+        let mut frontier = Antichain::new();
+        for t in self.least_valid_write(id_bundle) {
+            frontier.insert(t.step_back().unwrap_or(t));
+        }
+        frontier
+    }
+
     fn generate_timestamp_not_valid_error_msg(
         &self,
         id_bundle: &CollectionIdBundle,


### PR DESCRIPTION
This PR changes the `as_of` bootstrapping of MVs and indexes to allow for REFRESH warmup:
- Instead of moving an MV `as_of` to the write frontier of the Storage collection (which would be at the next refresh), we move it to just `least_valid_write - 1`. (Except if this would be past the write frontier of the Storage collection, in which case we use that.) This is also consistent with the `warmup_capabilities` that the Compute controller is normally holding.
- The PR removes the special logic that we had for REFRESH MVs, because it was also making the `as_of` go to the next refresh, preventing warmups.
- The PR also slightly changes the `as_of` bootstrapping of indexes: Instead of `least_valid_write`, we now consider `least_valid_write - 1`. This makes the code consistent with the MV bootstrapping, and also enables the warmup of an index that is on top of a REFRESH MV. (However, such an index still won't actually be readable before the next refresh minus the compaction window, which is tracked in https://github.com/MaterializeInc/materialize/issues/25379)
- (This PR doesn't yet touch the logic that prevents bootstrapping to an empty `as_of`s, which is tracked in https://github.com/MaterializeInc/materialize/issues/25380.)

Unfortunately, I don't know how to write a test for this. I manually tested it as follows:
Run
```
CREATE TABLE t (a int);

create materialized view mv2 with (refresh every '2 minutes') as
select count(*) from (select generate_series(1,a) from t);

insert into t values (10000000);
```
Then do a restart, and then wait until the next refresh time, and check that the refresh immediately happens (i.e., that EXPLAIN TIMESTAMP always says that it's immediately queryable when I'm around the refresh time), which means that the dataflow was warmed up already.

I also [triggered a Nightly run](https://buildkite.com/materialize/nightlies/builds/6539) to check that existing functionality is not impacted.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/25279

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
