### PR TITLE
For an MV with empty `as_of`, don't even create a dataflow

### DIFF
--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -352,7 +352,9 @@ impl ShouldHalt for DataflowCreationError {
             DataflowCreationError::SinceViolation(_)
             | DataflowCreationError::InstanceMissing(_)
             | DataflowCreationError::CollectionMissing(_)
-            | DataflowCreationError::MissingAsOf => false,
+            | DataflowCreationError::MissingAsOf
+            | DataflowCreationError::EmptyAsOfForSubscribe
+            | DataflowCreationError::EmptyAsOfForCopyTo => false,
         }
     }
 }

--- a/src/compute-client/src/controller/error.rs
+++ b/src/compute-client/src/controller/error.rs
@@ -131,6 +131,14 @@ pub enum DataflowCreationError {
     /// TODO(#25239): Add documentation.
     #[error("dataflow has an as_of not beyond the since of collection: {0}")]
     SinceViolation(GlobalId),
+    /// We skip dataflow creation for empty `as_of`s, which would be a problem for a SUBSCRIBE,
+    /// because an initial response is expected.
+    #[error("subscribe dataflow has an empty as_of")]
+    EmptyAsOfForSubscribe,
+    /// We skip dataflow creation for empty `as_of`s, which would be a problem for a COPY TO,
+    /// because it should always have an external side effect.
+    #[error("copy to dataflow has an empty as_of")]
+    EmptyAsOfForCopyTo,
 }
 
 impl From<InstanceMissing> for DataflowCreationError {
@@ -146,6 +154,8 @@ impl From<instance::DataflowCreationError> for DataflowCreationError {
             CollectionMissing(id) => Self::CollectionMissing(id),
             MissingAsOf => Self::MissingAsOf,
             SinceViolation(id) => Self::SinceViolation(id),
+            EmptyAsOfForSubscribe => Self::EmptyAsOfForSubscribe,
+            EmptyAsOfForCopyTo => Self::EmptyAsOfForCopyTo,
         }
     }
 }


### PR DESCRIPTION
To prevent rehydration of MVs after their last refresh (https://github.com/MaterializeInc/materialize/issues/25380), this PR allows `bootstrap_materialized_view_as_of` to create an MV dataflow with an empty `as_of` (which is the state of MVs after their last refresh). It also tweaks `create_dataflow` to entirely skip creating a dataflow in this case (as per @teskje), to avoid [issues](https://github.com/MaterializeInc/materialize/pull/25353) with actually running a dataflow that has an empty `as_of`.

Note that, surprisingly, the original issue is no longer occurring on main! However, I think we should still go through with this PR, because it's probably brittle whether the issue is happening on main or not. (It might depend on little details of how exactly the Persist source gives us the data, which might influence whether we move the frontier to `[]` already before we actually get into doing real work.) (A commit on main where the issue was still happening is c6081c9b7832405757844acf15962836ff83ea7d. I have [a branch](https://github.com/ggevay/materialize/tree/empty-as-of2-ported-to-main500) where I ported the current change on top of that commit, which fixed the issue also there.)

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/25380

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
