### PR TITLE
remove default privatelink kafka flag

### DIFF
--- a/doc/user/content/ingest-data/redpanda-cloud.md
+++ b/doc/user/content/ingest-data/redpanda-cloud.md
@@ -157,7 +157,7 @@ possible configurations in the [reference documentation](/sql/create-source/kafk
 
 {{< tab "Use AWS PrivateLink">}}
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 [AWS PrivateLink](https://aws.amazon.com/privatelink/) lets you connect
 Materialize to your Redpanda Cloud instance without exposing traffic to the

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -385,11 +385,11 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 
 ##### Default connections {#kafka-privatelink-default}
 
-{{< private-preview />}}
+{{< public-preview />}}
 
-Some hosted services (like [Redpanda Cloud](/ingest-data/redpanda-cloud/)) do
-not require listing every broker individually. For such cases, you should
-specify a PrivateLink connection and the port of the bootstrap server instead.
+[Redpanda Cloud](/ingest-data/redpanda-cloud/)) does not require listing every
+broker individually. In this case, you should specify a PrivateLink connection
+and the port of the bootstrap server instead.
 
 ##### Default connection syntax {#kafka-privatelink-default-syntax}
 

--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -260,11 +260,6 @@ impl ConnectionOptionExtracted {
                     )?;
                 }
 
-                if self.aws_privatelink.is_some() {
-                    scx.require_feature_flag(
-                        &crate::session::vars::ENABLE_DEFAULT_KAFKA_AWS_PRIVATE_LINK,
-                    )?;
-                }
                 let (tls, sasl) = plan_kafka_security(&self)?;
 
                 Connection::Kafka(KafkaConnection {

--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -254,12 +254,6 @@ impl ConnectionOptionExtracted {
                 Connection::AwsPrivatelink(connection)
             }
             CreateConnectionType::Kafka => {
-                if self.ssh_tunnel.is_some() {
-                    scx.require_feature_flag(
-                        &crate::session::vars::ENABLE_DEFAULT_KAFKA_SSH_TUNNEL,
-                    )?;
-                }
-
                 let (tls, sasl) = plan_kafka_security(&self)?;
 
                 Connection::Kafka(KafkaConnection {

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1986,13 +1986,6 @@ feature_flags!(
         enable_for_item_parsing: false,
     },
     {
-        name: enable_default_kafka_ssh_tunnel,
-        desc: "the top-level SSH TUNNEL feature for kafka connections",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_time_at_time_zone,
         desc: "use of AT TIME ZONE or timezone() with time type",
         default: false,

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1993,13 +1993,6 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_default_kafka_aws_private_link,
-        desc: "the top-level Aws Privatelink feature for kafka connections",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_time_at_time_zone,
         desc: "use of AT TIME ZONE or timezone() with time type",
         default: false,

--- a/test/cloudtest/test_privatelink_connection.py
+++ b/test/cloudtest/test_privatelink_connection.py
@@ -50,11 +50,6 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
         port="internal",
         user="mz_system",
     )
-    mz.environmentd.sql(
-        "ALTER SYSTEM SET enable_default_kafka_aws_private_link = true",
-        port="internal",
-        user="mz_system",
-    )
     mz.environmentd.sql(create_connection_statement)
 
     aws_connection_id = mz.environmentd.sql_query(

--- a/test/ssh-connection/setup.td
+++ b/test/ssh-connection/setup.td
@@ -13,7 +13,6 @@
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 ALTER SYSTEM SET enable_connection_validation_syntax = true
-ALTER SYSTEM SET enable_default_kafka_ssh_tunnel = true
 
 > CREATE CONNECTION IF NOT EXISTS thancred TO SSH TUNNEL (
     HOST 'ssh-bastion-host',


### PR DESCRIPTION

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Removes the feature flag gating on the privatelink default connection for kafka syntax.
This feature is working and we do not wish to gate it per organization, per https://github.com/MaterializeInc/materialize/issues/25468

Fixes #25468.
Fixes #26011.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
