### PR TITLE
balancerd: reload ssl certs every hour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3758,10 +3758,12 @@ dependencies = [
  "openssl",
  "postgres",
  "prometheus",
+ "reqwest",
  "semver",
  "tokio",
  "tokio-openssl",
  "tokio-postgres",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "uuid",
@@ -7600,11 +7602,11 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.5",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -7623,9 +7625,12 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -7801,6 +7806,15 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.4.12",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.5",
 ]
 
 [[package]]
@@ -8584,9 +8598,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -8627,6 +8641,27 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -9046,9 +9081,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -9917,11 +9952,12 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -170,10 +170,30 @@ who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
 delta = "0.16.20 -> 0.17.7"
 
+[[audits.rustls-pemfile]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.4"
+
 [[audits.spin]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
 delta = "0.5.2 -> 0.9.8"
+
+[[audits.sync_wrapper]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+
+[[audits.system-configuration]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.1"
+
+[[audits.system-configuration-sys]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.0"
 
 [[audits.tempfile]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
@@ -234,6 +254,11 @@ version = "1.7.0"
 who = "Gus Wynn <gus@materialize.com>"
 criteria = "maintained-and-necessary"
 version = "0.2.4"
+
+[[audits.winreg]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.50.0"
 
 [[audits.wyz]]
 who = "Roshan Jobanputra <roshan@materialize.com>"

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -1486,10 +1486,6 @@ criteria = "safe-to-deploy"
 version = "10.2.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.sync_wrapper]]
-version = "0.1.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.synstructure]]
 version = "0.12.3"
 criteria = "safe-to-deploy"
@@ -1804,10 +1800,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.windows_x86_64_msvc]]
 version = "0.48.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.winreg]]
-version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.workspace-hack]]

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -595,6 +595,13 @@ user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
+[[publisher.reqwest]]
+version = "0.11.24"
+when = "2024-01-31"
+user-id = 359
+user-login = "seanmonstar"
+user-name = "Sean McArthur"
+
 [[publisher.rustc-demangle]]
 version = "0.1.16"
 when = "2019-08-13"
@@ -1411,6 +1418,13 @@ who = "David Koloski <dkoloski@google.com>"
 criteria = "safe-to-deploy"
 version = "0.1.11"
 notes = "Reviewed on https://fxrev.dev/804724"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.tokio-stream]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.11 -> 0.1.14"
+notes = "Reviewed on https://fxrev.dev/907732."
 aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.version_check]]

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -35,6 +35,7 @@ semver = "1.0.16"
 tokio = { version = "1.24.2", default-features = false }
 tokio-openssl = "0.6.3"
 tokio-postgres = { version = "0.7.8" }
+tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["codec"] }
 tracing = "0.1.37"
 uuid = "1.2.2"
@@ -44,6 +45,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 mz-environmentd = { path = "../environmentd", features = ["test"] }
 mz-frontegg-mock = { path = "../frontegg-mock" }
 postgres = "0.19.5"
+reqwest = "0.11.24"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, Instant};
 use axum::response::IntoResponse;
 use axum::{routing, Router};
 use bytes::BytesMut;
+use futures::stream::BoxStream;
 use futures::TryFutureExt;
 use hyper::StatusCode;
 use mz_build_info::{build_info, BuildInfo};
@@ -40,12 +41,16 @@ use mz_pgwire_common::{
     decode_startup, Conn, ErrorResponse, FrontendMessage, FrontendStartupMessage,
     ACCEPT_SSL_ENCRYPTION, REJECT_ENCRYPTION, VERSION_3,
 };
