### PR TITLE
*: fix clippy for 1.76

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -847,8 +847,10 @@ impl Coordinator {
             depends_on: validity.dependency_ids.clone(),
         };
         // Add metadata for the new COPY TO.
-        self.add_active_compute_sink(sink_id, ActiveComputeSink::CopyTo(active_copy_to))
-            .await;
+        drop(
+            self.add_active_compute_sink(sink_id, ActiveComputeSink::CopyTo(active_copy_to))
+                .await,
+        );
 
         // Ship dataflow.
         self.ship_dataflow(df_desc, cluster_id).await;

--- a/src/catalog/src/durable/impls/stash.rs
+++ b/src/catalog/src/durable/impls/stash.rs
@@ -1099,7 +1099,7 @@ impl DurableCatalogState for Connection {
                             is_initialized,
                         )
                         .await?;
-                        tx.append(batches).await?;
+                        drop(tx.append(batches).await?);
 
                         Ok(())
                     })

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -801,6 +801,8 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     let persist_pubsub_server = PersistGrpcPubSubServer::new(&persist_config, &metrics_registry);
     let persist_pubsub_client = persist_pubsub_server.new_same_process_connection();
 
+    // We can remove the last branch once we upgrade to 1.75
+    #[allow(unreachable_patterns)]
     match args.persist_isolated_runtime_threads {
         // Use the default.
         None | Some(0) => (),
@@ -812,7 +814,6 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             let threads = usize::try_from(x).expect("pattern matched a positive value");
             persist_config.isolated_runtime_worker_threads = threads;
         }
-        // We can remove this branch once we upgrade to 1.75
         Some(_) => unreachable!("isize is technically non-exhaustive"),
     };
 

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -1383,22 +1383,21 @@ mod tests {
     fn test_mfp() {
         // Regression test for https://github.com/MaterializeInc/materialize/issues/19338
         use MirScalarExpr::*;
+
+        // Broken out so 1.74 and 1.76 rustfmt format it the same
+        let call_unary = CallUnary {
+            func: UnaryFunc::IsNull(IsNull),
+            expr: Box::new(CallBinary {
+                func: BinaryFunc::MulInt32,
+                expr1: Box::new(Column(0)),
+                expr2: Box::new(Column(0)),
+            }),
+        };
         let mfp = MapFilterProject {
             expressions: vec![],
             predicates: vec![
                 // Always fails on the known input range
-                (
-                    1,
-                    CallUnary {
-                        func: UnaryFunc::IsNull(IsNull),
-                        expr:
-                            Box::new(CallBinary {
-                                func: BinaryFunc::MulInt32,
-                                expr1: Box::new(Column(0)),
-                                expr2: Box::new(Column(0)),
-                            }),
-                    },
-                ),
+                (1, call_unary),
                 // Always returns false on the known input range
                 (
                     1,

--- a/src/service/src/boot.rs
+++ b/src/service/src/boot.rs
@@ -99,7 +99,7 @@ pub mod r#private {
             let file = BufReader::new(file);
             Some(
                 file.lines()
-                    .flatten()
+                    .map_while(Result::ok)
                     .filter_map(CgroupEntry::from_line)
                     .collect(),
             )
@@ -149,7 +149,7 @@ pub mod r#private {
             let file = BufReader::new(file);
             Some(
                 file.lines()
-                    .flatten()
+                    .map_while(Result::ok)
                     .filter_map(MountInfo::from_line)
                     .filter(|mi| mi.fs_type == "cgroup" || mi.fs_type == "cgroup2")
                     .partition(|mi| mi.fs_type == "cgroup2"),

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -297,7 +297,7 @@ where
                             InternalStashError::PeekSinceUpper(_) => {
                                 // If the upper isn't > since, bump the upper and try again to find a sealed
                                 // entry. Do this by appending the empty batch which will advance the upper.
-                                tx.append(vec![batch]).await?;
+                                drop(tx.append(vec![batch]).await?);
                                 let lower = tx.upper(collection.id).await?;
                                 batch = collection.make_batch_lower(lower)?;
                                 tx.peek_key_one(collection, &key).await?
@@ -309,7 +309,7 @@ where
                         Some(prev) => Ok(prev),
                         None => {
                             collection.append_to_batch(&mut batch, &key, &value, 1);
-                            tx.append(vec![batch]).await?;
+                            drop(tx.append(vec![batch]).await?);
                             Ok((*value).clone())
                         }
                     }
@@ -350,7 +350,7 @@ where
                             InternalStashError::PeekSinceUpper(_) => {
                                 // If the upper isn't > since, bump the upper and try again to find a sealed
                                 // entry. Do this by appending the empty batch which will advance the upper.
-                                tx.append(vec![batch]).await?;
+                                drop(tx.append(vec![batch]).await?);
                                 let lower = tx.upper(collection.id).await?;
                                 batch = collection.make_batch_lower(lower)?;
                                 tx.peek_one(collection).await?
@@ -364,7 +364,7 @@ where
                             prev.insert(k.clone(), v.clone());
                         }
                     }
-                    tx.append(vec![batch]).await?;
+                    drop(tx.append(vec![batch]).await?);
                     Ok(prev)
                 })
             })
@@ -401,7 +401,7 @@ where
                             InternalStashError::PeekSinceUpper(_) => {
                                 // If the upper isn't > since, bump the upper and try again to find a sealed
                                 // entry. Do this by appending the empty batch which will advance the upper.
-                                tx.append(vec![batch]).await?;
+                                drop(tx.append(vec![batch]).await?);
                                 let lower = tx.upper(collection.id).await?;
                                 batch = collection.make_batch_lower(lower)?;
                                 tx.peek_key_one(collection, &key).await?
@@ -419,7 +419,7 @@ where
                             collection.append_to_batch(&mut batch, &key, prev, -1);
                         }
                         collection.append_to_batch(&mut batch, &key, &next, 1);
-                        tx.append(vec![batch]).await?;
+                        drop(tx.append(vec![batch]).await?);
                     }
                     Ok(Ok((prev, next)))
                 })
