### PR TITLE
pg: subsource status reporting tidy up

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2709,7 +2709,7 @@ pub static MZ_SOURCE_STATUSES: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
             -- If self not errored, but parent is, use parent; else self
             CASE
                 WHEN
-                    self_events.status <> 'stalled' AND
+                    self_events.status <> 'ceased' AND
                     parent_events.status = 'stalled'
                 THEN parent_events.source_id
                 ELSE self_events.source_id

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -331,10 +331,10 @@ impl Status {
     /// status.
     pub fn superseded_by(self, new: Status) -> bool {
         match (self, new) {
-            (Status::Dropped, _) => false,
             (_, Status::Dropped) => true,
-            (Status::Ceased, _) => false,
+            (Status::Dropped, _) => false,
             (_, Status::Ceased) => true,
+            (Status::Ceased, _) => false,
             // Don't re-mark that object as paused.
             (Status::Paused, Status::Paused) => false,
             // De-duplication of other statuses is currently managed by the

--- a/test/pg-cdc/status/01-setup.td
+++ b/test/pg-cdc/status/01-setup.td
@@ -7,10 +7,18 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
+{
+  "name": "postgres",
+  "listen": "0.0.0.0:5432",
+  "upstream": "postgres:5432",
+  "enabled": true
+}
+
 > CREATE SECRET pgpass AS 'postgres'
 
 > CREATE CONNECTION pg TO POSTGRES (
-    HOST postgres,
+    HOST toxiproxy,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass
@@ -40,5 +48,18 @@ ALTER TABLE t DROP COLUMN a;
 ALTER TABLE t ADD COLUMN a int;
 INSERT INTO t VALUES (2);
 
-> SELECT status = 'ceased' AND error ILIKE '%incompatible schema change%' FROM mz_internal.mz_source_statuses WHERE name = 't';
+> SELECT name, status FROM mz_internal.mz_source_statuses;
+pg_source           running
+pg_source_progress  running
+t                   ceased
+
+> SELECT
+        status = 'ceased'
+            AND
+        error ILIKE '%incompatible schema change%'
+    FROM mz_internal.mz_source_statuses
+    WHERE name = 't';
 true
+
+! SELECT * FROM t;
+contains: incompatible schema change

--- a/test/pg-cdc/status/02-after-mz-restart.td
+++ b/test/pg-cdc/status/02-after-mz-restart.td
@@ -13,7 +13,5 @@
     WHERE name = 't'
 true
 
-# Drop the source + subsources because some tests expect
-# all remaining sources at the end of the test to be
-# healthy.
-> DROP SOURCE pg_source;
+! SELECT * FROM t;
+contains:incompatible schema change

--- a/test/pg-cdc/status/03-toxiproxy-interrupt.td
+++ b/test/pg-cdc/status/03-toxiproxy-interrupt.td
@@ -1,0 +1,38 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT COUNT(*) = 0 FROM mz_internal.mz_source_statuses WHERE error LIKE '%connection closed%';
+true
+
+# This REST call will cause toxiproxy to close the connection.
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies/postgres content-type=application/json
+{
+  "name": "postgres",
+  "listen": "0.0.0.0:5432",
+  "upstream": "postgres:5432",
+  "enabled": false
+}
+
+> SELECT COUNT(*) > 0 FROM mz_internal.mz_source_statuses WHERE error LIKE '%connection closed%';
+true
+
+# Ensure we don't lose ceased status even if source is stalled
+> SELECT name, status FROM mz_internal.mz_source_statuses;
+pg_source           stalled
+pg_source_progress  running
+t                   ceased
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies/postgres content-type=application/json
+{
+  "name": "postgres",
+  "listen": "0.0.0.0:5432",
+  "upstream": "postgres:5432",
+  "enabled": true
+}

--- a/test/pg-cdc/status/04-drop-publication.td
+++ b/test/pg-cdc/status/04-drop-publication.td
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP PUBLICATION mz_source;
+INSERT INTO t VALUES (1);
+
+> SELECT name, status FROM mz_internal.mz_source_statuses;
+pg_source           stalled
+pg_source_progress  running
+t                   ceased
+
+> SELECT error ILIKE '%publication "mz_source" does not exist' FROM mz_internal.mz_source_statuses WHERE name = 'pg_source';
+true
+
+# Check that new status reflects error from source.
+> SELECT error ILIKE '%publication "mz_source" does not exist' FROM mz_internal.mz_source_statuses WHERE name = 't';
+true
+
+! SELECT * FROM t;
+contains:publication "mz_source" does not exist
+
+# Tests must exit with healthy sources
+> DROP SOURCE pg_source;


### PR DESCRIPTION
I think there were some very mild deficiencies in how we reported subsource statuses:

- If the subsource was in `ceased` and the parent source was `stalled`, the subsource would report `stalled` which is goofy.
- If a subsource encounters multiple definite errors, it reports the most recent of them. We should mirror this in the status collection.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
