### PR TITLE
testdrive: More deterministic output order, no duplicated output

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -9,6 +9,7 @@
 
 import os
 import subprocess
+import sys
 from inspect import Traceback
 
 from kubernetes.client import V1Container, V1EnvVar, V1ObjectMeta, V1Pod, V1PodSpec
@@ -156,10 +157,13 @@ class TestdrivePod(K8sPod, TestdriveBase):
                 "--",
                 *command,
                 input=input,
-                capture_output=True,
                 suppress_command_error_output=suppress_command_error_output,
             )
         except subprocess.CalledProcessError as e:
+            if e.stdout is not None:
+                print(e.stdout, end="")
+            if e.stderr is not None:
+                print(e.stderr, file=sys.stderr, end="")
             error_chunks = extract_error_chunks_from_output(e.stderr or e.stdout)
             error_text = "\n".join(error_chunks)
             raise CommandFailureCausedUIError(

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -581,10 +581,6 @@ class Composition:
         ]
 
         if isinstance(e, CommandFailureCausedUIError):
-            if e.stderr is not None:
-                # This is to avoid that captured stderr is missing in the logs.
-                print(e.stderr, file=sys.stderr, flush=True)
-
             try:
                 extracted_errors = try_determine_errors_from_cmd_execution(e)
             except:

--- a/misc/python/materialize/mzcompose/test_result.py
+++ b/misc/python/materialize/mzcompose/test_result.py
@@ -125,6 +125,4 @@ def extract_error_chunks_from_output(output: str) -> list[str]:
     error_output = output[: output.index("+++ !!! Error Report") - 1]
     error_chunks = error_output.split("^^^ +++")
 
-    # The first part is uninteresting, contains only general testdrive
-    # executable output, not what actually failed, so cut it off.
-    return [chunk.strip() for chunk in error_chunks if len(chunk.strip()) > 0][1:]
+    return [chunk.strip() for chunk in error_chunks if len(chunk.strip()) > 0]

--- a/src/testdrive/src/error.rs
+++ b/src/testdrive/src/error.rs
@@ -70,15 +70,15 @@ impl Error {
                 color_spec.set_bold(false);
                 stderr.set_color(&color_spec)?;
                 write!(&mut stderr, "{}", location.snippet)?;
-                writeln!(&mut stderr, "{}^", " ".repeat(location.col - 1))
+                writeln!(&mut stderr, "{}^", " ".repeat(location.col - 1))?;
             }
             None => {
                 let color_spec = ColorSpec::new();
                 write_error_heading(&mut stderr, &color_spec)?;
                 writeln!(&mut stderr, "{}", self.source.display_with_causes())?;
-                Ok(())
             }
         }
+        std::io::stderr().flush()
     }
 }
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
