### PR TITLE
frontegg-auth: remove dead code

### DIFF
--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -299,23 +299,6 @@ impl Authentication {
         Ok(result)
     }
 
-    /// Validates an API token response, returning a validated response
-    /// containing the validated claims.
-    ///
-    /// Like [`Authentication::validate_access_token`], but operates on an
-    /// [`ApiTokenResponse`] rather than a raw access token.
-    pub fn validate_api_token_response(
-        &self,
-        response: ApiTokenResponse,
-        expected_email: Option<&str>,
-    ) -> Result<ValidatedApiTokenResponse, Error> {
-        let claims = self.validate_access_token(&response.access_token, expected_email)?;
-        Ok(ValidatedApiTokenResponse {
-            claims,
-            refresh_token: response.refresh_token,
-        })
-    }
-
     /// Validates an access token, returning the validated claims.
     ///
     /// The following validations are always performed:
@@ -531,15 +514,6 @@ fn continuously_refresh(
     });
 
     id
-}
-
-/// An [`ApiTokenResponse`] that has been validated by
-/// [`Authentication::validate_api_token_response`].
-pub struct ValidatedApiTokenResponse {
-    /// The validated claims.
-    pub claims: ValidatedClaims,
-    /// The refresh token from the API response.
-    pub refresh_token: String,
 }
 
 // TODO: Do we care about the sub? Do we need to validate the sub or other

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -16,8 +16,7 @@ mod metrics;
 use std::path::PathBuf;
 
 pub use auth::{
-    Authentication, AuthenticationConfig, Claims, ExchangePasswordForTokenResponse,
-    ValidatedApiTokenResponse, REFRESH_SUFFIX,
+    Authentication, AuthenticationConfig, Claims, ExchangePasswordForTokenResponse, REFRESH_SUFFIX,
 };
 pub use client::tokens::{ApiTokenArgs, ApiTokenResponse, RefreshToken};
 pub use client::Client;


### PR DESCRIPTION
Easy split out from https://github.com/MaterializeInc/materialize/pull/25409.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
