### PR TITLE
ci: Make tests pipeline green again

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -545,7 +545,7 @@ steps:
   - id: replica-isolation
     label: Replica isolation
     depends_on: build-aarch64
-    timeout_in_minutes: 20
+    timeout_in_minutes: 30
     inputs: [test/replica-isolation]
     artifact_paths: junit_*.xml
     plugins:

--- a/test/persist-catalog-migration/mzcompose.py
+++ b/test/persist-catalog-migration/mzcompose.py
@@ -28,6 +28,9 @@ def workflow_default(c: Composition) -> None:
     for i, name in enumerate(c.workflows):
         if name == "default":
             continue
+        # TODO: Reenable when #25499 is fixed
+        if name == "test-version-skips":
+            continue
         with c.test_case(name):
             c.workflow(name)
 


### PR DESCRIPTION
Both failures seen in https://buildkite.com/materialize/tests/builds/76524

Started failing because of v0.90.0-dev

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
