### PR TITLE
qa canary env: Add MySQL source

### DIFF
--- a/test/canary-environment/README.md
+++ b/test/canary-environment/README.md
@@ -25,6 +25,12 @@ The postgres source is an RDS instance running in AWS that is replicating two ta
 
 In order to continously emit updates, pg_cron jobs that update the tables are set up to run with a 1-second interval.
 
+## MySQL source (`models/mysql-cdc`)
+
+The mysql source is an RDS instance running in AWS that is replicating two tables.
+
+In order to continously emit updates, events that update the tables are set up to run with a 1-second interval.
+
 ## Kafka sources (`models/loadgen`)
 
 A Kafka broker running on the Confluent cloud is used to ingest topics that are being
@@ -43,6 +49,8 @@ export MATERIALIZE_PROD_SANDBOX_PASSWORD=mzp_...
 
 export MATERIALIZE_PROD_SANDBOX_RDS_HOSTNAME=...eu-west-1.rds.amazonaws.com
 export MATERIALIZE_PROD_SANDBOX_RDS_PASSWORD=...
+export MATERIALIZE_PROD_SANDBOX_RDS_MYSQL_HOSTNAME=...eu-west-1.rds.amazonaws.com
+export MATERIALIZE_PROD_SANDBOX_RDS_MYSQL_PASSWORD=...
 
 export CONFLUENT_CLOUD_FIELDENG_KAFKA_BROKER=...confluent.cloud:9092
 export CONFLUENT_CLOUD_FIELDENG_CSR_URL=https://...aws.confluent.cloud

--- a/test/canary-environment/dbt_project.yml
+++ b/test/canary-environment/dbt_project.yml
@@ -26,12 +26,19 @@ models:
   canary_environment:
     loadgen:
       schema: loadgen
+      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\""
     tpch:
       schema: tpch
+      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\""
     pg_cdc:
       schema: pg_cdc
+      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\""
+    mysql_cdc:
+      schema: mysql_cdc
+      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\""
     simple_table:
       schema: simple_table
+      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\""
 
 tests:
     +cluster: qa_canary_environment_compute

--- a/test/canary-environment/models/mysql_cdc/mysql_cdc.sql
+++ b/test/canary-environment/models/mysql_cdc/mysql_cdc.sql
@@ -1,0 +1,15 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+{{ config(materialized='source') }}
+
+CREATE SOURCE {{ this }}
+IN CLUSTER qa_canary_environment_storage
+FROM MYSQL CONNECTION mysql
+FOR TABLES (public.people, public.relationships)

--- a/test/canary-environment/models/mysql_cdc/mysql_wmr.sql
+++ b/test/canary-environment/models/mysql_cdc/mysql_wmr.sql
@@ -1,0 +1,37 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+-- TPC-H Query #Q18, chosen for the workload for its GROUP BY clause
+-- We have modified the predicate to sum(l_quantity) > 250
+-- to ensure the result updates frequently
+
+-- depends_on: {{ ref('mysql_cdc') }}
+{{ config(materialized='materialized_view', cluster="qa_canary_environment_compute", indexes=[{'default': True}]) }}
+
+WITH MUTUALLY RECURSIVE
+    symm (a int, b int) AS (
+        SELECT a, b FROM {{ source('mysql_cdc','relationships') }}
+        UNION
+        SELECT b, a FROM {{ source('mysql_cdc','relationships') }}
+    ),
+    candidates (a int, b int, degree int) AS (
+        SELECT a, b, 1 FROM symm
+        UNION
+        SELECT symm.a, reach.b, reach.degree + 1
+        FROM symm, reach
+        WHERE symm.b = reach.a
+    ),
+    reach(a int, b int, degree int) AS (
+        SELECT a, b, min(degree) FROM candidates group by a, b HAVING a != b
+    )
+SELECT DISTINCT a_people.name AS a_name, b_people.name AS b_name, degree
+FROM reach
+LEFT JOIN {{ source('mysql_cdc','people') }} AS a_people ON (a = a_people.id)
+LEFT JOIN {{ source('mysql_cdc','people') }} AS b_people ON (b = b_people.id)
+WHERE degree >= 2

--- a/test/canary-environment/models/mysql_cdc/schema.yml
+++ b/test/canary-environment/models/mysql_cdc/schema.yml
@@ -1,0 +1,29 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: 2
+
+sources:
+  - name: mysql_cdc
+    schema: public_mysql_cdc
+    tables:
+      - name: mysql_cdc_progress
+        tests:
+          - makes_progress
+      - name: people
+        tests:
+          - makes_progress
+      - name: relationships
+        tests:
+          - makes_progress
+
+models:
+    - name: mysql_wmr
+      tests:
+        - makes_progress

--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -106,7 +106,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                                     > SELECT COUNT(DISTINCT c_name) FROM qa_canary_environment.public_tpch.tpch_q18 WHERE o_orderdate >= '2023-01-01'
                                     0
 
-                                    > SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_pg_cdc.wmr WHERE degree > 2
+                                    > SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_pg_cdc.wmr WHERE degree > 3
+                                    0
+
+                                    > SELECT COUNT(DISTINCT a_name) FROM qa_canary_environment.public_mysql_cdc.wmr WHERE degree > 3
                                     0
 
                                     > SELECT COUNT(DISTINCT count_star) FROM qa_canary_environment.public_loadgen.sales_product_product_category WHERE count_distinct_product_id < 0


### PR DESCRIPTION
Currently fails because enable_mysql_source isn't set for the Canary environment @rjobanp Can we already enable it or are there concerns?

Part of https://github.com/MaterializeInc/materialize/issues/24927

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
