### PR TITLE
storage: hook up snapshot_records_known/staged

### DIFF
--- a/src/storage-client/src/statistics.rs
+++ b/src/storage-client/src/statistics.rs
@@ -312,7 +312,9 @@ impl StorageMetric for Total {
         // A `Total` regressing to is a bug.
         if other.0 < self.0 {
             tracing::error!(
-                "boolean gauge for field {field_name} erroneously regressed from true to false",
+                "total gauge {field_name} erroneously regressed from {} to {}",
+                self.0,
+                other.0
             );
             return;
         }

--- a/src/storage/src/metrics/source/mysql.rs
+++ b/src/storage/src/metrics/source/mysql.rs
@@ -10,41 +10,23 @@
 //! Metrics for Postgres.
 
 use mz_ore::metric;
-use mz_ore::metrics::{DeleteOnDropGauge, GaugeVec, GaugeVecExt, MetricsRegistry, UIntGaugeVec};
+use mz_ore::metrics::{DeleteOnDropGauge, GaugeVec, GaugeVecExt, MetricsRegistry};
 use mz_repr::GlobalId;
-use prometheus::core::{AtomicF64, AtomicU64};
+use prometheus::core::AtomicF64;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 #[derive(Clone, Debug)]
 pub(crate) struct MySqlSourceMetricDefs {
-    pub(crate) table_count: UIntGaugeVec,
     pub(crate) table_count_latency: GaugeVec,
-    pub(crate) table_estimate: UIntGaugeVec,
-    pub(crate) table_estimate_latency: GaugeVec,
 }
 
 impl MySqlSourceMetricDefs {
     pub(crate) fn register_with(registry: &MetricsRegistry) -> Self {
         Self {
-            table_count: registry.register(metric!(
-                name: "mz_mysql_snapshot_count",
-                help: "The count(*) of tables in the sources snapshot.",
-                var_labels: ["source_id", "table_name", "schema"],
-            )),
             table_count_latency: registry.register(metric!(
                 name: "mz_mysql_snapshot_count_latency",
-                help: "The wall time used to obtain `mz_mysql_snapshot_count`.",
-                var_labels: ["source_id", "table_name", "schema"],
-            )),
-            table_estimate: registry.register(metric!(
-                name: "mz_mysql_snapshot_estimate",
-                help: "An estimate of the size of tables in the sources snapshot.",
-                var_labels: ["source_id", "table_name", "schema"],
-            )),
-            table_estimate_latency: registry.register(metric!(
-                name: "mz_mysql_snapshot_estimate_latency",
-                help: "The wall time used to obtain `mz_mysql_snapshot_estimate`.",
+                help: "The wall time used to obtain snapshot sizes.",
                 var_labels: ["source_id", "table_name", "schema"],
             )),
         }
@@ -57,64 +39,24 @@ pub(crate) struct MySqlSnapshotMetrics {
     // This has to be shared between tokio tasks and the replication operator, as the collection
     // of these metrics happens once in those tasks, which do not live long enough to keep them
     // alive.
-    gauges: Arc<
-        Mutex<
-            Vec<(
-                DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-                DeleteOnDropGauge<'static, AtomicF64, Vec<String>>,
-            )>,
-        >,
-    >,
+    gauges: Arc<Mutex<Vec<DeleteOnDropGauge<'static, AtomicF64, Vec<String>>>>>,
     defs: MySqlSourceMetricDefs,
 }
 
 impl MySqlSnapshotMetrics {
-    pub(crate) fn record_table_count(
+    pub(crate) fn record_table_count_latency(
         &self,
         table_name: String,
         schema: String,
-        count: u64,
         latency: f64,
     ) {
-        let gauge = self.defs.table_count.get_delete_on_drop_gauge(vec![
-            self.source_id.to_string(),
-            table_name.clone(),
-            schema.clone(),
-        ]);
         let latency_gauge = self.defs.table_count_latency.get_delete_on_drop_gauge(vec![
             self.source_id.to_string(),
             table_name,
             schema,
         ]);
-        gauge.set(count);
         latency_gauge.set(latency);
-        self.gauges
-            .lock()
-            .expect("poisoned")
-            .push((gauge, latency_gauge))
-    }
-    pub(crate) fn record_table_estimate(
-        &self,
-        table_name: String,
-        schema: String,
-        estimate: u64,
-        latency: f64,
-    ) {
-        let gauge = self.defs.table_estimate.get_delete_on_drop_gauge(vec![
-            self.source_id.to_string(),
-            table_name.clone(),
-            schema.clone(),
-        ]);
-        let latency_gauge = self
-            .defs
-            .table_estimate_latency
-            .get_delete_on_drop_gauge(vec![self.source_id.to_string(), table_name.clone(), schema]);
-        gauge.set(estimate);
-        latency_gauge.set(latency);
-        self.gauges
-            .lock()
-            .expect("poisoned")
-            .push((gauge, latency_gauge))
+        self.gauges.lock().expect("poisoned").push(latency_gauge)
     }
 }
 

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -171,7 +171,7 @@ impl SourceRender for LoadGeneratorSourceConnection {
                                     Some(frontier) = resume_uppers.next() => {
                                         if let Some(offset) = frontier.as_option() {
                                             let total = offset.offset.saturating_sub(1);
-                                            if total > offset_committed{
+                                            if total > offset_committed {
                                                 // Note we don't subtract from the upper, as we
                                                 // want to report total number of offsets we have processed.
                                                 offset_committed = total;
@@ -180,6 +180,10 @@ impl SourceRender for LoadGeneratorSourceConnection {
                                     }
                                 }
                             }
+
+                            // TODO(guswynn): generators have various definitions of "snapshot", so
+                            // we are not going to implement snapshot progress statistics for them
+                            // right now, but will come back to it.
                             stats_output
                                 .give(
                                     &stats_cap,

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -731,7 +731,7 @@ impl SourceRender for KafkaSourceConnection {
                     stats_output
                         .give(
                             &stats_cap,
-                            ProgressStatisticsUpdate {
+                            ProgressStatisticsUpdate::SteadyState {
                                 offset_committed,
                                 offset_known,
                             },

--- a/src/storage/src/source/mysql/statistics.rs
+++ b/src/storage/src/source/mysql/statistics.rs
@@ -55,7 +55,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                 stats_output
                     .give(
                         &stats_cap[0],
-                        ProgressStatisticsUpdate {
+                        ProgressStatisticsUpdate::SteadyState {
                             offset_known: 0,
                             offset_committed: 0,
                         },
@@ -122,7 +122,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                     stats_output
                         .give(
                             &stats_cap[0],
-                            ProgressStatisticsUpdate {
+                            ProgressStatisticsUpdate::SteadyState {
                                 offset_known,
                                 offset_committed,
                             },

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -188,7 +188,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 stats_output
                     .give(
                         &stats_cap[0],
-                        ProgressStatisticsUpdate {
+                        ProgressStatisticsUpdate::SteadyState {
                             offset_known: 0,
                             offset_committed: 0,
                         },
@@ -588,7 +588,7 @@ async fn raw_stream<'a>(
                     stats_output
                         .give(
                             stats_cap,
-                            ProgressStatisticsUpdate {
+                            ProgressStatisticsUpdate::SteadyState {
                                 // Similar to the kafka source, we don't subtract 1 from the upper as we want to report the
                                 // _number of bytes_ we have processed/in upstream.
                                 offset_known: upstream_stat.offset,

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -136,21 +136,17 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::pin::pin;
 use std::rc::Rc;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{bail, Context};
+use anyhow::bail;
 use differential_dataflow::{AsCollection, Collection};
 use futures::TryStreamExt;
 use mz_expr::MirScalarExpr;
 use mz_ore::result::ResultExt;
-use mz_ore::task::{AbortOnDropHandle, JoinHandleExt};
 use mz_postgres_util::desc::PostgresTableDesc;
-use mz_postgres_util::tunnel::Config;
 use mz_postgres_util::{simple_query_opt, PostgresError};
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
-use mz_storage_types::parameters::PgSourceSnapshotConfig;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
 use mz_timely_util::builder_async::{
     Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
@@ -162,11 +158,12 @@ use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp};
 use tokio_postgres::types::{Oid, PgLsn};
 use tokio_postgres::Client;
-use tracing::{trace, warn};
+use tracing::{error, trace};
 
 use crate::metrics::source::postgres::PgSnapshotMetrics;
 use crate::source::postgres::replication::RewindRequest;
 use crate::source::postgres::{verify_schema, DefiniteError, ReplicationError, TransientError};
+use crate::source::types::ProgressStatisticsUpdate;
 use crate::source::types::SourceReaderError;
 use crate::source::RawSourceCreationConfig;
 
@@ -181,6 +178,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
 ) -> (
     Collection<G, (usize, Result<Row, SourceReaderError>), Diff>,
     Stream<G, RewindRequest>,
+    Stream<G, ProgressStatisticsUpdate>,
     Stream<G, ReplicationError>,
     PressOnDropButton,
 ) {
@@ -193,6 +191,8 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
     let (mut rewinds_handle, rewinds) = builder.new_output();
     let (mut snapshot_handle, snapshot) = builder.new_output();
     let (mut definite_error_handle, definite_errors) = builder.new_output();
+
+    let (mut stats_output, stats_stream) = builder.new_output();
 
     // This operator needs to broadcast data to itself in order to synchronize the transaction
     // snapshot. However, none of the feedback capabilities result in output messages and for the
@@ -242,8 +242,9 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 data_cap_set,
                 rewind_cap_set,
                 snapshot_cap_set,
-                definite_error_cap_set
-            ]: &mut [_; 4] = caps.try_into().unwrap();
+                definite_error_cap_set,
+                stats_cap,
+            ]: &mut [_; 5] = caps.try_into().unwrap();
 
             trace!(
                 %id,
@@ -255,6 +256,9 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             // Nothing needs to be snapshot.
             if exports_to_snapshot.is_empty() {
                 trace!(%id, "no exports to snapshot");
+                // Note we do not emit a `ProgressStatisticsUpdate::Snapshot` update here,
+                // as we do not want to attempt to override the current value with 0. We
+                // just leave it null.
                 return Ok(());
             }
 
@@ -402,17 +406,20 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 })
                 .collect();
 
-            let client = Arc::new(client);
-            let _count_join_handle = record_table_sizes(
-                &config,
-                &connection_config,
-                &snapshot,
-                metrics,
-                worker_tables,
-                Arc::clone(&client),
-            )
-            .await?;
+            let snapshot_total =
+                fetch_snapshot_size(&client, worker_tables, metrics, &config).await?;
 
+            stats_output
+                .give(
+                    &stats_cap[0],
+                    ProgressStatisticsUpdate::Snapshot {
+                        records_known: snapshot_total,
+                        records_staged: 0,
+                    },
+                )
+                .await;
+
+            let mut snapshot_staged = 0;
             for (&oid, (_, expected_desc, _)) in reader_snapshot_table_info.iter() {
                 let desc = match verify_schema(oid, expected_desc, &upstream_info) {
                     Ok(()) => expected_desc,
@@ -443,8 +450,37 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                     raw_handle
                         .give(&data_cap_set[0], ((oid, Ok(bytes)), MzOffset::minimum(), 1))
                         .await;
+                    snapshot_staged += 1;
+                    // TODO(guswynn): does this 1000 need to be configurable?
+                    if snapshot_staged % 1000 == 0 {
+                        stats_output
+                            .give(
+                                &stats_cap[0],
+                                ProgressStatisticsUpdate::Snapshot {
+                                    records_known: snapshot_total,
+                                    records_staged: snapshot_staged,
+                                },
+                            )
+                            .await;
+                    }
                 }
             }
+
+            if snapshot_staged < snapshot_total {
+                error!(%id, "timely-{worker_id} snapshot size {snapshot_total} is somehow
+                                 bigger than records staged {snapshot_staged}");
+                snapshot_staged = snapshot_total;
+            }
+            stats_output
+                .give(
+                    &stats_cap[0],
+                    ProgressStatisticsUpdate::Snapshot {
+                        records_known: snapshot_total,
+                        records_staged: snapshot_staged,
+                    },
+                )
+                .await;
+
             // Failure scenario after we have produced the snapshot, but before a successful COMMIT
             fail::fail_point!("pg_snapshot_failure", |_| Err(
                 TransientError::SyntheticError
@@ -490,7 +526,13 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
 
     let errors = definite_errors.concat(&transient_errors.map(ReplicationError::from));
 
-    (snapshot_updates, rewinds, errors, button.press_on_drop())
+    (
+        snapshot_updates,
+        rewinds,
+        stats_stream,
+        errors,
+        button.press_on_drop(),
+    )
 }
 
 /// Starts a read-only transaction on the SQL session of `client` at a consistent LSN point by
@@ -561,139 +603,76 @@ fn decode_copy_row(data: &[u8], col_len: usize, row: &mut Row) -> Result<(), Def
 }
 
 /// Record the sizes of the tables being snapshotted in `PgSnapshotMetrics`.
-async fn record_table_sizes(
-    config: &RawSourceCreationConfig,
-    connection_config: &Config,
-    snapshot: &str,
-    metrics: PgSnapshotMetrics,
+async fn fetch_snapshot_size(
+    client: &Client,
     // The table names and oids owned by this worker.
     tables: Vec<(String, Oid)>,
-    // An optimization: when `wait_for_count` is true, we can use the client
-    // used for replication.
-    replication_client: Arc<Client>,
-) -> Result<Option<AbortOnDropHandle<Result<(), anyhow::Error>>>, anyhow::Error> {
+    metrics: PgSnapshotMetrics,
+    config: &RawSourceCreationConfig,
+) -> Result<u64, anyhow::Error> {
+    // TODO(guswynn): delete unused configs
     let snapshot_config = config.config.parameters.pg_snapshot_config;
-    let statement_timeout = config
-        .config
-        .parameters
-        .pg_source_snapshot_statement_timeout;
-    let connection_context = &config.config.connection_context;
 
-    let source_id = config.id;
-    let worker_id = config.worker_id;
-
-    if tables.is_empty() {
-        return Ok(None);
+    let mut total = 0;
+    for (table, oid) in tables {
+        let stats =
+            collect_table_statistics(client, snapshot_config.collect_strict_count, &table, oid)
+                .await?;
+        metrics.record_table_count_latency(
+            table,
+            stats.count_latency,
+            snapshot_config.collect_strict_count,
+        );
+        total += stats.count;
     }
-
-    let task_name = format!("timely-{worker_id} PG snapshot counter");
-
-    // We create a new connection here so that postgres can actually process this in parallel
-    // with the main snapshotting, unless we are waiting for the count.
-    let client = if snapshot_config.wait_for_count {
-        replication_client
-    } else {
-        let new_client = connection_config
-            .connect(&task_name, &connection_context.ssh_tunnel_manager)
-            .await?;
-
-        set_statement_timeout(&new_client, statement_timeout).await?;
-
-        // If we want a strict count, we want to count the rows in the snapshot
-        // determined in the operator.
-        if snapshot_config.collect_strict_count || snapshot_config.fallback_to_strict_count {
-            use_snapshot(&new_client, snapshot).await?
-        }
-        Arc::new(new_client)
-    };
-
-    let jh = mz_ore::task::spawn(|| format!("pg_source_count"), async move {
-        let metrics = &metrics;
-        let client = &client;
-
-        let mut result = Ok(());
-        for (table, oid) in tables {
-            match collect_table_statistics(client, snapshot_config, &table, oid).await {
-                Ok(stats) => {
-                    if let Some(count) = stats.estimate_count {
-                        metrics.record_table_estimate(table.clone(), count, stats.estimate_latency);
-                    }
-                    if let Some(count) = stats.count {
-                        metrics.record_table_count(table.clone(), count, stats.count_latency);
-                    }
-                }
-                Err(err) => {
-                    if !snapshot_config.wait_for_count {
-                        warn!(?err, "error when collecting pg count");
-                    }
-                    result = result.and(Err(err));
-                }
-            }
-        }
-        result.context(format!("{source_id}: "))?;
-
-        // If we want a strict count, we want to count the rows in the snapshot
-        // determined in the operator.
-        if !snapshot_config.wait_for_count
-            && (snapshot_config.collect_strict_count || snapshot_config.fallback_to_strict_count)
-        {
-            client.simple_query("COMMIT").await?;
-        }
-        Ok(())
-    });
-
-    if snapshot_config.wait_for_count {
-        jh.wait_and_assert_finished().await.map(|_| None)
-    } else {
-        // TODO(guswynn): should errors be communicated back to the health stream?
-        Ok(Some(jh.abort_on_drop()))
-    }
+    Ok(total)
 }
 
 #[derive(Default)]
 struct TableStatistics {
+    count: u64,
     count_latency: f64,
-    count: Option<i64>,
-    estimate_latency: f64,
-    estimate_count: Option<i64>,
 }
 
 async fn collect_table_statistics(
     client: &Client,
-    config: PgSourceSnapshotConfig,
+    strict: bool,
     table: &str,
     oid: u32,
 ) -> Result<TableStatistics, anyhow::Error> {
     use mz_ore::metrics::MetricsFutureExt;
     let mut stats = TableStatistics::default();
 
-    let estimate_row = simple_query_opt(
-        client,
-        &format!("SELECT reltuples::bigint AS estimate_count FROM pg_class WHERE oid = '{oid}'"),
-    )
-    .wall_time()
-    .set_at(&mut stats.estimate_latency)
-    .await?;
-
-    match estimate_row {
-        Some(row) => match row.get("estimate_count").unwrap().parse().unwrap() {
-            -1 => stats.estimate_count = None,
-            n => stats.estimate_count = Some(n),
-        },
-        None => bail!("failed to get estimate count for {table}"),
-    }
-
-    // Postgres returns an estimate of -1 if the table doesn't have sufficient writes/analysis/vacuuming happening.
-    let should_fallback = config.fallback_to_strict_count && stats.estimate_count.is_none();
-    if config.collect_strict_count || should_fallback {
+    if strict {
         let count_row = simple_query_opt(client, &format!("SELECT count(*) as count from {table}"))
             .wall_time()
             .set_at(&mut stats.count_latency)
             .await?;
         match count_row {
-            Some(row) => stats.count = Some(row.get("count").unwrap().parse().unwrap()),
+            Some(row) => {
+                let count: i64 = row.get("count").unwrap().parse().unwrap();
+                stats.count = count.try_into()?;
+            }
             None => bail!("failed to get count for {table}"),
         }
+    } else {
+        let estimate_row = simple_query_opt(
+            client,
+            &format!(
+                "SELECT reltuples::bigint AS estimate_count FROM pg_class WHERE oid = '{oid}'"
+            ),
+        )
+        .wall_time()
+        .set_at(&mut stats.count_latency)
+        .await?;
+        match estimate_row {
+            Some(row) => match row.get("estimate_count").unwrap().parse().unwrap() {
+                -1 => stats.count = 0,
+                n => stats.count = n.try_into()?,
+            },
+            None => bail!("failed to get estimate count for {table}"),
+        };
     }
+
     Ok(stats)
 }

--- a/src/storage/src/source/statistics.rs
+++ b/src/storage/src/source/statistics.rs
@@ -47,8 +47,22 @@ pub fn process_statistics<G, FromTime>(
             );
 
             for d in data {
-                source_statistics.set_offset_known(d.offset_known);
-                source_statistics.set_offset_committed(d.offset_committed);
+                match d {
+                    ProgressStatisticsUpdate::Snapshot {
+                        records_known,
+                        records_staged,
+                    } => {
+                        source_statistics.set_snapshot_records_known(records_known);
+                        source_statistics.set_snapshot_records_staged(records_staged);
+                    }
+                    ProgressStatisticsUpdate::SteadyState {
+                        offset_known,
+                        offset_committed,
+                    } => {
+                        source_statistics.set_offset_known(offset_known);
+                        source_statistics.set_offset_committed(offset_committed);
+                    }
+                }
             }
         }
     });

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -34,9 +34,15 @@ use crate::source::RawSourceCreationConfig;
 /// The aggregate is required to be a 64 bit unsigned integer, whose units are
 /// implementation-defined.
 #[derive(Clone, Debug)]
-pub struct ProgressStatisticsUpdate {
-    pub offset_known: u64,
-    pub offset_committed: u64,
+pub enum ProgressStatisticsUpdate {
+    SteadyState {
+        offset_known: u64,
+        offset_committed: u64,
+    },
+    Snapshot {
+        records_known: u64,
+        records_staged: u64,
+    },
 }
 
 /// Describes a source that can render itself in a timely scope.

--- a/test/cluster/storage/01-create-sources.td
+++ b/test/cluster/storage/01-create-sources.td
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# To ensure we get statistics in time
+$ set-sql-timeout duration=180s
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
 

--- a/test/mysql-cdc/statistics.td
+++ b/test/mysql-cdc/statistics.td
@@ -32,7 +32,9 @@ CREATE TABLE t1 (f1 TEXT);
 
 INSERT INTO t1 VALUES ('one');
 
-> CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqc FOR TABLES (public.t1);
+> CREATE CLUSTER stats_cluster SIZE '${arg.default-replica-size}'
+
+> CREATE SOURCE mz_source IN CLUSTER stats_cluster FROM MYSQL CONNECTION mysqc FOR TABLES (public.t1);
 
 > SELECT COUNT(*) > 0 FROM t1;
 true
@@ -43,13 +45,15 @@ $ set-sql-timeout duration=2minutes
 > SELECT
     s.name,
     SUM(u.offset_committed) > 0,
-    SUM(u.offset_known) >= SUM(u.offset_committed)
+    SUM(u.offset_known) >= SUM(u.offset_committed),
+    SUM(u.snapshot_records_known),
+    SUM(u.snapshot_records_staged)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('mz_source')
   GROUP BY s.name
   ORDER BY s.name
-mz_source true true
+mz_source true true 1 1
 
 $ set-from-sql var=previous-offset-committed
 SELECT
@@ -62,14 +66,47 @@ SELECT
 $ mysql-execute name=mysql
 INSERT INTO t1 VALUES ('two');
 
-
 > SELECT
     s.name,
     SUM(u.offset_committed) > ${previous-offset-committed},
-    SUM(u.offset_known) >= SUM(u.offset_committed)
+    SUM(u.offset_known) >= SUM(u.offset_committed),
+    SUM(u.snapshot_records_known),
+    SUM(u.snapshot_records_staged)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('mz_source')
   GROUP BY s.name
   ORDER BY s.name
-mz_source true true
+mz_source true true 1 1
+
+$ set-from-sql var=pre-restart-offset-committed
+SELECT
+    (SUM(u.offset_committed))::text
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('mz_source')
+
+> ALTER CLUSTER stats_cluster SET (REPLICATION FACTOR 0)
+
+$ mysql-execute name=mysql
+INSERT INTO t1 VALUES ('three');
+
+> ALTER CLUSTER stats_cluster SET (REPLICATION FACTOR 1)
+
+# Ensure the snapshot stats stay there, and don't change.
+> SELECT
+    s.name,
+    SUM(u.offset_committed) > ${pre-restart-offset-committed},
+    SUM(u.offset_known) >= SUM(u.offset_committed),
+    SUM(u.snapshot_records_known),
+    SUM(u.snapshot_records_staged)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('mz_source')
+  GROUP BY s.name
+  ORDER BY s.name
+mz_source true true 1 1
+
+# TODO(guswynn/roshan): test snapshot stats when alter cluster add table is supported by mysql
+
+> DROP CLUSTER stats_cluster CASCADE

--- a/test/pg-cdc/statistics.td
+++ b/test/pg-cdc/statistics.td
@@ -27,14 +27,17 @@ CREATE SCHEMA public;
 
 CREATE TABLE t1 (f1 TEXT);
 ALTER TABLE t1 REPLICA IDENTITY FULL;
-
 INSERT INTO t1 VALUES ('one');
+INSERT INTO t1 VALUES ('two');
 
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
+> CREATE CLUSTER stats_cluster SIZE '${arg.default-replica-size}'
+
 > CREATE SOURCE mz_source
+  IN CLUSTER stats_cluster
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
-  FOR ALL TABLES;
+  FOR TABLES ("t1")
 
 > SELECT COUNT(*) > 0 FROM t1;
 true
@@ -43,13 +46,15 @@ true
 > SELECT
     s.name,
     SUM(u.offset_committed) > 0,
-    SUM(u.offset_known) >= SUM(u.offset_committed)
+    SUM(u.offset_known) >= SUM(u.offset_committed),
+    SUM(u.snapshot_records_known),
+    SUM(u.snapshot_records_staged)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('mz_source')
   GROUP BY s.name
   ORDER BY s.name
-mz_source true true
+mz_source true true 2 2
 
 $ set-from-sql var=previous-offset-committed
 SELECT
@@ -60,16 +65,69 @@ SELECT
 
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-INSERT INTO t1 VALUES ('two');
+INSERT INTO t1 VALUES ('three');
 
 
 > SELECT
     s.name,
     SUM(u.offset_committed) > ${previous-offset-committed},
-    SUM(u.offset_known) >= SUM(u.offset_committed)
+    SUM(u.offset_known) >= SUM(u.offset_committed),
+    SUM(u.snapshot_records_known),
+    SUM(u.snapshot_records_staged)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('mz_source')
   GROUP BY s.name
   ORDER BY s.name
-mz_source true true
+mz_source true true 2 2
+
+$ set-from-sql var=pre-restart-offset-committed
+SELECT
+    (SUM(u.offset_committed))::text
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('mz_source')
+
+> ALTER CLUSTER stats_cluster SET (REPLICATION FACTOR 0)
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t1 VALUES ('four');
+
+> ALTER CLUSTER stats_cluster SET (REPLICATION FACTOR 1)
+
+# Ensure the snapshot stats stay there, and don't change.
+> SELECT
+    s.name,
+    SUM(u.offset_committed) > ${pre-restart-offset-committed},
+    SUM(u.offset_known) >= SUM(u.offset_committed),
+    SUM(u.snapshot_records_known),
+    SUM(u.snapshot_records_staged)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('mz_source')
+  GROUP BY s.name
+  ORDER BY s.name
+mz_source true true 2 2
+
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE alt (f1 TEXT);
+ALTER TABLE alt REPLICA IDENTITY FULL;
+INSERT INTO alt VALUES ('one');
+
+> ALTER SOURCE mz_source ADD SUBSOURCE alt;
+
+> SELECT COUNT(*) > 0 FROM alt;
+true
+
+# Ensure snapshot stats are overridden when we add a new table
+> SELECT
+    s.name,
+    SUM(u.snapshot_records_known),
+    SUM(u.snapshot_records_staged)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('mz_source')
+  GROUP BY s.name
+  ORDER BY s.name
+mz_source 1 1

--- a/test/testdrive/snapshot-source-statistics.td
+++ b/test/testdrive/snapshot-source-statistics.td
@@ -49,18 +49,16 @@ goofus,gallant
     URL '${testdrive.schema-registry-url}'
   );
 
+> CREATE CLUSTER stats_cluster SIZE '${arg.default-replica-size}'
+
 > CREATE SOURCE upsert
-  IN CLUSTER ${arg.single-replica-cluster}
+  IN CLUSTER stats_cluster
   FROM KAFKA CONNECTION kafka_conn (TOPIC
   'testdrive-upsert-${testdrive.seed}'
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE OFFSET
   ENVELOPE UPSERT
-
-> CREATE SOURCE counter
-  IN CLUSTER ${arg.single-replica-cluster}
-  FROM LOAD GENERATOR COUNTER;
 
 # Adding a select here so that the ingests after this
 # triggers lookup from the upsert state
@@ -71,7 +69,8 @@ fish          fish    1000
 birdmore      geese   56
 mammalmore    moose   2
 
-# statistics are only populated every minute by default
+# statistics are only populated every minute by default, and kafka has a 60 second
+# interval on when it collects partition metadata.
 $ set-sql-timeout duration=3minutes
 
 # NOTE: These queries are slow to succeed because the default metrics scraping
@@ -79,25 +78,14 @@ $ set-sql-timeout duration=3minutes
 
 > SELECT
     s.name,
-    SUM(u.offset_known) > 0,
-    SUM(u.offset_known) = SUM(u.offset_committed)
+    SUM(u.snapshot_records_known),
+    SUM(u.snapshot_records_staged)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
-upsert true true
-
-> SELECT
-    s.name,
-    SUM(u.offset_known) > 0,
-    SUM(u.offset_committed) > 0
-  FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
-  WHERE s.name IN ('counter')
-  GROUP BY s.name
-  ORDER BY s.name
-counter true true
+upsert 9 9
 
 $ set-from-sql var=previous-offset-known
 SELECT
@@ -110,16 +98,45 @@ SELECT
 $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
 {"key": "mammalmore"}
 
+# Snapshot counts don't move...
 > SELECT
     s.name,
     SUM(u.offset_known) > ${previous-offset-known},
-    SUM(u.offset_known) = SUM(u.offset_committed)
+    SUM(u.snapshot_records_known),
+    SUM(u.snapshot_records_staged)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
-upsert true true
+upsert true 9 9
+
+# ...even if we restart.
+
+$ set-from-sql var=pre-restart-offset-committed
+SELECT
+    (SUM(u.offset_committed))::text
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+
+> ALTER CLUSTER stats_cluster SET (REPLICATION FACTOR 0)
+
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "mammalmore"} {"f1":"moose", "f2": 100}
+
+> ALTER CLUSTER stats_cluster SET (REPLICATION FACTOR 1)
+
+> SELECT
+    s.name,
+    SUM(u.offset_committed) > ${pre-restart-offset-committed},
+    SUM(u.snapshot_records_known),
+    SUM(u.snapshot_records_staged)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+  GROUP BY s.name
+  ORDER BY s.name
+upsert true 9 9
 
 > DROP SOURCE upsert
-> DROP SOURCE counter

--- a/test/testdrive/statistics-maintenance.td
+++ b/test/testdrive/statistics-maintenance.td
@@ -54,13 +54,12 @@ sink1 1 1 true true
 
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
-  SUM(u.messages_received),
-  SUM(snapshot_records_staged) IS NULL
+  SUM(u.messages_received)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 true 1 true
+upsert1 true 1
 
 # Shut down the cluster
 > ALTER CLUSTER cluster1 SET (REPLICATION FACTOR = 0)
@@ -75,13 +74,12 @@ sink1 1 1 true true
 
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
-  SUM(u.messages_received),
-  SUM(snapshot_records_staged) IS NULL
+  SUM(u.messages_received)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 true 1 true
+upsert1 true 1
 
 # Ingest some more data, and ensure counters are maintained
 
@@ -100,10 +98,9 @@ sink1 2 2 true true
 
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
-  SUM(u.messages_received),
-  SUM(snapshot_records_staged) IS NULL
+  SUM(u.messages_received)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('upsert1')
   GROUP BY s.id, s.name
-upsert1 true 2 true
+upsert1 true 2


### PR DESCRIPTION
Implements the final pieces of the [source metrics design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20240108_source_metrics_2.md).

This pr hooks up the already-partially-collected snapshot statistics and hooks it up to the `mz_source_statistics_raw` table.

It implements this for mysql/pg/kafka (I am skipping generators for now, because they have annoying semantics), and tests them. After this, the final piece is indexing the data in the user-facing view. That will be a followup pr 

### Motivation

  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
