### PR TITLE
ci: Wait for build before starting QA canary base load

### DIFF
--- a/ci/qa-canary/pipeline.template.yml
+++ b/ci/qa-canary/pipeline.template.yml
@@ -15,6 +15,8 @@ steps:
     agents:
       queue: builder-linux-aarch64
 
+  - wait: ~
+
   - id: qa-canary-load
     label: "QA Canary Environment Base Load"
     artifact_paths: junit_*.xml

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -156,7 +156,7 @@ steps:
           - Cargo.lock
           - misc/cargo-vet/config.toml
         depends_on: []
-        timeout_in_minutes: 5
+        timeout_in_minutes: 20
         agents:
           queue: linux-aarch64-small
         coverage: skip


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/qa-canary-environment-base-load/builds/14#018dd86c-5b30-4687-9458-ca55e0cb4f83

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
