### PR TITLE
adapter: Remove redundant message count metric

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2496,7 +2496,7 @@ impl Coordinator {
                         self.metrics
                             .message_handling
                             .with_label_values(&["watchdog"])
-                            .observe(0);
+                            .observe(0.0);
                         continue;
                     }
                 };

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2407,10 +2407,6 @@ impl Coordinator {
             flags::tracing_config(self.catalog.system_config()).apply(&self.tracing_handle);
 
             // Report if the handling of a single message takes longer than this threshold.
-            let prometheus_threshold = self
-                .catalog
-                .system_config()
-                .coord_slow_message_reporting_threshold();
             let warn_threshold = self
                 .catalog()
                 .system_config()
@@ -2497,7 +2493,10 @@ impl Coordinator {
                     // https://docs.rs/tokio/1.8.0/tokio/sync/mpsc/struct.Receiver.html#cancel-safety
                     timer = idle_rx.recv() => {
                         timer.expect("does not drop").observe_duration();
-                        self.metrics.watchdog_messages_processed.inc();
+                        self.metrics
+                            .message_handling
+                            .with_label_values(&["watchdog"])
+                            .observe(0);
                         continue;
                     }
                 };
@@ -2536,13 +2535,10 @@ impl Coordinator {
                 self.handle_message(span, msg).await;
                 let duration = start.elapsed();
 
-                // Report slow messages to Prometheus.
-                if duration > prometheus_threshold {
-                    self.metrics
-                        .slow_message_handling
-                        .with_label_values(&[msg_kind])
-                        .observe(duration.as_secs_f64());
-                }
+                self.metrics
+                    .message_handling
+                    .with_label_values(&[msg_kind])
+                    .observe(duration.as_secs_f64());
 
                 // If something is _really_ slow, print a trace id for debugging, if OTEL is enabled.
                 if duration > warn_threshold {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2497,13 +2497,11 @@ impl Coordinator {
                     // https://docs.rs/tokio/1.8.0/tokio/sync/mpsc/struct.Receiver.html#cancel-safety
                     timer = idle_rx.recv() => {
                         timer.expect("does not drop").observe_duration();
-                        self.metrics.messages_processed.inc();
                         self.metrics.watchdog_messages_processed.inc();
                         continue;
                     }
                 };
 
-                self.metrics.messages_processed.inc();
                 // All message processing functions trace. Start a parent span
                 // for them to make it easy to find slow messages.
                 let msg_kind = msg.kind();

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -22,7 +22,6 @@ pub struct Metrics {
     pub active_subscribes: IntGaugeVec,
     pub active_copy_tos: IntGaugeVec,
     pub queue_busy_seconds: HistogramVec,
-    pub watchdog_messages_processed: IntCounter,
     pub determine_timestamp: IntCounterVec,
     pub timestamp_difference_for_strict_serializable_ms: HistogramVec,
     pub commands: IntCounterVec,
@@ -33,7 +32,7 @@ pub struct Metrics {
     pub time_to_first_row_seconds: HistogramVec,
     pub statement_logging_unsampled_bytes: IntCounterVec,
     pub statement_logging_actual_bytes: IntCounterVec,
-    pub slow_message_handling: HistogramVec,
+    pub message_handling: HistogramVec,
     pub optimization_notices: IntCounterVec,
     pub append_table_duration_seconds: HistogramVec,
     pub webhook_validation_reduce_failures: IntCounterVec,
@@ -67,10 +66,6 @@ impl Metrics {
                 name: "mz_coord_queue_busy_seconds",
                 help: "The number of seconds the coord queue was processing before it was empty. This is a sampled metric and does not measure the full coord queue wait/idle times.",
                 buckets: histogram_seconds_buckets(0.000_128, 32.0)
-            )),
-            watchdog_messages_processed: registry.register(metric!(
-                name: "mz_coord_watchdog_messages_processed",
-                help: "The total number of watchdog messages processed by the coord.",
             )),
             determine_timestamp: registry.register(metric!(
                 name: "mz_determine_timestamp",
@@ -122,10 +117,9 @@ impl Metrics {
                 name: "mz_statement_logging_actual_bytes",
                 help: "The total amount of SQL text that was logged by statement logging.",
             )),
-            slow_message_handling: registry.register(metric!(
+            message_handling: registry.register(metric!(
                 name: "mz_slow_message_handling",
-                help: "Latency for coordinator messages that are 'slow' to process. 'Slow' is \
-                    defined by the LaunchDarkly variable 'coord_slow_message_reporting_threshold'",
+                help: "Latency for ALL coordinator messages. 'slow' is in the name for legacy reasons, but is not accurate.",
                 var_labels: ["message_kind"],
                 buckets: histogram_seconds_buckets(0.128, 32.0),
             )),

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -22,7 +22,6 @@ pub struct Metrics {
     pub active_subscribes: IntGaugeVec,
     pub active_copy_tos: IntGaugeVec,
     pub queue_busy_seconds: HistogramVec,
-    pub messages_processed: IntCounter,
     pub watchdog_messages_processed: IntCounter,
     pub determine_timestamp: IntCounterVec,
     pub timestamp_difference_for_strict_serializable_ms: HistogramVec,
@@ -68,10 +67,6 @@ impl Metrics {
                 name: "mz_coord_queue_busy_seconds",
                 help: "The number of seconds the coord queue was processing before it was empty. This is a sampled metric and does not measure the full coord queue wait/idle times.",
                 buckets: histogram_seconds_buckets(0.000_128, 32.0)
-            )),
-            messages_processed: registry.register(metric!(
-                name: "mz_coord_messages_processed",
-                help: "The total number of messages processed by the coord.",
             )),
             watchdog_messages_processed: registry.register(metric!(
                 name: "mz_coord_watchdog_messages_processed",

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -940,17 +940,6 @@ static WEBHOOKS_SECRETS_CACHING_TTL_SECS: Lazy<ServerVar<usize>> = Lazy::new(|| 
     internal: true,
 });
 
-const COORD_SLOW_MESSAGE_REPORTING_THRESHOLD: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("coord_slow_message_reporting_threshold"),
-    // Default to recording all messages, but left here so we can dynamically increase if this
-    // causes unexpected problems.
-    value: Duration::from_millis(0),
-    description:
-        "Sets the threshold at which we will report the handling of a coordinator message \
-    for being slow.",
-    internal: true,
-};
-
 const COORD_SLOW_MESSAGE_WARN_THRESHOLD: ServerVar<Duration> = ServerVar {
     name: UncasedStr::new("coord_slow_message_warn_threshold"),
     // Note(parkmycar): This value was chosen arbitrarily.
@@ -2956,7 +2945,6 @@ impl SystemVars {
             .with_var(&OPENTELEMETRY_FILTER_DEFAULTS)
             .with_var(&SENTRY_FILTERS)
             .with_var(&WEBHOOKS_SECRETS_CACHING_TTL_SECS)
-            .with_var(&COORD_SLOW_MESSAGE_REPORTING_THRESHOLD)
             .with_var(&COORD_SLOW_MESSAGE_WARN_THRESHOLD)
             .with_var(&grpc_client::CONNECT_TIMEOUT)
             .with_var(&grpc_client::HTTP2_KEEP_ALIVE_INTERVAL)
@@ -3753,10 +3741,6 @@ impl SystemVars {
 
     pub fn webhooks_secrets_caching_ttl_secs(&self) -> usize {
         *self.expect_value(&*WEBHOOKS_SECRETS_CACHING_TTL_SECS)
-    }
-
-    pub fn coord_slow_message_reporting_threshold(&self) -> Duration {
-        *self.expect_value(&COORD_SLOW_MESSAGE_REPORTING_THRESHOLD)
     }
 
     pub fn coord_slow_message_warn_threshold(&self) -> Duration {


### PR DESCRIPTION
This commit removes the mz_coord_messages_processed metric that counts the total number of messages processed by the Coordinator. This metric was added in 57a56d6f46681ec25cf5592930396a2f4c70c5cf. It is redundant with the slow_message_handling metric. As of
02bb658a445ffb87d3c8d28872f2aee08c5f2144, slow_message_handling counts all messages not just the slow ones.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
