### PR TITLE
dyncfg: extract list of all dyncfgs in the system into a new crate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,7 @@
 /src/controller                     @MaterializeInc/compute @MaterializeInc/storage
 /src/controller-types               @MaterializeInc/compute @MaterializeInc/storage
 /src/dyncfg                         @danhhz
+/src/dyncfgs                        @danhhz
 /src/environmentd                   @MaterializeInc/adapter
 /src/expr                           @MaterializeInc/compute
 /src/expr-test-util                 @MaterializeInc/compute

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4009,7 +4009,7 @@ dependencies = [
  "mz-cluster",
  "mz-compute",
  "mz-compute-client",
- "mz-dyncfg",
+ "mz-dyncfgs",
  "mz-http-util",
  "mz-metrics",
  "mz-orchestrator-tracing",
@@ -4213,6 +4213,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mz-dyncfgs"
+version = "0.0.0"
+dependencies = [
+ "mz-dyncfg",
+ "mz-persist-client",
+ "mz-persist-txn",
+ "prost-build",
+ "protobuf-src",
+ "workspace-hack",
+]
+
+[[package]]
 name = "mz-environmentd"
 version = "0.89.0-dev"
 dependencies = [
@@ -4251,6 +4263,7 @@ dependencies = [
  "mz-catalog",
  "mz-cloud-resources",
  "mz-controller",
+ "mz-dyncfgs",
  "mz-environmentd",
  "mz-expr",
  "mz-frontegg-auth",
@@ -5538,6 +5551,7 @@ dependencies = [
  "mz-cloud-resources",
  "mz-controller-types",
  "mz-dyncfg",
+ "mz-dyncfgs",
  "mz-expr",
  "mz-interchange",
  "mz-kafka-util",
@@ -5649,6 +5663,7 @@ dependencies = [
  "mz-build-info",
  "mz-cloud-resources",
  "mz-controller",
+ "mz-dyncfgs",
  "mz-environmentd",
  "mz-orchestrator",
  "mz-orchestrator-process",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "src/controller",
     "src/controller-types",
     "src/dyncfg",
+    "src/dyncfgs",
     "src/environmentd",
     "src/expr",
     "src/expr-parser",

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -21,7 +21,7 @@ mz-cloud-resources = { path = "../cloud-resources" }
 mz-compute = { path = "../compute" }
 mz-cluster = { path = "../cluster" }
 mz-compute-client = { path = "../compute-client" }
-mz-dyncfg = { path = "../dyncfg" }
+mz-dyncfgs = { path = "../dyncfgs" }
 mz-http-util = { path = "../http-util" }
 mz-metrics = { path = "../metrics" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }

--- a/src/dyncfgs/Cargo.toml
+++ b/src/dyncfgs/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "mz-dyncfgs"
+description = "A registry of every mz_dyncfg."
+version = "0.0.0"
+license = "Apache-2.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+mz-dyncfg = { path = "../dyncfg"}
+mz-persist-client = { path = "../persist-client"}
+mz-persist-txn = { path = "../persist-txn"}
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+
+[build-dependencies]
+prost-build = "0.11.2"
+protobuf-src = "1.1.0"
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["workspace-hack"]

--- a/src/dyncfgs/src/lib.rs
+++ b/src/dyncfgs/src/lib.rs
@@ -1,0 +1,32 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A registry of every mz_dyncfg.
+
+use mz_dyncfg::ConfigSet;
+
+/// Returns a new ConfigSet containing every `Config`` in Materialize.
+///
+/// Each time this is called, it returns a new ConfigSet disconnected from any
+/// others. It may be cloned and passed around, and updates to any of these
+/// copies will be reflected in the clones. Values from a `ConfigSet` may be
+/// copied to a disconnected `ConfigSet` via `ConfigUpdates`, which can be
+/// passed over the network to do the same across processes.
+///
+/// TODO(cfg): Consider replacing this with a static global registry powered by
+/// something like the `ctor` or `inventory` crate. This would solve the
+/// dependency issue of this crate depending on every crate that uses dyncfgs.
+/// However, on the other hand, it would involve managing the footgun of a
+/// Config being linked into one binary but not the other.
+pub fn all_dyncfgs() -> ConfigSet {
+    let mut configs = ConfigSet::default();
+    configs = mz_persist_client::cfg::all_dyncfgs(configs);
+    configs = mz_persist_txn::all_dyncfgs(configs);
+    configs
+}

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -47,6 +47,7 @@ mz-adapter-types = { path = "../adapter-types" }
 mz-catalog = { path = "../catalog" }
 mz-cloud-resources = { path = "../cloud-resources" }
 mz-controller = { path = "../controller" }
+mz-dyncfgs = { path = "../dyncfgs" }
 mz-expr = { path = "../expr" }
 mz-frontegg-auth = { path = "../frontegg-auth" }
 mz-frontegg-mock = { path = "../frontegg-mock", optional = true }

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -796,7 +796,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     let mut persist_config = PersistConfig::new(
         &mz_environmentd::BUILD_INFO,
         now.clone(),
-        mz_sql::session::vars::all_dyn_configs(),
+        mz_dyncfgs::all_dyncfgs(),
     );
     let persist_pubsub_server = PersistGrpcPubSubServer::new(&persist_config, &metrics_registry);
     let persist_pubsub_client = persist_pubsub_server.new_same_process_connection();

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -42,7 +42,6 @@ use mz_persist_client::PersistLocation;
 use mz_secrets::SecretsController;
 use mz_server_core::TlsCertConfig;
 use mz_sql::catalog::EnvironmentId;
-use mz_sql::session::vars::all_dyn_configs;
 use mz_stash_types::metrics::Metrics as StashMetrics;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::controller::PersistTxnTablesImpl;
@@ -345,8 +344,11 @@ impl Listeners {
         // Messing with the clock causes persist to expire leases, causing hangs and
         // panics. Is it possible/desirable to put this back somehow?
         let persist_now = SYSTEM_TIME.clone();
-        let mut persist_cfg =
-            PersistConfig::new(&crate::BUILD_INFO, persist_now.clone(), all_dyn_configs());
+        let mut persist_cfg = PersistConfig::new(
+            &crate::BUILD_INFO,
+            persist_now.clone(),
+            mz_dyncfgs::all_dyncfgs(),
+        );
         persist_cfg.build_version = config.code_version;
         // Tune down the number of connections to make this all work a little easier
         // with local postgres.

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -160,7 +160,7 @@ impl PersistConfig {
     /// Returns a new instance of [PersistConfig] with default tuning and
     /// default ConfigSet.
     pub fn new_default_configs(build_info: &BuildInfo, now: NowFn) -> Self {
-        Self::new(build_info, now, all_dyn_configs(ConfigSet::default()))
+        Self::new(build_info, now, all_dyncfgs(ConfigSet::default()))
     }
 
     /// Returns a new instance of [PersistConfig] with default tuning and the
@@ -276,7 +276,7 @@ pub(crate) const MiB: usize = 1024 * 1024;
 /// TODO(cfg): Consider replacing this with a static global registry powered by
 /// something like the `ctor` or `inventory` crate. This would involve managing
 /// the footgun of a Config being linked into one binary but not the other.
-pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
+pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     mz_persist::cfg::all_dyn_configs(configs)
         .add(&crate::batch::BATCH_DELETE_ENABLED)
         .add(&crate::batch::BLOB_TARGET_SIZE)

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -31,7 +31,7 @@ use tracing::info;
 
 use crate::async_runtime::IsolatedRuntime;
 use crate::cache::StateCache;
-use crate::cfg::all_dyn_configs;
+use crate::cfg::all_dyncfgs;
 use crate::cli::args::{make_blob, make_consensus, StateArgs, StoreArgs};
 use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
 use crate::internal::encoding::Schemas;
@@ -101,7 +101,7 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
     match command.command {
         Command::ForceCompaction(args) => {
             let shard_id = ShardId::from_str(&args.state.shard_id).expect("invalid shard id");
-            let configs = all_dyn_configs(ConfigSet::default());
+            let configs = all_dyncfgs(ConfigSet::default());
             // TODO: Fetch the latest values of these configs from Launch Darkly.
             let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), configs);
             if args.compaction_memory_bound_bytes > 0 {
@@ -124,7 +124,7 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
         }
         Command::ForceGc(args) => {
             let shard_id = ShardId::from_str(&args.state.shard_id).expect("invalid shard id");
-            let configs = all_dyn_configs(ConfigSet::default());
+            let configs = all_dyncfgs(ConfigSet::default());
             // TODO: Fetch the latest values of these configs from Launch Darkly.
             let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), configs);
             let metrics_registry = MetricsRegistry::new();
@@ -150,7 +150,7 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
             let shard_id = ShardId::from_str(&shard_id).expect("invalid shard id");
             let commit = command.commit;
 
-            let configs = all_dyn_configs(ConfigSet::default());
+            let configs = all_dyncfgs(ConfigSet::default());
             // TODO: Fetch the latest values of these configs from Launch Darkly.
             let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), configs);
             let metrics_registry = MetricsRegistry::new();
@@ -176,7 +176,7 @@ pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
                 concurrency,
             } = args;
             let commit = command.commit;
-            let configs = all_dyn_configs(ConfigSet::default());
+            let configs = all_dyncfgs(ConfigSet::default());
             // TODO: Fetch the latest values of these configs from Launch Darkly.
             let cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), configs);
             let metrics_registry = MetricsRegistry::new();

--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -262,7 +262,7 @@ mod proto {
 }
 
 /// Adds the full set of all persist-txn `Config`s.
-pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
+pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&crate::operator::DATA_SHARD_RETRYER_INITIAL_BACKOFF)
         .add(&crate::operator::DATA_SHARD_RETRYER_MULTIPLIER)

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -36,6 +36,7 @@ mz-ccsr = { path = "../ccsr" }
 mz-cloud-resources = { path = "../cloud-resources" }
 mz-controller-types = { path = "../controller-types" }
 mz-dyncfg = { path = "../dyncfg" }
