### PR TITLE
doc/user: polish v0.88 release notes

### DIFF
--- a/doc/user/content/releases/v0.88.md
+++ b/doc/user/content/releases/v0.88.md
@@ -7,4 +7,30 @@ patch: 1
 
 ## v0.88
 
-**WIP**
+#### SQL
+
+* Allow `LIMIT` expressions to contain parameters.
+
+	```sql
+	  PREPARE foo AS SELECT generate_series(1, 10) LIMIT $1;
+	  EXECUTE foo (7::bigint);
+
+	  generate_series
+	  -----------------
+	                 1
+	                 2
+	                 3
+	                 4
+	                 5
+	                 6
+	                 7
+	```
+
+#### Bug fixes and other improvements
+
+* Fix a bug that potentially prevented timestamp with timezone data from being
+  correctly parsed when ingested through PostgreSQL sources {{% gh 25216 %}}.
+
+* Fix float parsing of certain zero values, such as `0.` and `.0` {{% gh 25141 %}}.
+
+* Fix multiple bugs related to interval rounding {{% gh 25202%}}.

--- a/doc/user/content/releases/v0.88.md
+++ b/doc/user/content/releases/v0.88.md
@@ -2,7 +2,7 @@
 title: "Materialize v0.88"
 date: 2024-02-21
 released: true
-patch: 2
+patch: 1
 ---
 
 ## v0.88

--- a/doc/user/content/releases/v0.88.md
+++ b/doc/user/content/releases/v0.88.md
@@ -1,11 +1,10 @@
 ---
 title: "Materialize v0.88"
 date: 2024-02-21
-released: false
+released: true
+patch: 2
 ---
 
 ## v0.88
 
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
+**WIP**

--- a/doc/user/content/releases/v0.89.md
+++ b/doc/user/content/releases/v0.89.md
@@ -1,0 +1,11 @@
+---
+title: "Materialize v0.89"
+date: 2024-02-28
+released: false
+---
+
+## v0.89
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}


### PR DESCRIPTION
Release notes for v0.88. 🌻 

@alex-hunt-materialize @petrosagg: this covers the step of bumping the release version in the docs.