### PR TITLE
tests: Increase history retention

### DIFF
--- a/test/mysql-cdc/correctness-property-2.td
+++ b/test/mysql-cdc/correctness-property-2.td
@@ -42,7 +42,7 @@ INSERT INTO t1 (f2) SELECT @i:=@i+1 FROM mysql.time_zone t1, mysql.time_zone t2 
   IN CLUSTER storage
   FROM MYSQL CONNECTION mysql_conn
   FOR ALL TABLES
-  WITH (RETAIN HISTORY = FOR '1 day');
+  WITH (RETAIN HISTORY = FOR '365000 days');
 
 # Grab a cursor at timestamp 0
 > BEGIN

--- a/test/pg-cdc/correctness-property-2.td
+++ b/test/pg-cdc/correctness-property-2.td
@@ -41,7 +41,7 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
   IN CLUSTER storage
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR ALL TABLES
-  WITH (RETAIN HISTORY = FOR '1 day');
+  WITH (RETAIN HISTORY = FOR '365000 days');
 
 # Grab a cursor at timestamp 0
 > BEGIN

--- a/test/testdrive/correctness-property-2.td
+++ b/test/testdrive/correctness-property-2.td
@@ -51,7 +51,7 @@ $ kafka-ingest format=avro topic=correctness-data key-format=avro key-schema=${k
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-correctness-data-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
-  WITH (RETAIN HISTORY = FOR '1 day');
+  WITH (RETAIN HISTORY = FOR '365000 days');
 
 # Prime tokio-postgres with the missing OIDs.
 > SELECT mz_now(), * FROM correctness_data WHERE false AS OF AT LEAST 0


### PR DESCRIPTION
Since timestamp 0 is actually Unix TS 0, so 1970

Fixes: #25507

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
