### PR TITLE
ci: Smaller agent for pg-cdc

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -363,7 +363,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc
         agents:
-          queue: linux-aarch64 # TODO(def-) Switch to small when #24324 is fixed
+          queue: linux-aarch64-small
 
       - id: pg-cdc-resumption
         label: Postgres CDC resumption tests

--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -61,7 +61,7 @@ IGNORE_RE = re.compile(
     r"""
     ( discussion\ of\ this\ in
     | discussed\ in
-    | See\ \<
+    | [sS]ee\ \<
     # is_null_propagation.slt
     | isnull\(\#0\)
     # src/transform/tests/test_transforms/column_knowledge.spec

--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -304,7 +304,7 @@ impl ConnectionOptionExtracted {
                     password: self.password.map(|secret| secret.into()),
                 });
 
-                // TODO we should move to self.port being unsupported if aws_privatelink is some  https://github.com/MaterializeInc/materialize/issues/24712#issuecomment-1925443977
+                // TODO we should move to self.port being unsupported if aws_privatelink is some, see <https://github.com/MaterializeInc/materialize/issues/24712#issuecomment-1925443977>
                 if let Some(privatelink) = self.aws_privatelink.as_ref() {
                     if privatelink.port.is_some() {
                         sql_bail!("invalid CONNECTION: PORT in AWS PRIVATELINK is only supported for kafka")
@@ -344,7 +344,7 @@ impl ConnectionOptionExtracted {
                     Some(m) => sql_bail!("invalid CONNECTION: unknown SSL MODE {}", m.quoted()),
                 };
 
-                // TODO we should move to self.port being unsupported if aws_privatelink is some  https://github.com/MaterializeInc/materialize/issues/24712#issuecomment-1925443977
+                // TODO we should move to self.port being unsupported if aws_privatelink is some, see <https://github.com/MaterializeInc/materialize/issues/24712#issuecomment-1925443977>
                 if let Some(privatelink) = self.aws_privatelink.as_ref() {
                     if privatelink.port.is_some() {
                         sql_bail!("invalid CONNECTION: PORT in AWS PRIVATELINK is only supported for kafka")
@@ -417,7 +417,7 @@ impl ConnectionOptionExtracted {
                     Some(m) => sql_bail!("invalid CONNECTION: unknown SSL MODE {}", m.quoted()),
                 };
 
-                // TODO we should move to self.port being unsupported if aws_privatelink is some  https://github.com/MaterializeInc/materialize/issues/24712#issuecomment-1925443977
+                // TODO we should move to self.port being unsupported if aws_privatelink is some, see <https://github.com/MaterializeInc/materialize/issues/24712#issuecomment-1925443977>
                 if let Some(privatelink) = self.aws_privatelink.as_ref() {
                     if privatelink.port.is_some() {
                         sql_bail!("invalid CONNECTION: PORT in AWS PRIVATELINK is only supported for kafka")


### PR DESCRIPTION
As suggested by https://buildkite.com/materialize/nightlies/builds/6592#018dd5f2-e81f-4b68-bdeb-b9dd9db69379

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
