### PR TITLE
sql: disallow ALTER CONNECTION on UPSERT sources

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -12,7 +12,7 @@
 //! This module houses the handlers for statements that modify the catalog, like
 //! `ALTER`, `CREATE`, and `DROP`.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Write;
 use std::iter;
 use std::time::Duration;
@@ -5099,6 +5099,26 @@ pub fn plan_alter_connection(
             id: entry.id(),
             action: crate::plan::AlterConnectionAction::RotateKeys,
         }));
+    }
+
+    // Check that the `ALTER CONNECTION` does not occur on an UPSERT source.
+    // This is a stopgap while we implement #25417.
+    let mut deps = VecDeque::from_iter(entry.used_by().iter().cloned());
+    while let Some(dep) = deps.pop_front() {
+        let dep = scx.catalog.get_item(&dep);
+        match dep.item_type() {
+            CatalogItemType::Connection => deps.extend(dep.used_by().iter().cloned()),
+            CatalogItemType::Source => {
+                if let Some(desc) = dep.source_desc()? {
+                    if matches!(desc.envelope(), SourceEnvelope::Upsert(_)) {
+                        sql_bail!(
+                            "cannot currently alter connections depended on by upsert sources"
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
     }
 
     let options = AlterConnectionOptionExtracted::try_from(with_options)?;

--- a/test/testdrive/kafka-avro-sinks-defaults.td
+++ b/test/testdrive/kafka-avro-sinks-defaults.td
@@ -49,6 +49,10 @@ $ kafka-ingest format=avro topic=upsert-avro key-format=avro key-schema=${upsert
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
 
+# TODO: remove this when implementing #25417
+! ALTER CONNECTION kafka_conn SET (BROKER = '${testdrive.kafka-addr}');
+contains:cannot currently alter connections depended on by upsert sources
+
 # we split avro unions into separate columns
 > SELECT * FROM upsert_input;
 fisch  42  <null>   1000  <null>  hello


### PR DESCRIPTION
While waiting to implement #25417, we should remove the footgun of letting users alter upsert sources.

Users have not reported this failure to us, so I don't think it's very common, which is why I don't think it's worth threading the needle with the error reporting.

### Motivation

This PR patches a previously reported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Temporarily disallow `ALTER CONNECTION` on sources using the `UPSERT` envelope.
