### PR TITLE
storage/mysql: Add support for TEXT COLUMNS for unsupported types that can be decoded as strings

### DIFF
--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -25,10 +25,35 @@ pub use replication::{
 };
 
 pub mod schemas;
-pub use schemas::{schema_info, SchemaRequest};
+pub use schemas::{schema_info, QualifiedTableRef, SchemaRequest};
 
 pub mod decoding;
 pub use decoding::pack_mysql_row;
+
+#[derive(Debug, Clone)]
+pub struct UnsupportedDataType {
+    pub column_type: String,
+    pub qualified_table_name: String,
+    pub column_name: String,
+    pub intended_type: Option<String>,
+}
+
+impl std::fmt::Display for UnsupportedDataType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match &self.intended_type {
+            Some(intended_type) => write!(
+                f,
+                "'{}.{}' of type '{}' represented as: '{}'",
+                self.qualified_table_name, self.column_name, self.column_type, intended_type
+            ),
+            None => write!(
+                f,
+                "'{}.{}' of type '{}'",
+                self.qualified_table_name, self.column_name, self.column_type
+            ),
+        }
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum MySqlError {
@@ -42,12 +67,8 @@ pub enum MySqlError {
         qualified_table_name: String,
         error: String,
     },
-    #[error("unsupported data type: '{column_type}' for '{qualified_table_name}' column '{column_name}'.")]
-    UnsupportedDataType {
-        column_type: String,
-        qualified_table_name: String,
-        column_name: String,
-    },
+    #[error("unsupported data types: {columns:?}")]
+    UnsupportedDataTypes { columns: Vec<UnsupportedDataType> },
     #[error("invalid mysql system setting '{setting}'. Expected '{expected}'. Got '{actual}'.")]
     InvalidSystemSetting {
         setting: String,

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -933,12 +933,15 @@ pub enum MySqlConfigOptionName {
     /// Hex encoded string of binary serialization of
     /// `mz_storage_types::sources::mysql::MySqlSourceDetails`
     Details,
+    /// Columns whose types you want to unconditionally format as text
+    TextColumns,
 }
 
 impl AstDisplay for MySqlConfigOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             MySqlConfigOptionName::Details => "DETAILS",
+            MySqlConfigOptionName::TextColumns => "TEXT COLUMNS",
         })
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3115,14 +3115,34 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_mysql_connection_option(&mut self) -> Result<MySqlConfigOption<Raw>, ParserError> {
-        let name = match self.expect_one_of_keywords(&[DETAILS])? {
-            DETAILS => MySqlConfigOptionName::Details,
+        match self.expect_one_of_keywords(&[DETAILS, TEXT])? {
+            DETAILS => Ok(MySqlConfigOption {
+                name: MySqlConfigOptionName::Details,
+                value: self.parse_optional_option_value()?,
+            }),
+            TEXT => {
+                self.expect_keyword(COLUMNS)?;
+
+                let _ = self.consume_token(&Token::Eq);
+
+                let value = self
+                    .parse_option_sequence(Parser::parse_item_name)?
+                    .map(|inner| {
+                        WithOptionValue::Sequence(
+                            inner
+                                .into_iter()
+                                .map(WithOptionValue::UnresolvedItemName)
+                                .collect_vec(),
+                        )
+                    });
+
+                Ok(MySqlConfigOption {
+                    name: MySqlConfigOptionName::TextColumns,
+                    value,
+                })
+            }
             _ => unreachable!(),
-        };
-        Ok(MySqlConfigOption {
-            name,
-            value: self.parse_optional_option_value()?,
-        })
+        }
     }
 
     fn parse_load_generator_option(&mut self) -> Result<LoadGeneratorOption<Raw>, ParserError> {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -83,7 +83,7 @@ use mz_storage_types::sources::envelope::{
 use mz_storage_types::sources::kafka::{KafkaMetadataKind, KafkaSourceConnection};
 use mz_storage_types::sources::load_generator::{LoadGenerator, LoadGeneratorSourceConnection};
 use mz_storage_types::sources::mysql::{
-    MySqlSourceConnection, MySqlSourceDetails, ProtoMySqlSourceDetails,
+    MySqlColumnRef, MySqlSourceConnection, MySqlSourceDetails, ProtoMySqlSourceDetails,
 };
 use mz_storage_types::sources::postgres::{
     PostgresSourceConnection, PostgresSourcePublicationDetails,
@@ -424,7 +424,11 @@ generate_extracted_config!(
     (TextColumns, Vec::<UnresolvedItemName>, Default(vec![]))
 );
 
-generate_extracted_config!(MySqlConfigOption, (Details, String));
+generate_extracted_config!(
+    MySqlConfigOption,
+    (Details, String),
+    (TextColumns, Vec::<UnresolvedItemName>, Default(vec![]))
+);
 
 pub fn plan_create_webhook_source(
     scx: &StatementContext,
@@ -993,7 +997,11 @@ pub fn plan_create_source(
                     scx.catalog.resolve_full_name(connection_item.name())
                 ),
             };
-            let MySqlConfigOptionExtracted { details, seen: _ } = options.clone().try_into()?;
+            let MySqlConfigOptionExtracted {
+                details,
+                text_columns: text_cols,
+                seen: _,
+            } = options.clone().try_into()?;
 
             let details = details
                 .as_ref()
@@ -1019,11 +1027,29 @@ pub fn plan_create_source(
                 available_subsources.insert(name, index + 1);
             }
 
+            let mut text_columns = vec![];
+            for name in text_cols {
+                // We already verified that this is a fully-qualified column name during purification
+                // but we double check to be sure
+                if name.0.len() != 3 {
+                    sql_bail!(
+                        "internal error: Expected fully qualified mysql column name, got {}",
+                        name
+                    );
+                }
+                text_columns.push(MySqlColumnRef {
+                    schema_name: name.0[0].to_string(),
+                    table_name: name.0[1].to_string(),
+                    column_name: name.0[2].to_string(),
+                });
+            }
+
             let connection =
                 GenericSourceConnection::<ReferencedConnection>::from(MySqlSourceConnection {
                     connection: connection_item.id(),
                     connection_id: connection_item.id(),
                     details,
+                    text_columns,
                 });
 
             (connection, Some(available_subsources))

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -891,8 +891,11 @@ async fn purify_create_source(
                     scx.catalog.resolve_full_name(connection_item.name()),
                 ))?,
             };
-            let crate::plan::statement::ddl::MySqlConfigOptionExtracted { details, seen: _ } =
-                options.clone().try_into()?;
+            let crate::plan::statement::ddl::MySqlConfigOptionExtracted {
+                details,
+                text_columns,
+                seen: _,
+            } = options.clone().try_into()?;
 
             if details.is_some() {
                 Err(MySqlSourcePurificationError::UserSpecifiedDetails)?;
@@ -973,27 +976,73 @@ async fn purify_create_source(
                 ),
             };
 
+            let mut text_cols_map = BTreeMap::new();
+
+            for name in text_columns.iter() {
+                // We only support fully qualified references for now (e.g. `schema_name.table_name.column_name`)
+                if name.0.len() == 3 {
+                    let key = mz_mysql_util::QualifiedTableRef {
+                        schema_name: name.0[0].as_str(),
+                        table_name: name.0[1].as_str(),
+                    };
+                    text_cols_map
+                        .entry(key)
+                        .or_insert_with(BTreeSet::new)
+                        .insert(name.0[2].as_str());
+                } else {
+                    return Err(PlanError::InvalidOptionValue {
+                        option_name: MySqlConfigOptionName::TextColumns.to_ast_string(),
+                        err: Box::new(PlanError::UnderqualifiedColumnName(name.to_string())),
+                    });
+                };
+            }
+
             // Retrieve schemas for all requested tables
-            let tables = mz_mysql_util::schema_info(&mut *conn, &table_schema_request)
-                .await
-                .map_err(|err| match err {
-                    // TODO: Refactor schema_info to return all unsupported columns rather than
-                    // just the first one
-                    mz_mysql_util::MySqlError::UnsupportedDataType {
-                        qualified_table_name,
-                        column_type,
-                        column_name,
-                    } => PlanError::from(MySqlSourcePurificationError::UnrecognizedTypes {
-                        cols: vec![(qualified_table_name, column_name, column_type)],
-                    }),
-                    _ => err.into(),
-                })?;
+            let tables =
+                mz_mysql_util::schema_info(&mut *conn, &table_schema_request, Some(&text_cols_map))
+                    .await
+                    .map_err(|err| match err {
+                        mz_mysql_util::MySqlError::UnsupportedDataTypes { mut columns } => {
+                            PlanError::from(MySqlSourcePurificationError::UnrecognizedTypes {
+                                cols: columns
+                                    .drain(..)
+                                    .map(|c| (c.qualified_table_name, c.column_name, c.column_type))
+                                    .collect(),
+                            })
+                        }
+                        _ => err.into(),
+                    })?;
 
             if tables.is_empty() {
                 Err(MySqlSourcePurificationError::EmptyDatabase)?;
             }
 
             let mysql_catalog = mysql::derive_catalog_from_tables(&tables)?;
+
+            // Normalize text columns option and remove unused text column references.
+            if let Some(text_cols_option) = options
+                .iter_mut()
+                .find(|option| option.name == MySqlConfigOptionName::TextColumns)
+            {
+                let mut seq: Vec<_> = text_columns
+                    .into_iter()
+                    .filter(|name| {
+                        let (column_name, qual) = name.0.split_last().expect("non-empty");
+                        match mysql_catalog.resolve(UnresolvedItemName::qualified(qual)) {
+                            Ok((_, desc)) => {
+                                desc.columns.iter().any(|n| &n.name == column_name.as_str())
+                            }
+                            Err(_) => false,
+                        }
+                    })
+                    .map(WithOptionValue::UnresolvedItemName)
+                    .collect();
+
+                seq.sort();
+                seq.dedup();
+
+                text_cols_option.value = Some(WithOptionValue::Sequence(seq));
+            }
 
             let mut validated_requested_subsources = vec![];
             match referenced_subsources

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -296,6 +296,11 @@ impl MySqlSourcePurificationError {
             Self::InvalidTableReference(_) => Some(
                 "Specify tables names as SCHEMA_NAME.TABLE_NAME in a FOR TABLES (..) clause".into(),
             ),
+            Self::UnrecognizedTypes { cols: _ } => Some(
+                "If the types are supported as text, use the TEXT COLUMNS option to \
+                ingest their values as text."
+                    .into(),
+            ),
             _ => None,
         }
     }

