### PR TITLE
testdrive: Remove useless cleanup

### DIFF
--- a/test/testdrive/audit-log.td
+++ b/test/testdrive/audit-log.td
@@ -41,5 +41,3 @@ create source "{\"database\":\"materialize\",\"id\":\"<GID>\",\"item\":\"counter
 create source "{\"database\":\"materialize\",\"id\":\"<GID>\",\"item\":\"counter_src_progress\",\"schema\":\"public\",\"type\":\"progress\"}" materialize
 create cluster-replica "{\"cluster_id\":\"<GID>\",\"cluster_name\":\"audit_log_counter_src\",\"disk\":true,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"r1\"}" materialize
 create cluster "{\"id\":\"<GID>\",\"name\":\"audit_log_counter_src\"}" materialize
-
-> DROP CLUSTER audit_log_kafka_src, audit_log_counter_src CASCADE;

--- a/test/testdrive/blue-green.td
+++ b/test/testdrive/blue-green.td
@@ -154,10 +154,3 @@ SELECT id FROM mz_clusters WHERE name = 'green_serving';
 
 > EXPLAIN SELECT * FROM blue.mv1;
 "Explained Query (fast path):\n  ReadIndex on=materialize.blue.mv1 mv1_primary_idx=[*** full scan ***]\n\nUsed Indexes:\n  - materialize.blue.mv1_primary_idx (*** full scan ***)\n"
-
-# Cleanup.
-
-> SET CLUSTER TO quickstart;
-
-> DROP CLUSTER blue_compute CASCADE;
-> DROP CLUSTER blue_serving CASCADE;

--- a/test/testdrive/cc_cluster_sizes.td
+++ b/test/testdrive/cc_cluster_sizes.td
@@ -123,5 +123,3 @@ contains:DISK option not supported for cluster sizes ending in cc or C
 
 ! CREATE CLUSTER REPLICA c.r SIZE '1cc', DISK = false;
 contains:DISK option not supported for cluster sizes ending in cc or C
-
-> DROP CLUSTER c

--- a/test/testdrive/controller-frontiers.td
+++ b/test/testdrive/controller-frontiers.td
@@ -341,8 +341,3 @@ r3 <null>
   JOIN mz_indexes ON (id = object_id)
   WHERE name = 'idx2'
 true true
-
-# Cleanup
-
-> DROP CLUSTER test CASCADE
-> DROP CLUSTER test_source CASCADE

--- a/test/testdrive/correctness-property-2.td
+++ b/test/testdrive/correctness-property-2.td
@@ -70,5 +70,3 @@ CREATE CLUSTER REPLICA storage.r1 SIZE = '1';
 0 1 crustycrab ${count}
 
 > COMMIT
-
-> DROP CLUSTER storage CASCADE;

--- a/test/testdrive/dataflow-cleanup.td
+++ b/test/testdrive/dataflow-cleanup.td
@@ -102,7 +102,3 @@ true
 > DROP MATERIALIZED VIEW q14
 > SELECT count(*)  FROM mz_internal.mz_dataflow_operators
 0
-
-# Clean up.
-> DROP CLUSTER test CASCADE
-> DROP SOURCE lgtpch CASCADE

--- a/test/testdrive/github-15095.td
+++ b/test/testdrive/github-15095.td
@@ -18,5 +18,3 @@
   FROM mz_cluster_replicas r, mz_internal.mz_cluster_replica_heartbeats h
   WHERE r.id = h.replica_id AND r.name = 'r'
 1
-
-> DROP CLUSTER c CASCADE;

--- a/test/testdrive/github-23037.td
+++ b/test/testdrive/github-23037.td
@@ -47,6 +47,3 @@ DROP DATABASE materialize
 
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 CREATE DATABASE materialize
-
-# Cleanup.
-> DROP CLUSTER gh_23037_cluster CASCADE;

--- a/test/testdrive/github-24310.td
+++ b/test/testdrive/github-24310.td
@@ -44,5 +44,3 @@ DROP CLUSTER REPLICA sources.unbilled;
 
 ! CREATE CLUSTER REPLICA sources.r1 SIZE '1'
 contains:cannot modify managed cluster sources
-
-> DROP SOURCE counter CASCADE;

--- a/test/testdrive/hydration-status.td
+++ b/test/testdrive/hydration-status.td
@@ -411,6 +411,3 @@ mv_wmr_stuck hydrated_test_4 false
 mv_wmr       hydrated_test_4 true
 mv_wmr_const hydrated_test_4 true
 mv_wmr_stuck hydrated_test_4 false
-
-# Cleanup
-> DROP CLUSTER test CASCADE;

--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -266,7 +266,3 @@ true
   WHERE m.name = 'mv8'
 r1 true
 r2 true
