### PR TITLE
sql: support [NOT] [I]LIKE operators with ANY/ALL

### DIFF
--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1625,6 +1625,16 @@ SELECT 1 AS "FOO"
 SELECT 1 AS "FOO"
 
 parse-statement roundtrip
+SELECT 'foo' LIKE ANY (SELECT 'f%')
+----
+SELECT 'foo' ~~ ANY (SELECT 'f%')
+
+parse-statement roundtrip
+SELECT 'foo' ~~ ANY (SELECT 'f%')
+----
+SELECT 'foo' ~~ ANY (SELECT 'f%')
+
+parse-statement roundtrip
 SELECT 1 < ANY (SELECT 1)
 ----
 SELECT 1 < ANY (SELECT 1)

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -811,6 +811,11 @@ impl<'a> Desugarer<'a> {
                         }
                         *expr = new;
                     }
+                    _ if left.len() == 1 && right.len() == 1 => {
+                        let left = left.remove(0);
+                        let right = right.remove(0);
+                        *expr = left.binop(op.clone(), right);
+                    }
                     _ => (),
                 }
             }

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -133,6 +133,41 @@ select 'hello'::text <= ANY(ARRAY['there'::text])
 ----
 true
 
+query B
+select 'apple' like any (VALUES('a%'), ('b%'));
+----
+true
+
+query B
+select 'apple' not like any (VALUES('a%'), ('b%'));
+----
+true
+
+query B
+select 'apple' ilike any (VALUES('A%'), ('B%'));
+----
+true
+
+query B
+select 'apple' like any (VALUES('A%'), ('B%'));
+----
+false
+
+query B
+select 'apple' ~~ any (VALUES('a%'), ('b%'));
+----
+true
+
+query B
+select 'apple' !~~ any (VALUES('a%'), ('b%'));
+----
+true
+
+query B
+select 'apple' ~~* any (VALUES('A%'), ('B%'));
+----
+true
+
 # Test ALL
 
 query B
@@ -144,6 +179,31 @@ query B
 SELECT 5 <> ALL(ARRAY[ARRAY[1, 2], ARRAY[3,4]])
 ----
 true
+
+query B
+select 'apple' like all (VALUES('a%'), ('b%'));
+----
+false
+
+query B
+select 'apple' like all (VALUES('a%'), ('appl%'));
+----
+true
+
+query B
+select 'apple' not like all (VALUES('a%'), ('b%'));
+----
+false
+
+query B
+select 'apple' ilike all (VALUES('A%'), ('B%'));
+----
+false
+
+query B
+select 'apple' like all (VALUES('A%'), ('B%'));
+----
+false
 
 # 🔬🔬 unnest
 


### PR DESCRIPTION
For PostgreSQL compatibility.

Fix #25530.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support using the `LIKE`, `NOT LIKE`, `ILIKE`, and `NOT ILIKE` as operators within `ANY`, `SOME`, and `ALL` expressions.
