### PR TITLE
ci: Automatically fill commit and branch for preflight checks

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -26,7 +26,7 @@ import os
 import subprocess
 import sys
 from collections import OrderedDict
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -34,8 +34,10 @@ import yaml
 
 from materialize import buildkite, mzbuild, spawn
 from materialize.ci_util.trim_pipeline import permit_rerunning_successful_steps
+from materialize.mz_version import MzVersion
 from materialize.mzcompose.composition import Composition
 from materialize.ui import UIError
+from materialize.version_list import get_previous_published_version
 from materialize.xcompile import Arch
 
 from .deploy.deploy_util import rust_version
@@ -50,6 +52,13 @@ from .deploy.deploy_util import rust_version
 # bin/resync-submodules is not presently used by CI, but it's just not worth
 # trying to capture that.)
 CI_GLUE_GLOBS = ["bin", "ci", "misc/python"]
+
+
+def steps(pipeline: Any) -> Iterator[dict[str, Any]]:
+    for step in pipeline["steps"]:
+        yield step
+        if "group" in step:
+            yield from step.get("steps", [])
 
 
 def main() -> int:
@@ -106,7 +115,7 @@ so it is executed.""",
         pipeline["env"]["CI_BUILDER_SCCACHE"] = 1
         pipeline["env"]["CI_COVERAGE_ENABLED"] = 1
 
-        def visit(step: dict[str, Any]) -> None:
+        for step in steps(pipeline):
             # Coverage runs are slower
             if "timeout_in_minutes" in step:
                 step["timeout_in_minutes"] *= 3
@@ -115,24 +124,10 @@ so it is executed.""",
                 step["skip"] = True
             if step.get("id") == "build-x86_64":
                 step["name"] = "Build x86_64 with coverage"
-
-        for step in pipeline["steps"]:
-            visit(step)
-            # Groups can't be nested, so handle them explicitly here instead of recursing
-            if "group" in step:
-                for inner_step in step.get("steps", []):
-                    visit(inner_step)
     else:
-
-        def visit(step: dict[str, Any]) -> None:
+        for step in steps(pipeline):
             if step.get("coverage") == "only":
                 step["skip"] = True
-
-        for step in pipeline["steps"]:
-            visit(step)
-            if "group" in step:
-                for inner_step in step.get("steps", []):
-                    visit(inner_step)
 
     prioritize_pipeline(pipeline)
 
@@ -147,11 +142,13 @@ so it is executed.""",
 
     check_depends_on(pipeline, args.pipeline)
 
+    add_version_to_preflight_tests(pipeline)
+
     trim_builds(pipeline, args.coverage)
 
     # Remove the Materialize-specific keys from the configuration that are
     # only used to inform how to trim the pipeline and for coverage runs.
-    def visit(step: dict[str, Any]) -> None:
+    for step in steps(pipeline):
         if "inputs" in step:
             del step["inputs"]
         if "coverage" in step:
@@ -167,12 +164,6 @@ so it is executed.""",
             raise UIError(
                 f"Every step should have an explicit timeout_in_minutes value, missing in: {step}"
             )
-
-    for step in pipeline["steps"]:
-        visit(step)
-        if "group" in step:
-            for inner_step in step.get("steps", []):
-                visit(inner_step)
 
     spawn.runv(
         ["buildkite-agent", "pipeline", "upload"], stdin=yaml.dump(pipeline).encode()
@@ -221,7 +212,7 @@ def prioritize_pipeline(pipeline: Any) -> None:
 
 
 def set_default_agents_queue(pipeline: Any) -> None:
-    def visit(step: dict[str, Any]) -> None:
+    for step in steps(pipeline):
         if (
             "agents" not in step
             and "prompt" not in step
@@ -231,18 +222,12 @@ def set_default_agents_queue(pipeline: Any) -> None:
         ):
             step["agents"] = {"queue": "linux-aarch64-small"}
 
-    for step in pipeline["steps"]:
-        visit(step)
-        if "group" in step:
-            for inner_step in step.get("steps", []):
-                visit(inner_step)
-
 
 def check_depends_on(pipeline: Any, pipeline_name: str) -> None:
     if pipeline_name != "test":
         return
 
-    def visit(step: dict[str, Any]) -> None:
+    for step in steps(pipeline):
         # From buildkite documentation:
         # Note that a step with an explicit dependency specified with the
         # depends_on attribute will run immediately after the dependency step
@@ -261,15 +246,23 @@ def check_depends_on(pipeline: Any, pipeline_name: str) -> None:
                 f"Every step should have an explicit depends_on value, missing in: {step}"
             )
 
