### PR TITLE
storage: collect new steady-state statistics in mz_source_statistics_raw

### DIFF
--- a/src/storage-client/src/statistics.rs
+++ b/src/storage-client/src/statistics.rs
@@ -364,7 +364,7 @@ impl<T> SkippableGauge<T> {
     }
 }
 
-impl<T: StorageMetric + Default + Clone> SkippableGauge<T> {
+impl<T: StorageMetric + Default + Clone + std::fmt::Debug> SkippableGauge<T> {
     fn summarize<'a, I>(values: I) -> Self
     where
         I: IntoIterator<Item = &'a Self>,
@@ -378,12 +378,13 @@ impl<T: StorageMetric + Default + Clone> SkippableGauge<T> {
         }));
 
         // If any are none, we can't aggregate.
-        Self(any_none.then_some(inner))
+        Self((!any_none).then_some(inner))
     }
 
     fn incorporate(&mut self, other: Self, field_name: &'static str) {
         match (&mut self.0, other.0) {
-            (None, _) | (_, None) => {}
+            (_, None) => {}
+            (None, Some(other)) => self.0 = Some(other),
             (Some(this), Some(other)) => this.incorporate(other, field_name),
         }
     }

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -93,6 +93,16 @@ impl SourceRender for LoadGeneratorSourceConnection {
             let [mut cap, stats_cap]: [_; 2] = caps.try_into().unwrap();
 
             if !config.responsible_for(()) {
+                // Emit 0, to mark this worker as having started up correctly.
+                stats_output
+                    .give(
+                        &stats_cap,
+                        ProgressStatisticsUpdate {
+                            offset_known: 0,
+                            offset_committed: 0,
+                        },
+                    )
+                    .await;
                 return;
             }
 

--- a/src/storage/src/source/mysql/statistics.rs
+++ b/src/storage/src/source/mysql/statistics.rs
@@ -51,6 +51,16 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
 
             // Only run the replication reader on the worker responsible for it.
             if !config.responsible_for(STATISTICS) {
+                // Emit 0, to mark this worker as having started up correctly.
+                stats_output
+                    .give(
+                        &stats_cap[0],
+                        ProgressStatisticsUpdate {
+                            offset_known: 0,
+                            offset_committed: 0,
+                        },
+                    )
+                    .await;
                 return Ok(());
             }
 

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -184,6 +184,16 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 caps.try_into().unwrap();
 
             if !config.responsible_for("slot") {
+                // Emit 0, to mark this worker as having started up correctly.
+                stats_output
+                    .give(
+                        &stats_cap[0],
+                        ProgressStatisticsUpdate {
+                            offset_known: 0,
+                            offset_committed: 0,
+                        },
+                    )
+                    .await;
                 return Ok(());
             }
 

--- a/src/storage/src/statistics.rs
+++ b/src/storage/src/statistics.rs
@@ -706,17 +706,15 @@ impl SourceStatistics {
 
     /// Set the `offset_known` stat to the given value.
     pub fn set_offset_known(&self, value: u64) {
-        let cur = self.stats.borrow_mut();
-        // Not yet exposed to users.
-        // cur.prom.offset_known = value;
+        let mut cur = self.stats.borrow_mut();
+        cur.stats.offset_known = Some(Some(value));
         cur.prom.offset_known.set(value);
     }
 
     /// Set the `offset_committed` stat to the given value.
     pub fn set_offset_committed(&self, value: u64) {
-        let cur = self.stats.borrow_mut();
-        // Not yet exposed to users.
-        // cur.prom.offset_committed = value;
+        let mut cur = self.stats.borrow_mut();
+        cur.stats.offset_committed = Some(Some(value));
         cur.prom.offset_committed.set(value);
     }
 }

--- a/test/cluster/storage/01-create-sources.td
+++ b/test/cluster/storage/01-create-sources.td
@@ -49,10 +49,12 @@ one
 
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
-  SUM(u.messages_received)
+  SUM(u.messages_received),
+  SUM(u.offset_known),
+  SUM(u.offset_committed)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true 1
-remote2 true 1
+remote1 true 1 1 1
+remote2 true 1 1 1

--- a/test/cluster/storage/02-after-environmentd-restart.td
+++ b/test/cluster/storage/02-after-environmentd-restart.td
@@ -21,13 +21,15 @@ one
 # ensure after envd has restarted, we have maintained statistics.
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
-  SUM(u.messages_received)
+  SUM(u.messages_received),
+  SUM(u.offset_known),
+  SUM(u.offset_committed)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true 1
-remote2 true 1
+remote1 true 1 1 1
+remote2 true 1 1 1
 
 $ kafka-ingest format=bytes topic=remote1
 two
@@ -41,12 +43,15 @@ two
 one
 two
 
+# Ensure that offsets/counters can be updated correctly.
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
-  SUM(u.messages_received)
+  SUM(u.messages_received),
+  SUM(u.offset_known),
+  SUM(u.offset_committed)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('remote1', 'remote2')
   GROUP BY s.id, s.name
-remote1 true 2
-remote2 true 2
+remote1 true 2 2 2
+remote2 true 2 2 2

--- a/test/cluster/storage/04-after-clusterd-restart.td
+++ b/test/cluster/storage/04-after-clusterd-restart.td
@@ -37,3 +37,13 @@ one
 two
 three
 four
+
+> SELECT s.name,
+  SUM(u.offset_known),
+  SUM(u.offset_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('remote1', 'remote2')
+  GROUP BY s.id, s.name
+remote1 4 4
+remote2 4 4

--- a/test/mysql-cdc/statistics.td
+++ b/test/mysql-cdc/statistics.td
@@ -1,0 +1,75 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test progress statistics
+#
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_mysql_source = true
+
+> CREATE CONNECTION mysqc TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+CREATE TABLE t1 (f1 TEXT);
+
+INSERT INTO t1 VALUES ('one');
+
+> CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqc FOR TABLES (public.t1);
+
+> SELECT COUNT(*) > 0 FROM t1;
+true
+
+# statistics are only populated every minute by default
+$ set-sql-timeout duration=2minutes
+
+> SELECT
+    s.name,
+    SUM(u.offset_committed) > 0,
+    SUM(u.offset_known) >= SUM(u.offset_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('mz_source')
+  GROUP BY s.name
+  ORDER BY s.name
+mz_source true true
+
+$ set-from-sql var=previous-offset-committed
+SELECT
+    (SUM(u.offset_committed))::text
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('mz_source')
+
+
+$ mysql-execute name=mysql
+INSERT INTO t1 VALUES ('two');
+
+
+> SELECT
+    s.name,
+    SUM(u.offset_committed) > ${previous-offset-committed},
+    SUM(u.offset_known) >= SUM(u.offset_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('mz_source')
+  GROUP BY s.name
+  ORDER BY s.name
+mz_source true true

--- a/test/pg-cdc/privileges.td
+++ b/test/pg-cdc/privileges.td
@@ -88,3 +88,6 @@ REVOKE SELECT ON public."""select""" FROM priv;
   FOR SCHEMAS(public);
 contains:insufficient privileges
 detail:user priv lacks SELECT privileges for tables public."""select""", public."select"
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP SCHEMA IF EXISTS other CASCADE;

--- a/test/pg-cdc/statistics.td
+++ b/test/pg-cdc/statistics.td
@@ -1,0 +1,75 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test progress statistics
+#
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (f1 TEXT);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+
+INSERT INTO t1 VALUES ('one');
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT COUNT(*) > 0 FROM t1;
+true
+
+
+> SELECT
+    s.name,
+    SUM(u.offset_committed) > 0,
+    SUM(u.offset_known) >= SUM(u.offset_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('mz_source')
+  GROUP BY s.name
+  ORDER BY s.name
+mz_source true true
+
+$ set-from-sql var=previous-offset-committed
+SELECT
+    (SUM(u.offset_committed))::text
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('mz_source')
+
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t1 VALUES ('two');
+
+
+> SELECT
+    s.name,
+    SUM(u.offset_committed) > ${previous-offset-committed},
+    SUM(u.offset_known) >= SUM(u.offset_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('mz_source')
+  GROUP BY s.name
+  ORDER BY s.name
+mz_source true true

--- a/test/pg-cdc/subsource-resolution-empty.td
+++ b/test/pg-cdc/subsource-resolution-empty.td
@@ -55,3 +55,6 @@ contains:missing TABLES specification
   FOR SCHEMAS (dne);
 contains:database postgres missing referenced schemas
 detail:missing schemas: dne
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP SCHEMA other CASCADE;

--- a/test/testdrive/steady-state-source-statistics.td
+++ b/test/testdrive/steady-state-source-statistics.td
@@ -1,0 +1,125 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-create-topic topic=upsert partitions=1
+
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"} {"f1": "fish", "f2": 1000}
+{"key": "bird1"} {"f1":"goose", "f2": 1}
+{"key": "birdmore"} {"f1":"geese", "f2": 2}
+{"key": "mammal1"} {"f1": "moose", "f2": 1}
+{"key": "bird1"}
+{"key": "birdmore"} {"f1":"geese", "f2": 56}
+{"key": "mammalmore"} {"f1": "moose", "f2": 42}
+{"key": "mammal1"}
+{"key": "mammalmore"} {"f1":"moose", "f2": 2}
+
+$ kafka-create-topic topic=metrics-test partitions=1
+$ kafka-ingest topic=metrics-test format=bytes
+jack,jill
+goofus,gallant
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> CREATE SOURCE upsert
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM KAFKA CONNECTION kafka_conn (TOPIC
+  'testdrive-upsert-${testdrive.seed}'
+  )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  INCLUDE OFFSET
+  ENVELOPE UPSERT
+
+> CREATE SOURCE counter
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM LOAD GENERATOR COUNTER;
+
+# Adding a select here so that the ingests after this
+# triggers lookup from the upsert state
+> SELECT key, f1, f2 FROM upsert
+key           f1      f2
+------------------------
+fish          fish    1000
+birdmore      geese   56
+mammalmore    moose   2
+
+# statistics are only populated every minute by default
+$ set-sql-timeout duration=2minutes
+
+# NOTE: These queries are slow to succeed because the default metrics scraping
+# interval is 30 seconds.
+
+> SELECT
+    s.name,
+    SUM(u.offset_known) > 0,
+    SUM(u.offset_known) = SUM(u.offset_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+  GROUP BY s.name
+  ORDER BY s.name
+upsert true true
+
+> SELECT
+    s.name,
+    SUM(u.offset_known) > 0,
+    SUM(u.offset_committed) > 0
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('counter')
+  GROUP BY s.name
+  ORDER BY s.name
+counter true true
+
+$ set-from-sql var=previous-offset-known
+SELECT
+    (SUM(u.offset_known))::text
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+
+
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "mammalmore"}
+
+> SELECT
+    s.name,
+    SUM(u.offset_known) > ${previous-offset-known},
+    SUM(u.offset_known) = SUM(u.offset_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+  GROUP BY s.name
+  ORDER BY s.name
+upsert true true
+
+> DROP SOURCE upsert
+> DROP SOURCE counter


### PR DESCRIPTION
This consolidates all my prior art, and finishes publishing the _steady-state metrics_ (as defined here: https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20240108_source_metrics_2.md) in the `mz_source_statistics_raw` table.

This is the last big pr for this work, other than snapshot progress, which will have a similar shape as this one.

Note that I tested this pr (though don't really care about the accuracy of the metrics for loadgen sources). 

### Motivation
  * This PR adds a known-desirable feature.

### Tips for reviewer
These are now populating the `_raw` table, but not the user-facing view on top.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
