### PR TITLE
expr,sql: fix `to_jsonb` implementation for arrays

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -268,7 +268,9 @@ message ProtoUnaryFunc {
         mz_repr.relation_and_scalar.ProtoScalarType cast_record_to_string = 132;
         ProtoCastRecord1ToRecord2 cast_record1_to_record2 = 133;
         mz_repr.relation_and_scalar.ProtoScalarType cast_array_to_string = 134;
+        ProtoMirScalarExpr cast_array_to_jsonb = 318;
         mz_repr.relation_and_scalar.ProtoScalarType cast_list_to_string = 135;
+        ProtoMirScalarExpr cast_list_to_jsonb = 319;
         ProtoCastToVariableType cast_list1_to_list2 = 136;
         google.protobuf.Empty cast_array_to_list_one_dim = 137;
         mz_repr.relation_and_scalar.ProtoScalarType cast_map_to_string = 138;

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4614,8 +4614,10 @@ derive_unary!(
     CastRecordToString,
     CastRecord1ToRecord2,
     CastArrayToArray,
+    CastArrayToJsonb,
     CastArrayToString,
     CastListToString,
+    CastListToJsonb,
     CastList1ToList2,
     CastArrayToListOneDim,
     CastMapToString,
@@ -5005,8 +5007,10 @@ impl Arbitrary for UnaryFunc {
                     })
                 })
                 .boxed(),
+            CastArrayToJsonb::arbitrary().prop_map_into().boxed(),
             CastArrayToString::arbitrary().prop_map_into().boxed(),
             CastListToString::arbitrary().prop_map_into().boxed(),
+            CastListToJsonb::arbitrary().prop_map_into().boxed(),
             (any::<ScalarType>(), any::<MirScalarExpr>())
                 .prop_map(|(return_ty, expr)| {
                     UnaryFunc::CastList1ToList2(CastList1ToList2 {
@@ -5392,7 +5396,9 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                     cast_expr: Some(inner.cast_expr.into_proto()),
                 }))
             }
+            UnaryFunc::CastArrayToJsonb(inner) => CastArrayToJsonb(inner.cast_element.into_proto()),
             UnaryFunc::CastArrayToString(func) => CastArrayToString(func.ty.into_proto()),
+            UnaryFunc::CastListToJsonb(inner) => CastListToJsonb(inner.cast_element.into_proto()),
             UnaryFunc::CastListToString(func) => CastListToString(func.ty.into_proto()),
             UnaryFunc::CastList1ToList2(inner) => {
                 CastList1ToList2(Box::new(ProtoCastToVariableType {
@@ -5824,8 +5830,16 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                         .into_rust_if_some("ProtoCastArrayToArray::cast_expr")?,
                 }
                 .into()),
+                CastArrayToJsonb(cast_element) => Ok(impls::CastArrayToJsonb {
+                    cast_element: cast_element.into_rust()?,
+                }
+                .into()),
                 CastArrayToString(ty) => Ok(impls::CastArrayToString {
                     ty: ty.into_rust()?,
+                }
+                .into()),
+                CastListToJsonb(cast_element) => Ok(impls::CastListToJsonb {
+                    cast_element: cast_element.into_rust()?,
                 }
                 .into()),
                 CastListToString(ty) => Ok(impls::CastListToString {

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -1052,6 +1052,77 @@ SELECT to_jsonb(1.234::FLOAT)
 ----
 1.234
 
+query T
+SELECT to_jsonb(null::int[])
+----
+NULL
+
+query T
+SELECT to_jsonb(array[1]::int[])
+----
+[1]
+
+query T
+SELECT to_jsonb(array[1, 2]::int[])
+----
+[1,2]
+
+query T
+SELECT to_jsonb(array[array[1, 2], array[3, 4]]::int[])
+----
+[[1,2],[3,4]]
+
+query T
+SELECT to_jsonb(array[array[array[1, 2], array[3, 4]], array[array[5, 6], array[7, 8]]]::int[])
+----
+[[[1,2],[3,4]],[[5,6],[7,8]]]
+
+query T
+SELECT to_jsonb(array[1.2, .3]::float[])
+----
+[1.2,0.3]
+
+query T
+SELECT to_jsonb(array[row(1, 2), row(3, 4)])
+----
+[{"f1":1,"f2":2},{"f1":3,"f2":4}]
+
+query T
+SELECT to_jsonb(null::int list)
+----
+NULL
+
+query T
+SELECT to_jsonb(list[1]::int list)
+----
+[1]
+
+query T
+SELECT to_jsonb(list[1, 2]::int list)
+----
+[1,2]
+
+query T
+SELECT to_jsonb(list[list[1], list[3, 4]]::int list list)
+----
+[[1],[3,4]]
+
+query T
+SELECT to_jsonb(list[list[list[1, 2], list[3]], list[list[7, 8]]]::int list list list)
+----
+[[[1,2],[3]],[[7,8]]]
+
+query T
+SELECT to_jsonb(list[1.2, .3]::float list)
+----
+[1.2,0.3]
+
+query T
+SELECT to_jsonb(list[row(1, 2), row(3, 4)])
+----
+[{"f1":1,"f2":2},{"f1":3,"f2":4}]
+
+
 # query T
 # SELECT to_jsonb(1.234::DECIMAL)
 # ----


### PR DESCRIPTION
Materialize was not correctly handling arrays in `to_jsonb`. Instead of converting the arrays to JSON arrays, Materialize was converting them to a JSON string of the array's textual representation. This behavior was at variance with PostgreSQL.

The implementation is somewhat irritating, as the size of the array is not known at plan time. So the planner has to construct an expression to cast the array's element type and plumb that through to the dataflow layer, so that each value in the array can be cast to JSON at runtime.

This commit also adjust the implementation for lists in the same way, for symmetry, even though it's not required for PostgreSQL compatibility, as lists are a custom Materialize type.

Fix #12181.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix the implementation of `to_jsonb` for list and array types. The return value is now a JSON array, rather than a JSON string literal containing the textual representation of the list or array.
