### PR TITLE
ci: Don't show useless "workflow-default" failure for testdrive

### DIFF
--- a/misc/python/materialize/mzcompose/test_result.py
+++ b/misc/python/materialize/mzcompose/test_result.py
@@ -125,4 +125,6 @@ def extract_error_chunks_from_output(output: str) -> list[str]:
     error_output = output[: output.index("+++ !!! Error Report") - 1]
     error_chunks = error_output.split("^^^ +++")
 
-    return [chunk.strip() for chunk in error_chunks if len(chunk.strip()) > 0]
+    # The first part is uninteresting, contains only general testdrive
+    # executable output, not what actually failed, so cut it off.
+    return [chunk.strip() for chunk in error_chunks if len(chunk.strip()) > 0][1:]


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/6589#018dd35f-5e0d-4fcc-81de-b2b7a1236fb2

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