-    for step in pipeline["steps"]:
-        visit(step)
-        if "group" in step:
-            for inner_step in step.get("steps", []):
-                visit(inner_step)
+
+def add_version_to_preflight_tests(pipeline: Any) -> None:
+    for step in steps(pipeline):
+        if step.get("id", "") in (
+            "tests-preflight-check-rollback",
+            "nightlies-preflight-check-rollback",
+        ):
+            current_version = MzVersion.parse_cargo()
+            version = get_previous_published_version(
+                current_version, previous_minor=True
+            )
+            step["build"]["commit"] = str(version)
+            step["build"]["branch"] = str(version)
 
 
 def trim_test_selection(pipeline: Any, steps_to_run: set[str]) -> None:
-    def visit(step: dict[str, Any]) -> None:
+    for step in steps(pipeline):
         ident = step.get("id") or step.get("command")
         if (
             ident not in steps_to_run
@@ -287,12 +280,6 @@ def trim_test_selection(pipeline: Any, steps_to_run: set[str]) -> None:
             and not step.get("async")
         ):
             step["skip"] = True
-
-    for step in pipeline["steps"]:
-        visit(step)
-        if "group" in step:
-            for inner_step in step.get("steps", []):
-                visit(inner_step)
 
 
 def add_test_selection_block(pipeline: Any, pipeline_name: str) -> None:
@@ -318,19 +305,13 @@ def add_test_selection_block(pipeline: Any, pipeline_name: str) -> None:
     else:
         return
 
-    def visit(step: dict[str, Any]) -> None:
+    for step in steps(pipeline):
         if (
             "id" in step
             and step["id"] not in ("analyze", "build-x86_64")
             and "skip" not in step
         ):
             selection_step["fields"][0]["options"].append({"value": step["id"]})
-
-    for step in pipeline["steps"]:
-        visit(step)
-        if "group" in step:
-            for inner_step in step.get("steps", []):
-                visit(inner_step)
 
     pipeline["steps"].insert(0, selection_step)
 
@@ -461,7 +442,7 @@ def trim_builds(pipeline: Any, coverage: bool) -> None:
             h.update(dep.spec().encode())
         return h.hexdigest()
 
-    def visit(step: dict[str, Any]) -> None:
+    for step in steps(pipeline):
         if step.get("id") == "build-x86_64":
             deps = deps_publish(Arch.X86_64)
             if deps.check():
@@ -482,12 +463,6 @@ def trim_builds(pipeline: Any, coverage: bool) -> None:
                 # resources.
                 step["concurrency"] = 1
                 step["concurrency_group"] = f"build-aarch64/{hash(deps)}"
-
-    for step in pipeline["steps"]:
-        visit(step)
-        if "group" in step:
-            for inner_step in step.get("steps", []):
-                visit(inner_step)
 
 
 def have_paths_changed(globs: Iterable[str]) -> bool:

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -167,26 +167,18 @@ steps:
     trigger: tests
     async: false
     build:
-      # TODO(def-): Set version with mkpipeline.py
-      commit: "9f64f909a77849684e978b840b4f5c1edbd396e8"
-      branch: "v0.88.1"
       env:
         CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
         CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 1
-    skip: "TODO(def-) reenable when greener"
 
   - id: nightlies-preflight-check-rollback
     label: Nightlies with preflight check and rollback
     trigger: nightlies
     async: false
     build:
-      # TODO(def-): Set version with mkpipeline.py
-      commit: "9f64f909a77849684e978b840b4f5c1edbd396e8"
-      branch: "v0.88.1"
       env:
         CI_FINAL_PREFLIGHT_CHECK_VERSION: "${BUILDKITE_TAG}"
         CI_FINAL_PREFLIGHT_CHECK_ROLLBACK: 1
-    skip: "TODO(def-) reenable when greener"
 
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
in release qualification. Also use iterator in mkpipeline.py to reduce duplicate code

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
