### PR TITLE
Start using dyncfg for compute configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4089,6 +4089,7 @@ dependencies = [
  "mz-cluster-client",
  "mz-compute-client",
  "mz-compute-types",
+ "mz-dyncfg",
  "mz-expr",
  "mz-ore",
  "mz-persist-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4090,6 +4090,7 @@ dependencies = [
  "mz-compute-client",
  "mz-compute-types",
  "mz-dyncfg",
+ "mz-dyncfgs",
  "mz-expr",
  "mz-ore",
  "mz-persist-client",
@@ -4171,6 +4172,7 @@ dependencies = [
  "columnation",
  "differential-dataflow",
  "itertools",
+ "mz-dyncfg",
  "mz-expr",
  "mz-ore",
  "mz-proto",
@@ -4254,6 +4256,7 @@ dependencies = [
 name = "mz-dyncfgs"
 version = "0.0.0"
 dependencies = [
+ "mz-compute-types",
  "mz-dyncfg",
  "mz-persist-client",
  "mz-persist-txn",

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -43,9 +43,9 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
             config.enable_compute_operator_hydration_status_logging(),
         ),
         enable_lgalloc_eager_reclamation: Some(config.enable_lgalloc_eager_reclamation()),
-        persist: persist_config(config),
         tracing: tracing_config(config),
         grpc_client: grpc_client_config(config),
+        dyncfg_updates: config.persist_configs(),
     }
 }
 

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -45,7 +45,7 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
         enable_lgalloc_eager_reclamation: Some(config.enable_lgalloc_eager_reclamation()),
         tracing: tracing_config(config),
         grpc_client: grpc_client_config(config),
-        dyncfg_updates: config.persist_configs(),
+        dyncfg_updates: config.dyncfg_updates(),
     }
 }
 
