### PR TITLE
fivetran-destination: Specify workspace default-members to make building easier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,19 @@ members = [
 
 # Here we should specify our high level binaries to prevent folks from needing to take extra steps
 # like updating git submodules when building the workspace without a target specified.
-default-members = ["src/clusterd", "src/environmentd", "src/balancerd"]
+#
+# Crates we want to make sure are _excluded_ are:
+# * `fivetran-destination` since it depends on the `fivetran-sdk` submodule.
+#
+default-members = [
+    "src/clusterd",
+    "src/environmentd",
+    "src/balancerd",
+    "src/testdrive",
+    "src/sqllogictest",
+    "src/stash-debug",
+    "src/catalog-debug",
+]
 
 exclude = [
     # All WASM crates are split into their own workspace to avoid needles cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,10 @@ members = [
     "src/regexp",
 ]
 
+# Here we should specify our high level binaries to prevent folks from needing to take extra steps
+# like updating git submodules when building the workspace without a target specified.
+default-members = ["src/clusterd", "src/environmentd", "src/balancerd"]
+
 exclude = [
     # All WASM crates are split into their own workspace to avoid needles cache
     #  invalidations for the core Mz crates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,19 +111,23 @@ members = [
 # * `fivetran-destination` since it depends on the `fivetran-sdk` submodule.
 #
 default-members = [
+    "src/balancerd",
+    "src/catalog-debug",
     "src/clusterd",
     "src/environmentd",
-    "src/balancerd",
-    "src/testdrive",
+    "src/kafka-util",
+    "src/mz",
+    "src/persist-cli",
     "src/sqllogictest",
     "src/stash-debug",
-    "src/catalog-debug",
+    "src/testdrive",
+    "test/metabase/smoketest",
 ]
 
 exclude = [
     # All WASM crates are split into their own workspace to avoid needles cache
     #  invalidations for the core Mz crates.
-    "misc/wasm/*"
+    "misc/wasm/*",
 ]
 
 # Use Cargo's new feature resolver, which can handle target-specific features.

--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -75,6 +75,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 "cargo",
                 "llvm-cov",
                 "run",
+                "--workspace",
                 "--bin",
                 "clusterd",
                 "--release",
@@ -120,6 +121,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 [
                     "cargo",
                     "build",
+                    "--workspace",
                     "--bin",
                     "clusterd",
                     "--profile=ci",
@@ -138,6 +140,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     "cargo",
                     "nextest",
                     "run",
+                    "--workspace",
                     "--profile=ci",
                     "--cargo-profile=ci",
                     f"--partition=count:{partition}/{total}",

--- a/ci/test/lint-deps.sh
+++ b/ci/test/lint-deps.sh
@@ -53,7 +53,7 @@ function deps() {
     # output if there is no dependency to any of the specified packages.
     for crate in "${crates[@]}"; do
         # Gather data for the current target, reverse lines, find the dependency hierarchy to the root, reverse lines.
-        output=$(cargo tree --format ':{lib}:{f}' \
+        output=$(cargo tree --workspace --format ':{lib}:{f}' \
             --prefix depth \
             --edges normal,build \
             --locked \

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -258,7 +258,10 @@ class CargoBuild(CargoPreImage):
     ) -> list[str]:
         rustflags = rustc_flags.coverage if rd.coverage else ["--cfg=tokio_unstable"]
 
-        cargo_build = [*rd.cargo("build", channel=None, rustflags=rustflags), "--workspace"]
+        cargo_build = [
+            *rd.cargo("build", channel=None, rustflags=rustflags),
+            "--workspace",
+        ]
 
         for bin in bins:
             cargo_build.extend(["--bin", bin])

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -258,7 +258,7 @@ class CargoBuild(CargoPreImage):
     ) -> list[str]:
         rustflags = rustc_flags.coverage if rd.coverage else ["--cfg=tokio_unstable"]
 
-        cargo_build = [*rd.cargo("build", channel=None, rustflags=rustflags)]
+        cargo_build = [*rd.cargo("build", channel=None, rustflags=rustflags), "--workspace"]
 
         for bin in bins:
             cargo_build.extend(["--bin", bin])


### PR DESCRIPTION
Many folks will run `cargo check` from the root of the workspace to make sure everything builds successfully. Often they hit an issue where the `fivetran-destination` fails to build because it depends on the `/misc/fivetran-sdk` submodule, and then they have to figure out how to update the submodule which isn't the best experience. The `fivetran-destination` is touched by very few people (only me at the moment) so forcing everyone to build it adds unnecessary friction.

The crates specified in `default-members` are the ones that will get built when running `cargo` commands from the root of our workspace when a target is not specified. Currently the list of `default-members` are all binaries that are referenced from `mzbuild.yml` files which should encompass everything.

Note: This also changes the behavior of `cargo test` when run from the root of the workspace, it will now only test the crates in `default-members`. I don't think this is too big of an issue because the only workflow that requires this is CI. I updated CI to specify the `--workspace` flag where needed to test the entire workspace.

### Motivation

Improve the developer experience.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
