### PR TITLE
adapter: remove async_trait from Staged after 1.76 bump

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -782,7 +782,6 @@ pub(crate) enum StageResult<T> {
 }
 
 /// Common functionality for [Coordinator::sequence_staged].
-#[async_trait::async_trait(?Send)]
 pub(crate) trait Staged: Send {
     fn validity(&mut self) -> &mut PlanValidity;
 

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -30,7 +30,6 @@ use crate::optimize::{self, Optimize, OverrideFrom};
 use crate::session::Session;
 use crate::{catalog, AdapterNotice, ExecuteContext, TimestampProvider};
 
-#[async_trait::async_trait(?Send)]
 impl Staged for CreateIndexStage {
     fn validity(&mut self) -> &mut PlanValidity {
         match self {

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -39,7 +39,6 @@ use crate::session::Session;
 use crate::util::ResultExt;
 use crate::{catalog, AdapterNotice, CollectionIdBundle, ExecuteContext, TimestampProvider};
 
-#[async_trait::async_trait(?Send)]
 impl Staged for CreateMaterializedViewStage {
     fn validity(&mut self) -> &mut PlanValidity {
         match self {

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -26,7 +26,6 @@ use crate::optimize::{self, Optimize};
 use crate::session::Session;
 use crate::{catalog, AdapterNotice, ExecuteContext};
 
-#[async_trait::async_trait(?Send)]
 impl Staged for CreateViewStage {
     fn validity(&mut self) -> &mut PlanValidity {
         match self {

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -25,7 +25,6 @@ use crate::session::{Session, TransactionOps};
 use crate::util::ResultExt;
 use crate::{optimize, AdapterNotice, ExecuteContext, TimelineContext};
 
-#[async_trait::async_trait(?Send)]
 impl Staged for SubscribeStage {
     fn validity(&mut self) -> &mut PlanValidity {
         match self {


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a