--- a/src/storage-types/src/sources/mysql.proto
+++ b/src/storage-types/src/sources/mysql.proto
@@ -15,10 +15,18 @@ import "mysql-util/src/desc.proto";
 
 package mz_storage_types.sources.mysql;
 
+message ProtoMySqlColumnRef {
+    string schema_name = 1;
+    string table_name = 2;
+    string column_name = 3;
+}
+
 message ProtoMySqlSourceConnection {
     mz_repr.global_id.ProtoGlobalId connection_id = 1;
     mz_storage_types.connections.ProtoMySqlConnection connection = 2;
     ProtoMySqlSourceDetails details = 3;
+
+    repeated ProtoMySqlColumnRef text_columns = 4;
 }
 
 message ProtoMySqlSourceDetails {

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -39,10 +39,36 @@ include!(concat!(
 ));
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
+pub struct MySqlColumnRef {
+    pub schema_name: String,
+    pub table_name: String,
+    pub column_name: String,
+}
+
+impl RustType<ProtoMySqlColumnRef> for MySqlColumnRef {
+    fn into_proto(&self) -> ProtoMySqlColumnRef {
+        ProtoMySqlColumnRef {
+            schema_name: self.schema_name.clone(),
+            table_name: self.table_name.clone(),
+            column_name: self.column_name.clone(),
+        }
+    }
+
+    fn from_proto(proto: ProtoMySqlColumnRef) -> Result<Self, TryFromProtoError> {
+        Ok(MySqlColumnRef {
+            schema_name: proto.schema_name,
+            table_name: proto.table_name,
+            column_name: proto.column_name,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct MySqlSourceConnection<C: ConnectionAccess = InlinedConnection> {
     pub connection_id: GlobalId,
     pub connection: C::MySql,
     pub details: MySqlSourceDetails,
+    pub text_columns: Vec<MySqlColumnRef>,
 }
 
 impl<R: ConnectionResolver> IntoInlineConnection<MySqlSourceConnection, R>
@@ -53,12 +79,14 @@ impl<R: ConnectionResolver> IntoInlineConnection<MySqlSourceConnection, R>
             connection_id,
             connection,
             details,
+            text_columns,
         } = self;
 
         MySqlSourceConnection {
             connection_id,
             connection: r.resolve_connection(connection).unwrap_mysql(),
             details,
+            text_columns,
         }
     }
 }
@@ -111,6 +139,7 @@ impl RustType<ProtoMySqlSourceConnection> for MySqlSourceConnection {
             connection: Some(self.connection.into_proto()),
             connection_id: Some(self.connection_id.into_proto()),
             details: Some(self.details.into_proto()),
+            text_columns: self.text_columns.iter().map(|c| c.into_proto()).collect(),
         }
     }
 
@@ -125,6 +154,11 @@ impl RustType<ProtoMySqlSourceConnection> for MySqlSourceConnection {
             details: proto
                 .details
                 .into_rust_if_some("ProtoMySqlSourceConnection::details")?,
+            text_columns: proto
+                .text_columns
+                .into_iter()
+                .map(MySqlColumnRef::from_proto)
+                .collect::<Result<_, _>>()?,
         })
     }
 }

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -294,6 +294,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                 &connection_config,
                 stream.as_mut(),
                 &table_info,
