### PR TITLE
release-qualification: bump pipeline to v0.88.1

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -167,50 +167,24 @@ steps:
     trigger: tests
     async: false
     build:
-      # TODO(def-): How to get the last release version here? For now v0.87.2
-      commit: "f79ca55f07854fa0f1c0f7bdba8001b615c822e6"
-      branch: "v0.87.2"
+      # TODO(def-): Set version with mkpipeline.py
+      commit: "9f64f909a77849684e978b840b4f5c1edbd396e8"
+      branch: "v0.88.1"
       env:
         CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
         CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 1
 
-  - id: tests-preflight-check-upgrade
-    label: Tests with preflight check and upgrade
-    trigger: tests
-    async: false
-    build:
-      # TODO(def-): How to get the last release version here? For now v0.87.2
-      commit: "f79ca55f07854fa0f1c0f7bdba8001b615c822e6"
-      branch: "v0.87.2"
-      env:
-        CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
-        CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 0
-    skip: "Currently can't run pipeline two times at once, rollback is more interesting anyway"
   - id: nightlies-preflight-check-rollback
     label: Nightlies with preflight check and rollback
     trigger: nightlies
     async: false
     build:
-      # TODO(def-): How to get the last release version here? For now v0.87.2
-      commit: "f79ca55f07854fa0f1c0f7bdba8001b615c822e6"
-      branch: "v0.87.2"
+      # TODO(def-): Set version with mkpipeline.py
+      commit: "9f64f909a77849684e978b840b4f5c1edbd396e8"
+      branch: "v0.88.1"
       env:
         CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
         CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 1
-
-  - id: nightlies-preflight-check-upgrade
-    label: Nightlies with preflight check and upgrade
-    trigger: nightlies
-    async: false
-    build:
-      # TODO(def-): How to get the last release version here? For now v0.87.2
-      commit: "f79ca55f07854fa0f1c0f7bdba8001b615c822e6"
-      branch: "v0.87.2"
-      env:
-        CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
-        CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 0
-    skip: "Currently can't run pipeline two times at once, rollback is more interesting anyway"
-
 
   - wait: ~
     continue_on_failure: true

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -173,6 +173,7 @@ steps:
       env:
         CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
         CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 1
+    skip: "TODO(def-) reenable when greener"
 
   - id: nightlies-preflight-check-rollback
     label: Nightlies with preflight check and rollback
@@ -185,6 +186,7 @@ steps:
       env:
         CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
         CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 1
+    skip: "TODO(def-) reenable when greener"
 
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
and fix skip message being too long, seen in https://buildkite.com/materialize/release-qualification/builds/440#018dd2db-5612-4d38-840e-a364d5be31dc


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
