### PR TITLE
sql: Fix timestamp precision in HTTP API

### DIFF
--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -456,3 +456,16 @@ http
 ----
 200 OK
 {"results":[{"error":{"message":"cannot materialize call to current_timestamp","code":"0A000","detail":"See: https://materialize.com/docs/sql/functions/now_and_mz_now/","hint":"Try using `mz_now()` here instead."},"notices":[]}]}
+
+# Test timestamp precision.
+http
+{"query":"select TIMESTAMP '2023-12-19T06:50:37.123056' as col"}
+----
+200 OK
+{"results":[{"tag":"SELECT 1","rows":[["1702968637123.056"]],"desc":{"columns":[{"name":"col","type_oid":1114,"type_len":8,"type_mod":-1}]},"notices":[]}]}
+
+http
+{"query":"select TIMESTAMPTZ '2023-12-19T06:50:37.123056' as col"}
+----
+200 OK
+{"results":[{"tag":"SELECT 1","rows":[["1702968637123.056"]],"desc":{"columns":[{"name":"col","type_oid":1184,"type_len":8,"type_mod":-1}]},"notices":[]}]}

--- a/src/environmentd/tests/testdata/http/ws
+++ b/src/environmentd/tests/testdata/http/ws
@@ -321,6 +321,25 @@ ws-text
 {"type":"Error","payload":{"message":"SUBSCRIBE in transactions must be the only read statement","code":"25000"}}
 {"type":"ReadyForQuery","payload":"I"}
 
+# Test timestamp precision.
+ws-text
+{"query":"select TIMESTAMP '2023-12-19T06:50:37.123056' as col"}
+----
+{"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
+{"type":"Rows","payload":{"columns":[{"name":"col","type_oid":1114,"type_len":8,"type_mod":-1}]}}
+{"type":"Row","payload":["1702968637123.056"]}
+{"type":"CommandComplete","payload":"SELECT 1"}
+{"type":"ReadyForQuery","payload":"I"}
+
+ws-text
+{"query":"select TIMESTAMPTZ '2023-12-19T06:50:37.123056' as col"}
+----
+{"type":"CommandStarting","payload":{"has_rows":true,"is_streaming":false}}
+{"type":"Rows","payload":{"columns":[{"name":"col","type_oid":1184,"type_len":8,"type_mod":-1}]}}
+{"type":"Row","payload":["1702968637123.056"]}
+{"type":"CommandComplete","payload":"SELECT 1"}
+{"type":"ReadyForQuery","payload":"I"}
+
 ws-text rows=2 fixtimestamp=true
 {"query": "SUBSCRIBE t"}
 ----
@@ -328,3 +347,5 @@ ws-text rows=2 fixtimestamp=true
 {"type":"Rows","payload":{"columns":[{"name":"mz_timestamp","type_oid":1700,"type_len":-1,"type_mod":2555908},{"name":"mz_diff","type_oid":20,"type_len":8,"type_mod":-1},{"name":"i","type_oid":23,"type_len":4,"type_mod":-1}]}}
 {"type":"Row","payload":["<TIMESTAMP>","1","1"]}
 {"type":"Row","payload":["<TIMESTAMP>","1","2"]}
+
+# The above query never completes, so don't put anything below this.

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -76,7 +76,7 @@ $ kafka-verify-data format=json sink=materialize.public.simple_view_upsert key=t
 
 # Due to limitations in $ kafka-verify, the entire expected JSON output needs to be provided on a single line
 $ kafka-verify-data format=json sink=materialize.public.types_sink key=false
-{"before":null,"after":{"c1":true,"c2":false,"c3":null,"c4":123456789,"c5":1234.5678,"c6":"1234.5678","c7":"1321009871123","c8":"1320966671123","c9":"2011-11-11","c10":"11:11:11.123456","c11":"1 year","c12":"324373a5-7718-46b1-a7ea-4a7c9981fc4e","c13":[209,130,208,181,208,186,209,129,209,130],"c14":{"a":2}}}
+{"before":null,"after":{"c1":true,"c2":false,"c3":null,"c4":123456789,"c5":1234.5678,"c6":"1234.5678","c7":"1321009871123.450","c8":"1320966671123.450","c9":"2011-11-11","c10":"11:11:11.123456","c11":"1 year","c12":"324373a5-7718-46b1-a7ea-4a7c9981fc4e","c13":[209,130,208,181,208,186,209,129,209,130],"c14":{"a":2}}}
 
 # Special characters
 


### PR DESCRIPTION
Previously, the HTTP and WS API would return TIMESTAMPs and TIMESTAMPTZs with only millisecond precision, even though internally and via the pgwire API we represent these types with microsecond precision. This commit updates the HTTP and WS API to return microsecond precision.

To avoid issues of compatibility with current users, the microsecond portion of the timestamp is stored as a decimal. For example, previously `TIMESTAMP '2023-12-19T06:50:37.123456 '` would return `"1703011837123"`, now it returns `"1703011837123.456"`.

An alternative implementation that used arbitrary precision decimals (the `Numeric` type in mz_repr) was explored, but the performance was 2-4x slower than the current implementation.

Fixes #24026

### Motivation
 This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add microsecond precision to `TIMESTAMP` and `TIMESTAMPTZ` in the HTTP and WS APIs.
