### PR TITLE
sql: Refactor Variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5558,6 +5558,7 @@ dependencies = [
  "chrono",
  "clap",
  "datadriven",
+ "derivative",
  "dynfmt",
  "enum-kinds",
  "fail",

--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -141,7 +141,7 @@ impl SynchronizedParameters {
     pub fn enable_launchdarkly(&self) -> bool {
         let var_name = self.get(ENABLE_LAUNCHDARKLY.name());
         let var_input = VarInput::Flat(&var_name);
-        bool::parse(&ENABLE_LAUNCHDARKLY, var_input).expect("This is known to be a bool")
+        bool::parse(var_input).expect("This is known to be a bool")
     }
 }
 

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -404,8 +404,8 @@ impl AdapterError {
             AdapterError::Catalog(e) => match &e.kind {
                 mz_catalog::memory::error::ErrorKind::VarError(e) => match e {
                     VarError::ConstrainedParameter { .. } => SqlState::INVALID_PARAMETER_VALUE,
-                    VarError::FixedValueParameter(_) => SqlState::INVALID_PARAMETER_VALUE,
-                    VarError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,
+                    VarError::FixedValueParameter { .. } => SqlState::INVALID_PARAMETER_VALUE,
+                    VarError::InvalidParameterType { .. } => SqlState::INVALID_PARAMETER_VALUE,
                     VarError::InvalidParameterValue { .. } => SqlState::INVALID_PARAMETER_VALUE,
                     VarError::ReadOnlyParameter(_) => SqlState::CANT_CHANGE_RUNTIME_PARAM,
                     VarError::UnknownParameter(_) => SqlState::UNDEFINED_OBJECT,

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -304,7 +304,7 @@ impl<T: TimestampManipulation> Session<T> {
 
         if let Some(isolation_level) = isolation_level {
             self.vars
-                .set(None, mz_sql::session::vars::TRANSACTION_ISOLATION_VAR_NAME.as_str(), VarInput::Flat(IsolationLevel::from(isolation_level).as_str()), true)
+                .set(None, mz_sql::session::vars::TRANSACTION_ISOLATION_VAR_NAME, VarInput::Flat(IsolationLevel::from(isolation_level).as_str()), true)
                 .expect("transaction_isolation should be a valid var and isolation level is a valid value");
         }
 

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -18,6 +18,7 @@ aws-sdk-sts = { version = "1.7.0", default-features = false, features = [
 bitflags = "1.3.2"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive"] }
+derivative = "2.2.0"
 dynfmt = { version = "0.1.5", features = ["curly"] }
 enum-kinds = "0.5.1"
 fail = { version = "0.5.1", features = ["failpoints"] }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -67,45 +67,38 @@ use std::any::Any;
 use std::borrow::Borrow;
 use std::clone::Clone;
 use std::collections::BTreeMap;
-use std::fmt::{Debug, Display};
-use std::ops::RangeBounds;
-use std::str::FromStr;
+use std::fmt::Debug;
 use std::string::ToString;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use clap::clap_derive::ArgEnum;
-use clap::ValueEnum;
-use itertools::Itertools;
-use mz_adapter_types::timestamp_oracle::{
-    DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT,
-    DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
-};
 use mz_build_info::BuildInfo;
 use mz_dyncfg::{ConfigSet, ConfigType, ConfigUpdates as PersistConfigUpdates, ConfigVal};
-use mz_ore::cast;
 use mz_ore::cast::CastFrom;
-use mz_ore::str::StrExt;
 use mz_persist_client::cfg::{CRDB_CONNECT_TIMEOUT, CRDB_TCP_USER_TIMEOUT};
-use mz_pgwire_common::Severity;
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::adt::timestamp::CheckedTimestamp;
-use mz_repr::bytes::ByteSize;
-use mz_repr::strconv;
 use mz_repr::user::ExternalUserMetadata;
-use mz_sql_parser::ast::TransactionIsolationLevel;
-use mz_sql_parser::ident;
 use mz_storage_types::controller::PersistTxnTablesImpl;
 use mz_tracing::{CloneableEnvFilter, SerializableDirective};
 use once_cell::sync::Lazy;
-use proptest_derive::Arbitrary;
 use serde::Serialize;
 use uncased::UncasedStr;
 
 use crate::ast::Ident;
-use crate::session::user::{User, SUPPORT_USER, SYSTEM_USER};
-use crate::{DEFAULT_SCHEMA, WEBHOOK_CONCURRENCY_LIMIT};
+use crate::session::user::User;
+
+mod constraints;
+mod definitions;
+mod errors;
+mod value;
+
+use constraints::*;
+
+pub use definitions::*;
+pub use errors::*;
+pub use value::*;
 
 /// The action to take during end_transaction.
 ///
@@ -118,2067 +111,6 @@ pub enum EndTransactionAction {
     /// Rollback the transaction.
     Rollback,
 }
-
-/// Errors that can occur when working with [`Var`]s
-#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
-pub enum VarError {
-    /// The specified session parameter is constrained to a finite set of
-    /// values.
-    #[error(
-        "invalid value for parameter {}: {}",
-        parameter.name.quoted(),
-        values.iter().map(|v| v.quoted()).join(",")
-    )]
-    ConstrainedParameter {
-        parameter: VarErrParam,
-        values: Vec<String>,
-        valid_values: Option<Vec<&'static str>>,
-    },
-    /// The specified parameter is fixed to a single specific value.
-    ///
-    /// We allow setting the parameter to its fixed value for compatibility
-    /// with PostgreSQL-based tools.
-    #[error(
-        "parameter {} can only be set to {}",
-        .0.name.quoted(),
-        .0.value.quoted(),
-    )]
-    FixedValueParameter(VarErrParam),
-    /// The value for the specified parameter does not have the right type.
-    #[error(
-        "parameter {} requires a {} value",
-        .0.name.quoted(),
-        .0.type_name.quoted()
-    )]
-    InvalidParameterType(VarErrParam),
-    /// The value of the specified parameter is incorrect.
-    #[error(
-        "parameter {} cannot have value {}: {}",
-        parameter.name.quoted(),
-        values
-            .iter()
-            .map(|v| v.quoted().to_string())
-            .collect::<Vec<_>>()
-            .join(","),
-        reason,
-    )]
-    InvalidParameterValue {
-        parameter: VarErrParam,
-        values: Vec<String>,
-        reason: String,
-    },
-    /// The specified session parameter is read only.
-    #[error("parameter {} cannot be changed", .0.quoted())]
-    ReadOnlyParameter(&'static str),
-    /// The named parameter is unknown to the system.
-    #[error("unrecognized configuration parameter {}", .0.quoted())]
-    UnknownParameter(String),
-    /// The specified session parameter is read only unless in unsafe mode.
-    #[error("parameter {} can only be set in unsafe mode", .0.quoted())]
-    RequiresUnsafeMode(&'static str),
-    #[error("{} is not supported", .feature)]
-    RequiresFeatureFlag {
-        feature: String,
-        detail: Option<String>,
-        /// If we're running in unsafe mode and hit this error, we should surface the flag name that
-        /// needs to be set to make the feature work.
-        name_hint: Option<&'static UncasedStr>,
-    },
-}
-
-impl VarError {
-    pub fn detail(&self) -> Option<String> {
-        match self {
-            Self::RequiresFeatureFlag { detail, .. } => {
-                match detail {
-                    None => Some("The requested feature is typically meant only for internal development and testing of Materialize.".into()),
-                    o => o.clone()
-                }
-            }
-            _ => None,
-        }
-    }
-
-    pub fn hint(&self) -> Option<String> {
-        match self {
-            VarError::ConstrainedParameter {
-                valid_values: Some(valid_values),
-                ..
-            } => Some(format!("Available values: {}.", valid_values.join(", "))),
-            VarError::RequiresFeatureFlag { name_hint, .. } => {
-                name_hint.map(|name| format!("Enable with {name} flag"))
-            }
-            _ => None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-/// We don't want to hold a static reference to a variable while erroring, so take an owned version
-/// of the fields we want.
-pub struct VarErrParam {
-    name: &'static str,
-    value: String,
-    type_name: String,
-}
-
-impl<'a, V: Var + Send + Sync + ?Sized> From<&'a V> for VarErrParam {
-    fn from(var: &'a V) -> VarErrParam {
-        VarErrParam {
-            name: var.name(),
-            value: var.value(),
-            type_name: var.type_name(),
-        }
-    }
-}
-
-// We pretend to be Postgres v9.5.0, which is also what CockroachDB pretends to
-// be. Too new and some clients will emit a "server too new" warning. Too old
-// and some clients will fall back to legacy code paths. v9.5.0 empirically
-// seems to be a good compromise.
-
-/// The major version of PostgreSQL that Materialize claims to be.
-pub const SERVER_MAJOR_VERSION: u8 = 9;
-
-/// The minor version of PostgreSQL that Materialize claims to be.
-pub const SERVER_MINOR_VERSION: u8 = 5;
-
-/// The patch version of PostgreSQL that Materialize claims to be.
-pub const SERVER_PATCH_VERSION: u8 = 0;
-
-/// The name of the default database that Materialize uses.
-pub const DEFAULT_DATABASE_NAME: &str = "materialize";
-
-pub static APPLICATION_NAME: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("application_name"),
-    value: "".to_string(),
-    description: "Sets the application name to be reported in statistics and logs (PostgreSQL).",
-    internal: false,
-});
-
-pub static CLIENT_ENCODING: ServerVar<ClientEncoding> = ServerVar {
-    name: UncasedStr::new("client_encoding"),
-    value: ClientEncoding::Utf8,
-    description: "Sets the client's character set encoding (PostgreSQL).",
-    internal: false,
-};
-
-const CLIENT_MIN_MESSAGES: ServerVar<ClientSeverity> = ServerVar {
-    name: UncasedStr::new("client_min_messages"),
-    value: ClientSeverity::Notice,
-    description: "Sets the message levels that are sent to the client (PostgreSQL).",
-    internal: false,
-};
-
-pub const CLUSTER_VAR_NAME: &UncasedStr = UncasedStr::new("cluster");
-pub static CLUSTER: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
-    name: CLUSTER_VAR_NAME,
-    value: "quickstart".to_string(),
-    description: "Sets the current cluster (Materialize).",
-    internal: false,
-});
-
-const CLUSTER_REPLICA: ServerVar<Option<String>> = ServerVar {
-    name: UncasedStr::new("cluster_replica"),
-    value: None,
-    description: "Sets a target cluster replica for SELECT queries (Materialize).",
-    internal: false,
-};
-
-pub const DATABASE_VAR_NAME: &UncasedStr = UncasedStr::new("database");
-pub static DATABASE: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
-    name: DATABASE_VAR_NAME,
-    value: DEFAULT_DATABASE_NAME.to_string(),
-    description: "Sets the current database (CockroachDB).",
-    internal: false,
-});
-
-static DATE_STYLE: ServerVar<DateStyle> = ServerVar {
-    // DateStyle has nonstandard capitalization for historical reasons.
-    name: UncasedStr::new("DateStyle"),
-    value: DEFAULT_DATE_STYLE,
-    description: "Sets the display format for date and time values (PostgreSQL).",
-    internal: false,
-};
-
-const EXTRA_FLOAT_DIGITS: ServerVar<i32> = ServerVar {
-    name: UncasedStr::new("extra_float_digits"),
-    value: 3,
-    description: "Adjusts the number of digits displayed for floating-point values (PostgreSQL).",
-    internal: false,
-};
-
-const FAILPOINTS: ServerVar<Failpoints> = ServerVar {
-    name: UncasedStr::new("failpoints"),
-    value: Failpoints,
-    description: "Allows failpoints to be dynamically activated.",
-    internal: false,
-};
-
-const INTEGER_DATETIMES: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("integer_datetimes"),
-    value: true,
-    description: "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL).",
-    internal: false,
-};
-
-pub static INTERVAL_STYLE: ServerVar<IntervalStyle> = ServerVar {
-    // IntervalStyle has nonstandard capitalization for historical reasons.
-    name: UncasedStr::new("IntervalStyle"),
-    value: IntervalStyle::Postgres,
-    description: "Sets the display format for interval values (PostgreSQL).",
-    internal: false,
-};
-
-const MZ_VERSION_NAME: &UncasedStr = UncasedStr::new("mz_version");
-const IS_SUPERUSER_NAME: &UncasedStr = UncasedStr::new("is_superuser");
-
-// Schema can be used an alias for a search path with a single element.
-pub const SCHEMA_ALIAS: &UncasedStr = UncasedStr::new("schema");
-static SEARCH_PATH: Lazy<ServerVar<Vec<Ident>>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("search_path"),
-    value: vec![ident!(DEFAULT_SCHEMA)],
-    description:
-        "Sets the schema search order for names that are not schema-qualified (PostgreSQL).",
-    internal: false,
-});
-
-const STATEMENT_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("statement_timeout"),
-    value: Duration::from_secs(10),
-    description:
-        "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations. \
-        If this value is specified without units, it is taken as milliseconds.",
-    internal: false,
-};
-
-const IDLE_IN_TRANSACTION_SESSION_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("idle_in_transaction_session_timeout"),
-    value: Duration::from_secs(60 * 2),
-    description:
-        "Sets the maximum allowed duration that a session can sit idle in a transaction before \
-         being terminated. If this value is specified without units, it is taken as milliseconds. \
-         A value of zero disables the timeout (PostgreSQL).",
-    internal: false,
-};
-
-pub static SERVER_VERSION: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("server_version"),
-    value: format!(
-        "{}.{}.{}",
-        SERVER_MAJOR_VERSION, SERVER_MINOR_VERSION, SERVER_PATCH_VERSION
-    ),
-    description: "Shows the PostgreSQL compatible server version (PostgreSQL).",
-    internal: false,
-});
-
-const SERVER_VERSION_NUM: ServerVar<i32> = ServerVar {
-    name: UncasedStr::new("server_version_num"),
-    value: ((cast::u8_to_i32(SERVER_MAJOR_VERSION) * 10_000)
-        + (cast::u8_to_i32(SERVER_MINOR_VERSION) * 100)
-        + cast::u8_to_i32(SERVER_PATCH_VERSION)),
-    description: "Shows the PostgreSQL compatible server version as an integer (PostgreSQL).",
-    internal: false,
-};
-
-const SQL_SAFE_UPDATES: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("sql_safe_updates"),
-    value: false,
-    description: "Prohibits SQL statements that may be overly destructive (CockroachDB).",
-    internal: false,
-};
-
-const STANDARD_CONFORMING_STRINGS: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("standard_conforming_strings"),
-    value: true,
-    description: "Causes '...' strings to treat backslashes literally (PostgreSQL).",
-    internal: false,
-};
-
-const TIMEZONE: ServerVar<TimeZone> = ServerVar {
-    // TimeZone has nonstandard capitalization for historical reasons.
-    name: UncasedStr::new("TimeZone"),
-    value: TimeZone::UTC,
-    description: "Sets the time zone for displaying and interpreting time stamps (PostgreSQL).",
-    internal: false,
-};
-
-pub const TRANSACTION_ISOLATION_VAR_NAME: &UncasedStr = UncasedStr::new("transaction_isolation");
-const TRANSACTION_ISOLATION: ServerVar<IsolationLevel> = ServerVar {
-    name: TRANSACTION_ISOLATION_VAR_NAME,
-    value: IsolationLevel::StrictSerializable,
-    description: "Sets the current transaction's isolation level (PostgreSQL).",
-    internal: false,
-};
-
-pub const MAX_KAFKA_CONNECTIONS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_kafka_connections"),
-    value: 1000,
-    description:
-        "The maximum number of Kafka connections in the region, across all schemas (Materialize).",
-    internal: false,
-};
-
-pub const MAX_POSTGRES_CONNECTIONS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_postgres_connections"),
-    value: 1000,
-    description: "The maximum number of PostgreSQL connections in the region, across all schemas (Materialize).",
-    internal: false
-};
-
-pub const MAX_AWS_PRIVATELINK_CONNECTIONS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_aws_privatelink_connections"),
-    value: 0,
-    description: "The maximum number of AWS PrivateLink connections in the region, across all schemas (Materialize).",
-    internal: false
-};
-
-pub const MAX_TABLES: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_tables"),
-    value: 25,
-    description: "The maximum number of tables in the region, across all schemas (Materialize).",
-    internal: false,
-};
-
-pub const MAX_SOURCES: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_sources"),
-    value: 25,
-    description: "The maximum number of sources in the region, across all schemas (Materialize).",
-    internal: false,
-};
-
-pub const MAX_SINKS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_sinks"),
-    value: 25,
-    description: "The maximum number of sinks in the region, across all schemas (Materialize).",
-    internal: false,
-};
-
-pub const MAX_MATERIALIZED_VIEWS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_materialized_views"),
-    value: 100,
-    description:
-        "The maximum number of materialized views in the region, across all schemas (Materialize).",
-    internal: false,
-};
-
-pub const MAX_CLUSTERS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_clusters"),
-    value: 10,
-    description: "The maximum number of clusters in the region (Materialize).",
-    internal: false,
-};
-
-pub const MAX_REPLICAS_PER_CLUSTER: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_replicas_per_cluster"),
-    value: 5,
-    description: "The maximum number of replicas of a single cluster (Materialize).",
-    internal: false,
-};
-
-pub static MAX_CREDIT_CONSUMPTION_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| {
-    ServerVar {
-        name: UncasedStr::new("max_credit_consumption_rate"),
-        value: 1024.into(),
-        description: "The maximum rate of credit consumption in a region. Credits are consumed based on the size of cluster replicas in use (Materialize).",
-        internal: false
-    }
-});
-
-pub const MAX_DATABASES: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_databases"),
-    value: 1000,
-    description: "The maximum number of databases in the region (Materialize).",
-    internal: false,
-};
-
-pub const MAX_SCHEMAS_PER_DATABASE: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_schemas_per_database"),
-    value: 1000,
-    description: "The maximum number of schemas in a database (Materialize).",
-    internal: false,
-};
-
-pub const MAX_OBJECTS_PER_SCHEMA: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_objects_per_schema"),
-    value: 1000,
-    description: "The maximum number of objects in a schema (Materialize).",
-    internal: false,
-};
-
-pub const MAX_SECRETS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_secrets"),
-    value: 100,
-    description: "The maximum number of secrets in the region, across all schemas (Materialize).",
-    internal: false,
-};
-
-pub const MAX_ROLES: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_roles"),
-    value: 1000,
-    description: "The maximum number of roles in the region (Materialize).",
-    internal: false,
-};
-
-// Cloud environmentd is configured with 4 GiB of RAM, so 1 GiB is a good heuristic for a single
-// query.
-// TODO(jkosh44) Eventually we want to be able to return arbitrary sized results.
-pub const MAX_RESULT_SIZE: ServerVar<ByteSize> = ServerVar {
-    name: UncasedStr::new("max_result_size"),
-    value: ByteSize::gb(1),
-    description: "The maximum size in bytes for an internal query result (Materialize).",
-    internal: false,
-};
-
-pub const MAX_QUERY_RESULT_SIZE: ServerVar<ByteSize> = ServerVar {
-    name: UncasedStr::new("max_query_result_size"),
-    value: ByteSize::gb(1),
-    description: "The maximum size in bytes for a single query's result (Materialize).",
-    internal: false,
-};
-
-pub const MAX_COPY_FROM_SIZE: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_copy_from_size"),
-    // 1 GiB, this limit is noted in the docs, if you change it make sure to update our docs.
-    value: 1_073_741_824,
-    description: "The maximum size in bytes we buffer for COPY FROM statements (Materialize).",
-    internal: false,
-};
-
-pub const MAX_IDENTIFIER_LENGTH: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("max_identifier_length"),
-    value: mz_sql_lexer::lexer::MAX_IDENTIFIER_LENGTH,
-    description: "The maximum length of object identifiers in bytes (PostgreSQL).",
-    internal: false,
-};
-
-pub const WELCOME_MESSAGE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("welcome_message"),
-    value: true,
-    description: "Whether to send a notice with a welcome message after a successful connection (Materialize).",
-    internal: false,
-};
-
-/// The logical compaction window for builtin tables and sources that have the
-/// `retained_metrics_relation` flag set.
-///
-/// The existence of this variable is a bit of a hack until we have a fully
-/// general solution for controlling retention windows.
-pub const METRICS_RETENTION: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("metrics_retention"),
-    // 30 days
-    value: Duration::from_secs(30 * 24 * 60 * 60),
-    description: "The time to retain cluster utilization metrics (Materialize).",
-    internal: true,
-};
-
-static ALLOWED_CLUSTER_REPLICA_SIZES: Lazy<ServerVar<Vec<Ident>>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("allowed_cluster_replica_sizes"),
-    value: Vec::new(),
-    description: "The allowed sizes when creating a new cluster replica (Materialize).",
-    internal: false,
-});
-
-const PERSIST_FAST_PATH_LIMIT: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("persist_fast_path_limit"),
-    value: 0,
-    description:
-        "An exclusive upper bound on the number of results we may return from a Persist fast-path peek; \
-        queries that may return more results will follow the normal / slow path. \
-        Setting this to 0 disables the feature.",
-    internal: true,
-};
-
-pub const PERSIST_TXN_TABLES: ServerVar<PersistTxnTablesImpl> = ServerVar {
-    name: UncasedStr::new("persist_txn_tables"),
-    value: PersistTxnTablesImpl::Eager,
-    description: "\
-        Whether to use the new persist-txn tables implementation or the legacy \
-        one.
-
-        Only takes effect on restart. Any changes will also cause clusterd \
-        processes to restart.
-
-        This value is also configurable via a Launch Darkly parameter of the \
-        same name, but we keep the flag to make testing easier. If specified, \
-        the flag takes precedence over the Launch Darkly param.",
-    internal: true,
-};
-
-const TIMESTAMP_ORACLE_IMPL: ServerVar<TimestampOracleImpl> = ServerVar {
-    name: UncasedStr::new("timestamp_oracle"),
-    value: TimestampOracleImpl::Postgres,
-    description: "Backing implementation of TimestampOracle.",
-    internal: true,
-};
-
-pub const CATALOG_KIND_IMPL: ServerVar<Option<CatalogKind>> = ServerVar {
-    name: UncasedStr::new("catalog_kind"),
-    value: None,
-    description: "Backing implementation of catalog.",
-    internal: true,
-};
-
-/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_max_size`.
-const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_max_size"),
-    value: DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE,
-    description: "Maximum size of the Postgres/CRDB connection pool, used by the Postgres/CRDB timestamp oracle.",
-    internal: true,
-};
-
-/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_max_wait`.
-const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT: ServerVar<Option<Duration>> = ServerVar {
-    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_max_wait"),
-    value: Some(DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT),
-    description: "The maximum time to wait when attempting to obtain a connection from the Postgres/CRDB connection pool, used by the Postgres/CRDB timestamp oracle.",
-    internal: true,
-};
-
-/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_ttl`.
-const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_ttl"),
-    value: DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL,
-    description: "The minimum TTL of a Consensus connection to Postgres/CRDB before it is proactively terminated",
-    internal: true,
-};
-
-/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_ttl_stagger`.
-const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_ttl_stagger"),
-    value: DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
-    description: "The minimum time between TTLing Consensus connections to Postgres/CRDB.",
-    internal: true,
-};
-
-/// The default for the `DISK` option when creating managed clusters and cluster replicas.
-const DISK_CLUSTER_REPLICAS_DEFAULT: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("disk_cluster_replicas_default"),
-    value: false,
-    description: "Whether the disk option for managed clusters and cluster replicas should be enabled by default.",
-    internal: true,
-};
-
-const UNSAFE_NEW_TRANSACTION_WALL_TIME: ServerVar<Option<CheckedTimestamp<DateTime<Utc>>>> = ServerVar {
-    name: UncasedStr::new("unsafe_new_transaction_wall_time"),
-    value: None,
-    description:
-        "Sets the wall time for all new explicit or implicit transactions to control the value of `now()`. \
-        If not set, uses the system's clock.",
-    // This needs to be false because `internal: true` things are only modifiable by the mz_system
-    // and mz_support users, and we want sqllogictest to have access with its user. Because the name
-    // starts with "unsafe" it still won't be visible or changeable by users unless unsafe mode is
-    // enabled.
-    internal: false,
-};
-
-/// Tuning for RocksDB used by `UPSERT` sources that takes effect on restart.
-mod upsert_rocksdb {
-    use std::str::FromStr;
-
-    use mz_rocksdb_types::config::{CompactionStyle, CompressionType};
-
-    use super::*;
-
-    impl Value for CompactionStyle {
-        fn type_name() -> String {
-            "rocksdb_compaction_style".to_string()
-        }
-
-        fn parse<'a>(
-            param: &'a (dyn Var + Send + Sync),
-            input: VarInput,
-        ) -> Result<Self::Owned, VarError> {
-            let s = extract_single_value(param, input)?;
-            CompactionStyle::from_str(s).map_err(|_| VarError::InvalidParameterType(param.into()))
-        }
-
-        fn format(&self) -> String {
-            self.to_string()
-        }
-    }
-
-    impl Value for CompressionType {
-        fn type_name() -> String {
-            "rocksdb_compression_type".to_string()
-        }
-
-        fn parse<'a>(
-            param: &'a (dyn Var + Send + Sync),
-            input: VarInput,
-        ) -> Result<Self::Owned, VarError> {
-            let s = extract_single_value(param, input)?;
-            CompressionType::from_str(s).map_err(|_| VarError::InvalidParameterType(param.into()))
-        }
-
-        fn format(&self) -> String {
-            self.to_string()
-        }
-    }
-
-    pub static UPSERT_ROCKSDB_COMPACTION_STYLE: ServerVar<CompactionStyle> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_compaction_style"),
-        value: mz_rocksdb_types::defaults::DEFAULT_COMPACTION_STYLE,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub const UPSERT_ROCKSDB_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET: ServerVar<usize> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_optimize_compaction_memtable_budget"),
-        value: mz_rocksdb_types::defaults::DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub const UPSERT_ROCKSDB_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_level_compaction_dynamic_level_bytes"),
-        value: mz_rocksdb_types::defaults::DEFAULT_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub const UPSERT_ROCKSDB_UNIVERSAL_COMPACTION_RATIO: ServerVar<i32> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_universal_compaction_ratio"),
-        value: mz_rocksdb_types::defaults::DEFAULT_UNIVERSAL_COMPACTION_RATIO,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub const UPSERT_ROCKSDB_PARALLELISM: ServerVar<Option<i32>> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_parallelism"),
-        value: mz_rocksdb_types::defaults::DEFAULT_PARALLELISM,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub static UPSERT_ROCKSDB_COMPRESSION_TYPE: ServerVar<CompressionType> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_compression_type"),
-        value: mz_rocksdb_types::defaults::DEFAULT_COMPRESSION_TYPE,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub static UPSERT_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE: ServerVar<CompressionType> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_bottommost_compression_type"),
-        value: mz_rocksdb_types::defaults::DEFAULT_BOTTOMMOST_COMPRESSION_TYPE,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-
-    pub static UPSERT_ROCKSDB_BATCH_SIZE: ServerVar<usize> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_batch_size"),
-        value: mz_rocksdb_types::defaults::DEFAULT_BATCH_SIZE,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Can be changed dynamically (Materialize).",
-        internal: true,
-    };
-
-    pub static UPSERT_ROCKSDB_RETRY_DURATION: ServerVar<Duration> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_retry_duration"),
-        value: mz_rocksdb_types::defaults::DEFAULT_RETRY_DURATION,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-
-    /// Controls whether automatic spill to disk should be turned on when using `DISK`.
-    pub const UPSERT_ROCKSDB_AUTO_SPILL_TO_DISK: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_auto_spill_to_disk"),
-        value: false,
-        description:
-            "Controls whether automatic spill to disk should be turned on when using `DISK`",
-        internal: true,
-    };
-
-    /// The upsert in memory state size threshold after which it will spill to disk.
-    /// The default is 85 MiB = 89128960 bytes
-    pub const UPSERT_ROCKSDB_AUTO_SPILL_THRESHOLD_BYTES: ServerVar<usize> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_auto_spill_threshold_bytes"),
-        value: mz_rocksdb_types::defaults::DEFAULT_AUTO_SPILL_MEMORY_THRESHOLD,
-        description:
-            "The upsert in-memory state size threshold in bytes after which it will spill to disk",
-        internal: true,
-    };
-
-    pub static UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS: ServerVar<u32> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_stats_log_interval_seconds"),
-        value: mz_rocksdb_types::defaults::DEFAULT_STATS_LOG_INTERVAL_S,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub static UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS: ServerVar<u32> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_stats_persist_interval_seconds"),
-        value: mz_rocksdb_types::defaults::DEFAULT_STATS_PERSIST_INTERVAL_S,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub static UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB: ServerVar<Option<u32>> =
-        ServerVar {
-            name: UncasedStr::new("upsert_rocksdb_point_lookup_block_cache_size_mb"),
-            value: None,
-            description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-            internal: true,
-        };
-
-    /// The number of times by which allocated buffers will be shrinked in upsert rocksdb.
-    /// If value is 0, then no shrinking will occur.
-    pub static UPSERT_ROCKSDB_SHRINK_ALLOCATED_BUFFERS_BY_RATIO: ServerVar<usize> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_shrink_allocated_buffers_by_ratio"),
-        value: mz_rocksdb_types::defaults::DEFAULT_SHRINK_BUFFERS_BY_RATIO,
-        description:
-            "The number of times by which allocated buffers will be shrinked in upsert rocksdb.",
-        internal: true,
-    };
-    /// Only used if `upsert_rocksdb_write_buffer_manager_memory_bytes` is also set
-    /// and write buffer manager is enabled
-    pub static UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_CLUSTER_MEMORY_FRACTION: Lazy<
-        ServerVar<Option<Numeric>>,
-    > = Lazy::new(|| ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_write_buffer_manager_cluster_memory_fraction"),
-        value: None,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    });
-    /// `upsert_rocksdb_write_buffer_manager_memory_bytes` needs to be set for write buffer manager to be
-    /// used.
-    pub static UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_MEMORY_BYTES: ServerVar<Option<usize>> =
-        ServerVar {
-            name: UncasedStr::new("upsert_rocksdb_write_buffer_manager_memory_bytes"),
-            value: None,
-            description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-            internal: true,
-        };
-    pub static UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_ALLOW_STALL: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_write_buffer_manager_allow_stall"),
-        value: false,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-}
-
-static LOGGING_FILTER: Lazy<ServerVar<CloneableEnvFilter>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("log_filter"),
-    value: CloneableEnvFilter::from_str("info").expect("valid EnvFilter"),
-    description: "Sets the filter to apply to stderr logging.",
-    internal: true,
-});
-
-static OPENTELEMETRY_FILTER: Lazy<ServerVar<CloneableEnvFilter>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("opentelemetry_filter"),
-    value: CloneableEnvFilter::from_str("off").expect("valid EnvFilter"),
-    description: "Sets the filter to apply to OpenTelemetry-backed distributed tracing.",
-    internal: true,
-});
-
-static LOGGING_FILTER_DEFAULTS: Lazy<ServerVar<Vec<SerializableDirective>>> =
-    Lazy::new(|| ServerVar {
-        name: UncasedStr::new("log_filter_defaults"),
-        value: mz_ore::tracing::LOGGING_DEFAULTS
-            .iter()
-            .map(|d| d.clone().into())
-            .collect(),
-        description: "Sets additional default directives to apply to stderr logging. \
-            These apply to all variations of `log_filter`. Directives other than \
-            `module=off` are likely incorrect.",
-        internal: true,
-    });
-
-static OPENTELEMETRY_FILTER_DEFAULTS: Lazy<ServerVar<Vec<SerializableDirective>>> =
-    Lazy::new(|| ServerVar {
-        name: UncasedStr::new("opentelemetry_filter_defaults"),
-        value: mz_ore::tracing::OPENTELEMETRY_DEFAULTS
-            .iter()
-            .map(|d| d.clone().into())
-            .collect(),
-        description: "Sets additional default directives to apply to OpenTelemetry-backed \
-            distributed tracing. \
-            These apply to all variations of `opentelemetry_filter`. Directives other than \
-            `module=off` are likely incorrect.",
-        internal: true,
-    });
-
-static SENTRY_FILTERS: Lazy<ServerVar<Vec<SerializableDirective>>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("sentry_filters"),
-    value: mz_ore::tracing::SENTRY_DEFAULTS
-        .iter()
-        .map(|d| d.clone().into())
-        .collect(),
-    description: "Sets additional default directives to apply to sentry logging. \
-            These apply on top of a default `info` directive. Directives other than \
-            `module=off` are likely incorrect.",
-    internal: true,
-});
-
-static WEBHOOKS_SECRETS_CACHING_TTL_SECS: Lazy<ServerVar<usize>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("webhooks_secrets_caching_ttl_secs"),
-    value: usize::cast_from(
-        mz_secrets::cache::DEFAULT_TTL_SECS.load(std::sync::atomic::Ordering::Relaxed),
-    ),
-    description: "Sets the time-to-live for values in the Webhooks secrets cache.",
-    internal: true,
-});
-
-const COORD_SLOW_MESSAGE_WARN_THRESHOLD: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("coord_slow_message_warn_threshold"),
-    // Note(parkmycar): This value was chosen arbitrarily.
-    value: Duration::from_secs(5),
-    description: "Sets the threshold at which we will warn! for a coordinator message being slow.",
-    internal: true,
-};
-
-/// Controls the connect_timeout setting when connecting to PG via `mz_postgres_util`.
-const PG_SOURCE_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_source_connect_timeout"),
-    value: mz_postgres_util::DEFAULT_CONNECT_TIMEOUT,
-    description: "Sets the timeout applied to socket-level connection attempts for PG \
-    replication connections. (Materialize)",
-    internal: true,
-};
-
-/// Sets the maximum number of TCP keepalive probes that will be sent before dropping a connection
-/// when connecting to PG via `mz_postgres_util`.
-const PG_SOURCE_KEEPALIVES_RETRIES: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("pg_source_keepalives_retries"),
-    value: mz_postgres_util::DEFAULT_KEEPALIVE_RETRIES,
-    description:
-        "Sets the maximum number of TCP keepalive probes that will be sent before dropping \
-    a connection when connecting to PG via `mz_postgres_util`. (Materialize)",
-    internal: true,
-};
-
-/// Sets the amount of idle time before a keepalive packet is sent on the connection when connecting
-/// to PG via `mz_postgres_util`.
-const PG_SOURCE_KEEPALIVES_IDLE: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_source_keepalives_idle"),
-    value: mz_postgres_util::DEFAULT_KEEPALIVE_IDLE,
-    description:
-        "Sets the amount of idle time before a keepalive packet is sent on the connection \
-    when connecting to PG via `mz_postgres_util`. (Materialize)",
-    internal: true,
-};
-
-/// Sets the time interval between TCP keepalive probes when connecting to PG via `mz_postgres_util`.
-const PG_SOURCE_KEEPALIVES_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_source_keepalives_interval"),
-    value: mz_postgres_util::DEFAULT_KEEPALIVE_INTERVAL,
-    description: "Sets the time interval between TCP keepalive probes when connecting to PG via \
-    replication. (Materialize)",
-    internal: true,
-};
-
-/// Sets the TCP user timeout when connecting to PG via `mz_postgres_util`.
-const PG_SOURCE_TCP_USER_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_source_tcp_user_timeout"),
-    value: mz_postgres_util::DEFAULT_TCP_USER_TIMEOUT,
-    description:
-        "Sets the TCP user timeout when connecting to PG via `mz_postgres_util`. (Materialize)",
-    internal: true,
-};
-
-/// Sets the `statement_timeout` value to use during the snapshotting phase of
-/// PG sources.
-const PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_source_snapshot_statement_timeout"),
-    value: mz_postgres_util::DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT,
-    description: "Sets the `statement_timeout` value to use during the snapshotting phase of PG sources (Materialize)",
-    internal: true,
-};
-
-/// Please see `PgSourceSnapshotConfig`.
-const PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("pg_source_snapshot_collect_strict_count"),
-    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().collect_strict_count,
-    description: "Please see <https://dev.materialize.com/api/rust-private\
-        /mz_storage_types/parameters\
-        /struct.PgSourceSnapshotConfig.html#structfield.collect_strict_count>",
-    internal: true,
-};
-/// Please see `PgSourceSnapshotConfig`.
-const PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("pg_source_snapshot_fallback_to_strict_count"),
-    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().fallback_to_strict_count,
-    description: "Please see <https://dev.materialize.com/api/rust-private\
-        /mz_storage_types/parameters\
-        /struct.PgSourceSnapshotConfig.html#structfield.fallback_to_strict_count>",
-    internal: true,
-};
-/// Please see `PgSourceSnapshotConfig`.
-const PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("pg_source_snapshot_wait_for_count"),
-    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().wait_for_count,
-    description: "Please see <https://dev.materialize.com/api/rust-private\
-        /mz_storage_types/parameters\
-        /struct.PgSourceSnapshotConfig.html#structfield.wait_for_count>",
-    internal: true,
-};
-
-/// Controls the check interval for connections to SSH bastions via `mz_ssh_util`.
-const SSH_CHECK_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("ssh_check_interval"),
-    value: mz_ssh_util::tunnel::DEFAULT_CHECK_INTERVAL,
-    description: "Controls the check interval for connections to SSH bastions via `mz_ssh_util`.",
-    internal: true,
-};
-
-/// Controls the connect timeout for connections to SSH bastions via `mz_ssh_util`.
-const SSH_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("ssh_connect_timeout"),
-    value: mz_ssh_util::tunnel::DEFAULT_CONNECT_TIMEOUT,
-    description: "Controls the connect timeout for connections to SSH bastions via `mz_ssh_util`.",
-    internal: true,
-};
-
-/// Controls the keepalive idle interval for connections to SSH bastions via `mz_ssh_util`.
-const SSH_KEEPALIVES_IDLE: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("ssh_keepalives_idle"),
-    value: mz_ssh_util::tunnel::DEFAULT_KEEPALIVES_IDLE,
-    description:
-        "Controls the keepalive idle interval for connections to SSH bastions via `mz_ssh_util`.",
-    internal: true,
-};
-
-/// Enables `socket.keepalive.enable` for rdkafka client connections. Defaults to true.
-const KAFKA_SOCKET_KEEPALIVE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("kafka_socket_keepalive"),
-    value: mz_kafka_util::client::DEFAULT_KEEPALIVE,
-    description:
-        "Enables `socket.keepalive.enable` for rdkafka client connections. Defaults to true.",
-    internal: true,
-};
-
-/// Controls `socket.timeout.ms` for rdkafka client connections. Defaults to the rdkafka default
-/// (60000ms). Cannot be greater than 300000ms, more than 100ms greater than
-/// `kafka_transaction_timeout`, or less than 10ms.
-const KAFKA_SOCKET_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_socket_timeout"),
-    value: mz_kafka_util::client::DEFAULT_SOCKET_TIMEOUT,
-    description: "Controls `socket.timeout.ms` for rdkafka \
-        client connections. Defaults to the rdkafka default (60000ms). \
-        Cannot be greater than 300000ms or more than 100ms greater than \
-        Cannot be greater than 300000ms, more than 100ms greater than \
-        `kafka_transaction_timeout`, or less than 10ms.",
-    internal: true,
-};
-
-/// Controls `transaction.timeout.ms` for rdkafka client connections. Defaults to the rdkafka default
-/// (60000ms). Cannot be greater than `i32::MAX` or less than 1000ms.
-const KAFKA_TRANSACTION_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_transaction_timeout"),
-    value: mz_kafka_util::client::DEFAULT_TRANSACTION_TIMEOUT,
-    description: "Controls `transaction.timeout.ms` for rdkafka \
-        client connections. Defaults to the rdkafka default (60000ms). \
-        Cannot be greater than `i32::MAX` or less than 1000ms.",
-    internal: true,
-};
-
-/// Controls `socket.connection.setup.timeout.ms` for rdkafka client connections. Defaults to the rdkafka default
-/// (30000ms). Cannot be greater than `i32::MAX` or less than 1000ms
-const KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_socket_connection_setup_timeout"),
-    value: mz_kafka_util::client::DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT,
-    description: "Controls `socket.connection.setup.timeout.ms` for rdkafka \
-        client connections. Defaults to the rdkafka default (30000ms). \
-        Cannot be greater than `i32::MAX` or less than 1000ms",
-    internal: true,
-};
-
-/// Controls the timeout when fetching kafka metadata. Defaults to 10s.
-const KAFKA_FETCH_METADATA_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_fetch_metadata_timeout"),
-    value: mz_kafka_util::client::DEFAULT_FETCH_METADATA_TIMEOUT,
-    description: "Controls the timeout when fetching kafka metadata. \
-        Defaults to 10s.",
-    internal: true,
-};
-
-/// Controls the timeout when fetching kafka progress records. Defaults to 60s.
-const KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_progress_record_fetch_timeout"),
-    value: mz_kafka_util::client::DEFAULT_PROGRESS_RECORD_FETCH_TIMEOUT,
-    description: "Controls the timeout when fetching kafka progress records. \
-        Defaults to 60s.",
-    internal: true,
-};
-
-/// The interval we will fetch metadata from, unless overridden by the source.
-const KAFKA_DEFAULT_METADATA_FETCH_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_default_metadata_fetch_interval"),
-    value: mz_kafka_util::client::DEFAULT_METADATA_FETCH_INTERVAL,
-    description: "The interval we will fetch metadata from, unless overridden by the source. \
-        Defaults to 60s.",
-    internal: true,
-};
-
-/// The maximum number of in-flight bytes emitted by persist_sources feeding compute dataflows.
-const COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar {
-    name: UncasedStr::new("compute_dataflow_max_inflight_bytes"),
-    value: None,
-    description: "The maximum number of in-flight bytes emitted by persist_sources feeding \
-                  compute dataflows (Materialize).",
-    internal: true,
-};
-
-/// The maximum number of in-flight bytes emitted by persist_sources feeding _storage
-/// dataflows_.
-/// Currently defaults to 256MiB = 268435456 bytes
-/// Note: Backpressure will only be turned on if disk is enabled based on
-/// `storage_dataflow_max_inflight_bytes_disk_only` flag
-const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar {
-    name: UncasedStr::new("storage_dataflow_max_inflight_bytes"),
-    value: Some(256 * 1024 * 1024),
-    description: "The maximum number of in-flight bytes emitted by persist_sources feeding \
-                  storage dataflows. Defaults to backpressure enabled (Materialize).",
-    internal: true,
-};
-
-/// Whether or not to delay sources producing values in some scenarios
-/// (namely, upsert) till after rehydration is finished.
-const STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("storage_dataflow_delay_sources_past_rehydration"),
-    value: false,
-    description: "Whether or not to delay sources producing values in some scenarios \
-                  (namely, upsert) till after rehydration is finished",
-    internal: true,
-};
-
-/// Configuration ratio to shrink unusef buffers in upsert by.
-/// For eg: is 2 is set, then the buffers will be reduced by 2 i.e. halved.
-/// Default is 0, which means shrinking is disabled.
-const STORAGE_SHRINK_UPSERT_UNUSED_BUFFERS_BY_RATIO: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("storage_shrink_upsert_unused_buffers_by_ratio"),
-    value: 0,
-    description: "Configuration ratio to shrink unusef buffers in upsert by",
-    internal: true,
-};
-
-/// The fraction of the cluster replica size to be used as the maximum number of
-/// in-flight bytes emitted by persist_sources feeding storage dataflows.
-/// If not configured, the storage_dataflow_max_inflight_bytes value will be used.
-/// For this value to be used storage_dataflow_max_inflight_bytes needs to be set.
-pub static STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION: Lazy<
-    ServerVar<Option<Numeric>>,
-> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("storage_dataflow_max_inflight_bytes_to_cluster_size_fraction"),
-    value: Some(0.0025.into()),
-    description: "The fraction of the cluster replica size to be used as the maximum number of \
-    in-flight bytes emitted by persist_sources feeding storage dataflows. \
-    If not configured, the storage_dataflow_max_inflight_bytes value will be used.",
-    internal: true,
-});
-
-const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("storage_dataflow_max_inflight_bytes_disk_only"),
-    value: true,
-    description: "Whether or not `storage_dataflow_max_inflight_bytes` applies only to \
-        upsert dataflows using disks. Defaults to true (Materialize).",
-    internal: true,
-};
-
-/// The interval to submit statistics to `mz_source_statistics_raw` and `mz_sink_statistics_raw`.
-const STORAGE_STATISTICS_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("storage_statistics_interval"),
-    value: mz_storage_types::parameters::STATISTICS_INTERVAL_DEFAULT,
-    description: "The interval to submit statistics to `mz_source_statistics_raw` \
-        and `mz_sink_statistics` (Materialize).",
-    internal: true,
-};
-
-/// The interval to collect statistics for `mz_source_statistics_raw` and `mz_sink_statistics_raw` in
-/// clusterd. Controls the accuracy of metrics.
-const STORAGE_STATISTICS_COLLECTION_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("storage_statistics_collection_interval"),
-    value: mz_storage_types::parameters::STATISTICS_COLLECTION_INTERVAL_DEFAULT,
-    description: "The interval to collect statistics for `mz_source_statistics_raw` \
-        and `mz_sink_statistics_raw` in clusterd. Controls the accuracy of metrics \
-        (Materialize).",
-    internal: true,
-};
-
-const STORAGE_RECORD_SOURCE_SINK_NAMESPACED_ERRORS: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("storage_record_source_sink_namespaced_errors"),
-    value: true,
-    description: "Whether or not to record namespaced errors in the status history tables",
-    internal: true,
-};
-
-/// Boolean flag indicating whether to enable syncing from
-/// LaunchDarkly. Can be turned off as an emergency measure to still
-/// be able to alter parameters while LD is broken.
-pub static ENABLE_LAUNCHDARKLY: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_launchdarkly"),
-    value: true,
-    description: "Boolean flag indicating whether flag synchronization from LaunchDarkly should be enabled (Materialize).",
-    internal: true
-};
-
-/// Feature flag indicating whether real time recency is enabled. Not that
-/// unlike other feature flags, this is made available at the session level, so
-/// is additionally gated by a feature flag.
-static REAL_TIME_RECENCY: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("real_time_recency"),
-    value: false,
-    description: "Feature flag indicating whether real time recency is enabled (Materialize).",
-    internal: false,
-};
-
-static EMIT_TIMESTAMP_NOTICE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("emit_timestamp_notice"),
-    value: false,
-    description:
-        "Boolean flag indicating whether to send a NOTICE with timestamp explanations of queries (Materialize).",
-    internal: false
-};
-
-static EMIT_TRACE_ID_NOTICE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("emit_trace_id_notice"),
-    value: false,
-    description:
-        "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize).",
-    internal: false
-};
-
-static UNSAFE_MOCK_AUDIT_EVENT_TIMESTAMP: ServerVar<Option<mz_repr::Timestamp>> = ServerVar {
-    name: UncasedStr::new("unsafe_mock_audit_event_timestamp"),
-    value: None,
-    description: "Mocked timestamp to use for audit events for testing purposes",
-    internal: true,
-};
-
-pub const ENABLE_RBAC_CHECKS: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_rbac_checks"),
-    value: true,
-    description: "User facing global boolean flag indicating whether to apply RBAC checks before \
-    executing statements (Materialize).",
-    internal: false,
-};
-
-pub const ENABLE_SESSION_RBAC_CHECKS: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_session_rbac_checks"),
-    // TODO(jkosh44) Once RBAC is complete, change this to `true`.
-    value: false,
-    description: "User facing session boolean flag indicating whether to apply RBAC checks before \
-    executing statements (Materialize).",
-    internal: false,
-};
-
-pub const EMIT_INTROSPECTION_QUERY_NOTICE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("emit_introspection_query_notice"),
-    value: true,
-    description: "Whether to print a notice when querying per-replica introspection sources.",
-    internal: false,
-};
-
-// TODO(mgree) change this to a SelectOption
-pub const ENABLE_SESSION_CARDINALITY_ESTIMATES: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_session_cardinality_estimates"),
-    value: false,
-    description:
-        "Feature flag indicating whether to use cardinality estimates when optimizing queries; \
-    does not affect EXPLAIN WITH(cardinality) (Materialize).",
-    internal: false,
-};
-
-const OPTIMIZER_STATS_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("optimizer_stats_timeout"),
-    value: Duration::from_millis(250),
-    description: "Sets the timeout applied to the optimizer's statistics collection from storage; \
-    applied to non-oneshot, i.e., long-lasting queries, like CREATE MATERIALIZED VIEW (Materialize).",
-    internal: true,
-};
-
-const OPTIMIZER_ONESHOT_STATS_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("optimizer_oneshot_stats_timeout"),
-    value: Duration::from_millis(20),
-    description: "Sets the timeout applied to the optimizer's statistics collection from storage; \
-    applied to oneshot queries, like SELECT (Materialize).",
-    internal: true,
-};
-
-const PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("privatelink_status_update_quota_per_minute"),
-    value: 20,
-    description: "Sets the per-minute quota for privatelink vpc status updates to be written to \
-    the storage-collection-backed system table. This value implies the total and burst quota per-minute.",
-    internal: true,
-};
-
-pub static STATEMENT_LOGGING_SAMPLE_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| {
-    ServerVar {
-    name: UncasedStr::new("statement_logging_sample_rate"),
-    value: 0.1.into(),
-    description: "User-facing session variable indicating how many statement executions should be \
-    logged, subject to constraint by the system variable `statement_logging_max_sample_rate` (Materialize).",
-    internal: false,
-}
-});
-
-/// Whether compute rendering should use Materialize's custom linear join implementation rather
-/// than the one from Differential Dataflow.
-const ENABLE_MZ_JOIN_CORE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_mz_join_core"),
-    value: true,
-    description:
-        "Feature flag indicating whether compute rendering should use Materialize's custom linear \
-         join implementation rather than the one from Differential Dataflow. (Materialize).",
-    internal: true,
-};
-
-pub static DEFAULT_LINEAR_JOIN_YIELDING: Lazy<String> =
-    Lazy::new(|| "work:1000000,time:100".into());
-static LINEAR_JOIN_YIELDING: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("linear_join_yielding"),
-    value: DEFAULT_LINEAR_JOIN_YIELDING.clone(),
-    description:
-        "The yielding behavior compute rendering should apply for linear join operators. Either \
-         'work:<amount>' or 'time:<milliseconds>' or 'work:<amount>,time:<milliseconds>'. Note \
-         that omitting one of 'work' or 'time' will entirely disable join yielding by time or \
-         work, respectively, rather than falling back to some default.",
-    internal: true,
-});
-
-pub const DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("default_idle_arrangement_merge_effort"),
-    value: 0,
-    description:
-        "The default value to use for the `IDLE ARRANGEMENT MERGE EFFORT` cluster/replica option.",
-    internal: true,
-};
-
-pub const DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("default_arrangement_exert_proportionality"),
-    value: 16,
-    description:
-        "The default value to use for the `ARRANGEMENT EXERT PROPORTIONALITY` cluster/replica option.",
-    internal: true,
-};
-
-pub const ENABLE_DEFAULT_CONNECTION_VALIDATION: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_default_connection_validation"),
-    value: true,
-    description:
-        "LD facing global boolean flag that allows turning default connection validation off for everyone (Materialize).",
-    internal: true,
-};
-
-pub static STATEMENT_LOGGING_MAX_DATA_CREDIT: Lazy<ServerVar<Option<usize>>> = Lazy::new(|| {
-    ServerVar {
-    name: UncasedStr::new("statement_logging_max_data_credit"),
-    value: None,
-    // The idea is that during periods of low logging, tokens can accumulate up to this value,
-    // and then be depleted during periods of high logging.
-    description: "The maximum number of bytes that can be logged for statement logging in short burts, or NULL if unlimited (Materialize).",
-    internal: true,
-}
-});
-
-pub static STATEMENT_LOGGING_TARGET_DATA_RATE: Lazy<ServerVar<Option<usize>>> = Lazy::new(|| {
-    ServerVar {
-    name: UncasedStr::new("statement_logging_target_data_rate"),
-    value: None,
-    description: "The maximum sustained data rate of statement logging, in bytes per second, or NULL if unlimited (Materialize).",
-    internal: true,
-}
-});
-
-pub static STATEMENT_LOGGING_MAX_SAMPLE_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("statement_logging_max_sample_rate"),
-    value: 0.0.into(),
-    description: "The maximum rate at which statements may be logged. If this value is less than \
-that of `statement_logging_sample_rate`, the latter is ignored (Materialize).",
-    internal: false,
-});
-
-pub static STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE: Lazy<ServerVar<Numeric>> =
-    Lazy::new(|| ServerVar {
-        name: UncasedStr::new("statement_logging_default_sample_rate"),
-        value: 0.0.into(),
-        description:
-            "The default value of `statement_logging_sample_rate` for new sessions (Materialize).",
-        internal: false,
-    });
-
-pub const AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("auto_route_introspection_queries"),
-    value: true,
-    description:
-        "Whether to force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize).",
-    internal: false
-};
-
-pub const MAX_CONNECTIONS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_connections"),
-    value: 1000,
-    description: "The maximum number of concurrent connections (Materialize).",
-    internal: false,
-};
-
-/// Controls [`mz_storage_types::parameters::StorageParameters::keep_n_source_status_history_entries`].
-const KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("keep_n_source_status_history_entries"),
-    value: 5,
-    description: "On reboot, truncate all but the last n entries per ID in the source_status_history collection (Materialize).",
-    internal: true
-};
-
-/// Controls [`mz_storage_types::parameters::StorageParameters::keep_n_sink_status_history_entries`].
-const KEEP_N_SINK_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("keep_n_sink_status_history_entries"),
-    value: 5,
-    description: "On reboot, truncate all but the last n entries per ID in the sink_status_history collection (Materialize).",
-    internal: true
-};
-
-/// Controls [`mz_storage_types::parameters::StorageParameters::keep_n_privatelink_status_history_entries`].
-const KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("keep_n_privatelink_status_history_entries"),
-    value: 5,
-    description: "On reboot, truncate all but the last n entries per ID in the mz_aws_privatelink_connection_status_history \
-    collection (Materialize).",
-    internal: true
-};
-
-const ENABLE_STORAGE_SHARD_FINALIZATION: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_storage_shard_finalization"),
-    value: true,
-    description: "Whether to allow the storage client to finalize shards (Materialize).",
-    internal: true,
-};
-
-pub const ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_consolidate_after_union_negate"),
-    value: true,
-    description: "consolidation after Unions that have a Negated input (Materialize).",
-    internal: false,
-};
-
-pub const MIN_TIMESTAMP_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("min_timestamp_interval"),
-    value: Duration::from_millis(1000),
-    description: "Minimum timestamp interval",
-    internal: true,
-};
-
-pub const MAX_TIMESTAMP_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("max_timestamp_interval"),
-    value: Duration::from_millis(1000),
-    description: "Maximum timestamp interval",
-    internal: true,
-};
-
-pub const WEBHOOK_CONCURRENT_REQUEST_LIMIT: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("webhook_concurrent_request_limit"),
-    value: WEBHOOK_CONCURRENCY_LIMIT,
-    description: "Maximum number of concurrent requests for appending to a webhook source.",
-    internal: true,
-};
-
-pub const ENABLE_COLUMNATION_LGALLOC: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_columnation_lgalloc"),
-    value: false,
-    description: "Enable allocating regions from lgalloc",
-    internal: true,
-};
-
-pub const ENABLE_COMPUTE_CHUNKED_STACK: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_compute_chunked_stack"),
-    value: false,
-    description: "Enable the chunked stack implementation in compute",
-    internal: true,
-};
-
-pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_statement_lifecycle_logging"),
-    value: false,
-    description:
-        "Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history",
-    internal: true,
-};
-
-const ENABLE_DEPENDENCY_READ_HOLD_ASSERTS: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_dependency_read_hold_asserts"),
-    value: true,
-    description:
-        "Whether to have the storage client check if a subsource's implied capability is less than \
-        its write frontier. This should only be set to false in cases where customer envs cannot
-        boot (Materialize).",
-    internal: true,
-};
-
-/// Configuration for gRPC client connections.
-mod grpc_client {
-    use super::*;
-
-    pub const CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
-        name: UncasedStr::new("grpc_client_connect_timeout"),
-        value: Duration::from_secs(5),
-        description: "Timeout to apply to initial gRPC client connection establishment.",
-        internal: true,
-    };
-    pub const HTTP2_KEEP_ALIVE_INTERVAL: ServerVar<Duration> = ServerVar {
-        name: UncasedStr::new("grpc_client_http2_keep_alive_interval"),
-        value: Duration::from_secs(3),
-        description: "Idle time to wait before sending HTTP/2 PINGs to maintain established gRPC client connections.",
-        internal: true,
-    };
-    pub const HTTP2_KEEP_ALIVE_TIMEOUT: ServerVar<Duration> = ServerVar {
-        name: UncasedStr::new("grpc_client_http2_keep_alive_timeout"),
-        value: Duration::from_secs(5),
-        description:
-            "Time to wait for HTTP/2 pong response before terminating a gRPC client connection.",
-        internal: true,
-    };
-}
-
-/// Configuration for how cluster replicas are scheduled.
-mod cluster_scheduling {
-    use super::*;
-    use mz_orchestrator::scheduling_config::*;
-
-    pub const CLUSTER_MULTI_PROCESS_REPLICA_AZ_AFFINITY_WEIGHT: ServerVar<Option<i32>> =
-        ServerVar {
-            name: UncasedStr::new("cluster_multi_process_replica_az_affinity_weight"),
-            value: DEFAULT_POD_AZ_AFFINITY_WEIGHT,
-            description:
-                "Whether or not to add an availability zone affinity between instances of \
-            multi-process replicas. Either an affinity weight or empty (off) (Materialize).",
-            internal: true,
-        };
-
-    pub const CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("cluster_soften_replication_anti_affinity"),
-        value: DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY,
-        description: "Whether or not to turn the node-scope anti affinity between replicas \
-            in the same cluster into a preference (Materialize).",
-        internal: true,
-    };
-
-    pub const CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT: ServerVar<i32> = ServerVar {
-        name: UncasedStr::new("cluster_soften_replication_anti_affinity_weight"),
-        value: DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT,
-        description:
-            "The preference weight for `cluster_soften_replication_anti_affinity` (Materialize).",
-        internal: true,
-    };
-
-    pub const CLUSTER_ENABLE_TOPOLOGY_SPREAD: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("cluster_enable_topology_spread"),
-        value: DEFAULT_TOPOLOGY_SPREAD_ENABLED,
-        description:
-            "Whether or not to add topology spread constraints among replicas in the same cluster (Materialize).",
-        internal: true,
-    };
-
-    pub const CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("cluster_topology_spread_ignore_non_singular_scale"),
-        value: DEFAULT_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE,
-        description:
-            "If true, ignore replicas with more than 1 process when adding topology spread constraints (Materialize).",
-        internal: true,
-    };
-
-    pub const CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW: ServerVar<i32> = ServerVar {
-        name: UncasedStr::new("cluster_topology_spread_max_skew"),
-        value: DEFAULT_TOPOLOGY_SPREAD_MAX_SKEW,
-        description: "The `maxSkew` for replica topology spread constraints (Materialize).",
-        internal: true,
-    };
-
-    pub const CLUSTER_TOPOLOGY_SPREAD_SOFT: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("cluster_topology_spread_soft"),
-        value: DEFAULT_TOPOLOGY_SPREAD_SOFT,
-        description: "If true, soften the topology spread constraints for replicas (Materialize).",
-        internal: true,
-    };
-
-    pub const CLUSTER_SOFTEN_AZ_AFFINITY: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("cluster_soften_az_affinity"),
-        value: DEFAULT_SOFTEN_AZ_AFFINITY,
-        description: "Whether or not to turn the az-scope node affinity for replicas. \
-            Note this could violate requests from the user (Materialize).",
-        internal: true,
-    };
-
-    pub const CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT: ServerVar<i32> = ServerVar {
-        name: UncasedStr::new("cluster_soften_az_affinity_weight"),
-        value: DEFAULT_SOFTEN_AZ_AFFINITY_WEIGHT,
-        description: "The preference weight for `cluster_soften_az_affinity` (Materialize).",
-        internal: true,
-    };
-
-    pub const CLUSTER_ALWAYS_USE_DISK: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("cluster_always_use_disk"),
-        value: DEFAULT_ALWAYS_USE_DISK,
-        description: "Always provisions a replica with disk, regardless of `DISK` DDL option.",
-        internal: true,
-    };
-}
-
-/// Macro to simplify creating feature flags, i.e. boolean flags that we use to toggle the
-/// availability of features.
-///
-/// The arguments to `feature_flags!` are:
-/// - `$name`, which will be the name of the feature flag, in snake_case,
-/// - `$feature_desc`, a human-readable description of the feature,
-/// - `$value`, which if not provided, defaults to `false` and also defaults `$internal` to `true`.
-/// - `$internal`, which if not provided, defaults to `true`. Requires `$value`.
-///
-/// Note that not all `ServerVar<bool>` are feature flags. Feature flags are for variables that:
-/// - Belong to `SystemVars`, _not_ `SessionVars`
-/// - Default to false and must be explicitly enabled, or default to `true` and can be explicitly disabled.
-///
-/// WARNING / CONTRACT: Syntax-related feature flags must always *enable* behavior. In other words,
-/// setting a feature flag must make the system more permissive. For example, let's suppose we'd like
-/// to gate deprecated upsert syntax behind a feature flag. In this case, do not add a feature flag
-/// like `disable_deprecated_upsert_syntax`, as `disable_deprecated_upsert_syntax = on` would
-/// _prevent_ the system from parsing the deprecated upsert syntax. Instead, use a feature flag
-/// like `enable_deprecated_upsert_syntax`.
-///
-/// The hazard this protects against is related to reboots after feature flags have been disabled.
-/// Say someone creates a Kinesis source while `enable_kinesis_sources = on`. Materialize will
-/// commit this source to the system catalog. Then, suppose we discover a catastrophic bug in
-/// Kinesis sources and set `enable_kinesis_sources` to `off`. This prevents users from creating
-/// new Kinesis sources, but leaves the existing Kinesis sources in place. This is because
-/// disabling a feature flag doesn't remove access to catalog objects created while the feature
-/// flag was live. On the next reboot, Materialize will proceed to load the Kinesis source from the
-/// catalog, reparsing and replanning the `CREATE SOURCE` definition and rechecking the
-/// `enable_kinesis_sources` feature flag along the way. Even though the feature flag has been
-/// switched to `off`, we need to temporarily re-enable it during parsing and planning to be able
-/// to boot successfully.
-///
-/// Ensuring that all syntax-related feature flags *enable* behavior means that setting all such
-/// feature flags to `on` during catalog boot has the desired effect.
-macro_rules! feature_flags {
-    // Match `$name, $feature_desc, $value, $internal`.
-    (@inner
-        // The feature flag name.
-        name: $name:expr,
-        // The feature flag description.
-        desc: $desc:literal,
-        // The feature flag default value.
-        default: $value:expr,
-        // Should this feature be visible only internally.
-        internal: $internal:expr,
-    ) => {
-        paste::paste!{
-            // Note that the ServerVar is not directly exported; we expect these to be
-            // accessible through their FeatureFlag variant.
-            static [<$name:upper _VAR>]: ServerVar<bool> = ServerVar {
-                name: UncasedStr::new(stringify!($name)),
-                value: $value,
-                description: concat!("Whether ", $desc, " is allowed (Materialize)."),
-                internal: $internal
-            };
-
-            pub static [<$name:upper >]: FeatureFlag = FeatureFlag {
-                flag: &[<$name:upper _VAR>],
-                feature_desc: $desc,
-            };
-        }
-    };
-    ($({
-        // The feature flag name.
-        name: $name:expr,
-        // The feature flag description.
-        desc: $desc:literal,
-        // The feature flag default value.
-        default: $value:expr,
-        // Should this feature be visible only internally.
-        internal: $internal:expr,
-        // Should the feature be turned on during catalog rehydration when
-        // parsing a catalog item.
-        enable_for_item_parsing: $enable_for_item_parsing:expr,
-    },)+) => {
-        $(feature_flags! { @inner
-            name: $name,
-            desc: $desc,
-            default: $value,
-            internal: $internal,
-        })+
-
-        paste::paste!{
-            impl SystemVars {
-                fn with_feature_flags(self) -> Self
-                {
-                    self
-                    $(
-                        .with_var(&[<$name:upper _VAR>])
-                    )+
-                }
-
-                pub fn enable_all_feature_flags_by_default(&mut self) {
-                    $(
-                        self.set_default(stringify!($name), VarInput::Flat("on"))
-                            .expect("setting default value must work");
-                    )+
-                }
-
-                pub fn enable_for_item_parsing(&mut self) {
-                    $(
-                        if $enable_for_item_parsing {
-                            self.set(stringify!($name), VarInput::Flat("on"))
-                                .expect("setting default value must work");
-                        }
-                    )+
-                }
-
-                $(
-                    pub fn [<$name:lower>](&self) -> bool {
-                        *self.expect_value(&[<$name:upper _VAR>])
-                    }
-                )+
-            }
-        }
-    }
-}
-
-feature_flags!(
-    // Gates for other feature flags
-    {
-        name: allow_real_time_recency,
-        desc: "real time recency",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    // Actual feature flags
-    {
-        name: enable_binary_date_bin,
-        desc: "the binary version of date_bin function",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_create_sink_denylist_with_options,
-        desc: "CREATE SINK with unsafe options",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_create_source_denylist_with_options,
-        desc: "CREATE SOURCE with unsafe options",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_date_bin_hopping,
-        desc: "the date_bin_hopping function",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_envelope_debezium_in_subscribe,
-        desc: "`ENVELOPE DEBEZIUM (KEY (..))`",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_envelope_materialize,
-        desc: "ENVELOPE MATERIALIZE",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_explain_pushdown,
-        desc: "EXPLAIN FILTER PUSHDOWN",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_index_options,
-        desc: "INDEX OPTIONS",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_list_length_max,
-        desc: "the list_length_max function",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_list_n_layers,
-        desc: "the list_n_layers function",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_list_remove,
-        desc: "the list_remove function",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-
-        name: enable_logical_compaction_window,
-        desc: "RETAIN HISTORY",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_primary_key_not_enforced,
-        desc: "PRIMARY KEY NOT ENFORCED",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_mfp_pushdown_explain,
-        desc: "`filter_pushdown` explain",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_multi_worker_storage_persist_sink,
-        desc: "multi-worker storage persist sink",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_persist_streaming_snapshot_and_fetch,
-        desc: "use the new streaming consolidate for snapshot_and_fetch",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_persist_streaming_compaction,
-        desc: "use the new streaming consolidate for compaction",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_raise_statement,
-        desc: "RAISE statement",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_repeat_row,
-        desc: "the repeat_row function",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_table_check_constraint,
-        desc: "CREATE TABLE with a check constraint",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_table_foreign_key,
-        desc: "CREATE TABLE with a foreign key",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_table_keys,
-        desc: "CREATE TABLE with a primary key or unique constraint",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_unorchestrated_cluster_replicas,
-        desc: "unorchestrated cluster replicas",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_unstable_dependencies,
-        desc: "depending on unstable objects",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_disk_cluster_replicas,
-        desc: "`WITH (DISK)` for cluster replicas",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_within_timestamp_order_by_in_subscribe,
-        desc: "`WITHIN TIMESTAMP ORDER BY ..`",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_cardinality_estimates,
-        desc: "join planning with cardinality estimates",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_connection_validation_syntax,
-        desc: "CREATE CONNECTION .. WITH (VALIDATE) and VALIDATE CONNECTION syntax",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_try_parse_monotonic_iso8601_timestamp,
-        desc: "the try_parse_monotonic_iso8601_timestamp function",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_alter_set_cluster,
-        desc: "ALTER ... SET CLUSTER syntax",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_unsafe_functions,
-        desc: "executing potentially dangerous functions",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_managed_cluster_availability_zones,
-        desc: "MANAGED, AVAILABILITY ZONES syntax",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: statement_logging_use_reproducible_rng,
-        desc: "statement logging with reproducible RNG",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_notices_for_index_already_exists,
-        desc: "emitting notices for IndexAlreadyExists (doesn't affect EXPLAIN)",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_notices_for_index_too_wide_for_literal_constraints,
-        desc: "emitting notices for IndexTooWideForLiteralConstraints (doesn't affect EXPLAIN)",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_notices_for_index_empty_key,
-        desc: "emitting notices for indexes with an empty key (doesn't affect EXPLAIN)",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_explain_broken,
-        desc: "EXPLAIN ... BROKEN <query> syntax",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_comment,
-        desc: "the COMMENT ON feature for objects",
-        default: true,
-        internal: false,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_sink_doc_on_option,
-        desc: "DOC ON option for sinks",
-        default: false,
-        internal: false,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_assert_not_null,
-        desc: "ASSERT NOT NULL for materialized views",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_alter_swap,
-        desc: "the ALTER SWAP feature for objects",
-        default: true,
-        internal: false,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_new_outer_join_lowering,
-        desc: "new outer join lowering",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: enable_default_kafka_ssh_tunnel,
-        desc: "the top-level SSH TUNNEL feature for kafka connections",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_default_kafka_aws_private_link,
-        desc: "the top-level Aws Privatelink feature for kafka connections",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_time_at_time_zone,
-        desc: "use of AT TIME ZONE or timezone() with time type",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_aws_connection,
-        desc: "CREATE CONNECTION ... TO AWS",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: enable_mysql_source,
-        desc: "Create a MySQL connection or source",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: enable_expressions_in_limit_syntax,
-        desc: "LIMIT <expr> syntax",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_mz_notices,
-        desc: "Populate the contents of `mz_internal.mz_notices`",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: enable_eager_delta_joins,
-        desc:
-            "eager delta joins",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: enable_off_thread_optimization,
-        desc: "use off-thread optimization in `CREATE` statements",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: enable_refresh_every_mvs,
-        desc: "REFRESH EVERY materialized views",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_reduce_mfp_fusion,
-        desc: "fusion of MFPs in reductions",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: enable_worker_core_affinity,
-        desc: "set core affinity for replica worker threads",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: wait_catalog_consolidation_on_startup,
-        desc: "When opening the Catalog, wait for consolidation to complete before returning",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: enable_copy_to_expr,
-        desc: "COPY ... TO 's3://...'",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: enable_compute_aggressive_readhold_downgrades,
-        desc: "let the compute controller aggressively downgrade read holds for sink dataflows",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: enable_session_timelines,
-        desc: "strong session serializable isolation levels",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: enable_compute_operator_hydration_status_logging,
-        desc: "log the hydration status of compute operators",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-);
 
 /// Represents the input to a variable.
 ///
@@ -2219,6 +151,222 @@ impl OwnedVarInput {
         match self {
             OwnedVarInput::Flat(v) => VarInput::Flat(v),
             OwnedVarInput::SqlSet(v) => VarInput::SqlSet(v),
+        }
+    }
+}
+
+/// A `Var` represents a configuration parameter of an arbitrary type.
+pub trait Var: Debug {
+    /// Returns the name of the configuration parameter.
+    fn name(&self) -> &'static str;
+
+    /// Constructs a flattened string representation of the current value of the
+    /// configuration parameter.
+    ///
+    /// The resulting string is guaranteed to be parsable if provided to
+    /// `Value::parse` as a [`VarInput::Flat`].
+    fn value(&self) -> String;
+
+    /// Returns a short sentence describing the purpose of the configuration
+    /// parameter.
+    fn description(&self) -> &'static str;
+
+    /// Returns the name of the type of this variable.
+    fn type_name(&self) -> String;
+
+    /// Indicates wither the [`Var`] is visible as a function of the `user` and `system_vars`.
+    /// "Invisible" parameters return `VarErrors`.
+    ///
+    /// Variables marked as `internal` are only visible for the system user.
+    fn visible(&self, user: &User, system_vars: Option<&SystemVars>) -> Result<(), VarError>;
+}
+
+/// A `SessionVar` is the session value for a configuration parameter. If unset,
+/// the server default is used instead.
+#[derive(Debug)]
+struct SessionVar<V>
+where
+    V: Value + ToOwned + Debug + PartialEq + 'static,
+{
+    /// Value compiled into the binary.
+    parent: ServerVar<V>,
+    /// Sysetm or Role default value.
+    default_value: Option<V::Owned>,
+    /// Value `LOCAL` to a transaction, will be unset at the completion of the transaction.
+    local_value: Option<V::Owned>,
+    /// Value set during a transaction, will be set if the transaction is committed.
+    staged_value: Option<V::Owned>,
+    /// Value that overrides the default.
+    session_value: Option<V::Owned>,
+    feature_flag: Option<&'static FeatureFlag>,
+    constraints: Vec<ValueConstraint<V>>,
+}
+
+impl<V> SessionVar<V>
+where
+    V: Value + Clone + Debug + PartialEq + 'static,
+    V::Owned: Debug + Send + Sync,
+{
+    fn new(parent: &ServerVar<V>) -> SessionVar<V> {
+        SessionVar {
+            default_value: None,
+            local_value: None,
+            staged_value: None,
+            session_value: None,
+            parent: parent.clone(),
+            feature_flag: None,
+            constraints: vec![],
+        }
+    }
+
+    fn add_feature_flag(mut self, flag: &'static FeatureFlag) -> Self {
+        self.feature_flag = Some(flag);
+        self
+    }
+
+    fn with_value_constraint(mut self, c: ValueConstraint<V>) -> SessionVar<V> {
+        assert!(
+            !self
+                .constraints
+                .iter()
+                .any(|c| matches!(c, ValueConstraint::ReadOnly | ValueConstraint::Fixed)),
+            "fixed value and read only params do not support any other constraints"
+        );
+        self.constraints.push(c);
+        self
+    }
+
+    fn check_constraints(&self, v: &V::Owned) -> Result<(), VarError> {
+        let cur_v = self.value();
+        for constraint in &self.constraints {
+            constraint.check_constraint(self, cur_v, v)?;
+        }
+
+        Ok(())
+    }
+
+    fn value(&self) -> &V {
+        self.local_value
+            .as_ref()
+            .map(|v| v.borrow())
+            .or_else(|| self.staged_value.as_ref().map(|v| v.borrow()))
+            .or_else(|| self.session_value.as_ref().map(|v| v.borrow()))
+            .or_else(|| self.default_value.as_ref().map(|v| v.borrow()))
+            .unwrap_or(&self.parent.value)
+    }
+}
+
+impl<V> Var for SessionVar<V>
+where
+    V: Value + Clone + Debug + PartialEq + 'static,
+    V::Owned: Debug + Send + Sync,
+{
+    fn name(&self) -> &'static str {
+        self.parent.name()
+    }
+
+    fn value(&self) -> String {
+        SessionVar::value(self).format()
+    }
+
+    fn description(&self) -> &'static str {
+        self.parent.description()
+    }
+
+    fn type_name(&self) -> String {
+        V::type_name()
+    }
+
+    fn visible(&self, user: &User, system_vars: Option<&SystemVars>) -> Result<(), VarError> {
+        if let Some(flag) = self.feature_flag {
+            flag.enabled(system_vars, None, None)?;
+        }
+
+        self.parent.visible(user, system_vars)
+    }
+}
+
+/// A `Var` with additional methods for mutating the value, as well as
+/// helpers that enable various operations in a `dyn` context.
+pub trait SessionVarMut: Var + Send + Sync {
+    /// Upcast to Var, for use with `dyn`.
+    fn as_var(&self) -> &dyn Var;
+
+    fn value_any(&self) -> &(dyn Any + 'static);
+
+    /// Parse the input and update the stored value to match.
+    fn set(&mut self, input: VarInput, local: bool) -> Result<(), VarError>;
+
+    /// Sets the default value for the variable.
+    fn set_default(&mut self, value: VarInput) -> Result<(), VarError>;
+
+    /// Reset the stored value to the default.
+    fn reset(&mut self, local: bool);
+
+    fn end_transaction(&mut self, action: EndTransactionAction);
+}
+
+impl<V> SessionVarMut for SessionVar<V>
+where
+    V: Value + Clone + Debug + PartialEq + 'static,
+    V::Owned: Debug + Clone + Send + Sync,
+{
+    /// Upcast to Var, for use with `dyn`.
+    fn as_var(&self) -> &dyn Var {
+        self
+    }
+
+    fn value_any(&self) -> &(dyn Any + 'static) {
+        let value = SessionVar::value(self);
+        value
+    }
+
+    /// Parse the input and update the stored value to match.
+    fn set(&mut self, input: VarInput, local: bool) -> Result<(), VarError> {
+        let v = V::parse(self, input)?;
+
+        self.check_constraints(&v)?;
+
+        if local {
+            self.local_value = Some(v);
+        } else {
+            self.local_value = None;
+            self.staged_value = Some(v);
+        }
+        Ok(())
+    }
+
+    /// Sets the default value for the variable.
+    fn set_default(&mut self, input: VarInput) -> Result<(), VarError> {
+        let v = V::parse(self, input)?;
+        self.check_constraints(&v)?;
+        self.default_value = Some(v);
+        Ok(())
+    }
+
+    /// Reset the stored value to the default.
+    fn reset(&mut self, local: bool) {
+        let value = self
+            .default_value
+            .as_ref()
+            .map(|v| v.borrow())
+            .unwrap_or(&self.parent.value)
+            .to_owned();
+        if local {
+            self.local_value = Some(value);
+        } else {
+            self.local_value = None;
+            self.staged_value = Some(value);
+        }
+    }
+
+    fn end_transaction(&mut self, action: EndTransactionAction) {
+        self.local_value = None;
+        match action {
+            EndTransactionAction::Commit if self.staged_value.is_some() => {
+                self.session_value = self.staged_value.take()
+            }
+            _ => self.staged_value = None,
         }
     }
 }
@@ -2713,6 +861,188 @@ impl SessionVars {
     /// Returns the value of the `welcome_message` configuration parameter.
     pub fn welcome_message(&self) -> bool {
         *self.expect_value(&WELCOME_MESSAGE)
+    }
+}
+
+/// A `SystemVar` is persisted on disk value for a configuration parameter. If unset,
+/// the server default is used instead.
+#[derive(Debug, Clone)]
+struct SystemVar<V>
+where
+    V: Value + Debug + PartialEq + 'static,
+    V::Owned: Debug + Clone + Send + Sync,
+{
+    persisted_value: Option<V::Owned>,
+    dynamic_default: Option<V::Owned>,
+    parent: ServerVar<V>,
+    constraints: Vec<ValueConstraint<V>>,
+}
+
+impl<V> SystemVar<V>
+where
+    V: Value + Debug + Clone + PartialEq + 'static,
+    V::Owned: Debug + Clone + Send + Sync,
+{
+    fn new(parent: &ServerVar<V>) -> SystemVar<V> {
+        SystemVar {
+            persisted_value: None,
+            dynamic_default: None,
+            parent: parent.clone(),
+            constraints: vec![],
+        }
+    }
+
+    fn with_value_constraint(mut self, c: ValueConstraint<V>) -> SystemVar<V> {
+        assert!(
+            !self
+                .constraints
+                .iter()
+                .any(|c| matches!(c, ValueConstraint::ReadOnly | ValueConstraint::Fixed)),
+            "fixed value and read only params do not support any other constraints"
+        );
+        self.constraints.push(c);
+        self
+    }
+
+    fn check_constraints(&self, v: &V::Owned) -> Result<(), VarError> {
+        let cur_v = self.value();
+        for constraint in &self.constraints {
+            constraint.check_constraint(self, cur_v, v)?;
+        }
+
+        Ok(())
+    }
+
+    fn persisted_value(&self) -> Option<&V> {
+        self.persisted_value.as_ref().map(|v| v.borrow())
+    }
+
+    fn value(&self) -> &V {
+        self.persisted_value
+            .as_ref()
+            .map(|v| v.borrow())
+            .unwrap_or_else(|| {
+                self.dynamic_default
+                    .as_ref()
+                    .map(|v| v.borrow())
+                    .unwrap_or(&self.parent.value)
+            })
+    }
+}
+
+impl<V> Var for SystemVar<V>
+where
+    V: Value + Debug + Clone + PartialEq + 'static,
+    V::Owned: Debug + Clone + Send + Sync,
+{
+    fn name(&self) -> &'static str {
+        self.parent.name()
+    }
+
+    fn value(&self) -> String {
+        SystemVar::value(self).format()
+    }
+
+    fn description(&self) -> &'static str {
+        self.parent.description()
+    }
+
+    fn type_name(&self) -> String {
+        V::type_name()
+    }
+
+    fn visible(&self, user: &User, system_vars: Option<&SystemVars>) -> Result<(), VarError> {
+        self.parent.visible(user, system_vars)
+    }
+}
+
+/// A `Var` with additional methods for mutating the value, as well as
+/// helpers that enable various operations in a `dyn` context.
+pub trait SystemVarMut: Var + Send + Sync {
+    /// Upcast to Var, for use with `dyn`.
+    fn as_var(&self) -> &dyn Var;
+
+    /// Creates a [`SessionVarMut`] from this [`SystemVarMut`].
+    fn to_session_var(&self) -> Box<dyn SessionVarMut>;
+
+    /// Return the value as `dyn Any`.
+    fn value_any(&self) -> &(dyn Any + 'static);
+
+    /// Clone, but object safe and specialized to `VarMut`.
+    fn clone_var(&self) -> Box<dyn SystemVarMut>;
+
+    /// Return whether or not `input` is equal to this var's default value,
+    /// if there is one.
+    fn is_default(&self, input: VarInput) -> Result<bool, VarError>;
+
+    /// Parse the input and update the stored value to match.
+    fn set(&mut self, input: VarInput) -> Result<bool, VarError>;
+
+    /// Reset the stored value to the default.
+    fn reset(&mut self) -> bool;
+
+    /// Set the default for this variable. This is the value this
+    /// variable will be be `reset` to.
+    fn set_default(&mut self, input: VarInput) -> Result<(), VarError>;
+}
+
+impl<V> SystemVarMut for SystemVar<V>
+where
+    V: Value + Debug + Clone + PartialEq + 'static,
+    V::Owned: Debug + Clone + Send + Sync,
+{
+    fn as_var(&self) -> &dyn Var {
+        self
+    }
+
+    fn to_session_var(&self) -> Box<dyn SessionVarMut> {
+        let mut var = SessionVar::new(&self.parent);
+        for constraint in &self.constraints {
+            var = var.with_value_constraint(constraint.clone());
+        }
+        Box::new(var)
+    }
+
+    fn value_any(&self) -> &(dyn Any + 'static) {
+        let value = SystemVar::value(self);
+        value
+    }
+
+    fn clone_var(&self) -> Box<dyn SystemVarMut> {
+        Box::new(self.clone())
+    }
+
+    fn is_default(&self, input: VarInput) -> Result<bool, VarError> {
+        let v = V::parse(self, input)?;
+        Ok(self.parent.value.borrow() == v.borrow())
+    }
+
+    fn set(&mut self, input: VarInput) -> Result<bool, VarError> {
+        let v = V::parse(self, input)?;
+
+        self.check_constraints(&v)?;
+
+        if self.persisted_value() != Some(v.borrow()) {
+            self.persisted_value = Some(v);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn reset(&mut self) -> bool {
+        if self.persisted_value() != None {
+            self.persisted_value = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn set_default(&mut self, input: VarInput) -> Result<(), VarError> {
+        let v = V::parse(self, input)?;
+        self.dynamic_default = Some(v);
+        Ok(())
     }
 }
 
@@ -3888,273 +2218,119 @@ impl SystemVars {
     pub fn enable_dependency_read_hold_asserts(&self) -> bool {
         *self.expect_value(&ENABLE_DEPENDENCY_READ_HOLD_ASSERTS)
     }
-}
 
-/// A `Var` represents a configuration parameter of an arbitrary type.
-pub trait Var: Debug {
-    /// Returns the name of the configuration parameter.
-    fn name(&self) -> &'static str;
+    /// Returns whether the named variable is a compute configuration parameter
+    /// (things that go in `ComputeParameters` and are sent to replicas via `UpdateConfiguration`
+    /// commands).
+    pub fn is_compute_config_var(&self, name: &str) -> bool {
+        name == MAX_RESULT_SIZE.name()
+            || name == COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
+            || name == LINEAR_JOIN_YIELDING.name()
+            || name == ENABLE_MZ_JOIN_CORE.name()
+            || name == ENABLE_JEMALLOC_PROFILING.name()
+            || name == ENABLE_COLUMNATION_LGALLOC.name()
+            || name == ENABLE_COMPUTE_OPERATOR_HYDRATION_STATUS_LOGGING.name()
+            || self.is_persist_config_var(name)
+            || is_tracing_var(name)
+    }
 
-    /// Constructs a flattened string representation of the current value of the
-    /// configuration parameter.
-    ///
-    /// The resulting string is guaranteed to be parsable if provided to
-    /// `Value::parse` as a [`VarInput::Flat`].
-    fn value(&self) -> String;
+    /// Returns whether the named variable is a storage configuration parameter.
+    pub fn is_storage_config_var(&self, name: &str) -> bool {
+        name == PG_SOURCE_CONNECT_TIMEOUT.name()
+            || name == PG_SOURCE_KEEPALIVES_IDLE.name()
+            || name == PG_SOURCE_KEEPALIVES_INTERVAL.name()
+            || name == PG_SOURCE_KEEPALIVES_RETRIES.name()
+            || name == PG_SOURCE_TCP_USER_TIMEOUT.name()
+            || name == PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT.name()
+            || name == PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT.name()
+            || name == PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT.name()
+            || name == PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT.name()
+            || name == ENABLE_STORAGE_SHARD_FINALIZATION.name()
+            || name == SSH_CHECK_INTERVAL.name()
+            || name == SSH_CONNECT_TIMEOUT.name()
+            || name == SSH_KEEPALIVES_IDLE.name()
+            || name == KAFKA_SOCKET_KEEPALIVE.name()
+            || name == KAFKA_SOCKET_TIMEOUT.name()
+            || name == KAFKA_TRANSACTION_TIMEOUT.name()
+            || name == KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT.name()
+            || name == KAFKA_FETCH_METADATA_TIMEOUT.name()
+            || name == KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT.name()
+            || name == KAFKA_DEFAULT_METADATA_FETCH_INTERVAL.name()
+            || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
+            || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION.name()
+            || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY.name()
+            || name == STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION.name()
+            || name == STORAGE_SHRINK_UPSERT_UNUSED_BUFFERS_BY_RATIO.name()
+            || name == STORAGE_RECORD_SOURCE_SINK_NAMESPACED_ERRORS.name()
+            || name == STORAGE_STATISTICS_INTERVAL.name()
+            || name == STORAGE_STATISTICS_COLLECTION_INTERVAL.name()
+            || is_upsert_rocksdb_config_var(name)
+            || self.is_persist_config_var(name)
+            || is_tracing_var(name)
+    }
 
-    /// Returns a short sentence describing the purpose of the configuration
-    /// parameter.
-    fn description(&self) -> &'static str;
-
-    /// Returns the name of the type of this variable.
-    fn type_name(&self) -> String;
-
-    /// Indicates wither the [`Var`] is visible as a function of the `user` and `system_vars`.
-    /// "Invisible" parameters return `VarErrors`.
-    ///
-    /// Variables marked as `internal` are only visible for the system user.
-    fn visible(&self, user: &User, system_vars: Option<&SystemVars>) -> Result<(), VarError>;
-}
-
-/// A `Var` with additional methods for mutating the value, as well as
-/// helpers that enable various operations in a `dyn` context.
-pub trait SystemVarMut: Var + Send + Sync {
-    /// Upcast to Var, for use with `dyn`.
-    fn as_var(&self) -> &dyn Var;
-
-    /// Creates a [`SessionVarMut`] from this [`SystemVarMut`].
-    fn to_session_var(&self) -> Box<dyn SessionVarMut>;
-
-    /// Return the value as `dyn Any`.
-    fn value_any(&self) -> &(dyn Any + 'static);
-
-    /// Clone, but object safe and specialized to `VarMut`.
-    fn clone_var(&self) -> Box<dyn SystemVarMut>;
-
-    /// Return whether or not `input` is equal to this var's default value,
-    /// if there is one.
-    fn is_default(&self, input: VarInput) -> Result<bool, VarError>;
-
-    /// Parse the input and update the stored value to match.
-    fn set(&mut self, input: VarInput) -> Result<bool, VarError>;
-
-    /// Reset the stored value to the default.
-    fn reset(&mut self) -> bool;
-
-    /// Set the default for this variable. This is the value this
-    /// variable will be be `reset` to.
-    fn set_default(&mut self, input: VarInput) -> Result<(), VarError>;
-}
-
-/// A `ServerVar` is the default value for a configuration parameter.
-#[derive(Debug)]
-pub struct ServerVar<V>
-where
-    V: Debug + 'static,
-{
-    name: &'static UncasedStr,
-    value: V,
-    description: &'static str,
-    internal: bool,
-}
-
-impl<V: Clone + Debug + 'static> Clone for ServerVar<V> {
-    fn clone(&self) -> Self {
-        Self {
-            name: self.name,
-            value: self.value.clone(),
-            description: self.description,
-            internal: self.internal,
-        }
+    /// Returns whether the named variable is a persist configuration parameter.
+    fn is_persist_config_var(&self, name: &str) -> bool {
+        self.persist_configs.entries().any(|e| name == e.name())
     }
 }
 
-impl<V> Var for ServerVar<V>
-where
-    V: Value + Debug + PartialEq + 'static,
-{
-    fn name(&self) -> &'static str {
-        self.name.as_str()
-    }
-
-    fn value(&self) -> String {
-        self.value.format()
-    }
-
-    fn description(&self) -> &'static str {
-        self.description
-    }
-
-    fn type_name(&self) -> String {
-        V::type_name()
-    }
-
-    fn visible(&self, user: &User, system_vars: Option<&SystemVars>) -> Result<(), VarError> {
-        if self.internal && user != &*SYSTEM_USER && user != &*SUPPORT_USER {
-            Err(VarError::UnknownParameter(self.name().to_string()))
-        } else if self.name().starts_with("unsafe")
-            && match system_vars {
-                None => true,
-                Some(system_vars) => !system_vars.allow_unsafe,
-            }
-        {
-            Err(VarError::RequiresUnsafeMode(self.name()))
-        } else {
-            Ok(())
-        }
-    }
+pub fn is_tracing_var(name: &str) -> bool {
+    name == LOGGING_FILTER.name()
+        || name == LOGGING_FILTER_DEFAULTS.name()
+        || name == OPENTELEMETRY_FILTER.name()
+        || name == OPENTELEMETRY_FILTER_DEFAULTS.name()
+        || name == SENTRY_FILTERS.name()
 }
 
-/// A `SystemVar` is persisted on disk value for a configuration parameter. If unset,
-/// the server default is used instead.
-#[derive(Debug, Clone)]
-struct SystemVar<V>
-where
-    V: Value + Debug + PartialEq + 'static,
-    V::Owned: Debug + Clone + Send + Sync,
-{
-    persisted_value: Option<V::Owned>,
-    dynamic_default: Option<V::Owned>,
-    parent: ServerVar<V>,
-    constraints: Vec<ValueConstraint<V>>,
+/// Returns whether the named variable is a caching configuration parameter.
+pub fn is_secrets_caching_var(name: &str) -> bool {
+    name == WEBHOOKS_SECRETS_CACHING_TTL_SECS.name()
 }
 
-impl<V> SystemVar<V>
-where
-    V: Value + Debug + Clone + PartialEq + 'static,
-    V::Owned: Debug + Clone + Send + Sync,
-{
-    fn new(parent: &ServerVar<V>) -> SystemVar<V> {
-        SystemVar {
-            persisted_value: None,
-            dynamic_default: None,
-            parent: parent.clone(),
-            constraints: vec![],
-        }
-    }
-
-    fn with_value_constraint(mut self, c: ValueConstraint<V>) -> SystemVar<V> {
-        assert!(
-            !self
-                .constraints
-                .iter()
-                .any(|c| matches!(c, ValueConstraint::ReadOnly | ValueConstraint::Fixed)),
-            "fixed value and read only params do not support any other constraints"
-        );
-        self.constraints.push(c);
-        self
-    }
-
-    fn check_constraints(&self, v: &V::Owned) -> Result<(), VarError> {
-        let cur_v = self.value();
-        for constraint in &self.constraints {
-            constraint.check_constraint(self, cur_v, v)?;
-        }
-
-        Ok(())
-    }
-
-    fn persisted_value(&self) -> Option<&V> {
-        self.persisted_value.as_ref().map(|v| v.borrow())
-    }
-
-    fn value(&self) -> &V {
-        self.persisted_value
-            .as_ref()
-            .map(|v| v.borrow())
-            .unwrap_or_else(|| {
-                self.dynamic_default
-                    .as_ref()
-                    .map(|v| v.borrow())
-                    .unwrap_or(&self.parent.value)
-            })
-    }
+fn is_upsert_rocksdb_config_var(name: &str) -> bool {
+    name == upsert_rocksdb::UPSERT_ROCKSDB_COMPACTION_STYLE.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_UNIVERSAL_COMPACTION_RATIO.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_PARALLELISM.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_COMPRESSION_TYPE.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_BATCH_SIZE.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_SHRINK_ALLOCATED_BUFFERS_BY_RATIO.name()
 }
 
-impl<V> Var for SystemVar<V>
-where
-    V: Value + Debug + Clone + PartialEq + 'static,
-    V::Owned: Debug + Clone + Send + Sync,
-{
-    fn name(&self) -> &'static str {
-        self.parent.name()
-    }
-
-    fn value(&self) -> String {
-        SystemVar::value(self).format()
-    }
-
-    fn description(&self) -> &'static str {
-        self.parent.description()
-    }
-
-    fn type_name(&self) -> String {
-        V::type_name()
-    }
-
-    fn visible(&self, user: &User, system_vars: Option<&SystemVars>) -> Result<(), VarError> {
-        self.parent.visible(user, system_vars)
-    }
+/// Returns whether the named variable is a Postgres/CRDB timestamp oracle
+/// configuration parameter.
+pub fn is_pg_timestamp_oracle_config_var(name: &str) -> bool {
+    name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE.name()
+        || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT.name()
+        || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL.name()
+        || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER.name()
+        || name == CRDB_CONNECT_TIMEOUT.name()
+        || name == CRDB_TCP_USER_TIMEOUT.name()
 }
 
-impl<V> SystemVarMut for SystemVar<V>
-where
-    V: Value + Debug + Clone + PartialEq + 'static,
-    V::Owned: Debug + Clone + Send + Sync,
-{
-    fn as_var(&self) -> &dyn Var {
-        self
-    }
+/// Returns whether the named variable is a cluster scheduling config
+pub fn is_cluster_scheduling_var(name: &str) -> bool {
+    name == cluster_scheduling::CLUSTER_MULTI_PROCESS_REPLICA_AZ_AFFINITY_WEIGHT.name()
+        || name == cluster_scheduling::CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY.name()
+        || name == cluster_scheduling::CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT.name()
+        || name == cluster_scheduling::CLUSTER_ENABLE_TOPOLOGY_SPREAD.name()
+        || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE.name()
+        || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW.name()
+        || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT.name()
+        || name == cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY.name()
+        || name == cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT.name()
+        || name == cluster_scheduling::CLUSTER_ALWAYS_USE_DISK.name()
+}
 
-    fn to_session_var(&self) -> Box<dyn SessionVarMut> {
-        let mut var = SessionVar::new(&self.parent);
-        for constraint in &self.constraints {
-            var = var.with_value_constraint(constraint.clone());
-        }
-        Box::new(var)
-    }
-
-    fn value_any(&self) -> &(dyn Any + 'static) {
-        let value = SystemVar::value(self);
-        value
-    }
-
-    fn clone_var(&self) -> Box<dyn SystemVarMut> {
-        Box::new(self.clone())
-    }
-
-    fn is_default(&self, input: VarInput) -> Result<bool, VarError> {
-        let v = V::parse(self, input)?;
-        Ok(self.parent.value.borrow() == v.borrow())
-    }
-
-    fn set(&mut self, input: VarInput) -> Result<bool, VarError> {
-        let v = V::parse(self, input)?;
-
-        self.check_constraints(&v)?;
-
-        if self.persisted_value() != Some(v.borrow()) {
-            self.persisted_value = Some(v);
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    fn reset(&mut self) -> bool {
-        if self.persisted_value() != None {
-            self.persisted_value = None;
-            true
-        } else {
-            false
-        }
-    }
-
-    fn set_default(&mut self, input: VarInput) -> Result<(), VarError> {
-        let v = V::parse(self, input)?;
-        self.dynamic_default = Some(v);
-        Ok(())
-    }
+/// Returns whether the named variable is an HTTP server related config var.
+pub fn is_http_config_var(name: &str) -> bool {
+    name == WEBHOOK_CONCURRENT_REQUEST_LIMIT.name()
 }
 
 // Provides a wrapper to express that a particular `ServerVar` is meant to be used as a feature
@@ -4213,252 +2389,6 @@ impl FeatureFlag {
     }
 }
 
-/// A `SessionVar` is the session value for a configuration parameter. If unset,
-/// the server default is used instead.
-#[derive(Debug)]
-struct SessionVar<V>
-where
-    V: Value + ToOwned + Debug + PartialEq + 'static,
-{
-    /// Value compiled into the binary.
-    parent: ServerVar<V>,
-    /// Sysetm or Role default value.
-    default_value: Option<V::Owned>,
-    /// Value `LOCAL` to a transaction, will be unset at the completion of the transaction.
-    local_value: Option<V::Owned>,
-    /// Value set during a transaction, will be set if the transaction is committed.
-    staged_value: Option<V::Owned>,
-    /// Value that overrides the default.
-    session_value: Option<V::Owned>,
-    feature_flag: Option<&'static FeatureFlag>,
-    constraints: Vec<ValueConstraint<V>>,
-}
-
-#[derive(Debug)]
-enum ValueConstraint<V>
-where
-    V: Value + ToOwned + Debug + PartialEq + 'static,
-{
-    Fixed,
-    ReadOnly,
-    // Arbitrary constraints over values.
-    Domain(&'static dyn DomainConstraint<V>),
-}
-
-impl<V> ValueConstraint<V>
-where
-    V: Value + ToOwned + Debug + PartialEq + 'static,
-{
-    fn check_constraint(
-        &self,
-        var: &(dyn Var + Send + Sync),
-        cur_value: &V,
-        new_value: &V::Owned,
-    ) -> Result<(), VarError> {
-        match self {
-            ValueConstraint::ReadOnly => return Err(VarError::ReadOnlyParameter(var.name())),
-            ValueConstraint::Fixed => {
-                if cur_value != new_value.borrow() {
-                    return Err(VarError::FixedValueParameter(var.into()));
-                }
-            }
-            ValueConstraint::Domain(check) => check.check(var, new_value)?,
-        }
-
-        Ok(())
-    }
-}
-
-impl<V> Clone for ValueConstraint<V>
-where
-    V: Value + ToOwned + Debug + PartialEq + 'static,
-{
-    fn clone(&self) -> Self {
-        match self {
-            ValueConstraint::Fixed => ValueConstraint::Fixed,
-            ValueConstraint::ReadOnly => ValueConstraint::ReadOnly,
-            ValueConstraint::Domain(c) => ValueConstraint::Domain(*c),
-        }
-    }
-}
-
-trait DomainConstraint<V>: Debug + Send + Sync
-where
-    V: Value + Debug + PartialEq + 'static,
-{
-    // `self` is make a trait object
-    fn check(&self, var: &(dyn Var + Send + Sync), v: &V::Owned) -> Result<(), VarError>;
-}
-
-impl<V> SessionVar<V>
-where
-    V: Value + Clone + Debug + PartialEq + 'static,
-    V::Owned: Debug + Send + Sync,
-{
-    fn new(parent: &ServerVar<V>) -> SessionVar<V> {
-        SessionVar {
-            default_value: None,
-            local_value: None,
-            staged_value: None,
-            session_value: None,
-            parent: parent.clone(),
-            feature_flag: None,
-            constraints: vec![],
-        }
-    }
-
-    fn add_feature_flag(mut self, flag: &'static FeatureFlag) -> Self {
-        self.feature_flag = Some(flag);
-        self
-    }
-
-    fn with_value_constraint(mut self, c: ValueConstraint<V>) -> SessionVar<V> {
-        assert!(
-            !self
-                .constraints
-                .iter()
-                .any(|c| matches!(c, ValueConstraint::ReadOnly | ValueConstraint::Fixed)),
-            "fixed value and read only params do not support any other constraints"
-        );
-        self.constraints.push(c);
-        self
-    }
-
-    fn check_constraints(&self, v: &V::Owned) -> Result<(), VarError> {
-        let cur_v = self.value();
-        for constraint in &self.constraints {
-            constraint.check_constraint(self, cur_v, v)?;
-        }
-
-        Ok(())
-    }
-
-    fn value(&self) -> &V {
-        self.local_value
-            .as_ref()
-            .map(|v| v.borrow())
-            .or_else(|| self.staged_value.as_ref().map(|v| v.borrow()))
-            .or_else(|| self.session_value.as_ref().map(|v| v.borrow()))
-            .or_else(|| self.default_value.as_ref().map(|v| v.borrow()))
-            .unwrap_or(&self.parent.value)
-    }
-}
-
-impl<V> Var for SessionVar<V>
-where
-    V: Value + Clone + Debug + PartialEq + 'static,
-    V::Owned: Debug + Send + Sync,
-{
-    fn name(&self) -> &'static str {
-        self.parent.name()
-    }
-
-    fn value(&self) -> String {
-        SessionVar::value(self).format()
-    }
-
-    fn description(&self) -> &'static str {
-        self.parent.description()
-    }
-
-    fn type_name(&self) -> String {
-        V::type_name()
-    }
-
-    fn visible(&self, user: &User, system_vars: Option<&SystemVars>) -> Result<(), VarError> {
-        if let Some(flag) = self.feature_flag {
-            flag.enabled(system_vars, None, None)?;
-        }
-
-        self.parent.visible(user, system_vars)
-    }
-}
-
-/// A `Var` with additional methods for mutating the value, as well as
-/// helpers that enable various operations in a `dyn` context.
-pub trait SessionVarMut: Var + Send + Sync {
-    /// Upcast to Var, for use with `dyn`.
-    fn as_var(&self) -> &dyn Var;
-
-    fn value_any(&self) -> &(dyn Any + 'static);
-
-    /// Parse the input and update the stored value to match.
-    fn set(&mut self, input: VarInput, local: bool) -> Result<(), VarError>;
-
-    /// Sets the default value for the variable.
-    fn set_default(&mut self, value: VarInput) -> Result<(), VarError>;
-
-    /// Reset the stored value to the default.
-    fn reset(&mut self, local: bool);
-
-    fn end_transaction(&mut self, action: EndTransactionAction);
-}
-
-impl<V> SessionVarMut for SessionVar<V>
-where
-    V: Value + Clone + Debug + PartialEq + 'static,
-    V::Owned: Debug + Clone + Send + Sync,
-{
-    /// Upcast to Var, for use with `dyn`.
-    fn as_var(&self) -> &dyn Var {
-        self
-    }
-
-    fn value_any(&self) -> &(dyn Any + 'static) {
-        let value = SessionVar::value(self);
-        value
-    }
-
-    /// Parse the input and update the stored value to match.
-    fn set(&mut self, input: VarInput, local: bool) -> Result<(), VarError> {
-        let v = V::parse(self, input)?;
-
-        self.check_constraints(&v)?;
-
-        if local {
-            self.local_value = Some(v);
-        } else {
-            self.local_value = None;
-            self.staged_value = Some(v);
-        }
-        Ok(())
-    }
-
-    /// Sets the default value for the variable.
-    fn set_default(&mut self, input: VarInput) -> Result<(), VarError> {
-        let v = V::parse(self, input)?;
-        self.check_constraints(&v)?;
-        self.default_value = Some(v);
-        Ok(())
-    }
-
-    /// Reset the stored value to the default.
-    fn reset(&mut self, local: bool) {
-        let value = self
-            .default_value
-            .as_ref()
-            .map(|v| v.borrow())
-            .unwrap_or(&self.parent.value)
-            .to_owned();
-        if local {
-            self.local_value = Some(value);
-        } else {
-            self.local_value = None;
-            self.staged_value = Some(value);
-        }
-    }
-
-    fn end_transaction(&mut self, action: EndTransactionAction) {
-        self.local_value = None;
-        match action {
-            EndTransactionAction::Commit if self.staged_value.is_some() => {
-                self.session_value = self.staged_value.take()
-            }
-            _ => self.staged_value = None,
-        }
-    }
-}
-
 impl Var for BuildInfo {
     fn name(&self) -> &'static str {
         MZ_VERSION_NAME.as_str()
@@ -4500,1390 +2430,5 @@ impl Var for User {
 
     fn visible(&self, _: &User, _: Option<&SystemVars>) -> Result<(), VarError> {
         Ok(())
-    }
-}
-
-/// A value that can be stored in a session or server variable.
-pub trait Value: ToOwned + Send + Sync {
-    /// The name of the value type.
-    fn type_name() -> String;
-
-    /// Parses a value of this type from a [`VarInput`].
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError>;
-    /// Formats this value as a flattened string.
-    ///
-    /// The resulting string is guaranteed to be parsable if provided to
-    /// [`Value::parse`] as a [`VarInput::Flat`].
-    fn format(&self) -> String;
-}
-
-fn extract_single_value<'var, 'input: 'var>(
-    param: &'var (dyn Var + Send + Sync),
-    input: VarInput<'input>,
-) -> Result<&'input str, VarError> {
-    match input {
-        VarInput::Flat(value) => Ok(value),
-        VarInput::SqlSet([value]) => Ok(value),
-        VarInput::SqlSet(values) => Err(VarError::InvalidParameterValue {
-            parameter: param.into(),
-            values: values.to_vec(),
-            reason: "expects a single value".to_string(),
-        }),
-    }
-}
-
-impl Value for bool {
-    fn type_name() -> String {
-        "boolean".to_string()
-    }
-
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<Self, VarError> {
-        let s = extract_single_value(param, input)?;
-        match s {
-            "t" | "true" | "on" => Ok(true),
-            "f" | "false" | "off" => Ok(false),
-            _ => Err(VarError::InvalidParameterType(param.into())),
-        }
-    }
-
-    fn format(&self) -> String {
-        match self {
-            true => "on".into(),
-            false => "off".into(),
-        }
-    }
-}
-
-impl Value for i32 {
-    fn type_name() -> String {
-        "integer".to_string()
-    }
-
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<i32, VarError> {
-        let s = extract_single_value(param, input)?;
-        s.parse()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
-    }
-
-    fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
-impl Value for u32 {
-    fn type_name() -> String {
-        "unsigned integer".to_string()
-    }
-
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<u32, VarError> {
-        let s = extract_single_value(param, input)?;
-        s.parse()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
-    }
-
-    fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
-impl Value for mz_repr::Timestamp {
-    fn type_name() -> String {
-        "mz-timestamp".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<mz_repr::Timestamp, VarError> {
-        let s = extract_single_value(param, input)?;
-        s.parse()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
-    }
-
-    fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
-impl Value for usize {
-    fn type_name() -> String {
-        "unsigned integer".to_string()
-    }
-
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<usize, VarError> {
-        let s = extract_single_value(param, input)?;
-        s.parse()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
-    }
-
-    fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
-impl Value for f64 {
-    fn type_name() -> String {
-        "double-precision floating-point number".to_string()
-    }
-
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<f64, VarError> {
-        let s = extract_single_value(param, input)?;
-        s.parse()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
-    }
-
-    fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
-impl Value for Option<CheckedTimestamp<DateTime<Utc>>> {
-    fn type_name() -> String {
-        "timestamptz".to_string()
-    }
-
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<Self, VarError> {
-        let s = extract_single_value(param, input)?;
-        strconv::parse_timestamptz(s)
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
-            .map(Some)
-    }
-
-    fn format(&self) -> String {
-        self.map(|t| t.to_string()).unwrap_or_default()
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-struct NumericNonNegNonNan;
-
-impl DomainConstraint<Numeric> for NumericNonNegNonNan {
-    fn check(&self, var: &(dyn Var + Send + Sync), n: &Numeric) -> Result<(), VarError> {
-        if n.is_nan() || n.is_negative() {
-            Err(VarError::InvalidParameterValue {
-                parameter: var.into(),
-                values: vec![n.to_string()],
-                reason: "only supports non-negative, non-NaN numeric values".to_string(),
-            })
-        } else {
-            Ok(())
-        }
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-struct NumericInRange<R>(R);
-
-impl<R> DomainConstraint<Numeric> for NumericInRange<R>
-where
-    R: RangeBounds<f64> + std::fmt::Debug + Send + Sync,
-{
-    fn check(&self, var: &(dyn Var + Send + Sync), n: &Numeric) -> Result<(), VarError> {
-        let n: f64 = (*n)
-            .try_into()
-            .map_err(|_e| VarError::InvalidParameterValue {
-                parameter: var.into(),
-                values: vec![n.to_string()],
-                // This first check can fail if the value is NaN, out of range,
-                // OR if it underflows (i.e. is very close to 0 without actually being 0, and the closest
-                // representable float is 0).
-                //
-                // The underflow case is very unlikely to be accidentally hit by a user, so let's
-                // not make the error message more confusing by talking about it, even though that makes
-                // the error message slightly inaccurate.
-                //
-                // If the user tries to set the paramater to 0.000<hundreds more zeros>001
-                // and gets the message "only supports values in range [0.0..=1.0]", I think they will
-                // understand, or at least accept, what's going on.
-                reason: format!("only supports values in range {:?}", self.0),
-            })?;
-        if !self.0.contains(&n) {
-            Err(VarError::InvalidParameterValue {
-                parameter: var.into(),
-                values: vec![n.to_string()],
-                reason: format!("only supports values in range {:?}", self.0),
-            })
-        } else {
-            Ok(())
-        }
-    }
-}
-
-impl Value for Numeric {
-    fn type_name() -> String {
-        "numeric".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        let n = s
-            .parse()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))?;
-        Ok(n)
-    }
-
-    fn format(&self) -> String {
-        self.to_standard_notation_string()
-    }
-}
-
-impl Value for ByteSize {
-    fn type_name() -> String {
-        "bytes".to_string()
-    }
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<ByteSize, VarError> {
-        let s = extract_single_value(param, input)?;
-        s.parse::<ByteSize>()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
-    }
-
-    fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
-const SEC_TO_MIN: u64 = 60u64;
-const SEC_TO_HOUR: u64 = 60u64 * 60;
-const SEC_TO_DAY: u64 = 60u64 * 60 * 24;
-const MICRO_TO_MILLI: u32 = 1000u32;
-
-impl Value for Duration {
-    fn type_name() -> String {
-        "duration".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Duration, VarError> {
-        let s = extract_single_value(param, input)?;
-        let s = s.trim();
-        // Take all numeric values from [0..]
-        let split_pos = s
-            .chars()
-            .position(|p| !char::is_numeric(p))
-            .unwrap_or_else(|| s.chars().count());
-
-        // Error if the numeric values don't parse, i.e. there aren't any.
-        let d = s[..split_pos]
-            .parse::<u64>()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))?;
-
-        // We've already trimmed end
-        let (f, m): (fn(u64) -> Duration, u64) = match s[split_pos..].trim_start() {
-            "us" => (Duration::from_micros, 1),
-            // Default unit is milliseconds
-            "ms" | "" => (Duration::from_millis, 1),
-            "s" => (Duration::from_secs, 1),
-            "min" => (Duration::from_secs, SEC_TO_MIN),
-            "h" => (Duration::from_secs, SEC_TO_HOUR),
-            "d" => (Duration::from_secs, SEC_TO_DAY),
-            o => {
-                return Err(VarError::InvalidParameterValue {
-                    parameter: param.into(),
-                    values: vec![s.to_string()],
-                    reason: format!("expected us, ms, s, min, h, or d but got {:?}", o),
-                })
-            }
-        };
-
-        let d = f(d.checked_mul(m).ok_or(VarError::InvalidParameterValue {
-            parameter: param.into(),
-            values: vec![s.to_string()],
-            reason: "expected value to fit in u64".to_string(),
-        })?);
-        Ok(d)
-    }
-
-    // The strategy for formatting these strings is to find the least
-    // significant unit of time that can be printed as an integer––we know this
-    // is always possible because the input can only be an integer of a single
-    // unit of time.
-    fn format(&self) -> String {
-        let micros = self.subsec_micros();
-        if micros > 0 {
-            match micros {
-                ms if ms != 0 && ms % MICRO_TO_MILLI == 0 => {
-                    format!(
-                        "{} ms",
-                        self.as_secs() * 1000 + u64::from(ms / MICRO_TO_MILLI)
-                    )
-                }
-                us => format!("{} us", self.as_secs() * 1_000_000 + u64::from(us)),
-            }
-        } else {
-            match self.as_secs() {
-                zero if zero == u64::MAX => "0".to_string(),
-                d if d != 0 && d % SEC_TO_DAY == 0 => format!("{} d", d / SEC_TO_DAY),
-                h if h != 0 && h % SEC_TO_HOUR == 0 => format!("{} h", h / SEC_TO_HOUR),
-                m if m != 0 && m % SEC_TO_MIN == 0 => format!("{} min", m / SEC_TO_MIN),
-                s => format!("{} s", s),
-            }
-        }
-    }
-}
-
-#[mz_ore::test]
-fn test_value_duration() {
-    fn inner(t: &'static str, e: Duration, expected_format: Option<&'static str>) {
-        let d = Duration::parse(&STATEMENT_TIMEOUT, VarInput::Flat(t)).expect("invalid duration");
-        assert_eq!(d, e);
-        let mut d_format = d.format();
-        d_format.retain(|c| !c.is_whitespace());
-        if let Some(expected) = expected_format {
-            assert_eq!(d_format, expected);
-        } else {
-            assert_eq!(
-                t.chars().filter(|c| !c.is_whitespace()).collect::<String>(),
-                d_format
-            )
-        }
-    }
-    inner("1", Duration::from_millis(1), Some("1ms"));
-    inner("0", Duration::from_secs(0), Some("0s"));
-    inner("1ms", Duration::from_millis(1), None);
-    inner("1000ms", Duration::from_millis(1000), Some("1s"));
-    inner("1001ms", Duration::from_millis(1001), None);
-    inner("1us", Duration::from_micros(1), None);
-    inner("1000us", Duration::from_micros(1000), Some("1ms"));
-    inner("1s", Duration::from_secs(1), None);
-    inner("60s", Duration::from_secs(60), Some("1min"));
-    inner("3600s", Duration::from_secs(3600), Some("1h"));
-    inner("3660s", Duration::from_secs(3660), Some("61min"));
-    inner("1min", Duration::from_secs(1 * SEC_TO_MIN), None);
-    inner("60min", Duration::from_secs(60 * SEC_TO_MIN), Some("1h"));
-    inner("1h", Duration::from_secs(1 * SEC_TO_HOUR), None);
-    inner("24h", Duration::from_secs(24 * SEC_TO_HOUR), Some("1d"));
-    inner("1d", Duration::from_secs(1 * SEC_TO_DAY), None);
-    inner("2d", Duration::from_secs(2 * SEC_TO_DAY), None);
-    inner("  1   s ", Duration::from_secs(1), None);
-    inner("1s ", Duration::from_secs(1), None);
-    inner("   1s", Duration::from_secs(1), None);
-    inner("0d", Duration::from_secs(0), Some("0s"));
-    inner(
-        "18446744073709551615",
-        Duration::from_millis(u64::MAX),
-        Some("18446744073709551615ms"),
-    );
-    inner(
-        "18446744073709551615 s",
-        Duration::from_secs(u64::MAX),
-        Some("0"),
-    );
-
-    fn errs(t: &'static str) {
-        assert!(Duration::parse(&STATEMENT_TIMEOUT, VarInput::Flat(t)).is_err());
-    }
-    errs("1 m");
-    errs("1 sec");
-    errs("1 min 1 s");
-    errs("1m1s");
-    errs("1.1");
-    errs("1.1 min");
-    errs("-1 s");
-    errs("");
-    errs("   ");
-    errs("x");
-    errs("s");
-    errs("18446744073709551615 min");
-}
-
-impl Value for String {
-    fn type_name() -> String {
-        "string".to_string()
-    }
-
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<String, VarError> {
-        let s = extract_single_value(param, input)?;
-        Ok(s.to_owned())
-    }
-
-    fn format(&self) -> String {
-        self.to_owned()
-    }
-}
-
-/// This style should actually be some more complex struct, but we only support this configuration
-/// of it, so this is fine for the time being.
-#[derive(Debug, Clone, Eq, PartialEq)]
-struct DateStyle([&'static str; 2]);
-
-const DEFAULT_DATE_STYLE: DateStyle = DateStyle(["ISO", "MDY"]);
-
-impl Value for DateStyle {
-    fn type_name() -> String {
-        "string list".to_string()
-    }
-
-    /// This impl is unlike most others because we have under-implemented its backing struct.
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<DateStyle, VarError> {
-        let input = match input {
-            VarInput::Flat(v) => mz_sql_parser::parser::split_identifier_string(v)
-                .map_err(|_| VarError::InvalidParameterType(param.into()))?,
-            // Unlike parsing `Vec<Ident>`, we further split each element.
-            // This matches PostgreSQL.
-            VarInput::SqlSet(values) => {
-                let mut out = vec![];
-                for v in values {
-                    let idents = mz_sql_parser::parser::split_identifier_string(v)
-                        .map_err(|_| VarError::InvalidParameterType(param.into()))?;
-                    out.extend(idents)
-                }
-                out
-            }
-        };
-
-        for input in input {
-            if !DEFAULT_DATE_STYLE
-                .0
-                .iter()
-                .any(|valid| UncasedStr::new(valid) == &input)
-            {
-                return Err(VarError::FixedValueParameter((&DATE_STYLE).into()));
-            }
-        }
-
-        Ok(DEFAULT_DATE_STYLE.clone())
-    }
-
-    fn format(&self) -> String {
-        self.0.join(", ")
-    }
-}
-
-impl Value for Vec<Ident> {
-    fn type_name() -> String {
-        "identifier list".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Vec<Ident>, VarError> {
-        let holder;
-        let values = match input {
-            VarInput::Flat(value) => {
-                holder = mz_sql_parser::parser::split_identifier_string(value)
-                    .map_err(|_| VarError::InvalidParameterType(param.into()))?;
-                &holder
-            }
-            // Unlike parsing `Vec<String>`, we do *not* further split each
-            // element. This matches PostgreSQL.
-            VarInput::SqlSet(values) => values,
-        };
-        let values = values
-            .iter()
-            .map(Ident::new)
-            .collect::<Result<_, _>>()
-            .map_err(|e| VarError::InvalidParameterValue {
-                parameter: param.into(),
-                values: values.to_vec(),
-                reason: e.to_string(),
-            })?;
-        Ok(values)
-    }
-
-    fn format(&self) -> String {
-        self.iter().map(|ident| ident.to_string()).join(", ")
-    }
-}
-
-impl Value for Vec<SerializableDirective> {
-    fn type_name() -> String {
-        "directive list".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Vec<SerializableDirective>, VarError> {
-        let values = input.to_vec();
-        let dirs: Result<_, _> = values
-            .iter()
-            .flat_map(|i| i.split(','))
-            .map(|d| SerializableDirective::from_str(d.trim()))
-            .collect();
-        dirs.map_err(|e| VarError::InvalidParameterValue {
-            parameter: param.into(),
-            values: values.to_vec(),
-            reason: e.to_string(),
-        })
-    }
-
-    fn format(&self) -> String {
-        self.iter().map(|d| d.to_string()).join(", ")
-    }
-}
-
-// Implement `Value` for `Option<V>` for any owned `V`.
-impl<V> Value for Option<V>
-where
-    V: Value + Clone + ToOwned<Owned = V>,
-{
-    fn type_name() -> String {
-        format!("optional {}", V::type_name())
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Option<V>, VarError> {
-        let s = extract_single_value(param, input)?;
-        match s {
-            "" => Ok(None),
-            _ => <V as Value>::parse(param, VarInput::Flat(s)).map(Some),
-        }
-    }
-
-    fn format(&self) -> String {
-        match self {
-            Some(s) => s.format(),
-            None => "".into(),
-        }
-    }
-}
-
-// This unorthodox design lets us escape complex errors from value parsing.
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct Failpoints;
-
-impl Value for Failpoints {
-    fn type_name() -> String {
-        "failpoints config".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Failpoints, VarError> {
-        let values = input.to_vec();
-        for mut cfg in values.iter().map(|v| v.trim().split(';')).flatten() {
-            cfg = cfg.trim();
-            if cfg.is_empty() {
-                continue;
-            }
-            let mut splits = cfg.splitn(2, '=');
-            let failpoint = splits
-                .next()
-                .ok_or_else(|| VarError::InvalidParameterValue {
-                    parameter: param.into(),
-                    values: input.to_vec(),
-                    reason: "missing failpoint name".into(),
-                })?;
-            let action = splits
-                .next()
-                .ok_or_else(|| VarError::InvalidParameterValue {
-                    parameter: param.into(),
-                    values: input.to_vec(),
-                    reason: "missing failpoint action".into(),
-                })?;
-            fail::cfg(failpoint, action).map_err(|e| VarError::InvalidParameterValue {
-                parameter: param.into(),
-                values: input.to_vec(),
-                reason: e,
-            })?;
-        }
-
-        Ok(Failpoints)
-    }
-
-    fn format(&self) -> String {
-        "<omitted>".to_string()
-    }
-}
-
-/// Severity levels can used to be used to filter which messages get sent
-/// to a client.
-///
-/// The ordering of severity levels used for client-level filtering differs from the
-/// one used for server-side logging in two aspects: INFO messages are always sent,
-/// and the LOG severity is considered as below NOTICE, while it is above ERROR for
-/// server-side logs.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ClientSeverity {
-    /// Sends only INFO, ERROR, FATAL and PANIC level messages.
-    Error,
-    /// Sends only WARNING, INFO, ERROR, FATAL and PANIC level messages.
-    Warning,
-    /// Sends only NOTICE, WARNING, INFO, ERROR, FATAL and PANIC level messages.
-    Notice,
-    /// Sends only LOG, NOTICE, WARNING, INFO, ERROR, FATAL and PANIC level messages.
-    Log,
-    /// Sends all messages to the client, since all DEBUG levels are treated as the same right now.
-    Debug1,
-    /// Sends all messages to the client, since all DEBUG levels are treated as the same right now.
-    Debug2,
-    /// Sends all messages to the client, since all DEBUG levels are treated as the same right now.
-    Debug3,
-    /// Sends all messages to the client, since all DEBUG levels are treated as the same right now.
-    Debug4,
-    /// Sends all messages to the client, since all DEBUG levels are treated as the same right now.
-    Debug5,
-    /// Sends only NOTICE, WARNING, INFO, ERROR, FATAL and PANIC level messages.
-    /// Not listed as a valid value, but accepted by Postgres
-    Info,
-}
-
-impl Serialize for ClientSeverity {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl ClientSeverity {
-    fn as_str(&self) -> &'static str {
-        match self {
-            ClientSeverity::Error => "error",
-            ClientSeverity::Warning => "warning",
-            ClientSeverity::Notice => "notice",
-            ClientSeverity::Info => "info",
-            ClientSeverity::Log => "log",
-            ClientSeverity::Debug1 => "debug1",
-            ClientSeverity::Debug2 => "debug2",
-            ClientSeverity::Debug3 => "debug3",
-            ClientSeverity::Debug4 => "debug4",
-            ClientSeverity::Debug5 => "debug5",
-        }
-    }
-
-    fn valid_values() -> Vec<&'static str> {
-        // INFO left intentionally out, to match Postgres
-        vec![
-            ClientSeverity::Debug5.as_str(),
-            ClientSeverity::Debug4.as_str(),
-            ClientSeverity::Debug3.as_str(),
-            ClientSeverity::Debug2.as_str(),
-            ClientSeverity::Debug1.as_str(),
-            ClientSeverity::Log.as_str(),
-            ClientSeverity::Notice.as_str(),
-            ClientSeverity::Warning.as_str(),
-            ClientSeverity::Error.as_str(),
-        ]
-    }
-
-    /// Checks if a message of a given severity level should be sent to a client.
-    ///
-    /// The ordering of severity levels used for client-level filtering differs from the
-    /// one used for server-side logging in two aspects: INFO messages are always sent,
-    /// and the LOG severity is considered as below NOTICE, while it is above ERROR for
-    /// server-side logs.
-    ///
-    /// Postgres only considers the session setting after the client authentication
-    /// handshake is completed. Since this function is only called after client authentication
-    /// is done, we are not treating this case right now, but be aware if refactoring it.
-    pub fn should_output_to_client(&self, severity: &Severity) -> bool {
-        match (self, severity) {
-            // INFO messages are always sent
-            (_, Severity::Info) => true,
-            (ClientSeverity::Error, Severity::Error | Severity::Fatal | Severity::Panic) => true,
-            (
-                ClientSeverity::Warning,
-                Severity::Error | Severity::Fatal | Severity::Panic | Severity::Warning,
-            ) => true,
-            (
-                ClientSeverity::Notice,
-                Severity::Error
-                | Severity::Fatal
-                | Severity::Panic
-                | Severity::Warning
-                | Severity::Notice,
-            ) => true,
-            (
-                ClientSeverity::Info,
-                Severity::Error
-                | Severity::Fatal
-                | Severity::Panic
-                | Severity::Warning
-                | Severity::Notice,
-            ) => true,
-            (
-                ClientSeverity::Log,
-                Severity::Error
-                | Severity::Fatal
-                | Severity::Panic
-                | Severity::Warning
-                | Severity::Notice
-                | Severity::Log,
-            ) => true,
-            (
-                ClientSeverity::Debug1
-                | ClientSeverity::Debug2
-                | ClientSeverity::Debug3
-                | ClientSeverity::Debug4
-                | ClientSeverity::Debug5,
-                _,
-            ) => true,
-
-            (
-                ClientSeverity::Error,
-                Severity::Warning | Severity::Notice | Severity::Log | Severity::Debug,
-            ) => false,
-            (ClientSeverity::Warning, Severity::Notice | Severity::Log | Severity::Debug) => false,
-            (ClientSeverity::Notice, Severity::Log | Severity::Debug) => false,
-            (ClientSeverity::Info, Severity::Log | Severity::Debug) => false,
-            (ClientSeverity::Log, Severity::Debug) => false,
-        }
-    }
-}
-
-impl Value for ClientSeverity {
-    fn type_name() -> String {
-        "string".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        let s = UncasedStr::new(s);
-
-        if s == ClientSeverity::Error.as_str() {
-            Ok(ClientSeverity::Error)
-        } else if s == ClientSeverity::Warning.as_str() {
-            Ok(ClientSeverity::Warning)
-        } else if s == ClientSeverity::Notice.as_str() {
-            Ok(ClientSeverity::Notice)
-        } else if s == ClientSeverity::Info.as_str() {
-            Ok(ClientSeverity::Info)
-        } else if s == ClientSeverity::Log.as_str() {
-            Ok(ClientSeverity::Log)
-        } else if s == ClientSeverity::Debug1.as_str() {
-            Ok(ClientSeverity::Debug1)
-        // Postgres treats `debug` as an input as equivalent to `debug2`
-        } else if s == ClientSeverity::Debug2.as_str() || s == "debug" {
-            Ok(ClientSeverity::Debug2)
-        } else if s == ClientSeverity::Debug3.as_str() {
-            Ok(ClientSeverity::Debug3)
-        } else if s == ClientSeverity::Debug4.as_str() {
-            Ok(ClientSeverity::Debug4)
-        } else if s == ClientSeverity::Debug5.as_str() {
-            Ok(ClientSeverity::Debug5)
-        } else {
-            Err(VarError::ConstrainedParameter {
-                parameter: param.into(),
-                values: input.to_vec(),
-                valid_values: Some(ClientSeverity::valid_values()),
-            })
-        }
-    }
-
-    fn format(&self) -> String {
-        self.as_str().into()
-    }
-}
-
-/// List of valid time zones.
-///
-/// Names are following the tz database, but only time zones equivalent
-/// to UTC±00:00 are supported.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum TimeZone {
-    /// UTC
-    UTC,
-    /// Fixed offset from UTC, currently only "+00:00" is supported.
-    /// A string representation is kept here for compatibility with Postgres.
-    FixedOffset(&'static str),
-}
-
-impl TimeZone {
-    fn as_str(&self) -> &'static str {
-        match self {
-            TimeZone::UTC => "UTC",
-            TimeZone::FixedOffset(s) => s,
-        }
-    }
-}
-
-impl Value for TimeZone {
-    fn type_name() -> String {
-        "string".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        let s = UncasedStr::new(s);
-
-        if s == TimeZone::UTC.as_str() {
-            Ok(TimeZone::UTC)
-        } else if s == "+00:00" {
-            Ok(TimeZone::FixedOffset("+00:00"))
-        } else {
-            Err(VarError::ConstrainedParameter {
-                parameter: (&TIMEZONE).into(),
-                values: input.to_vec(),
-                valid_values: None,
-            })
-        }
-    }
-
-    fn format(&self) -> String {
-        self.as_str().into()
-    }
-}
-
-/// List of valid isolation levels.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum IsolationLevel {
-    ReadUncommitted,
-    ReadCommitted,
-    RepeatableRead,
-    Serializable,
-    /* TODO(jkosh44) Move this comment to user facing docs when this isolation level becomes available to users.
-     * The Strong Session Serializable isolation level combines the Serializable isolation level
-     * (https://jepsen.io/consistency/models/serializable) with the Sequential consistency model
-     * (https://jepsen.io/consistency/models/sequential). See
-     * http://dbmsmusings.blogspot.com/2019/06/correctness-anomalies-under.html and
-     * https://cs.uwaterloo.ca/~kmsalem/pubs/DaudjeeICDE04.pdf. Operations within a single session
-     * are linearizable, but operations across sessions are not linearizable.
-     *
-     * Operations in sessions that use Strong Session Serializable are not linearizable with
-     * operations in sessions that use Strict Serializable. For example, consider the following
-     * sequence of events in order:
-     *
-     *   1. Session s0 executes read at timestamp t0 under Strong Session Serializable.
-     *   2. Session s1 executes read at timestamp t1 under Strict Serializable.
-     *
-     * If t0 > t1, then this is not considered a consistency violation. This matches with the
-     * semantics of Serializable, which can execute queries arbitrarily in the future without
-     * violating the consistency of Strict Serializable queries.
-     *
-     * All operations within a session that use Strong Session Serializable are only
-     * linearizable within operations within the same session that also use Strong Session
-     * Serializable. For example, consider the following sequence of events in order:
-     *
-     *   1. Session s0 executes read at timestamp t0 under Strong Session Serializable.
-     *   2. Session s0 executes read at timestamp t1 under I.
-     *
-     * If I is Strong Session Serializable then t0 > t1 is guaranteed. If I is any other isolation
-     * level then t0 < t1 is not considered a consistency violation. This matches the semantics of
-     * Serializable, which can execute queries arbitrarily in the future without violating the
-     * consistency of Strict Serializable queries within the same session.
-     *
-     * The items left TODO before this is considered ready for prod are:
-     *
-     * - Add more tests.
-     * - Linearize writes to system tables under this isolation (most of these are the side effect
-     *   of some DDL).
-     */
-    StrongSessionSerializable,
-    StrictSerializable,
-}
-
-impl IsolationLevel {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::ReadUncommitted => "read uncommitted",
-            Self::ReadCommitted => "read committed",
-            Self::RepeatableRead => "repeatable read",
-            Self::Serializable => "serializable",
-            Self::StrongSessionSerializable => "strong session serializable",
-            Self::StrictSerializable => "strict serializable",
-        }
-    }
-
-    fn valid_values() -> Vec<&'static str> {
-        vec![
-            Self::ReadUncommitted.as_str(),
-            Self::ReadCommitted.as_str(),
-            Self::RepeatableRead.as_str(),
-            Self::Serializable.as_str(),
-            // TODO(jkosh44) Add StrongSessionSerializable when it becomes available to users.
-            Self::StrictSerializable.as_str(),
-        ]
-    }
-}
-
-impl Display for IsolationLevel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl Value for IsolationLevel {
-    fn type_name() -> String {
-        "string".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        let s = UncasedStr::new(s);
-
-        // We don't have any optimizations for levels below Serializable,
-        // so we upgrade them all to Serializable.
-        if s == Self::ReadUncommitted.as_str()
-            || s == Self::ReadCommitted.as_str()
-            || s == Self::RepeatableRead.as_str()
-            || s == Self::Serializable.as_str()
-        {
-            Ok(Self::Serializable)
-        } else if s == Self::StrongSessionSerializable.as_str() {
-            Ok(Self::StrongSessionSerializable)
-        } else if s == Self::StrictSerializable.as_str() {
-            Ok(Self::StrictSerializable)
-        } else {
-            Err(VarError::ConstrainedParameter {
-                parameter: (&TRANSACTION_ISOLATION).into(),
-                values: input.to_vec(),
-                valid_values: Some(IsolationLevel::valid_values()),
-            })
-        }
-    }
-
-    fn format(&self) -> String {
-        self.as_str().into()
-    }
-}
-
-impl From<TransactionIsolationLevel> for IsolationLevel {
-    fn from(transaction_isolation_level: TransactionIsolationLevel) -> Self {
-        match transaction_isolation_level {
-            TransactionIsolationLevel::ReadUncommitted => Self::ReadUncommitted,
-            TransactionIsolationLevel::ReadCommitted => Self::ReadCommitted,
-            TransactionIsolationLevel::RepeatableRead => Self::RepeatableRead,
-            TransactionIsolationLevel::Serializable => Self::Serializable,
-            TransactionIsolationLevel::StrongSessionSerializable => Self::StrongSessionSerializable,
-            TransactionIsolationLevel::StrictSerializable => Self::StrictSerializable,
-        }
-    }
-}
-
-impl Value for CloneableEnvFilter {
-    fn type_name() -> String {
-        "EnvFilter".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        CloneableEnvFilter::from_str(s).map_err(|e| VarError::InvalidParameterValue {
-            parameter: param.into(),
-            values: vec![s.to_string()],
-            reason: format!("{}", e),
-        })
-    }
-
-    fn format(&self) -> String {
-        format!("{}", self)
-    }
-}
-
-pub fn is_tracing_var(name: &str) -> bool {
-    name == LOGGING_FILTER.name()
-        || name == LOGGING_FILTER_DEFAULTS.name()
-        || name == OPENTELEMETRY_FILTER.name()
-        || name == OPENTELEMETRY_FILTER_DEFAULTS.name()
-        || name == SENTRY_FILTERS.name()
-}
-
-impl SystemVars {
-    /// Returns whether the named variable is a compute configuration parameter
-    /// (things that go in `ComputeParameters` and are sent to replicas via `UpdateConfiguration`
-    /// commands).
-    pub fn is_compute_config_var(&self, name: &str) -> bool {
-        name == MAX_RESULT_SIZE.name()
-            || name == COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
-            || name == LINEAR_JOIN_YIELDING.name()
-            || name == ENABLE_MZ_JOIN_CORE.name()
-            || name == ENABLE_COLUMNATION_LGALLOC.name()
-            || name == ENABLE_COMPUTE_OPERATOR_HYDRATION_STATUS_LOGGING.name()
-            || self.is_persist_config_var(name)
-            || is_tracing_var(name)
-    }
-
-    /// Returns whether the named variable is a storage configuration parameter.
-    pub fn is_storage_config_var(&self, name: &str) -> bool {
-        name == PG_SOURCE_CONNECT_TIMEOUT.name()
-            || name == PG_SOURCE_KEEPALIVES_IDLE.name()
-            || name == PG_SOURCE_KEEPALIVES_INTERVAL.name()
-            || name == PG_SOURCE_KEEPALIVES_RETRIES.name()
-            || name == PG_SOURCE_TCP_USER_TIMEOUT.name()
-            || name == PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT.name()
-            || name == PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT.name()
-            || name == PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT.name()
-            || name == PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT.name()
-            || name == ENABLE_STORAGE_SHARD_FINALIZATION.name()
-            || name == SSH_CHECK_INTERVAL.name()
-            || name == SSH_CONNECT_TIMEOUT.name()
-            || name == SSH_KEEPALIVES_IDLE.name()
-            || name == KAFKA_SOCKET_KEEPALIVE.name()
-            || name == KAFKA_SOCKET_TIMEOUT.name()
-            || name == KAFKA_TRANSACTION_TIMEOUT.name()
-            || name == KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT.name()
-            || name == KAFKA_FETCH_METADATA_TIMEOUT.name()
-            || name == KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT.name()
-            || name == KAFKA_DEFAULT_METADATA_FETCH_INTERVAL.name()
-            || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
-            || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION.name()
-            || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY.name()
-            || name == STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION.name()
-            || name == STORAGE_SHRINK_UPSERT_UNUSED_BUFFERS_BY_RATIO.name()
-            || name == STORAGE_RECORD_SOURCE_SINK_NAMESPACED_ERRORS.name()
-            || name == STORAGE_STATISTICS_INTERVAL.name()
-            || name == STORAGE_STATISTICS_COLLECTION_INTERVAL.name()
-            || is_upsert_rocksdb_config_var(name)
-            || self.is_persist_config_var(name)
-            || is_tracing_var(name)
-    }
-}
-
-/// Returns whether the named variable is a caching configuration parameter.
-pub fn is_secrets_caching_var(name: &str) -> bool {
-    name == WEBHOOKS_SECRETS_CACHING_TTL_SECS.name()
-}
-
-fn is_upsert_rocksdb_config_var(name: &str) -> bool {
-    name == upsert_rocksdb::UPSERT_ROCKSDB_COMPACTION_STYLE.name()
-        || name == upsert_rocksdb::UPSERT_ROCKSDB_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET.name()
-        || name == upsert_rocksdb::UPSERT_ROCKSDB_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES.name()
-        || name == upsert_rocksdb::UPSERT_ROCKSDB_UNIVERSAL_COMPACTION_RATIO.name()
-        || name == upsert_rocksdb::UPSERT_ROCKSDB_PARALLELISM.name()
-        || name == upsert_rocksdb::UPSERT_ROCKSDB_COMPRESSION_TYPE.name()
-        || name == upsert_rocksdb::UPSERT_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE.name()
-        || name == upsert_rocksdb::UPSERT_ROCKSDB_BATCH_SIZE.name()
-        || name == upsert_rocksdb::UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS.name()
-        || name == upsert_rocksdb::UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS.name()
-        || name == upsert_rocksdb::UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB.name()
-        || name == upsert_rocksdb::UPSERT_ROCKSDB_SHRINK_ALLOCATED_BUFFERS_BY_RATIO.name()
-}
-
-impl SystemVars {
-    /// Returns whether the named variable is a persist configuration parameter.
-    fn is_persist_config_var(&self, name: &str) -> bool {
-        self.persist_configs.entries().any(|e| name == e.name())
-    }
-}
-
-/// Returns whether the named variable is a Postgres/CRDB timestamp oracle
-/// configuration parameter.
-pub fn is_pg_timestamp_oracle_config_var(name: &str) -> bool {
-    name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE.name()
-        || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT.name()
-        || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL.name()
-        || name == PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER.name()
-        || name == CRDB_CONNECT_TIMEOUT.name()
-        || name == CRDB_TCP_USER_TIMEOUT.name()
-}
-
-/// Returns whether the named variable is a cluster scheduling config
-pub fn is_cluster_scheduling_var(name: &str) -> bool {
-    name == cluster_scheduling::CLUSTER_MULTI_PROCESS_REPLICA_AZ_AFFINITY_WEIGHT.name()
-        || name == cluster_scheduling::CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY.name()
-        || name == cluster_scheduling::CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT.name()
-        || name == cluster_scheduling::CLUSTER_ENABLE_TOPOLOGY_SPREAD.name()
-        || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE.name()
-        || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW.name()
-        || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT.name()
-        || name == cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY.name()
-        || name == cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT.name()
-        || name == cluster_scheduling::CLUSTER_ALWAYS_USE_DISK.name()
-}
-
-/// Returns whether the named variable is an HTTP server related config var.
-pub fn is_http_config_var(name: &str) -> bool {
-    name == WEBHOOK_CONCURRENT_REQUEST_LIMIT.name()
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum ClientEncoding {
-    Utf8,
-}
-
-impl ClientEncoding {
-    fn as_str(&self) -> &'static str {
-        match self {
-            ClientEncoding::Utf8 => "UTF8",
-        }
-    }
-
-    fn valid_values() -> Vec<&'static str> {
-        vec![ClientEncoding::Utf8.as_str()]
-    }
-}
-
-impl Value for ClientEncoding {
-    fn type_name() -> String {
-        "string".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        let s = UncasedStr::new(s);
-        if s == Self::Utf8.as_str() {
-            Ok(Self::Utf8)
-        } else {
-            Err(VarError::ConstrainedParameter {
-                parameter: (&CLIENT_ENCODING).into(),
-                values: vec![s.to_string()],
-                valid_values: Some(ClientEncoding::valid_values()),
-            })
-        }
-    }
-
-    fn format(&self) -> String {
-        self.as_str().to_string()
-    }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum IntervalStyle {
-    Postgres,
-}
-
-impl IntervalStyle {
-    fn as_str(&self) -> &'static str {
-        match self {
-            IntervalStyle::Postgres => "postgres",
-        }
-    }
-
-    fn valid_values() -> Vec<&'static str> {
-        vec![IntervalStyle::Postgres.as_str()]
-    }
-}
-
-impl Value for IntervalStyle {
-    fn type_name() -> String {
-        "string".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        let s = UncasedStr::new(s);
-        if s == Self::Postgres.as_str() {
-            Ok(Self::Postgres)
-        } else {
-            Err(VarError::ConstrainedParameter {
-                parameter: (&INTERVAL_STYLE).into(),
-                values: vec![s.to_string()],
-                valid_values: Some(IntervalStyle::valid_values()),
-            })
-        }
-    }
-
-    fn format(&self) -> String {
-        self.as_str().to_string()
-    }
-}
-
-/// List of valid TimestampOracle implementations
-///
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum TimestampOracleImpl {
-    /// Timestamp oracle backed by Postgres/CRDB.
-    Postgres,
-    /// Legacy, in-memory oracle backed by Catalog/Stash.
-    Catalog,
-}
-
-impl TimestampOracleImpl {
-    fn as_str(&self) -> &'static str {
-        match self {
-            TimestampOracleImpl::Postgres => "postgres",
-            TimestampOracleImpl::Catalog => "catalog",
-        }
-    }
-
-    fn valid_values() -> Vec<&'static str> {
-        vec![Self::Postgres.as_str(), Self::Catalog.as_str()]
-    }
-}
-
-impl Value for TimestampOracleImpl {
-    fn type_name() -> String {
-        "string".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        let s = UncasedStr::new(s);
-
-        if s == TimestampOracleImpl::Postgres.as_str() {
-            Ok(TimestampOracleImpl::Postgres)
-        } else if s == TimestampOracleImpl::Catalog.as_str() {
-            Ok(TimestampOracleImpl::Catalog)
-        } else {
-            Err(VarError::ConstrainedParameter {
-                parameter: (&TIMESTAMP_ORACLE_IMPL).into(),
-                values: input.to_vec(),
-                valid_values: Some(TimestampOracleImpl::valid_values()),
-            })
-        }
-    }
-
-    fn format(&self) -> String {
-        self.as_str().into()
-    }
-}
-
-impl Value for PersistTxnTablesImpl {
-    fn type_name() -> String {
-        "string".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        let s = UncasedStr::new(s);
-
-        PersistTxnTablesImpl::from_str(s.as_str()).map_err(|_| VarError::ConstrainedParameter {
-            parameter: (&PERSIST_TXN_TABLES).into(),
-            values: input.to_vec(),
-            valid_values: Some(vec!["off", "eager", "lazy"]),
-        })
-    }
-
-    fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
-#[derive(
-    ArgEnum,
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    num_enum::TryFromPrimitive,
-    num_enum::IntoPrimitive,
-    Arbitrary,
-)]
-#[repr(u64)]
-pub enum CatalogKind {
-    Stash = 0,
-    Persist = 1,
-    Shadow = 2,
-    /// Escape hatch to use the stash directly without trying to rollover from persist.
-    EmergencyStash = 3,
-}
-
-impl CatalogKind {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            CatalogKind::Stash => "stash",
-            CatalogKind::Persist => "persist",
-            CatalogKind::Shadow => "shadow",
-            CatalogKind::EmergencyStash => "emergency-stash",
-        }
-    }
-
-    fn valid_values() -> Vec<&'static str> {
-        vec![
-            CatalogKind::Stash.as_str(),
-            CatalogKind::Persist.as_str(),
-            CatalogKind::Shadow.as_str(),
-            CatalogKind::EmergencyStash.as_str(),
-        ]
-    }
-}
-
-impl Value for CatalogKind {
-    fn type_name() -> String {
-        "string".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        CatalogKind::from_str(s, true).map_err(|_| VarError::ConstrainedParameter {
-            parameter: (&CATALOG_KIND_IMPL).into(),
-            values: input.to_vec(),
-            valid_values: Some(CatalogKind::valid_values()),
-        })
-    }
-
-    fn format(&self) -> String {
-        self.as_str().into()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use proptest::prelude::*;
-
-    #[mz_ore::test]
-    fn test_should_output_to_client() {
-        #[rustfmt::skip]
-        let test_cases = [
-            (ClientSeverity::Debug1, vec![Severity::Debug, Severity::Log, Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
-            (ClientSeverity::Debug2, vec![Severity::Debug, Severity::Log, Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
-            (ClientSeverity::Debug3, vec![Severity::Debug, Severity::Log, Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
-            (ClientSeverity::Debug4, vec![Severity::Debug, Severity::Log, Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
-            (ClientSeverity::Debug5, vec![Severity::Debug, Severity::Log, Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
-            (ClientSeverity::Log, vec![Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
-            (ClientSeverity::Log, vec![Severity::Debug], false),
-            (ClientSeverity::Info, vec![Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
-            (ClientSeverity::Info, vec![Severity::Debug, Severity::Log], false),
-            (ClientSeverity::Notice, vec![Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
-            (ClientSeverity::Notice, vec![Severity::Debug, Severity::Log], false),
-            (ClientSeverity::Warning, vec![Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
-            (ClientSeverity::Warning, vec![Severity::Debug, Severity::Log, Severity::Notice], false),
-            (ClientSeverity::Error, vec![Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
-            (ClientSeverity::Error, vec![Severity::Debug, Severity::Log, Severity::Notice, Severity::Warning], false),
-        ];
-
-        for test_case in test_cases {
-            run_test(test_case)
-        }
-
-        fn run_test(test_case: (ClientSeverity, Vec<Severity>, bool)) {
-            let client_min_messages_setting = test_case.0;
-            let expected = test_case.2;
-            for message_severity in test_case.1 {
-                assert!(
-                    client_min_messages_setting.should_output_to_client(&message_severity)
-                        == expected
-                )
-            }
-        }
-    }
-
-    proptest! {
-        #[mz_ore::test]
-        #[cfg_attr(miri, ignore)] // slow
-        fn catalog_kind_roundtrip(catalog_kind: CatalogKind) {
-            let s = catalog_kind.as_str();
-            let round = CatalogKind::from_str(s, true).expect("to roundtrip");
-
-            prop_assert_eq!(catalog_kind, round);
-        }
     }
 }

--- a/src/sql/src/session/vars/constraints.rs
+++ b/src/sql/src/session/vars/constraints.rs
@@ -1,0 +1,131 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Defines constraints that can be imposed on variables.
+
+use std::borrow::Borrow;
+use std::fmt::Debug;
+use std::ops::RangeBounds;
+
+use mz_repr::adt::numeric::Numeric;
+
+use super::{Value, Var, VarError};
+
+#[derive(Debug)]
+pub enum ValueConstraint<V>
+where
+    V: Value + ToOwned + Debug + PartialEq + 'static,
+{
+    /// Variable is read-only and cannot be updated.
+    ReadOnly,
+    /// The variables value can be updated, but only to a fixed value.
+    Fixed,
+    // Arbitrary constraints over values.
+    Domain(&'static dyn DomainConstraint<V>),
+}
+
+impl<V> ValueConstraint<V>
+where
+    V: Value + ToOwned + Debug + PartialEq + 'static,
+{
+    pub fn check_constraint(
+        &self,
+        var: &(dyn Var + Send + Sync),
+        cur_value: &V,
+        new_value: &V::Owned,
+    ) -> Result<(), VarError> {
+        match self {
+            ValueConstraint::ReadOnly => return Err(VarError::ReadOnlyParameter(var.name())),
+            ValueConstraint::Fixed => {
+                if cur_value != new_value.borrow() {
+                    return Err(VarError::FixedValueParameter(var.into()));
+                }
+            }
+            ValueConstraint::Domain(check) => check.check(var, new_value)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl<V> Clone for ValueConstraint<V>
+where
+    V: Value + ToOwned + Debug + PartialEq + 'static,
+{
+    fn clone(&self) -> Self {
+        match self {
+            ValueConstraint::Fixed => ValueConstraint::Fixed,
+            ValueConstraint::ReadOnly => ValueConstraint::ReadOnly,
+            ValueConstraint::Domain(c) => ValueConstraint::Domain(*c),
+        }
+    }
+}
+
+pub trait DomainConstraint<V>: Debug + Send + Sync
+where
+    V: Value + Debug + PartialEq + 'static,
+{
+    // `self` is make a trait object
+    fn check(&self, var: &(dyn Var + Send + Sync), v: &V::Owned) -> Result<(), VarError>;
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct NumericNonNegNonNan;
+
+impl DomainConstraint<Numeric> for NumericNonNegNonNan {
+    fn check(&self, var: &(dyn Var + Send + Sync), n: &Numeric) -> Result<(), VarError> {
+        if n.is_nan() || n.is_negative() {
+            Err(VarError::InvalidParameterValue {
+                parameter: var.into(),
+                values: vec![n.to_string()],
+                reason: "only supports non-negative, non-NaN numeric values".to_string(),
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct NumericInRange<R>(pub R);
+
+impl<R> DomainConstraint<Numeric> for NumericInRange<R>
+where
+    R: RangeBounds<f64> + std::fmt::Debug + Send + Sync,
+{
+    fn check(&self, var: &(dyn Var + Send + Sync), n: &Numeric) -> Result<(), VarError> {
+        let n: f64 = (*n)
+            .try_into()
+            .map_err(|_e| VarError::InvalidParameterValue {
+                parameter: var.into(),
+                values: vec![n.to_string()],
+                // This first check can fail if the value is NaN, out of range,
+                // OR if it underflows (i.e. is very close to 0 without actually being 0, and the closest
+                // representable float is 0).
+                //
+                // The underflow case is very unlikely to be accidentally hit by a user, so let's
+                // not make the error message more confusing by talking about it, even though that makes
+                // the error message slightly inaccurate.
+                //
+                // If the user tries to set the paramater to 0.000<hundreds more zeros>001
+                // and gets the message "only supports values in range [0.0..=1.0]", I think they will
+                // understand, or at least accept, what's going on.
+                reason: format!("only supports values in range {:?}", self.0),
+            })?;
+        if !self.0.contains(&n) {
+            Err(VarError::InvalidParameterValue {
+                parameter: var.into(),
+                values: vec![n.to_string()],
+                reason: format!("only supports values in range {:?}", self.0),
+            })
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1,0 +1,2008 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// We pretend to be Postgres v9.5.0, which is also what CockroachDB pretends to
+// be. Too new and some clients will emit a "server too new" warning. Too old
+// and some clients will fall back to legacy code paths. v9.5.0 empirically
+// seems to be a good compromise.
+
+use std::clone::Clone;
+use std::fmt::Debug;
+use std::str::FromStr;
+use std::string::ToString;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use mz_adapter_types::timestamp_oracle::{
+    DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT,
+    DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
+};
+use mz_ore::cast;
+use mz_ore::cast::CastFrom;
+use mz_repr::adt::numeric::Numeric;
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::bytes::ByteSize;
+use mz_sql_parser::ast::Ident;
+use mz_sql_parser::ident;
+use mz_storage_types::controller::PersistTxnTablesImpl;
+use mz_tracing::{CloneableEnvFilter, SerializableDirective};
+use once_cell::sync::Lazy;
+use uncased::UncasedStr;
+
+use crate::session::user::{User, SUPPORT_USER, SYSTEM_USER};
+use crate::session::vars::errors::VarError;
+use crate::session::vars::value::{
+    CatalogKind, ClientEncoding, ClientSeverity, DateStyle, Failpoints, IntervalStyle,
+    IsolationLevel, TimeZone, TimestampOracleImpl, DEFAULT_DATE_STYLE,
+};
+use crate::session::vars::{FeatureFlag, SystemVars, Value, Var, VarInput};
+use crate::{DEFAULT_SCHEMA, WEBHOOK_CONCURRENCY_LIMIT};
+
+/// A `ServerVar` is the default value for a configuration parameter.
+#[derive(Debug)]
+pub struct ServerVar<V>
+where
+    V: Debug + 'static,
+{
+    pub name: &'static UncasedStr,
+    pub value: V,
+    pub description: &'static str,
+    pub internal: bool,
+}
+
+impl<V: Clone + Debug + 'static> Clone for ServerVar<V> {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name,
+            value: self.value.clone(),
+            description: self.description,
+            internal: self.internal,
+        }
+    }
+}
+
+impl<V> Var for ServerVar<V>
+where
+    V: Value + Debug + PartialEq + 'static,
+{
+    fn name(&self) -> &'static str {
+        self.name.as_str()
+    }
+
+    fn value(&self) -> String {
+        self.value.format()
+    }
+
+    fn description(&self) -> &'static str {
+        self.description
+    }
+
+    fn type_name(&self) -> String {
+        V::type_name()
+    }
+
+    fn visible(&self, user: &User, system_vars: Option<&SystemVars>) -> Result<(), VarError> {
+        if self.internal && user != &*SYSTEM_USER && user != &*SUPPORT_USER {
+            Err(VarError::UnknownParameter(self.name().to_string()))
+        } else if self.name().starts_with("unsafe")
+            && match system_vars {
+                None => true,
+                Some(system_vars) => !system_vars.allow_unsafe,
+            }
+        {
+            Err(VarError::RequiresUnsafeMode(self.name()))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// The major version of PostgreSQL that Materialize claims to be.
+pub const SERVER_MAJOR_VERSION: u8 = 9;
+
+/// The minor version of PostgreSQL that Materialize claims to be.
+pub const SERVER_MINOR_VERSION: u8 = 5;
+
+/// The patch version of PostgreSQL that Materialize claims to be.
+pub const SERVER_PATCH_VERSION: u8 = 0;
+
+/// The name of the default database that Materialize uses.
+pub const DEFAULT_DATABASE_NAME: &str = "materialize";
+
+pub static APPLICATION_NAME: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("application_name"),
+    value: "".to_string(),
+    description: "Sets the application name to be reported in statistics and logs (PostgreSQL).",
+    internal: false,
+});
+
+pub static CLIENT_ENCODING: ServerVar<ClientEncoding> = ServerVar {
+    name: UncasedStr::new("client_encoding"),
+    value: ClientEncoding::Utf8,
+    description: "Sets the client's character set encoding (PostgreSQL).",
+    internal: false,
+};
+
+pub const CLIENT_MIN_MESSAGES: ServerVar<ClientSeverity> = ServerVar {
+    name: UncasedStr::new("client_min_messages"),
+    value: ClientSeverity::Notice,
+    description: "Sets the message levels that are sent to the client (PostgreSQL).",
+    internal: false,
+};
+
+pub const CLUSTER_VAR_NAME: &UncasedStr = UncasedStr::new("cluster");
+pub static CLUSTER: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
+    name: CLUSTER_VAR_NAME,
+    value: "quickstart".to_string(),
+    description: "Sets the current cluster (Materialize).",
+    internal: false,
+});
+
+pub const CLUSTER_REPLICA: ServerVar<Option<String>> = ServerVar {
+    name: UncasedStr::new("cluster_replica"),
+    value: None,
+    description: "Sets a target cluster replica for SELECT queries (Materialize).",
+    internal: false,
+};
+
+pub const DATABASE_VAR_NAME: &UncasedStr = UncasedStr::new("database");
+pub static DATABASE: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
+    name: DATABASE_VAR_NAME,
+    value: DEFAULT_DATABASE_NAME.to_string(),
+    description: "Sets the current database (CockroachDB).",
+    internal: false,
+});
+
+pub static DATE_STYLE: ServerVar<DateStyle> = ServerVar {
+    // DateStyle has nonstandard capitalization for historical reasons.
+    name: UncasedStr::new("DateStyle"),
+    value: DEFAULT_DATE_STYLE,
+    description: "Sets the display format for date and time values (PostgreSQL).",
+    internal: false,
+};
+
+pub const EXTRA_FLOAT_DIGITS: ServerVar<i32> = ServerVar {
+    name: UncasedStr::new("extra_float_digits"),
+    value: 3,
+    description: "Adjusts the number of digits displayed for floating-point values (PostgreSQL).",
+    internal: false,
+};
+
+pub const FAILPOINTS: ServerVar<Failpoints> = ServerVar {
+    name: UncasedStr::new("failpoints"),
+    value: Failpoints,
+    description: "Allows failpoints to be dynamically activated.",
+    internal: false,
+};
+
+pub const INTEGER_DATETIMES: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("integer_datetimes"),
+    value: true,
+    description: "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL).",
+    internal: false,
+};
+
+pub static INTERVAL_STYLE: ServerVar<IntervalStyle> = ServerVar {
+    // IntervalStyle has nonstandard capitalization for historical reasons.
+    name: UncasedStr::new("IntervalStyle"),
+    value: IntervalStyle::Postgres,
+    description: "Sets the display format for interval values (PostgreSQL).",
+    internal: false,
+};
+
+pub const MZ_VERSION_NAME: &UncasedStr = UncasedStr::new("mz_version");
+pub const IS_SUPERUSER_NAME: &UncasedStr = UncasedStr::new("is_superuser");
+
+// Schema can be used an alias for a search path with a single element.
+pub const SCHEMA_ALIAS: &UncasedStr = UncasedStr::new("schema");
+pub static SEARCH_PATH: Lazy<ServerVar<Vec<Ident>>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("search_path"),
+    value: vec![ident!(DEFAULT_SCHEMA)],
+    description:
+        "Sets the schema search order for names that are not schema-qualified (PostgreSQL).",
+    internal: false,
+});
+
+pub const STATEMENT_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("statement_timeout"),
+    value: Duration::from_secs(10),
+    description:
+        "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations. \
+        If this value is specified without units, it is taken as milliseconds.",
+    internal: false,
+};
+
+pub const IDLE_IN_TRANSACTION_SESSION_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("idle_in_transaction_session_timeout"),
+    value: Duration::from_secs(60 * 2),
+    description:
+        "Sets the maximum allowed duration that a session can sit idle in a transaction before \
+         being terminated. If this value is specified without units, it is taken as milliseconds. \
+         A value of zero disables the timeout (PostgreSQL).",
+    internal: false,
+};
+
+pub static SERVER_VERSION: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("server_version"),
+    value: format!(
+        "{}.{}.{}",
+        SERVER_MAJOR_VERSION, SERVER_MINOR_VERSION, SERVER_PATCH_VERSION
+    ),
+    description: "Shows the PostgreSQL compatible server version (PostgreSQL).",
+    internal: false,
+});
+
+pub const SERVER_VERSION_NUM: ServerVar<i32> = ServerVar {
+    name: UncasedStr::new("server_version_num"),
+    value: ((cast::u8_to_i32(SERVER_MAJOR_VERSION) * 10_000)
+        + (cast::u8_to_i32(SERVER_MINOR_VERSION) * 100)
+        + cast::u8_to_i32(SERVER_PATCH_VERSION)),
+    description: "Shows the PostgreSQL compatible server version as an integer (PostgreSQL).",
+    internal: false,
+};
+
+pub const SQL_SAFE_UPDATES: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("sql_safe_updates"),
+    value: false,
+    description: "Prohibits SQL statements that may be overly destructive (CockroachDB).",
+    internal: false,
+};
+
+pub const STANDARD_CONFORMING_STRINGS: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("standard_conforming_strings"),
+    value: true,
+    description: "Causes '...' strings to treat backslashes literally (PostgreSQL).",
+    internal: false,
+};
+
+pub const TIMEZONE: ServerVar<TimeZone> = ServerVar {
+    // TimeZone has nonstandard capitalization for historical reasons.
+    name: UncasedStr::new("TimeZone"),
+    value: TimeZone::UTC,
+    description: "Sets the time zone for displaying and interpreting time stamps (PostgreSQL).",
+    internal: false,
+};
+
+pub const TRANSACTION_ISOLATION_VAR_NAME: &UncasedStr = UncasedStr::new("transaction_isolation");
+pub const TRANSACTION_ISOLATION: ServerVar<IsolationLevel> = ServerVar {
+    name: TRANSACTION_ISOLATION_VAR_NAME,
+    value: IsolationLevel::StrictSerializable,
+    description: "Sets the current transaction's isolation level (PostgreSQL).",
+    internal: false,
+};
+
+pub const MAX_KAFKA_CONNECTIONS: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_kafka_connections"),
+    value: 1000,
+    description:
+        "The maximum number of Kafka connections in the region, across all schemas (Materialize).",
+    internal: false,
+};
+
+pub const MAX_POSTGRES_CONNECTIONS: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_postgres_connections"),
+    value: 1000,
+    description: "The maximum number of PostgreSQL connections in the region, across all schemas (Materialize).",
+    internal: false
+};
+
+pub const MAX_AWS_PRIVATELINK_CONNECTIONS: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_aws_privatelink_connections"),
+    value: 0,
+    description: "The maximum number of AWS PrivateLink connections in the region, across all schemas (Materialize).",
+    internal: false
+};
+
+pub const MAX_TABLES: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_tables"),
+    value: 25,
+    description: "The maximum number of tables in the region, across all schemas (Materialize).",
+    internal: false,
+};
+
+pub const MAX_SOURCES: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_sources"),
+    value: 25,
+    description: "The maximum number of sources in the region, across all schemas (Materialize).",
+    internal: false,
+};
+
+pub const MAX_SINKS: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_sinks"),
+    value: 25,
+    description: "The maximum number of sinks in the region, across all schemas (Materialize).",
+    internal: false,
+};
+
+pub const MAX_MATERIALIZED_VIEWS: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_materialized_views"),
+    value: 100,
+    description:
+        "The maximum number of materialized views in the region, across all schemas (Materialize).",
+    internal: false,
+};
+
+pub const MAX_CLUSTERS: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_clusters"),
+    value: 10,
+    description: "The maximum number of clusters in the region (Materialize).",
+    internal: false,
+};
+
+pub const MAX_REPLICAS_PER_CLUSTER: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_replicas_per_cluster"),
+    value: 5,
+    description: "The maximum number of replicas of a single cluster (Materialize).",
+    internal: false,
+};
+
+pub static MAX_CREDIT_CONSUMPTION_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| {
+    ServerVar {
+        name: UncasedStr::new("max_credit_consumption_rate"),
+        value: 1024.into(),
+        description: "The maximum rate of credit consumption in a region. Credits are consumed based on the size of cluster replicas in use (Materialize).",
+        internal: false
+    }
+});
+
+pub const MAX_DATABASES: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_databases"),
+    value: 1000,
+    description: "The maximum number of databases in the region (Materialize).",
+    internal: false,
+};
+
+pub const MAX_SCHEMAS_PER_DATABASE: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_schemas_per_database"),
+    value: 1000,
+    description: "The maximum number of schemas in a database (Materialize).",
+    internal: false,
+};
+
+pub const MAX_OBJECTS_PER_SCHEMA: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_objects_per_schema"),
+    value: 1000,
+    description: "The maximum number of objects in a schema (Materialize).",
+    internal: false,
+};
+
+pub const MAX_SECRETS: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_secrets"),
+    value: 100,
+    description: "The maximum number of secrets in the region, across all schemas (Materialize).",
+    internal: false,
+};
+
+pub const MAX_ROLES: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_roles"),
+    value: 1000,
+    description: "The maximum number of roles in the region (Materialize).",
+    internal: false,
+};
+
+// Cloud environmentd is configured with 4 GiB of RAM, so 1 GiB is a good heuristic for a single
+// query.
+// TODO(jkosh44) Eventually we want to be able to return arbitrary sized results.
+pub const MAX_RESULT_SIZE: ServerVar<ByteSize> = ServerVar {
+    name: UncasedStr::new("max_result_size"),
+    value: ByteSize::gb(1),
+    description: "The maximum size in bytes for an internal query result (Materialize).",
+    internal: false,
+};
+
+pub const MAX_QUERY_RESULT_SIZE: ServerVar<ByteSize> = ServerVar {
+    name: UncasedStr::new("max_query_result_size"),
+    value: ByteSize::gb(1),
+    description: "The maximum size in bytes for a single query's result (Materialize).",
+    internal: false,
+};
+
+pub const MAX_COPY_FROM_SIZE: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_copy_from_size"),
+    // 1 GiB, this limit is noted in the docs, if you change it make sure to update our docs.
+    value: 1_073_741_824,
+    description: "The maximum size in bytes we buffer for COPY FROM statements (Materialize).",
+    internal: false,
+};
+
+pub const MAX_IDENTIFIER_LENGTH: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("max_identifier_length"),
+    value: mz_sql_lexer::lexer::MAX_IDENTIFIER_LENGTH,
+    description: "The maximum length of object identifiers in bytes (PostgreSQL).",
+    internal: false,
+};
+
+pub const WELCOME_MESSAGE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("welcome_message"),
+    value: true,
+    description: "Whether to send a notice with a welcome message after a successful connection (Materialize).",
+    internal: false,
+};
+
+/// The logical compaction window for builtin tables and sources that have the
+/// `retained_metrics_relation` flag set.
+///
+/// The existence of this variable is a bit of a hack until we have a fully
+/// general solution for controlling retention windows.
+pub const METRICS_RETENTION: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("metrics_retention"),
+    // 30 days
+    value: Duration::from_secs(30 * 24 * 60 * 60),
+    description: "The time to retain cluster utilization metrics (Materialize).",
+    internal: true,
+};
+
+pub static ALLOWED_CLUSTER_REPLICA_SIZES: Lazy<ServerVar<Vec<Ident>>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("allowed_cluster_replica_sizes"),
+    value: Vec::new(),
+    description: "The allowed sizes when creating a new cluster replica (Materialize).",
+    internal: false,
+});
+
+pub const PERSIST_FAST_PATH_LIMIT: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("persist_fast_path_limit"),
+    value: 0,
+    description:
+        "An exclusive upper bound on the number of results we may return from a Persist fast-path peek; \
+        queries that may return more results will follow the normal / slow path. \
+        Setting this to 0 disables the feature.",
+    internal: true,
+};
+
+pub const PERSIST_TXN_TABLES: ServerVar<PersistTxnTablesImpl> = ServerVar {
+    name: UncasedStr::new("persist_txn_tables"),
+    value: PersistTxnTablesImpl::Eager,
+    description: "\
+        Whether to use the new persist-txn tables implementation or the legacy \
+        one.
+
+        Only takes effect on restart. Any changes will also cause clusterd \
+        processes to restart.
+
+        This value is also configurable via a Launch Darkly parameter of the \
+        same name, but we keep the flag to make testing easier. If specified, \
+        the flag takes precedence over the Launch Darkly param.",
+    internal: true,
+};
+
+pub const TIMESTAMP_ORACLE_IMPL: ServerVar<TimestampOracleImpl> = ServerVar {
+    name: UncasedStr::new("timestamp_oracle"),
+    value: TimestampOracleImpl::Postgres,
+    description: "Backing implementation of TimestampOracle.",
+    internal: true,
+};
+
+pub const CATALOG_KIND_IMPL: ServerVar<Option<CatalogKind>> = ServerVar {
+    name: UncasedStr::new("catalog_kind"),
+    value: None,
+    description: "Backing implementation of catalog.",
+    internal: true,
+};
+
+/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_max_size`.
+pub const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_max_size"),
+    value: DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE,
+    description: "Maximum size of the Postgres/CRDB connection pool, used by the Postgres/CRDB timestamp oracle.",
+    internal: true,
+};
+
+/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_max_wait`.
+pub const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT: ServerVar<Option<Duration>> = ServerVar {
+    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_max_wait"),
+    value: Some(DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT),
+    description: "The maximum time to wait when attempting to obtain a connection from the Postgres/CRDB connection pool, used by the Postgres/CRDB timestamp oracle.",
+    internal: true,
+};
+
+/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_ttl`.
+pub const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_ttl"),
+    value: DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL,
+    description: "The minimum TTL of a Consensus connection to Postgres/CRDB before it is proactively terminated",
+    internal: true,
+};
+
+/// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_ttl_stagger`.
+pub const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_ttl_stagger"),
+    value: DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
+    description: "The minimum time between TTLing Consensus connections to Postgres/CRDB.",
+    internal: true,
+};
+
+/// The default for the `DISK` option when creating managed clusters and cluster replicas.
+pub const DISK_CLUSTER_REPLICAS_DEFAULT: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("disk_cluster_replicas_default"),
+    value: false,
+    description: "Whether the disk option for managed clusters and cluster replicas should be enabled by default.",
+    internal: true,
+};
+
+pub const UNSAFE_NEW_TRANSACTION_WALL_TIME: ServerVar<Option<CheckedTimestamp<DateTime<Utc>>>> = ServerVar {
+    name: UncasedStr::new("unsafe_new_transaction_wall_time"),
+    value: None,
+    description:
+        "Sets the wall time for all new explicit or implicit transactions to control the value of `now()`. \
+        If not set, uses the system's clock.",
+    // This needs to be false because `internal: true` things are only modifiable by the mz_system
+    // and mz_support users, and we want sqllogictest to have access with its user. Because the name
+    // starts with "unsafe" it still won't be visible or changeable by users unless unsafe mode is
+    // enabled.
+    internal: false,
+};
+
+/// Tuning for RocksDB used by `UPSERT` sources that takes effect on restart.
+pub mod upsert_rocksdb {
+    use super::*;
+    use mz_rocksdb_types::config::{CompactionStyle, CompressionType};
+
+    pub static UPSERT_ROCKSDB_COMPACTION_STYLE: ServerVar<CompactionStyle> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_compaction_style"),
+        value: mz_rocksdb_types::defaults::DEFAULT_COMPACTION_STYLE,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+    pub const UPSERT_ROCKSDB_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET: ServerVar<usize> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_optimize_compaction_memtable_budget"),
+        value: mz_rocksdb_types::defaults::DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+    pub const UPSERT_ROCKSDB_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_level_compaction_dynamic_level_bytes"),
+        value: mz_rocksdb_types::defaults::DEFAULT_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+    pub const UPSERT_ROCKSDB_UNIVERSAL_COMPACTION_RATIO: ServerVar<i32> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_universal_compaction_ratio"),
+        value: mz_rocksdb_types::defaults::DEFAULT_UNIVERSAL_COMPACTION_RATIO,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+    pub const UPSERT_ROCKSDB_PARALLELISM: ServerVar<Option<i32>> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_parallelism"),
+        value: mz_rocksdb_types::defaults::DEFAULT_PARALLELISM,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+    pub static UPSERT_ROCKSDB_COMPRESSION_TYPE: ServerVar<CompressionType> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_compression_type"),
+        value: mz_rocksdb_types::defaults::DEFAULT_COMPRESSION_TYPE,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+    pub static UPSERT_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE: ServerVar<CompressionType> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_bottommost_compression_type"),
+        value: mz_rocksdb_types::defaults::DEFAULT_BOTTOMMOST_COMPRESSION_TYPE,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+
+    pub static UPSERT_ROCKSDB_BATCH_SIZE: ServerVar<usize> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_batch_size"),
+        value: mz_rocksdb_types::defaults::DEFAULT_BATCH_SIZE,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Can be changed dynamically (Materialize).",
+        internal: true,
+    };
+
+    pub static UPSERT_ROCKSDB_RETRY_DURATION: ServerVar<Duration> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_retry_duration"),
+        value: mz_rocksdb_types::defaults::DEFAULT_RETRY_DURATION,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+
+    /// Controls whether automatic spill to disk should be turned on when using `DISK`.
+    pub const UPSERT_ROCKSDB_AUTO_SPILL_TO_DISK: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_auto_spill_to_disk"),
+        value: false,
+        description:
+            "Controls whether automatic spill to disk should be turned on when using `DISK`",
+        internal: true,
+    };
+
+    /// The upsert in memory state size threshold after which it will spill to disk.
+    /// The default is 85 MiB = 89128960 bytes
+    pub const UPSERT_ROCKSDB_AUTO_SPILL_THRESHOLD_BYTES: ServerVar<usize> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_auto_spill_threshold_bytes"),
+        value: mz_rocksdb_types::defaults::DEFAULT_AUTO_SPILL_MEMORY_THRESHOLD,
+        description:
+            "The upsert in-memory state size threshold in bytes after which it will spill to disk",
+        internal: true,
+    };
+
+    pub static UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS: ServerVar<u32> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_stats_log_interval_seconds"),
+        value: mz_rocksdb_types::defaults::DEFAULT_STATS_LOG_INTERVAL_S,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+    pub static UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS: ServerVar<u32> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_stats_persist_interval_seconds"),
+        value: mz_rocksdb_types::defaults::DEFAULT_STATS_PERSIST_INTERVAL_S,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+    pub static UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB: ServerVar<Option<u32>> =
+        ServerVar {
+            name: UncasedStr::new("upsert_rocksdb_point_lookup_block_cache_size_mb"),
+            value: None,
+            description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+            internal: true,
+        };
+
+    /// The number of times by which allocated buffers will be shrinked in upsert rocksdb.
+    /// If value is 0, then no shrinking will occur.
+    pub static UPSERT_ROCKSDB_SHRINK_ALLOCATED_BUFFERS_BY_RATIO: ServerVar<usize> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_shrink_allocated_buffers_by_ratio"),
+        value: mz_rocksdb_types::defaults::DEFAULT_SHRINK_BUFFERS_BY_RATIO,
+        description:
+            "The number of times by which allocated buffers will be shrinked in upsert rocksdb.",
+        internal: true,
+    };
+    /// Only used if `upsert_rocksdb_write_buffer_manager_memory_bytes` is also set
+    /// and write buffer manager is enabled
+    pub static UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_CLUSTER_MEMORY_FRACTION: Lazy<
+        ServerVar<Option<Numeric>>,
+    > = Lazy::new(|| ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_write_buffer_manager_cluster_memory_fraction"),
+        value: None,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    });
+    /// `upsert_rocksdb_write_buffer_manager_memory_bytes` needs to be set for write buffer manager to be
+    /// used.
+    pub static UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_MEMORY_BYTES: ServerVar<Option<usize>> =
+        ServerVar {
+            name: UncasedStr::new("upsert_rocksdb_write_buffer_manager_memory_bytes"),
+            value: None,
+            description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+            internal: true,
+        };
+    pub static UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_ALLOW_STALL: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_write_buffer_manager_allow_stall"),
+        value: false,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+}
+
+pub static LOGGING_FILTER: Lazy<ServerVar<CloneableEnvFilter>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("log_filter"),
+    value: CloneableEnvFilter::from_str("info").expect("valid EnvFilter"),
+    description: "Sets the filter to apply to stderr logging.",
+    internal: true,
+});
+
+pub static OPENTELEMETRY_FILTER: Lazy<ServerVar<CloneableEnvFilter>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("opentelemetry_filter"),
+    value: CloneableEnvFilter::from_str("off").expect("valid EnvFilter"),
+    description: "Sets the filter to apply to OpenTelemetry-backed distributed tracing.",
+    internal: true,
+});
+
+pub static LOGGING_FILTER_DEFAULTS: Lazy<ServerVar<Vec<SerializableDirective>>> =
+    Lazy::new(|| ServerVar {
+        name: UncasedStr::new("log_filter_defaults"),
+        value: mz_ore::tracing::LOGGING_DEFAULTS
+            .iter()
+            .map(|d| d.clone().into())
+            .collect(),
+        description: "Sets additional default directives to apply to stderr logging. \
+            These apply to all variations of `log_filter`. Directives other than \
+            `module=off` are likely incorrect.",
+        internal: true,
+    });
+
+pub static OPENTELEMETRY_FILTER_DEFAULTS: Lazy<ServerVar<Vec<SerializableDirective>>> =
+    Lazy::new(|| ServerVar {
+        name: UncasedStr::new("opentelemetry_filter_defaults"),
+        value: mz_ore::tracing::OPENTELEMETRY_DEFAULTS
+            .iter()
+            .map(|d| d.clone().into())
+            .collect(),
+        description: "Sets additional default directives to apply to OpenTelemetry-backed \
+            distributed tracing. \
+            These apply to all variations of `opentelemetry_filter`. Directives other than \
+            `module=off` are likely incorrect.",
+        internal: true,
+    });
+
+pub static SENTRY_FILTERS: Lazy<ServerVar<Vec<SerializableDirective>>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("sentry_filters"),
+    value: mz_ore::tracing::SENTRY_DEFAULTS
+        .iter()
+        .map(|d| d.clone().into())
+        .collect(),
+    description: "Sets additional default directives to apply to sentry logging. \
+            These apply on top of a default `info` directive. Directives other than \
+            `module=off` are likely incorrect.",
+    internal: true,
+});
+
+pub static WEBHOOKS_SECRETS_CACHING_TTL_SECS: Lazy<ServerVar<usize>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("webhooks_secrets_caching_ttl_secs"),
+    value: usize::cast_from(
+        mz_secrets::cache::DEFAULT_TTL_SECS.load(std::sync::atomic::Ordering::Relaxed),
+    ),
+    description: "Sets the time-to-live for values in the Webhooks secrets cache.",
+    internal: true,
+});
+
+pub const COORD_SLOW_MESSAGE_WARN_THRESHOLD: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("coord_slow_message_warn_threshold"),
+    // Note(parkmycar): This value was chosen arbitrarily.
+    value: Duration::from_secs(5),
+    description: "Sets the threshold at which we will warn! for a coordinator message being slow.",
+    internal: true,
+};
+
+/// Controls the connect_timeout setting when connecting to PG via `mz_postgres_util`.
+pub const PG_SOURCE_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("pg_source_connect_timeout"),
+    value: mz_postgres_util::DEFAULT_CONNECT_TIMEOUT,
+    description: "Sets the timeout applied to socket-level connection attempts for PG \
+    replication connections. (Materialize)",
+    internal: true,
+};
+
+/// Sets the maximum number of TCP keepalive probes that will be sent before dropping a connection
+/// when connecting to PG via `mz_postgres_util`.
+pub const PG_SOURCE_KEEPALIVES_RETRIES: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("pg_source_keepalives_retries"),
+    value: mz_postgres_util::DEFAULT_KEEPALIVE_RETRIES,
+    description:
+        "Sets the maximum number of TCP keepalive probes that will be sent before dropping \
+    a connection when connecting to PG via `mz_postgres_util`. (Materialize)",
+    internal: true,
+};
+
+/// Sets the amount of idle time before a keepalive packet is sent on the connection when connecting
+/// to PG via `mz_postgres_util`.
+pub const PG_SOURCE_KEEPALIVES_IDLE: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("pg_source_keepalives_idle"),
+    value: mz_postgres_util::DEFAULT_KEEPALIVE_IDLE,
+    description:
+        "Sets the amount of idle time before a keepalive packet is sent on the connection \
+    when connecting to PG via `mz_postgres_util`. (Materialize)",
+    internal: true,
+};
+
+/// Sets the time interval between TCP keepalive probes when connecting to PG via `mz_postgres_util`.
+pub const PG_SOURCE_KEEPALIVES_INTERVAL: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("pg_source_keepalives_interval"),
+    value: mz_postgres_util::DEFAULT_KEEPALIVE_INTERVAL,
+    description: "Sets the time interval between TCP keepalive probes when connecting to PG via \
+    replication. (Materialize)",
+    internal: true,
+};
+
+/// Sets the TCP user timeout when connecting to PG via `mz_postgres_util`.
+pub const PG_SOURCE_TCP_USER_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("pg_source_tcp_user_timeout"),
+    value: mz_postgres_util::DEFAULT_TCP_USER_TIMEOUT,
+    description:
+        "Sets the TCP user timeout when connecting to PG via `mz_postgres_util`. (Materialize)",
+    internal: true,
+};
+
+/// Sets the `statement_timeout` value to use during the snapshotting phase of
+/// PG sources.
+pub const PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("pg_source_snapshot_statement_timeout"),
+    value: mz_postgres_util::DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT,
+    description: "Sets the `statement_timeout` value to use during the snapshotting phase of PG sources (Materialize)",
+    internal: true,
+};
+
+/// Please see `PgSourceSnapshotConfig`.
+pub const PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("pg_source_snapshot_collect_strict_count"),
+    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().collect_strict_count,
+    description: "Please see <https://dev.materialize.com/api/rust-private\
+        /mz_storage_types/parameters\
+        /struct.PgSourceSnapshotConfig.html#structfield.collect_strict_count>",
+    internal: true,
+};
+/// Please see `PgSourceSnapshotConfig`.
+pub const PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("pg_source_snapshot_fallback_to_strict_count"),
+    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().fallback_to_strict_count,
+    description: "Please see <https://dev.materialize.com/api/rust-private\
+        /mz_storage_types/parameters\
+        /struct.PgSourceSnapshotConfig.html#structfield.fallback_to_strict_count>",
+    internal: true,
+};
+/// Please see `PgSourceSnapshotConfig`.
+pub const PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("pg_source_snapshot_wait_for_count"),
+    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().wait_for_count,
+    description: "Please see <https://dev.materialize.com/api/rust-private\
+        /mz_storage_types/parameters\
+        /struct.PgSourceSnapshotConfig.html#structfield.wait_for_count>",
+    internal: true,
+};
+
+/// Controls the check interval for connections to SSH bastions via `mz_ssh_util`.
+pub const SSH_CHECK_INTERVAL: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("ssh_check_interval"),
+    value: mz_ssh_util::tunnel::DEFAULT_CHECK_INTERVAL,
+    description: "Controls the check interval for connections to SSH bastions via `mz_ssh_util`.",
+    internal: true,
+};
+
+/// Controls the connect timeout for connections to SSH bastions via `mz_ssh_util`.
+pub const SSH_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("ssh_connect_timeout"),
+    value: mz_ssh_util::tunnel::DEFAULT_CONNECT_TIMEOUT,
+    description: "Controls the connect timeout for connections to SSH bastions via `mz_ssh_util`.",
+    internal: true,
+};
+
+/// Controls the keepalive idle interval for connections to SSH bastions via `mz_ssh_util`.
+pub const SSH_KEEPALIVES_IDLE: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("ssh_keepalives_idle"),
+    value: mz_ssh_util::tunnel::DEFAULT_KEEPALIVES_IDLE,
+    description:
+        "Controls the keepalive idle interval for connections to SSH bastions via `mz_ssh_util`.",
+    internal: true,
+};
+
+/// Enables `socket.keepalive.enable` for rdkafka client connections. Defaults to true.
+pub const KAFKA_SOCKET_KEEPALIVE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("kafka_socket_keepalive"),
+    value: mz_kafka_util::client::DEFAULT_KEEPALIVE,
+    description:
+        "Enables `socket.keepalive.enable` for rdkafka client connections. Defaults to true.",
+    internal: true,
+};
+
+/// Controls `socket.timeout.ms` for rdkafka client connections. Defaults to the rdkafka default
+/// (60000ms). Cannot be greater than 300000ms, more than 100ms greater than
+/// `kafka_transaction_timeout`, or less than 10ms.
+pub const KAFKA_SOCKET_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("kafka_socket_timeout"),
+    value: mz_kafka_util::client::DEFAULT_SOCKET_TIMEOUT,
+    description: "Controls `socket.timeout.ms` for rdkafka \
+        client connections. Defaults to the rdkafka default (60000ms). \
+        Cannot be greater than 300000ms or more than 100ms greater than \
+        Cannot be greater than 300000ms, more than 100ms greater than \
+        `kafka_transaction_timeout`, or less than 10ms.",
+    internal: true,
+};
+
+/// Controls `transaction.timeout.ms` for rdkafka client connections. Defaults to the rdkafka default
+/// (60000ms). Cannot be greater than `i32::MAX` or less than 1000ms.
+pub const KAFKA_TRANSACTION_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("kafka_transaction_timeout"),
+    value: mz_kafka_util::client::DEFAULT_TRANSACTION_TIMEOUT,
+    description: "Controls `transaction.timeout.ms` for rdkafka \
+        client connections. Defaults to the rdkafka default (60000ms). \
+        Cannot be greater than `i32::MAX` or less than 1000ms.",
+    internal: true,
+};
+
+/// Controls `socket.connection.setup.timeout.ms` for rdkafka client connections. Defaults to the rdkafka default
+/// (30000ms). Cannot be greater than `i32::MAX` or less than 1000ms
+pub const KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("kafka_socket_connection_setup_timeout"),
+    value: mz_kafka_util::client::DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT,
+    description: "Controls `socket.connection.setup.timeout.ms` for rdkafka \
+        client connections. Defaults to the rdkafka default (30000ms). \
+        Cannot be greater than `i32::MAX` or less than 1000ms",
+    internal: true,
+};
+
+/// Controls the timeout when fetching kafka metadata. Defaults to 10s.
+pub const KAFKA_FETCH_METADATA_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("kafka_fetch_metadata_timeout"),
+    value: mz_kafka_util::client::DEFAULT_FETCH_METADATA_TIMEOUT,
+    description: "Controls the timeout when fetching kafka metadata. \
+        Defaults to 10s.",
+    internal: true,
+};
+
+/// Controls the timeout when fetching kafka progress records. Defaults to 60s.
+pub const KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("kafka_progress_record_fetch_timeout"),
+    value: mz_kafka_util::client::DEFAULT_PROGRESS_RECORD_FETCH_TIMEOUT,
+    description: "Controls the timeout when fetching kafka progress records. \
+        Defaults to 60s.",
+    internal: true,
+};
+
+/// The interval we will fetch metadata from, unless overridden by the source.
+pub const KAFKA_DEFAULT_METADATA_FETCH_INTERVAL: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("kafka_default_metadata_fetch_interval"),
+    value: mz_kafka_util::client::DEFAULT_METADATA_FETCH_INTERVAL,
+    description: "The interval we will fetch metadata from, unless overridden by the source. \
+        Defaults to 60s.",
+    internal: true,
+};
+
+/// The maximum number of in-flight bytes emitted by persist_sources feeding compute dataflows.
+pub const COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar {
+    name: UncasedStr::new("compute_dataflow_max_inflight_bytes"),
+    value: None,
+    description: "The maximum number of in-flight bytes emitted by persist_sources feeding \
+                  compute dataflows (Materialize).",
+    internal: true,
+};
+
+/// The maximum number of in-flight bytes emitted by persist_sources feeding _storage
+/// dataflows_.
+/// Currently defaults to 256MiB = 268435456 bytes
+/// Note: Backpressure will only be turned on if disk is enabled based on
+/// `storage_dataflow_max_inflight_bytes_disk_only` flag
+pub const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar {
+    name: UncasedStr::new("storage_dataflow_max_inflight_bytes"),
+    value: Some(256 * 1024 * 1024),
+    description: "The maximum number of in-flight bytes emitted by persist_sources feeding \
+                  storage dataflows. Defaults to backpressure enabled (Materialize).",
+    internal: true,
+};
+
+/// Whether or not to delay sources producing values in some scenarios
+/// (namely, upsert) till after rehydration is finished.
+pub const STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("storage_dataflow_delay_sources_past_rehydration"),
+    value: false,
+    description: "Whether or not to delay sources producing values in some scenarios \
+                  (namely, upsert) till after rehydration is finished",
+    internal: true,
+};
+
+/// Configuration ratio to shrink unusef buffers in upsert by.
+/// For eg: is 2 is set, then the buffers will be reduced by 2 i.e. halved.
+/// Default is 0, which means shrinking is disabled.
+pub const STORAGE_SHRINK_UPSERT_UNUSED_BUFFERS_BY_RATIO: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("storage_shrink_upsert_unused_buffers_by_ratio"),
+    value: 0,
+    description: "Configuration ratio to shrink unusef buffers in upsert by",
+    internal: true,
+};
+
+/// The fraction of the cluster replica size to be used as the maximum number of
+/// in-flight bytes emitted by persist_sources feeding storage dataflows.
+/// If not configured, the storage_dataflow_max_inflight_bytes value will be used.
+/// For this value to be used storage_dataflow_max_inflight_bytes needs to be set.
+pub static STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION: Lazy<
+    ServerVar<Option<Numeric>>,
+> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("storage_dataflow_max_inflight_bytes_to_cluster_size_fraction"),
+    value: Some(0.0025.into()),
+    description: "The fraction of the cluster replica size to be used as the maximum number of \
+    in-flight bytes emitted by persist_sources feeding storage dataflows. \
+    If not configured, the storage_dataflow_max_inflight_bytes value will be used.",
+    internal: true,
+});
+
+pub const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("storage_dataflow_max_inflight_bytes_disk_only"),
+    value: true,
+    description: "Whether or not `storage_dataflow_max_inflight_bytes` applies only to \
+        upsert dataflows using disks. Defaults to true (Materialize).",
+    internal: true,
+};
+
+/// The interval to submit statistics to `mz_source_statistics_raw` and `mz_sink_statistics_raw`.
+pub const STORAGE_STATISTICS_INTERVAL: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("storage_statistics_interval"),
+    value: mz_storage_types::parameters::STATISTICS_INTERVAL_DEFAULT,
+    description: "The interval to submit statistics to `mz_source_statistics_raw` \
+        and `mz_sink_statistics` (Materialize).",
+    internal: true,
+};
+
+/// The interval to collect statistics for `mz_source_statistics_raw` and `mz_sink_statistics_raw` in
+/// clusterd. Controls the accuracy of metrics.
+pub const STORAGE_STATISTICS_COLLECTION_INTERVAL: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("storage_statistics_collection_interval"),
+    value: mz_storage_types::parameters::STATISTICS_COLLECTION_INTERVAL_DEFAULT,
+    description: "The interval to collect statistics for `mz_source_statistics_raw` \
+        and `mz_sink_statistics_raw` in clusterd. Controls the accuracy of metrics \
+        (Materialize).",
+    internal: true,
+};
+
+pub const STORAGE_RECORD_SOURCE_SINK_NAMESPACED_ERRORS: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("storage_record_source_sink_namespaced_errors"),
+    value: true,
+    description: "Whether or not to record namespaced errors in the status history tables",
+    internal: true,
+};
+
+/// Boolean flag indicating whether to enable syncing from
+/// LaunchDarkly. Can be turned off as an emergency measure to still
+/// be able to alter parameters while LD is broken.
+pub static ENABLE_LAUNCHDARKLY: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_launchdarkly"),
+    value: true,
+    description: "Boolean flag indicating whether flag synchronization from LaunchDarkly should be enabled (Materialize).",
+    internal: true
+};
+
+/// Feature flag indicating whether real time recency is enabled. Not that
+/// unlike other feature flags, this is made available at the session level, so
+/// is additionally gated by a feature flag.
+pub static REAL_TIME_RECENCY: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("real_time_recency"),
+    value: false,
+    description: "Feature flag indicating whether real time recency is enabled (Materialize).",
+    internal: false,
+};
+
+pub static EMIT_TIMESTAMP_NOTICE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("emit_timestamp_notice"),
+    value: false,
+    description:
+        "Boolean flag indicating whether to send a NOTICE with timestamp explanations of queries (Materialize).",
+    internal: false
+};
+
+pub static EMIT_TRACE_ID_NOTICE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("emit_trace_id_notice"),
+    value: false,
+    description:
+        "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize).",
+    internal: false
+};
+
+pub static UNSAFE_MOCK_AUDIT_EVENT_TIMESTAMP: ServerVar<Option<mz_repr::Timestamp>> = ServerVar {
+    name: UncasedStr::new("unsafe_mock_audit_event_timestamp"),
+    value: None,
+    description: "Mocked timestamp to use for audit events for testing purposes",
+    internal: true,
+};
+
+pub const ENABLE_RBAC_CHECKS: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_rbac_checks"),
+    value: true,
+    description: "User facing global boolean flag indicating whether to apply RBAC checks before \
+    executing statements (Materialize).",
+    internal: false,
+};
+
+pub const ENABLE_SESSION_RBAC_CHECKS: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_session_rbac_checks"),
+    // TODO(jkosh44) Once RBAC is complete, change this to `true`.
+    value: false,
+    description: "User facing session boolean flag indicating whether to apply RBAC checks before \
+    executing statements (Materialize).",
+    internal: false,
+};
+
+pub const EMIT_INTROSPECTION_QUERY_NOTICE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("emit_introspection_query_notice"),
+    value: true,
+    description: "Whether to print a notice when querying per-replica introspection sources.",
+    internal: false,
+};
+
+// TODO(mgree) change this to a SelectOption
+pub const ENABLE_SESSION_CARDINALITY_ESTIMATES: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_session_cardinality_estimates"),
+    value: false,
+    description:
+        "Feature flag indicating whether to use cardinality estimates when optimizing queries; \
+    does not affect EXPLAIN WITH(cardinality) (Materialize).",
+    internal: false,
+};
+
+pub const OPTIMIZER_STATS_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("optimizer_stats_timeout"),
+    value: Duration::from_millis(250),
+    description: "Sets the timeout applied to the optimizer's statistics collection from storage; \
+    applied to non-oneshot, i.e., long-lasting queries, like CREATE MATERIALIZED VIEW (Materialize).",
+    internal: true,
+};
+
+pub const OPTIMIZER_ONESHOT_STATS_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("optimizer_oneshot_stats_timeout"),
+    value: Duration::from_millis(20),
+    description: "Sets the timeout applied to the optimizer's statistics collection from storage; \
+    applied to oneshot queries, like SELECT (Materialize).",
+    internal: true,
+};
+
+pub const PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("privatelink_status_update_quota_per_minute"),
+    value: 20,
+    description: "Sets the per-minute quota for privatelink vpc status updates to be written to \
+    the storage-collection-backed system table. This value implies the total and burst quota per-minute.",
+    internal: true,
+};
+
+pub static STATEMENT_LOGGING_SAMPLE_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| {
+    ServerVar {
+    name: UncasedStr::new("statement_logging_sample_rate"),
+    value: 0.1.into(),
+    description: "User-facing session variable indicating how many statement executions should be \
+    logged, subject to constraint by the system variable `statement_logging_max_sample_rate` (Materialize).",
+    internal: false,
+}
+});
+
+/// Whether compute rendering should use Materialize's custom linear join implementation rather
+/// than the one from Differential Dataflow.
+pub const ENABLE_MZ_JOIN_CORE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_mz_join_core"),
+    value: true,
+    description:
+        "Feature flag indicating whether compute rendering should use Materialize's custom linear \
+         join implementation rather than the one from Differential Dataflow. (Materialize).",
+    internal: true,
+};
+
+pub static DEFAULT_LINEAR_JOIN_YIELDING: Lazy<String> =
+    Lazy::new(|| "work:1000000,time:100".into());
+pub static LINEAR_JOIN_YIELDING: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("linear_join_yielding"),
+    value: DEFAULT_LINEAR_JOIN_YIELDING.clone(),
+    description:
+        "The yielding behavior compute rendering should apply for linear join operators. Either \
+         'work:<amount>' or 'time:<milliseconds>' or 'work:<amount>,time:<milliseconds>'. Note \
+         that omitting one of 'work' or 'time' will entirely disable join yielding by time or \
+         work, respectively, rather than falling back to some default.",
+    internal: true,
+});
+
+pub const DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("default_idle_arrangement_merge_effort"),
+    value: 0,
+    description:
+        "The default value to use for the `IDLE ARRANGEMENT MERGE EFFORT` cluster/replica option.",
+    internal: true,
+};
+
+pub const DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("default_arrangement_exert_proportionality"),
+    value: 16,
+    description:
+        "The default value to use for the `ARRANGEMENT EXERT PROPORTIONALITY` cluster/replica option.",
+    internal: true,
+};
+
+pub const ENABLE_DEFAULT_CONNECTION_VALIDATION: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_default_connection_validation"),
+    value: true,
+    description:
+        "LD facing global boolean flag that allows turning default connection validation off for everyone (Materialize).",
+    internal: true,
+};
+
+pub static STATEMENT_LOGGING_MAX_DATA_CREDIT: Lazy<ServerVar<Option<usize>>> = Lazy::new(|| {
+    ServerVar {
+    name: UncasedStr::new("statement_logging_max_data_credit"),
+    value: None,
+    // The idea is that during periods of low logging, tokens can accumulate up to this value,
+    // and then be depleted during periods of high logging.
+    description: "The maximum number of bytes that can be logged for statement logging in short burts, or NULL if unlimited (Materialize).",
+    internal: true,
+}
+});
+
+pub static STATEMENT_LOGGING_TARGET_DATA_RATE: Lazy<ServerVar<Option<usize>>> = Lazy::new(|| {
+    ServerVar {
+    name: UncasedStr::new("statement_logging_target_data_rate"),
+    value: None,
+    description: "The maximum sustained data rate of statement logging, in bytes per second, or NULL if unlimited (Materialize).",
+    internal: true,
+}
+});
+
+pub static STATEMENT_LOGGING_MAX_SAMPLE_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("statement_logging_max_sample_rate"),
+    value: 0.0.into(),
+    description: "The maximum rate at which statements may be logged. If this value is less than \
+that of `statement_logging_sample_rate`, the latter is ignored (Materialize).",
+    internal: false,
+});
+
+pub static STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE: Lazy<ServerVar<Numeric>> =
+    Lazy::new(|| ServerVar {
+        name: UncasedStr::new("statement_logging_default_sample_rate"),
+        value: 0.0.into(),
+        description:
+            "The default value of `statement_logging_sample_rate` for new sessions (Materialize).",
+        internal: false,
+    });
+
+pub const AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("auto_route_introspection_queries"),
+    value: true,
+    description:
+        "Whether to force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize).",
+    internal: false
+};
+
+pub const MAX_CONNECTIONS: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("max_connections"),
+    value: 1000,
+    description: "The maximum number of concurrent connections (Materialize).",
+    internal: false,
+};
+
+/// Controls [`mz_storage_types::parameters::StorageParameters::keep_n_source_status_history_entries`].
+pub const KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("keep_n_source_status_history_entries"),
+    value: 5,
+    description: "On reboot, truncate all but the last n entries per ID in the source_status_history collection (Materialize).",
+    internal: true
+};
+
+/// Controls [`mz_storage_types::parameters::StorageParameters::keep_n_sink_status_history_entries`].
+pub const KEEP_N_SINK_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("keep_n_sink_status_history_entries"),
+    value: 5,
+    description: "On reboot, truncate all but the last n entries per ID in the sink_status_history collection (Materialize).",
+    internal: true
+};
+
+/// Controls [`mz_storage_types::parameters::StorageParameters::keep_n_privatelink_status_history_entries`].
+pub const KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("keep_n_privatelink_status_history_entries"),
+    value: 5,
+    description: "On reboot, truncate all but the last n entries per ID in the mz_aws_privatelink_connection_status_history \
+    collection (Materialize).",
+    internal: true
+};
+
+pub const ENABLE_STORAGE_SHARD_FINALIZATION: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_storage_shard_finalization"),
+    value: true,
+    description: "Whether to allow the storage client to finalize shards (Materialize).",
+    internal: true,
+};
+
+pub const ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_consolidate_after_union_negate"),
+    value: true,
+    description: "consolidation after Unions that have a Negated input (Materialize).",
+    internal: false,
+};
+
+pub const MIN_TIMESTAMP_INTERVAL: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("min_timestamp_interval"),
+    value: Duration::from_millis(1000),
+    description: "Minimum timestamp interval",
+    internal: true,
+};
+
+pub const MAX_TIMESTAMP_INTERVAL: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("max_timestamp_interval"),
+    value: Duration::from_millis(1000),
+    description: "Maximum timestamp interval",
+    internal: true,
+};
+
+pub const WEBHOOK_CONCURRENT_REQUEST_LIMIT: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("webhook_concurrent_request_limit"),
+    value: WEBHOOK_CONCURRENCY_LIMIT,
+    description: "Maximum number of concurrent requests for appending to a webhook source.",
+    internal: true,
+};
+
+pub const ENABLE_COLUMNATION_LGALLOC: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_columnation_lgalloc"),
+    value: false,
+    description: "Enable allocating regions from lgalloc",
+    internal: true,
+};
+
+pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_statement_lifecycle_logging"),
+    value: false,
+    description:
+        "Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history",
+    internal: true,
+};
+
+pub const ENABLE_DEPENDENCY_READ_HOLD_ASSERTS: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_dependency_read_hold_asserts"),
+    value: true,
+    description:
+        "Whether to have the storage client check if a subsource's implied capability is less than \
+        its write frontier. This should only be set to false in cases where customer envs cannot
+        boot (Materialize).",
+    internal: true,
+};
+
+/// Configuration for gRPC client connections.
+pub mod grpc_client {
+    use super::*;
+
+    pub const CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
+        name: UncasedStr::new("grpc_client_connect_timeout"),
+        value: Duration::from_secs(5),
+        description: "Timeout to apply to initial gRPC client connection establishment.",
+        internal: true,
+    };
+    pub const HTTP2_KEEP_ALIVE_INTERVAL: ServerVar<Duration> = ServerVar {
+        name: UncasedStr::new("grpc_client_http2_keep_alive_interval"),
+        value: Duration::from_secs(3),
+        description: "Idle time to wait before sending HTTP/2 PINGs to maintain established gRPC client connections.",
+        internal: true,
+    };
+    pub const HTTP2_KEEP_ALIVE_TIMEOUT: ServerVar<Duration> = ServerVar {
+        name: UncasedStr::new("grpc_client_http2_keep_alive_timeout"),
+        value: Duration::from_secs(5),
+        description:
+            "Time to wait for HTTP/2 pong response before terminating a gRPC client connection.",
+        internal: true,
+    };
+}
+
+/// Configuration for how cluster replicas are scheduled.
+pub mod cluster_scheduling {
+    use super::*;
+    use mz_orchestrator::scheduling_config::*;
+
+    pub const CLUSTER_MULTI_PROCESS_REPLICA_AZ_AFFINITY_WEIGHT: ServerVar<Option<i32>> =
+        ServerVar {
+            name: UncasedStr::new("cluster_multi_process_replica_az_affinity_weight"),
+            value: DEFAULT_POD_AZ_AFFINITY_WEIGHT,
+            description:
+                "Whether or not to add an availability zone affinity between instances of \
+            multi-process replicas. Either an affinity weight or empty (off) (Materialize).",
+            internal: true,
+        };
+
+    pub const CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("cluster_soften_replication_anti_affinity"),
+        value: DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY,
+        description: "Whether or not to turn the node-scope anti affinity between replicas \
+            in the same cluster into a preference (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT: ServerVar<i32> = ServerVar {
+        name: UncasedStr::new("cluster_soften_replication_anti_affinity_weight"),
+        value: DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT,
+        description:
+            "The preference weight for `cluster_soften_replication_anti_affinity` (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_ENABLE_TOPOLOGY_SPREAD: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("cluster_enable_topology_spread"),
+        value: DEFAULT_TOPOLOGY_SPREAD_ENABLED,
+        description:
+            "Whether or not to add topology spread constraints among replicas in the same cluster (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("cluster_topology_spread_ignore_non_singular_scale"),
+        value: DEFAULT_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE,
+        description:
+            "If true, ignore replicas with more than 1 process when adding topology spread constraints (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW: ServerVar<i32> = ServerVar {
+        name: UncasedStr::new("cluster_topology_spread_max_skew"),
+        value: DEFAULT_TOPOLOGY_SPREAD_MAX_SKEW,
+        description: "The `maxSkew` for replica topology spread constraints (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_TOPOLOGY_SPREAD_SOFT: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("cluster_topology_spread_soft"),
+        value: DEFAULT_TOPOLOGY_SPREAD_SOFT,
+        description: "If true, soften the topology spread constraints for replicas (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_SOFTEN_AZ_AFFINITY: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("cluster_soften_az_affinity"),
+        value: DEFAULT_SOFTEN_AZ_AFFINITY,
+        description: "Whether or not to turn the az-scope node affinity for replicas. \
+            Note this could violate requests from the user (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT: ServerVar<i32> = ServerVar {
+        name: UncasedStr::new("cluster_soften_az_affinity_weight"),
+        value: DEFAULT_SOFTEN_AZ_AFFINITY_WEIGHT,
+        description: "The preference weight for `cluster_soften_az_affinity` (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_ALWAYS_USE_DISK: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("cluster_always_use_disk"),
+        value: DEFAULT_ALWAYS_USE_DISK,
+        description: "Always provisions a replica with disk, regardless of `DISK` DDL option.",
+        internal: true,
+    };
+}
+
+/// Macro to simplify creating feature flags, i.e. boolean flags that we use to toggle the
+/// availability of features.
+///
+/// The arguments to `feature_flags!` are:
+/// - `$name`, which will be the name of the feature flag, in snake_case,
+/// - `$feature_desc`, a human-readable description of the feature,
+/// - `$value`, which if not provided, defaults to `false` and also defaults `$internal` to `true`.
+/// - `$internal`, which if not provided, defaults to `true`. Requires `$value`.
+///
+/// Note that not all `ServerVar<bool>` are feature flags. Feature flags are for variables that:
+/// - Belong to `SystemVars`, _not_ `SessionVars`
+/// - Default to false and must be explicitly enabled, or default to `true` and can be explicitly disabled.
+///
+/// WARNING / CONTRACT: Syntax-related feature flags must always *enable* behavior. In other words,
+/// setting a feature flag must make the system more permissive. For example, let's suppose we'd like
+/// to gate deprecated upsert syntax behind a feature flag. In this case, do not add a feature flag
+/// like `disable_deprecated_upsert_syntax`, as `disable_deprecated_upsert_syntax = on` would
+/// _prevent_ the system from parsing the deprecated upsert syntax. Instead, use a feature flag
+/// like `enable_deprecated_upsert_syntax`.
+///
+/// The hazard this protects against is related to reboots after feature flags have been disabled.
+/// Say someone creates a Kinesis source while `enable_kinesis_sources = on`. Materialize will
+/// commit this source to the system catalog. Then, suppose we discover a catastrophic bug in
+/// Kinesis sources and set `enable_kinesis_sources` to `off`. This prevents users from creating
+/// new Kinesis sources, but leaves the existing Kinesis sources in place. This is because
+/// disabling a feature flag doesn't remove access to catalog objects created while the feature
+/// flag was live. On the next reboot, Materialize will proceed to load the Kinesis source from the
+/// catalog, reparsing and replanning the `CREATE SOURCE` definition and rechecking the
+/// `enable_kinesis_sources` feature flag along the way. Even though the feature flag has been
+/// switched to `off`, we need to temporarily re-enable it during parsing and planning to be able
+/// to boot successfully.
+///
+/// Ensuring that all syntax-related feature flags *enable* behavior means that setting all such
+/// feature flags to `on` during catalog boot has the desired effect.
+macro_rules! feature_flags {
+    // Match `$name, $feature_desc, $value, $internal`.
+    (@inner
+        // The feature flag name.
+        name: $name:expr,
+        // The feature flag description.
+        desc: $desc:literal,
+        // The feature flag default value.
+        default: $value:expr,
+        // Should this feature be visible only internally.
+        internal: $internal:expr,
+    ) => {
+        paste::paste!{
+            // Note that the ServerVar is not directly exported; we expect these to be
+            // accessible through their FeatureFlag variant.
+            pub static [<$name:upper _VAR>]: ServerVar<bool> = ServerVar {
+                name: UncasedStr::new(stringify!($name)),
+                value: $value,
+                description: concat!("Whether ", $desc, " is allowed (Materialize)."),
+                internal: $internal
+            };
+
+            pub static [<$name:upper >]: FeatureFlag = FeatureFlag {
+                flag: &[<$name:upper _VAR>],
+                feature_desc: $desc,
+            };
+        }
+    };
+    ($({
+        // The feature flag name.
+        name: $name:expr,
+        // The feature flag description.
+        desc: $desc:literal,
+        // The feature flag default value.
+        default: $value:expr,
+        // Should this feature be visible only internally.
+        internal: $internal:expr,
+        // Should the feature be turned on during catalog rehydration when
+        // parsing a catalog item.
+        enable_for_item_parsing: $enable_for_item_parsing:expr,
+    },)+) => {
+        $(feature_flags! { @inner
+            name: $name,
+            desc: $desc,
+            default: $value,
+            internal: $internal,
+        })+
+
+        paste::paste!{
+            impl SystemVars {
+                pub fn with_feature_flags(self) -> Self
+                {
+                    self
+                    $(
+                        .with_var(&[<$name:upper _VAR>])
+                    )+
+                }
+
+                pub fn enable_all_feature_flags_by_default(&mut self) {
+                    $(
+                        self.set_default(stringify!($name), VarInput::Flat("on"))
+                            .expect("setting default value must work");
+                    )+
+                }
+
+                pub fn enable_for_item_parsing(&mut self) {
+                    $(
+                        if $enable_for_item_parsing {
+                            self.set(stringify!($name), VarInput::Flat("on"))
+                                .expect("setting default value must work");
+                        }
+                    )+
+                }
+
+                $(
+                    pub fn [<$name:lower>](&self) -> bool {
+                        *self.expect_value(&[<$name:upper _VAR>])
+                    }
+                )+
+            }
+        }
+    }
+}
+
+feature_flags!(
+    // Gates for other feature flags
+    {
+        name: allow_real_time_recency,
+        desc: "real time recency",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    // Actual feature flags
+    {
+        name: enable_binary_date_bin,
+        desc: "the binary version of date_bin function",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_create_sink_denylist_with_options,
+        desc: "CREATE SINK with unsafe options",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_create_source_denylist_with_options,
+        desc: "CREATE SOURCE with unsafe options",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_date_bin_hopping,
+        desc: "the date_bin_hopping function",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_envelope_debezium_in_subscribe,
+        desc: "`ENVELOPE DEBEZIUM (KEY (..))`",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_envelope_materialize,
+        desc: "ENVELOPE MATERIALIZE",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_explain_pushdown,
+        desc: "EXPLAIN FILTER PUSHDOWN",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_index_options,
+        desc: "INDEX OPTIONS",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_list_length_max,
+        desc: "the list_length_max function",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_list_n_layers,
+        desc: "the list_n_layers function",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_list_remove,
+        desc: "the list_remove function",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+
+        name: enable_logical_compaction_window,
+        desc: "RETAIN HISTORY",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_primary_key_not_enforced,
+        desc: "PRIMARY KEY NOT ENFORCED",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_mfp_pushdown_explain,
+        desc: "`filter_pushdown` explain",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_multi_worker_storage_persist_sink,
+        desc: "multi-worker storage persist sink",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_persist_streaming_snapshot_and_fetch,
+        desc: "use the new streaming consolidate for snapshot_and_fetch",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_persist_streaming_compaction,
+        desc: "use the new streaming consolidate for compaction",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_raise_statement,
+        desc: "RAISE statement",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_repeat_row,
+        desc: "the repeat_row function",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_table_check_constraint,
+        desc: "CREATE TABLE with a check constraint",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_table_foreign_key,
+        desc: "CREATE TABLE with a foreign key",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_table_keys,
+        desc: "CREATE TABLE with a primary key or unique constraint",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_unorchestrated_cluster_replicas,
+        desc: "unorchestrated cluster replicas",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_unstable_dependencies,
+        desc: "depending on unstable objects",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_disk_cluster_replicas,
+        desc: "`WITH (DISK)` for cluster replicas",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_within_timestamp_order_by_in_subscribe,
+        desc: "`WITHIN TIMESTAMP ORDER BY ..`",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_cardinality_estimates,
+        desc: "join planning with cardinality estimates",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_connection_validation_syntax,
+        desc: "CREATE CONNECTION .. WITH (VALIDATE) and VALIDATE CONNECTION syntax",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_try_parse_monotonic_iso8601_timestamp,
+        desc: "the try_parse_monotonic_iso8601_timestamp function",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_alter_set_cluster,
+        desc: "ALTER ... SET CLUSTER syntax",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_unsafe_functions,
+        desc: "executing potentially dangerous functions",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_managed_cluster_availability_zones,
+        desc: "MANAGED, AVAILABILITY ZONES syntax",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: statement_logging_use_reproducible_rng,
+        desc: "statement logging with reproducible RNG",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_notices_for_index_already_exists,
+        desc: "emitting notices for IndexAlreadyExists (doesn't affect EXPLAIN)",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_notices_for_index_too_wide_for_literal_constraints,
+        desc: "emitting notices for IndexTooWideForLiteralConstraints (doesn't affect EXPLAIN)",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_notices_for_index_empty_key,
+        desc: "emitting notices for indexes with an empty key (doesn't affect EXPLAIN)",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_explain_broken,
+        desc: "EXPLAIN ... BROKEN <query> syntax",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_jemalloc_profiling,
+        desc: "jemalloc heap memory profiling",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_comment,
+        desc: "the COMMENT ON feature for objects",
+        default: true,
+        internal: false,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_sink_doc_on_option,
+        desc: "DOC ON option for sinks",
+        default: false,
+        internal: false,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_assert_not_null,
+        desc: "ASSERT NOT NULL for materialized views",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_alter_swap,
+        desc: "the ALTER SWAP feature for objects",
+        default: true,
+        internal: false,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_new_outer_join_lowering,
+        desc: "new outer join lowering",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+    {
+        name: enable_default_kafka_ssh_tunnel,
+        desc: "the top-level SSH TUNNEL feature for kafka connections",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_default_kafka_aws_private_link,
+        desc: "the top-level Aws Privatelink feature for kafka connections",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_time_at_time_zone,
+        desc: "use of AT TIME ZONE or timezone() with time type",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_aws_connection,
+        desc: "CREATE CONNECTION ... TO AWS",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+    {
+        name: enable_mysql_source,
+        desc: "Create a MySQL connection or source",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+    {
+        name: enable_expressions_in_limit_syntax,
+        desc: "LIMIT <expr> syntax",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_mz_notices,
+        desc: "Populate the contents of `mz_internal.mz_notices`",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+    {
+        name: enable_eager_delta_joins,
+        desc:
+            "eager delta joins",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+    {
+        name: enable_off_thread_optimization,
+        desc: "use off-thread optimization in `CREATE` statements",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+    {
+        name: enable_refresh_every_mvs,
+        desc: "REFRESH EVERY materialized views",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_reduce_mfp_fusion,
+        desc: "fusion of MFPs in reductions",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+    {
+        name: enable_worker_core_affinity,
+        desc: "set core affinity for replica worker threads",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+    {
+        name: wait_catalog_consolidation_on_startup,
+        desc: "When opening the Catalog, wait for consolidation to complete before returning",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+    {
+        name: enable_copy_to_expr,
+        desc: "COPY ... TO 's3://...'",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+    {
+        name: enable_compute_aggressive_readhold_downgrades,
+        desc: "let the compute controller aggressively downgrade read holds for sink dataflows",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+    {
+        name: enable_session_timelines,
+        desc: "strong session serializable isolation levels",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+    {
+        name: enable_compute_operator_hydration_status_logging,
+        desc: "log the hydration status of compute operators",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
+);

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -7,24 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// We pretend to be Postgres v9.5.0, which is also what CockroachDB pretends to
-// be. Too new and some clients will emit a "server too new" warning. Too old
-// and some clients will fall back to legacy code paths. v9.5.0 empirically
-// seems to be a good compromise.
-
-use std::clone::Clone;
-use std::fmt::Debug;
+use std::borrow::Cow;
 use std::str::FromStr;
-use std::string::ToString;
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use derivative::Derivative;
 use mz_adapter_types::timestamp_oracle::{
     DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT,
     DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL, DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
 };
-use mz_ore::cast;
-use mz_ore::cast::CastFrom;
+use mz_ore::cast::{self, CastFrom};
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::bytes::ByteSize;
@@ -36,72 +30,214 @@ use once_cell::sync::Lazy;
 use uncased::UncasedStr;
 
 use crate::session::user::{User, SUPPORT_USER, SYSTEM_USER};
-use crate::session::vars::errors::VarError;
-use crate::session::vars::value::{
-    CatalogKind, ClientEncoding, ClientSeverity, DateStyle, Failpoints, IntervalStyle,
-    IsolationLevel, TimeZone, TimestampOracleImpl, DEFAULT_DATE_STYLE,
+use crate::session::vars::constraints::{
+    DomainConstraint, ValueConstraint, NUMERIC_BOUNDED_0_1_INCLUSIVE, NUMERIC_NON_NEGATIVE,
 };
-use crate::session::vars::{FeatureFlag, SystemVars, Value, Var, VarInput};
+use crate::session::vars::errors::VarError;
+use crate::session::vars::polyfill::{lazy_value, value, LazyValueFn};
+use crate::session::vars::value::{
+    CatalogKind, ClientEncoding, ClientSeverity, Failpoints, IntervalStyle, IsolationLevel,
+    TimeZone, TimestampOracleImpl, Value, DEFAULT_DATE_STYLE,
+};
+use crate::session::vars::{FeatureFlag, Var, VarInput, VarParseError};
 use crate::{DEFAULT_SCHEMA, WEBHOOK_CONCURRENCY_LIMIT};
 
-/// A `ServerVar` is the default value for a configuration parameter.
-#[derive(Debug)]
-pub struct ServerVar<V>
-where
-    V: Debug + 'static,
-{
+/// Definition of a variable.
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
+pub struct VarDefinition {
+    /// Name of the variable, case-insensitive matching.
     pub name: &'static UncasedStr,
-    pub value: V,
+    /// Description of the variable.
     pub description: &'static str,
+    /// TODO(parkmcar): What does internal mean?
     pub internal: bool,
-}
 
-impl<V: Clone + Debug + 'static> Clone for ServerVar<V> {
-    fn clone(&self) -> Self {
-        Self {
-            name: self.name,
-            value: self.value.clone(),
-            description: self.description,
-            internal: self.internal,
+    /// Default compiled in value for this variable.
+    pub value: VarDefaultValue,
+    /// Constraint that must be upheld for this variable to be valid.
+    pub constraint: Option<ValueConstraint>,
+    /// Optionally hides this variable if it's related to a feature flag being enabled.
+    pub feature_flag: Option<&'static FeatureFlag>,
+
+    /// Method to parse [`VarInput`] into a type that implements [`Value`].
+    ///
+    /// The reason `parse` exists as a function pointer is because we want to achieve two things:
+    ///   1. `VarDefinition` has no generic parameters.
+    ///   2. `Value::parse` returns an instance of `Self`.
+    /// `VarDefinition` holds a `dyn Value`, but `Value::parse` is not object safe because it
+    /// returns `Self`, so we can't call that method. We could change `Value::parse` to return a
+    /// `Box<dyn Value>` making it object safe, but that creates a footgun where it's possible for
+    /// `Value::parse` to return a type that isn't `Self`, e.g. `<String as Value>::parse` could
+    /// return a `usize`!
+    ///
+    /// So to prevent making `VarDefinition` generic over some type `V: Value`, but also defining
+    /// `Value::parse` as returning `Self`, we store a static function pointer to the `parse`
+    /// implementation of our default value.
+    #[derivative(Debug = "ignore")]
+    parse: fn(VarInput) -> Result<Box<dyn Value>, VarParseError>,
+    /// Returns a human readable name for the type of this variable. We store this as a static
+    /// function pointer for the same reason as `parse`.
+    #[derivative(Debug = "ignore")]
+    type_name: fn() -> Cow<'static, str>,
+}
+static_assertions::assert_impl_all!(VarDefinition: Send, Sync);
+
+impl VarDefinition {
+    pub const fn new<V: Value>(
+        name: &'static str,
+        value: &'static V,
+        description: &'static str,
+        internal: bool,
+    ) -> Self {
+        VarDefinition {
+            name: UncasedStr::new(name),
+            description,
+            value: VarDefaultValue::Static(value),
+            internal,
+            parse: V::parse_dyn_value,
+            type_name: V::type_name,
+            constraint: None,
+            feature_flag: None,
         }
+    }
+
+    pub const fn new_lazy<V: Value, L: LazyValueFn<V>>(
+        name: &'static str,
+        _value: L,
+        description: &'static str,
+        internal: bool,
+    ) -> Self {
+        VarDefinition {
+            name: UncasedStr::new(name),
+            description,
+            value: VarDefaultValue::Lazy(L::LAZY_VALUE_FN),
+            internal,
+            parse: V::parse_dyn_value,
+            type_name: V::type_name,
+            constraint: None,
+            feature_flag: None,
+        }
+    }
+
+    pub fn new_runtime<V: Value>(
+        name: &'static str,
+        value: V,
+        description: &'static str,
+        internal: bool,
+    ) -> Self {
+        VarDefinition {
+            name: UncasedStr::new(name),
+            description,
+            value: VarDefaultValue::Runtime(Arc::new(value)),
+            internal,
+            parse: V::parse_dyn_value,
+            type_name: V::type_name,
+            constraint: None,
+            feature_flag: None,
+        }
+    }
+
+    /// TODO(parkmycar): Refactor this method onto a `VarDefinitionBuilder` that would allow us to
+    /// constrain `V` here to be the same `V` used in [`VarDefinition::new`].
+    pub const fn with_constraint<V: Value, D: DomainConstraint<Value = V>>(
+        mut self,
+        constraint: &'static D,
+    ) -> Self {
+        self.constraint = Some(ValueConstraint::Domain(constraint));
+        self
+    }
+
+    pub const fn fixed(mut self) -> Self {
+        self.constraint = Some(ValueConstraint::Fixed);
+        self
+    }
+
+    pub const fn read_only(mut self) -> Self {
+        self.constraint = Some(ValueConstraint::ReadOnly);
+        self
+    }
+
+    pub const fn with_feature_flag(mut self, feature_flag: &'static FeatureFlag) -> Self {
+        self.feature_flag = Some(feature_flag);
+        self
+    }
+
+    pub fn parse(&self, input: VarInput) -> Result<Box<dyn Value>, VarError> {
+        (self.parse)(input).map_err(|err| err.into_var_error(self))
+    }
+
+    pub fn default_value(&self) -> &'_ dyn Value {
+        self.value.value()
     }
 }
 
-impl<V> Var for ServerVar<V>
-where
-    V: Value + Debug + PartialEq + 'static,
-{
+impl Var for VarDefinition {
     fn name(&self) -> &'static str {
         self.name.as_str()
     }
 
     fn value(&self) -> String {
-        self.value.format()
+        self.default_value().format()
     }
 
     fn description(&self) -> &'static str {
         self.description
     }
 
-    fn type_name(&self) -> String {
-        V::type_name()
+    fn type_name(&self) -> Cow<'static, str> {
+        (self.type_name)()
     }
 
-    fn visible(&self, user: &User, system_vars: Option<&SystemVars>) -> Result<(), VarError> {
+    fn visible(
+        &self,
+        user: &User,
+        system_vars: Option<&super::SystemVars>,
+    ) -> Result<(), VarError> {
         if self.internal && user != &*SYSTEM_USER && user != &*SUPPORT_USER {
             Err(VarError::UnknownParameter(self.name().to_string()))
         } else if self.name().starts_with("unsafe")
             && match system_vars {
                 None => true,
-                Some(system_vars) => !system_vars.allow_unsafe,
+                Some(system_vars) => !system_vars.allow_unsafe(),
             }
         {
             Err(VarError::RequiresUnsafeMode(self.name()))
         } else {
+            if let Some(flag) = self.feature_flag {
+                flag.enabled(system_vars, None, None)?;
+            }
+
             Ok(())
         }
     }
 }
+
+/// The kinds of compiled in default values that can be used with [`VarDefinition`].
+#[derive(Clone, Debug)]
+pub enum VarDefaultValue {
+    /// Static that can be evaluated at compile time.
+    Static(&'static dyn Value),
+    /// Lazy value that is defined at compile time, but created at runtime.
+    Lazy(fn() -> &'static dyn Value),
+    /// Value created at runtime. Note: This is generally an escape hatch.
+    Runtime(Arc<dyn Value>),
+}
+
+impl VarDefaultValue {
+    pub fn value(&self) -> &'_ dyn Value {
+        match self {
+            VarDefaultValue::Static(s) => *s,
+            VarDefaultValue::Lazy(l) => (l)(),
+            VarDefaultValue::Runtime(r) => r.as_ref(),
+        }
+    }
+}
+
+// We pretend to be Postgres v9.5.0, which is also what CockroachDB pretends to
+// be. Too new and some clients will emit a "server too new" warning. Too old
+// and some clients will fall back to legacy code paths. v9.5.0 empirically
+// seems to be a good compromise.
 
 /// The major version of PostgreSQL that Materialize claims to be.
 pub const SERVER_MAJOR_VERSION: u8 = 9;
@@ -115,1260 +251,1254 @@ pub const SERVER_PATCH_VERSION: u8 = 0;
 /// The name of the default database that Materialize uses.
 pub const DEFAULT_DATABASE_NAME: &str = "materialize";
 
-pub static APPLICATION_NAME: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("application_name"),
-    value: "".to_string(),
-    description: "Sets the application name to be reported in statistics and logs (PostgreSQL).",
-    internal: false,
-});
+pub static APPLICATION_NAME: VarDefinition = VarDefinition::new(
+    "application_name",
+    value!(String; String::new()),
+    "Sets the application name to be reported in statistics and logs (PostgreSQL).",
+    false,
+);
 
-pub static CLIENT_ENCODING: ServerVar<ClientEncoding> = ServerVar {
-    name: UncasedStr::new("client_encoding"),
-    value: ClientEncoding::Utf8,
-    description: "Sets the client's character set encoding (PostgreSQL).",
-    internal: false,
-};
+pub static CLIENT_ENCODING: VarDefinition = VarDefinition::new(
+    "client_encoding",
+    value!(ClientEncoding; ClientEncoding::Utf8),
+    "Sets the client's character set encoding (PostgreSQL).",
+    false,
+);
 
-pub const CLIENT_MIN_MESSAGES: ServerVar<ClientSeverity> = ServerVar {
-    name: UncasedStr::new("client_min_messages"),
-    value: ClientSeverity::Notice,
-    description: "Sets the message levels that are sent to the client (PostgreSQL).",
-    internal: false,
-};
+pub static CLIENT_MIN_MESSAGES: VarDefinition = VarDefinition::new(
+    "client_min_messages",
+    value!(ClientSeverity; ClientSeverity::Notice),
+    "Sets the message levels that are sent to the client (PostgreSQL).",
+    false,
+);
 
-pub const CLUSTER_VAR_NAME: &UncasedStr = UncasedStr::new("cluster");
-pub static CLUSTER: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
-    name: CLUSTER_VAR_NAME,
-    value: "quickstart".to_string(),
-    description: "Sets the current cluster (Materialize).",
-    internal: false,
-});
+pub static CLUSTER: VarDefinition = VarDefinition::new_lazy(
+    "cluster",
+    lazy_value!(String; || "quickstart".to_string()),
+    "Sets the current cluster (Materialize).",
+    false,
+);
 
-pub const CLUSTER_REPLICA: ServerVar<Option<String>> = ServerVar {
-    name: UncasedStr::new("cluster_replica"),
-    value: None,
-    description: "Sets a target cluster replica for SELECT queries (Materialize).",
-    internal: false,
-};
+pub static CLUSTER_REPLICA: VarDefinition = VarDefinition::new(
+    "cluster_replica",
+    value!(Option<String>; None),
+    "Sets a target cluster replica for SELECT queries (Materialize).",
+    false,
+);
 
-pub const DATABASE_VAR_NAME: &UncasedStr = UncasedStr::new("database");
-pub static DATABASE: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
-    name: DATABASE_VAR_NAME,
-    value: DEFAULT_DATABASE_NAME.to_string(),
-    description: "Sets the current database (CockroachDB).",
-    internal: false,
-});
+pub static DATABASE: VarDefinition = VarDefinition::new_lazy(
+    "database",
+    lazy_value!(String; || DEFAULT_DATABASE_NAME.to_string()),
+    "Sets the current database (CockroachDB).",
+    false,
+);
 
-pub static DATE_STYLE: ServerVar<DateStyle> = ServerVar {
+pub static DATE_STYLE: VarDefinition = VarDefinition::new(
     // DateStyle has nonstandard capitalization for historical reasons.
-    name: UncasedStr::new("DateStyle"),
-    value: DEFAULT_DATE_STYLE,
-    description: "Sets the display format for date and time values (PostgreSQL).",
-    internal: false,
-};
+    "DateStyle",
+    &DEFAULT_DATE_STYLE,
+    "Sets the display format for date and time values (PostgreSQL).",
+    false,
+);
 
-pub const EXTRA_FLOAT_DIGITS: ServerVar<i32> = ServerVar {
-    name: UncasedStr::new("extra_float_digits"),
-    value: 3,
-    description: "Adjusts the number of digits displayed for floating-point values (PostgreSQL).",
-    internal: false,
-};
+pub static EXTRA_FLOAT_DIGITS: VarDefinition = VarDefinition::new(
+    "extra_float_digits",
+    value!(i32; 3),
+    "Adjusts the number of digits displayed for floating-point values (PostgreSQL).",
+    false,
+);
 
-pub const FAILPOINTS: ServerVar<Failpoints> = ServerVar {
-    name: UncasedStr::new("failpoints"),
-    value: Failpoints,
-    description: "Allows failpoints to be dynamically activated.",
-    internal: false,
-};
+pub static FAILPOINTS: VarDefinition = VarDefinition::new(
+    "failpoints",
+    value!(Failpoints; Failpoints),
+    "Allows failpoints to be dynamically activated.",
+    false,
+);
 
-pub const INTEGER_DATETIMES: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("integer_datetimes"),
-    value: true,
-    description: "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL).",
-    internal: false,
-};
+pub static INTEGER_DATETIMES: VarDefinition = VarDefinition::new(
+    "integer_datetimes",
+    value!(bool; true),
+    "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL).",
+    false,
+)
+.fixed();
 
-pub static INTERVAL_STYLE: ServerVar<IntervalStyle> = ServerVar {
+pub static INTERVAL_STYLE: VarDefinition = VarDefinition::new(
     // IntervalStyle has nonstandard capitalization for historical reasons.
-    name: UncasedStr::new("IntervalStyle"),
-    value: IntervalStyle::Postgres,
-    description: "Sets the display format for interval values (PostgreSQL).",
-    internal: false,
-};
+    "IntervalStyle",
+    value!(IntervalStyle; IntervalStyle::Postgres),
+    "Sets the display format for interval values (PostgreSQL).",
+    false,
+);
 
 pub const MZ_VERSION_NAME: &UncasedStr = UncasedStr::new("mz_version");
 pub const IS_SUPERUSER_NAME: &UncasedStr = UncasedStr::new("is_superuser");
 
 // Schema can be used an alias for a search path with a single element.
 pub const SCHEMA_ALIAS: &UncasedStr = UncasedStr::new("schema");
-pub static SEARCH_PATH: Lazy<ServerVar<Vec<Ident>>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("search_path"),
-    value: vec![ident!(DEFAULT_SCHEMA)],
-    description:
-        "Sets the schema search order for names that are not schema-qualified (PostgreSQL).",
-    internal: false,
-});
+pub static SEARCH_PATH: VarDefinition = VarDefinition::new_lazy(
+    "search_path",
+    lazy_value!(Vec<Ident>; || vec![ident!(DEFAULT_SCHEMA)]),
+    "Sets the schema search order for names that are not schema-qualified (PostgreSQL).",
+    false,
+);
 
-pub const STATEMENT_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("statement_timeout"),
-    value: Duration::from_secs(10),
-    description:
-        "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations. \
-        If this value is specified without units, it is taken as milliseconds.",
-    internal: false,
-};
+pub static STATEMENT_TIMEOUT: VarDefinition = VarDefinition::new(
+    "statement_timeout",
+    value!(Duration; Duration::from_secs(10)),
+    "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations. \
+    If this value is specified without units, it is taken as milliseconds.",
+    false,
+);
 
-pub const IDLE_IN_TRANSACTION_SESSION_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("idle_in_transaction_session_timeout"),
-    value: Duration::from_secs(60 * 2),
-    description:
-        "Sets the maximum allowed duration that a session can sit idle in a transaction before \
-         being terminated. If this value is specified without units, it is taken as milliseconds. \
-         A value of zero disables the timeout (PostgreSQL).",
-    internal: false,
-};
+pub static IDLE_IN_TRANSACTION_SESSION_TIMEOUT: VarDefinition = VarDefinition::new(
+    "idle_in_transaction_session_timeout",
+    value!(Duration; Duration::from_secs(60 * 2)),
+    "Sets the maximum allowed duration that a session can sit idle in a transaction before \
+    being terminated. If this value is specified without units, it is taken as milliseconds. \
+    A value of zero disables the timeout (PostgreSQL).",
+    false,
+);
 
-pub static SERVER_VERSION: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("server_version"),
-    value: format!(
-        "{}.{}.{}",
-        SERVER_MAJOR_VERSION, SERVER_MINOR_VERSION, SERVER_PATCH_VERSION
-    ),
-    description: "Shows the PostgreSQL compatible server version (PostgreSQL).",
-    internal: false,
-});
+pub static SERVER_VERSION: VarDefinition = VarDefinition::new_lazy(
+    "server_version",
+    lazy_value!(String; || {
+        format!("{SERVER_MAJOR_VERSION}.{SERVER_MINOR_VERSION}.{SERVER_PATCH_VERSION}")
+    }),
+    "Shows the PostgreSQL compatible server version (PostgreSQL).",
+    false,
+)
+.read_only();
 
-pub const SERVER_VERSION_NUM: ServerVar<i32> = ServerVar {
-    name: UncasedStr::new("server_version_num"),
-    value: ((cast::u8_to_i32(SERVER_MAJOR_VERSION) * 10_000)
+pub static SERVER_VERSION_NUM: VarDefinition = VarDefinition::new(
+    "server_version_num",
+    value!(i32; (cast::u8_to_i32(SERVER_MAJOR_VERSION) * 10_000)
         + (cast::u8_to_i32(SERVER_MINOR_VERSION) * 100)
         + cast::u8_to_i32(SERVER_PATCH_VERSION)),
-    description: "Shows the PostgreSQL compatible server version as an integer (PostgreSQL).",
-    internal: false,
-};
+    "Shows the PostgreSQL compatible server version as an integer (PostgreSQL).",
+    false,
+)
+.read_only();
 
-pub const SQL_SAFE_UPDATES: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("sql_safe_updates"),
-    value: false,
-    description: "Prohibits SQL statements that may be overly destructive (CockroachDB).",
-    internal: false,
-};
+pub static SQL_SAFE_UPDATES: VarDefinition = VarDefinition::new(
+    "sql_safe_updates",
+    value!(bool; false),
+    "Prohibits SQL statements that may be overly destructive (CockroachDB).",
+    false,
+);
 
-pub const STANDARD_CONFORMING_STRINGS: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("standard_conforming_strings"),
-    value: true,
-    description: "Causes '...' strings to treat backslashes literally (PostgreSQL).",
-    internal: false,
-};
+pub static STANDARD_CONFORMING_STRINGS: VarDefinition = VarDefinition::new(
+    "standard_conforming_strings",
+    value!(bool; true),
+    "Causes '...' strings to treat backslashes literally (PostgreSQL).",
+    false,
+)
+.fixed();
 
-pub const TIMEZONE: ServerVar<TimeZone> = ServerVar {
+pub static TIMEZONE: VarDefinition = VarDefinition::new(
     // TimeZone has nonstandard capitalization for historical reasons.
-    name: UncasedStr::new("TimeZone"),
-    value: TimeZone::UTC,
-    description: "Sets the time zone for displaying and interpreting time stamps (PostgreSQL).",
-    internal: false,
-};
+    "TimeZone",
+    value!(TimeZone; TimeZone::UTC),
+    "Sets the time zone for displaying and interpreting time stamps (PostgreSQL).",
+    false,
+);
 
-pub const TRANSACTION_ISOLATION_VAR_NAME: &UncasedStr = UncasedStr::new("transaction_isolation");
-pub const TRANSACTION_ISOLATION: ServerVar<IsolationLevel> = ServerVar {
-    name: TRANSACTION_ISOLATION_VAR_NAME,
-    value: IsolationLevel::StrictSerializable,
-    description: "Sets the current transaction's isolation level (PostgreSQL).",
-    internal: false,
-};
+pub const TRANSACTION_ISOLATION_VAR_NAME: &str = "transaction_isolation";
+pub static TRANSACTION_ISOLATION: VarDefinition = VarDefinition::new(
+    TRANSACTION_ISOLATION_VAR_NAME,
+    value!(IsolationLevel; IsolationLevel::StrictSerializable),
+    "Sets the current transaction's isolation level (PostgreSQL).",
+    false,
+);
 
-pub const MAX_KAFKA_CONNECTIONS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_kafka_connections"),
-    value: 1000,
-    description:
-        "The maximum number of Kafka connections in the region, across all schemas (Materialize).",
-    internal: false,
-};
+pub static MAX_KAFKA_CONNECTIONS: VarDefinition = VarDefinition::new(
+    "max_kafka_connections",
+    value!(u32; 1000),
+    "The maximum number of Kafka connections in the region, across all schemas (Materialize).",
+    false,
+);
 
-pub const MAX_POSTGRES_CONNECTIONS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_postgres_connections"),
-    value: 1000,
-    description: "The maximum number of PostgreSQL connections in the region, across all schemas (Materialize).",
-    internal: false
-};
+pub static MAX_POSTGRES_CONNECTIONS: VarDefinition = VarDefinition::new(
+    "max_postgres_connections",
+    value!(u32; 1000),
+    "The maximum number of PostgreSQL connections in the region, across all schemas (Materialize).",
+    false,
+);
 
-pub const MAX_AWS_PRIVATELINK_CONNECTIONS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_aws_privatelink_connections"),
-    value: 0,
-    description: "The maximum number of AWS PrivateLink connections in the region, across all schemas (Materialize).",
-    internal: false
-};
+pub static MAX_AWS_PRIVATELINK_CONNECTIONS: VarDefinition = VarDefinition::new(
+    "max_aws_privatelink_connections",
+    value!(u32; 0),
+     "The maximum number of AWS PrivateLink connections in the region, across all schemas (Materialize).",
+    false
+);
 
-pub const MAX_TABLES: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_tables"),
-    value: 25,
-    description: "The maximum number of tables in the region, across all schemas (Materialize).",
-    internal: false,
-};
+pub static MAX_TABLES: VarDefinition = VarDefinition::new(
+    "max_tables",
+    value!(u32; 25),
+    "The maximum number of tables in the region, across all schemas (Materialize).",
+    false,
+);
 
-pub const MAX_SOURCES: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_sources"),
-    value: 25,
-    description: "The maximum number of sources in the region, across all schemas (Materialize).",
-    internal: false,
-};
+pub static MAX_SOURCES: VarDefinition = VarDefinition::new(
+    "max_sources",
+    value!(u32; 25),
+    "The maximum number of sources in the region, across all schemas (Materialize).",
+    false,
+);
 
-pub const MAX_SINKS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_sinks"),
-    value: 25,
-    description: "The maximum number of sinks in the region, across all schemas (Materialize).",
-    internal: false,
-};
+pub static MAX_SINKS: VarDefinition = VarDefinition::new(
+    "max_sinks",
+    value!(u32; 25),
+    "The maximum number of sinks in the region, across all schemas (Materialize).",
+    false,
+);
 
-pub const MAX_MATERIALIZED_VIEWS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_materialized_views"),
-    value: 100,
-    description:
-        "The maximum number of materialized views in the region, across all schemas (Materialize).",
-    internal: false,
-};
+pub static MAX_MATERIALIZED_VIEWS: VarDefinition = VarDefinition::new(
+    "max_materialized_views",
+    value!(u32; 100),
+    "The maximum number of materialized views in the region, across all schemas (Materialize).",
+    false,
+);
 
-pub const MAX_CLUSTERS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_clusters"),
-    value: 10,
-    description: "The maximum number of clusters in the region (Materialize).",
-    internal: false,
-};
+pub static MAX_CLUSTERS: VarDefinition = VarDefinition::new(
+    "max_clusters",
+    value!(u32; 10),
+    "The maximum number of clusters in the region (Materialize).",
+    false,
+);
 
-pub const MAX_REPLICAS_PER_CLUSTER: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_replicas_per_cluster"),
-    value: 5,
-    description: "The maximum number of replicas of a single cluster (Materialize).",
-    internal: false,
-};
+pub static MAX_REPLICAS_PER_CLUSTER: VarDefinition = VarDefinition::new(
+    "max_replicas_per_cluster",
+    value!(u32; 5),
+    "The maximum number of replicas of a single cluster (Materialize).",
+    false,
+);
 
-pub static MAX_CREDIT_CONSUMPTION_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| {
-    ServerVar {
-        name: UncasedStr::new("max_credit_consumption_rate"),
-        value: 1024.into(),
-        description: "The maximum rate of credit consumption in a region. Credits are consumed based on the size of cluster replicas in use (Materialize).",
-        internal: false
-    }
-});
+pub static MAX_CREDIT_CONSUMPTION_RATE: VarDefinition = VarDefinition::new_lazy(
+    "max_credit_consumption_rate",
+    lazy_value!(Numeric; || 1024.into()),
+    "The maximum rate of credit consumption in a region. Credits are consumed based on the size of cluster replicas in use (Materialize).",
+    false,
+)
+.with_constraint(&NUMERIC_NON_NEGATIVE);
 
-pub const MAX_DATABASES: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_databases"),
-    value: 1000,
-    description: "The maximum number of databases in the region (Materialize).",
-    internal: false,
-};
+pub static MAX_DATABASES: VarDefinition = VarDefinition::new(
+    "max_databases",
+    value!(u32; 1000),
+    "The maximum number of databases in the region (Materialize).",
+    false,
+);
 
-pub const MAX_SCHEMAS_PER_DATABASE: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_schemas_per_database"),
-    value: 1000,
-    description: "The maximum number of schemas in a database (Materialize).",
-    internal: false,
-};
+pub static MAX_SCHEMAS_PER_DATABASE: VarDefinition = VarDefinition::new(
+    "max_schemas_per_database",
+    value!(u32; 1000),
+    "The maximum number of schemas in a database (Materialize).",
+    false,
+);
 
-pub const MAX_OBJECTS_PER_SCHEMA: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_objects_per_schema"),
-    value: 1000,
-    description: "The maximum number of objects in a schema (Materialize).",
-    internal: false,
-};
+pub static MAX_OBJECTS_PER_SCHEMA: VarDefinition = VarDefinition::new(
+    "max_objects_per_schema",
+    value!(u32; 1000),
+    "The maximum number of objects in a schema (Materialize).",
+    false,
+);
 
-pub const MAX_SECRETS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_secrets"),
-    value: 100,
-    description: "The maximum number of secrets in the region, across all schemas (Materialize).",
-    internal: false,
-};
+pub static MAX_SECRETS: VarDefinition = VarDefinition::new(
+    "max_secrets",
+    value!(u32; 100),
+    "The maximum number of secrets in the region, across all schemas (Materialize).",
+    false,
+);
 
-pub const MAX_ROLES: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_roles"),
-    value: 1000,
-    description: "The maximum number of roles in the region (Materialize).",
-    internal: false,
-};
+pub static MAX_ROLES: VarDefinition = VarDefinition::new(
+    "max_roles",
+    value!(u32; 1000),
+    "The maximum number of roles in the region (Materialize).",
+    false,
+);
 
 // Cloud environmentd is configured with 4 GiB of RAM, so 1 GiB is a good heuristic for a single
 // query.
 // TODO(jkosh44) Eventually we want to be able to return arbitrary sized results.
-pub const MAX_RESULT_SIZE: ServerVar<ByteSize> = ServerVar {
-    name: UncasedStr::new("max_result_size"),
-    value: ByteSize::gb(1),
-    description: "The maximum size in bytes for an internal query result (Materialize).",
-    internal: false,
-};
+pub static MAX_RESULT_SIZE: VarDefinition = VarDefinition::new(
+    "max_result_size",
+    value!(ByteSize; ByteSize::gb(1)),
+    "The maximum size in bytes for an internal query result (Materialize).",
+    false,
+);
 
-pub const MAX_QUERY_RESULT_SIZE: ServerVar<ByteSize> = ServerVar {
-    name: UncasedStr::new("max_query_result_size"),
-    value: ByteSize::gb(1),
-    description: "The maximum size in bytes for a single query's result (Materialize).",
-    internal: false,
-};
+pub static MAX_QUERY_RESULT_SIZE: VarDefinition = VarDefinition::new(
+    "max_query_result_size",
+    value!(ByteSize; ByteSize::gb(1)),
+    "The maximum size in bytes for a single query's result (Materialize).",
+    false,
+);
 
-pub const MAX_COPY_FROM_SIZE: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_copy_from_size"),
+pub static MAX_COPY_FROM_SIZE: VarDefinition = VarDefinition::new(
+    "max_copy_from_size",
     // 1 GiB, this limit is noted in the docs, if you change it make sure to update our docs.
-    value: 1_073_741_824,
-    description: "The maximum size in bytes we buffer for COPY FROM statements (Materialize).",
-    internal: false,
-};
+    value!(u32; 1_073_741_824),
+    "The maximum size in bytes we buffer for COPY FROM statements (Materialize).",
+    false,
+);
 
-pub const MAX_IDENTIFIER_LENGTH: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("max_identifier_length"),
-    value: mz_sql_lexer::lexer::MAX_IDENTIFIER_LENGTH,
-    description: "The maximum length of object identifiers in bytes (PostgreSQL).",
-    internal: false,
-};
+pub static MAX_IDENTIFIER_LENGTH: VarDefinition = VarDefinition::new(
+    "max_identifier_length",
+    value!(usize; mz_sql_lexer::lexer::MAX_IDENTIFIER_LENGTH),
+    "The maximum length of object identifiers in bytes (PostgreSQL).",
+    false,
+);
 
-pub const WELCOME_MESSAGE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("welcome_message"),
-    value: true,
-    description: "Whether to send a notice with a welcome message after a successful connection (Materialize).",
-    internal: false,
-};
+pub static WELCOME_MESSAGE: VarDefinition = VarDefinition::new(
+    "welcome_message",
+    value!(bool; true),
+    "Whether to send a notice with a welcome message after a successful connection (Materialize).",
+    false,
+);
 
 /// The logical compaction window for builtin tables and sources that have the
 /// `retained_metrics_relation` flag set.
 ///
 /// The existence of this variable is a bit of a hack until we have a fully
 /// general solution for controlling retention windows.
-pub const METRICS_RETENTION: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("metrics_retention"),
+pub static METRICS_RETENTION: VarDefinition = VarDefinition::new(
+    "metrics_retention",
     // 30 days
-    value: Duration::from_secs(30 * 24 * 60 * 60),
-    description: "The time to retain cluster utilization metrics (Materialize).",
-    internal: true,
-};
+    value!(Duration; Duration::from_secs(30 * 24 * 60 * 60)),
+    "The time to retain cluster utilization metrics (Materialize).",
+    true,
+);
 
-pub static ALLOWED_CLUSTER_REPLICA_SIZES: Lazy<ServerVar<Vec<Ident>>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("allowed_cluster_replica_sizes"),
-    value: Vec::new(),
-    description: "The allowed sizes when creating a new cluster replica (Materialize).",
-    internal: false,
-});
+pub static ALLOWED_CLUSTER_REPLICA_SIZES: VarDefinition = VarDefinition::new(
+    "allowed_cluster_replica_sizes",
+    value!(Vec<Ident>; Vec::new()),
+    "The allowed sizes when creating a new cluster replica (Materialize).",
+    false,
+);
 
-pub const PERSIST_FAST_PATH_LIMIT: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("persist_fast_path_limit"),
-    value: 0,
-    description:
-        "An exclusive upper bound on the number of results we may return from a Persist fast-path peek; \
-        queries that may return more results will follow the normal / slow path. \
-        Setting this to 0 disables the feature.",
-    internal: true,
-};
+pub static PERSIST_FAST_PATH_LIMIT: VarDefinition = VarDefinition::new(
+    "persist_fast_path_limit",
+    value!(usize; 0),
+    "An exclusive upper bound on the number of results we may return from a Persist fast-path peek; \
+    queries that may return more results will follow the normal / slow path. \
+    Setting this to 0 disables the feature.",
+    true,
+);
 
-pub const PERSIST_TXN_TABLES: ServerVar<PersistTxnTablesImpl> = ServerVar {
-    name: UncasedStr::new("persist_txn_tables"),
-    value: PersistTxnTablesImpl::Eager,
-    description: "\
-        Whether to use the new persist-txn tables implementation or the legacy \
-        one.
+pub static PERSIST_TXN_TABLES: VarDefinition = VarDefinition::new(
+    "persist_txn_tables",
+    value!(PersistTxnTablesImpl; PersistTxnTablesImpl::Eager),
+    "\
+    Whether to use the new persist-txn tables implementation or the legacy \
+    one.
 
-        Only takes effect on restart. Any changes will also cause clusterd \
-        processes to restart.
+    Only takes effect on restart. Any changes will also cause clusterd \
+    processes to restart.
 
-        This value is also configurable via a Launch Darkly parameter of the \
-        same name, but we keep the flag to make testing easier. If specified, \
-        the flag takes precedence over the Launch Darkly param.",
-    internal: true,
-};
+    This value is also configurable via a Launch Darkly parameter of the \
+    same name, but we keep the flag to make testing easier. If specified, \
+    the flag takes precedence over the Launch Darkly param.",
+    true,
+);
 
-pub const TIMESTAMP_ORACLE_IMPL: ServerVar<TimestampOracleImpl> = ServerVar {
-    name: UncasedStr::new("timestamp_oracle"),
-    value: TimestampOracleImpl::Postgres,
-    description: "Backing implementation of TimestampOracle.",
-    internal: true,
-};
+pub static TIMESTAMP_ORACLE_IMPL: VarDefinition = VarDefinition::new(
+    "timestamp_oracle",
+    value!(TimestampOracleImpl; TimestampOracleImpl::Postgres),
+    "Backing implementation of TimestampOracle.",
+    true,
+);
 
-pub const CATALOG_KIND_IMPL: ServerVar<Option<CatalogKind>> = ServerVar {
-    name: UncasedStr::new("catalog_kind"),
-    value: None,
-    description: "Backing implementation of catalog.",
-    internal: true,
-};
+pub static CATALOG_KIND_IMPL: VarDefinition = VarDefinition::new(
+    "catalog_kind",
+    value!(Option<CatalogKind>; None),
+    "Backing implementation of catalog.",
+    true,
+);
 
 /// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_max_size`.
-pub const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_max_size"),
-    value: DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE,
-    description: "Maximum size of the Postgres/CRDB connection pool, used by the Postgres/CRDB timestamp oracle.",
-    internal: true,
-};
+pub static PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE: VarDefinition = VarDefinition::new(
+    "pg_timestamp_oracle_connection_pool_max_size",
+    value!(usize; DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_SIZE),
+    "Maximum size of the Postgres/CRDB connection pool, used by the Postgres/CRDB timestamp oracle.",
+    true,
+);
 
 /// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_max_wait`.
-pub const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT: ServerVar<Option<Duration>> = ServerVar {
-    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_max_wait"),
-    value: Some(DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT),
-    description: "The maximum time to wait when attempting to obtain a connection from the Postgres/CRDB connection pool, used by the Postgres/CRDB timestamp oracle.",
-    internal: true,
-};
+pub static PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT: VarDefinition = VarDefinition::new(
+    "pg_timestamp_oracle_connection_pool_max_wait",
+    value!(Option<Duration>; Some(DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_MAX_WAIT)),
+    "The maximum time to wait when attempting to obtain a connection from the Postgres/CRDB connection pool, used by the Postgres/CRDB timestamp oracle.",
+    true,
+);
 
 /// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_ttl`.
-pub const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_ttl"),
-    value: DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL,
-    description: "The minimum TTL of a Consensus connection to Postgres/CRDB before it is proactively terminated",
-    internal: true,
-};
+pub static PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL: VarDefinition = VarDefinition::new(
+    "pg_timestamp_oracle_connection_pool_ttl",
+    value!(Duration; DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL),
+    "The minimum TTL of a Consensus connection to Postgres/CRDB before it is proactively terminated",
+    true,
+);
 
 /// Controls `mz_adapter::coord::timestamp_oracle::postgres_oracle::DynamicConfig::pg_connection_pool_ttl_stagger`.
-pub const PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_timestamp_oracle_connection_pool_ttl_stagger"),
-    value: DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER,
-    description: "The minimum time between TTLing Consensus connections to Postgres/CRDB.",
-    internal: true,
-};
+pub static PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER: VarDefinition = VarDefinition::new(
+    "pg_timestamp_oracle_connection_pool_ttl_stagger",
+    value!(Duration; DEFAULT_PG_TIMESTAMP_ORACLE_CONNPOOL_TTL_STAGGER),
+    "The minimum time between TTLing Consensus connections to Postgres/CRDB.",
+    true,
+);
 
 /// The default for the `DISK` option when creating managed clusters and cluster replicas.
-pub const DISK_CLUSTER_REPLICAS_DEFAULT: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("disk_cluster_replicas_default"),
-    value: false,
-    description: "Whether the disk option for managed clusters and cluster replicas should be enabled by default.",
-    internal: true,
-};
+pub static DISK_CLUSTER_REPLICAS_DEFAULT: VarDefinition = VarDefinition::new(
+    "disk_cluster_replicas_default",
+    value!(bool; false),
+    "Whether the disk option for managed clusters and cluster replicas should be enabled by default.",
+    true,
+);
 
-pub const UNSAFE_NEW_TRANSACTION_WALL_TIME: ServerVar<Option<CheckedTimestamp<DateTime<Utc>>>> = ServerVar {
-    name: UncasedStr::new("unsafe_new_transaction_wall_time"),
-    value: None,
-    description:
-        "Sets the wall time for all new explicit or implicit transactions to control the value of `now()`. \
-        If not set, uses the system's clock.",
+pub static UNSAFE_NEW_TRANSACTION_WALL_TIME: VarDefinition = VarDefinition::new(
+    "unsafe_new_transaction_wall_time",
+    value!(Option<CheckedTimestamp<DateTime<Utc>>>; None),
+    "Sets the wall time for all new explicit or implicit transactions to control the value of `now()`. \
+    If not set, uses the system's clock.",
     // This needs to be false because `internal: true` things are only modifiable by the mz_system
     // and mz_support users, and we want sqllogictest to have access with its user. Because the name
     // starts with "unsafe" it still won't be visible or changeable by users unless unsafe mode is
     // enabled.
-    internal: false,
-};
+    false,
+);
 
 /// Tuning for RocksDB used by `UPSERT` sources that takes effect on restart.
 pub mod upsert_rocksdb {
     use super::*;
     use mz_rocksdb_types::config::{CompactionStyle, CompressionType};
 
-    pub static UPSERT_ROCKSDB_COMPACTION_STYLE: ServerVar<CompactionStyle> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_compaction_style"),
-        value: mz_rocksdb_types::defaults::DEFAULT_COMPACTION_STYLE,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub const UPSERT_ROCKSDB_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET: ServerVar<usize> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_optimize_compaction_memtable_budget"),
-        value: mz_rocksdb_types::defaults::DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub const UPSERT_ROCKSDB_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_level_compaction_dynamic_level_bytes"),
-        value: mz_rocksdb_types::defaults::DEFAULT_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub const UPSERT_ROCKSDB_UNIVERSAL_COMPACTION_RATIO: ServerVar<i32> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_universal_compaction_ratio"),
-        value: mz_rocksdb_types::defaults::DEFAULT_UNIVERSAL_COMPACTION_RATIO,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub const UPSERT_ROCKSDB_PARALLELISM: ServerVar<Option<i32>> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_parallelism"),
-        value: mz_rocksdb_types::defaults::DEFAULT_PARALLELISM,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub static UPSERT_ROCKSDB_COMPRESSION_TYPE: ServerVar<CompressionType> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_compression_type"),
-        value: mz_rocksdb_types::defaults::DEFAULT_COMPRESSION_TYPE,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub static UPSERT_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE: ServerVar<CompressionType> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_bottommost_compression_type"),
-        value: mz_rocksdb_types::defaults::DEFAULT_BOTTOMMOST_COMPRESSION_TYPE,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
+    pub static UPSERT_ROCKSDB_COMPACTION_STYLE: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_compaction_style",
+        value!(CompactionStyle; mz_rocksdb_types::defaults::DEFAULT_COMPACTION_STYLE),
+        "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+        true,
+    );
 
-    pub static UPSERT_ROCKSDB_BATCH_SIZE: ServerVar<usize> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_batch_size"),
-        value: mz_rocksdb_types::defaults::DEFAULT_BATCH_SIZE,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Can be changed dynamically (Materialize).",
-        internal: true,
-    };
+    pub static UPSERT_ROCKSDB_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET: VarDefinition =
+        VarDefinition::new(
+            "upsert_rocksdb_optimize_compaction_memtable_budget",
+            value!(usize; mz_rocksdb_types::defaults::DEFAULT_OPTIMIZE_COMPACTION_MEMTABLE_BUDGET),
+            "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+            true,
+        );
 
-    pub static UPSERT_ROCKSDB_RETRY_DURATION: ServerVar<Duration> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_retry_duration"),
-        value: mz_rocksdb_types::defaults::DEFAULT_RETRY_DURATION,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
+    pub static UPSERT_ROCKSDB_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES: VarDefinition =
+        VarDefinition::new(
+            "upsert_rocksdb_level_compaction_dynamic_level_bytes",
+            value!(bool; mz_rocksdb_types::defaults::DEFAULT_LEVEL_COMPACTION_DYNAMIC_LEVEL_BYTES),
+            "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+            true,
+        );
+
+    pub static UPSERT_ROCKSDB_UNIVERSAL_COMPACTION_RATIO: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_universal_compaction_ratio",
+        value!(i32; mz_rocksdb_types::defaults::DEFAULT_UNIVERSAL_COMPACTION_RATIO),
+        "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+        true,
+    );
+
+    pub static UPSERT_ROCKSDB_PARALLELISM: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_parallelism",
+        value!(Option<i32>; mz_rocksdb_types::defaults::DEFAULT_PARALLELISM),
+        "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+        true,
+    );
+
+    pub static UPSERT_ROCKSDB_COMPRESSION_TYPE: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_compression_type",
+        value!(CompressionType; mz_rocksdb_types::defaults::DEFAULT_COMPRESSION_TYPE),
+        "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+        true,
+    );
+
+    pub static UPSERT_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_bottommost_compression_type",
+        value!(CompressionType; mz_rocksdb_types::defaults::DEFAULT_BOTTOMMOST_COMPRESSION_TYPE),
+        "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+        true,
+    );
+
+    pub static UPSERT_ROCKSDB_BATCH_SIZE: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_batch_size",
+        value!(usize; mz_rocksdb_types::defaults::DEFAULT_BATCH_SIZE),
+        "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Can be changed dynamically (Materialize).",
+        true,
+    );
+
+    pub static UPSERT_ROCKSDB_RETRY_DURATION: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_retry_duration",
+        value!(Duration; mz_rocksdb_types::defaults::DEFAULT_RETRY_DURATION),
+        "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+        true,
+    );
 
     /// Controls whether automatic spill to disk should be turned on when using `DISK`.
-    pub const UPSERT_ROCKSDB_AUTO_SPILL_TO_DISK: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_auto_spill_to_disk"),
-        value: false,
-        description:
-            "Controls whether automatic spill to disk should be turned on when using `DISK`",
-        internal: true,
-    };
+    pub static UPSERT_ROCKSDB_AUTO_SPILL_TO_DISK: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_auto_spill_to_disk",
+        value!(bool; false),
+        "Controls whether automatic spill to disk should be turned on when using `DISK`",
+        true,
+    );
 
     /// The upsert in memory state size threshold after which it will spill to disk.
     /// The default is 85 MiB = 89128960 bytes
-    pub const UPSERT_ROCKSDB_AUTO_SPILL_THRESHOLD_BYTES: ServerVar<usize> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_auto_spill_threshold_bytes"),
-        value: mz_rocksdb_types::defaults::DEFAULT_AUTO_SPILL_MEMORY_THRESHOLD,
-        description:
-            "The upsert in-memory state size threshold in bytes after which it will spill to disk",
-        internal: true,
-    };
+    pub static UPSERT_ROCKSDB_AUTO_SPILL_THRESHOLD_BYTES: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_auto_spill_threshold_bytes",
+        value!(usize; mz_rocksdb_types::defaults::DEFAULT_AUTO_SPILL_MEMORY_THRESHOLD),
+        "The upsert in-memory state size threshold in bytes after which it will spill to disk",
+        true,
+    );
 
-    pub static UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS: ServerVar<u32> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_stats_log_interval_seconds"),
-        value: mz_rocksdb_types::defaults::DEFAULT_STATS_LOG_INTERVAL_S,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub static UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS: ServerVar<u32> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_stats_persist_interval_seconds"),
-        value: mz_rocksdb_types::defaults::DEFAULT_STATS_PERSIST_INTERVAL_S,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
-    pub static UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB: ServerVar<Option<u32>> =
-        ServerVar {
-            name: UncasedStr::new("upsert_rocksdb_point_lookup_block_cache_size_mb"),
-            value: None,
-            description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-            internal: true,
-        };
+    pub static UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_stats_log_interval_seconds",
+        value!(u32; mz_rocksdb_types::defaults::DEFAULT_STATS_LOG_INTERVAL_S),
+        "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+        true,
+    );
+
+    pub static UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_stats_persist_interval_seconds",
+        value!(u32; mz_rocksdb_types::defaults::DEFAULT_STATS_PERSIST_INTERVAL_S),
+        "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+        true,
+    );
+
+    pub static UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_point_lookup_block_cache_size_mb",
+        value!(Option<u32>; None),
+        "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+        true,
+    );
 
     /// The number of times by which allocated buffers will be shrinked in upsert rocksdb.
     /// If value is 0, then no shrinking will occur.
-    pub static UPSERT_ROCKSDB_SHRINK_ALLOCATED_BUFFERS_BY_RATIO: ServerVar<usize> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_shrink_allocated_buffers_by_ratio"),
-        value: mz_rocksdb_types::defaults::DEFAULT_SHRINK_BUFFERS_BY_RATIO,
-        description:
-            "The number of times by which allocated buffers will be shrinked in upsert rocksdb.",
-        internal: true,
-    };
+    pub static UPSERT_ROCKSDB_SHRINK_ALLOCATED_BUFFERS_BY_RATIO: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_shrink_allocated_buffers_by_ratio",
+        value!(usize; mz_rocksdb_types::defaults::DEFAULT_SHRINK_BUFFERS_BY_RATIO),
+        "The number of times by which allocated buffers will be shrinked in upsert rocksdb.",
+        true,
+    );
+
     /// Only used if `upsert_rocksdb_write_buffer_manager_memory_bytes` is also set
     /// and write buffer manager is enabled
-    pub static UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_CLUSTER_MEMORY_FRACTION: Lazy<
-        ServerVar<Option<Numeric>>,
-    > = Lazy::new(|| ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_write_buffer_manager_cluster_memory_fraction"),
-        value: None,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    });
+    pub static UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_CLUSTER_MEMORY_FRACTION: VarDefinition =
+        VarDefinition::new(
+            "upsert_rocksdb_write_buffer_manager_cluster_memory_fraction",
+            value!(Option<Numeric>; None),
+            "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+            true,
+        );
+
     /// `upsert_rocksdb_write_buffer_manager_memory_bytes` needs to be set for write buffer manager to be
     /// used.
-    pub static UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_MEMORY_BYTES: ServerVar<Option<usize>> =
-        ServerVar {
-            name: UncasedStr::new("upsert_rocksdb_write_buffer_manager_memory_bytes"),
-            value: None,
-            description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-            internal: true,
-        };
-    pub static UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_ALLOW_STALL: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("upsert_rocksdb_write_buffer_manager_allow_stall"),
-        value: false,
-        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
-                  sources. Described in the `mz_rocksdb_types::config` module. \
-                  Only takes effect on source restart (Materialize).",
-        internal: true,
-    };
+    pub static UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_MEMORY_BYTES: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_write_buffer_manager_memory_bytes",
+        value!(Option<usize>; None),
+        "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+        true,
+    );
+
+    pub static UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_ALLOW_STALL: VarDefinition = VarDefinition::new(
+        "upsert_rocksdb_write_buffer_manager_allow_stall",
+        value!(bool; false),
+        "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+        sources. Described in the `mz_rocksdb_types::config` module. \
+        Only takes effect on source restart (Materialize).",
+        true,
+    );
 }
 
-pub static LOGGING_FILTER: Lazy<ServerVar<CloneableEnvFilter>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("log_filter"),
-    value: CloneableEnvFilter::from_str("info").expect("valid EnvFilter"),
-    description: "Sets the filter to apply to stderr logging.",
-    internal: true,
-});
+pub static LOGGING_FILTER: VarDefinition = VarDefinition::new_lazy(
+    "log_filter",
+    lazy_value!(CloneableEnvFilter; || CloneableEnvFilter::from_str("info").expect("valid EnvFilter")),
+    "Sets the filter to apply to stderr logging.",
+    true,
+);
 
-pub static OPENTELEMETRY_FILTER: Lazy<ServerVar<CloneableEnvFilter>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("opentelemetry_filter"),
-    value: CloneableEnvFilter::from_str("off").expect("valid EnvFilter"),
-    description: "Sets the filter to apply to OpenTelemetry-backed distributed tracing.",
-    internal: true,
-});
+pub static OPENTELEMETRY_FILTER: VarDefinition = VarDefinition::new_lazy(
+    "opentelemetry_filter",
+    lazy_value!(CloneableEnvFilter; || CloneableEnvFilter::from_str("off").expect("valid EnvFilter")),
+    "Sets the filter to apply to OpenTelemetry-backed distributed tracing.",
+    true,
+);
 
-pub static LOGGING_FILTER_DEFAULTS: Lazy<ServerVar<Vec<SerializableDirective>>> =
-    Lazy::new(|| ServerVar {
-        name: UncasedStr::new("log_filter_defaults"),
-        value: mz_ore::tracing::LOGGING_DEFAULTS
+pub static LOGGING_FILTER_DEFAULTS: VarDefinition = VarDefinition::new_lazy(
+    "log_filter_defaults",
+    lazy_value!(Vec<SerializableDirective>; || {
+        mz_ore::tracing::LOGGING_DEFAULTS
             .iter()
             .map(|d| d.clone().into())
-            .collect(),
-        description: "Sets additional default directives to apply to stderr logging. \
-            These apply to all variations of `log_filter`. Directives other than \
-            `module=off` are likely incorrect.",
-        internal: true,
-    });
+            .collect()
+    }),
+    "Sets additional default directives to apply to stderr logging. \
+        These apply to all variations of `log_filter`. Directives other than \
+        `module=off` are likely incorrect.",
+    true,
+);
 
-pub static OPENTELEMETRY_FILTER_DEFAULTS: Lazy<ServerVar<Vec<SerializableDirective>>> =
-    Lazy::new(|| ServerVar {
-        name: UncasedStr::new("opentelemetry_filter_defaults"),
-        value: mz_ore::tracing::OPENTELEMETRY_DEFAULTS
+pub static OPENTELEMETRY_FILTER_DEFAULTS: VarDefinition = VarDefinition::new_lazy(
+    "opentelemetry_filter_defaults",
+    lazy_value!(Vec<SerializableDirective>; || {
+        mz_ore::tracing::OPENTELEMETRY_DEFAULTS
             .iter()
             .map(|d| d.clone().into())
-            .collect(),
-        description: "Sets additional default directives to apply to OpenTelemetry-backed \
-            distributed tracing. \
-            These apply to all variations of `opentelemetry_filter`. Directives other than \
-            `module=off` are likely incorrect.",
-        internal: true,
-    });
+            .collect()
+    }),
+    "Sets additional default directives to apply to OpenTelemetry-backed \
+        distributed tracing. \
+        These apply to all variations of `opentelemetry_filter`. Directives other than \
+        `module=off` are likely incorrect.",
+    true,
+);
 
-pub static SENTRY_FILTERS: Lazy<ServerVar<Vec<SerializableDirective>>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("sentry_filters"),
-    value: mz_ore::tracing::SENTRY_DEFAULTS
-        .iter()
-        .map(|d| d.clone().into())
-        .collect(),
-    description: "Sets additional default directives to apply to sentry logging. \
-            These apply on top of a default `info` directive. Directives other than \
-            `module=off` are likely incorrect.",
-    internal: true,
-});
+pub static SENTRY_FILTERS: VarDefinition = VarDefinition::new_lazy(
+    "sentry_filters",
+    lazy_value!(Vec<SerializableDirective>; || {
+        mz_ore::tracing::SENTRY_DEFAULTS
+            .iter()
+            .map(|d| d.clone().into())
+            .collect()
+    }),
+    "Sets additional default directives to apply to sentry logging. \
+        These apply on top of a default `info` directive. Directives other than \
+        `module=off` are likely incorrect.",
+    true,
+);
 
-pub static WEBHOOKS_SECRETS_CACHING_TTL_SECS: Lazy<ServerVar<usize>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("webhooks_secrets_caching_ttl_secs"),
-    value: usize::cast_from(
-        mz_secrets::cache::DEFAULT_TTL_SECS.load(std::sync::atomic::Ordering::Relaxed),
-    ),
-    description: "Sets the time-to-live for values in the Webhooks secrets cache.",
-    internal: true,
-});
+pub static WEBHOOKS_SECRETS_CACHING_TTL_SECS: VarDefinition = VarDefinition::new_lazy(
+    "webhooks_secrets_caching_ttl_secs",
+    lazy_value!(usize; || {
+        usize::cast_from(
+            mz_secrets::cache::DEFAULT_TTL_SECS.load(std::sync::atomic::Ordering::Relaxed),
+        )
+    }),
+    "Sets the time-to-live for values in the Webhooks secrets cache.",
+    true,
+);
 
-pub const COORD_SLOW_MESSAGE_WARN_THRESHOLD: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("coord_slow_message_warn_threshold"),
+pub static COORD_SLOW_MESSAGE_WARN_THRESHOLD: VarDefinition = VarDefinition::new(
+    "coord_slow_message_warn_threshold",
     // Note(parkmycar): This value was chosen arbitrarily.
-    value: Duration::from_secs(5),
-    description: "Sets the threshold at which we will warn! for a coordinator message being slow.",
-    internal: true,
-};
+    value!(Duration; Duration::from_secs(5)),
+    "Sets the threshold at which we will warn! for a coordinator message being slow.",
+    true,
+);
 
 /// Controls the connect_timeout setting when connecting to PG via `mz_postgres_util`.
-pub const PG_SOURCE_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_source_connect_timeout"),
-    value: mz_postgres_util::DEFAULT_CONNECT_TIMEOUT,
-    description: "Sets the timeout applied to socket-level connection attempts for PG \
+pub static PG_SOURCE_CONNECT_TIMEOUT: VarDefinition = VarDefinition::new(
+    "pg_source_connect_timeout",
+    value!(Duration; mz_postgres_util::DEFAULT_CONNECT_TIMEOUT),
+    "Sets the timeout applied to socket-level connection attempts for PG \
     replication connections. (Materialize)",
-    internal: true,
-};
+    true,
+);
 
 /// Sets the maximum number of TCP keepalive probes that will be sent before dropping a connection
 /// when connecting to PG via `mz_postgres_util`.
-pub const PG_SOURCE_KEEPALIVES_RETRIES: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("pg_source_keepalives_retries"),
-    value: mz_postgres_util::DEFAULT_KEEPALIVE_RETRIES,
-    description:
-        "Sets the maximum number of TCP keepalive probes that will be sent before dropping \
+pub static PG_SOURCE_KEEPALIVES_RETRIES: VarDefinition = VarDefinition::new(
+    "pg_source_keepalives_retries",
+    value!(u32; mz_postgres_util::DEFAULT_KEEPALIVE_RETRIES),
+    "Sets the maximum number of TCP keepalive probes that will be sent before dropping \
     a connection when connecting to PG via `mz_postgres_util`. (Materialize)",
-    internal: true,
-};
+    true,
+);
 
 /// Sets the amount of idle time before a keepalive packet is sent on the connection when connecting
 /// to PG via `mz_postgres_util`.
-pub const PG_SOURCE_KEEPALIVES_IDLE: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_source_keepalives_idle"),
-    value: mz_postgres_util::DEFAULT_KEEPALIVE_IDLE,
-    description:
-        "Sets the amount of idle time before a keepalive packet is sent on the connection \
-    when connecting to PG via `mz_postgres_util`. (Materialize)",
-    internal: true,
-};
+pub static PG_SOURCE_KEEPALIVES_IDLE: VarDefinition = VarDefinition::new(
+    "pg_source_keepalives_idle",
+    value!(Duration; mz_postgres_util::DEFAULT_KEEPALIVE_IDLE),
+    "Sets the amount of idle time before a keepalive packet is sent on the connection \
+        when connecting to PG via `mz_postgres_util`. (Materialize)",
+    true,
+);
 
 /// Sets the time interval between TCP keepalive probes when connecting to PG via `mz_postgres_util`.
-pub const PG_SOURCE_KEEPALIVES_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_source_keepalives_interval"),
-    value: mz_postgres_util::DEFAULT_KEEPALIVE_INTERVAL,
-    description: "Sets the time interval between TCP keepalive probes when connecting to PG via \
-    replication. (Materialize)",
-    internal: true,
-};
+pub static PG_SOURCE_KEEPALIVES_INTERVAL: VarDefinition = VarDefinition::new(
+    "pg_source_keepalives_interval",
+    value!(Duration; mz_postgres_util::DEFAULT_KEEPALIVE_INTERVAL),
+    "Sets the time interval between TCP keepalive probes when connecting to PG via \
+        replication. (Materialize)",
+    true,
+);
 
 /// Sets the TCP user timeout when connecting to PG via `mz_postgres_util`.
-pub const PG_SOURCE_TCP_USER_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_source_tcp_user_timeout"),
-    value: mz_postgres_util::DEFAULT_TCP_USER_TIMEOUT,
-    description:
-        "Sets the TCP user timeout when connecting to PG via `mz_postgres_util`. (Materialize)",
-    internal: true,
-};
+pub static PG_SOURCE_TCP_USER_TIMEOUT: VarDefinition = VarDefinition::new(
+    "pg_source_tcp_user_timeout",
+    value!(Duration; mz_postgres_util::DEFAULT_TCP_USER_TIMEOUT),
+    "Sets the TCP user timeout when connecting to PG via `mz_postgres_util`. (Materialize)",
+    true,
+);
 
 /// Sets the `statement_timeout` value to use during the snapshotting phase of
 /// PG sources.
-pub const PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("pg_source_snapshot_statement_timeout"),
-    value: mz_postgres_util::DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT,
-    description: "Sets the `statement_timeout` value to use during the snapshotting phase of PG sources (Materialize)",
-    internal: true,
-};
+pub static PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT: VarDefinition = VarDefinition::new(
+    "pg_source_snapshot_statement_timeout",
+    value!(Duration; mz_postgres_util::DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT),
+    "Sets the `statement_timeout` value to use during the snapshotting phase of PG sources (Materialize)",
+    true,
+);
 
 /// Please see `PgSourceSnapshotConfig`.
-pub const PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("pg_source_snapshot_collect_strict_count"),
-    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().collect_strict_count,
-    description: "Please see <https://dev.materialize.com/api/rust-private\
+pub static PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT: VarDefinition = VarDefinition::new(
+    "pg_source_snapshot_collect_strict_count",
+    value!(bool; mz_storage_types::parameters::PgSourceSnapshotConfig::new().collect_strict_count),
+    "Please see <https://dev.materialize.com/api/rust-private\
         /mz_storage_types/parameters\
         /struct.PgSourceSnapshotConfig.html#structfield.collect_strict_count>",
-    internal: true,
-};
+    true,
+);
+
 /// Please see `PgSourceSnapshotConfig`.
-pub const PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("pg_source_snapshot_fallback_to_strict_count"),
-    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().fallback_to_strict_count,
-    description: "Please see <https://dev.materialize.com/api/rust-private\
+pub static PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT: VarDefinition = VarDefinition::new(
+    "pg_source_snapshot_fallback_to_strict_count",
+    value!(bool; mz_storage_types::parameters::PgSourceSnapshotConfig::new().fallback_to_strict_count),
+    "Please see <https://dev.materialize.com/api/rust-private\
         /mz_storage_types/parameters\
         /struct.PgSourceSnapshotConfig.html#structfield.fallback_to_strict_count>",
-    internal: true,
-};
+    true,
+);
+
 /// Please see `PgSourceSnapshotConfig`.
-pub const PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("pg_source_snapshot_wait_for_count"),
-    value: mz_storage_types::parameters::PgSourceSnapshotConfig::new().wait_for_count,
-    description: "Please see <https://dev.materialize.com/api/rust-private\
+pub static PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT: VarDefinition = VarDefinition::new(
+    "pg_source_snapshot_wait_for_count",
+    value!(bool; mz_storage_types::parameters::PgSourceSnapshotConfig::new().wait_for_count),
+    "Please see <https://dev.materialize.com/api/rust-private\
         /mz_storage_types/parameters\
         /struct.PgSourceSnapshotConfig.html#structfield.wait_for_count>",
-    internal: true,
-};
+    true,
+);
 
 /// Controls the check interval for connections to SSH bastions via `mz_ssh_util`.
-pub const SSH_CHECK_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("ssh_check_interval"),
-    value: mz_ssh_util::tunnel::DEFAULT_CHECK_INTERVAL,
-    description: "Controls the check interval for connections to SSH bastions via `mz_ssh_util`.",
-    internal: true,
-};
+pub static SSH_CHECK_INTERVAL: VarDefinition = VarDefinition::new(
+    "ssh_check_interval",
+    value!(Duration; mz_ssh_util::tunnel::DEFAULT_CHECK_INTERVAL),
+    "Controls the check interval for connections to SSH bastions via `mz_ssh_util`.",
+    true,
+);
 
 /// Controls the connect timeout for connections to SSH bastions via `mz_ssh_util`.
-pub const SSH_CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("ssh_connect_timeout"),
-    value: mz_ssh_util::tunnel::DEFAULT_CONNECT_TIMEOUT,
-    description: "Controls the connect timeout for connections to SSH bastions via `mz_ssh_util`.",
-    internal: true,
-};
+pub static SSH_CONNECT_TIMEOUT: VarDefinition = VarDefinition::new(
+    "ssh_connect_timeout",
+    value!(Duration; mz_ssh_util::tunnel::DEFAULT_CONNECT_TIMEOUT),
+    "Controls the connect timeout for connections to SSH bastions via `mz_ssh_util`.",
+    true,
+);
 
 /// Controls the keepalive idle interval for connections to SSH bastions via `mz_ssh_util`.
-pub const SSH_KEEPALIVES_IDLE: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("ssh_keepalives_idle"),
-    value: mz_ssh_util::tunnel::DEFAULT_KEEPALIVES_IDLE,
-    description:
-        "Controls the keepalive idle interval for connections to SSH bastions via `mz_ssh_util`.",
-    internal: true,
-};
+pub static SSH_KEEPALIVES_IDLE: VarDefinition = VarDefinition::new(
+    "ssh_keepalives_idle",
+    value!(Duration; mz_ssh_util::tunnel::DEFAULT_KEEPALIVES_IDLE),
+    "Controls the keepalive idle interval for connections to SSH bastions via `mz_ssh_util`.",
+    true,
+);
 
 /// Enables `socket.keepalive.enable` for rdkafka client connections. Defaults to true.
-pub const KAFKA_SOCKET_KEEPALIVE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("kafka_socket_keepalive"),
-    value: mz_kafka_util::client::DEFAULT_KEEPALIVE,
-    description:
-        "Enables `socket.keepalive.enable` for rdkafka client connections. Defaults to true.",
-    internal: true,
-};
+pub static KAFKA_SOCKET_KEEPALIVE: VarDefinition = VarDefinition::new(
+    "kafka_socket_keepalive",
+    value!(bool; mz_kafka_util::client::DEFAULT_KEEPALIVE),
+    "Enables `socket.keepalive.enable` for rdkafka client connections. Defaults to true.",
+    true,
+);
 
 /// Controls `socket.timeout.ms` for rdkafka client connections. Defaults to the rdkafka default
 /// (60000ms). Cannot be greater than 300000ms, more than 100ms greater than
 /// `kafka_transaction_timeout`, or less than 10ms.
-pub const KAFKA_SOCKET_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_socket_timeout"),
-    value: mz_kafka_util::client::DEFAULT_SOCKET_TIMEOUT,
-    description: "Controls `socket.timeout.ms` for rdkafka \
+pub static KAFKA_SOCKET_TIMEOUT: VarDefinition = VarDefinition::new(
+    "kafka_socket_timeout",
+    value!(Duration; mz_kafka_util::client::DEFAULT_SOCKET_TIMEOUT),
+    "Controls `socket.timeout.ms` for rdkafka \
         client connections. Defaults to the rdkafka default (60000ms). \
         Cannot be greater than 300000ms or more than 100ms greater than \
         Cannot be greater than 300000ms, more than 100ms greater than \
         `kafka_transaction_timeout`, or less than 10ms.",
-    internal: true,
-};
+    true,
+);
 
 /// Controls `transaction.timeout.ms` for rdkafka client connections. Defaults to the rdkafka default
 /// (60000ms). Cannot be greater than `i32::MAX` or less than 1000ms.
-pub const KAFKA_TRANSACTION_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_transaction_timeout"),
-    value: mz_kafka_util::client::DEFAULT_TRANSACTION_TIMEOUT,
-    description: "Controls `transaction.timeout.ms` for rdkafka \
+pub static KAFKA_TRANSACTION_TIMEOUT: VarDefinition = VarDefinition::new(
+    "kafka_transaction_timeout",
+    value!(Duration; mz_kafka_util::client::DEFAULT_TRANSACTION_TIMEOUT),
+    "Controls `transaction.timeout.ms` for rdkafka \
         client connections. Defaults to the rdkafka default (60000ms). \
         Cannot be greater than `i32::MAX` or less than 1000ms.",
-    internal: true,
-};
+    true,
+);
 
 /// Controls `socket.connection.setup.timeout.ms` for rdkafka client connections. Defaults to the rdkafka default
 /// (30000ms). Cannot be greater than `i32::MAX` or less than 1000ms
-pub const KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_socket_connection_setup_timeout"),
-    value: mz_kafka_util::client::DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT,
-    description: "Controls `socket.connection.setup.timeout.ms` for rdkafka \
+pub static KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT: VarDefinition = VarDefinition::new(
+    "kafka_socket_connection_setup_timeout",
+    value!(Duration; mz_kafka_util::client::DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT),
+    "Controls `socket.connection.setup.timeout.ms` for rdkafka \
         client connections. Defaults to the rdkafka default (30000ms). \
         Cannot be greater than `i32::MAX` or less than 1000ms",
-    internal: true,
-};
+    true,
+);
 
 /// Controls the timeout when fetching kafka metadata. Defaults to 10s.
-pub const KAFKA_FETCH_METADATA_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_fetch_metadata_timeout"),
-    value: mz_kafka_util::client::DEFAULT_FETCH_METADATA_TIMEOUT,
-    description: "Controls the timeout when fetching kafka metadata. \
+pub static KAFKA_FETCH_METADATA_TIMEOUT: VarDefinition = VarDefinition::new(
+    "kafka_fetch_metadata_timeout",
+    value!(Duration; mz_kafka_util::client::DEFAULT_FETCH_METADATA_TIMEOUT),
+    "Controls the timeout when fetching kafka metadata. \
         Defaults to 10s.",
-    internal: true,
-};
+    true,
+);
 
 /// Controls the timeout when fetching kafka progress records. Defaults to 60s.
-pub const KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_progress_record_fetch_timeout"),
-    value: mz_kafka_util::client::DEFAULT_PROGRESS_RECORD_FETCH_TIMEOUT,
-    description: "Controls the timeout when fetching kafka progress records. \
+pub static KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT: VarDefinition = VarDefinition::new(
+    "kafka_progress_record_fetch_timeout",
+    value!(Duration; mz_kafka_util::client::DEFAULT_PROGRESS_RECORD_FETCH_TIMEOUT),
+    "Controls the timeout when fetching kafka progress records. \
         Defaults to 60s.",
-    internal: true,
-};
+    true,
+);
 
 /// The interval we will fetch metadata from, unless overridden by the source.
-pub const KAFKA_DEFAULT_METADATA_FETCH_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("kafka_default_metadata_fetch_interval"),
-    value: mz_kafka_util::client::DEFAULT_METADATA_FETCH_INTERVAL,
-    description: "The interval we will fetch metadata from, unless overridden by the source. \
+pub static KAFKA_DEFAULT_METADATA_FETCH_INTERVAL: VarDefinition = VarDefinition::new(
+    "kafka_default_metadata_fetch_interval",
+    value!(Duration; mz_kafka_util::client::DEFAULT_METADATA_FETCH_INTERVAL),
+    "The interval we will fetch metadata from, unless overridden by the source. \
         Defaults to 60s.",
-    internal: true,
-};
+    true,
+);
 
 /// The maximum number of in-flight bytes emitted by persist_sources feeding compute dataflows.
-pub const COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar {
-    name: UncasedStr::new("compute_dataflow_max_inflight_bytes"),
-    value: None,
-    description: "The maximum number of in-flight bytes emitted by persist_sources feeding \
-                  compute dataflows (Materialize).",
-    internal: true,
-};
+pub static COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES: VarDefinition = VarDefinition::new(
+    "compute_dataflow_max_inflight_bytes",
+    value!(Option<usize>; None),
+    "The maximum number of in-flight bytes emitted by persist_sources feeding \
+        compute dataflows (Materialize).",
+    true,
+);
 
 /// The maximum number of in-flight bytes emitted by persist_sources feeding _storage
 /// dataflows_.
 /// Currently defaults to 256MiB = 268435456 bytes
 /// Note: Backpressure will only be turned on if disk is enabled based on
 /// `storage_dataflow_max_inflight_bytes_disk_only` flag
-pub const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar {
-    name: UncasedStr::new("storage_dataflow_max_inflight_bytes"),
-    value: Some(256 * 1024 * 1024),
-    description: "The maximum number of in-flight bytes emitted by persist_sources feeding \
-                  storage dataflows. Defaults to backpressure enabled (Materialize).",
-    internal: true,
-};
+pub static STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES: VarDefinition = VarDefinition::new(
+    "storage_dataflow_max_inflight_bytes",
+    value!(Option<usize>; Some(256 * 1024 * 1024)),
+    "The maximum number of in-flight bytes emitted by persist_sources feeding \
+        storage dataflows. Defaults to backpressure enabled (Materialize).",
+    true,
+);
 
 /// Whether or not to delay sources producing values in some scenarios
 /// (namely, upsert) till after rehydration is finished.
-pub const STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("storage_dataflow_delay_sources_past_rehydration"),
-    value: false,
-    description: "Whether or not to delay sources producing values in some scenarios \
-                  (namely, upsert) till after rehydration is finished",
-    internal: true,
-};
+pub static STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION: VarDefinition = VarDefinition::new(
+    "storage_dataflow_delay_sources_past_rehydration",
+    value!(bool; false),
+    "Whether or not to delay sources producing values in some scenarios \
+        (namely, upsert) till after rehydration is finished",
+    true,
+);
 
 /// Configuration ratio to shrink unusef buffers in upsert by.
 /// For eg: is 2 is set, then the buffers will be reduced by 2 i.e. halved.
 /// Default is 0, which means shrinking is disabled.
-pub const STORAGE_SHRINK_UPSERT_UNUSED_BUFFERS_BY_RATIO: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("storage_shrink_upsert_unused_buffers_by_ratio"),
-    value: 0,
-    description: "Configuration ratio to shrink unusef buffers in upsert by",
-    internal: true,
-};
+pub static STORAGE_SHRINK_UPSERT_UNUSED_BUFFERS_BY_RATIO: VarDefinition = VarDefinition::new(
+    "storage_shrink_upsert_unused_buffers_by_ratio",
+    value!(usize; 0),
+    "Configuration ratio to shrink unusef buffers in upsert by",
+    true,
+);
 
 /// The fraction of the cluster replica size to be used as the maximum number of
 /// in-flight bytes emitted by persist_sources feeding storage dataflows.
 /// If not configured, the storage_dataflow_max_inflight_bytes value will be used.
 /// For this value to be used storage_dataflow_max_inflight_bytes needs to be set.
-pub static STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION: Lazy<
-    ServerVar<Option<Numeric>>,
-> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("storage_dataflow_max_inflight_bytes_to_cluster_size_fraction"),
-    value: Some(0.0025.into()),
-    description: "The fraction of the cluster replica size to be used as the maximum number of \
-    in-flight bytes emitted by persist_sources feeding storage dataflows. \
-    If not configured, the storage_dataflow_max_inflight_bytes value will be used.",
-    internal: true,
-});
+pub static STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION: VarDefinition =
+    VarDefinition::new_lazy(
+        "storage_dataflow_max_inflight_bytes_to_cluster_size_fraction",
+        lazy_value!(Option<Numeric>; || Some(0.0025.into())),
+        "The fraction of the cluster replica size to be used as the maximum number of \
+            in-flight bytes emitted by persist_sources feeding storage dataflows. \
+            If not configured, the storage_dataflow_max_inflight_bytes value will be used.",
+        true,
+    );
 
-pub const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("storage_dataflow_max_inflight_bytes_disk_only"),
-    value: true,
-    description: "Whether or not `storage_dataflow_max_inflight_bytes` applies only to \
+pub static STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY: VarDefinition = VarDefinition::new(
+    "storage_dataflow_max_inflight_bytes_disk_only",
+    value!(bool; true),
+    "Whether or not `storage_dataflow_max_inflight_bytes` applies only to \
         upsert dataflows using disks. Defaults to true (Materialize).",
-    internal: true,
-};
+    true,
+);
 
-/// The interval to submit statistics to `mz_source_statistics_raw` and `mz_sink_statistics_raw`.
-pub const STORAGE_STATISTICS_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("storage_statistics_interval"),
-    value: mz_storage_types::parameters::STATISTICS_INTERVAL_DEFAULT,
-    description: "The interval to submit statistics to `mz_source_statistics_raw` \
+/// The interval to submit statistics to `mz_source_statistics_per_worker` and `mz_sink_statistics_per_worker`.
+pub static STORAGE_STATISTICS_INTERVAL: VarDefinition = VarDefinition::new(
+    "storage_statistics_interval",
+    value!(Duration; mz_storage_types::parameters::STATISTICS_INTERVAL_DEFAULT),
+    "The interval to submit statistics to `mz_source_statistics_per_worker` \
         and `mz_sink_statistics` (Materialize).",
-    internal: true,
-};
+    true,
+);
 
-/// The interval to collect statistics for `mz_source_statistics_raw` and `mz_sink_statistics_raw` in
+/// The interval to collect statistics for `mz_source_statistics_per_worker` and `mz_sink_statistics_per_worker` in
 /// clusterd. Controls the accuracy of metrics.
-pub const STORAGE_STATISTICS_COLLECTION_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("storage_statistics_collection_interval"),
-    value: mz_storage_types::parameters::STATISTICS_COLLECTION_INTERVAL_DEFAULT,
-    description: "The interval to collect statistics for `mz_source_statistics_raw` \
-        and `mz_sink_statistics_raw` in clusterd. Controls the accuracy of metrics \
+pub static STORAGE_STATISTICS_COLLECTION_INTERVAL: VarDefinition = VarDefinition::new(
+    "storage_statistics_collection_interval",
+    value!(Duration; mz_storage_types::parameters::STATISTICS_COLLECTION_INTERVAL_DEFAULT),
+    "The interval to collect statistics for `mz_source_statistics_per_worker` \
+        and `mz_sink_statistics_per_worker` in clusterd. Controls the accuracy of metrics \
         (Materialize).",
-    internal: true,
-};
+    true,
+);
 
-pub const STORAGE_RECORD_SOURCE_SINK_NAMESPACED_ERRORS: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("storage_record_source_sink_namespaced_errors"),
-    value: true,
-    description: "Whether or not to record namespaced errors in the status history tables",
-    internal: true,
-};
+pub static STORAGE_RECORD_SOURCE_SINK_NAMESPACED_ERRORS: VarDefinition = VarDefinition::new(
+    "storage_record_source_sink_namespaced_errors",
+    value!(bool; true),
+    "Whether or not to record namespaced errors in the status history tables",
+    true,
+);
 
 /// Boolean flag indicating whether to enable syncing from
 /// LaunchDarkly. Can be turned off as an emergency measure to still
 /// be able to alter parameters while LD is broken.
-pub static ENABLE_LAUNCHDARKLY: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_launchdarkly"),
-    value: true,
-    description: "Boolean flag indicating whether flag synchronization from LaunchDarkly should be enabled (Materialize).",
-    internal: true
-};
+pub static ENABLE_LAUNCHDARKLY: VarDefinition = VarDefinition::new(
+    "enable_launchdarkly",
+    value!(bool; true),
+    "Boolean flag indicating whether flag synchronization from LaunchDarkly should be enabled (Materialize).",
+    true
+);
 
 /// Feature flag indicating whether real time recency is enabled. Not that
 /// unlike other feature flags, this is made available at the session level, so
 /// is additionally gated by a feature flag.
-pub static REAL_TIME_RECENCY: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("real_time_recency"),
-    value: false,
-    description: "Feature flag indicating whether real time recency is enabled (Materialize).",
-    internal: false,
-};
+pub static REAL_TIME_RECENCY: VarDefinition = VarDefinition::new(
+    "real_time_recency",
+    value!(bool; false),
+    "Feature flag indicating whether real time recency is enabled (Materialize).",
+    false,
+)
+.with_feature_flag(&ALLOW_REAL_TIME_RECENCY);
 
-pub static EMIT_TIMESTAMP_NOTICE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("emit_timestamp_notice"),
-    value: false,
-    description:
-        "Boolean flag indicating whether to send a NOTICE with timestamp explanations of queries (Materialize).",
-    internal: false
-};
+pub static EMIT_TIMESTAMP_NOTICE: VarDefinition = VarDefinition::new(
+    "emit_timestamp_notice",
+    value!(bool; false),
+    "Boolean flag indicating whether to send a NOTICE with timestamp explanations of queries (Materialize).",
+    false,
+);
 
-pub static EMIT_TRACE_ID_NOTICE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("emit_trace_id_notice"),
-    value: false,
-    description:
-        "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize).",
-    internal: false
-};
+pub static EMIT_TRACE_ID_NOTICE: VarDefinition = VarDefinition::new(
+    "emit_trace_id_notice",
+    value!(bool; false),
+    "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize).",
+    false,
+);
 
-pub static UNSAFE_MOCK_AUDIT_EVENT_TIMESTAMP: ServerVar<Option<mz_repr::Timestamp>> = ServerVar {
-    name: UncasedStr::new("unsafe_mock_audit_event_timestamp"),
-    value: None,
-    description: "Mocked timestamp to use for audit events for testing purposes",
-    internal: true,
-};
+pub static UNSAFE_MOCK_AUDIT_EVENT_TIMESTAMP: VarDefinition = VarDefinition::new(
+    "unsafe_mock_audit_event_timestamp",
+    value!(Option<mz_repr::Timestamp>; None),
+    "Mocked timestamp to use for audit events for testing purposes",
+    true,
+);
 
-pub const ENABLE_RBAC_CHECKS: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_rbac_checks"),
-    value: true,
-    description: "User facing global boolean flag indicating whether to apply RBAC checks before \
-    executing statements (Materialize).",
-    internal: false,
-};
+pub static ENABLE_RBAC_CHECKS: VarDefinition = VarDefinition::new(
+    "enable_rbac_checks",
+    value!(bool; true),
+    "User facing global boolean flag indicating whether to apply RBAC checks before \
+        executing statements (Materialize).",
+    false,
+);
 
-pub const ENABLE_SESSION_RBAC_CHECKS: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_session_rbac_checks"),
+pub static ENABLE_SESSION_RBAC_CHECKS: VarDefinition = VarDefinition::new(
+    "enable_session_rbac_checks",
     // TODO(jkosh44) Once RBAC is complete, change this to `true`.
-    value: false,
-    description: "User facing session boolean flag indicating whether to apply RBAC checks before \
-    executing statements (Materialize).",
-    internal: false,
-};
+    value!(bool; false),
+    "User facing session boolean flag indicating whether to apply RBAC checks before \
+        executing statements (Materialize).",
+    false,
+);
 
-pub const EMIT_INTROSPECTION_QUERY_NOTICE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("emit_introspection_query_notice"),
-    value: true,
-    description: "Whether to print a notice when querying per-replica introspection sources.",
-    internal: false,
-};
+pub static EMIT_INTROSPECTION_QUERY_NOTICE: VarDefinition = VarDefinition::new(
+    "emit_introspection_query_notice",
+    value!(bool; true),
+    "Whether to print a notice when querying per-replica introspection sources.",
+    false,
+);
 
 // TODO(mgree) change this to a SelectOption
-pub const ENABLE_SESSION_CARDINALITY_ESTIMATES: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_session_cardinality_estimates"),
-    value: false,
-    description:
-        "Feature flag indicating whether to use cardinality estimates when optimizing queries; \
-    does not affect EXPLAIN WITH(cardinality) (Materialize).",
-    internal: false,
-};
+pub static ENABLE_SESSION_CARDINALITY_ESTIMATES: VarDefinition = VarDefinition::new(
+    "enable_session_cardinality_estimates",
+    value!(bool; false),
+    "Feature flag indicating whether to use cardinality estimates when optimizing queries; \
+        does not affect EXPLAIN WITH(cardinality) (Materialize).",
+    false,
+)
+.with_feature_flag(&ENABLE_CARDINALITY_ESTIMATES);
 
-pub const OPTIMIZER_STATS_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("optimizer_stats_timeout"),
-    value: Duration::from_millis(250),
-    description: "Sets the timeout applied to the optimizer's statistics collection from storage; \
-    applied to non-oneshot, i.e., long-lasting queries, like CREATE MATERIALIZED VIEW (Materialize).",
-    internal: true,
-};
+pub static OPTIMIZER_STATS_TIMEOUT: VarDefinition = VarDefinition::new(
+    "optimizer_stats_timeout",
+    value!(Duration; Duration::from_millis(250)),
+    "Sets the timeout applied to the optimizer's statistics collection from storage; \
+        applied to non-oneshot, i.e., long-lasting queries, like CREATE MATERIALIZED VIEW (Materialize).",
+    true,
+);
 
-pub const OPTIMIZER_ONESHOT_STATS_TIMEOUT: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("optimizer_oneshot_stats_timeout"),
-    value: Duration::from_millis(20),
-    description: "Sets the timeout applied to the optimizer's statistics collection from storage; \
-    applied to oneshot queries, like SELECT (Materialize).",
-    internal: true,
-};
+pub static OPTIMIZER_ONESHOT_STATS_TIMEOUT: VarDefinition = VarDefinition::new(
+    "optimizer_oneshot_stats_timeout",
+    value!(Duration; Duration::from_millis(20)),
+    "Sets the timeout applied to the optimizer's statistics collection from storage; \
+        applied to oneshot queries, like SELECT (Materialize).",
+    true,
+);
 
-pub const PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("privatelink_status_update_quota_per_minute"),
-    value: 20,
-    description: "Sets the per-minute quota for privatelink vpc status updates to be written to \
-    the storage-collection-backed system table. This value implies the total and burst quota per-minute.",
-    internal: true,
-};
+pub static PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE: VarDefinition = VarDefinition::new(
+    "privatelink_status_update_quota_per_minute",
+    value!(u32; 20),
+    "Sets the per-minute quota for privatelink vpc status updates to be written to \
+        the storage-collection-backed system table. This value implies the total and burst quota per-minute.",
+    true,
+);
 
-pub static STATEMENT_LOGGING_SAMPLE_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| {
-    ServerVar {
-    name: UncasedStr::new("statement_logging_sample_rate"),
-    value: 0.1.into(),
-    description: "User-facing session variable indicating how many statement executions should be \
-    logged, subject to constraint by the system variable `statement_logging_max_sample_rate` (Materialize).",
-    internal: false,
-}
-});
+pub static STATEMENT_LOGGING_SAMPLE_RATE: VarDefinition = VarDefinition::new_lazy(
+    "statement_logging_sample_rate",
+    lazy_value!(Numeric; || 0.1.into()),
+    "User-facing session variable indicating how many statement executions should be \
+        logged, subject to constraint by the system variable `statement_logging_max_sample_rate` (Materialize).",
+    false,
+).with_constraint(&NUMERIC_BOUNDED_0_1_INCLUSIVE);
 
 /// Whether compute rendering should use Materialize's custom linear join implementation rather
 /// than the one from Differential Dataflow.
-pub const ENABLE_MZ_JOIN_CORE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_mz_join_core"),
-    value: true,
-    description:
-        "Feature flag indicating whether compute rendering should use Materialize's custom linear \
-         join implementation rather than the one from Differential Dataflow. (Materialize).",
-    internal: true,
-};
+pub static ENABLE_MZ_JOIN_CORE: VarDefinition = VarDefinition::new(
+    "enable_mz_join_core",
+    value!(bool; true),
+    "Feature flag indicating whether compute rendering should use Materialize's custom linear \
+        join implementation rather than the one from Differential Dataflow. (Materialize).",
+    true,
+);
 
-pub static DEFAULT_LINEAR_JOIN_YIELDING: Lazy<String> =
-    Lazy::new(|| "work:1000000,time:100".into());
-pub static LINEAR_JOIN_YIELDING: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("linear_join_yielding"),
-    value: DEFAULT_LINEAR_JOIN_YIELDING.clone(),
-    description:
-        "The yielding behavior compute rendering should apply for linear join operators. Either \
-         'work:<amount>' or 'time:<milliseconds>' or 'work:<amount>,time:<milliseconds>'. Note \
-         that omitting one of 'work' or 'time' will entirely disable join yielding by time or \
-         work, respectively, rather than falling back to some default.",
-    internal: true,
-});
+pub const DEFAULT_LINEAR_JOIN_YIELDING: Cow<'static, str> = Cow::Borrowed("work:1000000,time:100");
+pub static LINEAR_JOIN_YIELDING: VarDefinition = VarDefinition::new(
+    "linear_join_yielding",
+    value!(Cow<'static, str>; DEFAULT_LINEAR_JOIN_YIELDING),
+    "The yielding behavior compute rendering should apply for linear join operators. Either \
+        'work:<amount>' or 'time:<milliseconds>' or 'work:<amount>,time:<milliseconds>'. Note \
+        that omitting one of 'work' or 'time' will entirely disable join yielding by time or \
+        work, respectively, rather than falling back to some default.",
+    true,
+);
 
-pub const DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("default_idle_arrangement_merge_effort"),
-    value: 0,
-    description:
-        "The default value to use for the `IDLE ARRANGEMENT MERGE EFFORT` cluster/replica option.",
-    internal: true,
-};
+pub static DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT: VarDefinition = VarDefinition::new(
+    "default_idle_arrangement_merge_effort",
+    value!(u32; 0),
+    "The default value to use for the `IDLE ARRANGEMENT MERGE EFFORT` cluster/replica option.",
+    true,
+);
 
-pub const DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("default_arrangement_exert_proportionality"),
-    value: 16,
-    description:
-        "The default value to use for the `ARRANGEMENT EXERT PROPORTIONALITY` cluster/replica option.",
-    internal: true,
-};
+pub static DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY: VarDefinition = VarDefinition::new(
+    "default_arrangement_exert_proportionality",
+    value!(u32; 16),
+    "The default value to use for the `ARRANGEMENT EXERT PROPORTIONALITY` cluster/replica option.",
+    true,
+);
 
-pub const ENABLE_DEFAULT_CONNECTION_VALIDATION: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_default_connection_validation"),
-    value: true,
-    description:
-        "LD facing global boolean flag that allows turning default connection validation off for everyone (Materialize).",
-    internal: true,
-};
+pub static ENABLE_DEFAULT_CONNECTION_VALIDATION: VarDefinition = VarDefinition::new(
+    "enable_default_connection_validation",
+    value!(bool; true),
+    "LD facing global boolean flag that allows turning default connection validation off for everyone (Materialize).",
+    true,
+);
 
-pub static STATEMENT_LOGGING_MAX_DATA_CREDIT: Lazy<ServerVar<Option<usize>>> = Lazy::new(|| {
-    ServerVar {
-    name: UncasedStr::new("statement_logging_max_data_credit"),
-    value: None,
+pub static STATEMENT_LOGGING_MAX_DATA_CREDIT: VarDefinition = VarDefinition::new(
+    "statement_logging_max_data_credit",
+    value!(Option<usize>; None),
     // The idea is that during periods of low logging, tokens can accumulate up to this value,
     // and then be depleted during periods of high logging.
-    description: "The maximum number of bytes that can be logged for statement logging in short burts, or NULL if unlimited (Materialize).",
-    internal: true,
-}
-});
+    "The maximum number of bytes that can be logged for statement logging in short burts, or NULL if unlimited (Materialize).",
+    true,
+);
 
-pub static STATEMENT_LOGGING_TARGET_DATA_RATE: Lazy<ServerVar<Option<usize>>> = Lazy::new(|| {
-    ServerVar {
-    name: UncasedStr::new("statement_logging_target_data_rate"),
-    value: None,
-    description: "The maximum sustained data rate of statement logging, in bytes per second, or NULL if unlimited (Materialize).",
-    internal: true,
-}
-});
+pub static STATEMENT_LOGGING_TARGET_DATA_RATE: VarDefinition = VarDefinition::new(
+    "statement_logging_target_data_rate",
+    value!(Option<usize>; None),
+    "The maximum sustained data rate of statement logging, in bytes per second, or NULL if unlimited (Materialize).",
+    true,
+);
 
-pub static STATEMENT_LOGGING_MAX_SAMPLE_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| ServerVar {
-    name: UncasedStr::new("statement_logging_max_sample_rate"),
-    value: 0.0.into(),
-    description: "The maximum rate at which statements may be logged. If this value is less than \
-that of `statement_logging_sample_rate`, the latter is ignored (Materialize).",
-    internal: false,
-});
+pub static STATEMENT_LOGGING_MAX_SAMPLE_RATE: VarDefinition = VarDefinition::new_lazy(
+    "statement_logging_max_sample_rate",
+    lazy_value!(Numeric; || 0.0.into()),
+    "The maximum rate at which statements may be logged. If this value is less than \
+        that of `statement_logging_sample_rate`, the latter is ignored (Materialize).",
+    false,
+)
+.with_constraint(&NUMERIC_BOUNDED_0_1_INCLUSIVE);
 
-pub static STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE: Lazy<ServerVar<Numeric>> =
-    Lazy::new(|| ServerVar {
-        name: UncasedStr::new("statement_logging_default_sample_rate"),
-        value: 0.0.into(),
-        description:
-            "The default value of `statement_logging_sample_rate` for new sessions (Materialize).",
-        internal: false,
-    });
+pub static STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE: VarDefinition = VarDefinition::new_lazy(
+    "statement_logging_default_sample_rate",
+    lazy_value!(Numeric; || 0.0.into()),
+    "The default value of `statement_logging_sample_rate` for new sessions (Materialize).",
+    false,
+)
+.with_constraint(&NUMERIC_BOUNDED_0_1_INCLUSIVE);
 
-pub const AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("auto_route_introspection_queries"),
-    value: true,
-    description:
-        "Whether to force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize).",
-    internal: false
-};
+pub static AUTO_ROUTE_INTROSPECTION_QUERIES: VarDefinition = VarDefinition::new(
+    "auto_route_introspection_queries",
+    value!(bool; true),
+    "Whether to force queries that depend only on system tables, to run on the mz_introspection cluster (Materialize).",
+    false,
+);
 
-pub const MAX_CONNECTIONS: ServerVar<u32> = ServerVar {
-    name: UncasedStr::new("max_connections"),
-    value: 1000,
-    description: "The maximum number of concurrent connections (Materialize).",
-    internal: false,
-};
+pub static MAX_CONNECTIONS: VarDefinition = VarDefinition::new(
+    "max_connections",
+    value!(u32; 1000),
+    "The maximum number of concurrent connections (Materialize).",
+    false,
+);
 
 /// Controls [`mz_storage_types::parameters::StorageParameters::keep_n_source_status_history_entries`].
-pub const KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("keep_n_source_status_history_entries"),
-    value: 5,
-    description: "On reboot, truncate all but the last n entries per ID in the source_status_history collection (Materialize).",
-    internal: true
-};
+pub static KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES: VarDefinition = VarDefinition::new(
+    "keep_n_source_status_history_entries",
+    value!(usize; 5),
+    "On reboot, truncate all but the last n entries per ID in the source_status_history collection (Materialize).",
+    true,
+);
 
 /// Controls [`mz_storage_types::parameters::StorageParameters::keep_n_sink_status_history_entries`].
-pub const KEEP_N_SINK_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("keep_n_sink_status_history_entries"),
-    value: 5,
-    description: "On reboot, truncate all but the last n entries per ID in the sink_status_history collection (Materialize).",
-    internal: true
-};
+pub static KEEP_N_SINK_STATUS_HISTORY_ENTRIES: VarDefinition = VarDefinition::new(
+    "keep_n_sink_status_history_entries",
+    value!(usize; 5),
+    "On reboot, truncate all but the last n entries per ID in the sink_status_history collection (Materialize).",
+    true,
+);
 
 /// Controls [`mz_storage_types::parameters::StorageParameters::keep_n_privatelink_status_history_entries`].
-pub const KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("keep_n_privatelink_status_history_entries"),
-    value: 5,
-    description: "On reboot, truncate all but the last n entries per ID in the mz_aws_privatelink_connection_status_history \
-    collection (Materialize).",
-    internal: true
-};
+pub static KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES: VarDefinition = VarDefinition::new(
+    "keep_n_privatelink_status_history_entries",
+    value!(usize; 5),
+    "On reboot, truncate all but the last n entries per ID in the mz_aws_privatelink_connection_status_history \
+        collection (Materialize).",
+    true,
+);
 
-pub const ENABLE_STORAGE_SHARD_FINALIZATION: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_storage_shard_finalization"),
-    value: true,
-    description: "Whether to allow the storage client to finalize shards (Materialize).",
-    internal: true,
-};
+pub static ENABLE_STORAGE_SHARD_FINALIZATION: VarDefinition = VarDefinition::new(
+    "enable_storage_shard_finalization",
+    value!(bool; true),
+    "Whether to allow the storage client to finalize shards (Materialize).",
+    true,
+);
 
-pub const ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_consolidate_after_union_negate"),
-    value: true,
-    description: "consolidation after Unions that have a Negated input (Materialize).",
-    internal: false,
-};
+pub static ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE: VarDefinition = VarDefinition::new(
+    "enable_consolidate_after_union_negate",
+    value!(bool; true),
+    "consolidation after Unions that have a Negated input (Materialize).",
+    false,
+);
 
-pub const MIN_TIMESTAMP_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("min_timestamp_interval"),
-    value: Duration::from_millis(1000),
-    description: "Minimum timestamp interval",
-    internal: true,
-};
+pub static MIN_TIMESTAMP_INTERVAL: VarDefinition = VarDefinition::new(
+    "min_timestamp_interval",
+    value!(Duration; Duration::from_millis(1000)),
+    "Minimum timestamp interval",
+    true,
+);
 
-pub const MAX_TIMESTAMP_INTERVAL: ServerVar<Duration> = ServerVar {
-    name: UncasedStr::new("max_timestamp_interval"),
-    value: Duration::from_millis(1000),
-    description: "Maximum timestamp interval",
-    internal: true,
-};
+pub static MAX_TIMESTAMP_INTERVAL: VarDefinition = VarDefinition::new(
+    "max_timestamp_interval",
+    value!(Duration; Duration::from_millis(1000)),
+    "Maximum timestamp interval",
+    true,
+);
 
-pub const WEBHOOK_CONCURRENT_REQUEST_LIMIT: ServerVar<usize> = ServerVar {
-    name: UncasedStr::new("webhook_concurrent_request_limit"),
-    value: WEBHOOK_CONCURRENCY_LIMIT,
-    description: "Maximum number of concurrent requests for appending to a webhook source.",
-    internal: true,
-};
+pub static WEBHOOK_CONCURRENT_REQUEST_LIMIT: VarDefinition = VarDefinition::new(
+    "webhook_concurrent_request_limit",
+    value!(usize; WEBHOOK_CONCURRENCY_LIMIT),
+    "Maximum number of concurrent requests for appending to a webhook source.",
+    true,
+);
 
-pub const ENABLE_COLUMNATION_LGALLOC: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_columnation_lgalloc"),
-    value: false,
-    description: "Enable allocating regions from lgalloc",
-    internal: true,
-};
+pub static ENABLE_COLUMNATION_LGALLOC: VarDefinition = VarDefinition::new(
+    "enable_columnation_lgalloc",
+    value!(bool; false),
+    "Enable allocating regions from lgalloc",
+    true,
+);
 
-pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_statement_lifecycle_logging"),
-    value: false,
-    description:
-        "Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history",
-    internal: true,
-};
+pub static ENABLE_COMPUTE_CHUNKED_STACK: VarDefinition = VarDefinition::new(
+    "enable_compute_chunked_stack",
+    value!(bool; false),
+    "Enable the chunked stack implementation in compute",
+    true,
+);
 
-pub const ENABLE_DEPENDENCY_READ_HOLD_ASSERTS: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_dependency_read_hold_asserts"),
-    value: true,
-    description:
-        "Whether to have the storage client check if a subsource's implied capability is less than \
+pub static ENABLE_STATEMENT_LIFECYCLE_LOGGING: VarDefinition = VarDefinition::new(
+    "enable_statement_lifecycle_logging",
+    value!(bool; false),
+    "Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history",
+    true,
+);
+
+pub static ENABLE_DEPENDENCY_READ_HOLD_ASSERTS: VarDefinition = VarDefinition::new(
+    "enable_dependency_read_hold_asserts",
+    value!(bool; true),
+    "Whether to have the storage client check if a subsource's implied capability is less than \
         its write frontier. This should only be set to false in cases where customer envs cannot
         boot (Materialize).",
-    internal: true,
-};
+    true,
+);
 
 /// Configuration for gRPC client connections.
 pub mod grpc_client {
     use super::*;
 
-    pub const CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
-        name: UncasedStr::new("grpc_client_connect_timeout"),
-        value: Duration::from_secs(5),
-        description: "Timeout to apply to initial gRPC client connection establishment.",
-        internal: true,
-    };
-    pub const HTTP2_KEEP_ALIVE_INTERVAL: ServerVar<Duration> = ServerVar {
-        name: UncasedStr::new("grpc_client_http2_keep_alive_interval"),
-        value: Duration::from_secs(3),
-        description: "Idle time to wait before sending HTTP/2 PINGs to maintain established gRPC client connections.",
-        internal: true,
-    };
-    pub const HTTP2_KEEP_ALIVE_TIMEOUT: ServerVar<Duration> = ServerVar {
-        name: UncasedStr::new("grpc_client_http2_keep_alive_timeout"),
-        value: Duration::from_secs(5),
-        description:
-            "Time to wait for HTTP/2 pong response before terminating a gRPC client connection.",
-        internal: true,
-    };
+    pub static CONNECT_TIMEOUT: VarDefinition = VarDefinition::new(
+        "grpc_client_connect_timeout",
+        value!(Duration; Duration::from_secs(5)),
+        "Timeout to apply to initial gRPC client connection establishment.",
+        true,
+    );
+
+    pub static HTTP2_KEEP_ALIVE_INTERVAL: VarDefinition = VarDefinition::new(
+        "grpc_client_http2_keep_alive_interval",
+        value!(Duration; Duration::from_secs(3)),
+        "Idle time to wait before sending HTTP/2 PINGs to maintain established gRPC client connections.",
+        true,
+    );
+
+    pub static HTTP2_KEEP_ALIVE_TIMEOUT: VarDefinition = VarDefinition::new(
+        "grpc_client_http2_keep_alive_timeout",
+        value!(Duration; Duration::from_secs(5)),
+        "Time to wait for HTTP/2 pong response before terminating a gRPC client connection.",
+        true,
+    );
 }
 
 /// Configuration for how cluster replicas are scheduled.
@@ -1376,83 +1506,78 @@ pub mod cluster_scheduling {
     use super::*;
     use mz_orchestrator::scheduling_config::*;
 
-    pub const CLUSTER_MULTI_PROCESS_REPLICA_AZ_AFFINITY_WEIGHT: ServerVar<Option<i32>> =
-        ServerVar {
-            name: UncasedStr::new("cluster_multi_process_replica_az_affinity_weight"),
-            value: DEFAULT_POD_AZ_AFFINITY_WEIGHT,
-            description:
-                "Whether or not to add an availability zone affinity between instances of \
+    pub static CLUSTER_MULTI_PROCESS_REPLICA_AZ_AFFINITY_WEIGHT: VarDefinition = VarDefinition::new(
+        "cluster_multi_process_replica_az_affinity_weight",
+        value!(Option<i32>; DEFAULT_POD_AZ_AFFINITY_WEIGHT),
+        "Whether or not to add an availability zone affinity between instances of \
             multi-process replicas. Either an affinity weight or empty (off) (Materialize).",
-            internal: true,
-        };
+        true,
+    );
 
-    pub const CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("cluster_soften_replication_anti_affinity"),
-        value: DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY,
-        description: "Whether or not to turn the node-scope anti affinity between replicas \
+    pub static CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY: VarDefinition = VarDefinition::new(
+        "cluster_soften_replication_anti_affinity",
+        value!(bool; DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY),
+        "Whether or not to turn the node-scope anti affinity between replicas \
             in the same cluster into a preference (Materialize).",
-        internal: true,
-    };
+        true,
+    );
 
-    pub const CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT: ServerVar<i32> = ServerVar {
-        name: UncasedStr::new("cluster_soften_replication_anti_affinity_weight"),
-        value: DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT,
-        description:
-            "The preference weight for `cluster_soften_replication_anti_affinity` (Materialize).",
-        internal: true,
-    };
+    pub static CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT: VarDefinition = VarDefinition::new(
+        "cluster_soften_replication_anti_affinity_weight",
+        value!(i32; DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT),
+        "The preference weight for `cluster_soften_replication_anti_affinity` (Materialize).",
+        true,
+    );
 
-    pub const CLUSTER_ENABLE_TOPOLOGY_SPREAD: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("cluster_enable_topology_spread"),
-        value: DEFAULT_TOPOLOGY_SPREAD_ENABLED,
-        description:
-            "Whether or not to add topology spread constraints among replicas in the same cluster (Materialize).",
-        internal: true,
-    };
+    pub static CLUSTER_ENABLE_TOPOLOGY_SPREAD: VarDefinition = VarDefinition::new(
+        "cluster_enable_topology_spread",
+        value!(bool; DEFAULT_TOPOLOGY_SPREAD_ENABLED),
+        "Whether or not to add topology spread constraints among replicas in the same cluster (Materialize).",
+        true,
+    );
 
-    pub const CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("cluster_topology_spread_ignore_non_singular_scale"),
-        value: DEFAULT_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE,
-        description:
-            "If true, ignore replicas with more than 1 process when adding topology spread constraints (Materialize).",
-        internal: true,
-    };
+    pub static CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE: VarDefinition = VarDefinition::new(
+        "cluster_topology_spread_ignore_non_singular_scale",
+        value!(bool; DEFAULT_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE),
+        "If true, ignore replicas with more than 1 process when adding topology spread constraints (Materialize).",
+        true,
+    );
 
-    pub const CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW: ServerVar<i32> = ServerVar {
-        name: UncasedStr::new("cluster_topology_spread_max_skew"),
-        value: DEFAULT_TOPOLOGY_SPREAD_MAX_SKEW,
-        description: "The `maxSkew` for replica topology spread constraints (Materialize).",
-        internal: true,
-    };
+    pub static CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW: VarDefinition = VarDefinition::new(
+        "cluster_topology_spread_max_skew",
+        value!(i32; DEFAULT_TOPOLOGY_SPREAD_MAX_SKEW),
+        "The `maxSkew` for replica topology spread constraints (Materialize).",
+        true,
+    );
 
-    pub const CLUSTER_TOPOLOGY_SPREAD_SOFT: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("cluster_topology_spread_soft"),
-        value: DEFAULT_TOPOLOGY_SPREAD_SOFT,
-        description: "If true, soften the topology spread constraints for replicas (Materialize).",
-        internal: true,
-    };
+    pub static CLUSTER_TOPOLOGY_SPREAD_SOFT: VarDefinition = VarDefinition::new(
+        "cluster_topology_spread_soft",
+        value!(bool; DEFAULT_TOPOLOGY_SPREAD_SOFT),
+        "If true, soften the topology spread constraints for replicas (Materialize).",
+        true,
+    );
 
-    pub const CLUSTER_SOFTEN_AZ_AFFINITY: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("cluster_soften_az_affinity"),
-        value: DEFAULT_SOFTEN_AZ_AFFINITY,
-        description: "Whether or not to turn the az-scope node affinity for replicas. \
+    pub static CLUSTER_SOFTEN_AZ_AFFINITY: VarDefinition = VarDefinition::new(
+        "cluster_soften_az_affinity",
+        value!(bool; DEFAULT_SOFTEN_AZ_AFFINITY),
+        "Whether or not to turn the az-scope node affinity for replicas. \
             Note this could violate requests from the user (Materialize).",
-        internal: true,
-    };
+        true,
+    );
 
-    pub const CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT: ServerVar<i32> = ServerVar {
-        name: UncasedStr::new("cluster_soften_az_affinity_weight"),
-        value: DEFAULT_SOFTEN_AZ_AFFINITY_WEIGHT,
-        description: "The preference weight for `cluster_soften_az_affinity` (Materialize).",
-        internal: true,
-    };
+    pub static CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT: VarDefinition = VarDefinition::new(
+        "cluster_soften_az_affinity_weight",
+        value!(i32; DEFAULT_SOFTEN_AZ_AFFINITY_WEIGHT),
+        "The preference weight for `cluster_soften_az_affinity` (Materialize).",
+        true,
+    );
 
-    pub const CLUSTER_ALWAYS_USE_DISK: ServerVar<bool> = ServerVar {
-        name: UncasedStr::new("cluster_always_use_disk"),
-        value: DEFAULT_ALWAYS_USE_DISK,
-        description: "Always provisions a replica with disk, regardless of `DISK` DDL option.",
-        internal: true,
-    };
+    pub static CLUSTER_ALWAYS_USE_DISK: VarDefinition = VarDefinition::new(
+        "cluster_always_use_disk",
+        value!(bool; DEFAULT_ALWAYS_USE_DISK),
+        "Always provisions a replica with disk, regardless of `DISK` DDL option.",
+        true,
+    );
 }
 
 /// Macro to simplify creating feature flags, i.e. boolean flags that we use to toggle the
@@ -1504,12 +1629,12 @@ macro_rules! feature_flags {
         paste::paste!{
             // Note that the ServerVar is not directly exported; we expect these to be
             // accessible through their FeatureFlag variant.
-            pub static [<$name:upper _VAR>]: ServerVar<bool> = ServerVar {
-                name: UncasedStr::new(stringify!($name)),
-                value: $value,
-                description: concat!("Whether ", $desc, " is allowed (Materialize)."),
-                internal: $internal
-            };
+            static [<$name:upper _VAR>]: VarDefinition = VarDefinition::new(
+                stringify!($name),
+                value!(bool; $value),
+                concat!("Whether ", $desc, " is allowed (Materialize)."),
+                $internal
+            );
 
             pub static [<$name:upper >]: FeatureFlag = FeatureFlag {
                 flag: &[<$name:upper _VAR>],
@@ -1538,18 +1663,16 @@ macro_rules! feature_flags {
         })+
 
         paste::paste!{
-            impl SystemVars {
-                pub fn with_feature_flags(self) -> Self
-                {
-                    self
-                    $(
-                        .with_var(&[<$name:upper _VAR>])
-                    )+
-                }
+            pub static FEATURE_FLAGS: &'static [&'static VarDefinition] = &[
+                $(  & [<$name:upper _VAR>] , )+
+            ];
+        }
 
+        paste::paste!{
+            impl super::SystemVars {
                 pub fn enable_all_feature_flags_by_default(&mut self) {
                     $(
-                        self.set_default(stringify!($name), VarInput::Flat("on"))
+                        self.set_default(stringify!($name), super::VarInput::Flat("on"))
                             .expect("setting default value must work");
                     )+
                 }
@@ -1557,7 +1680,7 @@ macro_rules! feature_flags {
                 pub fn enable_for_item_parsing(&mut self) {
                     $(
                         if $enable_for_item_parsing {
-                            self.set(stringify!($name), VarInput::Flat("on"))
+                            self.set(stringify!($name), super::VarInput::Flat("on"))
                                 .expect("setting default value must work");
                         }
                     )+
@@ -1840,13 +1963,6 @@ feature_flags!(
         name: enable_explain_broken,
         desc: "EXPLAIN ... BROKEN <query> syntax",
         default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_jemalloc_profiling,
-        desc: "jemalloc heap memory profiling",
-        default: true,
         internal: true,
         enable_for_item_parsing: true,
     },

--- a/src/sql/src/session/vars/errors.rs
+++ b/src/sql/src/session/vars/errors.rs
@@ -1,0 +1,128 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use itertools::Itertools;
+use uncased::UncasedStr;
+
+use mz_ore::str::StrExt;
+
+use crate::session::vars::Var;
+
+/// Errors that can occur when working with [`Var`]s
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum VarError {
+    /// The specified session parameter is constrained to a finite set of
+    /// values.
+    #[error(
+        "invalid value for parameter {}: {}",
+        parameter.name.quoted(),
+        values.iter().map(|v| v.quoted()).join(",")
+    )]
+    ConstrainedParameter {
+        parameter: VarErrParam,
+        values: Vec<String>,
+        valid_values: Option<Vec<&'static str>>,
+    },
+    /// The specified parameter is fixed to a single specific value.
+    ///
+    /// We allow setting the parameter to its fixed value for compatibility
+    /// with PostgreSQL-based tools.
+    #[error(
+        "parameter {} can only be set to {}",
+        .0.name.quoted(),
+        .0.value.quoted(),
+    )]
+    FixedValueParameter(VarErrParam),
+    /// The value for the specified parameter does not have the right type.
+    #[error(
+        "parameter {} requires a {} value",
+        .0.name.quoted(),
+        .0.type_name.quoted()
+    )]
+    InvalidParameterType(VarErrParam),
+    /// The value of the specified parameter is incorrect.
+    #[error(
+        "parameter {} cannot have value {}: {}",
+        parameter.name.quoted(),
+        values
+            .iter()
+            .map(|v| v.quoted().to_string())
+            .collect::<Vec<_>>()
+            .join(","),
+        reason,
+    )]
+    InvalidParameterValue {
+        parameter: VarErrParam,
+        values: Vec<String>,
+        reason: String,
+    },
+    /// The specified session parameter is read only.
+    #[error("parameter {} cannot be changed", .0.quoted())]
+    ReadOnlyParameter(&'static str),
+    /// The named parameter is unknown to the system.
+    #[error("unrecognized configuration parameter {}", .0.quoted())]
+    UnknownParameter(String),
+    /// The specified session parameter is read only unless in unsafe mode.
+    #[error("parameter {} can only be set in unsafe mode", .0.quoted())]
+    RequiresUnsafeMode(&'static str),
+    #[error("{} is not supported", .feature)]
+    RequiresFeatureFlag {
+        feature: String,
+        detail: Option<String>,
+        /// If we're running in unsafe mode and hit this error, we should surface the flag name that
+        /// needs to be set to make the feature work.
+        name_hint: Option<&'static UncasedStr>,
+    },
+}
+
+impl VarError {
+    pub fn detail(&self) -> Option<String> {
+        match self {
+            Self::RequiresFeatureFlag { detail, .. } => {
+                match detail {
+                    None => Some("The requested feature is typically meant only for internal development and testing of Materialize.".into()),
+                    o => o.clone()
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn hint(&self) -> Option<String> {
+        match self {
+            VarError::ConstrainedParameter {
+                valid_values: Some(valid_values),
+                ..
+            } => Some(format!("Available values: {}.", valid_values.join(", "))),
+            VarError::RequiresFeatureFlag { name_hint, .. } => {
+                name_hint.map(|name| format!("Enable with {name} flag"))
+            }
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+/// We don't want to hold a static reference to a variable while erroring, so take an owned version
+/// of the fields we want.
+pub struct VarErrParam {
+    name: &'static str,
+    value: String,
+    type_name: String,
+}
+
+impl<'a, V: Var + Send + Sync + ?Sized> From<&'a V> for VarErrParam {
+    fn from(var: &'a V) -> VarErrParam {
+        VarErrParam {
+            name: var.name(),
+            value: var.value(),
+            type_name: var.type_name(),
+        }
+    }
+}

--- a/src/sql/src/session/vars/polyfill.rs
+++ b/src/sql/src/session/vars/polyfill.rs
@@ -1,0 +1,63 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! The types in this module exist to overcome limitations of the Rust compiler, namely limitations
+//! in const generics.
+
+use super::Value;
+
+/// Trait that helps us convert a `fn() -> &'static impl Value` to a `fn() -> &'static dyn Value`.
+///
+/// For creating a type that implements [`LazyValueFn`] see the [`lazy_fn`] macro.
+///
+/// Note: Ideally we could use const generics to pass a function pointer directly to
+/// [`VarDefinition::new`], but Rust doesn't currently support this.
+pub trait LazyValueFn<V: Value>: Copy {
+    const LAZY_VALUE_FN: fn() -> &'static dyn Value = || {
+        let dyn_val: &'static dyn Value = Self::generate_value();
+        dyn_val
+    };
+
+    fn generate_value() -> &'static V;
+}
+
+/// Creates a temporary struct that implements [`LazyValueFn`] and returns an instance of it.
+///
+///
+macro_rules! lazy_value {
+    ($t: ty; $f: expr) => {{
+        // Note: We derive `Copy` on this type to avoid issues with `Drop` in const contexts.
+        #[derive(Copy, Clone)]
+        struct LazyFn(());
+
+        impl crate::session::vars::polyfill::LazyValueFn<$t> for LazyFn {
+            fn generate_value() -> &'static $t {
+                static MY_VALUE_LAZY: ::once_cell::sync::Lazy<$t> = Lazy::new($f);
+                &*MY_VALUE_LAZY
+            }
+        }
+
+        LazyFn(())
+    }};
+}
+pub(crate) use lazy_value;
+
+/// Assigns the provided value to a `static`, and returns a reference to it.
+///
+/// Note: [`VarDefinition::new`] requires a `&'static V`, where `V: Value`. Ideally we would be
+/// able to pass the value as a const generic parameter, but Rust doesn't yet support this.
+///
+/// [`VarDefinition::new`]: crate::session::vars2::VarDefinition::new
+macro_rules! value {
+    ($t: ty; $l: expr) => {{
+        static MY_STATIC: $t = $l;
+        &MY_STATIC
+    }};
+}
+pub(crate) use value;

--- a/src/sql/src/session/vars/value.rs
+++ b/src/sql/src/session/vars/value.rs
@@ -7,10 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::clone::Clone;
-use std::fmt::{Debug, Display};
+use std::any::Any;
+use std::borrow::Cow;
+use std::fmt::{self, Debug};
 use std::str::FromStr;
-use std::string::ToString;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -20,7 +20,6 @@ use itertools::Itertools;
 use mz_pgwire_common::Severity;
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::adt::timestamp::CheckedTimestamp;
-use mz_repr::bytes::ByteSize;
 use mz_repr::strconv;
 use mz_rocksdb_types::config::{CompactionStyle, CompressionType};
 use mz_sql_parser::ast::{Ident, TransactionIsolationLevel};
@@ -30,59 +29,183 @@ use proptest_derive::Arbitrary;
 use serde::Serialize;
 use uncased::UncasedStr;
 
-use crate::session::vars::definitions::{
-    CATALOG_KIND_IMPL, CLIENT_ENCODING, DATE_STYLE, INTERVAL_STYLE, PERSIST_TXN_TABLES,
-    TIMESTAMP_ORACLE_IMPL, TIMEZONE, TRANSACTION_ISOLATION,
-};
-use crate::session::vars::errors::VarError;
-use crate::session::vars::{Var, VarInput};
+use super::errors::VarParseError;
+use super::VarInput;
 
-// use super::*;
+/// Defines a value that get stored as part of a System or Session variable.
+///
+/// This trait is partially object safe, see [`VarDefinition`] for more details.
+///
+/// [`VarDefinition`]: crate::session::vars::definitions::VarDefinition
+pub trait Value: Any + AsAny + Debug + Send + Sync {
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized;
 
-/// A value that can be stored in a session or server variable.
-pub trait Value: ToOwned + Send + Sync {
-    /// The name of the value type.
-    fn type_name() -> String;
+    fn parse(input: VarInput) -> Result<Self, VarParseError>
+    where
+        Self: Sized;
 
-    /// Parses a value of this type from a [`VarInput`].
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError>;
-    /// Formats this value as a flattened string.
-    ///
-    /// The resulting string is guaranteed to be parsable if provided to
-    /// [`Value::parse`] as a [`VarInput::Flat`].
     fn format(&self) -> String;
+
+    fn box_clone(&self) -> Box<dyn Value>;
+
+    /// Parse an instance of `Self` from [`VarInput`], returning it as a `Box<dyn Value>`.
+    fn parse_dyn_value(input: VarInput) -> Result<Box<dyn Value>, VarParseError>
+    where
+        Self: Sized,
+    {
+        Self::parse(input).map(|val| {
+            let dyn_val: Box<dyn Value> = Box::new(val);
+            dyn_val
+        })
+    }
 }
 
-pub fn extract_single_value<'var, 'input: 'var>(
-    param: &'var (dyn Var + Send + Sync),
-    input: VarInput<'input>,
-) -> Result<&'input str, VarError> {
+// Note(parkmycar): We have a blanket impl for `PartialEq` instead of requiring it as a trait
+// bound because otherwise it's tricky to make `Value` object safe.
+impl PartialEq for Box<dyn Value> {
+    fn eq(&self, other: &Box<dyn Value>) -> bool {
+        self.format().eq(&other.format())
+    }
+}
+impl Eq for Box<dyn Value> {}
+
+impl<'a> PartialEq for &'a dyn Value {
+    fn eq(&self, other: &&dyn Value) -> bool {
+        self.format().eq(&other.format())
+    }
+}
+impl<'a> Eq for &'a dyn Value {}
+
+/// Helper trait ...
+///
+/// TODO(parkmycar): Document why this exists
+pub trait AsAny {
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T: Any> AsAny for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Helper method to extract a single value from any kind of [`VarInput`].
+fn extract_single_value(input: VarInput) -> Result<&str, VarParseError> {
     match input {
         VarInput::Flat(value) => Ok(value),
         VarInput::SqlSet([value]) => Ok(value),
-        VarInput::SqlSet(values) => Err(VarError::InvalidParameterValue {
-            parameter: param.into(),
-            values: values.to_vec(),
-            reason: "expects a single value".to_string(),
+        VarInput::SqlSet(values) => Err(VarParseError::InvalidParameterValue {
+            invalid_values: values.to_vec(),
+            reason: "expects a single value".into(),
         }),
     }
 }
 
-impl Value for bool {
-    fn type_name() -> String {
-        "boolean".to_string()
+impl<V: Value + Clone> Value for Option<V> {
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        format!("optional {}", V::type_name()).into()
     }
 
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<Self, VarError> {
-        let s = extract_single_value(param, input)?;
+    fn parse(input: VarInput) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
+        match s {
+            "" => Ok(None),
+            _ => <V as Value>::parse(VarInput::Flat(s)).map(Some),
+        }
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
+    }
+
+    fn format(&self) -> String {
+        match self {
+            Some(s) => s.format(),
+            None => "".to_string(),
+        }
+    }
+}
+
+impl Value for String {
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "string".into()
+    }
+
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
+        Ok(s.to_string())
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Value for Cow<'static, str> {
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "string".into()
+    }
+
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
+        Ok(s.to_string().into())
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Value for bool {
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "boolean".into()
+    }
+
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
         match s {
             "t" | "true" | "on" => Ok(true),
             "f" | "false" | "off" => Ok(false),
-            _ => Err(VarError::InvalidParameterType(param.into())),
+            _ => Err(VarParseError::InvalidParameterType),
         }
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -93,99 +216,26 @@ impl Value for bool {
     }
 }
 
-impl Value for i32 {
-    fn type_name() -> String {
-        "integer".to_string()
-    }
-
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<i32, VarError> {
-        let s = extract_single_value(param, input)?;
-        s.parse()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
-    }
-
-    fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
-impl Value for u32 {
-    fn type_name() -> String {
-        "unsigned integer".to_string()
-    }
-
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<u32, VarError> {
-        let s = extract_single_value(param, input)?;
-        s.parse()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
-    }
-
-    fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
-impl Value for mz_repr::Timestamp {
-    fn type_name() -> String {
-        "mz-timestamp".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<mz_repr::Timestamp, VarError> {
-        let s = extract_single_value(param, input)?;
-        s.parse()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
-    }
-
-    fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
-impl Value for usize {
-    fn type_name() -> String {
-        "unsigned integer".to_string()
-    }
-
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<usize, VarError> {
-        let s = extract_single_value(param, input)?;
-        s.parse()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
-    }
-
-    fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
-impl Value for f64 {
-    fn type_name() -> String {
-        "double-precision floating-point number".to_string()
-    }
-
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<f64, VarError> {
-        let s = extract_single_value(param, input)?;
-        s.parse()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
-    }
-
-    fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
 impl Value for Option<CheckedTimestamp<DateTime<Utc>>> {
-    fn type_name() -> String {
-        "timestamptz".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "timestamptz".into()
     }
 
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<Self, VarError> {
-        let s = extract_single_value(param, input)?;
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
         strconv::parse_timestamptz(s)
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
+            .map_err(|_| VarParseError::InvalidParameterType)
             .map(Some)
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -193,54 +243,117 @@ impl Value for Option<CheckedTimestamp<DateTime<Utc>>> {
     }
 }
 
-impl Value for CompactionStyle {
-    fn type_name() -> String {
-        "rocksdb_compaction_style".to_string()
+impl Value for Numeric {
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "numeric".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        CompactionStyle::from_str(s).map_err(|_| VarError::InvalidParameterType(param.into()))
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
+        s.parse::<Numeric>()
+            .map_err(|_| VarParseError::InvalidParameterType)
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
-        self.to_string()
+        self.to_standard_notation_string()
     }
 }
 
-impl Value for CompressionType {
-    fn type_name() -> String {
-        "rocksdb_compression_type".to_string()
+const SEC_TO_MIN: u64 = 60u64;
+const SEC_TO_HOUR: u64 = 60u64 * 60;
+const SEC_TO_DAY: u64 = 60u64 * 60 * 24;
+const MICRO_TO_MILLI: u32 = 1000u32;
+
+impl Value for Duration {
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "duration".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        CompressionType::from_str(s).map_err(|_| VarError::InvalidParameterType(param.into()))
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
+        let s = s.trim();
+        // Take all numeric values from [0..]
+        let split_pos = s
+            .chars()
+            .position(|p| !char::is_numeric(p))
+            .unwrap_or_else(|| s.chars().count());
+
+        // Error if the numeric values don't parse, i.e. there aren't any.
+        let d = s[..split_pos]
+            .parse::<u64>()
+            .map_err(|_| VarParseError::InvalidParameterType)?;
+
+        // We've already trimmed end
+        let (f, m): (fn(u64) -> Duration, u64) = match s[split_pos..].trim_start() {
+            "us" => (Duration::from_micros, 1),
+            // Default unit is milliseconds
+            "ms" | "" => (Duration::from_millis, 1),
+            "s" => (Duration::from_secs, 1),
+            "min" => (Duration::from_secs, SEC_TO_MIN),
+            "h" => (Duration::from_secs, SEC_TO_HOUR),
+            "d" => (Duration::from_secs, SEC_TO_DAY),
+            o => {
+                return Err(VarParseError::InvalidParameterValue {
+                    invalid_values: vec![s.to_string()],
+                    reason: format!("expected us, ms, s, min, h, or d but got {o:?}").into(),
+                })
+            }
+        };
+
+        let d = f(d
+            .checked_mul(m)
+            .ok_or(VarParseError::InvalidParameterValue {
+                invalid_values: vec![s.to_string()],
+                reason: "expected value to fit in u64".into(),
+            })?);
+        Ok(d)
     }
 
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
+    }
+
+    // The strategy for formatting these strings is to find the least
+    // significant unit of time that can be printed as an integer––we know this
+    // is always possible because the input can only be an integer of a single
+    // unit of time.
     fn format(&self) -> String {
-        self.to_string()
-    }
-}
-
-impl Value for String {
-    fn type_name() -> String {
-        "string".to_string()
-    }
-
-    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<String, VarError> {
-        let s = extract_single_value(param, input)?;
-        Ok(s.to_owned())
-    }
-
-    fn format(&self) -> String {
-        self.to_owned()
+        let micros = self.subsec_micros();
+        if micros > 0 {
+            match micros {
+                ms if ms != 0 && ms % MICRO_TO_MILLI == 0 => {
+                    format!(
+                        "{} ms",
+                        self.as_secs() * 1000 + u64::from(ms / MICRO_TO_MILLI)
+                    )
+                }
+                us => format!("{} us", self.as_secs() * 1_000_000 + u64::from(us)),
+            }
+        } else {
+            match self.as_secs() {
+                zero if zero == u64::MAX => "0".to_string(),
+                d if d != 0 && d % SEC_TO_DAY == 0 => format!("{} d", d / SEC_TO_DAY),
+                h if h != 0 && h % SEC_TO_HOUR == 0 => format!("{} h", h / SEC_TO_HOUR),
+                m if m != 0 && m % SEC_TO_MIN == 0 => format!("{} min", m / SEC_TO_MIN),
+                s => format!("{} s", s),
+            }
+        }
     }
 }
 
@@ -249,28 +362,31 @@ impl Value for String {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DateStyle(pub [&'static str; 2]);
 
-pub const DEFAULT_DATE_STYLE: DateStyle = DateStyle(["ISO", "MDY"]);
+pub static DEFAULT_DATE_STYLE: DateStyle = DateStyle(["ISO", "MDY"]);
 
 impl Value for DateStyle {
-    fn type_name() -> String {
-        "string list".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "string list".into()
     }
 
     /// This impl is unlike most others because we have under-implemented its backing struct.
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<DateStyle, VarError> {
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
         let input = match input {
             VarInput::Flat(v) => mz_sql_parser::parser::split_identifier_string(v)
-                .map_err(|_| VarError::InvalidParameterType(param.into()))?,
+                .map_err(|_| VarParseError::InvalidParameterType)?,
             // Unlike parsing `Vec<Ident>`, we further split each element.
             // This matches PostgreSQL.
             VarInput::SqlSet(values) => {
                 let mut out = vec![];
                 for v in values {
                     let idents = mz_sql_parser::parser::split_identifier_string(v)
-                        .map_err(|_| VarError::InvalidParameterType(param.into()))?;
+                        .map_err(|_| VarParseError::InvalidParameterType)?;
                     out.extend(idents)
                 }
                 out
@@ -283,11 +399,15 @@ impl Value for DateStyle {
                 .iter()
                 .any(|valid| UncasedStr::new(valid) == &input)
             {
-                return Err(VarError::FixedValueParameter((&DATE_STYLE).into()));
+                return Err(VarParseError::FixedValueParameter);
             }
         }
 
         Ok(DEFAULT_DATE_STYLE.clone())
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -296,19 +416,22 @@ impl Value for DateStyle {
 }
 
 impl Value for Vec<Ident> {
-    fn type_name() -> String {
-        "identifier list".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "identifier list".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Vec<Ident>, VarError> {
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
         let holder;
         let values = match input {
             VarInput::Flat(value) => {
                 holder = mz_sql_parser::parser::split_identifier_string(value)
-                    .map_err(|_| VarError::InvalidParameterType(param.into()))?;
+                    .map_err(|_| VarParseError::InvalidParameterType)?;
                 &holder
             }
             // Unlike parsing `Vec<String>`, we do *not* further split each
@@ -319,12 +442,15 @@ impl Value for Vec<Ident> {
             .iter()
             .map(Ident::new)
             .collect::<Result<_, _>>()
-            .map_err(|e| VarError::InvalidParameterValue {
-                parameter: param.into(),
-                values: values.to_vec(),
-                reason: e.to_string(),
+            .map_err(|e| VarParseError::InvalidParameterValue {
+                invalid_values: values.to_vec(),
+                reason: e.to_string().into(),
             })?;
         Ok(values)
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -333,57 +459,35 @@ impl Value for Vec<Ident> {
 }
 
 impl Value for Vec<SerializableDirective> {
-    fn type_name() -> String {
-        "directive list".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "directive list".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Vec<SerializableDirective>, VarError> {
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
         let values = input.to_vec();
         let dirs: Result<_, _> = values
             .iter()
             .flat_map(|i| i.split(','))
             .map(|d| SerializableDirective::from_str(d.trim()))
             .collect();
-        dirs.map_err(|e| VarError::InvalidParameterValue {
-            parameter: param.into(),
-            values: values.to_vec(),
-            reason: e.to_string(),
+        dirs.map_err(|e| VarParseError::InvalidParameterValue {
+            invalid_values: values.to_vec(),
+            reason: e.to_string().into(),
         })
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
         self.iter().map(|d| d.to_string()).join(", ")
-    }
-}
-
-// Implement `Value` for `Option<V>` for any owned `V`.
-impl<V> Value for Option<V>
-where
-    V: Value + Clone + ToOwned<Owned = V>,
-{
-    fn type_name() -> String {
-        format!("optional {}", V::type_name())
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Option<V>, VarError> {
-        let s = extract_single_value(param, input)?;
-        match s {
-            "" => Ok(None),
-            _ => <V as Value>::parse(param, VarInput::Flat(s)).map(Some),
-        }
-    }
-
-    fn format(&self) -> String {
-        match self {
-            Some(s) => s.format(),
-            None => "".into(),
-        }
     }
 }
 
@@ -392,14 +496,17 @@ where
 pub struct Failpoints;
 
 impl Value for Failpoints {
-    fn type_name() -> String {
-        "failpoints config".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "failpoints config".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Failpoints, VarError> {
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
         let values = input.to_vec();
         for mut cfg in values.iter().map(|v| v.trim().split(';')).flatten() {
             cfg = cfg.trim();
@@ -409,26 +516,27 @@ impl Value for Failpoints {
             let mut splits = cfg.splitn(2, '=');
             let failpoint = splits
                 .next()
-                .ok_or_else(|| VarError::InvalidParameterValue {
-                    parameter: param.into(),
-                    values: input.to_vec(),
+                .ok_or_else(|| VarParseError::InvalidParameterValue {
+                    invalid_values: input.to_vec(),
                     reason: "missing failpoint name".into(),
                 })?;
             let action = splits
                 .next()
-                .ok_or_else(|| VarError::InvalidParameterValue {
-                    parameter: param.into(),
-                    values: input.to_vec(),
+                .ok_or_else(|| VarParseError::InvalidParameterValue {
+                    invalid_values: input.to_vec(),
                     reason: "missing failpoint action".into(),
                 })?;
-            fail::cfg(failpoint, action).map_err(|e| VarError::InvalidParameterValue {
-                parameter: param.into(),
-                values: input.to_vec(),
-                reason: e,
+            fail::cfg(failpoint, action).map_err(|e| VarParseError::InvalidParameterValue {
+                invalid_values: input.to_vec(),
+                reason: e.to_string().into(),
             })?;
         }
 
         Ok(Failpoints)
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -574,15 +682,18 @@ impl ClientSeverity {
 }
 
 impl Value for ClientSeverity {
-    fn type_name() -> String {
-        "string".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "string".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
         let s = UncasedStr::new(s);
 
         if s == ClientSeverity::Error.as_str() {
@@ -607,12 +718,15 @@ impl Value for ClientSeverity {
         } else if s == ClientSeverity::Debug5.as_str() {
             Ok(ClientSeverity::Debug5)
         } else {
-            Err(VarError::ConstrainedParameter {
-                parameter: param.into(),
-                values: input.to_vec(),
+            Err(VarParseError::ConstrainedParameter {
+                invalid_values: input.to_vec(),
                 valid_values: Some(ClientSeverity::valid_values()),
             })
         }
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -643,15 +757,19 @@ impl TimeZone {
 }
 
 impl Value for TimeZone {
-    fn type_name() -> String {
-        "string".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        // TODO(parkmycar): It seems like we should change this?
+        "string".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
         let s = UncasedStr::new(s);
 
         if s == TimeZone::UTC.as_str() {
@@ -659,12 +777,15 @@ impl Value for TimeZone {
         } else if s == "+00:00" {
             Ok(TimeZone::FixedOffset("+00:00"))
         } else {
-            Err(VarError::ConstrainedParameter {
-                parameter: (&TIMEZONE).into(),
-                values: input.to_vec(),
+            Err(VarParseError::ConstrainedParameter {
+                invalid_values: input.to_vec(),
                 valid_values: None,
             })
         }
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -744,22 +865,25 @@ impl IsolationLevel {
     }
 }
 
-impl Display for IsolationLevel {
+impl fmt::Display for IsolationLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
 impl Value for IsolationLevel {
-    fn type_name() -> String {
-        "string".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "string".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
         let s = UncasedStr::new(s);
 
         // We don't have any optimizations for levels below Serializable,
@@ -775,12 +899,15 @@ impl Value for IsolationLevel {
         } else if s == Self::StrictSerializable.as_str() {
             Ok(Self::StrictSerializable)
         } else {
-            Err(VarError::ConstrainedParameter {
-                parameter: (&TRANSACTION_ISOLATION).into(),
-                values: input.to_vec(),
+            Err(VarParseError::ConstrainedParameter {
+                invalid_values: input.to_vec(),
                 valid_values: Some(IsolationLevel::valid_values()),
             })
         }
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -802,144 +929,30 @@ impl From<TransactionIsolationLevel> for IsolationLevel {
 }
 
 impl Value for CloneableEnvFilter {
-    fn type_name() -> String {
-        "EnvFilter".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "EnvFilter".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        CloneableEnvFilter::from_str(s).map_err(|e| VarError::InvalidParameterValue {
-            parameter: param.into(),
-            values: vec![s.to_string()],
-            reason: format!("{}", e),
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
+        CloneableEnvFilter::from_str(s).map_err(|e| VarParseError::InvalidParameterValue {
+            invalid_values: vec![s.to_string()],
+            reason: e.to_string().into(),
         })
     }
 
-    fn format(&self) -> String {
-        format!("{}", self)
-    }
-}
-
-impl Value for Numeric {
-    fn type_name() -> String {
-        "numeric".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        let n = s
-            .parse()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))?;
-        Ok(n)
-    }
-
-    fn format(&self) -> String {
-        self.to_standard_notation_string()
-    }
-}
-
-impl Value for ByteSize {
-    fn type_name() -> String {
-        "bytes".to_string()
-    }
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<ByteSize, VarError> {
-        let s = extract_single_value(param, input)?;
-        s.parse::<ByteSize>()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
         self.to_string()
-    }
-}
-
-const SEC_TO_MIN: u64 = 60u64;
-const SEC_TO_HOUR: u64 = 60u64 * 60;
-const SEC_TO_DAY: u64 = 60u64 * 60 * 24;
-const MICRO_TO_MILLI: u32 = 1000u32;
-
-impl Value for Duration {
-    fn type_name() -> String {
-        "duration".to_string()
-    }
-
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Duration, VarError> {
-        let s = extract_single_value(param, input)?;
-        let s = s.trim();
-        // Take all numeric values from [0..]
-        let split_pos = s
-            .chars()
-            .position(|p| !char::is_numeric(p))
-            .unwrap_or_else(|| s.chars().count());
-
-        // Error if the numeric values don't parse, i.e. there aren't any.
-        let d = s[..split_pos]
-            .parse::<u64>()
-            .map_err(|_| VarError::InvalidParameterType(param.into()))?;
-
-        // We've already trimmed end
-        let (f, m): (fn(u64) -> Duration, u64) = match s[split_pos..].trim_start() {
-            "us" => (Duration::from_micros, 1),
-            // Default unit is milliseconds
-            "ms" | "" => (Duration::from_millis, 1),
-            "s" => (Duration::from_secs, 1),
-            "min" => (Duration::from_secs, SEC_TO_MIN),
-            "h" => (Duration::from_secs, SEC_TO_HOUR),
-            "d" => (Duration::from_secs, SEC_TO_DAY),
-            o => {
-                return Err(VarError::InvalidParameterValue {
-                    parameter: param.into(),
-                    values: vec![s.to_string()],
-                    reason: format!("expected us, ms, s, min, h, or d but got {:?}", o),
-                })
-            }
-        };
-
-        let d = f(d.checked_mul(m).ok_or(VarError::InvalidParameterValue {
-            parameter: param.into(),
-            values: vec![s.to_string()],
-            reason: "expected value to fit in u64".to_string(),
-        })?);
-        Ok(d)
-    }
-
-    // The strategy for formatting these strings is to find the least
-    // significant unit of time that can be printed as an integer––we know this
-    // is always possible because the input can only be an integer of a single
-    // unit of time.
-    fn format(&self) -> String {
-        let micros = self.subsec_micros();
-        if micros > 0 {
-            match micros {
-                ms if ms != 0 && ms % MICRO_TO_MILLI == 0 => {
-                    format!(
-                        "{} ms",
-                        self.as_secs() * 1000 + u64::from(ms / MICRO_TO_MILLI)
-                    )
-                }
-                us => format!("{} us", self.as_secs() * 1_000_000 + u64::from(us)),
-            }
-        } else {
-            match self.as_secs() {
-                zero if zero == u64::MAX => "0".to_string(),
-                d if d != 0 && d % SEC_TO_DAY == 0 => format!("{} d", d / SEC_TO_DAY),
-                h if h != 0 && h % SEC_TO_HOUR == 0 => format!("{} h", h / SEC_TO_HOUR),
-                m if m != 0 && m % SEC_TO_MIN == 0 => format!("{} min", m / SEC_TO_MIN),
-                s => format!("{} s", s),
-            }
-        }
     }
 }
 
@@ -961,25 +974,31 @@ impl ClientEncoding {
 }
 
 impl Value for ClientEncoding {
-    fn type_name() -> String {
-        "string".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "string".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
         let s = UncasedStr::new(s);
         if s == Self::Utf8.as_str() {
             Ok(Self::Utf8)
         } else {
-            Err(VarError::ConstrainedParameter {
-                parameter: (&CLIENT_ENCODING).into(),
-                values: vec![s.to_string()],
+            Err(VarParseError::ConstrainedParameter {
+                invalid_values: vec![s.to_string()],
                 valid_values: Some(ClientEncoding::valid_values()),
             })
         }
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -1005,25 +1024,31 @@ impl IntervalStyle {
 }
 
 impl Value for IntervalStyle {
-    fn type_name() -> String {
-        "string".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "string".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
         let s = UncasedStr::new(s);
         if s == Self::Postgres.as_str() {
             Ok(Self::Postgres)
         } else {
-            Err(VarError::ConstrainedParameter {
-                parameter: (&INTERVAL_STYLE).into(),
-                values: vec![s.to_string()],
+            Err(VarParseError::ConstrainedParameter {
+                invalid_values: vec![s.to_string()],
                 valid_values: Some(IntervalStyle::valid_values()),
             })
         }
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -1055,15 +1080,18 @@ impl TimestampOracleImpl {
 }
 
 impl Value for TimestampOracleImpl {
-    fn type_name() -> String {
-        "string".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "string".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
         let s = UncasedStr::new(s);
 
         if s == TimestampOracleImpl::Postgres.as_str() {
@@ -1071,12 +1099,15 @@ impl Value for TimestampOracleImpl {
         } else if s == TimestampOracleImpl::Catalog.as_str() {
             Ok(TimestampOracleImpl::Catalog)
         } else {
-            Err(VarError::ConstrainedParameter {
-                parameter: (&TIMESTAMP_ORACLE_IMPL).into(),
-                values: input.to_vec(),
+            Err(VarParseError::ConstrainedParameter {
+                invalid_values: input.to_vec(),
                 valid_values: Some(TimestampOracleImpl::valid_values()),
             })
         }
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -1085,22 +1116,30 @@ impl Value for TimestampOracleImpl {
 }
 
 impl Value for PersistTxnTablesImpl {
-    fn type_name() -> String {
-        "string".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "string".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
         let s = UncasedStr::new(s);
 
-        PersistTxnTablesImpl::from_str(s.as_str()).map_err(|_| VarError::ConstrainedParameter {
-            parameter: (&PERSIST_TXN_TABLES).into(),
-            values: input.to_vec(),
-            valid_values: Some(vec!["off", "eager", "lazy"]),
+        PersistTxnTablesImpl::from_str(s.as_str()).map_err(|_| {
+            VarParseError::ConstrainedParameter {
+                invalid_values: input.to_vec(),
+                valid_values: Some(vec!["off", "eager", "lazy"]),
+            }
         })
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -1149,20 +1188,26 @@ impl CatalogKind {
 }
 
 impl Value for CatalogKind {
-    fn type_name() -> String {
-        "string".to_string()
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "string".into()
     }
 
-    fn parse<'a>(
-        param: &'a (dyn Var + Send + Sync),
-        input: VarInput,
-    ) -> Result<Self::Owned, VarError> {
-        let s = extract_single_value(param, input)?;
-        CatalogKind::from_str(s, true).map_err(|_| VarError::ConstrainedParameter {
-            parameter: (&CATALOG_KIND_IMPL).into(),
-            values: input.to_vec(),
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
+        CatalogKind::from_str(s, true).map_err(|_| VarParseError::ConstrainedParameter {
+            invalid_values: input.to_vec(),
             valid_values: Some(CatalogKind::valid_values()),
         })
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
     }
 
     fn format(&self) -> String {
@@ -1170,18 +1215,60 @@ impl Value for CatalogKind {
     }
 }
 
+/// Macro to implement [`Value`] for simpler types, i.e. ones that already implement `FromStr` and
+/// `ToString`.
+///
+/// Note: Macros can be hot garbage, if at any point folks think this is too complicated please
+/// feel free to refactor!
+macro_rules! impl_value_for_simple {
+    ($t: ty, $name: literal) => {
+        impl Value for $t {
+            fn type_name() -> Cow<'static, str>
+            where
+                Self: Sized,
+            {
+                $name.into()
+            }
+
+            fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+            where
+                Self: Sized,
+            {
+                let s = extract_single_value(input)?;
+                s.parse::<Self>()
+                    .map_err(|_| VarParseError::InvalidParameterType)
+            }
+
+            fn box_clone(&self) -> Box<dyn Value> {
+                Box::new(self.clone())
+            }
+
+            fn format(&self) -> String {
+                self.to_string()
+            }
+        }
+    };
+}
+
+impl_value_for_simple!(i32, "integer");
+impl_value_for_simple!(u32, "unsigned integer");
+impl_value_for_simple!(usize, "unsigned integer");
+impl_value_for_simple!(f64, "double-precision floating-point number");
+
+impl_value_for_simple!(mz_repr::Timestamp, "mz-timestamp");
+impl_value_for_simple!(mz_repr::bytes::ByteSize, "bytes");
+impl_value_for_simple!(CompactionStyle, "rocksdb_compaction_style");
+impl_value_for_simple!(CompressionType, "rocksdb_compression_type");
+
 #[cfg(test)]
 mod tests {
-    use proptest::prelude::*;
-
     use super::*;
-    use crate::session::vars::definitions::STATEMENT_TIMEOUT;
+    use proptest::prelude::*;
 
     #[mz_ore::test]
     fn test_value_duration() {
         fn inner(t: &'static str, e: Duration, expected_format: Option<&'static str>) {
-            let d =
-                Duration::parse(&STATEMENT_TIMEOUT, VarInput::Flat(t)).expect("invalid duration");
+            let d = Duration::parse(VarInput::Flat(t)).expect("invalid duration");
             assert_eq!(d, e);
             let mut d_format = d.format();
             d_format.retain(|c| !c.is_whitespace());
@@ -1227,7 +1314,7 @@ mod tests {
         );
 
         fn errs(t: &'static str) {
-            assert!(Duration::parse(&STATEMENT_TIMEOUT, VarInput::Flat(t)).is_err());
+            assert!(Duration::parse(VarInput::Flat(t)).is_err());
         }
         errs("1 m");
         errs("1 sec");

--- a/src/sql/src/session/vars/value.rs
+++ b/src/sql/src/session/vars/value.rs
@@ -1,0 +1,1293 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::clone::Clone;
+use std::fmt::{Debug, Display};
+use std::str::FromStr;
+use std::string::ToString;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use clap::clap_derive::ArgEnum;
+use clap::ValueEnum;
+use itertools::Itertools;
+use mz_pgwire_common::Severity;
+use mz_repr::adt::numeric::Numeric;
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::bytes::ByteSize;
+use mz_repr::strconv;
+use mz_rocksdb_types::config::{CompactionStyle, CompressionType};
+use mz_sql_parser::ast::{Ident, TransactionIsolationLevel};
+use mz_storage_types::controller::PersistTxnTablesImpl;
+use mz_tracing::{CloneableEnvFilter, SerializableDirective};
+use proptest_derive::Arbitrary;
+use serde::Serialize;
+use uncased::UncasedStr;
+
+use crate::session::vars::definitions::{
+    CATALOG_KIND_IMPL, CLIENT_ENCODING, DATE_STYLE, INTERVAL_STYLE, PERSIST_TXN_TABLES,
+    TIMESTAMP_ORACLE_IMPL, TIMEZONE, TRANSACTION_ISOLATION,
+};
+use crate::session::vars::errors::VarError;
+use crate::session::vars::{Var, VarInput};
+
+// use super::*;
+
+/// A value that can be stored in a session or server variable.
+pub trait Value: ToOwned + Send + Sync {
+    /// The name of the value type.
+    fn type_name() -> String;
+
+    /// Parses a value of this type from a [`VarInput`].
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError>;
+    /// Formats this value as a flattened string.
+    ///
+    /// The resulting string is guaranteed to be parsable if provided to
+    /// [`Value::parse`] as a [`VarInput::Flat`].
+    fn format(&self) -> String;
+}
+
+pub fn extract_single_value<'var, 'input: 'var>(
+    param: &'var (dyn Var + Send + Sync),
+    input: VarInput<'input>,
+) -> Result<&'input str, VarError> {
+    match input {
+        VarInput::Flat(value) => Ok(value),
+        VarInput::SqlSet([value]) => Ok(value),
+        VarInput::SqlSet(values) => Err(VarError::InvalidParameterValue {
+            parameter: param.into(),
+            values: values.to_vec(),
+            reason: "expects a single value".to_string(),
+        }),
+    }
+}
+
+impl Value for bool {
+    fn type_name() -> String {
+        "boolean".to_string()
+    }
+
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<Self, VarError> {
+        let s = extract_single_value(param, input)?;
+        match s {
+            "t" | "true" | "on" => Ok(true),
+            "f" | "false" | "off" => Ok(false),
+            _ => Err(VarError::InvalidParameterType(param.into())),
+        }
+    }
+
+    fn format(&self) -> String {
+        match self {
+            true => "on".into(),
+            false => "off".into(),
+        }
+    }
+}
+
+impl Value for i32 {
+    fn type_name() -> String {
+        "integer".to_string()
+    }
+
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<i32, VarError> {
+        let s = extract_single_value(param, input)?;
+        s.parse()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Value for u32 {
+    fn type_name() -> String {
+        "unsigned integer".to_string()
+    }
+
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<u32, VarError> {
+        let s = extract_single_value(param, input)?;
+        s.parse()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Value for mz_repr::Timestamp {
+    fn type_name() -> String {
+        "mz-timestamp".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<mz_repr::Timestamp, VarError> {
+        let s = extract_single_value(param, input)?;
+        s.parse()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Value for usize {
+    fn type_name() -> String {
+        "unsigned integer".to_string()
+    }
+
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<usize, VarError> {
+        let s = extract_single_value(param, input)?;
+        s.parse()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Value for f64 {
+    fn type_name() -> String {
+        "double-precision floating-point number".to_string()
+    }
+
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<f64, VarError> {
+        let s = extract_single_value(param, input)?;
+        s.parse()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Value for Option<CheckedTimestamp<DateTime<Utc>>> {
+    fn type_name() -> String {
+        "timestamptz".to_string()
+    }
+
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<Self, VarError> {
+        let s = extract_single_value(param, input)?;
+        strconv::parse_timestamptz(s)
+            .map_err(|_| VarError::InvalidParameterType(param.into()))
+            .map(Some)
+    }
+
+    fn format(&self) -> String {
+        self.map(|t| t.to_string()).unwrap_or_default()
+    }
+}
+
+impl Value for CompactionStyle {
+    fn type_name() -> String {
+        "rocksdb_compaction_style".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        CompactionStyle::from_str(s).map_err(|_| VarError::InvalidParameterType(param.into()))
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Value for CompressionType {
+    fn type_name() -> String {
+        "rocksdb_compression_type".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        CompressionType::from_str(s).map_err(|_| VarError::InvalidParameterType(param.into()))
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Value for String {
+    fn type_name() -> String {
+        "string".to_string()
+    }
+
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<String, VarError> {
+        let s = extract_single_value(param, input)?;
+        Ok(s.to_owned())
+    }
+
+    fn format(&self) -> String {
+        self.to_owned()
+    }
+}
+
+/// This style should actually be some more complex struct, but we only support this configuration
+/// of it, so this is fine for the time being.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DateStyle(pub [&'static str; 2]);
+
+pub const DEFAULT_DATE_STYLE: DateStyle = DateStyle(["ISO", "MDY"]);
+
+impl Value for DateStyle {
+    fn type_name() -> String {
+        "string list".to_string()
+    }
+
+    /// This impl is unlike most others because we have under-implemented its backing struct.
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<DateStyle, VarError> {
+        let input = match input {
+            VarInput::Flat(v) => mz_sql_parser::parser::split_identifier_string(v)
+                .map_err(|_| VarError::InvalidParameterType(param.into()))?,
+            // Unlike parsing `Vec<Ident>`, we further split each element.
+            // This matches PostgreSQL.
+            VarInput::SqlSet(values) => {
+                let mut out = vec![];
+                for v in values {
+                    let idents = mz_sql_parser::parser::split_identifier_string(v)
+                        .map_err(|_| VarError::InvalidParameterType(param.into()))?;
+                    out.extend(idents)
+                }
+                out
+            }
+        };
+
+        for input in input {
+            if !DEFAULT_DATE_STYLE
+                .0
+                .iter()
+                .any(|valid| UncasedStr::new(valid) == &input)
+            {
+                return Err(VarError::FixedValueParameter((&DATE_STYLE).into()));
+            }
+        }
+
+        Ok(DEFAULT_DATE_STYLE.clone())
+    }
+
+    fn format(&self) -> String {
+        self.0.join(", ")
+    }
+}
+
+impl Value for Vec<Ident> {
+    fn type_name() -> String {
+        "identifier list".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Vec<Ident>, VarError> {
+        let holder;
+        let values = match input {
+            VarInput::Flat(value) => {
+                holder = mz_sql_parser::parser::split_identifier_string(value)
+                    .map_err(|_| VarError::InvalidParameterType(param.into()))?;
+                &holder
+            }
+            // Unlike parsing `Vec<String>`, we do *not* further split each
+            // element. This matches PostgreSQL.
+            VarInput::SqlSet(values) => values,
+        };
+        let values = values
+            .iter()
+            .map(Ident::new)
+            .collect::<Result<_, _>>()
+            .map_err(|e| VarError::InvalidParameterValue {
+                parameter: param.into(),
+                values: values.to_vec(),
+                reason: e.to_string(),
+            })?;
+        Ok(values)
+    }
+
+    fn format(&self) -> String {
+        self.iter().map(|ident| ident.to_string()).join(", ")
+    }
+}
+
+impl Value for Vec<SerializableDirective> {
+    fn type_name() -> String {
+        "directive list".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Vec<SerializableDirective>, VarError> {
+        let values = input.to_vec();
+        let dirs: Result<_, _> = values
+            .iter()
+            .flat_map(|i| i.split(','))
+            .map(|d| SerializableDirective::from_str(d.trim()))
+            .collect();
+        dirs.map_err(|e| VarError::InvalidParameterValue {
+            parameter: param.into(),
+            values: values.to_vec(),
+            reason: e.to_string(),
+        })
+    }
+
+    fn format(&self) -> String {
+        self.iter().map(|d| d.to_string()).join(", ")
+    }
+}
+
+// Implement `Value` for `Option<V>` for any owned `V`.
+impl<V> Value for Option<V>
+where
+    V: Value + Clone + ToOwned<Owned = V>,
+{
+    fn type_name() -> String {
+        format!("optional {}", V::type_name())
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Option<V>, VarError> {
+        let s = extract_single_value(param, input)?;
+        match s {
+            "" => Ok(None),
+            _ => <V as Value>::parse(param, VarInput::Flat(s)).map(Some),
+        }
+    }
+
+    fn format(&self) -> String {
+        match self {
+            Some(s) => s.format(),
+            None => "".into(),
+        }
+    }
+}
+
+// This unorthodox design lets us escape complex errors from value parsing.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Failpoints;
+
+impl Value for Failpoints {
+    fn type_name() -> String {
+        "failpoints config".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Failpoints, VarError> {
+        let values = input.to_vec();
+        for mut cfg in values.iter().map(|v| v.trim().split(';')).flatten() {
+            cfg = cfg.trim();
+            if cfg.is_empty() {
+                continue;
+            }
+            let mut splits = cfg.splitn(2, '=');
+            let failpoint = splits
+                .next()
+                .ok_or_else(|| VarError::InvalidParameterValue {
+                    parameter: param.into(),
+                    values: input.to_vec(),
+                    reason: "missing failpoint name".into(),
+                })?;
+            let action = splits
+                .next()
+                .ok_or_else(|| VarError::InvalidParameterValue {
+                    parameter: param.into(),
+                    values: input.to_vec(),
+                    reason: "missing failpoint action".into(),
+                })?;
+            fail::cfg(failpoint, action).map_err(|e| VarError::InvalidParameterValue {
+                parameter: param.into(),
+                values: input.to_vec(),
+                reason: e,
+            })?;
+        }
+
+        Ok(Failpoints)
+    }
+
+    fn format(&self) -> String {
+        "<omitted>".to_string()
+    }
+}
+
+/// Severity levels can used to be used to filter which messages get sent
+/// to a client.
+///
+/// The ordering of severity levels used for client-level filtering differs from the
+/// one used for server-side logging in two aspects: INFO messages are always sent,
+/// and the LOG severity is considered as below NOTICE, while it is above ERROR for
+/// server-side logs.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ClientSeverity {
+    /// Sends only INFO, ERROR, FATAL and PANIC level messages.
+    Error,
+    /// Sends only WARNING, INFO, ERROR, FATAL and PANIC level messages.
+    Warning,
+    /// Sends only NOTICE, WARNING, INFO, ERROR, FATAL and PANIC level messages.
+    Notice,
+    /// Sends only LOG, NOTICE, WARNING, INFO, ERROR, FATAL and PANIC level messages.
+    Log,
+    /// Sends all messages to the client, since all DEBUG levels are treated as the same right now.
+    Debug1,
+    /// Sends all messages to the client, since all DEBUG levels are treated as the same right now.
+    Debug2,
+    /// Sends all messages to the client, since all DEBUG levels are treated as the same right now.
+    Debug3,
+    /// Sends all messages to the client, since all DEBUG levels are treated as the same right now.
+    Debug4,
+    /// Sends all messages to the client, since all DEBUG levels are treated as the same right now.
+    Debug5,
+    /// Sends only NOTICE, WARNING, INFO, ERROR, FATAL and PANIC level messages.
+    /// Not listed as a valid value, but accepted by Postgres
+    Info,
+}
+
+impl Serialize for ClientSeverity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl ClientSeverity {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ClientSeverity::Error => "error",
+            ClientSeverity::Warning => "warning",
+            ClientSeverity::Notice => "notice",
+            ClientSeverity::Info => "info",
+            ClientSeverity::Log => "log",
+            ClientSeverity::Debug1 => "debug1",
+            ClientSeverity::Debug2 => "debug2",
+            ClientSeverity::Debug3 => "debug3",
+            ClientSeverity::Debug4 => "debug4",
+            ClientSeverity::Debug5 => "debug5",
+        }
+    }
+
+    fn valid_values() -> Vec<&'static str> {
+        // INFO left intentionally out, to match Postgres
+        vec![
+            ClientSeverity::Debug5.as_str(),
+            ClientSeverity::Debug4.as_str(),
+            ClientSeverity::Debug3.as_str(),
+            ClientSeverity::Debug2.as_str(),
+            ClientSeverity::Debug1.as_str(),
+            ClientSeverity::Log.as_str(),
+            ClientSeverity::Notice.as_str(),
+            ClientSeverity::Warning.as_str(),
+            ClientSeverity::Error.as_str(),
+        ]
+    }
+
+    /// Checks if a message of a given severity level should be sent to a client.
+    ///
+    /// The ordering of severity levels used for client-level filtering differs from the
+    /// one used for server-side logging in two aspects: INFO messages are always sent,
+    /// and the LOG severity is considered as below NOTICE, while it is above ERROR for
+    /// server-side logs.
+    ///
+    /// Postgres only considers the session setting after the client authentication
+    /// handshake is completed. Since this function is only called after client authentication
+    /// is done, we are not treating this case right now, but be aware if refactoring it.
+    pub fn should_output_to_client(&self, severity: &Severity) -> bool {
+        match (self, severity) {
+            // INFO messages are always sent
+            (_, Severity::Info) => true,
+            (ClientSeverity::Error, Severity::Error | Severity::Fatal | Severity::Panic) => true,
+            (
+                ClientSeverity::Warning,
+                Severity::Error | Severity::Fatal | Severity::Panic | Severity::Warning,
+            ) => true,
+            (
+                ClientSeverity::Notice,
+                Severity::Error
+                | Severity::Fatal
+                | Severity::Panic
+                | Severity::Warning
+                | Severity::Notice,
+            ) => true,
+            (
+                ClientSeverity::Info,
+                Severity::Error
+                | Severity::Fatal
+                | Severity::Panic
+                | Severity::Warning
+                | Severity::Notice,
+            ) => true,
+            (
+                ClientSeverity::Log,
+                Severity::Error
+                | Severity::Fatal
+                | Severity::Panic
+                | Severity::Warning
+                | Severity::Notice
+                | Severity::Log,
+            ) => true,
+            (
+                ClientSeverity::Debug1
+                | ClientSeverity::Debug2
+                | ClientSeverity::Debug3
+                | ClientSeverity::Debug4
+                | ClientSeverity::Debug5,
+                _,
+            ) => true,
+
+            (
+                ClientSeverity::Error,
+                Severity::Warning | Severity::Notice | Severity::Log | Severity::Debug,
+            ) => false,
+            (ClientSeverity::Warning, Severity::Notice | Severity::Log | Severity::Debug) => false,
+            (ClientSeverity::Notice, Severity::Log | Severity::Debug) => false,
+            (ClientSeverity::Info, Severity::Log | Severity::Debug) => false,
+            (ClientSeverity::Log, Severity::Debug) => false,
+        }
+    }
+}
+
+impl Value for ClientSeverity {
+    fn type_name() -> String {
+        "string".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        let s = UncasedStr::new(s);
+
+        if s == ClientSeverity::Error.as_str() {
+            Ok(ClientSeverity::Error)
+        } else if s == ClientSeverity::Warning.as_str() {
+            Ok(ClientSeverity::Warning)
+        } else if s == ClientSeverity::Notice.as_str() {
+            Ok(ClientSeverity::Notice)
+        } else if s == ClientSeverity::Info.as_str() {
+            Ok(ClientSeverity::Info)
+        } else if s == ClientSeverity::Log.as_str() {
+            Ok(ClientSeverity::Log)
+        } else if s == ClientSeverity::Debug1.as_str() {
+            Ok(ClientSeverity::Debug1)
+        // Postgres treats `debug` as an input as equivalent to `debug2`
+        } else if s == ClientSeverity::Debug2.as_str() || s == "debug" {
+            Ok(ClientSeverity::Debug2)
+        } else if s == ClientSeverity::Debug3.as_str() {
+            Ok(ClientSeverity::Debug3)
+        } else if s == ClientSeverity::Debug4.as_str() {
+            Ok(ClientSeverity::Debug4)
+        } else if s == ClientSeverity::Debug5.as_str() {
+            Ok(ClientSeverity::Debug5)
+        } else {
+            Err(VarError::ConstrainedParameter {
+                parameter: param.into(),
+                values: input.to_vec(),
+                valid_values: Some(ClientSeverity::valid_values()),
+            })
+        }
+    }
+
+    fn format(&self) -> String {
+        self.as_str().into()
+    }
+}
+
+/// List of valid time zones.
+///
+/// Names are following the tz database, but only time zones equivalent
+/// to UTC±00:00 are supported.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TimeZone {
+    /// UTC
+    UTC,
+    /// Fixed offset from UTC, currently only "+00:00" is supported.
+    /// A string representation is kept here for compatibility with Postgres.
+    FixedOffset(&'static str),
+}
+
+impl TimeZone {
+    fn as_str(&self) -> &'static str {
+        match self {
+            TimeZone::UTC => "UTC",
+            TimeZone::FixedOffset(s) => s,
+        }
+    }
+}
+
+impl Value for TimeZone {
+    fn type_name() -> String {
+        "string".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        let s = UncasedStr::new(s);
+
+        if s == TimeZone::UTC.as_str() {
+            Ok(TimeZone::UTC)
+        } else if s == "+00:00" {
+            Ok(TimeZone::FixedOffset("+00:00"))
+        } else {
+            Err(VarError::ConstrainedParameter {
+                parameter: (&TIMEZONE).into(),
+                values: input.to_vec(),
+                valid_values: None,
+            })
+        }
+    }
+
+    fn format(&self) -> String {
+        self.as_str().into()
+    }
+}
+
+/// List of valid isolation levels.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IsolationLevel {
+    ReadUncommitted,
+    ReadCommitted,
+    RepeatableRead,
+    Serializable,
+    /* TODO(jkosh44) Move this comment to user facing docs when this isolation level becomes available to users.
+     * The Strong Session Serializable isolation level combines the Serializable isolation level
+     * (https://jepsen.io/consistency/models/serializable) with the Sequential consistency model
+     * (https://jepsen.io/consistency/models/sequential). See
+     * http://dbmsmusings.blogspot.com/2019/06/correctness-anomalies-under.html and
+     * https://cs.uwaterloo.ca/~kmsalem/pubs/DaudjeeICDE04.pdf. Operations within a single session
+     * are linearizable, but operations across sessions are not linearizable.
+     *
+     * Operations in sessions that use Strong Session Serializable are not linearizable with
+     * operations in sessions that use Strict Serializable. For example, consider the following
+     * sequence of events in order:
+     *
+     *   1. Session s0 executes read at timestamp t0 under Strong Session Serializable.
+     *   2. Session s1 executes read at timestamp t1 under Strict Serializable.
+     *
+     * If t0 > t1, then this is not considered a consistency violation. This matches with the
+     * semantics of Serializable, which can execute queries arbitrarily in the future without
+     * violating the consistency of Strict Serializable queries.
+     *
+     * All operations within a session that use Strong Session Serializable are only
+     * linearizable within operations within the same session that also use Strong Session
+     * Serializable. For example, consider the following sequence of events in order:
+     *
+     *   1. Session s0 executes read at timestamp t0 under Strong Session Serializable.
+     *   2. Session s0 executes read at timestamp t1 under I.
+     *
+     * If I is Strong Session Serializable then t0 > t1 is guaranteed. If I is any other isolation
+     * level then t0 < t1 is not considered a consistency violation. This matches the semantics of
+     * Serializable, which can execute queries arbitrarily in the future without violating the
+     * consistency of Strict Serializable queries within the same session.
+     *
+     * The items left TODO before this is considered ready for prod are:
+     *
+     * - Add more tests.
+     * - Linearize writes to system tables under this isolation (most of these are the side effect
+     *   of some DDL).
+     */
+    StrongSessionSerializable,
+    StrictSerializable,
+}
+
+impl IsolationLevel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ReadUncommitted => "read uncommitted",
+            Self::ReadCommitted => "read committed",
+            Self::RepeatableRead => "repeatable read",
+            Self::Serializable => "serializable",
+            Self::StrongSessionSerializable => "strong session serializable",
+            Self::StrictSerializable => "strict serializable",
+        }
+    }
+
+    fn valid_values() -> Vec<&'static str> {
+        vec![
+            Self::ReadUncommitted.as_str(),
+            Self::ReadCommitted.as_str(),
+            Self::RepeatableRead.as_str(),
+            Self::Serializable.as_str(),
+            // TODO(jkosh44) Add StrongSessionSerializable when it becomes available to users.
+            Self::StrictSerializable.as_str(),
+        ]
+    }
+}
+
+impl Display for IsolationLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Value for IsolationLevel {
+    fn type_name() -> String {
+        "string".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        let s = UncasedStr::new(s);
+
+        // We don't have any optimizations for levels below Serializable,
+        // so we upgrade them all to Serializable.
+        if s == Self::ReadUncommitted.as_str()
+            || s == Self::ReadCommitted.as_str()
+            || s == Self::RepeatableRead.as_str()
+            || s == Self::Serializable.as_str()
+        {
+            Ok(Self::Serializable)
+        } else if s == Self::StrongSessionSerializable.as_str() {
+            Ok(Self::StrongSessionSerializable)
+        } else if s == Self::StrictSerializable.as_str() {
+            Ok(Self::StrictSerializable)
+        } else {
+            Err(VarError::ConstrainedParameter {
+                parameter: (&TRANSACTION_ISOLATION).into(),
+                values: input.to_vec(),
+                valid_values: Some(IsolationLevel::valid_values()),
+            })
+        }
+    }
+
+    fn format(&self) -> String {
+        self.as_str().into()
+    }
+}
+
+impl From<TransactionIsolationLevel> for IsolationLevel {
+    fn from(transaction_isolation_level: TransactionIsolationLevel) -> Self {
+        match transaction_isolation_level {
+            TransactionIsolationLevel::ReadUncommitted => Self::ReadUncommitted,
+            TransactionIsolationLevel::ReadCommitted => Self::ReadCommitted,
+            TransactionIsolationLevel::RepeatableRead => Self::RepeatableRead,
+            TransactionIsolationLevel::Serializable => Self::Serializable,
+            TransactionIsolationLevel::StrongSessionSerializable => Self::StrongSessionSerializable,
+            TransactionIsolationLevel::StrictSerializable => Self::StrictSerializable,
+        }
+    }
+}
+
+impl Value for CloneableEnvFilter {
+    fn type_name() -> String {
+        "EnvFilter".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        CloneableEnvFilter::from_str(s).map_err(|e| VarError::InvalidParameterValue {
+            parameter: param.into(),
+            values: vec![s.to_string()],
+            reason: format!("{}", e),
+        })
+    }
+
+    fn format(&self) -> String {
+        format!("{}", self)
+    }
+}
+
+impl Value for Numeric {
+    fn type_name() -> String {
+        "numeric".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        let n = s
+            .parse()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))?;
+        Ok(n)
+    }
+
+    fn format(&self) -> String {
+        self.to_standard_notation_string()
+    }
+}
+
+impl Value for ByteSize {
+    fn type_name() -> String {
+        "bytes".to_string()
+    }
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<ByteSize, VarError> {
+        let s = extract_single_value(param, input)?;
+        s.parse::<ByteSize>()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+const SEC_TO_MIN: u64 = 60u64;
+const SEC_TO_HOUR: u64 = 60u64 * 60;
+const SEC_TO_DAY: u64 = 60u64 * 60 * 24;
+const MICRO_TO_MILLI: u32 = 1000u32;
+
+impl Value for Duration {
+    fn type_name() -> String {
+        "duration".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Duration, VarError> {
+        let s = extract_single_value(param, input)?;
+        let s = s.trim();
+        // Take all numeric values from [0..]
+        let split_pos = s
+            .chars()
+            .position(|p| !char::is_numeric(p))
+            .unwrap_or_else(|| s.chars().count());
+
+        // Error if the numeric values don't parse, i.e. there aren't any.
+        let d = s[..split_pos]
+            .parse::<u64>()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))?;
+
+        // We've already trimmed end
+        let (f, m): (fn(u64) -> Duration, u64) = match s[split_pos..].trim_start() {
+            "us" => (Duration::from_micros, 1),
+            // Default unit is milliseconds
+            "ms" | "" => (Duration::from_millis, 1),
+            "s" => (Duration::from_secs, 1),
+            "min" => (Duration::from_secs, SEC_TO_MIN),
+            "h" => (Duration::from_secs, SEC_TO_HOUR),
+            "d" => (Duration::from_secs, SEC_TO_DAY),
+            o => {
+                return Err(VarError::InvalidParameterValue {
+                    parameter: param.into(),
+                    values: vec![s.to_string()],
+                    reason: format!("expected us, ms, s, min, h, or d but got {:?}", o),
+                })
+            }
+        };
+
+        let d = f(d.checked_mul(m).ok_or(VarError::InvalidParameterValue {
+            parameter: param.into(),
+            values: vec![s.to_string()],
+            reason: "expected value to fit in u64".to_string(),
+        })?);
+        Ok(d)
+    }
+
+    // The strategy for formatting these strings is to find the least
+    // significant unit of time that can be printed as an integer––we know this
+    // is always possible because the input can only be an integer of a single
+    // unit of time.
+    fn format(&self) -> String {
+        let micros = self.subsec_micros();
+        if micros > 0 {
+            match micros {
+                ms if ms != 0 && ms % MICRO_TO_MILLI == 0 => {
+                    format!(
+                        "{} ms",
+                        self.as_secs() * 1000 + u64::from(ms / MICRO_TO_MILLI)
+                    )
+                }
+                us => format!("{} us", self.as_secs() * 1_000_000 + u64::from(us)),
+            }
+        } else {
+            match self.as_secs() {
+                zero if zero == u64::MAX => "0".to_string(),
+                d if d != 0 && d % SEC_TO_DAY == 0 => format!("{} d", d / SEC_TO_DAY),
+                h if h != 0 && h % SEC_TO_HOUR == 0 => format!("{} h", h / SEC_TO_HOUR),
+                m if m != 0 && m % SEC_TO_MIN == 0 => format!("{} min", m / SEC_TO_MIN),
+                s => format!("{} s", s),
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ClientEncoding {
+    Utf8,
+}
+
+impl ClientEncoding {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ClientEncoding::Utf8 => "UTF8",
+        }
+    }
+
+    fn valid_values() -> Vec<&'static str> {
+        vec![ClientEncoding::Utf8.as_str()]
+    }
+}
+
+impl Value for ClientEncoding {
+    fn type_name() -> String {
+        "string".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        let s = UncasedStr::new(s);
+        if s == Self::Utf8.as_str() {
+            Ok(Self::Utf8)
+        } else {
+            Err(VarError::ConstrainedParameter {
+                parameter: (&CLIENT_ENCODING).into(),
+                values: vec![s.to_string()],
+                valid_values: Some(ClientEncoding::valid_values()),
+            })
+        }
+    }
+
+    fn format(&self) -> String {
+        self.as_str().to_string()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum IntervalStyle {
+    Postgres,
+}
+
+impl IntervalStyle {
+    fn as_str(&self) -> &'static str {
+        match self {
+            IntervalStyle::Postgres => "postgres",
+        }
+    }
+
+    fn valid_values() -> Vec<&'static str> {
+        vec![IntervalStyle::Postgres.as_str()]
+    }
+}
+
+impl Value for IntervalStyle {
+    fn type_name() -> String {
+        "string".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        let s = UncasedStr::new(s);
+        if s == Self::Postgres.as_str() {
+            Ok(Self::Postgres)
+        } else {
+            Err(VarError::ConstrainedParameter {
+                parameter: (&INTERVAL_STYLE).into(),
+                values: vec![s.to_string()],
+                valid_values: Some(IntervalStyle::valid_values()),
+            })
+        }
+    }
+
+    fn format(&self) -> String {
+        self.as_str().to_string()
+    }
+}
+
+/// List of valid TimestampOracle implementations
+///
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TimestampOracleImpl {
+    /// Timestamp oracle backed by Postgres/CRDB.
+    Postgres,
+    /// Legacy, in-memory oracle backed by Catalog/Stash.
+    Catalog,
+}
+
+impl TimestampOracleImpl {
+    fn as_str(&self) -> &'static str {
+        match self {
+            TimestampOracleImpl::Postgres => "postgres",
+            TimestampOracleImpl::Catalog => "catalog",
+        }
+    }
+
+    fn valid_values() -> Vec<&'static str> {
+        vec![Self::Postgres.as_str(), Self::Catalog.as_str()]
+    }
+}
+
+impl Value for TimestampOracleImpl {
+    fn type_name() -> String {
+        "string".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        let s = UncasedStr::new(s);
+
+        if s == TimestampOracleImpl::Postgres.as_str() {
+            Ok(TimestampOracleImpl::Postgres)
+        } else if s == TimestampOracleImpl::Catalog.as_str() {
+            Ok(TimestampOracleImpl::Catalog)
+        } else {
+            Err(VarError::ConstrainedParameter {
+                parameter: (&TIMESTAMP_ORACLE_IMPL).into(),
+                values: input.to_vec(),
+                valid_values: Some(TimestampOracleImpl::valid_values()),
+            })
+        }
+    }
+
+    fn format(&self) -> String {
+        self.as_str().into()
+    }
+}
+
+impl Value for PersistTxnTablesImpl {
+    fn type_name() -> String {
+        "string".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        let s = UncasedStr::new(s);
+
+        PersistTxnTablesImpl::from_str(s.as_str()).map_err(|_| VarError::ConstrainedParameter {
+            parameter: (&PERSIST_TXN_TABLES).into(),
+            values: input.to_vec(),
+            valid_values: Some(vec!["off", "eager", "lazy"]),
+        })
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+#[derive(
+    ArgEnum,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    num_enum::TryFromPrimitive,
+    num_enum::IntoPrimitive,
+    Arbitrary,
+)]
+#[repr(u64)]
+pub enum CatalogKind {
+    Stash = 0,
+    Persist = 1,
+    Shadow = 2,
+    /// Escape hatch to use the stash directly without trying to rollover from persist.
+    EmergencyStash = 3,
+}
+
+impl CatalogKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CatalogKind::Stash => "stash",
+            CatalogKind::Persist => "persist",
+            CatalogKind::Shadow => "shadow",
+            CatalogKind::EmergencyStash => "emergency-stash",
+        }
+    }
+
+    fn valid_values() -> Vec<&'static str> {
+        vec![
+            CatalogKind::Stash.as_str(),
+            CatalogKind::Persist.as_str(),
+            CatalogKind::Shadow.as_str(),
+            CatalogKind::EmergencyStash.as_str(),
+        ]
+    }
+}
+
+impl Value for CatalogKind {
+    fn type_name() -> String {
+        "string".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        CatalogKind::from_str(s, true).map_err(|_| VarError::ConstrainedParameter {
+            parameter: (&CATALOG_KIND_IMPL).into(),
+            values: input.to_vec(),
+            valid_values: Some(CatalogKind::valid_values()),
+        })
+    }
+
+    fn format(&self) -> String {
+        self.as_str().into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::session::vars::definitions::STATEMENT_TIMEOUT;
+
+    #[mz_ore::test]
+    fn test_value_duration() {
+        fn inner(t: &'static str, e: Duration, expected_format: Option<&'static str>) {
+            let d =
+                Duration::parse(&STATEMENT_TIMEOUT, VarInput::Flat(t)).expect("invalid duration");
+            assert_eq!(d, e);
+            let mut d_format = d.format();
+            d_format.retain(|c| !c.is_whitespace());
+            if let Some(expected) = expected_format {
+                assert_eq!(d_format, expected);
+            } else {
+                assert_eq!(
+                    t.chars().filter(|c| !c.is_whitespace()).collect::<String>(),
+                    d_format
+                )
+            }
+        }
+        inner("1", Duration::from_millis(1), Some("1ms"));
+        inner("0", Duration::from_secs(0), Some("0s"));
+        inner("1ms", Duration::from_millis(1), None);
+        inner("1000ms", Duration::from_millis(1000), Some("1s"));
+        inner("1001ms", Duration::from_millis(1001), None);
+        inner("1us", Duration::from_micros(1), None);
+        inner("1000us", Duration::from_micros(1000), Some("1ms"));
+        inner("1s", Duration::from_secs(1), None);
+        inner("60s", Duration::from_secs(60), Some("1min"));
+        inner("3600s", Duration::from_secs(3600), Some("1h"));
+        inner("3660s", Duration::from_secs(3660), Some("61min"));
+        inner("1min", Duration::from_secs(1 * SEC_TO_MIN), None);
+        inner("60min", Duration::from_secs(60 * SEC_TO_MIN), Some("1h"));
+        inner("1h", Duration::from_secs(1 * SEC_TO_HOUR), None);
+        inner("24h", Duration::from_secs(24 * SEC_TO_HOUR), Some("1d"));
+        inner("1d", Duration::from_secs(1 * SEC_TO_DAY), None);
+        inner("2d", Duration::from_secs(2 * SEC_TO_DAY), None);
+        inner("  1   s ", Duration::from_secs(1), None);
+        inner("1s ", Duration::from_secs(1), None);
+        inner("   1s", Duration::from_secs(1), None);
+        inner("0d", Duration::from_secs(0), Some("0s"));
+        inner(
+            "18446744073709551615",
+            Duration::from_millis(u64::MAX),
+            Some("18446744073709551615ms"),
+        );
+        inner(
+            "18446744073709551615 s",
+            Duration::from_secs(u64::MAX),
+            Some("0"),
+        );
+
+        fn errs(t: &'static str) {
+            assert!(Duration::parse(&STATEMENT_TIMEOUT, VarInput::Flat(t)).is_err());
+        }
+        errs("1 m");
+        errs("1 sec");
+        errs("1 min 1 s");
+        errs("1m1s");
+        errs("1.1");
+        errs("1.1 min");
+        errs("-1 s");
+        errs("");
+        errs("   ");
+        errs("x");
+        errs("s");
+        errs("18446744073709551615 min");
+    }
+
+    #[mz_ore::test]
+    fn test_should_output_to_client() {
+        #[rustfmt::skip]
+        let test_cases = [
+            (ClientSeverity::Debug1, vec![Severity::Debug, Severity::Log, Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
+            (ClientSeverity::Debug2, vec![Severity::Debug, Severity::Log, Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
+            (ClientSeverity::Debug3, vec![Severity::Debug, Severity::Log, Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
+            (ClientSeverity::Debug4, vec![Severity::Debug, Severity::Log, Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
+            (ClientSeverity::Debug5, vec![Severity::Debug, Severity::Log, Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
+            (ClientSeverity::Log, vec![Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
+            (ClientSeverity::Log, vec![Severity::Debug], false),
+            (ClientSeverity::Info, vec![Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
+            (ClientSeverity::Info, vec![Severity::Debug, Severity::Log], false),
+            (ClientSeverity::Notice, vec![Severity::Notice, Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
+            (ClientSeverity::Notice, vec![Severity::Debug, Severity::Log], false),
+            (ClientSeverity::Warning, vec![Severity::Warning, Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
+            (ClientSeverity::Warning, vec![Severity::Debug, Severity::Log, Severity::Notice], false),
+            (ClientSeverity::Error, vec![Severity::Error, Severity::Fatal, Severity:: Panic, Severity::Info], true),
+            (ClientSeverity::Error, vec![Severity::Debug, Severity::Log, Severity::Notice, Severity::Warning], false),
+        ];
+
+        for test_case in test_cases {
+            run_test(test_case)
+        }
+
+        fn run_test(test_case: (ClientSeverity, Vec<Severity>, bool)) {
+            let client_min_messages_setting = test_case.0;
+            let expected = test_case.2;
+            for message_severity in test_case.1 {
+                assert!(
+                    client_min_messages_setting.should_output_to_client(&message_severity)
+                        == expected
+                )
+            }
+        }
+    }
+
+    proptest! {
+        #[mz_ore::test]
+        #[cfg_attr(miri, ignore)] // slow
+        fn catalog_kind_roundtrip(catalog_kind: CatalogKind) {
+            let s = catalog_kind.as_str();
+            let round = CatalogKind::from_str(s, true).expect("to roundtrip");
+
+            prop_assert_eq!(catalog_kind, round);
+        }
+    }
+}


### PR DESCRIPTION
This PR refactors Session and System variables to remove the generic parameter `V` from their definition, which should make them a bit easier to work with because we remove a layer of indirection by no longer needing the `SessionVarMut` and `SystemVarMut` traits that we'd use to create trait objects.

The main idea here is `VarDefinition` (formerly known as `ServerVar<V>`) is no longer generic over a type `V` and hides away all of the generic-ness using static function pointers. `VarDefinition::new<V:Value>` is generic over some type `V: Value`, and at construction time we store a function pointer to `V`'s parse method. This prevents the need for `VarDefinition` to be generic over some type `V`, while retaining the ability to guarantee all of the values we parse are the correct type. Also hidden in `VarDefinition`, specifically `VarDefaultValue` is whether the default value is known at compile time, or lazily instantiated (e.g. a `Vec<_>`). This allows all `VarDefinition`s to be the same type, as opposed to some needing to be wrapped in `once_cell::sync::Lazy<VarDefinition>`. This unlocks the ability to make one big list of all variables (see https://github.com/MaterializeInc/materialize/pull/25568), and allow `VarDefinition` to define if something is a Session var, System var, or both, among other properties.

Now the `SessionVar` and `SystemVar` structs are no longer generic, and the `SessionVars` and `SystemVars` collections contain maps with the structs themselves instead of trait objects. This makes changes like using immutable data structures much easier.

#### TODOs
This isn't totally done yet, but the PR is at a point where it unblocks other work and I didn't want it to bitrot while I work on other things. Follow ups I have queued up:

* Go through and update the docs, many seemed stale (even before the refactor) and could use a refresh.
* Remove most (all?) of the `pub` fields from structs, hide `VarDefinition` in an `internal` module.
* On `VarDefinition` define if something is Session or System, and use the `#[static_list]` macro to collect all of the definitions, define `SessionVars` and `SystemVars` as a filter on top of this list.

### Motivation

We want a `SessionVariable` to be clone-able, make it easier to define the "properties" of a variable (e.g. who it's visible to, does it sync with Launch Darkly), and hopefully reduce the type complexity with traits and what not.

### Tips for reviewer

This is a fairly large change so I broke it into separate commits, I would mainly focus on commits 2 and 5

1. _Pure code movement_, I broke apart the existing `vars.rs` file and grouped things together (e.g. `impl SystemVar` blocks) to make stacked commits easier to review.
2. **Introduction of `VarDefinition`** and refactor of all existing variables from `ServerVar<V>` to `VarDefinition`. Locally git displays the changes well, GitHub seems to render things a little off though, hopefully it's not too bad!
3. Refactor of `trait Value` to make it object safe, and re-impl of all types. This one does not require a thorough review.
4. Small refactors of errors and constraints to fit in the new model
5. **Refactor of Session and System vars**, deleting `SessionVarMut` and `SystemVarMut`, refactor of `SessionVars` and `SystemVars`.
6. Tiny changes to code outside of the `vars` module since a constant or two were moved

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Internal changes only
