### PR TITLE
adapter: refactor some catalog txn APIs

### DIFF
--- a/src/adapter/benches/catalog.rs
+++ b/src/adapter/benches/catalog.rs
@@ -64,7 +64,7 @@ fn bench_transact(c: &mut Criterion) {
                     owner_id: MZ_SYSTEM_ROLE_ID,
                 }];
                 catalog
-                    .transact(mz_repr::Timestamp::MIN, None, ops, |_| Ok(()))
+                    .transact(mz_repr::Timestamp::MIN, None, ops)
                     .await
                     .unwrap();
             })

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1940,7 +1940,6 @@ mod builtin_migration_tests {
                     item,
                     owner_id: MZ_SYSTEM_ROLE_ID,
                 }],
-                |_| Ok(()),
             )
             .await
             .expect("failed to transact");

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -186,7 +186,7 @@ pub enum AdapterError {
     DDLTransactionRace,
     /// Used to prevent us from durably committing state while a DDL transaction is open, should
     /// never be returned to the user.
-    DDLTransactionDryRun {
+    TransactionDryRun {
         /// New operations that were run in the transaction.
         new_ops: Vec<crate::catalog::Op>,
         /// New resulting `CatalogState`.
@@ -491,7 +491,7 @@ impl AdapterError {
             AdapterError::Unstructured(_) => SqlState::INTERNAL_ERROR,
             AdapterError::UntargetedLogRead { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::DDLTransactionRace => SqlState::T_R_SERIALIZATION_FAILURE,
-            AdapterError::DDLTransactionDryRun { .. } => SqlState::T_R_SERIALIZATION_FAILURE,
+            AdapterError::TransactionDryRun { .. } => SqlState::T_R_SERIALIZATION_FAILURE,
             // It's not immediately clear which error code to use here because a
             // "write-only transaction", "single table write transaction", or "ddl only
             // transaction" are not things in Postgres. This error code is the generic "bad txn
@@ -690,7 +690,7 @@ impl fmt::Display for AdapterError {
             AdapterError::DDLTransactionRace => {
                 f.write_str("object state changed while transaction was in progress")
             }
-            AdapterError::DDLTransactionDryRun { .. } => f.write_str("ddl transaction dry run"),
+            AdapterError::TransactionDryRun { .. } => f.write_str("transaction dry run"),
             AdapterError::Storage(e) => e.fmt(f),
             AdapterError::Compute(e) => e.fmt(f),
             AdapterError::Orchestrator(e) => e.fmt(f),

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -104,7 +104,6 @@ async fn datadriven() {
                                         }),
                                         owner_id: MZ_SYSTEM_ROLE_ID,
                                     }],
-                                    |_| Ok(()),
                                 )
                                 .await
                                 .unwrap();


### PR DESCRIPTION
In preparing for the storage collection metadata being moved to the persist catalog, I want to have maximum flexibility in exploring the catalog transaction API.

I noticed that it was possible to entire factor away `CatalogTxn` by moving the DDL dry run into an `Op`. I think `CatalogTxn` was heavily used before to ensure dataflow descriptions were valid, but the code has since moved away from that pattern, making the method mostly vestigial.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