@@ -79,7 +79,9 @@ fn parse_yield_spec(s: &str) -> Option<YieldSpec> {
 /// Return the current storage configuration, derived from the system configuration.
 pub fn storage_config(config: &SystemVars) -> StorageParameters {
     StorageParameters {
-        persist: persist_config(config),
+        persist: PersistParameters {
+            config_updates: config.dyncfg_updates(),
+        },
         pg_source_tcp_timeouts: mz_postgres_util::TcpTimeoutConfig {
             connect_timeout: Some(config.pg_source_connect_timeout()),
             keepalives_retries: Some(config.pg_source_keepalives_retries()),
@@ -211,12 +213,6 @@ pub fn caching_config(config: &SystemVars) -> mz_secrets::CachingPolicy {
     mz_secrets::CachingPolicy {
         enabled: ttl_secs > 0,
         ttl: Duration::from_secs(u64::cast_from(ttl_secs)),
-    }
-}
-
-fn persist_config(config: &SystemVars) -> PersistParameters {
-    PersistParameters {
-        config_updates: config.persist_configs(),
     }
 }
 

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -28,12 +28,6 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
     ComputeParameters {
         max_result_size: Some(config.max_result_size()),
         dataflow_max_inflight_bytes: Some(config.compute_dataflow_max_inflight_bytes()),
-        enable_columnation_lgalloc: Some(config.enable_columnation_lgalloc()),
-        enable_chunked_stack: Some(config.enable_compute_chunked_stack()),
-        enable_operator_hydration_status_logging: Some(
-            config.enable_compute_operator_hydration_status_logging(),
-        ),
-        enable_lgalloc_eager_reclamation: Some(config.enable_lgalloc_eager_reclamation()),
         tracing: tracing_config(config),
         grpc_client: grpc_client_config(config),
         dyncfg_updates: config.dyncfg_updates(),

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -10,13 +10,12 @@
 use std::time::Duration;
 
 use mz_compute_client::protocol::command::ComputeParameters;
-use mz_compute_types::dataflows::YieldSpec;
 use mz_orchestrator::scheduling_config::{ServiceSchedulingConfig, ServiceTopologySpreadConfig};
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
 use mz_persist_client::cfg::PersistParameters;
 use mz_service::params::GrpcClientParameters;
-use mz_sql::session::vars::{SystemVars, DEFAULT_LINEAR_JOIN_YIELDING};
+use mz_sql::session::vars::SystemVars;
 use mz_storage_types::parameters::{
     PgSourceSnapshotConfig, StorageMaxInflightBytesConfig, StorageParameters, UpsertAutoSpillConfig,
 };
@@ -26,17 +25,9 @@ use mz_timestamp_oracle::postgres_oracle::PostgresTimestampOracleParameters;
 
 /// Return the current compute configuration, derived from the system configuration.
 pub fn compute_config(config: &SystemVars) -> ComputeParameters {
-    let linear_join_yielding = config.linear_join_yielding();
-    let linear_join_yielding = parse_yield_spec(linear_join_yielding).unwrap_or_else(|| {
-        tracing::error!("invalid `linear_join_yielding` config: {linear_join_yielding}");
-        parse_yield_spec(&DEFAULT_LINEAR_JOIN_YIELDING).expect("default is valid")
-    });
-
     ComputeParameters {
         max_result_size: Some(config.max_result_size()),
         dataflow_max_inflight_bytes: Some(config.compute_dataflow_max_inflight_bytes()),
-        linear_join_yielding: Some(linear_join_yielding),
-        enable_mz_join_core: Some(config.enable_mz_join_core()),
         enable_columnation_lgalloc: Some(config.enable_columnation_lgalloc()),
         enable_chunked_stack: Some(config.enable_compute_chunked_stack()),
         enable_operator_hydration_status_logging: Some(
@@ -47,33 +38,6 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
         grpc_client: grpc_client_config(config),
         dyncfg_updates: config.dyncfg_updates(),
     }
-}
-
-fn parse_yield_spec(s: &str) -> Option<YieldSpec> {
-    let mut after_work = None;
-    let mut after_time = None;
-
-    let options = s.split(',').map(|o| o.trim());
-    for option in options {
-        let parts: Vec<_> = option.split(':').map(|p| p.trim()).collect();
-        match &parts[..] {
-            ["work", amount] => {
-                let amount = amount.parse().ok()?;
-                after_work = Some(amount);
-            }
-            ["time", millis] => {
-                let millis = millis.parse().ok()?;
-                let duration = Duration::from_millis(millis);
-                after_time = Some(duration);
-            }
-            _ => return None,
-        }
-    }
-
-    Some(YieldSpec {
-        after_work,
-        after_time,
-    })
 }
 
 /// Return the current storage configuration, derived from the system configuration.

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -81,10 +81,6 @@ message ProtoComputeParameters {
     ProtoComputeMaxInflightBytesConfig dataflow_max_inflight_bytes = 3;
     mz_tracing.params.ProtoTracingParameters tracing = 5;
     mz_service.params.ProtoGrpcClientParameters grpc_client = 6;
-    optional bool enable_columnation_lgalloc = 10;
-    optional bool enable_operator_hydration_status_logging = 11;
-    optional bool enable_chunked_stack = 12;
-    optional bool enable_lgalloc_eager_reclamation = 13;
 }
 
 message ProtoComputeMaxInflightBytesConfig {

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -77,7 +77,7 @@ message ProtoPeek {
 
 message ProtoComputeParameters {
     optional uint64 max_result_size = 1;
-    mz_dyncfg.ConfigUpdates persist = 2;
+    mz_dyncfg.ConfigUpdates dyncfg_updates = 2;
     ProtoComputeMaxInflightBytesConfig dataflow_max_inflight_bytes = 3;
     optional bool enable_mz_join_core = 4;
     mz_tracing.params.ProtoTracingParameters tracing = 5;

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -79,10 +79,8 @@ message ProtoComputeParameters {
     optional uint64 max_result_size = 1;
     mz_dyncfg.ConfigUpdates dyncfg_updates = 2;
     ProtoComputeMaxInflightBytesConfig dataflow_max_inflight_bytes = 3;
-    optional bool enable_mz_join_core = 4;
     mz_tracing.params.ProtoTracingParameters tracing = 5;
     mz_service.params.ProtoGrpcClientParameters grpc_client = 6;
-    mz_compute_types.dataflows.ProtoYieldSpec linear_join_yielding = 9;
     optional bool enable_columnation_lgalloc = 10;
     optional bool enable_operator_hydration_status_logging = 11;
     optional bool enable_chunked_stack = 12;

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -10,7 +10,7 @@
 //! Compute protocol commands.
 
 use mz_cluster_client::client::{ClusterStartupEpoch, TimelyConfig, TryIntoTimelyConfig};
-use mz_compute_types::dataflows::{DataflowDescription, YieldSpec};
+use mz_compute_types::dataflows::DataflowDescription;
 use mz_dyncfg::ConfigUpdates;
 use mz_expr::RowSetFinishing;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -375,10 +375,6 @@ pub struct ComputeParameters {
     /// NB: This value is optional, so the outer option indicates if this update
     /// includes an override and the inner option is part of the config value.
     pub dataflow_max_inflight_bytes: Option<Option<usize>>,
-    /// The yielding behavior with which linear joins should be rendered.
-    pub linear_join_yielding: Option<YieldSpec>,
-    /// Whether rendering should use `mz_join_core` rather than DD's `JoinCore::join_core`.
-    pub enable_mz_join_core: Option<bool>,
     /// Enable lgalloc for columnation.
     pub enable_columnation_lgalloc: Option<bool>,
     /// Enable the chunked stack implementation.
@@ -402,8 +398,6 @@ impl ComputeParameters {
         let ComputeParameters {
             max_result_size,
             dataflow_max_inflight_bytes,
-            linear_join_yielding,
-            enable_mz_join_core,
             enable_columnation_lgalloc,
             enable_chunked_stack,
             enable_operator_hydration_status_logging,
@@ -418,12 +412,6 @@ impl ComputeParameters {
         }
         if dataflow_max_inflight_bytes.is_some() {
             self.dataflow_max_inflight_bytes = dataflow_max_inflight_bytes;
-        }
-        if linear_join_yielding.is_some() {
-            self.linear_join_yielding = linear_join_yielding;
-        }
-        if enable_mz_join_core.is_some() {
-            self.enable_mz_join_core = enable_mz_join_core;
         }
         if enable_columnation_lgalloc.is_some() {
             self.enable_columnation_lgalloc = enable_columnation_lgalloc;
@@ -462,8 +450,6 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
                     dataflow_max_inflight_bytes: x.into_proto(),
                 }
             }),
-            linear_join_yielding: self.linear_join_yielding.into_proto(),
-            enable_mz_join_core: self.enable_mz_join_core.into_proto(),
             enable_columnation_lgalloc: self.enable_columnation_lgalloc.into_proto(),
             enable_chunked_stack: self.enable_chunked_stack.into_proto(),
             enable_operator_hydration_status_logging: self
@@ -483,8 +469,6 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
                 .dataflow_max_inflight_bytes
                 .map(|x| x.dataflow_max_inflight_bytes.into_rust())
                 .transpose()?,
-            linear_join_yielding: proto.linear_join_yielding.into_rust()?,
-            enable_mz_join_core: proto.enable_mz_join_core.into_rust()?,
             enable_columnation_lgalloc: proto.enable_columnation_lgalloc.into_rust()?,
             enable_chunked_stack: proto.enable_chunked_stack.into_rust()?,
             enable_operator_hydration_status_logging: proto

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -375,14 +375,6 @@ pub struct ComputeParameters {
     /// NB: This value is optional, so the outer option indicates if this update
     /// includes an override and the inner option is part of the config value.
     pub dataflow_max_inflight_bytes: Option<Option<usize>>,
-    /// Enable lgalloc for columnation.
-    pub enable_columnation_lgalloc: Option<bool>,
-    /// Enable the chunked stack implementation.
-    pub enable_chunked_stack: Option<bool>,
-    /// Enable operator hydration status logging.
-    pub enable_operator_hydration_status_logging: Option<bool>,
-    /// Enable lgalloc's eager memory return/reclamation feature.
-    pub enable_lgalloc_eager_reclamation: Option<bool>,
     /// Tracing configuration.
     pub tracing: TracingParameters,
     /// gRPC client configuration.
@@ -398,10 +390,6 @@ impl ComputeParameters {
         let ComputeParameters {
             max_result_size,
             dataflow_max_inflight_bytes,
-            enable_columnation_lgalloc,
-            enable_chunked_stack,
-            enable_operator_hydration_status_logging,
-            enable_lgalloc_eager_reclamation,
             tracing,
             grpc_client,
             dyncfg_updates,
@@ -412,19 +400,6 @@ impl ComputeParameters {
         }
         if dataflow_max_inflight_bytes.is_some() {
             self.dataflow_max_inflight_bytes = dataflow_max_inflight_bytes;
-        }
-        if enable_columnation_lgalloc.is_some() {
-            self.enable_columnation_lgalloc = enable_columnation_lgalloc;
-        }
-        if enable_chunked_stack.is_some() {
-            self.enable_chunked_stack = enable_chunked_stack;
-        }
-        if enable_operator_hydration_status_logging.is_some() {
-            self.enable_operator_hydration_status_logging =
-                enable_operator_hydration_status_logging;
-        }
-        if enable_lgalloc_eager_reclamation.is_some() {
-            self.enable_lgalloc_eager_reclamation = enable_lgalloc_eager_reclamation;
         }
 
         self.tracing.update(tracing);
@@ -450,12 +425,6 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
                     dataflow_max_inflight_bytes: x.into_proto(),
                 }
             }),
-            enable_columnation_lgalloc: self.enable_columnation_lgalloc.into_proto(),
-            enable_chunked_stack: self.enable_chunked_stack.into_proto(),
-            enable_operator_hydration_status_logging: self
-                .enable_operator_hydration_status_logging
-                .into_proto(),
-            enable_lgalloc_eager_reclamation: self.enable_lgalloc_eager_reclamation.into_proto(),
             tracing: Some(self.tracing.into_proto()),
             grpc_client: Some(self.grpc_client.into_proto()),
             dyncfg_updates: Some(self.dyncfg_updates.clone()),
@@ -469,12 +438,6 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
                 .dataflow_max_inflight_bytes
                 .map(|x| x.dataflow_max_inflight_bytes.into_rust())
                 .transpose()?,
-            enable_columnation_lgalloc: proto.enable_columnation_lgalloc.into_rust()?,
-            enable_chunked_stack: proto.enable_chunked_stack.into_rust()?,
-            enable_operator_hydration_status_logging: proto
-                .enable_operator_hydration_status_logging
-                .into_rust()?,
-            enable_lgalloc_eager_reclamation: proto.enable_lgalloc_eager_reclamation.into_rust()?,
             tracing: proto
                 .tracing
                 .into_rust_if_some("ProtoComputeParameters::tracing")?,

--- a/src/compute-types/Cargo.toml
+++ b/src/compute-types/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 columnation = { git = "https://github.com/frankmcsherry/columnation" }
 differential-dataflow = "0.12.0"
 itertools = "0.10.5"
+mz-dyncfg = { path = "../dyncfg" }
 mz-expr = { path = "../expr" }
 mz-ore = { path = "../ore", features = ["tracing_", "metrics"] }
 mz-proto = { path = "../proto" }

--- a/src/compute-types/src/dataflows.proto
+++ b/src/compute-types/src/dataflows.proto
@@ -66,8 +66,3 @@ message ProtoBuildDesc {
     mz_repr.global_id.ProtoGlobalId id = 1;
     plan.ProtoPlan plan = 2;
 }
-
-message ProtoYieldSpec {
-    optional uint64 after_work = 1;
-    optional mz_proto.ProtoDuration after_time = 2;
-}

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -11,7 +11,6 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
-use std::time::Duration;
 
 use mz_expr::{CollectionPlan, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr};
 use mz_ore::soft_assert_or_log;
@@ -722,31 +721,6 @@ impl RustType<ProtoBuildDesc> for BuildDesc<crate::plan::Plan> {
         Ok(BuildDesc {
             id: x.id.into_rust_if_some("ProtoBuildDesc::id")?,
             plan: x.plan.into_rust_if_some("ProtoBuildDesc::plan")?,
-        })
-    }
-}
-
-/// Specification of a dataflow operator's yielding behavior.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
-pub struct YieldSpec {
-    /// Yield after the given amount of work was performed.
-    pub after_work: Option<usize>,
-    /// Yield after the given amount of time has elapsed.
-    pub after_time: Option<Duration>,
-}
-
-impl RustType<ProtoYieldSpec> for YieldSpec {
-    fn into_proto(&self) -> ProtoYieldSpec {
-        ProtoYieldSpec {
-            after_work: self.after_work.into_proto(),
-            after_time: self.after_time.into_proto(),
-        }
-    }
-
-    fn from_proto(proto: ProtoYieldSpec) -> Result<Self, TryFromProtoError> {
-        Ok(Self {
-            after_work: proto.after_work.into_rust()?,
-            after_time: proto.after_time.into_rust()?,
         })
     }
 }

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -29,7 +29,41 @@ pub const LINEAR_JOIN_YIELDING: Config<String> = Config::new(
      work, respectively, rather than falling back to some default.",
 );
 
+/// Enable lgalloc for columnation.
+pub const ENABLE_COLUMNATION_LGALLOC: Config<bool> = Config::new(
+    "enable_columnation_lgalloc",
+    false,
+    "Enable allocating regions from lgalloc.",
+);
+
+/// Enable lgalloc's eager memory return/reclamation feature.
+pub const ENABLE_LGALLOC_EAGER_RECLAMATION: Config<bool> = Config::new(
+    "enable_lgalloc_eager_reclamation",
+    true,
+    "Enable lgalloc's eager return behavior.",
+);
+
+/// Enable the chunked stack implementation.
+pub const ENABLE_CHUNKED_STACK: Config<bool> = Config::new(
+    "enable_compute_chunked_stack",
+    false,
+    "Enable the chunked stack implementation in compute.",
+);
+
+/// Enable operator hydration status logging.
+pub const ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING: Config<bool> = Config::new(
+    "enable_compute_operator_hydration_status_logging",
+    true,
+    "Enable logging of the hydration status of compute operators.",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
-    configs.add(&ENABLE_MZ_JOIN_CORE).add(&LINEAR_JOIN_YIELDING)
+    configs
+        .add(&ENABLE_MZ_JOIN_CORE)
+        .add(&LINEAR_JOIN_YIELDING)
+        .add(&ENABLE_COLUMNATION_LGALLOC)
+        .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
+        .add(&ENABLE_CHUNKED_STACK)
+        .add(&ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING)
 }

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -1,0 +1,35 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Dyncfgs used by the compute layer.
+
+use mz_dyncfg::{Config, ConfigSet};
+
+/// Whether rendering should use `mz_join_core` rather than DD's `JoinCore::join_core`.
+pub const ENABLE_MZ_JOIN_CORE: Config<bool> = Config::new(
+    "enable_mz_join_core",
+    true,
+    "Whether compute should use `mz_join_core` rather than DD's `JoinCore::join_core` to render \
+     linear joins.",
+);
+
+/// The yielding behavior with which linear joins should be rendered.
+pub const LINEAR_JOIN_YIELDING: Config<String> = Config::new(
+    "linear_join_yielding",
+    "work:1000000,time:100",
+    "The yielding behavior compute rendering should apply for linear join operators. Either \
+     'work:<amount>' or 'time:<milliseconds>' or 'work:<amount>,time:<milliseconds>'. Note \
+     that omitting one of 'work' or 'time' will entirely disable join yielding by time or \
+     work, respectively, rather than falling back to some default.",
+);
+
+/// Adds the full set of all compute `Config`s.
+pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
+    configs.add(&ENABLE_MZ_JOIN_CORE).add(&LINEAR_JOIN_YIELDING)
+}

--- a/src/compute-types/src/lib.rs
+++ b/src/compute-types/src/lib.rs
@@ -14,6 +14,7 @@
 use std::time::Duration;
 
 pub mod dataflows;
+pub mod dyncfgs;
 pub mod explain;
 pub mod plan;
 pub mod sinks;

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -28,6 +28,7 @@ mz-cluster-client = { path = "../cluster-client" }
 mz-compute-client = { path = "../compute-client" }
 mz-compute-types = { path = "../compute-types" }
 mz-dyncfg = { path = "../dyncfg" }
+mz-dyncfgs = { path = "../dyncfgs" }
 mz-expr = { path = "../expr" }
 mz-ore = { path = "../ore", features = ["async", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -27,6 +27,7 @@ mz-cluster = { path = "../cluster" }
 mz-cluster-client = { path = "../cluster-client" }
 mz-compute-client = { path = "../compute-client" }
 mz-compute-types = { path = "../compute-types" }
+mz-dyncfg = { path = "../dyncfg" }
 mz-expr = { path = "../expr" }
 mz-ore = { path = "../ore", features = ["async", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -237,9 +237,9 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             enable_chunked_stack,
             enable_operator_hydration_status_logging,
             enable_lgalloc_eager_reclamation,
-            persist,
             tracing,
             grpc_client: _grpc_client,
+            dyncfg_updates,
         } = params;
 
         if let Some(v) = max_result_size {
@@ -301,8 +301,9 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             self.compute_state.enable_operator_hydration_status_logging = v;
         }
 
-        persist.apply(self.compute_state.persist_clients.cfg());
         tracing.apply(self.compute_state.tracing_handle.as_ref());
+
+        dyncfg_updates.apply(&self.compute_state.persist_clients.cfg().configs);
     }
 
     fn handle_create_dataflow(&mut self, dataflow: DataflowDescription<Plan, CollectionMetadata>) {

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -41,8 +41,7 @@ use crate::arrangement::manager::SpecializedTraceHandle;
 use crate::compute_state::{ComputeState, HydrationEvent};
 use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::render::errors::ErrorLogger;
-use crate::render::join::LinearJoinSpec;
-use crate::render::RenderTimestamp;
+use crate::render::{LinearJoinSpec, RenderTimestamp};
 use crate::typedefs::{
     ErrAgent, ErrEnter, ErrSpine, RowAgent, RowEnter, RowRowAgent, RowRowEnter, RowRowSpine,
     RowSpine,

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -90,8 +90,6 @@ where
     pub(super) linear_join_spec: LinearJoinSpec,
     /// Per-worker dynamic configuration.
     pub(super) worker_config: ConfigSet,
-    /// Whether to log operator hydration status.
-    pub(super) enable_operator_hydration_status_logging: bool,
 }
 
 impl<S: Scope> Context<S>
@@ -134,8 +132,6 @@ where
             hydration_logger,
             linear_join_spec: compute_state.linear_join_spec,
             worker_config: compute_state.worker_config.clone(),
-            enable_operator_hydration_status_logging: compute_state
-                .enable_operator_hydration_status_logging,
         }
     }
 }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -20,6 +20,7 @@ use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
 use differential_dataflow::{Collection, Data};
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::AvailableCollections;
+use mz_dyncfg::ConfigSet;
 use mz_expr::{Id, MapFilterProject, MirScalarExpr};
 use mz_repr::fixed_length::{FromRowByTypes, IntoRowByTypes};
 use mz_repr::{ColumnType, DatumVec, DatumVecBorrow, Diff, GlobalId, Row, RowArena, SharedRow};
@@ -88,6 +89,8 @@ where
     pub(super) hydration_logger: Option<HydrationLogger>,
     /// Specification for rendering linear joins.
     pub(super) linear_join_spec: LinearJoinSpec,
+    /// Per-worker dynamic configuration.
+    pub(super) worker_config: ConfigSet,
     /// Whether to log operator hydration status.
     pub(super) enable_operator_hydration_status_logging: bool,
 }
@@ -131,6 +134,7 @@ where
             shutdown_token: Default::default(),
             hydration_logger,
             linear_join_spec: compute_state.linear_join_spec,
+            worker_config: compute_state.worker_config.clone(),
             enable_operator_hydration_status_logging: compute_state
                 .enable_operator_hydration_status_logging,
         }

--- a/src/compute/src/render/join/mod.rs
+++ b/src/compute/src/render/join/mod.rs
@@ -15,4 +15,4 @@ mod delta_join;
 mod linear_join;
 mod mz_join_core;
 
-pub use linear_join::{LinearJoinImpl, LinearJoinSpec};
+pub use linear_join::LinearJoinSpec;

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -153,7 +153,7 @@ mod threshold;
 mod top_k;
 
 pub use context::CollectionBundle;
-pub use join::{LinearJoinImpl, LinearJoinSpec};
+pub use join::LinearJoinSpec;
 
 /// Assemble the "compute"  side of a dataflow, i.e. all but the sources.
 ///

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -112,6 +112,7 @@ use differential_dataflow::trace::{Batch, Batcher, Trace, TraceReader};
 use differential_dataflow::{AsCollection, Collection, Data, ExchangeData, Hashable};
 use itertools::izip;
 use mz_compute_types::dataflows::{BuildDesc, DataflowDescription, IndexDesc};
+use mz_compute_types::dyncfgs::ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING;
 use mz_compute_types::plan::Plan;
 use mz_expr::{EvalError, Id};
 use mz_persist_client::operators::shard_source::SnapshotMode;
@@ -753,7 +754,7 @@ where
 
         let mut bundle = mz_ore::stack::maybe_grow(|| self.render_plan_inner(plan));
 
-        if self.enable_operator_hydration_status_logging {
+        if ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING.get(&self.worker_config) {
             self.log_operator_hydration(&mut bundle, lir_id);
         }
 

--- a/src/dyncfgs/Cargo.toml
+++ b/src/dyncfgs/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 workspace = true
 
 [dependencies]
+mz-compute-types = { path = "../compute-types"}
 mz-dyncfg = { path = "../dyncfg"}
 mz-persist-client = { path = "../persist-client"}
 mz-persist-txn = { path = "../persist-txn"}

--- a/src/dyncfgs/src/lib.rs
+++ b/src/dyncfgs/src/lib.rs
@@ -28,5 +28,6 @@ pub fn all_dyncfgs() -> ConfigSet {
     let mut configs = ConfigSet::default();
     configs = mz_persist_client::cfg::all_dyncfgs(configs);
     configs = mz_persist_txn::all_dyncfgs(configs);
+    configs = mz_compute_types::dyncfgs::all_dyncfgs(configs);
     configs
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -74,7 +74,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use im::OrdMap;
 use mz_build_info::BuildInfo;
-use mz_dyncfg::{ConfigSet, ConfigType, ConfigUpdates as PersistConfigUpdates, ConfigVal};
+use mz_dyncfg::{ConfigSet, ConfigType, ConfigUpdates, ConfigVal};
 use mz_ore::cast::CastFrom;
 use mz_persist_client::cfg::{CRDB_CONNECT_TIMEOUT, CRDB_TCP_USER_TIMEOUT};
 use mz_repr::adt::numeric::Numeric;
@@ -1036,13 +1036,10 @@ pub struct SystemVars {
 
     active_connection_count: Arc<Mutex<ConnectionCounter>>,
     /// NB: This is intentionally disconnected from the one that is plumbed
-    /// around to various components (initially, just persist). This is so we
-    /// can explictly control and reason about when changes to config values are
-    /// propagated to the rest of the system.
-    ///
-    /// TODO(cfg): Rename this when components other than persist are pulled
-    /// into it.
-    persist_configs: ConfigSet,
+    /// around to various components. This is so we can explictly control and
+    /// reason about when changes to config values are propagated to the rest
+    /// of the system.
+    dyncfgs: ConfigSet,
 }
 
 impl Default for SystemVars {
@@ -1213,8 +1210,8 @@ impl SystemVars {
             &USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION,
         ];
 
-        let persist_configs = mz_dyncfgs::all_dyncfgs();
-        let persist_vars: Vec<_> = persist_configs
+        let dyncfgs = mz_dyncfgs::all_dyncfgs();
+        let dyncfg_vars: Vec<_> = dyncfgs
             .entries()
             .map(|cfg| match cfg.default() {
                 ConfigVal::Bool(default) => VarDefinition::new_runtime(
@@ -1258,7 +1255,7 @@ impl SystemVars {
             .chain(Self::SESSION_VARS.values().copied())
             .cloned()
             // Include Persist configs.
-            .chain(persist_vars.into_iter())
+            .chain(dyncfg_vars.into_iter())
             .map(|var| (var.name, SystemVar::new(var)))
             .collect();
 
@@ -1266,7 +1263,7 @@ impl SystemVars {
             vars,
             active_connection_count,
             allow_unsafe: false,
-            persist_configs,
+            dyncfgs,
         };
         vars.refresh_internal_state();
 
@@ -1856,9 +1853,9 @@ impl SystemVars {
         ))
     }
 
-    pub fn persist_configs(&self) -> PersistConfigUpdates {
-        let mut updates = PersistConfigUpdates::default();
-        for entry in self.persist_configs.entries() {
+    pub fn dyncfg_updates(&self) -> ConfigUpdates {
+        let mut updates = ConfigUpdates::default();
+        for entry in self.dyncfgs.entries() {
             let name = UncasedStr::new(entry.name());
             match entry.val() {
                 ConfigVal::Bool(x) => {
@@ -2150,7 +2147,7 @@ impl SystemVars {
             || name == ENABLE_COMPUTE_CHUNKED_STACK.name()
             || name == ENABLE_COMPUTE_OPERATOR_HYDRATION_STATUS_LOGGING.name()
             || name == ENABLE_LGALLOC_EAGER_RECLAMATION.name()
-            || self.is_persist_config_var(name)
+            || self.is_dyncfg_var(name)
             || is_tracing_var(name)
     }
 
@@ -2189,13 +2186,13 @@ impl SystemVars {
             || name == STORAGE_STATISTICS_COLLECTION_INTERVAL.name()
             || name == USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION.name()
             || is_upsert_rocksdb_config_var(name)
-            || self.is_persist_config_var(name)
+            || self.is_dyncfg_var(name)
             || is_tracing_var(name)
     }
 
     /// Returns whether the named variable is a persist configuration parameter.
-    fn is_persist_config_var(&self, name: &str) -> bool {
-        self.persist_configs.entries().any(|e| name == e.name())
+    fn is_dyncfg_var(&self, name: &str) -> bool {
+        self.dyncfgs.entries().any(|e| name == e.name())
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1195,9 +1195,6 @@ impl SystemVars {
             &OPTIMIZER_ONESHOT_STATS_TIMEOUT,
             &PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE,
             &WEBHOOK_CONCURRENT_REQUEST_LIMIT,
-            &ENABLE_COLUMNATION_LGALLOC,
-            &ENABLE_COMPUTE_CHUNKED_STACK,
-            &ENABLE_LGALLOC_EAGER_RECLAMATION,
             &ENABLE_STATEMENT_LIFECYCLE_LOGGING,
             &ENABLE_DEPENDENCY_READ_HOLD_ASSERTS,
             &TIMESTAMP_ORACLE_IMPL,
@@ -2070,21 +2067,6 @@ impl SystemVars {
         *self.expect_value(&WEBHOOK_CONCURRENT_REQUEST_LIMIT)
     }
 
-    /// Returns the `enable_columnation_lgalloc` configuration parameter.
-    pub fn enable_columnation_lgalloc(&self) -> bool {
-        *self.expect_value(&ENABLE_COLUMNATION_LGALLOC)
-    }
-
-    /// Returns the `enable_compute_chunked_stack` configuration parameter.
-    pub fn enable_compute_chunked_stack(&self) -> bool {
-        *self.expect_value(&ENABLE_COMPUTE_CHUNKED_STACK)
-    }
-
-    /// Returns the `enable_lgalloc_eager_reclamation` configuration parameter.
-    pub fn enable_lgalloc_eager_reclamation(&self) -> bool {
-        *self.expect_value(&ENABLE_LGALLOC_EAGER_RECLAMATION)
-    }
-
     pub fn enable_statement_lifecycle_logging(&self) -> bool {
         *self.expect_value(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
     }
@@ -2129,10 +2111,6 @@ impl SystemVars {
     pub fn is_compute_config_var(&self, name: &str) -> bool {
         name == MAX_RESULT_SIZE.name()
             || name == COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
-            || name == ENABLE_COLUMNATION_LGALLOC.name()
-            || name == ENABLE_COMPUTE_CHUNKED_STACK.name()
-            || name == ENABLE_COMPUTE_OPERATOR_HYDRATION_STATUS_LOGGING.name()
-            || name == ENABLE_LGALLOC_EAGER_RECLAMATION.name()
             || self.is_dyncfg_var(name)
             || is_tracing_var(name)
     }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1159,8 +1159,6 @@ impl SystemVars {
             &KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES,
             &KEEP_N_SINK_STATUS_HISTORY_ENTRIES,
             &KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES,
-            &ENABLE_MZ_JOIN_CORE,
-            &LINEAR_JOIN_YIELDING,
             &DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT,
             &DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY,
             &ENABLE_STORAGE_SHARD_FINALIZATION,
@@ -1916,16 +1914,6 @@ impl SystemVars {
         *self.expect_value(&KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES)
     }
 
-    /// Returns the `enable_mz_join_core` configuration parameter.
-    pub fn enable_mz_join_core(&self) -> bool {
-        *self.expect_value(&ENABLE_MZ_JOIN_CORE)
-    }
-
-    /// Returns the `linear_join_yielding` configuration parameter.
-    pub fn linear_join_yielding(&self) -> &Cow<'static, str> {
-        self.expect_value(&LINEAR_JOIN_YIELDING)
-    }
-
     /// Returns the `default_idle_arrangement_merge_effort` configuration parameter.
     pub fn default_idle_arrangement_merge_effort(&self) -> u32 {
         *self.expect_value(&DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT)
@@ -2141,8 +2129,6 @@ impl SystemVars {
     pub fn is_compute_config_var(&self, name: &str) -> bool {
         name == MAX_RESULT_SIZE.name()
             || name == COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
-            || name == LINEAR_JOIN_YIELDING.name()
-            || name == ENABLE_MZ_JOIN_CORE.name()
             || name == ENABLE_COLUMNATION_LGALLOC.name()
             || name == ENABLE_COMPUTE_CHUNKED_STACK.name()
             || name == ENABLE_COMPUTE_OPERATOR_HYDRATION_STATUS_LOGGING.name()

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1465,27 +1465,6 @@ pub static USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION: VarDefinition = VarD
     true,
 );
 
-pub static ENABLE_COLUMNATION_LGALLOC: VarDefinition = VarDefinition::new(
-    "enable_columnation_lgalloc",
-    value!(bool; false),
-    "Enable allocating regions from lgalloc",
-    true,
-);
-
-pub static ENABLE_COMPUTE_CHUNKED_STACK: VarDefinition = VarDefinition::new(
-    "enable_compute_chunked_stack",
-    value!(bool; false),
-    "Enable the chunked stack implementation in compute",
-    true,
-);
-
-pub static ENABLE_LGALLOC_EAGER_RECLAMATION: VarDefinition = VarDefinition::new(
-    "enable_lgalloc_eager_reclamation",
-    value!(bool; true),
-    "Enable lgalloc's eager return behavior.",
-    true,
-);
-
 pub static ENABLE_STATEMENT_LIFECYCLE_LOGGING: VarDefinition = VarDefinition::new(
     "enable_statement_lifecycle_logging",
     value!(bool; false),
@@ -2138,13 +2117,6 @@ feature_flags!(
         name: enable_session_timelines,
         desc: "strong session serializable isolation levels",
         default: false,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
-        name: enable_compute_operator_hydration_status_logging,
-        desc: "log the hydration status of compute operators",
-        default: true,
         internal: true,
         enable_for_item_parsing: false,
     },

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1323,27 +1323,6 @@ pub static STATEMENT_LOGGING_SAMPLE_RATE: VarDefinition = VarDefinition::new_laz
     false,
 ).with_constraint(&NUMERIC_BOUNDED_0_1_INCLUSIVE);
 
-/// Whether compute rendering should use Materialize's custom linear join implementation rather
-/// than the one from Differential Dataflow.
-pub static ENABLE_MZ_JOIN_CORE: VarDefinition = VarDefinition::new(
-    "enable_mz_join_core",
-    value!(bool; true),
-    "Feature flag indicating whether compute rendering should use Materialize's custom linear \
-        join implementation rather than the one from Differential Dataflow. (Materialize).",
-    true,
-);
-
-pub const DEFAULT_LINEAR_JOIN_YIELDING: Cow<'static, str> = Cow::Borrowed("work:1000000,time:100");
-pub static LINEAR_JOIN_YIELDING: VarDefinition = VarDefinition::new(
-    "linear_join_yielding",
-    value!(Cow<'static, str>; DEFAULT_LINEAR_JOIN_YIELDING),
-    "The yielding behavior compute rendering should apply for linear join operators. Either \
-        'work:<amount>' or 'time:<milliseconds>' or 'work:<amount>,time:<milliseconds>'. Note \
-        that omitting one of 'work' or 'time' will entirely disable join yielding by time or \
-        work, respectively, rather than falling back to some default.",
-    true,
-);
-
 pub static DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT: VarDefinition = VarDefinition::new(
     "default_idle_arrangement_merge_effort",
     value!(u32; 0),


### PR DESCRIPTION
This PR takes the dyncfg already plumbed through to `clusterd` processes and generalizes it so that it can be used by compute workers, in addition to persist. It then migrates some of the compute config parameters to dyncfg.

Some compute parameters are not ported here, for various reasons:

* `max_result_size` is a public `ServerVar` are the current dyncfg infrastructure support only internal ones.
* `compute_dataflow_max_inflight_bytes` has type `Option<usize>` and there is not `ConfigType` implementation for `Option` values.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

I recommend looking at the commits separately!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A