### PR TITLE
doc/user: deprecate credentials-based authentication

### DIFF
--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -39,7 +39,7 @@ Relational Database Service (RDS).
 |-------------------------------------------|------------------|------------------------------
 | `ENDPOINT`                                | `text`           | *Advanced.* Override the default AWS endpoint URL. Allows targeting AWS-compatible services like MinIO.
 | `REGION`                                  | `text`           | The AWS region to connect to.
-| `ACCESS KEY ID`                           | secret or `text` | The access key ID to connect with. Triggers credentials-based authentication.
+| `ACCESS KEY ID`                           | secret or `text` | The access key ID to connect with. Triggers credentials-based authentication.<br><br><strong>Warning!</strong> Use of credentials-based authentication is deprecated. AWS strongly encourages the use of role assumption-based authentication instead.
 | `SECRET ACCESS KEY`                       | secret           | The secret access key corresponding to the specified access key ID.<br><br>Required and only valid when `ACCESS KEY ID` is specified.
 | `SESSION TOKEN`                           | secret or `text` | The session token corresponding to the specified access key ID.<br><br>Only valid when `ACCESS KEY ID` is specified.
 | `ASSUME ROLE ARN`                         | `text`           | The Amazon Resource Name (ARN) of the IAM role to assume. Triggers role assumption-based authentication.
@@ -106,18 +106,6 @@ SELECT id, external_id, example_trust_policy FROM mz_internal.mz_aws_connections
 #### Examples
 
 {{< tabs >}}
-{{< tab "Credentials">}}
-To create an AWS connection that uses static access key credentials:
-
-```sql
-CREATE SECRET aws_secret_access_key = '...';
-CREATE CONNECTION aws_credentials TO AWS (
-    ACCESS KEY ID = 'ASIAV2KIV5LPTG6HGXG6',
-    SECRET ACCESS KEY = SECRET aws_secret_access_key
-);
-```
-{{< /tab >}}
-
 {{< tab "Role assumption">}}
 
 In this example, we have created the following IAM role for Materialize to
@@ -165,6 +153,24 @@ CREATE CONNECTION aws_role_assumption TO AWS (
 );
 ```
 {{< /tab >}}
+
+{{< tab "Credentials">}}
+{{< warning >}}
+Use of credentials-based authentication is deprecated.  AWS strongly encourages
+the use of role assumption-based authentication instead.
+{{< /warning >}}
+
+To create an AWS connection that uses static access key credentials:
+
+```sql
+CREATE SECRET aws_secret_access_key = '...';
+CREATE CONNECTION aws_credentials TO AWS (
+    ACCESS KEY ID = 'ASIAV2KIV5LPTG6HGXG6',
+    SECRET ACCESS KEY = SECRET aws_secret_access_key
+);
+```
+{{< /tab >}}
+
 {{< /tabs >}}
 
 ### Kafka


### PR DESCRIPTION
Per the AWS Foundational Technical Review, we need to mark the use of credentials-based authentication as deprecated, in favor of role assumption-based authentication.

More context: https://github.com/MaterializeInc/cloud/issues/8548

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR updates documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
