### PR TITLE
rust: Upgrade to 1.76

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.74.1"
+rust-version = "1.76.0"
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-NIGHTLY_RUST_DATE=2023-11-19
+NIGHTLY_RUST_DATE=2024-01-01
 
 cd "$(dirname "$0")/.."
 

--- a/bin/lint-versions
+++ b/bin/lint-versions
@@ -11,5 +11,5 @@
 #
 # lint-versions - Check rust version
 
-grep "rust-version = " Cargo.toml | grep -q "1\.74\.1" || \
+grep "rust-version = " Cargo.toml | grep -q "1\.76\.0" || \
 (echo "Please validate new Rust versions for compilation time performance regressions or ask Team Testing to do so. Afterwards change the tested version in bin/lint-versions" && exit 1)

--- a/misc/wasm/Cargo.toml
+++ b/misc/wasm/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.74.1"
+rust-version = "1.76.0"
 
 [workspace.metadata.vet]
 store = { path = "../cargo-vet" }


### PR DESCRIPTION
Bumps the version of Rust we use to 1.76

### Motivation

Get on the latest stable Rust!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
