### PR TITLE
mzcompose: Don't drop last few lines

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -344,11 +344,13 @@ class Composition:
                     sel.register(p.stderr, selectors.EVENT_READ)  # type: ignore
                     running = True
                     while running:
+                        running = False
                         for key, val in sel.select():
                             line = key.fileobj.readline()  # type: ignore
                             if not line:
-                                running = False
-                                break
+                                continue
+                            # Keep running as long as stdout or stderr have any content
+                            running = True
                             if key.fileobj is p.stdout:
                                 print(line, end="")
                                 stdout_result += line


### PR DESCRIPTION
in capture_and_print mode. Seen in https://buildkite.com/materialize/tests/builds/76472#_

Just broken in https://github.com/MaterializeInc/materialize/pull/25459

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
