### PR TITLE
persist-txn: fix "register ts ... not less_equal forget ts" bug

### DIFF
--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -545,9 +545,6 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64> TxnsCacheState
 
             // Advance the registration times.
             while let Some(x) = times.registered.front_mut() {
-                if x.register_ts < self.since_ts {
-                    x.register_ts.clone_from(&self.since_ts);
-                }
                 if let Some(forget_ts) = x.forget_ts.as_ref() {
                     if forget_ts < &self.since_ts {
                         times.registered.pop_front();


### PR DESCRIPTION
This debug assertion was getting tickled by the following sequence of events (`A < B < C < D`):

- At time `A`, a data shard is registered
- At time `B`, it is written to via txns
- At time `C`, it is forgotten
- We then open the txns cache with an as_of time `D`
- We read the register and write into the cache. The pushing the write into the cache triggers a call to `compact_data_times`, which advances the register ts from `A` to `D`
- We then read the forget into the cache, the advanced register ts `D` is not less_equal the forget ts `C` and boom

I can't think of any reason for us to advance the register ts. It's likely a holdover from before we kept around the original timestamps of things. So, fix the bug by removing the advancement from `A` -> `D`, leaving the register ts in the cache at `A`.

Closes #25384

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
