### PR TITLE
Update differential dataflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1784,7 +1784,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#15b7b8dcf606580b4cf50e3f1b408da91b27b4c1"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#8797bfb01101db2168e0007aa7aa606bbd2deda5"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1840,7 +1840,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#15b7b8dcf606580b4cf50e3f1b408da91b27b4c1"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#8797bfb01101db2168e0007aa7aa606bbd2deda5"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -38,7 +38,7 @@ version = "1.2.6"
 [[audits.differential-dataflow]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:15b7b8dcf606580b4cf50e3f1b408da91b27b4c1"
+version = "0.12.0@git:8797bfb01101db2168e0007aa7aa606bbd2deda5"
 
 [[audits.dynfmt]]
 who = "Sean Loiselle <sean@materialize.io>"

--- a/src/cluster/src/server.rs
+++ b/src/cluster/src/server.rs
@@ -199,7 +199,10 @@ where
 
                 // Layers are ordered from largest to smallest.
                 // Skip to the largest occupied layer.
-                let layers = layers.skip_while(|(_idx, count, _len)| *count == 0);
+                let layers = layers
+                    .iter()
+                    .copied()
+                    .skip_while(|(_idx, count, _len)| *count == 0);
 
                 let mut first = true;
                 for (_idx, count, len) in layers {


### PR DESCRIPTION
Update our dependency on differential dataflow to include the latest upstream changes. All changes are in https://github.com/MaterializeInc/differential-dataflow/commit/8797bfb01101db2168e0007aa7aa606bbd2deda5.

The change includes changes to avoid a heap allocation for every invocation of the exert logic.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
