### PR TITLE
adapter: acquire subscribe read holds

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -729,15 +729,14 @@ impl PlanValidity {
                 }
             }
         }
-        // It is sufficient to check that all the source_ids still exist because we assume:
+        // It is sufficient to check that all the dependency_ids still exist because we assume:
         // - Ids do not mutate.
         // - Ids are not reused.
         // - If an id was dropped, this will detect it and error.
         for id in &self.dependency_ids {
             if catalog.try_get_entry(id).is_none() {
                 return Err(AdapterError::ChangedPlan(format!(
-                    "dependency {} was removed",
-                    id
+                    "dependency was removed: {id}",
                 )));
             }
         }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -3022,9 +3022,10 @@ def workflow_test_subscribe_hydration_status(
         input=dedent(
             """
             > SELECT h.hydrated
-              FROM mz_internal.mz_subscriptions s
+              FROM mz_internal.mz_subscriptions s,
+              unnest(s.referenced_object_ids) as sroi(id)
               JOIN mz_internal.mz_compute_hydration_statuses h ON (h.object_id = s.id)
-              JOIN mz_tables t ON (s.referenced_object_ids = list[t.id])
+              JOIN mz_tables t ON (t.id = sroi.id)
               WHERE t.name = 'mz_tables'
             true
             """
@@ -3039,9 +3040,10 @@ def workflow_test_subscribe_hydration_status(
         input=dedent(
             """
             > SELECT h.hydrated
-              FROM mz_internal.mz_subscriptions s
-              JOIN mz_internal.mz_hydration_statuses h ON (h.object_id = s.id)
-              JOIN mz_tables t ON (s.referenced_object_ids = list[t.id])
+              FROM mz_internal.mz_subscriptions s,
+              unnest(s.referenced_object_ids) as sroi(id)
+              JOIN mz_internal.mz_compute_hydration_statuses h ON (h.object_id = s.id)
+              JOIN mz_tables t ON (t.id = sroi.id)
               WHERE t.name = 'mz_tables'
             """
         )


### PR DESCRIPTION
Previously we would go off thread during optimization, allowing sinces to compact past the determined as_of.

Fixes #25375

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a