### PR TITLE
storage/mysql: Add Decimal/Numeric support; move decoding code to mz-mysql-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4686,9 +4686,11 @@ name = "mz-mysql-util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "indexmap 1.9.1",
  "itertools",
  "mysql_async",
+ "mysql_common",
  "mz-cloud-resources",
  "mz-ore",
  "mz-proto",

--- a/src/mysql-util/Cargo.toml
+++ b/src/mysql-util/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = "0.10.5"
 mz-cloud-resources = { path = "../cloud-resources" }
@@ -18,6 +19,7 @@ mz-ore = { path = "../ore", features = ["async"] }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-ssh-util = { path = "../ssh-util" }
+mysql_common = { version = "0.31.0", default-features = false, features = ["chrono"] }
 mysql_async = { version = "0.33.0", default-features = false, features = ["minimal", "tracing"] }
 once_cell = "1.16.0"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }

--- a/src/mysql-util/src/decoding.rs
+++ b/src/mysql-util/src/decoding.rs
@@ -1,0 +1,170 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use itertools::{EitherOrBoth, Itertools};
+use mysql_common::value::convert::from_value_opt;
+use mysql_common::{Row as MySqlRow, Value};
+
+use mz_ore::cast::CastFrom;
+use mz_repr::adt::date::Date;
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::{Datum, Row, ScalarType};
+
+use crate::{MySqlColumnDesc, MySqlError, MySqlTableDesc};
+
+pub fn pack_mysql_row(
+    row_container: &mut Row,
+    row: MySqlRow,
+    table_desc: &MySqlTableDesc,
+) -> Result<Row, MySqlError> {
+    let mut packer = row_container.packer();
+    let mut temp_bytes = vec![];
+    let mut temp_strs = vec![];
+    let row_values = row.unwrap();
+
+    for values in table_desc.columns.iter().zip_longest(row_values) {
+        let (col_desc, value) = match values {
+            EitherOrBoth::Both(col_desc, value) => (col_desc, value),
+            EitherOrBoth::Left(col_desc) => {
+                tracing::error!(
+                    "mysql: extra column description {col_desc:?} for table {}",
+                    table_desc.name
+                );
+                Err(MySqlError::DecodeError(format!(
+                    "extra column description {col_desc:?} for table {}",
+                    table_desc.name
+                )))?
+            }
+            EitherOrBoth::Right(value) => {
+                tracing::error!("mysql: extra value {value:?} for table {}", table_desc.name);
+                Err(MySqlError::DecodeError(format!(
+                    "extra value found: {value:?} for table {}",
+                    table_desc.name
+                )))?
+            }
+        };
+        let datum = match val_to_datum(value, col_desc, &mut temp_strs, &mut temp_bytes) {
+            Err(err) => Err(MySqlError::ValueDecodeError {
+                column_name: col_desc.name.clone(),
+                qualified_table_name: format!("{}.{}", table_desc.schema_name, table_desc.name),
+                error: err.to_string(),
+            })?,
+            Ok(datum) => datum,
+        };
+        packer.push(datum);
+    }
+
+    Ok(row_container.clone())
+}
+
+fn val_to_datum<'a>(
+    value: Value,
+    col_desc: &MySqlColumnDesc,
+    temp_strs: &'a mut Vec<String>,
+    temp_bytes: &'a mut Vec<Vec<u8>>,
+) -> Result<Datum<'a>, anyhow::Error> {
+    Ok(match value {
+        Value::NULL => {
+            if col_desc.column_type.nullable {
+                Datum::Null
+            } else {
+                Err(anyhow::anyhow!(
+                    "received a null value in a non-null column".to_string(),
+                ))?
+            }
+        }
+        value => match &col_desc.column_type.scalar_type {
+            ScalarType::Bool => Datum::from(from_value_opt::<bool>(value)?),
+            ScalarType::UInt16 => Datum::from(from_value_opt::<u16>(value)?),
+            ScalarType::Int16 => Datum::from(from_value_opt::<i16>(value)?),
+            ScalarType::UInt32 => Datum::from(from_value_opt::<u32>(value)?),
+            ScalarType::Int32 => Datum::from(from_value_opt::<i32>(value)?),
+            ScalarType::UInt64 => Datum::from(from_value_opt::<u64>(value)?),
+            ScalarType::Int64 => Datum::from(from_value_opt::<i64>(value)?),
+            ScalarType::Float32 => Datum::from(from_value_opt::<f32>(value)?),
+            ScalarType::Float64 => Datum::from(from_value_opt::<f64>(value)?),
+            ScalarType::Char { length } => {
+                let val = from_value_opt::<String>(value)?;
+                check_char_length(length.map(|l| l.into_u32()), &val, col_desc)?;
+                temp_strs.push(val);
+                Datum::from(temp_strs.last().unwrap().as_str())
+            }
+            ScalarType::VarChar { max_length } => {
+                let val = from_value_opt::<String>(value)?;
+                check_char_length(max_length.map(|l| l.into_u32()), &val, col_desc)?;
+                temp_strs.push(val);
+                Datum::from(temp_strs.last().unwrap().as_str())
+            }
+            ScalarType::String => {
+                temp_strs.push(from_value_opt::<String>(value)?);
+                Datum::from(temp_strs.last().unwrap().as_str())
+            }
+            ScalarType::Bytes => {
+                let data = from_value_opt::<Vec<u8>>(value)?;
+                temp_bytes.push(data);
+                Datum::from(temp_bytes.last().unwrap().as_slice())
+            }
+            ScalarType::Date => {
+                let date = Date::try_from(from_value_opt::<chrono::NaiveDate>(value)?)?;
+                Datum::from(date)
+            }
+            ScalarType::Timestamp { precision: _ } => {
+                // Timestamps are encoded as different mysql_common::Value types depending on
+                // whether they are from a binlog event or a query, and depending on which
+                // mysql timestamp version is used. We handle those cases here
+                // https://github.com/blackbeam/rust_mysql_common/blob/v0.31.0/src/binlog/value.rs#L87-L155
+                // https://github.com/blackbeam/rust_mysql_common/blob/v0.31.0/src/value/mod.rs#L332
+                let chrono_timestamp = match value {
+                    Value::Date(..) => from_value_opt::<chrono::NaiveDateTime>(value)?,
+                    // old temporal format from before MySQL 5.6; didn't support fractional seconds
+                    Value::Int(val) => chrono::NaiveDateTime::from_timestamp_opt(val, 0)
+                        .ok_or(anyhow::anyhow!("received invalid timestamp value: {}", val))?,
+                    Value::Bytes(data) => {
+                        let data = std::str::from_utf8(&data)?;
+                        if data.contains('.') {
+                            chrono::NaiveDateTime::parse_from_str(data, "%s%.6f")?
+                        } else {
+                            chrono::NaiveDateTime::parse_from_str(data, "%s")?
+                        }
+                    }
+                    _ => Err(anyhow::anyhow!(
+                        "received unexpected value for timestamp type: {:?}",
+                        value
+                    ))?,
+                };
+                Datum::try_from(CheckedTimestamp::try_from(chrono_timestamp)?)?
+            }
+            ScalarType::Time => Datum::from(from_value_opt::<chrono::NaiveTime>(value)?),
+            // TODO(roshan): IMPLEMENT OTHER TYPES
+            data_type => Err(anyhow::anyhow!(
+                "received unexpected value for type: {:?}: {:?}",
+                data_type,
+                value
+            ))?,
+        },
+    })
+}
+
+fn check_char_length(
+    length: Option<u32>,
+    val: &str,
+    col_desc: &MySqlColumnDesc,
+) -> Result<(), anyhow::Error> {
+    if let Some(length) = length {
+        if let Some(_) = val.char_indices().nth(usize::cast_from(length)) {
+            Err(anyhow::anyhow!(
+                "received string value of length {} for column {} which has a max length of {}",
+                val.len(),
+                col_desc.name,
+                length
+            ))?
+        }
+    }
+    Ok(())
+}

