### PR TITLE
*: remove the enable_jemalloc_profiling flag

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -68,7 +68,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_disk_cluster_replicas": "true",
     "enable_eager_delta_joins": "true",
     "enable_expressions_in_limit_syntax": "true",
-    "enable_jemalloc_profiling": "true",
     "enable_logical_compaction_window": "true",
     "enable_multi_worker_storage_persist_sink": "true",
     "enable_mysql_source": "true",

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -233,7 +233,6 @@ impl Coordinator {
         let mut update_metrics_retention = false;
         let mut update_secrets_caching_config = false;
         let mut update_cluster_scheduling_config = false;
-        let mut update_jemalloc_profiling_config = false;
         let mut update_default_arrangement_merge_options = false;
         let mut update_http_config = false;
         let mut log_indexes_to_drop = Vec::new();
@@ -339,8 +338,6 @@ impl Coordinator {
                     update_metrics_retention |= name == vars::METRICS_RETENTION.name();
                     update_secrets_caching_config |= vars::is_secrets_caching_var(name);
                     update_cluster_scheduling_config |= vars::is_cluster_scheduling_var(name);
-                    update_jemalloc_profiling_config |=
-                        name == vars::ENABLE_JEMALLOC_PROFILING.name();
                     update_default_arrangement_merge_options |=
                         name == vars::DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT.name();
                     update_default_arrangement_merge_options |=
@@ -358,7 +355,6 @@ impl Coordinator {
                     update_metrics_retention = true;
                     update_secrets_caching_config = true;
                     update_cluster_scheduling_config = true;
-                    update_jemalloc_profiling_config = true;
                     update_default_arrangement_merge_options = true;
                     update_http_config = true;
                 }
@@ -652,9 +648,6 @@ impl Coordinator {
             }
             if update_cluster_scheduling_config {
                 self.update_cluster_scheduling_config();
-            }
-            if update_jemalloc_profiling_config {
-                self.update_jemalloc_profiling_config().await;
             }
             if update_default_arrangement_merge_options {
                 self.update_default_arrangement_merge_options();
@@ -1016,14 +1009,6 @@ impl Coordinator {
             .collect::<Vec<_>>();
         self.update_storage_base_read_policies(storage_policies);
         self.update_compute_base_read_policies(compute_policies);
-    }
-
-    async fn update_jemalloc_profiling_config(&mut self) {
-        if self.catalog().system_config().enable_jemalloc_profiling() {
-            mz_prof::activate_jemalloc_profiling().await
-        } else {
-            mz_prof::deactivate_jemalloc_profiling().await
-        }
     }
 
     fn update_default_arrangement_merge_options(&mut self) {

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -37,7 +37,6 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
         dataflow_max_inflight_bytes: Some(config.compute_dataflow_max_inflight_bytes()),
         linear_join_yielding: Some(linear_join_yielding),
         enable_mz_join_core: Some(config.enable_mz_join_core()),
-        enable_jemalloc_profiling: Some(config.enable_jemalloc_profiling()),
         enable_columnation_lgalloc: Some(config.enable_columnation_lgalloc()),
         enable_operator_hydration_status_logging: Some(
             config.enable_compute_operator_hydration_status_logging(),

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -82,7 +82,6 @@ message ProtoComputeParameters {
     optional bool enable_mz_join_core = 4;
     mz_tracing.params.ProtoTracingParameters tracing = 5;
     mz_service.params.ProtoGrpcClientParameters grpc_client = 6;
-    optional bool enable_jemalloc_profiling = 7;
     mz_compute_types.dataflows.ProtoYieldSpec linear_join_yielding = 9;
     optional bool enable_columnation_lgalloc = 10;
     optional bool enable_operator_hydration_status_logging = 11;

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -379,8 +379,6 @@ pub struct ComputeParameters {
     pub linear_join_yielding: Option<YieldSpec>,
     /// Whether rendering should use `mz_join_core` rather than DD's `JoinCore::join_core`.
     pub enable_mz_join_core: Option<bool>,
-    /// Whether to activate jemalloc heap profiling.
-    pub enable_jemalloc_profiling: Option<bool>,
     /// Enable lgalloc for columnation.
     pub enable_columnation_lgalloc: Option<bool>,
     /// Enable operator hydration status logging.
@@ -401,7 +399,6 @@ impl ComputeParameters {
             dataflow_max_inflight_bytes,
             linear_join_yielding,
             enable_mz_join_core,
-            enable_jemalloc_profiling,
             enable_columnation_lgalloc,
             enable_operator_hydration_status_logging,
             persist,
@@ -420,9 +417,6 @@ impl ComputeParameters {
         }
         if enable_mz_join_core.is_some() {
             self.enable_mz_join_core = enable_mz_join_core;
-        }
-        if enable_jemalloc_profiling.is_some() {
-            self.enable_jemalloc_profiling = enable_jemalloc_profiling;
         }
         if enable_columnation_lgalloc.is_some() {
             self.enable_columnation_lgalloc = enable_columnation_lgalloc;
@@ -454,7 +448,6 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
             }),
             linear_join_yielding: self.linear_join_yielding.into_proto(),
             enable_mz_join_core: self.enable_mz_join_core.into_proto(),
-            enable_jemalloc_profiling: self.enable_jemalloc_profiling.into_proto(),
             enable_columnation_lgalloc: self.enable_columnation_lgalloc.into_proto(),
             enable_operator_hydration_status_logging: self
                 .enable_operator_hydration_status_logging
@@ -474,7 +467,6 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
                 .transpose()?,
             linear_join_yielding: proto.linear_join_yielding.into_rust()?,
             enable_mz_join_core: proto.enable_mz_join_core.into_rust()?,
-            enable_jemalloc_profiling: proto.enable_jemalloc_profiling.into_rust()?,
             enable_columnation_lgalloc: proto.enable_columnation_lgalloc.into_rust()?,
             enable_operator_hydration_status_logging: proto
                 .enable_operator_hydration_status_logging

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -233,7 +233,6 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             dataflow_max_inflight_bytes,
             linear_join_yielding,
             enable_mz_join_core,
-            enable_jemalloc_profiling,
             enable_columnation_lgalloc,
             enable_operator_hydration_status_logging,
             persist,
@@ -255,21 +254,6 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                 false => LinearJoinImpl::DifferentialDataflow,
                 true => LinearJoinImpl::Materialize,
             };
-        }
-        match enable_jemalloc_profiling {
-            Some(true) => {
-                mz_ore::task::spawn(
-                    || "activate-jemalloc-profiling",
-                    mz_prof::activate_jemalloc_profiling(),
-                );
-            }
-            Some(false) => {
-                mz_ore::task::spawn(
-                    || "deactivate-jemalloc-profiling",
-                    mz_prof::deactivate_jemalloc_profiling(),
-                );
-            }
-            None => (),
         }
         match enable_columnation_lgalloc {
             Some(true) => {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2017,13 +2017,6 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_jemalloc_profiling,
-        desc: "jemalloc heap memory profiling",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_comment,
         desc: "the COMMENT ON feature for objects",
         default: true,
@@ -5502,7 +5495,6 @@ impl SystemVars {
             || name == COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
             || name == LINEAR_JOIN_YIELDING.name()
             || name == ENABLE_MZ_JOIN_CORE.name()
-            || name == ENABLE_JEMALLOC_PROFILING.name()
             || name == ENABLE_COLUMNATION_LGALLOC.name()
             || name == ENABLE_COMPUTE_OPERATOR_HYDRATION_STATUS_LOGGING.name()
             || self.is_persist_config_var(name)


### PR DESCRIPTION
Jemalloc profiling has been switched on for months now without a hitch, so it seems fine to remove the feature flag.

### Motivation

   * This PR removes an old feature flag.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
