### PR TITLE
Update lgalloc, expose metrics, conditionally enable eager_return

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,13 +3111,14 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lgalloc"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e3de70c23cbcf5613858a870f9c02185e6c337ebcd076453383a24fde8f64a"
+checksum = "7a7da66e048ec66e9bcd886b4f704a3702787a517ebed8fb5a0e7c4ed25ee742"
 dependencies = [
  "crossbeam-deque",
  "libc",
  "memmap2",
+ "numa_maps",
  "page_size",
  "tempfile",
  "thiserror",
@@ -6475,6 +6476,12 @@ dependencies = [
  "quote",
  "syn 1.0.107",
 ]
+
+[[package]]
+name = "numa_maps"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919af26e03f635d91244e3e3e5a63f0377a78044b39e09a69fdad36514dc919f"
 
 [[package]]
 name = "number_prefix"

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -763,7 +763,7 @@ version = "1.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.lgalloc]]
-version = "0.1.7"
+version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
@@ -892,6 +892,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.num_enum_derive]]
 version = "0.5.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.numa_maps]]
+version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.number_prefix]]

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -42,6 +42,7 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
         enable_operator_hydration_status_logging: Some(
             config.enable_compute_operator_hydration_status_logging(),
         ),
+        enable_lgalloc_eager_reclamation: Some(config.enable_lgalloc_eager_reclamation()),
         persist: persist_config(config),
         tracing: tracing_config(config),
         grpc_client: grpc_client_config(config),

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -86,6 +86,7 @@ message ProtoComputeParameters {
     optional bool enable_columnation_lgalloc = 10;
     optional bool enable_operator_hydration_status_logging = 11;
     optional bool enable_chunked_stack = 12;
+    optional bool enable_lgalloc_eager_reclamation = 13;
 }
 
 message ProtoComputeMaxInflightBytesConfig {

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -385,6 +385,8 @@ pub struct ComputeParameters {
     pub enable_chunked_stack: Option<bool>,
     /// Enable operator hydration status logging.
     pub enable_operator_hydration_status_logging: Option<bool>,
+    /// Enable lgalloc's eager memory return/reclamation feature.
+    pub enable_lgalloc_eager_reclamation: Option<bool>,
     /// Persist client configuration.
     pub persist: PersistParameters,
     /// Tracing configuration.
@@ -404,6 +406,7 @@ impl ComputeParameters {
             enable_columnation_lgalloc,
             enable_chunked_stack,
             enable_operator_hydration_status_logging,
+            enable_lgalloc_eager_reclamation,
             persist,
             tracing,
             grpc_client,
@@ -430,6 +433,9 @@ impl ComputeParameters {
         if enable_operator_hydration_status_logging.is_some() {
             self.enable_operator_hydration_status_logging =
                 enable_operator_hydration_status_logging;
+        }
+        if enable_lgalloc_eager_reclamation.is_some() {
+            self.enable_lgalloc_eager_reclamation = enable_lgalloc_eager_reclamation;
         }
 
         self.persist.update(persist);
@@ -459,6 +465,7 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
             enable_operator_hydration_status_logging: self
                 .enable_operator_hydration_status_logging
                 .into_proto(),
+            enable_lgalloc_eager_reclamation: self.enable_lgalloc_eager_reclamation.into_proto(),
             persist: Some(self.persist.into_proto()),
             tracing: Some(self.tracing.into_proto()),
             grpc_client: Some(self.grpc_client.into_proto()),
@@ -479,6 +486,7 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
             enable_operator_hydration_status_logging: proto
                 .enable_operator_hydration_status_logging
                 .into_rust()?,
+            enable_lgalloc_eager_reclamation: proto.enable_lgalloc_eager_reclamation.into_rust()?,
             persist: proto
                 .persist
                 .into_rust_if_some("ProtoComputeParameters::persist")?,

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -21,7 +21,7 @@ differential-dataflow = "0.12.0"
 dogsdogsdogs = "0.1.0"
 futures = "0.3.25"
 itertools = "0.10.5"
-lgalloc = "0.1"
+lgalloc = "0.2"
 mz-build-info = { path = "../build-info" }
 mz-cluster = { path = "../cluster" }
 mz-cluster-client = { path = "../cluster-client" }

--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -95,11 +95,12 @@ mod spines {
 
 /// A `Row`-specialized container using dictionary compression.
 mod container {
+    use std::cmp::Ordering;
 
     use differential_dataflow::trace::cursor::MyTrait;
     use differential_dataflow::trace::implementations::BatchContainer;
     use differential_dataflow::trace::implementations::OffsetList;
-
+    use mz_ore::region::Region;
     use mz_repr::{read_datum, Datum, Row};
 
     /// A slice container with four bytes overhead per slice.
@@ -189,7 +190,7 @@ mod container {
     /// The backing storage for this batch will not be resized.
     pub struct DatumBatch {
         offsets: OffsetList,
-        storage: lgalloc::Region<u8>,
+        storage: Region<u8>,
     }
 
     impl DatumBatch {
@@ -219,7 +220,7 @@ mod container {
             offsets.push(0);
             Self {
                 offsets,
-                storage: lgalloc::Region::new_auto(byte_cap.next_power_of_two()),
+                storage: Region::new_auto(byte_cap.next_power_of_two()),
             }
         }
     }
@@ -236,7 +237,6 @@ mod container {
         }
     }
 
-    use std::cmp::Ordering;
     impl<'a, 'b> PartialEq<DatumSeq<'a>> for DatumSeq<'b> {
         fn eq(&self, other: &DatumSeq<'a>) -> bool {
             self.bytes.eq(other.bytes)

--- a/src/metrics/Cargo.toml
+++ b/src/metrics/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-lgalloc = "0.1"
+lgalloc = "0.2"
 libc = "0.2.138"
 mz-ore = { path = "../ore", features = ["metrics"] }
 paste = "1.0"

--- a/src/metrics/src/lgalloc.rs
+++ b/src/metrics/src/lgalloc.rs
@@ -6,27 +6,65 @@
 //! Report lgalloc metrics.
 
 use std::collections::BTreeMap;
+use std::ops::AddAssign;
 use std::time::Duration;
 
-use lgalloc::SizeClassStats;
+use lgalloc::{FileStats, SizeClassStats};
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::{raw, MetricsRegistry};
 use paste::paste;
 use prometheus::core::{AtomicU64, GenericGauge};
 
-macro_rules! metrics {
-    ($namespace:ident $(($name:ident, $desc:expr, $suffix:expr, $conv:expr)),*) => {
-        metrics! { @define $namespace $(($name, $desc, $suffix, $conv)),*}
+/// An accumulator for [`FileStats`].
+#[derive(Default)]
+struct FileStatsAccum {
+    /// The size of the file in bytes.
+    pub file_size: usize,
+    /// Size of the file on disk in bytes.
+    pub allocated_size: usize,
+    /// Number of mapped bytes, if different from `dirty`. Consult `man 7 numa` for details.
+    pub mapped: usize,
+    /// Number of active bytes. Consult `man 7 numa` for details.
+    pub active: usize,
+    /// Number of dirty bytes. Consult `man 7 numa` for details.
+    pub dirty: usize,
+}
+
+impl AddAssign<&FileStats> for FileStatsAccum {
+    fn add_assign(&mut self, rhs: &FileStats) {
+        self.file_size += rhs.file_size;
+        self.allocated_size += rhs.allocated_size;
+        self.mapped += rhs.mapped;
+        self.active += rhs.active;
+        self.dirty += rhs.dirty;
+    }
+}
+
+macro_rules! metrics_size_class {
+    ($namespace:ident
+        @size_class ($(($name:ident, $desc:expr, $suffix:expr, $conv:expr)),*)
+        @file ($(($f_name:ident, $f_metric:ident, $f_desc:expr)),*)
+    ) => {
+        metrics_size_class! {
+            @define $namespace
+            @size_class $(($name, $desc, $suffix, $conv)),*
+            @file $(($f_name, $f_metric, $f_desc)),*
+        }
     };
-    (@define $namespace:ident $(($name:ident, $desc:expr, $suffix:expr, $conv:expr)),*) => {
+    (@define $namespace:ident
+        @size_class $(($name:ident, $desc:expr, $suffix:expr, $conv:expr)),*
+        @file $(($f_name:ident, $f_metric:ident, $f_desc:expr)),*
+    ) => {
         paste! {
             struct LgMetrics {
                 stats: lgalloc::LgAllocStats,
                 size_class: BTreeMap<usize, LgMetricsSC>,
                 $([<$name $suffix>]: raw::UIntGaugeVec,)*
+                $($f_metric: raw::UIntGaugeVec,)*
             }
             struct LgMetricsSC {
                 $([<$name $suffix>]: GenericGauge<AtomicU64>,)*
+                $($f_metric: GenericGauge<AtomicU64>,)*
             }
             impl LgMetrics {
                 fn new(registry: &MetricsRegistry) -> Self {
@@ -38,18 +76,39 @@ macro_rules! metrics {
                             help: $desc,
                             var_labels: ["size_class"],
                         )),)*
+                        $($f_metric: registry.register(mz_ore::metric!(
+                            name: concat!(stringify!($namespace), "_", stringify!($f_metric)),
+                            help: $f_desc,
+                            var_labels: ["size_class"],
+                        )),)*
                     }
                 }
+                fn get_size_class(&mut self, size_class: usize) -> &LgMetricsSC {
+                    self.size_class.entry(size_class).or_insert_with(|| {
+                        let labels: &[&str] = &[&size_class.to_string()];
+                        LgMetricsSC {
+                            $([<$name $suffix>]: self.[<$name $suffix>].with_label_values(labels),)*
+                            $($f_metric: self.$f_metric.with_label_values(labels),)*
+                        }
+                    })
+                }
                 fn update(&mut self) {
-                    lgalloc::lgalloc_stats(&mut self.stats);
-                    for sc in &self.stats.size_class {
-                        let sc_stats = self.size_class.entry(sc.size_class).or_insert_with(|| {
-                            LgMetricsSC {
-                                $([<$name $suffix>]: self.[<$name $suffix>].with_label_values(&[&sc.size_class.to_string()]),)*
-                            }
-                        });
+                    let mut stats = std::mem::take(&mut self.stats);
+                    lgalloc::lgalloc_stats(&mut stats);
+                    for sc in &stats.size_class {
+                        let sc_stats = self.get_size_class(sc.size_class);
                         $(sc_stats.[<$name $suffix>].set(($conv)(u64::cast_from(sc.$name), sc));)*
                     }
+                    let mut accums = BTreeMap::new();
+                    for file_stat in &stats.file_stats {
+                        let accum: &mut FileStatsAccum = accums.entry(file_stat.size_class).or_default();
+                        accum.add_assign(file_stat);
+                    }
+                    for (size_class, accum) in accums {
+                        let sc_stats = self.get_size_class(size_class);
+                        $(sc_stats.$f_metric.set(u64::cast_from(accum.$f_name));)*
+                    }
+                    self.stats = stats;
                 }
             }
         }
@@ -64,22 +123,31 @@ fn id(value: u64, _stats: &SizeClassStats) -> u64 {
     value
 }
 
-metrics! {
+metrics_size_class! {
     mz_metrics_lgalloc
-    (allocations, "Number of region allocations in size class", "_total", id),
-    (area_total_bytes, "Number of bytes in all areas in size class", "", id),
-    (areas, "Number of areas backing size class", "_total", id),
-    (clean_regions, "Number of clean regions in size class", "_total", id),
-    (clean_regions, "Number of clean regions in size class", "_bytes_total", normalize_by_size_class),
-    (deallocations, "Number of region deallocations for size class", "_total", id),
-    (free_regions, "Number of free regions in size class", "_total", id),
-    (free_regions, "Number of free regions in size class", "_bytes_total", normalize_by_size_class),
-    (global_regions, "Number of global regions in size class", "_total", id),
-    (global_regions, "Number of global regions in size class", "_bytes_total", normalize_by_size_class),
-    (refill, "Number of area refills for size class", "_total", id),
-    (slow_path, "Number of slow path region allocations for size class", "_total", id),
-    (thread_regions, "Number of thread regions in size class", "_total", id),
-    (thread_regions, "Number of thread regions in size class", "_bytes_total", normalize_by_size_class)
+    @size_class (
+        (allocations, "Number of region allocations in size class", "_total", id),
+        (area_total_bytes, "Number of bytes in all areas in size class", "", id),
+        (areas, "Number of areas backing size class", "_total", id),
+        (clean_regions, "Number of clean regions in size class", "_total", id),
+        (clean_regions, "Number of clean regions in size class", "_bytes_total", normalize_by_size_class),
+        (deallocations, "Number of region deallocations for size class", "_total", id),
+        (free_regions, "Number of free regions in size class", "_total", id),
+        (free_regions, "Number of free regions in size class", "_bytes_total", normalize_by_size_class),
+        (global_regions, "Number of global regions in size class", "_total", id),
+        (global_regions, "Number of global regions in size class", "_bytes_total", normalize_by_size_class),
+        (refill, "Number of area refills for size class", "_total", id),
+        (slow_path, "Number of slow path region allocations for size class", "_total", id),
+        (thread_regions, "Number of thread regions in size class", "_total", id),
+        (thread_regions, "Number of thread regions in size class", "_bytes_total", normalize_by_size_class)
+    )
+    @file (
+        (file_size, file_size_bytes, "Sum of file sizes in size class"),
+        (allocated_size, file_allocated_size_bytes, "Sum of allocated sizes in size class"),
+        (mapped, vm_mapped_bytes, "Sum of mapped sizes in size class"),
+        (active, vm_active_bytes, "Sum of active sizes in size class"),
+        (dirty, vm_dirty_bytes, "Sum of dirty sizes in size class")
+    )
 }
 
 /// Register a task to read lgalloc stats.

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -29,7 +29,7 @@ ctor = { version = "0.1.26", optional = true }
 either = "1.8.0"
 futures = { version = "0.3.25", optional = true }
 hibitset = { version = "0.6.4", optional = true }
-lgalloc = { version = "0.1", optional = true }
+lgalloc = { version = "0.2", optional = true }
 mz-ore-instrument-macro = { path = "../ore-instrument-macro", default-features = false }
 mz-test-macro = { path = "../test-macro", default-features = false }
 num = "0.4.0"

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1106,6 +1106,7 @@ impl SystemVars {
             &WEBHOOK_CONCURRENT_REQUEST_LIMIT,
             &ENABLE_COLUMNATION_LGALLOC,
             &ENABLE_COMPUTE_CHUNKED_STACK,
+            &ENABLE_LGALLOC_EAGER_RECLAMATION,
             &ENABLE_STATEMENT_LIFECYCLE_LOGGING,
             &ENABLE_DEPENDENCY_READ_HOLD_ASSERTS,
             &TIMESTAMP_ORACLE_IMPL,
@@ -1971,6 +1972,11 @@ impl SystemVars {
         *self.expect_value(&ENABLE_COMPUTE_CHUNKED_STACK)
     }
 
+    /// Returns the `enable_lgalloc_eager_reclamation` configuration parameter.
+    pub fn enable_lgalloc_eager_reclamation(&self) -> bool {
+        *self.expect_value(&ENABLE_LGALLOC_EAGER_RECLAMATION)
+    }
+
     pub fn enable_statement_lifecycle_logging(&self) -> bool {
         *self.expect_value(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
     }
@@ -2014,6 +2020,7 @@ impl SystemVars {
             || name == ENABLE_MZ_JOIN_CORE.name()
             || name == ENABLE_COLUMNATION_LGALLOC.name()
             || name == ENABLE_COMPUTE_OPERATOR_HYDRATION_STATUS_LOGGING.name()
+            || name == ENABLE_LGALLOC_EAGER_RECLAMATION.name()
             || self.is_persist_config_var(name)
             || is_tracing_var(name)
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1459,6 +1459,13 @@ pub static ENABLE_COMPUTE_CHUNKED_STACK: VarDefinition = VarDefinition::new(
     true,
 );
 
+pub static ENABLE_LGALLOC_EAGER_RECLAMATION: VarDefinition = VarDefinition::new(
+    "enable_lgalloc_eager_reclamation",
+    value!(bool; true),
+    "Enable lgalloc's eager return behavior.",
+    true,
+);
+
 pub static ENABLE_STATEMENT_LIFECYCLE_LOGGING: VarDefinition = VarDefinition::new(
     "enable_statement_lifecycle_logging",
     value!(bool; false),


### PR DESCRIPTION
### Motivation

Update lgalloc to 0.2.0. This allows us to:
* Expose metrics about physical and virtual memory related to files, giving us more insights about what portion of the memory managed by lgalloc is in memory, and what portion is in use.
* Eager returning of physical memory (eager_return) without punching holes into files. This is a significantly cheaper approach than always punching holes into files.

Fixes #24271.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
