### PR TITLE
storage: speed up statistics tests

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -175,6 +175,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             config.kafka_socket_connection_setup_timeout(),
             config.kafka_fetch_metadata_timeout(),
             config.kafka_progress_record_fetch_timeout(),
+            config.kafka_default_metadata_fetch_interval(),
         ),
         statistics_interval: config.storage_statistics_interval(),
         statistics_collection_interval: config.storage_statistics_collection_interval(),

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -667,6 +667,8 @@ pub const DEFAULT_FETCH_METADATA_TIMEOUT: Duration = Duration::from_secs(10);
 /// The timeout for reading records from the progress topic. Set to something slightly longer than
 /// the idle transaction timeout (60s) to wait out any stuck producers.
 pub const DEFAULT_PROGRESS_RECORD_FETCH_TIMEOUT: Duration = Duration::from_secs(90);
+/// The interval we will fetch metadata from, unless overridden by the source.
+pub const DEFAULT_METADATA_FETCH_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Configurable timeouts for Kafka connections.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -684,6 +686,8 @@ pub struct TimeoutConfig {
     pub fetch_metadata_timeout: Duration,
     /// The timeout for reading records from the progress topic.
     pub progress_record_fetch_timeout: Duration,
+    /// The interval we will fetch metadata from, unless overridden by the source.
+    pub default_metadata_fetch_interval: Duration,
 }
 
 impl Default for TimeoutConfig {
@@ -695,6 +699,7 @@ impl Default for TimeoutConfig {
             socket_connection_setup_timeout: DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT,
             fetch_metadata_timeout: DEFAULT_FETCH_METADATA_TIMEOUT,
             progress_record_fetch_timeout: DEFAULT_PROGRESS_RECORD_FETCH_TIMEOUT,
+            default_metadata_fetch_interval: DEFAULT_METADATA_FETCH_INTERVAL,
         }
     }
 }
