### PR TITLE
Iterate MFP optimization

### DIFF
--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -890,13 +890,12 @@ impl MapFilterProject {
     /// ```
     pub fn optimize(&mut self) {
         // Track sizes and iterate as long as they decrease.
-        let mut prev_size = usize::max_value();
-        let mut self_size = self.size();
-
+        let mut prev_size = None;
+        let mut self_size = 0;
         // Continue as long as strict improvements occur.
-        while self_size < prev_size {
+        while prev_size.map(|p| self_size < p).unwrap_or(true) {
             // Lock in current size.
-            prev_size = self_size;
+            prev_size = Some(self_size);
             // Optimization memoizes individual `ScalarExpr` expressions that
             // are sure to be evaluated, canonicalizes references to the first
             // occurrence of each, inlines expressions that have a reference
@@ -919,7 +918,7 @@ impl MapFilterProject {
         }
     }
 
-    /// Accumulate expression sizes across all expressions.
+    /// Total expression sizes across all expressions.
     pub fn size(&self) -> usize {
         self.expressions.iter().map(|e| e.size()).sum::<usize>()
             + self.predicates.iter().map(|(_, e)| e.size()).sum::<usize>()


### PR DESCRIPTION
This PR has `MFP::optimize` continue as long as the AST complexity strictly decreases.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
