### PR TITLE
Use sha256 for statement log instead of md5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,9 +1801,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -3564,7 +3564,6 @@ dependencies = [
  "itertools",
  "launchdarkly-server-sdk",
  "maplit",
- "md-5",
  "mz-adapter-types",
  "mz-audit-log",
  "mz-build-info",
@@ -3620,6 +3619,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
+ "sha2",
  "smallvec",
  "static_assertions",
  "thiserror",
@@ -8265,9 +8265,9 @@ checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,9 +1801,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -8265,9 +8265,9 @@ checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -90,7 +90,7 @@ semver = "1.0.16"
 serde = "1.0.152"
 serde_json = "1.0.89"
 serde_plain = "1.0.1"
-sha2 = "0.10.8"
+sha2 = "0.10.6"
 smallvec = { version = "1.10.0", features = ["union"] }
 static_assertions = "1.1"
 timely = { version = "0.12.0", default-features = false, features = [

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -31,7 +31,6 @@ launchdarkly-server-sdk = { version = "1.0.0", default_features = false, feature
   "hypertls",
 ] }
 maplit = "1.0.2"
-md-5 = "0.10.5"
 mz-adapter-types = { path = "../adapter-types" }
 mz-audit-log = { path = "../audit-log" }
 mz-build-info = { path = "../build-info" }
@@ -91,6 +90,7 @@ semver = "1.0.16"
 serde = "1.0.152"
 serde_json = "1.0.89"
 serde_plain = "1.0.1"
+sha2 = "0.10.8"
 smallvec = { version = "1.10.0", features = ["union"] }
 static_assertions = "1.1"
 timely = { version = "0.12.0", default-features = false, features = [

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -11,7 +11,6 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use md5::{Digest, Md5};
 use mz_controller_types::ClusterId;
 use mz_ore::now::{to_datetime, NowFn};
 use mz_ore::task::spawn;
@@ -25,6 +24,7 @@ use mz_storage_client::controller::IntrospectionType;
 use qcell::QCell;
 use rand::SeedableRng;
 use rand::{distributions::Bernoulli, prelude::Distribution, thread_rng};
+use sha2::{Digest, Sha256};
 use tokio::time::MissedTickBehavior;
 use tracing::debug;
 use uuid::Uuid;
@@ -280,7 +280,7 @@ impl Coordinator {
                 let uuid = Uuid::new_v4();
                 let sql = std::mem::take(sql);
                 let redacted_sql = std::mem::take(redacted_sql);
-                let sql_hash: [u8; 16] = Md5::digest(sql.as_bytes()).into();
+                let sql_hash: [u8; 32] = Sha256::digest(sql.as_bytes()).into();
                 let record = StatementPreparedRecord {
                     id: uuid,
                     sql_hash,

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -106,7 +106,7 @@ pub struct StatementEndedExecutionRecord {
 #[derive(Clone, Debug)]
 pub struct StatementPreparedRecord {
     pub id: Uuid,
-    pub sql_hash: [u8; 16],
+    pub sql_hash: [u8; 32],
     pub name: String,
     pub session_id: Uuid,
     pub prepared_at: EpochMillis,


### PR DESCRIPTION
md5 is known to be broken.

This causes an extra 16 bytes per row in MPSH and MST, but I think the increased memory usage is worth not having to worry about possible security bugs due to md5 collisions. 