### PR TITLE
Frontegg auth redux

### DIFF
--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -13,6 +13,7 @@ use mz_sql::session::user::SYSTEM_USER;
 use tracing::{error, info};
 
 use crate::config::SynchronizedParameters;
+use crate::session::SessionConfig;
 use crate::{AdapterError, Client, SessionClient};
 
 /// A backend client for pushing and pulling [SynchronizedParameters].
@@ -26,7 +27,11 @@ pub struct SystemParameterBackend {
 impl SystemParameterBackend {
     pub async fn new(client: Client) -> Result<Self, AdapterError> {
         let conn_id = client.new_conn_id()?;
-        let session = client.new_session(conn_id, SYSTEM_USER.clone());
+        let session = client.new_session(SessionConfig {
+            conn_id,
+            user: SYSTEM_USER.name.clone(),
+            external_metadata_rx: None,
+        });
         let session_client = client.startup(session).await?;
         Ok(Self { session_client })
     }

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -30,7 +30,7 @@ use bytes::BytesMut;
 use futures::TryFutureExt;
 use hyper::StatusCode;
 use mz_build_info::{build_info, BuildInfo};
-use mz_frontegg_auth::Authentication as FronteggAuthentication;
+use mz_frontegg_auth::Authenticator as FronteggAuthentication;
 use mz_ore::id_gen::conn_id_org_uuid;
 use mz_ore::metrics::{ComputedGauge, IntCounter, IntGauge, MetricsRegistry};
 use mz_ore::netio::AsyncReady;
@@ -712,11 +712,9 @@ impl Resolver {
                     _ => anyhow::bail!("expected Password message"),
                 };
 
-                let auth_response = auth
-                    .exchange_password_for_token(&password, user.to_string())
-                    .await;
-                let claims = match auth_response {
-                    Ok(result) => result.claims,
+                let auth_response = auth.authenticate(user.into(), &password).await;
+                let auth_session = match auth_response {
+                    Ok(auth_session) => auth_session,
                     Err(e) => {
                         warn!("pgwire connection failed authentication: {}", e);
                         // TODO: fix error codes.
@@ -724,7 +722,7 @@ impl Resolver {
                     }
                 };
 
-                let addr = addr_template.replace("{}", &claims.tenant_id.to_string());
+                let addr = addr_template.replace("{}", &auth_session.tenant_id().to_string());
                 let addr = lookup(&addr).await?;
                 Ok(ResolvedAddr {
                     addr,

--- a/src/balancerd/src/service.rs
+++ b/src/balancerd/src/service.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use anyhow::Context;
 use jsonwebtoken::DecodingKey;
 use mz_balancerd::{BalancerConfig, BalancerService, FronteggResolver, Resolver, BUILD_INFO};
-use mz_frontegg_auth::{Authentication, AuthenticationConfig};
+use mz_frontegg_auth::{Authenticator, AuthenticatorConfig};
 use mz_ore::metrics::MetricsRegistry;
 use mz_server_core::TlsCliArgs;
 use tracing::warn;
@@ -87,8 +87,8 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
     let metrics_registry = MetricsRegistry::new();
     let resolver = match (args.static_resolver_addr, args.frontegg_resolver_template) {
         (None, Some(addr_template)) => {
-            let auth = Authentication::new(
-                AuthenticationConfig {
+            let auth = Authenticator::new(
+                AuthenticatorConfig {
                     admin_api_token_url: args.frontegg_api_token_url.expect("clap enforced"),
                     decoding_key: match (args.frontegg_jwk, args.frontegg_jwk_file) {
                         (None, Some(path)) => {

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -20,7 +20,7 @@ use jsonwebtoken::{DecodingKey, EncodingKey};
 use mz_balancerd::{BalancerConfig, BalancerService, FronteggResolver, Resolver, BUILD_INFO};
 use mz_environmentd::test_util::{self, make_pg_tls, Ca};
 use mz_frontegg_auth::{
-    Authentication as FronteggAuthentication, AuthenticationConfig as FronteggConfig,
+    Authenticator as FronteggAuthentication, AuthenticatorConfig as FronteggConfig,
 };
 use mz_frontegg_mock::FronteggMockServer;
 use mz_ore::cast::CastFrom;

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -31,7 +31,7 @@ use mz_catalog::config::ClusterReplicaSizeMap;
 use mz_cloud_resources::{AwsExternalIdPrefix, CloudResourceController};
 use mz_controller::ControllerConfig;
 use mz_environmentd::{CatalogConfig, Listeners, ListenersConfig, BUILD_INFO};
-use mz_frontegg_auth::{Authentication, FronteggCliArgs};
+use mz_frontegg_auth::{Authenticator, FronteggCliArgs};
 use mz_orchestrator::Orchestrator;
 use mz_orchestrator_kubernetes::{
     KubernetesImagePullPolicy, KubernetesOrchestrator, KubernetesOrchestratorConfig,
@@ -633,7 +633,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
 
     // Configure connections.
     let tls = args.tls.into_config()?;
-    let frontegg = Authentication::from_args(args.frontegg, &metrics_registry)?;
+    let frontegg = Authenticator::from_args(args.frontegg, &metrics_registry)?;
 
     // Configure CORS.
     let allowed_origins = if !args.cors_allowed_origin.is_empty() {

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -35,7 +35,7 @@ use headers::{HeaderMapExt, HeaderName};
 use http::header::{AUTHORIZATION, CONTENT_TYPE};
 use http::{Method, Request, StatusCode};
 use hyper_openssl::MaybeHttpsStream;
-use mz_adapter::session::Session;
+use mz_adapter::session::{Session, SessionConfig};
 use mz_adapter::{AdapterError, AdapterNotice, Client, SessionClient, WebhookAppenderCache};
 use mz_frontegg_auth::{
     Authentication as FronteggAuthentication, Error as FronteggError,
@@ -47,9 +47,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::str::StrExt;
 use mz_repr::user::ExternalUserMetadata;
 use mz_server_core::{ConnectionHandler, Server};
-use mz_sql::session::user::{
-    User, HTTP_DEFAULT_USER, SUPPORT_USER, SUPPORT_USER_NAME, SYSTEM_USER, SYSTEM_USER_NAME,
-};
+use mz_sql::session::user::{HTTP_DEFAULT_USER, SUPPORT_USER_NAME, SYSTEM_USER_NAME};
 use mz_sql::session::vars::{
     ConnectionCounter, DropConnection, Value, Var, VarInput, WELCOME_MESSAGE,
 };
@@ -58,8 +56,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
-use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::TryRecvError;
+use tokio::sync::{oneshot, watch};
 use tokio_openssl::SslStream;
 use tower::limit::GlobalConcurrencyLimitLayer;
 use tower::ServiceBuilder;
@@ -495,16 +493,18 @@ async fn internal_http_auth<B>(mut req: Request<B>, next: Next<B>) -> impl IntoR
         .get("x-materialize-user")
         .map(|h| h.to_str())
         .unwrap_or_else(|| Ok(SYSTEM_USER_NAME));
-    let user = match user_name {
-        Ok(SUPPORT_USER_NAME) => AuthedUser(SUPPORT_USER.clone()),
-        Ok(SYSTEM_USER_NAME) => AuthedUser(SYSTEM_USER.clone()),
+    let user_name = match user_name {
+        Ok(name @ (SUPPORT_USER_NAME | SYSTEM_USER_NAME)) => name.to_string(),
         _ => {
             return Err(AuthError::MismatchedUser(format!(
             "user specified in x-materialize-user must be {SUPPORT_USER_NAME} or {SYSTEM_USER_NAME}"
         )));
         }
     };
-    req.extensions_mut().insert(user);
+    req.extensions_mut().insert(AuthedUser {
+        name: user_name,
+        external_metadata_rx: None,
+    });
     Ok(next.run(req).await)
 }
 
@@ -535,7 +535,10 @@ enum ConnProtocol {
 }
 
 #[derive(Clone, Debug)]
-pub struct AuthedUser(User);
+pub struct AuthedUser {
+    name: String,
+    external_metadata_rx: Option<watch::Receiver<ExternalUserMetadata>>,
+}
 
 pub struct AuthedClient {
     pub client: SessionClient,
@@ -553,10 +556,13 @@ impl AuthedClient {
     where
         F: FnOnce(&mut Session),
     {
-        let AuthedUser(user) = user;
-        let drop_connection = DropConnection::new_connection(&user, active_connection_count)?;
+        let drop_connection = DropConnection::new_connection(&user.name, active_connection_count)?;
         let conn_id = adapter_client.new_conn_id()?;
-        let mut session = adapter_client.new_session(conn_id, user);
+        let mut session = adapter_client.new_session(SessionConfig {
+            conn_id,
+            user: user.name,
+            external_metadata_rx: user.external_metadata_rx,
+        });
         session_config(&mut session);
         for (key, val) in options {
             const LOCAL: bool = false;
@@ -837,17 +843,11 @@ async fn auth(
     // that is also present.
 
     // Then, handle Frontegg authentication if required.
-    let user = match (frontegg, creds) {
+    let (name, external_metadata_rx) = match (frontegg, creds) {
         // If no Frontegg authentication, allow the default user.
-        (None, Credentials::DefaultUser) => User {
-            name: HTTP_DEFAULT_USER.name.to_string(),
-            external_metadata: None,
-        },
+        (None, Credentials::DefaultUser) => (HTTP_DEFAULT_USER.name.to_string(), None),
         // If no Frontegg authentication, allow a protocol-specified user.
-        (None, Credentials::User(name)) => User {
-            name,
-            external_metadata: None,
-        },
+        (None, Credentials::User(name)) => (name, None),
         // With frontegg disabled, specifying credentials is an error.
         (None, _) => return Err(AuthError::UnexpectedCredentials),
         // If we require Frontegg auth, fetch credentials from the HTTP auth
@@ -871,20 +871,21 @@ async fn auth(
                     return Err(AuthError::MissingHttpAuthentication)
                 }
             };
-            User {
-                external_metadata: Some(ExternalUserMetadata {
-                    user_id: claims.user_id,
-                    admin: claims.is_admin,
-                }),
-                name: claims.email,
-            }
+            let (_, external_metadata_rx) = watch::channel(ExternalUserMetadata {
+                user_id: claims.user_id,
+                admin: claims.is_admin,
+            });
+            (claims.email, Some(external_metadata_rx))
         }
     };
 
-    if mz_adapter::catalog::is_reserved_role_name(user.name.as_str()) {
-        return Err(AuthError::InvalidLogin(user.name));
+    if mz_adapter::catalog::is_reserved_role_name(name.as_str()) {
+        return Err(AuthError::InvalidLogin(name));
     }
-    Ok(AuthedUser(user))
+    Ok(AuthedUser {
+        name,
+        external_metadata_rx,
+    })
 }
 
 /// Configuration for [`base_router`].

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -37,10 +37,7 @@ use http::{Method, Request, StatusCode};
 use hyper_openssl::MaybeHttpsStream;
 use mz_adapter::session::{Session, SessionConfig};
 use mz_adapter::{AdapterError, AdapterNotice, Client, SessionClient, WebhookAppenderCache};
-use mz_frontegg_auth::{
-    Authentication as FronteggAuthentication, Error as FronteggError,
-    ExchangePasswordForTokenResponse,
-};
+use mz_frontegg_auth::{Authenticator as FronteggAuthentication, Error as FronteggError};
 use mz_http_util::DynamicFilterTarget;
 use mz_ore::cast::u64_to_usize;
 use mz_ore::metrics::MetricsRegistry;
@@ -855,28 +852,25 @@ async fn auth(
         // is the client+secret pair. Bearer auth is an existing JWT that must
         // be validated. In either case, if a username was specified in the
         // client cert, it must match that of the JWT.
-        (Some(frontegg), creds) => {
-            let claims = match creds {
-                Credentials::Password { username, password } => {
-                    let ExchangePasswordForTokenResponse { claims, .. } = frontegg
-                        .exchange_password_for_token(&password, username)
-                        .await?;
-                    claims
-                }
-                Credentials::Token { token } => {
-                    let claims = frontegg.validate_access_token(&token, None)?;
-                    claims
-                }
-                Credentials::DefaultUser | Credentials::User(_) => {
-                    return Err(AuthError::MissingHttpAuthentication)
-                }
-            };
-            let (_, external_metadata_rx) = watch::channel(ExternalUserMetadata {
-                user_id: claims.user_id,
-                admin: claims.is_admin,
-            });
-            (claims.email, Some(external_metadata_rx))
-        }
+        (Some(frontegg), creds) => match creds {
+            Credentials::Password { username, password } => {
+                let auth_session = frontegg.authenticate(&username, &password).await?;
+                let user = auth_session.user().into();
+                let external_metadata_rx = Some(auth_session.external_metadata_rx());
+                (user, external_metadata_rx)
+            }
+            Credentials::Token { token } => {
+                let claims = frontegg.validate_access_token(&token, None)?;
+                let (_, external_metadata_rx) = watch::channel(ExternalUserMetadata {
+                    user_id: claims.user_id,
+                    admin: claims.is_admin,
+                });
+                (claims.email, Some(external_metadata_rx))
+            }
+            Credentials::DefaultUser | Credentials::User(_) => {
+                return Err(AuthError::MissingHttpAuthentication)
+            }
+        },
     };
 
     if mz_adapter::catalog::is_reserved_role_name(name.as_str()) {

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -33,7 +33,7 @@ use mz_catalog::config::ClusterReplicaSizeMap;
 use mz_catalog::durable::{BootstrapArgs, CatalogError, OpenableDurableCatalogState, StashConfig};
 use mz_cloud_resources::CloudResourceController;
 use mz_controller::ControllerConfig;
-use mz_frontegg_auth::Authentication as FronteggAuthentication;
+use mz_frontegg_auth::Authenticator as FronteggAuthentication;
 use mz_ore::future::OreFutureExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -28,7 +28,7 @@ use jsonwebtoken::{self, DecodingKey, EncodingKey};
 use mz_environmentd::test_util::{self, make_header, make_pg_tls, Ca};
 use mz_environmentd::{WebSocketAuth, WebSocketResponse};
 use mz_frontegg_auth::{
-    Authentication as FronteggAuthentication, AuthenticationConfig as FronteggConfig, Claims,
+    Authenticator as FronteggAuthentication, AuthenticatorConfig as FronteggConfig, Claims,
 };
 use mz_frontegg_mock::FronteggMockServer;
 use mz_ore::assert_contains;

--- a/src/frontegg-auth/src/app_password.rs
+++ b/src/frontegg-auth/src/app_password.rs
@@ -34,7 +34,7 @@ pub const PREFIX: &str = "mzp_";
 ///     This format allows for the UUIDs to be formatted with hyphens, or
 ///     not.
 ///
-#[derive(Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AppPassword {
     /// The client ID embedded in the app password.
     pub client_id: Uuid,

--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -299,23 +299,6 @@ impl Authentication {
         Ok(result)
     }
 
-    /// Validates an API token response, returning a validated response
-    /// containing the validated claims.
-    ///
-    /// Like [`Authentication::validate_access_token`], but operates on an
-    /// [`ApiTokenResponse`] rather than a raw access token.
-    pub fn validate_api_token_response(
-        &self,
-        response: ApiTokenResponse,
-        expected_email: Option<&str>,
-    ) -> Result<ValidatedApiTokenResponse, Error> {
-        let claims = self.validate_access_token(&response.access_token, expected_email)?;
-        Ok(ValidatedApiTokenResponse {
-            claims,
-            refresh_token: response.refresh_token,
-        })
-    }
-
     /// Validates an access token, returning the validated claims.
     ///
     /// The following validations are always performed:
@@ -531,15 +514,6 @@ fn continuously_refresh(
     });
 
     id
-}
-
-/// An [`ApiTokenResponse`] that has been validated by
-/// [`Authentication::validate_api_token_response`].
-pub struct ValidatedApiTokenResponse {
-    /// The validated claims.
-    pub claims: ValidatedClaims,
-    /// The refresh token from the API response.
-    pub refresh_token: String,
 }
 
 // TODO: Do we care about the sub? Do we need to validate the sub or other

--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -7,31 +7,34 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use anyhow::Context;
+use anyhow::Context as _;
 use derivative::Derivative;
-use futures::future::BoxFuture;
+use futures::future::Shared;
+use futures::FutureExt;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation};
-use mz_ore::cast::{CastLossy, ReinterpretCast};
-use mz_ore::collections::HashMap;
+use mz_ore::cast::CastLossy;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 use mz_repr::user::ExternalUserMetadata;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{oneshot, watch};
+use tokio::sync::watch;
+use tokio::time;
+use tracing::{debug_span, instrument, trace, warn, Instrument};
 use uuid::Uuid;
 
 use crate::metrics::Metrics;
-use crate::{ApiTokenArgs, ApiTokenResponse, AppPassword, Client, Error, FronteggCliArgs};
+use crate::{ApiTokenArgs, AppPassword, Client, Error, FronteggCliArgs};
 
-pub const REFRESH_SUFFIX: &str = "/token/refresh";
-
+/// Configures an [`Authenticator`].
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
-pub struct AuthenticationConfig {
+pub struct AuthenticatorConfig {
     /// URL for the token endpoint, including full path.
     pub admin_api_token_url: String,
     /// JWK used to validate JWTs.
@@ -47,56 +50,13 @@ pub struct AuthenticationConfig {
 
 /// Facilitates authenticating users via Frontegg, and verifying returned JWTs.
 #[derive(Clone, Debug)]
-pub struct Authentication {
-    /// Configuration for validating JWTs.
-    validation_config: ValidationConfig,
-
-    /// Metrics to track the performance of Frontegg.
-    metrics: Metrics,
-
-    /// URL for the token endpoint, including full path.
-    admin_api_token_url: String,
-    /// HTTP client for making requests.
-    client: Client,
-    /// Map of inflight authentication requests, used for de-duplicating requests.
-    inflight_auth_requests: Arc<Mutex<HashMap<ApiTokenArgs, ResponseHandles>>>,
+pub struct Authenticator {
+    inner: Arc<AuthenticatorInner>,
 }
 
-type ResponseHandles =
-    Vec<oneshot::Sender<Result<(ExchangePasswordForTokenResponse, RefreshTaskId), Error>>>;
-
-/// An ID emitted in logs to help debug.
-#[derive(Copy, Clone, Debug)]
-pub struct RefreshTaskId(Uuid);
-
-impl RefreshTaskId {
-    /// Generates a new [`RefreshTaskId`].
-    pub fn new() -> Self {
-        RefreshTaskId(uuid::Uuid::new_v4())
-    }
-}
-
-impl fmt::Display for RefreshTaskId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-#[derive(Derivative)]
-#[derivative(Debug)]
-pub struct ExchangePasswordForTokenResponse {
-    /// Validated JWT.
-    pub claims: ValidatedClaims,
-    /// Recieves periodic updates of [`ExternalUserMetadata`] when the initial JWT is refreshed.
-    pub refresh_updates: watch::Receiver<ExternalUserMetadata>,
-    /// Our current authentication is valid, until this Future resolves.
-    #[derivative(Debug = "ignore")]
-    pub valid_until_fut: BoxFuture<'static, ()>,
-}
-
-impl Authentication {
-    /// Creates a new frontegg auth.
-    pub fn new(config: AuthenticationConfig, client: Client, registry: &MetricsRegistry) -> Self {
+impl Authenticator {
+    /// Creates a new authenticator.
+    pub fn new(config: AuthenticatorConfig, client: Client, registry: &MetricsRegistry) -> Self {
         let mut validation = Validation::new(Algorithm::RS256);
 
         // We validate the token expiration with our own now function.
@@ -117,23 +77,20 @@ impl Authentication {
         // [0]: https://materializeinc.slack.com/archives/C02940WNMRQ/p1704131331041669
         validation.validate_aud = false;
 
-        let validation_config = ValidationConfig {
-            decoding_key: config.decoding_key,
-            tenant_id: config.tenant_id,
-            now: config.now,
-            admin_role: config.admin_role,
-            validation,
-        };
-
-        let inflight_auth_requests = Arc::new(Mutex::new(HashMap::new()));
         let metrics = Metrics::register_into(registry);
-
-        Self {
-            validation_config,
-            metrics,
-            admin_api_token_url: config.admin_api_token_url,
-            client,
-            inflight_auth_requests,
+        let sessions = Mutex::new(BTreeMap::new());
+        Authenticator {
+            inner: Arc::new(AuthenticatorInner {
+                admin_api_token_url: config.admin_api_token_url,
+                client,
+                validation,
+                decoding_key: config.decoding_key,
+                tenant_id: config.tenant_id,
+                admin_role: config.admin_role,
+                now: config.now,
+                sessions,
+                metrics,
+            }),
         }
     }
 
@@ -165,7 +122,7 @@ impl Authentication {
                         .into())
                     }
                 };
-                AuthenticationConfig {
+                AuthenticatorConfig {
                     admin_api_token_url,
                     decoding_key,
                     tenant_id: Some(tenant_id),
@@ -180,123 +137,82 @@ impl Authentication {
         Ok(Some(Self::new(config, client, registry)))
     }
 
-    /// Exchanges a password for an access token and a refresh token.
-    pub async fn exchange_password_for_token(
+    /// Establishes a new authentication session.
+    ///
+    /// If successful, returns a handle to the authentication session.
+    /// Otherwise, returns the authentication error.
+    pub async fn authenticate(
         &self,
+        expected_email: &str,
         password: &str,
-        expected_email: String,
-    ) -> Result<ExchangePasswordForTokenResponse, Error> {
+    ) -> Result<AuthSessionHandle, Error> {
         let password: AppPassword = password.parse()?;
-        let req = ApiTokenArgs {
-            client_id: password.client_id,
-            secret: password.secret_key,
-        };
+        match self.authenticate_inner(expected_email, password).await {
+            Ok(handle) => {
+                trace!("authentication successful");
+                Ok(handle)
+            }
+            Err(e) => {
+                trace!(error = ?e, "authentication failed");
+                Err(e)
+            }
+        }
+    }
 
-        // Note: we get the reciever in a block to scope the access to the mutex.
-        let rx = {
-            let mut inflight = self
-                .inflight_auth_requests
-                .lock()
-                .expect("Frontegg Auth Client panicked");
-            let (tx, rx) = tokio::sync::oneshot::channel();
+    #[instrument(level = "trace", skip(password), fields(client_id = %password.client_id))]
+    async fn authenticate_inner(
+        &self,
+        expected_email: &str,
+        password: AppPassword,
+    ) -> Result<AuthSessionHandle, Error> {
+        let request = {
+            let mut sessions = self.inner.sessions.lock().expect("lock poisoned");
+            match sessions.get_mut(&password) {
+                // We have an existing session for this app password.
+                Some(AuthSession::Active {
+                    ident,
+                    external_metadata_tx,
+                    ..
+                }) => {
+                    trace!("joining active session");
 
-            match inflight.get_mut(&req) {
-                // Already have an inflight request, add to our list of waiters.
-                Some(senders) => {
-                    tracing::debug!(?req, "reusing request");
-                    senders.push(tx);
-                    rx
+                    validate_email(&ident.user, expected_email)?;
+
+                    // Return a handle to the existing session.
+                    return Ok(AuthSessionHandle {
+                        ident: Arc::clone(ident),
+                        external_metadata_rx: external_metadata_tx.subscribe(),
+                    });
                 }
-                // New request! Need to queue one up.
+
+                // We have an in flight request to establish a session.
+                Some(AuthSession::Pending(request)) => {
+                    // Latch on to the existing session.
+                    trace!("joining pending session");
+                    request.clone()
+                }
+
+                // We do not have an existing session for this API key.
                 None => {
-                    tracing::debug!(?req, "spawning new request");
+                    trace!("starting new session");
 
-                    inflight.insert(req.clone(), vec![tx]);
-                    // Explicitly drop the lock guard.
-                    drop(inflight);
-
-                    let client = self.client.clone();
-                    let inflight = Arc::clone(&self.inflight_auth_requests);
-                    let req_ = req.clone();
-                    let url = self.admin_api_token_url.clone();
-                    let validate_config = self.validation_config.clone();
-                    let metrics = self.metrics.clone();
-
-                    let name = format!("frontegg-auth-request-{}", req.client_id);
-                    mz_ore::task::spawn(move || name, async move {
-                        // Make the actual request.
-                        let result = client
-                            .exchange_client_secret_for_token(req_, &url, &metrics)
-                            .await;
-
-                        // Validate the returned JWT.
-                        let validated_result = result.and_then(|api_resp| {
-                            validate_access_token(
-                                &validate_config,
-                                &api_resp.access_token,
-                                Some(&expected_email),
-                            )
-                            .map(|claims| (api_resp, claims))
-                        });
-
-                        // Get all of our waiters.
-                        let mut inflight = inflight.lock().expect("Frontegg Auth Client panicked");
-                        let Some(waiters) = inflight.remove(&req) else {
-                            tracing::error!(?req, "Inflight entry already removed?");
-                            return;
-                        };
-
-                        // If the request failed then notify and bail.
-                        let (api_resp, claims) = match validated_result {
-                            Err(err) => {
-                                tracing::warn!(?err, "failed to exchange secret for token");
-                                for tx in waiters {
-                                    let _ = tx.send(Err(err.clone()));
-                                }
-                                return;
-                            }
-                            Ok(result) => result,
-                        };
-
-                        // Spawn a task to continuously refresh our token.
-                        let external_metadata = ExternalUserMetadata {
-                            user_id: claims.user_id,
-                            admin: claims.is_admin,
-                        };
-                        let (refresh_tx, refresh_rx) = watch::channel(external_metadata);
-                        let id = continuously_refresh(
-                            &url,
-                            client,
-                            metrics,
-                            api_resp,
-                            expected_email,
-                            validate_config,
-                            refresh_tx,
-                        );
-
-                        // Respond to all of our waiters.
-                        for tx in waiters {
-                            let valid_until_fut = make_valid_until_future(&refresh_rx);
-                            let resp = ExchangePasswordForTokenResponse {
-                                claims: claims.clone(),
-                                refresh_updates: refresh_rx.clone(),
-                                valid_until_fut,
-                            };
-                            let _ = tx.send(Ok((resp, id)));
-                        }
+                    // Prepare the request to create a new session.
+                    let request: Pin<Box<AuthFuture>> = Box::pin({
+                        let inner = Arc::clone(&self.inner);
+                        let expected_email = String::from(expected_email);
+                        async move { inner.authenticate(expected_email, password).await }
                     });
 
-                    rx
+                    // Store the future so that future requests can latch on.
+                    let request = request.shared();
+                    sessions.insert(password, AuthSession::Pending(request.clone()));
+
+                    // Wait for the request to complete.
+                    request
                 }
             }
         };
-
-        let resp = rx.await.context("waiting for inflight response")?;
-
-        let (result, id) = resp?;
-        tracing::debug!(?id, "token being refreshed");
-
-        Ok(result)
+        request.await
     }
 
     /// Validates an access token, returning the validated claims.
@@ -314,206 +230,250 @@ impl Authentication {
         token: &str,
         expected_email: Option<&str>,
     ) -> Result<ValidatedClaims, Error> {
-        validate_access_token(&self.validation_config, token, expected_email)
+        self.inner.validate_access_token(token, expected_email)
     }
 }
 
-#[derive(Clone, Derivative)]
+/// A handle to an authentication session.
+///
+/// An authentication session represents a duration of time during which a
+/// user's authentication is known to be valid.
+///
+/// An authentication session begins with a successful API key exchange with
+/// Frontegg. While there is at least one outstanding handle to the session, the
+/// session's metadata and validity are refreshed with Frontegg at a regular
+/// interval. The session ends when all outstanding handles are dropped and the
+/// refresh interval is reached.
+///
+/// [`AuthSessionHandle::external_metadata_rx`] can be used to receive events if
+/// the session's metadata is updated.
+///
+/// [`AuthSessionHandle::expired`] can be used to learn if the session has
+/// failed to refresh the validity of the API key.
+#[derive(Debug, Clone)]
+pub struct AuthSessionHandle {
+    ident: Arc<AuthSessionIdent>,
+    external_metadata_rx: watch::Receiver<ExternalUserMetadata>,
+}
+
+impl AuthSessionHandle {
+    /// Returns the name of the user that created the session.
+    pub fn user(&self) -> &str {
+        &self.ident.user
+    }
+
+    /// Returns the ID of the tenant that created the session.
+    pub fn tenant_id(&self) -> Uuid {
+        self.ident.tenant_id
+    }
+
+    /// Mints a receiver for updates to the session user's external metadata.
+    pub fn external_metadata_rx(&self) -> watch::Receiver<ExternalUserMetadata> {
+        self.external_metadata_rx.clone()
+    }
+
+    /// Completes when the authentication session has expired.
+    pub async fn expired(&mut self) {
+        // We piggyback on the external metadata channel to determine session
+        // expiration. The external metadata channel is closed when the session
+        // expires.
+        let _ = self.external_metadata_rx.wait_for(|_| false).await;
+    }
+}
+
+#[derive(Derivative)]
 #[derivative(Debug)]
-pub struct ValidationConfig {
-    /// Fields of a JWT that we validate.
-    pub validation: Validation,
-    /// JWK used to validate JWTs.
-    #[derivative(Debug = "ignore")]
-    pub decoding_key: DecodingKey,
-    /// Tenant id used to validate JWTs.
-    pub tenant_id: Option<Uuid>,
-    /// Function to provide system time to validate exp (expires at) field of JWTs.
-    pub now: NowFn,
-    /// Name of admin role.
-    pub admin_role: String,
-}
-
-/// Validates the provided JSON web token, returning [`ValidatedClaims`].
-fn validate_access_token(
-    config: &ValidationConfig,
-    jwt: &str,
-    expected_email: Option<&str>,
-) -> Result<ValidatedClaims, Error> {
-    let msg = jsonwebtoken::decode::<Claims>(jwt, &config.decoding_key, &config.validation)?;
-    if msg.claims.exp < config.now.as_secs() {
-        return Err(Error::TokenExpired);
-    }
-    if let Some(expected_tenant_id) = config.tenant_id {
-        if msg.claims.tenant_id != expected_tenant_id {
-            return Err(Error::UnauthorizedTenant);
-        }
-    }
-    if let Some(expected_email) = expected_email {
-        // To match Frontegg, email addresses are compared case
-        // insensitively.
-        //
-        // NOTE(benesch): we could save some allocations by using
-        // `unicase::eq` here, but the `unicase` crate has had some critical
-        // correctness bugs that make it scary to use in such
-        // security-sensitive code.
-        //
-        // See: https://github.com/seanmonstar/unicase/pull/39
-        if msg.claims.email.to_lowercase() != expected_email.to_lowercase() {
-            return Err(Error::WrongEmail);
-        }
-    }
-    Ok(ValidatedClaims {
-        exp: msg.claims.exp,
-        email: msg.claims.email,
-        tenant_id: msg.claims.tenant_id,
-        // If the claims come from the exchange of an API token, the `sub`
-        // will be the ID of the API token and the user ID will be in the
-        // `user_id` field. If the claims come from the exchange of a
-        // username and password, the `sub` is the user ID and the `user_id`
-        // field will not be present. This makes sense once you think about
-        // it, but is confusing enough that we massage into a single
-        // `user_id` field that always contains the user ID.
-        user_id: msg.claims.user_id.unwrap_or(msg.claims.sub),
-        // The user is an administrator if they have the admin role that the
-        // `Authenticator` has been configured with.
-        is_admin: msg.claims.roles.iter().any(|r| *r == config.admin_role),
-        _private: (),
-    })
-}
-
-/// Returns a [`Duration`] for how long the provided claims are valid for.
-fn valid_for(now: &NowFn, claims: &ValidatedClaims) -> Duration {
-    let valid_for = claims.exp - now.as_secs();
-    let valid_for = u64::try_from(valid_for).unwrap_or(0);
-
-    Duration::from_secs(valid_for)
-}
-
-/// Returns a `Future` that resolves when the sending side of the provided channel closes.
-fn make_valid_until_future(
-    refresh_rx: &watch::Receiver<ExternalUserMetadata>,
-) -> BoxFuture<'static, ()> {
-    // Our auth is valid for as long as the sender is alive.
-    let mut refresh_rx = refresh_rx.clone();
-    let future = async move { while let Ok(_) = refresh_rx.changed().await {} };
-    Box::pin(future)
-}
-
-/// Spawns a task that will continuously refresh the `RefreshToken` provided in `first_response`.
-fn continuously_refresh(
-    admin_api_token_url: &str,
+struct AuthenticatorInner {
+    // Frontegg API fields.
+    admin_api_token_url: String,
     client: Client,
+    // JWT decoding and validation fields.
+    validation: Validation,
+    #[derivative(Debug = "ignore")]
+    decoding_key: DecodingKey,
+    tenant_id: Option<Uuid>,
+    admin_role: String,
+    now: NowFn,
+    // Session tracking.
+    sessions: Mutex<BTreeMap<AppPassword, AuthSession>>,
+    // Metrics.
     metrics: Metrics,
-    first_response: ApiTokenResponse,
-    expected_email: String,
-    validation_config: ValidationConfig,
-    refresh_tx: watch::Sender<ExternalUserMetadata>,
-) -> RefreshTaskId {
-    let refresh_url = format!("{}{}", admin_api_token_url, REFRESH_SUFFIX);
-    let id = RefreshTaskId::new();
+}
 
-    // Continuously refresh.
-    let name = format!("frontegg-auth-refresh-{}", id);
-    mz_ore::task::spawn(|| name, async move {
-        tracing::debug!(?id, "starting refresh task");
-        let mut latest_response = first_response;
+impl AuthenticatorInner {
+    async fn authenticate(
+        self: &Arc<Self>,
+        expected_email: String,
+        password: AppPassword,
+    ) -> Result<AuthSessionHandle, Error> {
+        // Attempt initial app password exchange.
+        let mut claims = self
+            .exchange_app_password(&expected_email, password)
+            .await?;
 
-        let gauge = metrics.refresh_tasks_active.with_label_values(&[]);
-        gauge.inc();
+        // Prep session information.
+        let ident = Arc::new(AuthSessionIdent {
+            user: claims.email.clone(),
+            tenant_id: claims.tenant_id,
+        });
+        let external_metadata = claims.to_external_user_metadata();
+        let (external_metadata_tx, external_metadata_rx) = watch::channel(external_metadata);
+        let external_metadata_tx = Arc::new(external_metadata_tx);
 
-        loop {
-            // If the token is not valid, close the channel.
-            let validated = validate_access_token(
-                &validation_config,
-                &latest_response.access_token,
-                Some(&expected_email),
-            );
-            let claims = match validated {
-                Err(err) => {
-                    tracing::warn!(?id, ?err, "Token expired!");
-                    drop(refresh_tx);
-                    break;
-                }
-                Ok(claims) => claims,
-            };
-            let valid_for = valid_for(&validation_config.now, &claims);
-
-            // Notify listeners that we've refreshed.
-            let metadata = ExternalUserMetadata {
-                user_id: claims.user_id,
-                admin: claims.is_admin,
-            };
-            if let Err(_) = refresh_tx.send(metadata) {
-                tracing::info!(?id, "All listeners disappeared");
-                break;
-            }
-
-            // Odd, but guards against a negative "expires_in" value.
-            let expires_in = latest_response.expires_in.max(60);
-            // Safe because we know expires_in will always be positive.
-            let expires_in = u64::reinterpret_cast(expires_in);
-            // Need to to be a float so we can scale the value.
-            let expires_in = f64::cast_lossy(expires_in);
-
-            // The Frontegg Python SDK scales the expires_in this way.
-            //
-            // <https://github.com/frontegg/python-sdk/blob/840f8318aced35cea6a41d83270597edfceb4019/frontegg/common/frontegg_authenticator.py#L45>
-            let scaled_expires_in = expires_in * 0.8;
-            let scaled_expires_in = Duration::from_secs_f64(scaled_expires_in);
-            tracing::debug!(?id, ?expires_in, ?scaled_expires_in, "waiting to refresh");
-
-            // Weird. The token would expire before the refresh token window.
-            let refresh_in = if valid_for < scaled_expires_in {
-                tracing::warn!(
-                    ?id,
-                    ?valid_for,
-                    ?scaled_expires_in,
-                    "refresh after token expires"
-                );
-                valid_for.saturating_sub(Duration::from_secs(10))
-            } else {
-                scaled_expires_in
-            };
-
-            // While we wait for the refresh, continuously check if our listeners went away.
-            tokio::select! {
-                // Waiting on a tokio::Sleep is cancel safe.
-                _ = tokio::time::sleep(refresh_in) => (),
-                // Checking if the channel closed is cancel safe.
-                _ = refresh_tx.closed() => {
-                    tracing::debug!(?id, "channel closed, exiting");
-                    break;
+        // Store session to make it available for future requests to latch on
+        // to.
+        {
+            let mut sessions = self.sessions.lock().expect("lock poisoned");
+            sessions.insert(
+                password,
+                AuthSession::Active {
+                    ident: Arc::clone(&ident),
+                    external_metadata_tx: Arc::clone(&external_metadata_tx),
                 },
-            }
-
-            let current_response = client
-                .refresh_token(&refresh_url, &latest_response.refresh_token, &metrics)
-                .await;
-
-            // If we failed to refresh, then close the channel.
-            let current_response = match current_response {
-                Ok(resp) => {
-                    tracing::debug!(?id, "refresh successful");
-                    resp
-                }
-                Err(err) => {
-                    tracing::warn!(?id, ?err, "failed to refresh");
-
-                    // Dropping the channel will close it.
-                    drop(refresh_tx);
-                    break;
-                }
-            };
-
-            latest_response = current_response;
+            );
         }
 
-        gauge.dec();
-        tracing::debug!(?id, "shutting down refresh task");
-    });
+        // Start background refresh task.
+        let name = format!("frontegg-auth-refresh-{}", password.client_id);
+        mz_ore::task::spawn(|| name, {
+            let inner = Arc::clone(self);
+            async move {
+                let gauge = inner.metrics.refresh_tasks_active.with_label_values(&[]);
+                gauge.inc();
 
-    id
+                loop {
+                    // Scale the validity duration by 0.8. The Frontegg Python
+                    // SDK scales the expires_in this way.
+                    //
+                    // <https://github.com/frontegg/python-sdk/blob/840f8318aced35cea6a41d83270597edfceb4019/frontegg/common/frontegg_authenticator.py#L45>
+                    let valid_for = claims.exp - inner.now.as_secs();
+                    let valid_for = f64::cast_lossy(valid_for) * 0.8;
+                    let valid_for = u64::cast_lossy(valid_for);
+
+                    if valid_for < 60 {
+                        warn!(%valid_for, "unexpectedly low token validity");
+                    }
+
+                    trace!(%valid_for, "waiting for token validity period");
+
+                    // Wait out validity duration.
+                    time::sleep(Duration::from_secs(valid_for)).await;
+
+                    // Check to see if all external metadata receivers have gone
+                    // away. If no one is listening, we can clean up the
+                    // session.
+                    let receiver_count = external_metadata_tx.receiver_count();
+                    if receiver_count == 0 {
+                        trace!("all listeners have dropped");
+                        break;
+                    }
+
+                    trace!(receiver_count, "refreshing due to outstanding listeners");
+
+                    // We still have listeners. Attempt to refresh the session.
+                    let res = inner.exchange_app_password(&expected_email, password).await;
+                    claims = match res {
+                        Ok(claims) => {
+                            trace!("refresh successful");
+                            claims
+                        }
+                        Err(e) => {
+                            trace!(error = ?e, "refresh failed");
+                            break;
+                        }
+                    };
+                    external_metadata_tx.send_replace(ExternalUserMetadata {
+                        admin: claims.is_admin,
+                        user_id: claims.user_id,
+                    });
+                }
+
+                // The session has expired. Clean up the state.
+                {
+                    let mut sessions = inner.sessions.lock().expect("lock poisoned");
+                    sessions.remove(&password);
+                }
+                gauge.dec();
+            }
+            .instrument(debug_span!("frontegg_auth_refresh_task", client_id = %password.client_id))
+        });
+
+        // Return handle to session.
+        Ok(AuthSessionHandle {
+            ident,
+            external_metadata_rx,
+        })
+    }
+
+    async fn exchange_app_password(
+        &self,
+        expected_email: &str,
+        password: AppPassword,
+    ) -> Result<ValidatedClaims, Error> {
+        let req = ApiTokenArgs {
+            client_id: password.client_id,
+            secret: password.secret_key,
+        };
+        let res = self
+            .client
+            .exchange_client_secret_for_token(req, &self.admin_api_token_url, &self.metrics)
+            .await?;
+        self.validate_access_token(&res.access_token, Some(expected_email))
+    }
+
+    fn validate_access_token(
+        &self,
+        token: &str,
+        expected_email: Option<&str>,
+    ) -> Result<ValidatedClaims, Error> {
+        let msg = jsonwebtoken::decode::<Claims>(token, &self.decoding_key, &self.validation)?;
+        if msg.claims.exp < self.now.as_secs() {
+            return Err(Error::TokenExpired);
+        }
+        if let Some(expected_tenant_id) = self.tenant_id {
+            if msg.claims.tenant_id != expected_tenant_id {
+                return Err(Error::UnauthorizedTenant);
+            }
+        }
+        if let Some(expected_email) = expected_email {
+            validate_email(&msg.claims.email, expected_email)?;
+        }
+        Ok(ValidatedClaims {
+            exp: msg.claims.exp,
+            email: msg.claims.email,
+            tenant_id: msg.claims.tenant_id,
+            // If the claims come from the exchange of an API token, the `sub`
+            // will be the ID of the API token and the user ID will be in the
+            // `user_id` field. If the claims come from the exchange of a
+            // username and password, the `sub` is the user ID and the `user_id`
+            // field will not be present. This makes sense once you think about
+            // it, but is confusing enough that we massage into a single
+            // `user_id` field that always contains the user ID.
+            user_id: msg.claims.user_id.unwrap_or(msg.claims.sub),
+            // The user is an administrator if they have the admin role that the
+            // `Authenticator` has been configured with.
+            is_admin: msg.claims.roles.iter().any(|r| *r == self.admin_role),
+            _private: (),
+        })
+    }
+}
+
+type AuthFuture = dyn Future<Output = Result<AuthSessionHandle, Error>> + Send;
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+enum AuthSession {
+    Pending(Shared<Pin<Box<AuthFuture>>>),
+    Active {
+        ident: Arc<AuthSessionIdent>,
+        external_metadata_tx: Arc<watch::Sender<ExternalUserMetadata>>,
+    },
+}
+
+#[derive(Debug)]
+struct AuthSessionIdent {
+    user: String,
+    tenant_id: Uuid,
 }
 
 // TODO: Do we care about the sub? Do we need to validate the sub or other
@@ -551,4 +511,28 @@ pub struct ValidatedClaims {
     pub is_admin: bool,
     // Prevent construction outside of `Authentication::validate_access_token`.
     _private: (),
+}
+
+impl ValidatedClaims {
+    /// Constructs an [`ExternalUserMetadata`] from the claims data.
+    fn to_external_user_metadata(&self) -> ExternalUserMetadata {
+        ExternalUserMetadata {
+            admin: self.is_admin,
+            user_id: self.user_id,
+        }
+    }
+}
+
+fn validate_email(email: &str, expected_email: &str) -> Result<(), Error> {
+    // To match Frontegg, email addresses are compared case insensitively.
+    //
+    // NOTE(benesch): we could save some allocations by using `unicase::eq`
+    // here, but the `unicase` crate has had some critical correctness bugs that
+    // make it scary to use in such security-sensitive code.
+    //
+    // See: https://github.com/seanmonstar/unicase/pull/39
+    if email.to_lowercase() != expected_email.to_lowercase() {
+        return Err(Error::WrongEmail);
+    }
+    Ok(())
 }

--- a/src/frontegg-auth/src/error.rs
+++ b/src/frontegg-auth/src/error.rs
@@ -26,6 +26,8 @@ pub enum Error {
     TokenExpired,
     #[error("unauthorized organization")]
     UnauthorizedTenant,
+    #[error("the app password was not valid")]
+    InvalidAppPassword,
     #[error("email in access token did not match the expected email")]
     WrongEmail,
     #[error("request timeout")]

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -16,8 +16,7 @@ mod metrics;
 use std::path::PathBuf;
 
 pub use auth::{
-    Authentication, AuthenticationConfig, Claims, ExchangePasswordForTokenResponse,
-    ValidatedApiTokenResponse, REFRESH_SUFFIX,
+    Authentication, AuthenticationConfig, Claims, ExchangePasswordForTokenResponse, REFRESH_SUFFIX,
 };
 pub use client::tokens::{ApiTokenArgs, ApiTokenResponse, RefreshToken};
 pub use client::Client;

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -15,10 +15,8 @@ mod metrics;
 
 use std::path::PathBuf;
 
-pub use auth::{
-    Authentication, AuthenticationConfig, Claims, ExchangePasswordForTokenResponse, REFRESH_SUFFIX,
-};
-pub use client::tokens::{ApiTokenArgs, ApiTokenResponse, RefreshToken};
+pub use auth::{Authenticator, AuthenticatorConfig, Claims};
+pub use client::tokens::{ApiTokenArgs, ApiTokenResponse};
 pub use client::Client;
 pub use error::Error;
 use uuid::Uuid;

--- a/src/frontegg-mock/src/lib.rs
+++ b/src/frontegg-mock/src/lib.rs
@@ -18,12 +18,14 @@ use std::time::Duration;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{body, Body, Request, Response, Server as HyperServer};
 use jsonwebtoken::EncodingKey;
-use mz_frontegg_auth::{ApiTokenArgs, ApiTokenResponse, Claims, RefreshToken, REFRESH_SUFFIX};
+use mz_frontegg_auth::{ApiTokenArgs, ApiTokenResponse, Claims};
 use mz_ore::now::NowFn;
 use mz_ore::retry::Retry;
 use mz_ore::task::JoinHandle;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use uuid::Uuid;
+
+const REFRESH_SUFFIX: &str = "/token/refresh";
 
 pub struct FronteggMockServer {
     pub url: String,
@@ -206,4 +208,10 @@ struct Context {
     refreshes: Arc<Mutex<u64>>,
     enable_refresh: Arc<AtomicBool>,
     auth_requests: Arc<Mutex<u64>>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RefreshToken<'a> {
+    refresh_token: &'a str,
 }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -26,9 +26,7 @@ use mz_adapter::{
     AdapterError, AdapterNotice, ExecuteContextExtra, ExecuteResponse, PeekResponseUnary,
     RowsFuture,
 };
-use mz_frontegg_auth::{
-    Authentication as FronteggAuthentication, ExchangePasswordForTokenResponse,
-};
+use mz_frontegg_auth::Authenticator as FronteggAuthentication;
 use mz_ore::cast::CastFrom;
 use mz_ore::netio::AsyncReady;
 use mz_ore::str::StrExt;
@@ -152,7 +150,7 @@ where
         return conn.send(err).await;
     }
 
-    let (mut session, is_expired) = if let Some(frontegg) = frontegg {
+    let (mut session, expired) = if let Some(frontegg) = frontegg {
         conn.send(BackendMessage::AuthenticationCleartextPassword)
             .await?;
         conn.flush().await?;
@@ -168,28 +166,23 @@ where
             }
         };
 
-        let auth_response = frontegg.exchange_password_for_token(&password, user).await;
+        let auth_response = frontegg.authenticate(&user, &password).await;
         match auth_response {
-            Ok(result) => {
-                let ExchangePasswordForTokenResponse {
-                    claims,
-                    refresh_updates,
-                    valid_until_fut,
-                } = result;
-
-                // Create a session based on the validated claims.
+            Ok(mut auth_session) => {
+                // Create a session based on the auth session.
                 //
-                // In particular, it's important that the username come from the claims, as
-                // Frontegg may return an email address with different casing than the user
-                // supplied via the pgwire username field. We want to use the Frontegg casing as
+                // In particular, it's important that the username come from the
+                // auth session, as Frontegg may return an email address with
+                // different casing than the user supplied via the pgwire
+                // username field. We want to use the Frontegg casing as
                 // canonical.
                 let session = adapter_client.new_session(SessionConfig {
                     conn_id: conn.conn_id().clone(),
-                    user: claims.email.clone(),
-                    external_metadata_rx: Some(refresh_updates),
+                    user: auth_session.user().into(),
+                    external_metadata_rx: Some(auth_session.external_metadata_rx()),
                 });
-
-                (session, valid_until_fut.left_future())
+                let expired = async move { auth_session.expired().await };
+                (session, expired.left_future())
             }
             Err(err) => {
                 warn!(?err, "pgwire connection failed authentication");
@@ -207,9 +200,9 @@ where
             user,
             external_metadata_rx: None,
         });
-        // No frontegg check, so is_expired never resolves.
-        let is_expired = pending().right_future();
-        (session, is_expired)
+        // No frontegg check, so auth session lasts indefinitely.
+        let auth_session = pending().right_future();
+        (session, auth_session)
     };
 
     for (name, value) in params {
@@ -306,7 +299,7 @@ where
             }
             r
         },
-        _ = is_expired => {
+        _ = expired => {
             conn
                 .send(ErrorResponse::fatal(SqlState::INVALID_AUTHORIZATION_SPECIFICATION, "authentication expired"))
                 .await?;

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -19,7 +19,7 @@ use futures::future::{pending, BoxFuture, FutureExt};
 use itertools::izip;
 use mz_adapter::client::RecordFirstRowStream;
 use mz_adapter::session::{
-    EndTransactionAction, InProgressRows, Portal, PortalState, TransactionStatus,
+    EndTransactionAction, InProgressRows, Portal, PortalState, SessionConfig, TransactionStatus,
 };
 use mz_adapter::statement_logging::StatementEndedExecutionReason;
 use mz_adapter::{
@@ -34,14 +34,13 @@ use mz_ore::netio::AsyncReady;
 use mz_ore::str::StrExt;
 use mz_pgcopy::CopyFormatParams;
 use mz_pgwire_common::{ErrorResponse, Format, FrontendMessage, Severity, VERSIONS, VERSION_3};
-use mz_repr::user::ExternalUserMetadata;
 use mz_repr::{Datum, GlobalId, RelationDesc, RelationType, Row, RowArena, ScalarType};
 use mz_server_core::TlsMode;
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{FetchDirection, Ident, Raw, Statement};
 use mz_sql::parse::StatementParseResult;
 use mz_sql::plan::{CopyFormat, ExecuteTimeout, StatementDesc};
-use mz_sql::session::user::{User, INTERNAL_USER_NAMES};
+use mz_sql::session::user::INTERNAL_USER_NAMES;
 use mz_sql::session::vars::{ConnectionCounter, DropConnection, Var, VarInput, MAX_COPY_FROM_SIZE};
 use postgres::error::SqlState;
 use tokio::io::{self, AsyncRead, AsyncWrite};
@@ -184,32 +183,11 @@ where
                 // Frontegg may return an email address with different casing than the user
                 // supplied via the pgwire username field. We want to use the Frontegg casing as
                 // canonical.
-                let mut session = adapter_client.new_session(
-                    conn.conn_id().clone(),
-                    User {
-                        name: claims.email.clone(),
-                        external_metadata: Some(ExternalUserMetadata {
-                            user_id: claims.user_id,
-                            admin: claims.is_admin,
-                        }),
-                    },
-                );
-
-                // Whenever refreshing a token, if the metadata has changed we'll update our
-                // session vars.
-                if session
-                    .register_external_metadata_transmitter(refresh_updates)
-                    .is_err()
-                {
-                    // TODO(parkmycar): Promote this to a panic as long as we don't see it in production.
-                    tracing::error!("Double register of external metadata transmitter!");
-                    return conn
-                        .send(ErrorResponse::fatal(
-                            SqlState::INTERNAL_ERROR,
-                            "resource already registered",
-                        ))
-                        .await;
-                }
+                let session = adapter_client.new_session(SessionConfig {
+                    conn_id: conn.conn_id().clone(),
+                    user: claims.email.clone(),
+                    external_metadata_rx: Some(refresh_updates),
+                });
 
                 (session, valid_until_fut.left_future())
             }
@@ -224,13 +202,11 @@ where
             }
         }
     } else {
-        let session = adapter_client.new_session(
-            conn.conn_id().clone(),
-            User {
-                name: user,
-                external_metadata: None,
-            },
-        );
+        let session = adapter_client.new_session(SessionConfig {
+            conn_id: conn.conn_id().clone(),
+            user,
+            external_metadata_rx: None,
+        });
         // No frontegg check, so is_expired never resolves.
         let is_expired = pending().right_future();
         (session, is_expired)
@@ -271,13 +247,14 @@ where
         .vars_mut()
         .end_transaction(EndTransactionAction::Commit);
 
-    let _guard = match DropConnection::new_connection(session.user(), active_connection_count) {
-        Ok(drop_connection) => drop_connection,
-        Err(e) => {
-            let e: AdapterError = e.into();
-            return conn.send(e.into_response(Severity::Fatal)).await;
-        }
-    };
+    let _guard =
+        match DropConnection::new_connection(session.user().name(), active_connection_count) {
+            Ok(drop_connection) => drop_connection,
+            Err(e) => {
+                let e: AdapterError = e.into();
+                return conn.send(e.into_response(Severity::Fatal)).await;
+            }
+        };
 
     // Register session with adapter.
     let mut adapter_client = match adapter_client.startup(session).await {

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -13,7 +13,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use mz_frontegg_auth::Authentication as FronteggAuthentication;
+use mz_frontegg_auth::Authenticator as FronteggAuthentication;
 use mz_ore::netio::AsyncReady;
 use mz_pgwire_common::{
     decode_startup, Conn, FrontendStartupMessage, ACCEPT_SSL_ENCRYPTION, REJECT_ENCRYPTION,

--- a/src/sql/src/session/user.rs
+++ b/src/sql/src/session/user.rs
@@ -88,11 +88,6 @@ impl User {
         self == &*SYSTEM_USER
     }
 
-    /// Returns whether we should limit this user's connections to max_connections
-    pub fn limit_max_connections(&self) -> bool {
-        !self.is_internal() && !self.is_external_admin()
-    }
-
     /// Returns the kind of user this is.
     pub fn kind(&self) -> UserKind {
         if self.is_external_admin() || self.is_system_user() {


### PR DESCRIPTION
Rewrite the Frontegg authenticator module to:

  * Not depend on refresh tokens, which Frontegg has mishandled in the past (see incident 98).

  Frontegg bugs aside, not using refresh tokens provides a nice stability boost. If there's a transient network failure while using a refresh token, Frontegg might consume the token without being able to provide us with a new one, resulting in an unnecessary connection drop. Refreshing by re-exchanging the original app password allows us to retry the transient network failure as many times as we want.

  * Submit only one request to Frontegg every eight minutes per app
    password, to minimize the load on Frontegg's API servers even when
    there are many concurrent sessions in Materialize.

    The key idea is that we keep one "authentication session" live per
    app password. Any attempts to re-authenticate with the same app
    password while the authentication session is still live will simply
    join that existing authentication session, rather than
    reauthenticating with Frontegg.

    Authentication sessions refresh with Frontegg as necesasry until
    there are no outstanding listeners for the session.

    The one downside to this approach is that updates to Frontegg user
    roles will not take effect in Materialize until the existing auth
    session refreshes, which might take eight minutes in the worst case.
    This seems tolerable, though.

The code has copious trace loging to maximize our ability to introspect
what the the authenticator is doing if we encounter another issue with
Frontegg.

### Motivation

   * This PR refactors existing code to mitigate the impact of a future Frontegg bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
