### PR TITLE
ci: generate dummy junit.xml also for nightly

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -65,6 +65,8 @@ so it is executed.""",
     parser.add_argument("pipeline", type=str)
     args = parser.parse_args()
 
+    print(f"Pipeline is: {args.pipeline}")
+
     # Make sure we have an up to date view of main.
     spawn.runv(["git", "fetch", "origin", "main"])
 

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -94,6 +94,7 @@ so it is executed.""",
             print("--- Trimming unchanged steps from pipeline")
             trim_tests_pipeline(pipeline, args.coverage)
 
+    if args.pipeline in ["test", "nightly"]:
         # Upload a dummy JUnit report so that the "Analyze tests" step doesn't fail
         # if we trim away all the JUnit report-generating steps.
         Path("junit_dummy.xml").write_text("")


### PR DESCRIPTION
Needed for example if you only run "Detect closed issues".

Demo: https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Aci%2Fdummy-junit-xml-for-nightly