### PR TITLE
testdrive: Ignore part of webhook that only works with 1 replica

### DIFF
--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -506,18 +506,6 @@ foo-after
 bar-bar
 baz-after
 
-# Creating a webhook source without specifying the cluster.
-
-$ set-from-sql var=current-cluster
-SHOW cluster;
-
-> CREATE SOURCE webhook_in_current FROM WEBHOOK BODY FORMAT JSON;
-
-> SELECT c.name = '${current-cluster}' FROM mz_clusters c JOIN mz_sources s ON c.id = s.cluster_id WHERE s.name = 'webhook_in_current';
-true
-
-> DROP SOURCE webhook_in_current;
-
 # Dropping a webhook source should drop the underlying persist shards.
 
 $ set-from-sql var=webhook-source-id
@@ -535,3 +523,17 @@ SELECT id FROM mz_sources WHERE name = 'webhook_bytes';
 > DROP CLUSTER webhook_cluster CASCADE;
 
 > DROP CLUSTER webhook_compute CASCADE;
+
+# Creating a webhook source without specifying the cluster.
+$ skip-if
+SELECT ${arg.replicas} > 1;
+
+$ set-from-sql var=current-cluster
+SHOW cluster;
+
+> CREATE SOURCE webhook_in_current FROM WEBHOOK BODY FORMAT JSON;
+
+> SELECT c.name = '${current-cluster}' FROM mz_clusters c JOIN mz_sources s ON c.id = s.cluster_id WHERE s.name = 'webhook_in_current';
+true
+
+> DROP SOURCE webhook_in_current;


### PR DESCRIPTION
Just introduced with #25467

Failed in https://buildkite.com/materialize/nightlies/builds/6581#018dd217-bb4f-40fe-a2f7-7dd741b87314

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