+mz-dyncfgs = { path = "../dyncfgs" }
 mz-expr = { path = "../expr" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2175,20 +2175,6 @@ feature_flags!(
     },
 );
 
-/// Returns a new ConfigSet containing every `Config` in Materialize.
-///
-/// Each time this is called, it returns a new ConfigSet disconnected from any
-/// others. It may be cloned and passed around, and updates to any of these
-/// copies will be reflected in the clones. Values from a `ConfigSet` may be
-/// copied to a disconnected `ConfigSet` via `ConfigUpdates`, which can be
-/// passed over the network to do the same across processes.
-pub fn all_dyn_configs() -> ConfigSet {
-    let mut configs = ConfigSet::default();
-    configs = mz_persist_client::cfg::all_dyn_configs(configs);
-    configs = mz_persist_txn::all_dyn_configs(configs);
-    configs
-}
-
 /// Represents the input to a variable.
 ///
 /// Each variable has different rules for how it handles each style of input.
@@ -2857,7 +2843,7 @@ impl SystemVars {
             vars: Default::default(),
             active_connection_count,
             allow_unsafe: false,
-            persist_configs: all_dyn_configs(),
+            persist_configs: mz_dyncfgs::all_dyncfgs(),
         };
 
         let mut vars = vars

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -23,6 +23,7 @@ once_cell = "1.16.0"
 md-5 = "0.10.5"
 mz-build-info = { path = "../build-info" }
 mz-controller = { path = "../controller" }
