### PR TITLE
Analysis use

### DIFF
--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -14,8 +14,10 @@ use mz_expr::MirRelationExpr;
 pub use common::{Derived, DerivedBuilder, DerivedView};
 
 pub use arity::Arity;
+pub use non_negative::NonNegative;
 pub use subtree::SubtreeSize;
 pub use types::RelationType;
+pub use unique_keys::UniqueKeys;
 
 /// An analysis that can be applied bottom-up to a `MirRelationExpr`.
 pub trait Analysis: 'static {
@@ -155,13 +157,13 @@ pub mod common {
             // Each extracted slice corresponds to a child of the current expression.
             // We should end cleanly with an empty slice, otherwise there is an issue.
             let sizes = self.results::<SubtreeSize>().expect("SubtreeSize missing");
-            let sizes = &sizes[.. sizes.len() - 1];
+            let sizes = &sizes[..sizes.len() - 1];
 
             let offset = self.lower;
             let derived = self.derived;
             (0..).scan(sizes, move |sizes, _| {
                 if let Some(size) = sizes.last() {
-                    *sizes = &sizes[.. sizes.len() - size];
+                    *sizes = &sizes[..sizes.len() - size];
                     Some(Self {
                         derived,
                         lower: offset + sizes.len(),
@@ -170,7 +172,7 @@ pub mod common {
                 } else {
                     None
                 }
-            }).collect::<Vec<_>>().into_iter()
+            })
         }
     }
 

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -14,9 +14,10 @@
 //! can be simplified to a map operation.
 
 use itertools::Itertools;
-use mz_expr::visit::Visit;
 use mz_expr::MirRelationExpr;
 
+use crate::analysis::{DerivedBuilder, DerivedView};
+use crate::analysis::{RelationType, UniqueKeys};
 use crate::TransformCtx;
 
 /// Removes `Reduce` when the input has as unique keys the keys of the reduce.
@@ -35,48 +36,79 @@ impl crate::Transform for ReduceElision {
         relation: &mut MirRelationExpr,
         _: &mut TransformCtx,
     ) -> Result<(), crate::TransformError> {
-        let result = relation.try_visit_mut_post(&mut |e| self.action(e));
+        // Assemble type information once for the whole expression.
+        let mut builder = DerivedBuilder::default();
+        builder.require::<RelationType>();
+        builder.require::<UniqueKeys>();
+        let derived = builder.visit(relation);
+        let derived_view = derived.as_view();
+
+        self.action(relation, derived_view);
+
         mz_repr::explain::trace_plan(&*relation);
-        result
+        Ok(())
     }
 }
 
 impl ReduceElision {
     /// Removes `Reduce` when the input has as unique keys the keys of the reduce.
-    pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
-        if let MirRelationExpr::Reduce {
-            input,
-            group_key,
-            aggregates,
-            monotonic: _,
-            expected_group_size: _,
-        } = relation
-        {
-            let input_type = input.typ();
-            if input_type.keys.iter().any(|keys| {
-                keys.iter()
-                    .all(|k| group_key.contains(&mz_expr::MirScalarExpr::Column(*k)))
-            }) {
-                let map_scalars = aggregates
-                    .iter()
-                    .map(|a| a.on_unique(&input_type.column_types))
-                    .collect_vec();
+    pub fn action(&self, relation: &mut MirRelationExpr, derived: DerivedView) {
+        let mut todo = vec![(relation, derived)];
+        while let Some((expr, view)) = todo.pop() {
+            if let MirRelationExpr::Reduce {
+                input,
+                group_key,
+                aggregates,
+                monotonic: _,
+                expected_group_size: _,
+            } = expr
+            {
+                // Pull the input type information from the derived view.
+                let types = view
+                    .results::<RelationType>()
+                    .expect("RelationType required");
+                let input_type = types[types.len() - 2]
+                    .as_ref()
+                    .expect("Expression not well-typed");
+                let keys = view.results::<UniqueKeys>().expect("UniqueKeys required");
+                let input_keys = &keys[keys.len() - 2];
 
-                let mut result = input.take_dangerous();
+                if input_keys.iter().any(|keys| {
+                    keys.iter()
+                        .all(|k| group_key.contains(&mz_expr::MirScalarExpr::Column(*k)))
+                }) {
+                    let map_scalars = aggregates
+                        .iter()
+                        .map(|a| a.on_unique(input_type))
+                        .collect_vec();
 
-                // Append the group keys, then any `map_scalars`, then project
-                // to put them all in the right order.
-                let mut new_scalars = group_key.clone();
-                new_scalars.extend(map_scalars);
-                result = result.map(new_scalars).project(
-                    (input_type.column_types.len()
-                        ..(input_type.column_types.len() + (group_key.len() + aggregates.len())))
-                        .collect(),
-                );
+                    let mut result = input.take_dangerous();
 
-                *relation = result;
+                    let input_arity = input_type.len();
+
+                    assert_eq!(input_arity, result.arity());
+
+                    // Append the group keys, then any `map_scalars`, then project
+                    // to put them all in the right order.
+                    let mut new_scalars = group_key.clone();
+                    new_scalars.extend(map_scalars);
+                    result = result.map(new_scalars).project(
+                        (input_arity..(input_arity + (group_key.len() + aggregates.len())))
+                            .collect(),
+                    );
+
+                    *expr = result;
+
+                    // Continue on `input`, which is now hidden behind a map and project stage.
+                    if let MirRelationExpr::Project { input, .. } = expr {
+                        if let MirRelationExpr::Map { input, .. } = &mut **input {
+                            todo.push((&mut **input, view.children_rev().next().unwrap()))
+                        }
+                    }
+                }
+            } else {
+                todo.extend(expr.children_mut().rev().zip(view.children_rev()));
             }
         }
-        Ok(())
     }
 }


### PR DESCRIPTION
This PR starts out trying to use the new `Analysis` framework, porting over first `ReduceElision`, which requires type information and is currently just calling `.typ()` over and over again (potentially quadratic). This turns the code into two linear passes.

cc: @aalexandrov 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
