### PR TITLE
platform-checks: Fix preflight and rollback scenario

### DIFF
--- a/misc/python/materialize/checks/all_checks/statement_logging.py
+++ b/misc/python/materialize/checks/all_checks/statement_logging.py
@@ -60,7 +60,10 @@ class StatementLogging(Check):
                     """
                     $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     ALTER SYSTEM SET enable_rbac_checks TO false
-                    > SELECT sql, finished_status FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh, (SELECT DISTINCT sql, sql_hash, redacted_sql FROM mz_internal.mz_sql_text) mst WHERE mseh.prepared_statement_id = mpsh.id AND mst.sql_hash = mpsh.sql_hash AND sql LIKE '%/* Btv was here */' ORDER BY mseh.began_at;
+                    >[version>=8900] SELECT sql, finished_status FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh, (SELECT DISTINCT sql, sql_hash, redacted_sql FROM mz_internal.mz_sql_text) mst WHERE mseh.prepared_statement_id = mpsh.id AND mst.sql_hash = mpsh.sql_hash AND sql LIKE '%/* Btv was here */' ORDER BY mseh.began_at;
+                    "SELECT 'hello' /* Btv was here */" success
+                    "SELECT 'goodbye' /* Btv was here */" success
+                    >[version<8900] SELECT sql, finished_status FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh WHERE mseh.prepared_statement_id = mpsh.id AND sql LIKE '%/* Btv was here */' ORDER BY mseh.began_at;
                     "SELECT 'hello' /* Btv was here */" success
                     "SELECT 'goodbye' /* Btv was here */" success
                     $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
@@ -75,7 +78,9 @@ class StatementLogging(Check):
                     """
                     $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     ALTER SYSTEM SET enable_rbac_checks TO false
-                    > SELECT count(*) <= 2 FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh, (SELECT DISTINCT sql, sql_hash, redacted_sql FROM mz_internal.mz_sql_text) mst WHERE mseh.prepared_statement_id = mpsh.id AND mpsh.sql_hash = mst.sql_hash AND sql LIKE '%/* Btv was here */'
+                    >[version>=8900] SELECT count(*) <= 2 FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh, (SELECT DISTINCT sql, sql_hash, redacted_sql FROM mz_internal.mz_sql_text) mst WHERE mseh.prepared_statement_id = mpsh.id AND mpsh.sql_hash = mst.sql_hash AND sql LIKE '%/* Btv was here */'
+                    true
+                    >[version<8900] SELECT count(*) <= 2 FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh WHERE mseh.prepared_statement_id = mpsh.id AND sql LIKE '%/* Btv was here */'
                     true
                     $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
                     ALTER SYSTEM SET enable_rbac_checks TO true


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/6561#018dccef-ef30-4f63-824c-ff8d982392d8

Broken by https://github.com/MaterializeInc/materialize/pull/25276/files

This scenario is slightly annoying because it is the only one that ends up running the verify step in the old version. I'm not sure if this will be too much effort in the future to maintain.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