-
-######## Cleanup ########
-> DROP DATABASE materialized_view_refresh_options CASCADE;
-> DROP CLUSTER refresh_cluster CASCADE;

--- a/test/testdrive/privilege_checks.td
+++ b/test/testdrive/privilege_checks.td
@@ -251,16 +251,3 @@ GRANT CREATE ON SCHEMA materialize.public TO materialize;
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rbac-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
-
-$ postgres-execute connection=mz_system
-REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM materialize;
-REVOKE USAGE ON CONNECTION kafka_conn, csr_conn FROM materialize;
-REVOKE CREATECLUSTER ON SYSTEM FROM materialize;
-REVOKE CREATE ON CLUSTER source_cluster FROM materialize;
-DROP SOURCE s;
-DROP CLUSTER source_cluster;
-
-$ postgres-execute connection=mz_system
-DROP CONNECTION csr_conn;
-DROP CONNECTION kafka_conn;
-ALTER SYSTEM SET enable_rbac_checks TO false;

--- a/test/testdrive/quickstart.td
+++ b/test/testdrive/quickstart.td
@@ -127,9 +127,3 @@ INSERT INTO fraud_accounts VALUES (12)
 #     SELECT SUM(credits), SUM(debits) FROM funds_movement
 #   )
 # > FETCH 1 c WITH (timeout='1s')
-
-> DROP SOURCE auction_house CASCADE
-
-> DROP TABLE fraud_accounts
-
-> DROP CLUSTER quickstart_tutorial CASCADE

--- a/test/testdrive/replica-targeting.td
+++ b/test/testdrive/replica-targeting.td
@@ -103,6 +103,3 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 > FETCH c
 <TIMESTAMP> 1 1
 > COMMIT
-
-# Cleanup
-> DROP CLUSTER test CASCADE

--- a/test/testdrive/source-sink-clusters.td
+++ b/test/testdrive/source-sink-clusters.td
@@ -162,5 +162,3 @@ data2  <null>  storage
   WHERE s.id LIKE 'u%'
 sink1  <null>  storage
 sink2  <null>  storage
-
-> DROP CLUSTER storage CASCADE

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -99,5 +99,3 @@ CREATE CLUSTER REPLICA mz_system.r1 SIZE '${arg.default-replica-size}';
 
 > SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
 mz_system r1 ${arg.default-replica-size} <TRUE_OR_FALSE>
-
-$ unset-regex

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -519,11 +519,6 @@ SELECT id FROM mz_sources WHERE name = 'webhook_bytes';
 > SELECT COUNT(*) FROM mz_internal.mz_storage_shards WHERE object_id = '${webhook-source-id}';
 0
 
-# Cleanup.
-> DROP CLUSTER webhook_cluster CASCADE;
-
-> DROP CLUSTER webhook_compute CASCADE;
-
 # Creating a webhook source without specifying the cluster.
 $ skip-if
 SELECT ${arg.replicas} > 1;
@@ -535,5 +530,3 @@ SHOW cluster;
 
 > SELECT c.name = '${current-cluster}' FROM mz_clusters c JOIN mz_sources s ON c.id = s.cluster_id WHERE s.name = 'webhook_in_current';
 true
-
-> DROP SOURCE webhook_in_current;

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -506,18 +506,6 @@ foo-after
 bar-bar
 baz-after
 
-# Creating a webhook source without specifying the cluster.
-
-$ set-from-sql var=current-cluster
-SHOW cluster;
-
-> CREATE SOURCE webhook_in_current FROM WEBHOOK BODY FORMAT JSON;
-
-> SELECT c.name = '${current-cluster}' FROM mz_clusters c JOIN mz_sources s ON c.id = s.cluster_id WHERE s.name = 'webhook_in_current';
-true
-
-> DROP SOURCE webhook_in_current;
-
 # Dropping a webhook source should drop the underlying persist shards.
 
 $ set-from-sql var=webhook-source-id
@@ -535,3 +523,17 @@ SELECT id FROM mz_sources WHERE name = 'webhook_bytes';
 > DROP CLUSTER webhook_cluster CASCADE;
 
 > DROP CLUSTER webhook_compute CASCADE;
+
+# Creating a webhook source without specifying the cluster.
+$ skip-if
+SELECT ${arg.replicas} > 1;
+
+$ set-from-sql var=current-cluster
+SHOW cluster;
+
+> CREATE SOURCE webhook_in_current FROM WEBHOOK BODY FORMAT JSON;
+
+> SELECT c.name = '${current-cluster}' FROM mz_clusters c JOIN mz_sources s ON c.id = s.cluster_id WHERE s.name = 'webhook_in_current';
+true
+
+> DROP SOURCE webhook_in_current;


### PR DESCRIPTION
Testdrive automatically cleans up resources like sources and clusters

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
