### PR TITLE
docs: Update build instructions for fivetran-destination

### DIFF
--- a/src/fivetran-destination/README.md
+++ b/src/fivetran-destination/README.md
@@ -31,7 +31,7 @@ git submodule update --init --recursive misc/fivetran_sdk
 Once you have the `fivetran_sdk` submodule updated, run:
 
 ```shell
-cargo build --release --bin mz-fivetran-destination
+cargo build --release -p mz-fivetran-destination
 ```
 
 Cargo will emit the built binary at


### PR DESCRIPTION
After https://github.com/MaterializeInc/materialize/pull/25437 the instructions for building the fivetran-destination became stale, this PR updates them.

### Motivation

Update README build instructions

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