+mz-dyncfgs = { path = "../dyncfgs" }
 mz-environmentd = { path = "../environmentd", default-features = false }
 mz-ore = { path = "../ore", features = ["async", "tracing_"] }
 mz-orchestrator = { path = "../orchestrator" }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -68,7 +68,6 @@ use mz_repr::ColumnName;
 use mz_secrets::SecretsController;
 use mz_sql::ast::{Expr, Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
-use mz_sql::session::vars::all_dyn_configs;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
     CreateIndexStatement, CreateViewStatement, CteBlock, Distinct, DropObjectsStatement, Ident,
@@ -972,8 +971,11 @@ impl<'a> RunnerInner<'a> {
         let now = SYSTEM_TIME.clone();
         let metrics_registry = MetricsRegistry::new();
 
-        let persist_config =
-            PersistConfig::new(&mz_environmentd::BUILD_INFO, now.clone(), all_dyn_configs());
+        let persist_config = PersistConfig::new(
+            &mz_environmentd::BUILD_INFO,
+            now.clone(),
+            mz_dyncfgs::all_dyncfgs(),
+        );
         let persist_pubsub_server =
             PersistGrpcPubSubServer::new(&persist_config, &metrics_registry);
         let persist_pubsub_client = persist_pubsub_server.new_same_process_connection();


### PR DESCRIPTION
This deduplicates the two existing copies into one.

On on hand, it seems silly to have a whole crate just for this. On the other hand, there are some tricky dependency issues involved.

For dyncfgs to work, this list needs to be the same in both `clusterd` and `environmentd`. (Technically, I think it would be okay for the `clusterd` list to be a subset of the `environmentd` list, but that's pretty subtle to reason about to let's avoid it if possible.) This means we need to find a home for it that can depend on all crates that use dyncfgs (initially persist-client and persist-txn, but hopefully more soon) and that can be depended on by both `clusterd` and `environmentd` main files. The initial location (in mz-sql) already fails the latter requirement, which is why it had to be duplicated.

It's possible that we could find a crate that happens to meet these requirements now, but as we add more uses of dyncfgs, it seems like that would get increasingly harder. So, rip off the bandaid now and make a crate specifically for this, I guess.

They hypothesized link-time magic registry would sidestep all this, but it has some other footguns we're working through.

While I'm in here, rename the methods to `all_dyncfgs` to be more consistent with the "dyncfg" jargon.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

The `mz-dyncfgs` crate name is a strawman and I'm not attached to it. Happy to bikeshed!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
