### PR TITLE
fivetran-destination: Reuse scratch tables instead of creating TEMPORARY tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4457,6 +4457,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "socket2 0.5.3",
  "thiserror",
  "tokio",

--- a/src/fivetran-destination/Cargo.toml
+++ b/src/fivetran-destination/Cargo.toml
@@ -25,6 +25,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 prost-types = { version = "0.11.9" }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
+sha2 = "0.10.6"
 socket2 = "0.5.3"
 thiserror = "1.0.37"
 tonic = "0.9.2"

--- a/src/fivetran-destination/src/error.rs
+++ b/src/fivetran-destination/src/error.rs
@@ -55,7 +55,7 @@ impl fmt::Display for OpError {
 pub enum OpErrorKind {
     #[error("the required field '{0}' is missing")]
     FieldMissing(&'static str),
-    #[error("failed to create a temporary resource")]
+    #[error("failed to create a temporary resource: {0:?}")]
     TemporaryResource(tokio_postgres::Error),
     #[error("internal invariant was violated: {0}")]
     InvariantViolated(String),


### PR DESCRIPTION
This PR changes the Fivetran destination to reuse scratch tables for syncing, instead of creating a TEMPORARY table for every action.

### Motivation

After dropping a temporary table we keep a record of the shard's tombstone. If we're syncing multiple tables, creating a temporary table for each action, and syncing every few minutes, we can end up with millions of tombstones in a few months.

It's on the Persist roadmap to look into shard tombstones, but for now reusing scratch tables reduces the time pressure.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