@@ -709,6 +714,7 @@ impl TimeoutConfig {
         socket_connection_setup_timeout: Duration,
         fetch_metadata_timeout: Duration,
         progress_record_fetch_timeout: Duration,
+        default_metadata_fetch_interval: Duration,
     ) -> TimeoutConfig {
         // Constrain values based on ranges here:
         // <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
@@ -793,6 +799,7 @@ impl TimeoutConfig {
             socket_connection_setup_timeout,
             fetch_metadata_timeout,
             progress_record_fetch_timeout,
+            default_metadata_fetch_interval,
         }
     }
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1122,6 +1122,15 @@ const KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
+/// The interval we will fetch metadata from, unless overridden by the source.
+const KAFKA_DEFAULT_METADATA_FETCH_INTERVAL: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("kafka_default_metadata_fetch_interval"),
+    value: mz_kafka_util::client::DEFAULT_METADATA_FETCH_INTERVAL,
+    description: "The interval we will fetch metadata from, unless overridden by the source. \
+        Defaults to 60s.",
+    internal: true,
+};
+
 /// The maximum number of in-flight bytes emitted by persist_sources feeding compute dataflows.
 const COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar {
     name: UncasedStr::new("compute_dataflow_max_inflight_bytes"),
@@ -2918,6 +2927,7 @@ impl SystemVars {
             .with_var(&KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT)
             .with_var(&KAFKA_FETCH_METADATA_TIMEOUT)
             .with_var(&KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT)
+            .with_var(&KAFKA_DEFAULT_METADATA_FETCH_INTERVAL)
             .with_var(&ENABLE_LAUNCHDARKLY)
             .with_var(&MAX_CONNECTIONS)
             .with_var(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
@@ -3543,6 +3553,11 @@ impl SystemVars {
     /// Returns the `kafka_progress_record_fetch_timeout` configuration parameter.
     pub fn kafka_progress_record_fetch_timeout(&self) -> Duration {
         *self.expect_value(&KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT)
+    }
+
+    /// Returns the `kafka_default_metadata_fetch_interval` configuration parameter.
+    pub fn kafka_default_metadata_fetch_interval(&self) -> Duration {
+        *self.expect_value(&KAFKA_DEFAULT_METADATA_FETCH_INTERVAL)
     }
 
     /// Returns the `crdb_connect_timeout` configuration parameter.
@@ -5515,12 +5530,15 @@ impl SystemVars {
             || name == KAFKA_SOCKET_CONNECTION_SETUP_TIMEOUT.name()
             || name == KAFKA_FETCH_METADATA_TIMEOUT.name()
             || name == KAFKA_PROGRESS_RECORD_FETCH_TIMEOUT.name()
+            || name == KAFKA_DEFAULT_METADATA_FETCH_INTERVAL.name()
             || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
             || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION.name()
             || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY.name()
             || name == STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION.name()
             || name == STORAGE_SHRINK_UPSERT_UNUSED_BUFFERS_BY_RATIO.name()
             || name == STORAGE_RECORD_SOURCE_SINK_NAMESPACED_ERRORS.name()
+            || name == STORAGE_STATISTICS_INTERVAL.name()
+            || name == STORAGE_STATISTICS_COLLECTION_INTERVAL.name()
             || is_upsert_rocksdb_config_var(name)
             || self.is_persist_config_var(name)
             || is_tracing_var(name)

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -66,6 +66,7 @@ message ProtoKafkaTimeouts {
     mz_proto.ProtoDuration socket_connection_setup_timeout = 3;
     mz_proto.ProtoDuration fetch_metadata_timeout = 4;
     mz_proto.ProtoDuration progress_record_fetch_timeout = 7;
+    mz_proto.ProtoDuration default_metadata_fetch_interval = 8;
 }
 message ProtoSshTimeoutConfig {
     mz_proto.ProtoDuration check_interval = 1;

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -419,6 +419,9 @@ impl RustType<ProtoKafkaTimeouts> for mz_kafka_util::client::TimeoutConfig {
             ),
             fetch_metadata_timeout: Some(self.fetch_metadata_timeout.into_proto()),
             progress_record_fetch_timeout: Some(self.progress_record_fetch_timeout.into_proto()),
+            default_metadata_fetch_interval: Some(
+                self.default_metadata_fetch_interval.into_proto(),
+            ),
         }
     }
 
@@ -442,6 +445,11 @@ impl RustType<ProtoKafkaTimeouts> for mz_kafka_util::client::TimeoutConfig {
             progress_record_fetch_timeout: proto
                 .progress_record_fetch_timeout
                 .into_rust_if_some("ProtoKafkaSourceTcpTimeouts::progress_record_fetch_timeout")?,
+            default_metadata_fetch_interval: proto
+                .default_metadata_fetch_interval
+                .into_rust_if_some(
+                    "ProtoKafkaSourceTcpTimeouts::default_metadata_fetch_interval",
+                )?,
         })
     }
 }

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -337,7 +337,13 @@ impl SourceRender for KafkaSourceConnection {
 
                 // We want a fairly low ceiling on our polling frequency, since we rely
                 // on this heartbeat to determine the health of our Kafka connection.
-                let poll_interval = topic_metadata_refresh_interval.min(Duration::from_secs(60));
+                let poll_interval = topic_metadata_refresh_interval.min(
+                    config
+                        .config
+                        .parameters
+                        .kafka_timeout_config
+                        .default_metadata_fetch_interval,
+                );
 
                 let status_report = Arc::clone(&health_status);
 

--- a/test/mysql-cdc/statistics.td
+++ b/test/mysql-cdc/statistics.td
@@ -11,6 +11,10 @@
 # Test progress statistics
 #
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
+
 > CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
@@ -38,9 +42,6 @@ INSERT INTO t1 VALUES ('one');
 
 > SELECT COUNT(*) > 0 FROM t1;
 true
-
-# statistics are only populated every minute by default
-$ set-sql-timeout duration=2minutes
 
 > SELECT
     s.name,

--- a/test/pg-cdc/statistics.td
+++ b/test/pg-cdc/statistics.td
@@ -11,6 +11,10 @@
 # Test progress statistics
 #
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
+
 > CREATE SECRET pgpass AS 'postgres'
 > CREATE CONNECTION pg TO POSTGRES (
     HOST postgres,

--- a/test/testdrive/snapshot-source-statistics.td
+++ b/test/testdrive/snapshot-source-statistics.td
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET kafka_default_metadata_fetch_interval = 1000
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
+
 $ set keyschema={
     "type": "record",
     "name": "Key",
@@ -68,13 +73,6 @@ key           f1      f2
 fish          fish    1000
 birdmore      geese   56
 mammalmore    moose   2
-
-# statistics are only populated every minute by default, and kafka has a 60 second
-# interval on when it collects partition metadata.
-$ set-sql-timeout duration=3minutes
-
-# NOTE: These queries are slow to succeed because the default metrics scraping
-# interval is 30 seconds.
 
 > SELECT
     s.name,

--- a/test/testdrive/statistics-maintenance.td
+++ b/test/testdrive/statistics-maintenance.td
@@ -9,6 +9,9 @@
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET kafka_default_metadata_fetch_interval = 1000
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
 
 > CREATE CLUSTER cluster1 (SIZE '2')
 
@@ -40,9 +43,6 @@ one:two
   KEY FORMAT BYTES
   VALUE FORMAT BYTES
   ENVELOPE UPSERT
-
-# NOTE: These queries are slow to succeed because the default metrics scraping
-# interval is 30 seconds. Here we are just ensuring metrics were populated.
 
 # Ensure we produce statistics
 > SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed)

--- a/test/testdrive/steady-state-source-statistics.td
+++ b/test/testdrive/steady-state-source-statistics.td
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET kafka_default_metadata_fetch_interval = 1000
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
+
 $ set keyschema={
     "type": "record",
     "name": "Key",
@@ -71,12 +76,6 @@ fish          fish    1000
 birdmore      geese   56
 mammalmore    moose   2
 
-# statistics are only populated every minute by default
-$ set-sql-timeout duration=3minutes
-
-# NOTE: These queries are slow to succeed because the default metrics scraping
-# interval is 30 seconds.
-
 > SELECT
     s.name,
     SUM(u.offset_known) > 0,
@@ -109,6 +108,12 @@ SELECT
 
 $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
 {"key": "mammalmore"}
+
+> SELECT key, f1, f2 FROM upsert
+key           f1      f2
+------------------------
+fish          fish    1000
+birdmore      geese   56
 
 > SELECT
     s.name,


### PR DESCRIPTION
This also required some annoying stuff in the controller to dynamically update the statistics interval after it has started.

Fixes: https://github.com/MaterializeInc/materialize/issues/25458

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
