### PR TITLE
ci: error-extraction from logs: remove testdrive entries already captured by junit.xml error extraction

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -41,16 +41,6 @@ ERROR_RE = re.compile(
     | fatal runtime error: # stack overflow
     | \[SQLsmith\] # Unknown errors are logged
     | \[SQLancer\] # Unknown errors are logged
-    # From src/testdrive/src/action/sql.rs
-    | column\ name\ mismatch
-    | non-matching\ rows:
-    | wrong\ row\ count:
-    | wrong\ hash\ value:
-    | expected\ one\ statement
-    | query\ succeeded,\ but\ expected
-    | expected\ .*,\ got\ .*
-    | expected\ .*,\ but\ found\ none
-    | unsupported\ SQL\ type\ in\ testdrive:
     | environmentd:\ fatal: # startup failure
     | clusterd:\ fatal: # startup failure
     | error:\ Found\ argument\ '.*'\ which\ wasn't\ expected,\ or\ isn't\ valid\ in\ this\ context


### PR DESCRIPTION
<img width="1154" alt="Bildschirmfoto 2024-02-22 um 16 57 33" src="https://github.com/MaterializeInc/materialize/assets/129728240/40a0a14f-ac04-4efe-adc1-3cc63ebe11bc">

This removes testdrive entries from the box below (with incomplete data from logs) because these entries should already be covered by the box above (with data from the junit.xml file).