-use mz_server_core::{listen, ConnectionStream, ListenerHandle, TlsCertConfig, TlsConfig, TlsMode};
-use openssl::ssl::{NameType, Ssl, SslContext};
+use mz_server_core::{
+    listen, ConnectionStream, ListenerHandle, ReloadingSslContext, ReloadingTlsConfig,
+    TlsCertConfig, TlsMode,
+};
+use openssl::ssl::{NameType, Ssl};
 use prometheus::{IntCounterVec, IntGaugeVec};
 use semver::Version;
 use tokio::io::{self, AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
+use tokio::sync::oneshot;
 use tokio::task::JoinSet;
 use tokio_openssl::SslStream;
 use tokio_postgres::error::SqlState;
@@ -73,6 +78,7 @@ pub struct BalancerConfig {
     https_addr_template: String,
     tls: Option<TlsCertConfig>,
     metrics_registry: MetricsRegistry,
+    reload_certs: BoxStream<'static, oneshot::Sender<Result<(), anyhow::Error>>>,
 }
 
 impl BalancerConfig {
@@ -87,6 +93,7 @@ impl BalancerConfig {
         https_addr_template: String,
         tls: Option<TlsCertConfig>,
         metrics_registry: MetricsRegistry,
+        reload_certs: BoxStream<'static, oneshot::Sender<Result<(), anyhow::Error>>>,
     ) -> Self {
         Self {
             build_version: build_info.semver_version(),
@@ -99,6 +106,7 @@ impl BalancerConfig {
             https_addr_template,
             tls,
             metrics_registry,
+            reload_certs,
         }
     }
 }
@@ -154,9 +162,9 @@ impl BalancerService {
     pub async fn serve(self) -> Result<(), anyhow::Error> {
         let (pgwire_tls, https_tls) = match &self.cfg.tls {
             Some(tls) => {
-                let context = tls.context()?;
+                let context = tls.reloading_context(self.cfg.reload_certs)?;
                 (
-                    Some(TlsConfig {
+                    Some(ReloadingTlsConfig {
                         context: context.clone(),
                         mode: TlsMode::Require,
                     }),
@@ -189,7 +197,7 @@ impl BalancerService {
         }
         {
             let https = HttpsBalancer {
-                tls: Arc::new(https_tls),
+                tls: https_tls,
                 resolve_template: Arc::from(self.cfg.https_addr_template),
                 metrics: ServerMetrics::new(metrics, "https"),
             };
@@ -358,7 +366,7 @@ impl ServerMetrics {
 }
 
 struct PgwireBalancer {
-    tls: Option<TlsConfig>,
+    tls: Option<ReloadingTlsConfig>,
     cancellation_resolver: Option<Arc<String>>,
     resolver: Arc<Resolver>,
     metrics: ServerMetrics,
@@ -533,7 +541,10 @@ impl mz_server_core::Server for PgwireBalancer {
                         Some(FrontendStartupMessage::SslRequest) => match (conn, &tls) {
                             (Conn::Unencrypted(mut conn), Some(tls)) => {
                                 conn.write_all(&[ACCEPT_SSL_ENCRYPTION]).await?;
-                                let mut ssl_stream = SslStream::new(Ssl::new(&tls.context)?, conn)?;
+                                let mut ssl_stream = SslStream::new(
+                                    Ssl::new(&tls.context.context.read().expect("poisoned"))?,
+                                    conn,
+                                )?;
                                 if let Err(e) = Pin::new(&mut ssl_stream).accept().await {
                                     let _ = ssl_stream.get_mut().shutdown().await;
                                     return Err(e.into());
@@ -613,7 +624,7 @@ async fn cancel_request(conn_id: u32, secret_key: u32, cancellation_resolver: &s
 }
 
 struct HttpsBalancer {
-    tls: Arc<Option<SslContext>>,
+    tls: Option<ReloadingSslContext>,
     resolve_template: Arc<str>,
     metrics: ServerMetrics,
 }
@@ -622,16 +633,19 @@ impl mz_server_core::Server for HttpsBalancer {
     const NAME: &'static str = "https_balancer";
 
     fn handle_connection(&self, conn: TcpStream) -> mz_server_core::ConnectionHandler {
-        let tls_context = Arc::clone(&self.tls);
+        let tls_context = self.tls.clone();
         let resolve_template = Arc::clone(&self.resolve_template);
         let metrics = self.metrics.clone();
         Box::pin(async move {
             let active_guard = metrics.active_connections();
             let result = Box::pin(async move {
                 let (mut client_stream, servername): (Box<dyn ClientStream>, Option<String>) =
-                    match &*tls_context {
+                    match tls_context {
                         Some(tls_context) => {
-                            let mut ssl_stream = SslStream::new(Ssl::new(tls_context)?, conn)?;
+                            let mut ssl_stream = SslStream::new(
+                                Ssl::new(&tls_context.context.read().expect("poisoned"))?,
+                                conn,
+                            )?;
                             if let Err(e) = Pin::new(&mut ssl_stream).accept().await {
                                 let _ = ssl_stream.get_mut().shutdown().await;
                                 return Err(e.into());

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -78,7 +78,7 @@ pub struct BalancerConfig {
     https_addr_template: String,
     tls: Option<TlsCertConfig>,
     metrics_registry: MetricsRegistry,
-    reload_certs: BoxStream<'static, oneshot::Sender<Result<(), anyhow::Error>>>,
+    reload_certs: BoxStream<'static, Option<oneshot::Sender<Result<(), anyhow::Error>>>>,
 }
 
 impl BalancerConfig {
@@ -93,7 +93,7 @@ impl BalancerConfig {
         https_addr_template: String,
         tls: Option<TlsCertConfig>,
         metrics_registry: MetricsRegistry,
-        reload_certs: BoxStream<'static, oneshot::Sender<Result<(), anyhow::Error>>>,
+        reload_certs: BoxStream<'static, Option<oneshot::Sender<Result<(), anyhow::Error>>>>,
     ) -> Self {
         Self {
             build_version: build_info.semver_version(),

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -541,7 +541,8 @@ impl mz_server_core::Server for PgwireBalancer {
                         Some(FrontendStartupMessage::SslRequest) => match (conn, &tls) {
                             (Conn::Unencrypted(mut conn), Some(tls)) => {
                                 conn.write_all(&[ACCEPT_SSL_ENCRYPTION]).await?;
-                                let mut ssl_stream = SslStream::new(Ssl::new(&tls.get())?, conn)?;
+                                let mut ssl_stream =
+                                    SslStream::new(Ssl::new(&tls.context.get())?, conn)?;
                                 if let Err(e) = Pin::new(&mut ssl_stream).accept().await {
                                     let _ = ssl_stream.get_mut().shutdown().await;
                                     return Err(e.into());

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -213,7 +213,7 @@ async fn test_balancer() {
         assert_ne!(next_x509, server_x509);
         std::fs::copy(next_key, &server_key).unwrap();
         let (tx, rx) = oneshot::channel();
-        reload_tx.try_send(tx).unwrap();
+        reload_tx.try_send(Some(tx)).unwrap();
         let res = rx.await.unwrap();
         assert!(res.is_err());
 
@@ -234,7 +234,7 @@ async fn test_balancer() {
         // cert.
         std::fs::copy(next_cert, &server_cert).unwrap();
         let (tx, rx) = oneshot::channel();
-        reload_tx.try_send(tx).unwrap();
+        reload_tx.try_send(Some(tx)).unwrap();
         let res = rx.await.unwrap();
         assert!(res.is_ok());
         let resp = client

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -30,6 +30,8 @@ use mz_ore::retry::Retry;
 use mz_ore::{assert_contains, task};
 use mz_server_core::TlsCertConfig;
 use openssl::ssl::{SslConnectorBuilder, SslVerifyMode};
+use openssl::x509::X509;
+use tokio::sync::oneshot;
 use uuid::Uuid;
 
 #[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
@@ -112,11 +114,23 @@ async fn test_balancer() {
         }),
     ];
     let cert_config = Some(TlsCertConfig {
-        cert: server_cert,
-        key: server_key,
+        cert: server_cert.clone(),
+        key: server_key.clone(),
     });
 
+    let body = r#"{"query": "select 12234"}"#;
+    let ca_cert = reqwest::Certificate::from_pem(&ca.cert.to_pem().unwrap()).unwrap();
+    let client = reqwest::Client::builder()
+        .add_root_certificate(ca_cert)
+        // No pool so that connections are never re-used which can use old ssl certs.
+        .pool_max_idle_per_host(0)
+        .tls_info(true)
+        .build()
+        .unwrap();
+
     for resolver in resolvers {
+        let (mut reload_tx, reload_rx) = futures::channel::mpsc::channel(1);
+        let ticker = Box::pin(reload_rx);
         let is_frontegg_resolver = matches!(resolver, Resolver::Frontegg(_));
         let balancer_cfg = BalancerConfig::new(
             &BUILD_INFO,
@@ -126,12 +140,14 @@ async fn test_balancer() {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             Some(envd_server.inner.balancer_sql_local_addr().to_string()),
             resolver,
-            envd_server.inner.http_local_addr().to_string(),
+            envd_server.inner.balancer_http_local_addr().to_string(),
             cert_config.clone(),
             MetricsRegistry::new(),
+            ticker,
         );
         let balancer_server = BalancerService::new(balancer_cfg).await.unwrap();
         let balancer_pgwire_listen = balancer_server.pgwire.0.local_addr();
+        let balancer_https_listen = balancer_server.https.0.local_addr();
         task::spawn(|| "balancer", async {
             balancer_server.serve().await.unwrap();
         });
@@ -165,6 +181,73 @@ async fn test_balancer() {
         let _ = cancel.cancel_query(tls).await;
         let e = pin!(copy).next().await.unwrap().unwrap_err();
         assert_contains!(e.to_string(), "canceling statement due to user request");
+
+        // Various tests about reloading of certs.
+
+        // Assert the current certificate is as expected.
+        let https_url = format!(
+            "https://{host}:{port}/api/sql",
+            host = balancer_https_listen.ip(),
+            port = balancer_https_listen.port()
+        );
+        let resp = client
+            .post(&https_url)
+            .header("Content-Type", "application/json")
+            .basic_auth(frontegg_user, Some(&frontegg_password))
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        let tlsinfo = resp.extensions().get::<reqwest::tls::TlsInfo>().unwrap();
+        let resp_x509 = X509::from_der(tlsinfo.peer_certificate().unwrap()).unwrap();
+        let server_x509 = X509::from_pem(&std::fs::read(&server_cert).unwrap()).unwrap();
+        assert_eq!(resp_x509, server_x509);
+        assert_contains!(resp.text().await.unwrap(), "12234");
+
+        // Generate new certs. Install only the key, reload, and make sure the old cert is still in
+        // use.
+        let (next_cert, next_key) = ca
+            .request_cert("next", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
+            .unwrap();
+        let next_x509 = X509::from_pem(&std::fs::read(&next_cert).unwrap()).unwrap();
+        assert_ne!(next_x509, server_x509);
+        std::fs::copy(next_key, &server_key).unwrap();
+        let (tx, rx) = oneshot::channel();
+        reload_tx.try_send(tx).unwrap();
+        let res = rx.await.unwrap();
+        assert!(res.is_err());
+
+        // We should still be on the old cert because now the cert and key mismatch.
+        let resp = client
+            .post(&https_url)
+            .header("Content-Type", "application/json")
+            .basic_auth(frontegg_user, Some(&frontegg_password))
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        let tlsinfo = resp.extensions().get::<reqwest::tls::TlsInfo>().unwrap();
+        let resp_x509 = X509::from_der(tlsinfo.peer_certificate().unwrap()).unwrap();
+        assert_eq!(resp_x509, server_x509);
+
+        // Now move the cert too. Reloading should succeed and the response should have the new
+        // cert.
+        std::fs::copy(next_cert, &server_cert).unwrap();
+        let (tx, rx) = oneshot::channel();
+        reload_tx.try_send(tx).unwrap();
+        let res = rx.await.unwrap();
+        assert!(res.is_ok());
+        let resp = client
+            .post(&https_url)
+            .header("Content-Type", "application/json")
+            .basic_auth(frontegg_user, Some(&frontegg_password))
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        let tlsinfo = resp.extensions().get::<reqwest::tls::TlsInfo>().unwrap();
+        let resp_x509 = X509::from_der(tlsinfo.peer_certificate().unwrap()).unwrap();
+        assert_eq!(resp_x509, next_x509);
 
         if !is_frontegg_resolver {
             continue;

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -309,7 +309,7 @@ impl Listeners {
         let (pgwire_tls, http_tls) = match &config.tls {
             None => (None, None),
             Some(tls_config) => {
-                let context = tls_config.context()?;
+                let context = tls_config.load_context()?;
                 let pgwire_tls = mz_server_core::TlsConfig {
                     context: context.clone(),
                     mode: mz_server_core::TlsMode::Require,

--- a/src/server-core/src/lib.rs
+++ b/src/server-core/src/lib.rs
@@ -231,7 +231,7 @@ impl TlsCertConfig {
         Ok(builder.build().into_context())
     }
 
-    /// Like [Self::context] but attempts to reload the files each time `ticker` yields an item.
+    /// Like [Self::load_context] but attempts to reload the files each time `ticker` yields an item.
     /// Returns an error based on the files currently on disk. When `ticker` receives, the
     /// certificates are reloaded from the context. The result of the reloading is returned on the
     /// oneshot if present, and an Ok result means new connections will use the new certificates. An

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -16,29 +16,67 @@ publish = false
 [dependencies]
 ahash = { version = "0.8.0" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-async-compression = { version = "0.4.5", default-features = false, features = ["gzip", "tokio", "zstd"] }
+async-compression = { version = "0.4.5", default-features = false, features = [
+  "gzip",
+  "tokio",
+  "zstd",
+] }
 aws-config = { version = "1.1.1", default-features = false, features = ["sso"] }
-aws-credential-types = { version = "1.1.1", default-features = false, features = ["hardcoded-credentials", "test-util"] }
-aws-runtime = { version = "1.1.1", default-features = false, features = ["event-stream"] }
-aws-sdk-sts = { version = "1.7.0", default-features = false, features = ["rt-tokio"] }
-aws-sigv4 = { version = "1.1.1", features = ["http0-compat", "sign-eventstream"] }
-aws-smithy-async = { version = "1.1.1", default-features = false, features = ["rt-tokio"] }
-aws-smithy-http = { version = "0.60.1", default-features = false, features = ["event-stream"] }
-aws-smithy-runtime = { version = "1.1.1", default-features = false, features = ["client", "connector-hyper-0-14-x"] }
-aws-smithy-runtime-api = { version = "1.1.1", features = ["client", "http-02x", "http-auth"] }
-aws-smithy-types = { version = "1.1.1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "rt-tokio"] }
+aws-credential-types = { version = "1.1.1", default-features = false, features = [
+  "hardcoded-credentials",
+  "test-util",
+] }
+aws-runtime = { version = "1.1.1", default-features = false, features = [
+  "event-stream",
+] }
+aws-sdk-sts = { version = "1.7.0", default-features = false, features = [
+  "rt-tokio",
+] }
+aws-sigv4 = { version = "1.1.1", features = [
+  "http0-compat",
+  "sign-eventstream",
+] }
+aws-smithy-async = { version = "1.1.1", default-features = false, features = [
+  "rt-tokio",
+] }
+aws-smithy-http = { version = "0.60.1", default-features = false, features = [
+  "event-stream",
+] }
+aws-smithy-runtime = { version = "1.1.1", default-features = false, features = [
+  "client",
+  "connector-hyper-0-14-x",
+] }
+aws-smithy-runtime-api = { version = "1.1.1", features = [
+  "client",
+  "http-02x",
+  "http-auth",
+] }
+aws-smithy-types = { version = "1.1.1", default-features = false, features = [
+  "byte-stream-poll-next",
+  "http-body-0-4-x",
+  "rt-tokio",
+] }
 axum = { version = "0.6.20", features = ["headers", "ws"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
 bytes = { version = "1.4.0", features = ["serde"] }
-chrono = { version = "0.4.25", default-features = false, features = ["alloc", "clock", "serde"] }
+chrono = { version = "0.4.25", default-features = false, features = [
+  "alloc",
+  "clock",
+  "serde",
+] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
-console = { version = "0.15.5", default-features = false, features = ["ansi-parsing", "unicode-width"] }
+console = { version = "0.15.5", default-features = false, features = [
+  "ansi-parsing",
+  "unicode-width",
+] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 crossbeam-deque = { version = "0.8.3" }
 crossbeam-epoch = { version = "0.9.13" }
 crossbeam-utils = { version = "0.8.7" }
-crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
+crypto-common = { version = "0.1.3", default-features = false, features = [
+  "std",
+] }
 debugid = { version = "0.8.0", default-features = false, features = ["serde"] }
 dec = { version = "0.4.8", default-features = false, features = ["serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
@@ -56,19 +94,46 @@ hashbrown = { version = "0.14.0", features = ["raw"] }
 hyper = { version = "0.14.27", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
-k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_26"] }
-kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
-kube-client = { version = "0.87.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
-kube-core = { version = "0.87.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }
+k8s-openapi = { version = "0.20.0", default-features = false, features = [
+  "schemars",
+  "v1_26",
+] }
+kube = { version = "0.87.1", default-features = false, features = [
+  "client",
+  "derive",
+  "openssl-tls",
+  "runtime",
+  "ws",
+] }
+kube-client = { version = "0.87.1", default-features = false, features = [
+  "jsonpatch",
+  "openssl-tls",
+  "ws",
+] }
+kube-core = { version = "0.87.1", default-features = false, features = [
+  "jsonpatch",
+  "schema",
+  "ws",
+] }
 libc = { version = "0.2.148", features = ["extra_traits", "use_std"] }
 libz-sys = { version = "1.1.8", features = ["static"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.8", features = ["net", "os-ext"] }
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
-mysql_common = { version = "0.31.0", default-features = false, features = ["binlog", "chrono"] }
-native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
+mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = [
+  "binlog",
+  "minimal",
+  "native-tls-tls",
+  "tracing",
+] }
+mysql_common = { version = "0.31.0", default-features = false, features = [
+  "binlog",
+  "chrono",
+] }
+native-tls = { version = "0.2.11", default-features = false, features = [
+  "alpn",
+] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
 num-bigint = { version = "0.4.3" }
@@ -79,45 +144,122 @@ ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
-postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
+postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = [
+  "with-chrono-0_4",
+] }
+postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = [
+  "with-chrono-0_4",
+  "with-serde_json-1",
+  "with-uuid-1",
+] }
 predicates = { version = "2.1.4" }
 proc-macro2 = { version = "1.0.69", features = ["span-locations"] }
 prost = { version = "0.11.9", features = ["no-recursion-limit"] }
-prost-reflect = { version = "0.11.4", default-features = false, features = ["serde"] }
+prost-reflect = { version = "0.11.4", default-features = false, features = [
+  "serde",
+] }
 prost-types = { version = "0.11.9" }
 quote = { version = "1.0.28" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_chacha = { version = "0.3.0" }
-rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
+rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = [
+  "cmake-build",
+  "libz-static",
+  "ssl-vendored",
+  "zstd",
+] }
 regex = { version = "1.7.0" }
 regex-syntax = { version = "0.6.28" }
-reqwest = { version = "0.11.13", features = ["blocking", "json", "multipart", "native-tls-vendored"] }
+reqwest = { version = "0.11.24", features = [
+  "blocking",
+  "json",
+  "multipart",
+  "native-tls-vendored",
+] }
 schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
 semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.164", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.99", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value"] }
+serde_json = { version = "1.0.99", features = [
+  "alloc",
+  "arbitrary_precision",
+  "float_roundtrip",
+  "preserve_order",
+  "raw_value",
+] }
 sha2 = { version = "0.10.6" }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
-smallvec = { version = "1.10.0", default-features = false, features = ["const_generics", "serde", "union", "write"] }
+smallvec = { version = "1.10.0", default-features = false, features = [
+  "const_generics",
+  "serde",
+  "union",
+  "write",
+] }
 socket2 = { version = "0.5.3", default-features = false, features = ["all"] }
 subtle = { version = "2.4.1" }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.39", features = ["extra-traits", "full", "visit-mut"] }
-textwrap = { version = "0.16.0", default-features = false, features = ["terminal_size"] }
-time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
-timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = ["bincode", "getopts"] }
-timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = ["bincode", "getopts"] }
-tokio = { version = "1.32.0", features = ["full", "stats", "test-util", "tracing"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
-tokio-stream = { version = "0.1.11", features = ["net", "sync"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = [
+  "extra-traits",
+  "full",
+  "visit",
+  "visit-mut",
+] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.39", features = [
+  "extra-traits",
+  "full",
+  "visit-mut",
+] }
+textwrap = { version = "0.16.0", default-features = false, features = [
+  "terminal_size",
+] }
+time = { version = "0.3.17", features = [
+  "macros",
+  "quickcheck",
+  "serde-well-known",
+] }
+timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = [
+  "bincode",
+  "getopts",
+] }
+timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = [
+  "bincode",
+  "getopts",
+] }
+tokio = { version = "1.32.0", features = [
+  "full",
+  "stats",
+  "test-util",
+  "tracing",
+] }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = [
+  "serde",
+  "with-chrono-0_4",
+  "with-serde_json-1",
+  "with-uuid-1",
+] }
+tokio-stream = { version = "0.1.14", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
-toml_datetime = { version = "0.6.3", default-features = false, features = ["serde"] }
+toml_datetime = { version = "0.6.3", default-features = false, features = [
+  "serde",
+] }
 toml_edit = { version = "0.19.14", features = ["serde"] }
 tonic = { version = "0.9.2", features = ["gzip"] }
-tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "load-shed", "retry", "timeout", "util"] }
-tower-http = { version = "0.4.3", features = ["auth", "cors", "map-response-body", "trace", "util"] }
+tower = { version = "0.4.13", features = [
+  "balance",
+  "buffer",
+  "filter",
+  "limit",
+  "load-shed",
+  "retry",
+  "timeout",
+  "util",
+] }
+tower-http = { version = "0.4.3", features = [
+  "auth",
+  "cors",
+  "map-response-body",
+  "trace",
+  "util",
+] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
@@ -131,30 +273,68 @@ zstd-sys = { version = "2.0.9", features = ["std"] }
 [build-dependencies]
 ahash = { version = "0.8.0" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-async-compression = { version = "0.4.5", default-features = false, features = ["gzip", "tokio", "zstd"] }
+async-compression = { version = "0.4.5", default-features = false, features = [
+  "gzip",
+  "tokio",
+  "zstd",
+] }
 aws-config = { version = "1.1.1", default-features = false, features = ["sso"] }
-aws-credential-types = { version = "1.1.1", default-features = false, features = ["hardcoded-credentials", "test-util"] }
-aws-runtime = { version = "1.1.1", default-features = false, features = ["event-stream"] }
-aws-sdk-sts = { version = "1.7.0", default-features = false, features = ["rt-tokio"] }
-aws-sigv4 = { version = "1.1.1", features = ["http0-compat", "sign-eventstream"] }
-aws-smithy-async = { version = "1.1.1", default-features = false, features = ["rt-tokio"] }
-aws-smithy-http = { version = "0.60.1", default-features = false, features = ["event-stream"] }
-aws-smithy-runtime = { version = "1.1.1", default-features = false, features = ["client", "connector-hyper-0-14-x"] }
-aws-smithy-runtime-api = { version = "1.1.1", features = ["client", "http-02x", "http-auth"] }
-aws-smithy-types = { version = "1.1.1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "rt-tokio"] }
+aws-credential-types = { version = "1.1.1", default-features = false, features = [
+  "hardcoded-credentials",
+  "test-util",
+] }
+aws-runtime = { version = "1.1.1", default-features = false, features = [
+  "event-stream",
+] }
+aws-sdk-sts = { version = "1.7.0", default-features = false, features = [
+  "rt-tokio",
+] }
+aws-sigv4 = { version = "1.1.1", features = [
+  "http0-compat",
+  "sign-eventstream",
+] }
+aws-smithy-async = { version = "1.1.1", default-features = false, features = [
+  "rt-tokio",
+] }
+aws-smithy-http = { version = "0.60.1", default-features = false, features = [
+  "event-stream",
+] }
+aws-smithy-runtime = { version = "1.1.1", default-features = false, features = [
+  "client",
+  "connector-hyper-0-14-x",
+] }
+aws-smithy-runtime-api = { version = "1.1.1", features = [
+  "client",
+  "http-02x",
+  "http-auth",
+] }
+aws-smithy-types = { version = "1.1.1", default-features = false, features = [
+  "byte-stream-poll-next",
+  "http-body-0-4-x",
+  "rt-tokio",
+] }
 axum = { version = "0.6.20", features = ["headers", "ws"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
 bytes = { version = "1.4.0", features = ["serde"] }
 cc = { version = "1.0.83", default-features = false, features = ["parallel"] }
-chrono = { version = "0.4.25", default-features = false, features = ["alloc", "clock", "serde"] }
+chrono = { version = "0.4.25", default-features = false, features = [
+  "alloc",
+  "clock",
+  "serde",
+] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
-console = { version = "0.15.5", default-features = false, features = ["ansi-parsing", "unicode-width"] }
+console = { version = "0.15.5", default-features = false, features = [
+  "ansi-parsing",
+  "unicode-width",
+] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 crossbeam-deque = { version = "0.8.3" }
 crossbeam-epoch = { version = "0.9.13" }
 crossbeam-utils = { version = "0.8.7" }
-crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
+crypto-common = { version = "0.1.3", default-features = false, features = [
+  "std",
+] }
 debugid = { version = "0.8.0", default-features = false, features = ["serde"] }
 dec = { version = "0.4.8", default-features = false, features = ["serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
@@ -172,19 +352,46 @@ hashbrown = { version = "0.14.0", features = ["raw"] }
 hyper = { version = "0.14.27", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
-k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_26"] }
-kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
-kube-client = { version = "0.87.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
-kube-core = { version = "0.87.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }
+k8s-openapi = { version = "0.20.0", default-features = false, features = [
+  "schemars",
+  "v1_26",
+] }
+kube = { version = "0.87.1", default-features = false, features = [
+  "client",
+  "derive",
+  "openssl-tls",
+  "runtime",
+  "ws",
+] }
+kube-client = { version = "0.87.1", default-features = false, features = [
+  "jsonpatch",
+  "openssl-tls",
+  "ws",
+] }
+kube-core = { version = "0.87.1", default-features = false, features = [
+  "jsonpatch",
+  "schema",
+  "ws",
+] }
 libc = { version = "0.2.148", features = ["extra_traits", "use_std"] }
 libz-sys = { version = "1.1.8", features = ["static"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.8", features = ["net", "os-ext"] }
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
-mysql_common = { version = "0.31.0", default-features = false, features = ["binlog", "chrono"] }
-native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
+mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = [
+  "binlog",
+  "minimal",
+  "native-tls-tls",
+  "tracing",
+] }
+mysql_common = { version = "0.31.0", default-features = false, features = [
+  "binlog",
+  "chrono",
+] }
+native-tls = { version = "0.2.11", default-features = false, features = [
+  "alpn",
+] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
 num-bigint = { version = "0.4.3" }
@@ -195,46 +402,127 @@ ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
-postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
+postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = [
+  "with-chrono-0_4",
+] }
+postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = [
+  "with-chrono-0_4",
+  "with-serde_json-1",
+  "with-uuid-1",
+] }
 predicates = { version = "2.1.4" }
 proc-macro2 = { version = "1.0.69", features = ["span-locations"] }
 prost = { version = "0.11.9", features = ["no-recursion-limit"] }
-prost-reflect = { version = "0.11.4", default-features = false, features = ["serde"] }
+prost-reflect = { version = "0.11.4", default-features = false, features = [
+  "serde",
+] }
 prost-types = { version = "0.11.9" }
 quote = { version = "1.0.28" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_chacha = { version = "0.3.0" }
-rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
+rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = [
+  "cmake-build",
+  "libz-static",
+  "ssl-vendored",
+  "zstd",
+] }
 regex = { version = "1.7.0" }
 regex-syntax = { version = "0.6.28" }
-reqwest = { version = "0.11.13", features = ["blocking", "json", "multipart", "native-tls-vendored"] }
+reqwest = { version = "0.11.24", features = [
+  "blocking",
+  "json",
+  "multipart",
+  "native-tls-vendored",
+] }
 schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
 semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.164", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.99", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value"] }
+serde_json = { version = "1.0.99", features = [
+  "alloc",
+  "arbitrary_precision",
+  "float_roundtrip",
+  "preserve_order",
+  "raw_value",
+] }
 sha2 = { version = "0.10.6" }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
-smallvec = { version = "1.10.0", default-features = false, features = ["const_generics", "serde", "union", "write"] }
+smallvec = { version = "1.10.0", default-features = false, features = [
+  "const_generics",
+  "serde",
+  "union",
+  "write",
+] }
 socket2 = { version = "0.5.3", default-features = false, features = ["all"] }
 subtle = { version = "2.4.1" }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.39", features = ["extra-traits", "full", "visit-mut"] }
-textwrap = { version = "0.16.0", default-features = false, features = ["terminal_size"] }
-time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
-time-macros = { version = "0.2.6", default-features = false, features = ["formatting", "parsing", "serde"] }
-timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = ["bincode", "getopts"] }
-timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = ["bincode", "getopts"] }
-tokio = { version = "1.32.0", features = ["full", "stats", "test-util", "tracing"] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
-tokio-stream = { version = "0.1.11", features = ["net", "sync"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = [
+  "extra-traits",
+  "full",
+  "visit",
+  "visit-mut",
+] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.39", features = [
+  "extra-traits",
+  "full",
+  "visit-mut",
+] }
+textwrap = { version = "0.16.0", default-features = false, features = [
+  "terminal_size",
+] }
+time = { version = "0.3.17", features = [
+  "macros",
+  "quickcheck",
+  "serde-well-known",
+] }
+time-macros = { version = "0.2.6", default-features = false, features = [
+  "formatting",
+  "parsing",
+  "serde",
+] }
+timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = [
+  "bincode",
+  "getopts",
+] }
+timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = [
+  "bincode",
+  "getopts",
+] }
+tokio = { version = "1.32.0", features = [
+  "full",
+  "stats",
+  "test-util",
+  "tracing",
+] }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = [
+  "serde",
+  "with-chrono-0_4",
+  "with-serde_json-1",
+  "with-uuid-1",
+] }
+tokio-stream = { version = "0.1.14", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
-toml_datetime = { version = "0.6.3", default-features = false, features = ["serde"] }
+toml_datetime = { version = "0.6.3", default-features = false, features = [
+  "serde",
+] }
 toml_edit = { version = "0.19.14", features = ["serde"] }
 tonic = { version = "0.9.2", features = ["gzip"] }
-tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "load-shed", "retry", "timeout", "util"] }
-tower-http = { version = "0.4.3", features = ["auth", "cors", "map-response-body", "trace", "util"] }
+tower = { version = "0.4.13", features = [
+  "balance",
+  "buffer",
+  "filter",
+  "limit",
+  "load-shed",
+  "retry",
+  "timeout",
+  "util",
+] }
+tower-http = { version = "0.4.3", features = [
+  "auth",
+  "cors",
+  "map-response-body",
+  "trace",
+  "util",
+] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
@@ -247,28 +535,50 @@ zstd-sys = { version = "2.0.9", features = ["std"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.4.1", default-features = false, features = ["std"] }
-native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
+native-tls = { version = "0.2.11", default-features = false, features = [
+  "vendored",
+] }
 once_cell = { version = "1.19.0", features = ["unstable"] }
-openssl-sys = { version = "0.9.90", default-features = false, features = ["vendored"] }
+openssl-sys = { version = "0.9.90", default-features = false, features = [
+  "vendored",
+] }
 ring = { version = "0.17.7", features = ["std"] }
-tikv-jemalloc-sys = { version = "0.5.2", features = ["background_threads", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-sys = { version = "0.5.2", features = [
+  "background_threads",
+  "profiling",
+  "stats",
+  "unprefixed_malloc_on_supported_platforms",
+] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2.4.1", default-features = false, features = ["std"] }
-native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
+native-tls = { version = "0.2.11", default-features = false, features = [
+  "vendored",
+] }
 once_cell = { version = "1.19.0", features = ["unstable"] }
-openssl-sys = { version = "0.9.90", default-features = false, features = ["vendored"] }
+openssl-sys = { version = "0.9.90", default-features = false, features = [
+  "vendored",
+] }
 ring = { version = "0.17.7", features = ["std"] }
-tikv-jemalloc-sys = { version = "0.5.2", features = ["background_threads", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-sys = { version = "0.5.2", features = [
+  "background_threads",
+  "profiling",
+  "stats",
+  "unprefixed_malloc_on_supported_platforms",
+] }
 
 [target.x86_64-apple-darwin.dependencies]
-native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
+native-tls = { version = "0.2.11", default-features = false, features = [
+  "vendored",
+] }
 once_cell = { version = "1.19.0", features = ["unstable"] }
 ring = { version = "0.17.7", features = ["std"] }
 security-framework = { version = "2.7.0", features = ["alpn"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
+native-tls = { version = "0.2.11", default-features = false, features = [
+  "vendored",
+] }
 once_cell = { version = "1.19.0", features = ["unstable"] }
 ring = { version = "0.17.7", features = ["std"] }
 security-framework = { version = "2.7.0", features = ["alpn"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -16,67 +16,29 @@ publish = false
 [dependencies]
 ahash = { version = "0.8.0" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-async-compression = { version = "0.4.5", default-features = false, features = [
-  "gzip",
-  "tokio",
-  "zstd",
-] }
+async-compression = { version = "0.4.5", default-features = false, features = ["gzip", "tokio", "zstd"] }
 aws-config = { version = "1.1.1", default-features = false, features = ["sso"] }
-aws-credential-types = { version = "1.1.1", default-features = false, features = [
-  "hardcoded-credentials",
-  "test-util",
-] }
-aws-runtime = { version = "1.1.1", default-features = false, features = [
-  "event-stream",
-] }
-aws-sdk-sts = { version = "1.7.0", default-features = false, features = [
-  "rt-tokio",
-] }
-aws-sigv4 = { version = "1.1.1", features = [
-  "http0-compat",
-  "sign-eventstream",
-] }
-aws-smithy-async = { version = "1.1.1", default-features = false, features = [
-  "rt-tokio",
-] }
-aws-smithy-http = { version = "0.60.1", default-features = false, features = [
-  "event-stream",
-] }
-aws-smithy-runtime = { version = "1.1.1", default-features = false, features = [
-  "client",
-  "connector-hyper-0-14-x",
-] }
-aws-smithy-runtime-api = { version = "1.1.1", features = [
-  "client",
-  "http-02x",
-  "http-auth",
-] }
-aws-smithy-types = { version = "1.1.1", default-features = false, features = [
-  "byte-stream-poll-next",
-  "http-body-0-4-x",
-  "rt-tokio",
-] }
+aws-credential-types = { version = "1.1.1", default-features = false, features = ["hardcoded-credentials", "test-util"] }
+aws-runtime = { version = "1.1.1", default-features = false, features = ["event-stream"] }
+aws-sdk-sts = { version = "1.7.0", default-features = false, features = ["rt-tokio"] }
+aws-sigv4 = { version = "1.1.1", features = ["http0-compat", "sign-eventstream"] }
+aws-smithy-async = { version = "1.1.1", default-features = false, features = ["rt-tokio"] }
+aws-smithy-http = { version = "0.60.1", default-features = false, features = ["event-stream"] }
+aws-smithy-runtime = { version = "1.1.1", default-features = false, features = ["client", "connector-hyper-0-14-x"] }
+aws-smithy-runtime-api = { version = "1.1.1", features = ["client", "http-02x", "http-auth"] }
+aws-smithy-types = { version = "1.1.1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "rt-tokio"] }
 axum = { version = "0.6.20", features = ["headers", "ws"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
 bytes = { version = "1.4.0", features = ["serde"] }
-chrono = { version = "0.4.25", default-features = false, features = [
-  "alloc",
-  "clock",
-  "serde",
-] }
+chrono = { version = "0.4.25", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
-console = { version = "0.15.5", default-features = false, features = [
-  "ansi-parsing",
-  "unicode-width",
-] }
+console = { version = "0.15.5", default-features = false, features = ["ansi-parsing", "unicode-width"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 crossbeam-deque = { version = "0.8.3" }
 crossbeam-epoch = { version = "0.9.13" }
 crossbeam-utils = { version = "0.8.7" }
-crypto-common = { version = "0.1.3", default-features = false, features = [
-  "std",
-] }
+crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
 debugid = { version = "0.8.0", default-features = false, features = ["serde"] }
 dec = { version = "0.4.8", default-features = false, features = ["serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
@@ -94,46 +56,19 @@ hashbrown = { version = "0.14.0", features = ["raw"] }
 hyper = { version = "0.14.27", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
-k8s-openapi = { version = "0.20.0", default-features = false, features = [
-  "schemars",
-  "v1_26",
-] }
-kube = { version = "0.87.1", default-features = false, features = [
-  "client",
-  "derive",
-  "openssl-tls",
-  "runtime",
-  "ws",
-] }
-kube-client = { version = "0.87.1", default-features = false, features = [
-  "jsonpatch",
-  "openssl-tls",
-  "ws",
-] }
-kube-core = { version = "0.87.1", default-features = false, features = [
-  "jsonpatch",
-  "schema",
-  "ws",
-] }
+k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_26"] }
+kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
+kube-client = { version = "0.87.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
+kube-core = { version = "0.87.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }
 libc = { version = "0.2.148", features = ["extra_traits", "use_std"] }
 libz-sys = { version = "1.1.8", features = ["static"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.8", features = ["net", "os-ext"] }
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = [
-  "binlog",
-  "minimal",
-  "native-tls-tls",
-  "tracing",
-] }
-mysql_common = { version = "0.31.0", default-features = false, features = [
-  "binlog",
-  "chrono",
-] }
-native-tls = { version = "0.2.11", default-features = false, features = [
-  "alpn",
-] }
+mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
+mysql_common = { version = "0.31.0", default-features = false, features = ["binlog", "chrono"] }
+native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
 num-bigint = { version = "0.4.3" }
@@ -144,122 +79,45 @@ ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = [
-  "with-chrono-0_4",
-] }
-postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = [
-  "with-chrono-0_4",
-  "with-serde_json-1",
-  "with-uuid-1",
-] }
+postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
+postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 predicates = { version = "2.1.4" }
 proc-macro2 = { version = "1.0.69", features = ["span-locations"] }
 prost = { version = "0.11.9", features = ["no-recursion-limit"] }
-prost-reflect = { version = "0.11.4", default-features = false, features = [
-  "serde",
-] }
+prost-reflect = { version = "0.11.4", default-features = false, features = ["serde"] }
 prost-types = { version = "0.11.9" }
 quote = { version = "1.0.28" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_chacha = { version = "0.3.0" }
-rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = [
-  "cmake-build",
-  "libz-static",
-  "ssl-vendored",
-  "zstd",
-] }
+rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
 regex = { version = "1.7.0" }
 regex-syntax = { version = "0.6.28" }
-reqwest = { version = "0.11.24", features = [
-  "blocking",
-  "json",
-  "multipart",
-  "native-tls-vendored",
-] }
+reqwest = { version = "0.11.24", features = ["blocking", "json", "multipart", "native-tls-vendored"] }
 schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
 semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.164", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.99", features = [
-  "alloc",
-  "arbitrary_precision",
-  "float_roundtrip",
-  "preserve_order",
-  "raw_value",
-] }
+serde_json = { version = "1.0.99", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value"] }
 sha2 = { version = "0.10.6" }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
-smallvec = { version = "1.10.0", default-features = false, features = [
-  "const_generics",
-  "serde",
-  "union",
-  "write",
-] }
+smallvec = { version = "1.10.0", default-features = false, features = ["const_generics", "serde", "union", "write"] }
 socket2 = { version = "0.5.3", default-features = false, features = ["all"] }
 subtle = { version = "2.4.1" }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = [
-  "extra-traits",
-  "full",
-  "visit",
-  "visit-mut",
-] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.39", features = [
-  "extra-traits",
-  "full",
-  "visit-mut",
-] }
-textwrap = { version = "0.16.0", default-features = false, features = [
-  "terminal_size",
-] }
-time = { version = "0.3.17", features = [
-  "macros",
-  "quickcheck",
-  "serde-well-known",
-] }
-timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = [
-  "bincode",
-  "getopts",
-] }
-timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = [
-  "bincode",
-  "getopts",
-] }
-tokio = { version = "1.32.0", features = [
-  "full",
-  "stats",
-  "test-util",
-  "tracing",
-] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = [
-  "serde",
-  "with-chrono-0_4",
-  "with-serde_json-1",
-  "with-uuid-1",
-] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.39", features = ["extra-traits", "full", "visit-mut"] }
+textwrap = { version = "0.16.0", default-features = false, features = ["terminal_size"] }
+time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
+timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = ["bincode", "getopts"] }
+timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = ["bincode", "getopts"] }
+tokio = { version = "1.32.0", features = ["full", "stats", "test-util", "tracing"] }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.14", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
-toml_datetime = { version = "0.6.3", default-features = false, features = [
-  "serde",
-] }
+toml_datetime = { version = "0.6.3", default-features = false, features = ["serde"] }
 toml_edit = { version = "0.19.14", features = ["serde"] }
 tonic = { version = "0.9.2", features = ["gzip"] }
-tower = { version = "0.4.13", features = [
-  "balance",
-  "buffer",
-  "filter",
-  "limit",
-  "load-shed",
-  "retry",
-  "timeout",
-  "util",
-] }
-tower-http = { version = "0.4.3", features = [
-  "auth",
-  "cors",
-  "map-response-body",
-  "trace",
-  "util",
-] }
+tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "load-shed", "retry", "timeout", "util"] }
+tower-http = { version = "0.4.3", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
@@ -273,68 +131,30 @@ zstd-sys = { version = "2.0.9", features = ["std"] }
 [build-dependencies]
 ahash = { version = "0.8.0" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-async-compression = { version = "0.4.5", default-features = false, features = [
-  "gzip",
-  "tokio",
-  "zstd",
-] }
+async-compression = { version = "0.4.5", default-features = false, features = ["gzip", "tokio", "zstd"] }
 aws-config = { version = "1.1.1", default-features = false, features = ["sso"] }
-aws-credential-types = { version = "1.1.1", default-features = false, features = [
-  "hardcoded-credentials",
-  "test-util",
-] }
-aws-runtime = { version = "1.1.1", default-features = false, features = [
-  "event-stream",
-] }
-aws-sdk-sts = { version = "1.7.0", default-features = false, features = [
-  "rt-tokio",
-] }
-aws-sigv4 = { version = "1.1.1", features = [
-  "http0-compat",
-  "sign-eventstream",
-] }
-aws-smithy-async = { version = "1.1.1", default-features = false, features = [
-  "rt-tokio",
-] }
-aws-smithy-http = { version = "0.60.1", default-features = false, features = [
-  "event-stream",
-] }
-aws-smithy-runtime = { version = "1.1.1", default-features = false, features = [
-  "client",
-  "connector-hyper-0-14-x",
-] }
-aws-smithy-runtime-api = { version = "1.1.1", features = [
-  "client",
-  "http-02x",
-  "http-auth",
-] }
-aws-smithy-types = { version = "1.1.1", default-features = false, features = [
-  "byte-stream-poll-next",
-  "http-body-0-4-x",
-  "rt-tokio",
-] }
+aws-credential-types = { version = "1.1.1", default-features = false, features = ["hardcoded-credentials", "test-util"] }
+aws-runtime = { version = "1.1.1", default-features = false, features = ["event-stream"] }
+aws-sdk-sts = { version = "1.7.0", default-features = false, features = ["rt-tokio"] }
+aws-sigv4 = { version = "1.1.1", features = ["http0-compat", "sign-eventstream"] }
+aws-smithy-async = { version = "1.1.1", default-features = false, features = ["rt-tokio"] }
+aws-smithy-http = { version = "0.60.1", default-features = false, features = ["event-stream"] }
+aws-smithy-runtime = { version = "1.1.1", default-features = false, features = ["client", "connector-hyper-0-14-x"] }
+aws-smithy-runtime-api = { version = "1.1.1", features = ["client", "http-02x", "http-auth"] }
+aws-smithy-types = { version = "1.1.1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "rt-tokio"] }
 axum = { version = "0.6.20", features = ["headers", "ws"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
 bytes = { version = "1.4.0", features = ["serde"] }
 cc = { version = "1.0.83", default-features = false, features = ["parallel"] }
-chrono = { version = "0.4.25", default-features = false, features = [
-  "alloc",
-  "clock",
-  "serde",
-] }
+chrono = { version = "0.4.25", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
-console = { version = "0.15.5", default-features = false, features = [
-  "ansi-parsing",
-  "unicode-width",
-] }
+console = { version = "0.15.5", default-features = false, features = ["ansi-parsing", "unicode-width"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 crossbeam-deque = { version = "0.8.3" }
 crossbeam-epoch = { version = "0.9.13" }
 crossbeam-utils = { version = "0.8.7" }
-crypto-common = { version = "0.1.3", default-features = false, features = [
-  "std",
-] }
+crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
 debugid = { version = "0.8.0", default-features = false, features = ["serde"] }
 dec = { version = "0.4.8", default-features = false, features = ["serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
@@ -352,46 +172,19 @@ hashbrown = { version = "0.14.0", features = ["raw"] }
 hyper = { version = "0.14.27", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
-k8s-openapi = { version = "0.20.0", default-features = false, features = [
-  "schemars",
-  "v1_26",
-] }
-kube = { version = "0.87.1", default-features = false, features = [
-  "client",
-  "derive",
-  "openssl-tls",
-  "runtime",
-  "ws",
-] }
-kube-client = { version = "0.87.1", default-features = false, features = [
-  "jsonpatch",
-  "openssl-tls",
-  "ws",
-] }
-kube-core = { version = "0.87.1", default-features = false, features = [
-  "jsonpatch",
-  "schema",
-  "ws",
-] }
+k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_26"] }
+kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
+kube-client = { version = "0.87.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
+kube-core = { version = "0.87.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }
 libc = { version = "0.2.148", features = ["extra_traits", "use_std"] }
 libz-sys = { version = "1.1.8", features = ["static"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.8", features = ["net", "os-ext"] }
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = [
-  "binlog",
-  "minimal",
-  "native-tls-tls",
-  "tracing",
-] }
-mysql_common = { version = "0.31.0", default-features = false, features = [
-  "binlog",
-  "chrono",
-] }
-native-tls = { version = "0.2.11", default-features = false, features = [
-  "alpn",
-] }
+mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
+mysql_common = { version = "0.31.0", default-features = false, features = ["binlog", "chrono"] }
+native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
 num-bigint = { version = "0.4.3" }
@@ -402,127 +195,46 @@ ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = [
-  "with-chrono-0_4",
-] }
-postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = [
-  "with-chrono-0_4",
-  "with-serde_json-1",
-  "with-uuid-1",
-] }
+postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
+postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 predicates = { version = "2.1.4" }
 proc-macro2 = { version = "1.0.69", features = ["span-locations"] }
 prost = { version = "0.11.9", features = ["no-recursion-limit"] }
-prost-reflect = { version = "0.11.4", default-features = false, features = [
-  "serde",
-] }
+prost-reflect = { version = "0.11.4", default-features = false, features = ["serde"] }
 prost-types = { version = "0.11.9" }
 quote = { version = "1.0.28" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_chacha = { version = "0.3.0" }
-rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = [
-  "cmake-build",
-  "libz-static",
-  "ssl-vendored",
-  "zstd",
-] }
+rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
 regex = { version = "1.7.0" }
 regex-syntax = { version = "0.6.28" }
-reqwest = { version = "0.11.24", features = [
-  "blocking",
-  "json",
-  "multipart",
-  "native-tls-vendored",
-] }
+reqwest = { version = "0.11.24", features = ["blocking", "json", "multipart", "native-tls-vendored"] }
 schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
 semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.164", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.99", features = [
-  "alloc",
-  "arbitrary_precision",
-  "float_roundtrip",
-  "preserve_order",
-  "raw_value",
-] }
+serde_json = { version = "1.0.99", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value"] }
 sha2 = { version = "0.10.6" }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
-smallvec = { version = "1.10.0", default-features = false, features = [
-  "const_generics",
-  "serde",
-  "union",
-  "write",
-] }
+smallvec = { version = "1.10.0", default-features = false, features = ["const_generics", "serde", "union", "write"] }
 socket2 = { version = "0.5.3", default-features = false, features = ["all"] }
 subtle = { version = "2.4.1" }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = [
-  "extra-traits",
-  "full",
-  "visit",
-  "visit-mut",
-] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.39", features = [
-  "extra-traits",
-  "full",
-  "visit-mut",
-] }
-textwrap = { version = "0.16.0", default-features = false, features = [
-  "terminal_size",
-] }
-time = { version = "0.3.17", features = [
-  "macros",
-  "quickcheck",
-  "serde-well-known",
-] }
-time-macros = { version = "0.2.6", default-features = false, features = [
-  "formatting",
-  "parsing",
-  "serde",
-] }
-timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = [
-  "bincode",
-  "getopts",
-] }
-timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = [
-  "bincode",
-  "getopts",
-] }
-tokio = { version = "1.32.0", features = [
-  "full",
-  "stats",
-  "test-util",
-  "tracing",
-] }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = [
-  "serde",
-  "with-chrono-0_4",
-  "with-serde_json-1",
-  "with-uuid-1",
-] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.39", features = ["extra-traits", "full", "visit-mut"] }
+textwrap = { version = "0.16.0", default-features = false, features = ["terminal_size"] }
+time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
+time-macros = { version = "0.2.6", default-features = false, features = ["formatting", "parsing", "serde"] }
+timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = ["bincode", "getopts"] }
+timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = ["bincode", "getopts"] }
+tokio = { version = "1.32.0", features = ["full", "stats", "test-util", "tracing"] }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.14", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
-toml_datetime = { version = "0.6.3", default-features = false, features = [
-  "serde",
-] }
+toml_datetime = { version = "0.6.3", default-features = false, features = ["serde"] }
 toml_edit = { version = "0.19.14", features = ["serde"] }
 tonic = { version = "0.9.2", features = ["gzip"] }
-tower = { version = "0.4.13", features = [
-  "balance",
-  "buffer",
-  "filter",
-  "limit",
-  "load-shed",
-  "retry",
-  "timeout",
-  "util",
-] }
-tower-http = { version = "0.4.3", features = [
-  "auth",
-  "cors",
-  "map-response-body",
-  "trace",
-  "util",
-] }
+tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "load-shed", "retry", "timeout", "util"] }
+tower-http = { version = "0.4.3", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
@@ -535,50 +247,28 @@ zstd-sys = { version = "2.0.9", features = ["std"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.4.1", default-features = false, features = ["std"] }
-native-tls = { version = "0.2.11", default-features = false, features = [
-  "vendored",
-] }
+native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.19.0", features = ["unstable"] }
-openssl-sys = { version = "0.9.90", default-features = false, features = [
-  "vendored",
-] }
+openssl-sys = { version = "0.9.90", default-features = false, features = ["vendored"] }
 ring = { version = "0.17.7", features = ["std"] }
-tikv-jemalloc-sys = { version = "0.5.2", features = [
-  "background_threads",
-  "profiling",
-  "stats",
-  "unprefixed_malloc_on_supported_platforms",
-] }
+tikv-jemalloc-sys = { version = "0.5.2", features = ["background_threads", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2.4.1", default-features = false, features = ["std"] }
-native-tls = { version = "0.2.11", default-features = false, features = [
-  "vendored",
-] }
+native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.19.0", features = ["unstable"] }
-openssl-sys = { version = "0.9.90", default-features = false, features = [
-  "vendored",
-] }
+openssl-sys = { version = "0.9.90", default-features = false, features = ["vendored"] }
 ring = { version = "0.17.7", features = ["std"] }
-tikv-jemalloc-sys = { version = "0.5.2", features = [
-  "background_threads",
-  "profiling",
-  "stats",
-  "unprefixed_malloc_on_supported_platforms",
-] }
+tikv-jemalloc-sys = { version = "0.5.2", features = ["background_threads", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.x86_64-apple-darwin.dependencies]
-native-tls = { version = "0.2.11", default-features = false, features = [
-  "vendored",
-] }
+native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.19.0", features = ["unstable"] }
 ring = { version = "0.17.7", features = ["std"] }
 security-framework = { version = "2.7.0", features = ["alpn"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-native-tls = { version = "0.2.11", default-features = false, features = [
-  "vendored",
-] }
+native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.19.0", features = ["unstable"] }
 ring = { version = "0.17.7", features = ["std"] }
 security-framework = { version = "2.7.0", features = ["alpn"] }


### PR DESCRIPTION
Teach server-core about a reloading ssl context. Use channels to request a reload and return the response. Situations where only one of the new cert or key is present and one previous file still present will return an error but not interrupt active serving.

Fixes #25059

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a