--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -27,11 +27,22 @@ pub use replication::{
 pub mod schemas;
 pub use schemas::{schema_info, SchemaRequest};
 
+pub mod decoding;
+pub use decoding::pack_mysql_row;
+
 #[derive(Debug, thiserror::Error)]
 pub enum MySqlError {
     #[error("error setting up ssh: {0}")]
     Ssh(#[source] anyhow::Error),
-    #[error("unsupported data type: '{column_type}' for '{qualified_table_name}.{column_name}'.")]
+    #[error("decode error: {0}")]
+    DecodeError(String),
+    #[error("error decoding value for '{qualified_table_name}' column '{column_name}': {error}")]
+    ValueDecodeError {
+        column_name: String,
+        qualified_table_name: String,
+        error: String,
+    },
+    #[error("unsupported data type: '{column_type}' for '{qualified_table_name}' column '{column_name}'.")]
     UnsupportedDataType {
         column_type: String,
         qualified_table_name: String,

--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -207,7 +207,7 @@ where
                     ScalarType::Numeric {
                         max_scale: info
                             .numeric_scale
-                            .and_then(|f| Some(NumericMaxScale::try_from(f)))
+                            .map(NumericMaxScale::try_from)
                             .transpose()
                             .map_err(|_| MySqlError::UnsupportedDataType {
                                 column_type: info.column_type,

--- a/test/mysql-cdc/types-decimal.td
+++ b/test/mysql-cdc/types-decimal.td
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test mysql DECIMAL / NUMERIC type
+#
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_mysql_source = true
+
+> CREATE CONNECTION mysqc TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+# Insert data pre-snapshot
+# We insert values with both default precision (0) and a value of 6 where allowed
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+CREATE TABLE t1 (f1 DECIMAL(20, 0), f2 DECIMAL(20, 20), f3 DECIMAL(20,10), f4 NUMERIC(20,5));
+
+INSERT INTO t1 VALUES ('99999999999999999999', '0.99999999999999999999', '9999999999.9999999999', '9999999999.1111111111');
+INSERT INTO t1 VALUES ('-99999999999999999999', '-0.99999999999999999999', '-9999999999.9999999999', '-9999999999.1111111111');
+
+> CREATE SOURCE da FROM MYSQL CONNECTION mysqc FOR TABLES (public.t1);
+
+> SELECT * FROM t1;
+99999999999999999999 0.99999999999999999999 9999999999.9999999999 9999999999.11111
+-99999999999999999999 -0.99999999999999999999 -9999999999.9999999999 -9999999999.11111
+
+# Insert the same data post-snapshot
+$ mysql-execute name=mysql
+INSERT INTO t1 SELECT * FROM t1;
+
+> SELECT pg_typeof(f1), pg_typeof(f2), pg_typeof(f3), pg_typeof(f4) FROM t1 LIMIT 1;
+numeric numeric numeric numeric
+
+> SELECT * FROM t1;
+99999999999999999999 0.99999999999999999999 9999999999.9999999999 9999999999.11111
+-99999999999999999999 -0.99999999999999999999 -9999999999.9999999999 -9999999999.11111
+99999999999999999999 0.99999999999999999999 9999999999.9999999999 9999999999.11111
+-99999999999999999999 -0.99999999999999999999 -9999999999.9999999999 -9999999999.11111


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature. Adds Decimal / Numeric type support.
 
Part of the work in https://github.com/MaterializeInc/materialize/issues/15901

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

The first commit is entirely just a refactor to move the row decoding logic from `src/storage/src/source/mysql.rs` to `src/mysql-util/src/decoding.rs`. Some of the error messages were updated, but otherwise this should have no functional differences.

The second commit implements decoding of Decimal / Numeric types (https://dev.mysql.com/doc/refman/8.0/en/fixed-point-types.html) and a test to validate them.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
