### PR TITLE
adapter: require Session's external metadata rx at construction

### DIFF
--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -13,6 +13,7 @@ use mz_sql::session::user::SYSTEM_USER;
 use tracing::{error, info};
 
 use crate::config::SynchronizedParameters;
+use crate::session::SessionConfig;
 use crate::{AdapterError, Client, SessionClient};
 
 /// A backend client for pushing and pulling [SynchronizedParameters].
@@ -26,7 +27,11 @@ pub struct SystemParameterBackend {
 impl SystemParameterBackend {
     pub async fn new(client: Client) -> Result<Self, AdapterError> {
         let conn_id = client.new_conn_id()?;
-        let session = client.new_session(conn_id, SYSTEM_USER.clone());
+        let session = client.new_session(SessionConfig {
+            conn_id,
+            user: SYSTEM_USER.name.clone(),
+            external_metadata_rx: None,
+        });
         let session_client = client.startup(session).await?;
         Ok(Self { session_client })
     }


### PR DESCRIPTION
Easy split out from https://github.com/MaterializeInc/materialize/pull/25409.

Rather than allowing registration of an external metadata receiver at any point after a session's construction, require it as part of the construction of the session. This allows us to statically remove the possibility of double registration.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