+                &connection.text_columns,
                 &mut data_output,
                 data_cap_set,
                 upper_cap_set,

--- a/src/storage/src/source/mysql/replication/context.rs
+++ b/src/storage/src/source/mysql/replication/context.rs
@@ -19,7 +19,7 @@ use tracing::trace;
 use mz_mysql_util::{Config, MySqlTableDesc};
 use mz_repr::Row;
 use mz_sql_parser::ast::UnresolvedItemName;
-use mz_storage_types::sources::mysql::GtidPartition;
+use mz_storage_types::sources::mysql::{GtidPartition, MySqlColumnRef};
 use mz_timely_util::builder_async::AsyncOutputHandle;
 
 use super::super::{DefiniteError, RewindRequest};
@@ -32,6 +32,7 @@ pub(super) struct ReplContext<'a> {
     pub(super) connection_config: &'a Config,
     pub(super) stream: Pin<&'a mut futures::stream::Peekable<BinlogStream>>,
     pub(super) table_info: &'a BTreeMap<UnresolvedItemName, (usize, MySqlTableDesc)>,
+    pub(super) text_columns: &'a Vec<MySqlColumnRef>,
     pub(super) data_output: &'a mut AsyncOutputHandle<
         GtidPartition,
         Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>,
@@ -54,6 +55,7 @@ impl<'a> ReplContext<'a> {
         connection_config: &'a Config,
         stream: Pin<&'a mut futures::stream::Peekable<BinlogStream>>,
         table_info: &'a BTreeMap<UnresolvedItemName, (usize, MySqlTableDesc)>,
+        text_columns: &'a Vec<MySqlColumnRef>,
         data_output: &'a mut AsyncOutputHandle<
             GtidPartition,
             Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>,
@@ -68,6 +70,7 @@ impl<'a> ReplContext<'a> {
             connection_config,
             stream,
             table_info,
+            text_columns,
             data_output,
             data_cap_set,
             upper_cap_set,

--- a/src/storage/src/source/mysql/replication/events.rs
+++ b/src/storage/src/source/mysql/replication/events.rs
@@ -82,10 +82,11 @@ pub(super) async fn handle_query_event(
                         &ctx.config.config.connection_context.ssh_tunnel_manager,
                     )
                     .await?;
-                if let Some((err_table, err)) = verify_schemas(&mut *conn, &[(&table, table_desc)])
-                    .await?
-                    .drain(..)
-                    .next()
+                if let Some((err_table, err)) =
+                    verify_schemas(&mut *conn, &[(&table, table_desc)], ctx.text_columns)
+                        .await?
+                        .drain(..)
+                        .next()
                 {
                     assert_eq!(err_table, &table, "Unexpected table verification error");
                     trace!(%id, "timely-{worker_id} DDL change \
@@ -114,7 +115,7 @@ pub(super) async fn handle_query_event(
                 .filter(|(t, _)| !ctx.errored_tables.contains(t))
                 .map(|(t, d)| (t, &d.1))
                 .collect::<Vec<_>>();
-            let schema_errors = verify_schemas(&mut *conn, &expected).await?;
+            let schema_errors = verify_schemas(&mut *conn, &expected, ctx.text_columns).await?;
             for (dropped_table, err) in schema_errors {
                 if ctx.table_info.contains_key(dropped_table)
                     && !ctx.errored_tables.contains(dropped_table)

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -314,6 +314,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                         .iter()
                         .map(|(table, (_, desc))| (table, desc))
                         .collect::<Vec<_>>(),
+                    &connection.text_columns,
                 )
                 .await?;
                 let mut removed_tables = vec![];

--- a/test/mysql-cdc/30-text-columns.td
+++ b/test/mysql-cdc/30-text-columns.td
@@ -1,0 +1,67 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test mysql TEXT COLUMNS support
+#
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_mysql_source = true
+
+> CREATE CONNECTION mysqc TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+CREATE TABLE t1 (f1 JSON);
+
+INSERT INTO t1 VALUES (CAST('{"bar": "baz", "balance": 7.77, "active": false}' AS JSON));
+
+> CREATE SOURCE da
+  FROM MYSQL CONNECTION mysqc (
+    TEXT COLUMNS (public.t1.f1)
+  )
+  FOR TABLES (public.t1);
+
+# Insert the same data post-snapshot
+$ mysql-execute name=mysql
+USE public;
+INSERT INTO t1 SELECT * FROM t1;
+
+> SELECT f1::jsonb->>'balance' FROM t1;
+7.77
+7.77
+
+#
+# Validate that unsupported types error even as TEXT COLUMNS
+#
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+CREATE TABLE t1 (f1 BIT(5));
+
+INSERT INTO t1 VALUES (b'11111');
+
+! CREATE SOURCE da
+  FROM MYSQL CONNECTION mysqc (
+    TEXT COLUMNS (public.t1.f1)
+  )
+  FOR TABLES (public.t1);
+contains: unsupported type


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Adds support for specifying `TEXT COLUMNS`, but only for specific unsupported types that can be decoded as strings directly from the replication stream (for now). In this PR the only type that supports that is `json`. In a following PR I'll add support for `enum` columns, which we think will be enough type support for private preview (convo: https://materializeinc.slack.com/archives/C069K7ZUKS9/p1708623042493169)

This also fixes error handling during purification to report all columns with unsupported types rather than just the first one encountered.

The other caveat is that I'm requiring fully-qualified column references, e.g. `TEXT COLUMNS (database.table.column)`. This is similar to how we currently require the fully-qualified table name in `FOR TABLES (database.table)` for simplicity. After private preview starts we can add support for resolving less-qualified references. 

I added a very basic test to confirm `json` support, but once I add `enum` support in the next PR I'll uncomment the relevant test cases in the mysql-cdc test file:
https://github.com/MaterializeInc/materialize/blob/main/test/mysql-cdc/mysql-cdc.td#L553-L666

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Note that this feature is implemented differently than in the postgres source, since that has a bunch of code related to 'cast expressions', which I believe never actually got released. I opted to avoid that added complexity since it doesn't appear necessary for this use-case.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
