### PR TITLE
adapter: csv encoder for copy csv to s3

### DIFF
--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -852,10 +852,10 @@ mod tests {
     fn test_copy_csv_row() -> Result<(), io::Error> {
         let mut row = Row::default();
         let mut packer = row.packer();
-        packer.push(Datum::from("1,2,3"));
+        packer.push(Datum::from("1,2,\"3\""));
         packer.push(Datum::Null);
         packer.push(Datum::from(1000u64));
-        packer.push(Datum::from("q"));
+        packer.push(Datum::from("qe")); // overridden quote and escape character in test below
         packer.push(Datum::from(""));
 
         let typ: RelationType = RelationType::new(vec![
@@ -891,7 +891,7 @@ mod tests {
         let tests = [
             TestCase {
                 params: CopyCsvFormatParams::default(),
-                expected: b"\"1,2,3\",,1000,q,\"\"\n",
+                expected: b"\"1,2,\"\"3\"\"\",,1000,qe,\"\"\n",
             },
             TestCase {
                 params: CopyCsvFormatParams {
@@ -900,7 +900,7 @@ mod tests {
                     escape: b'e',
                     ..Default::default()
                 },
-                expected: b"q1,2,3q,NULL,1000,qeqq,\n",
+                expected: b"q1,2,\"3\"q,NULL,1000,qeqeeq,\n",
             },
         ];
 

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -471,7 +471,7 @@ pub fn encode_copy_format<'a>(
 #[derive(Debug, Clone)]
 pub struct CopyTextFormatParams<'a> {
     pub null: Cow<'a, str>,
-    pub delimiter: Cow<'a, str>,
+    pub delimiter: Cow<'a, str>, // TODO (mouli): refactor delimiter to be a single u8
 }
 
 impl<'a> Default for CopyTextFormatParams<'a> {

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -61,16 +61,6 @@ pub fn encode_copy_row_binary(
     Ok(())
 }
 
-/// Encodes given `row` into bytes with default param values
-/// in `CopyTextFormatParams`.
-pub fn encode_copy_row_text_default(
-    row: Row,
-    typ: &RelationType,
-    out: &mut Vec<u8>,
-) -> Result<(), io::Error> {
-    encode_copy_row_text(CopyTextFormatParams::default(), row, typ, out)
-}
-
 pub fn encode_copy_row_text(
     CopyTextFormatParams { null, delimiter }: CopyTextFormatParams,
     row: Row,

--- a/src/pgcopy/src/lib.rs
+++ b/src/pgcopy/src/lib.rs
@@ -16,6 +16,7 @@
 mod copy;
 
 pub use copy::{
-    decode_copy_format, encode_copy_row_binary, encode_copy_row_text, CopyCsvFormatParams,
-    CopyFormatParams, CopyTextFormatParams, CopyTextFormatParser,
+    decode_copy_format, encode_copy_format, encode_copy_row_binary, encode_copy_row_text,
+    encode_copy_row_text_default, CopyCsvFormatParams, CopyFormatParams, CopyTextFormatParams,
+    CopyTextFormatParser,
 };

--- a/src/pgcopy/src/lib.rs
+++ b/src/pgcopy/src/lib.rs
@@ -17,6 +17,5 @@ mod copy;
 
 pub use copy::{
     decode_copy_format, encode_copy_format, encode_copy_row_binary, encode_copy_row_text,
-    encode_copy_row_text_default, CopyCsvFormatParams, CopyFormatParams, CopyTextFormatParams,
-    CopyTextFormatParser,
+    CopyCsvFormatParams, CopyFormatParams, CopyTextFormatParams, CopyTextFormatParser,
 };

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1915,7 +1915,9 @@ where
             fn(Row, &RelationType, &mut Vec<u8>) -> Result<(), std::io::Error>,
             Format,
         ) = match format {
-            CopyFormat::Text => (mz_pgcopy::encode_copy_row_text, Format::Text),
+            // TODO (mouli): refactor to use `mz_pgcopy::encode_copy_format` and
+            // handle `Binary` there as well.
+            CopyFormat::Text => (mz_pgcopy::encode_copy_row_text_default, Format::Text),
             CopyFormat::Binary => (mz_pgcopy::encode_copy_row_binary, Format::Binary),
             _ => {
                 let msg = format!("COPY TO format {:?} not supported", format);


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Adds a method for encoding a `Row` to csv. The actual encoding logic is taken from [here](https://github.com/MaterializeInc/materialize/compare/v0.68.3...benesch:materialize:copy-more?expand=1#diff-7a9592753ee463a8c8b47910f19f2ed6dd0c76d533831dd86b629b255d61a376R101). 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

The encode method will be used for copying csv to S3 as part of #7256 

### Tips for reviewer

I have added some TODOs. The existing `CopyTextFormatParams` and the `Binary` formats can do with some refactors. I will do those in separate PRs to keep this PR as specific to the changes required for handling CSV.

cc @benesch @mjibson @petrosagg 

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