@@ -450,7 +450,7 @@ where
                             InternalStashError::PeekSinceUpper(_) => {
                                 // If the upper isn't > since, bump the upper and try again to find a sealed
                                 // entry. Do this by appending the empty batch which will advance the upper.
-                                tx.append(vec![batch]).await?;
+                                drop(tx.append(vec![batch]).await?);
                                 let lower = tx.upper(collection.id).await?;
                                 batch = collection.make_batch_lower(lower)?;
                                 tx.peek_one(collection).await?
@@ -464,7 +464,7 @@ where
                         }
                         collection.append_to_batch(&mut batch, k, v, 1);
                     }
-                    tx.append(vec![batch]).await?;
+                    drop(tx.append(vec![batch]).await?);
                     Ok(())
                 })
             })
@@ -511,7 +511,7 @@ where
                             collection.append_to_batch(&mut batch, &key, &v, -1);
                         }
                     }
-                    tx.append(vec![batch]).await?;
+                    drop(tx.append(vec![batch]).await?);
                     Ok(())
                 })
             })

--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -154,7 +154,7 @@ where
 
                 // Fix the upper, append should work now.
                 other_batch.upper = other_upper;
-                tx.append(vec![other_batch, orders_batch]).await.unwrap();
+                drop(tx.append(vec![other_batch, orders_batch]).await.unwrap());
                 assert_eq!(
                     tx.iter(orders).await.unwrap(),
                     &[(("k1".into(), "v1".into()), -9223372036854775808, 1),]
@@ -181,7 +181,7 @@ where
                 // must also compact and consolidate.
                 for _ in 0..5 {
                     let orders_batch = orders.make_batch_tx(&tx).await.unwrap();
-                    tx.append(vec![orders_batch]).await.unwrap();
+                    drop(tx.append(vec![orders_batch]).await.unwrap());
                     assert_eq!(
                         tx.since(orders.id).await.unwrap().into_option().unwrap(),
                         tx.upper(orders.id).await.unwrap().into_option().unwrap() - 1
@@ -248,7 +248,7 @@ where
             Box::pin(async move {
                 let mut orders_batch = orders.make_batch_tx(&tx).await.unwrap();
                 orders.append_to_batch(&mut orders_batch, &"k4".to_string(), &"v4".to_string(), 1);
-                tx.append(vec![orders_batch]).await.unwrap();
+                drop(tx.append(vec![orders_batch]).await.unwrap());
                 assert_eq!(
                     tx.peek_one(orders).await.unwrap(),
                     BTreeMap::from([
@@ -745,7 +745,7 @@ async fn append(stash: &mut Stash, batches: Vec<AppendBatch>) -> Result<(), Stas
         .with_transaction(move |tx| {
             Box::pin(async move {
                 let batches = batches.clone();
-                tx.append(batches).await?;
+                drop(tx.append(batches).await?);
                 for id in tx.collections().await?.keys() {
                     tx.consolidate(*id).await?;
                 }

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -52,7 +52,7 @@ where
                 InternalStashError::PeekSinceUpper(_) => {
                     // If the upper isn't > since, bump the upper and try again to find a sealed
                     // entry. Do this by appending the empty batch which will advance the upper.
-                    tx.append(vec![batch]).await?;
+                    drop(tx.append(vec![batch]).await?);
                     let lower = tx.upper(collection.id).await?;
                     batch = collection.make_batch_lower(lower)?;
                     tx.peek_one(collection).await?
@@ -92,7 +92,7 @@ where
             }
         }
 
-        tx.append(vec![batch]).await?;
+        drop(tx.append(vec![batch]).await?);
 
         Ok(())
     }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2194,7 +2194,8 @@ where
                     .filter_map(|b| b)
                     .collect();
 
-                    tx.append(batches).await
+                    // Drop the notification future we don't need.
+                    tx.append(batches).await.map(drop)
                 })
             })
             .await


### PR DESCRIPTION
Lots of unused extra futures that its now catching

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
