### PR TITLE
adapter: rename "unmanaged" replica to "unorchestrated" replica

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -247,8 +247,11 @@ class UseClusterdCompute(MzcomposeAction):
         )
 
         if self.base_version >= MzVersion(0, 55, 0):
+            param = "enable_unmanaged_cluster_replicas"
+            if self.base_version >= MzVersion.parse_mz("v0.90.0-dev"):
+                param = "enable_unorchestrated_cluster_replicas"
             c.sql(
-                "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = on;",
+                f"ALTER SYSTEM SET {param} = on;",
                 port=6877,
                 user="mz_system",
             )

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -239,7 +239,7 @@ impl Coordinator {
         tracing::debug!("sequence_create_unmanaged_cluster");
 
         self.ensure_valid_azs(replicas.iter().filter_map(|(_, r)| {
-            if let mz_sql::plan::ReplicaConfig::Managed {
+            if let mz_sql::plan::ReplicaConfig::Orchestrated {
                 availability_zone: Some(az),
                 ..
             } = &r
@@ -266,7 +266,7 @@ impl Coordinator {
             // If the AZ was not specified, choose one, round-robin, from the ones with
             // the lowest number of configured replicas for this cluster.
             let (compute, location) = match replica_config {
-                mz_sql::plan::ReplicaConfig::Unmanaged {
+                mz_sql::plan::ReplicaConfig::Unorchestrated {
                     storagectl_addrs,
                     storage_addrs,
                     computectl_addrs,
@@ -283,7 +283,7 @@ impl Coordinator {
                     };
                     (compute, location)
                 }
-                mz_sql::plan::ReplicaConfig::Managed {
+                mz_sql::plan::ReplicaConfig::Orchestrated {
                     availability_zone,
                     billed_as,
                     compute,
@@ -399,7 +399,7 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, AdapterError> {
         // Choose default AZ if necessary
         let (compute, location) = match config {
-            mz_sql::plan::ReplicaConfig::Unmanaged {
+            mz_sql::plan::ReplicaConfig::Unorchestrated {
                 storagectl_addrs,
                 storage_addrs,
                 computectl_addrs,
@@ -416,7 +416,7 @@ impl Coordinator {
                 };
                 (compute, location)
             }
-            mz_sql::plan::ReplicaConfig::Managed {
+            mz_sql::plan::ReplicaConfig::Orchestrated {
                 availability_zone,
                 billed_as,
                 compute,

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -535,7 +535,7 @@ fn test_pgtest_mz() {
         dir,
         &[
             "enable_raise_statement",
-            "enable_unmanaged_cluster_replicas",
+            "enable_unorchestrated_cluster_replicas",
             "enable_unsafe_functions",
             // The following flags are required to test out the COPY TO s3 feature
             "enable_aws_connection",

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -542,7 +542,7 @@ pub struct ComputeReplicaConfig {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ReplicaConfig {
-    Unmanaged {
+    Unorchestrated {
         storagectl_addrs: Vec<String>,
         storage_addrs: Vec<String>,
         computectl_addrs: Vec<String>,
@@ -550,7 +550,7 @@ pub enum ReplicaConfig {
         workers: usize,
         compute: ComputeReplicaConfig,
     },
-    Managed {
+    Orchestrated {
         size: String,
         availability_zone: Option<String>,
         compute: ComputeReplicaConfig,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3464,7 +3464,7 @@ fn plan_replica_config(
                 disk = true;
             }
 
-            Ok(ReplicaConfig::Managed {
+            Ok(ReplicaConfig::Orchestrated {
                 size,
                 availability_zone,
                 compute,
@@ -3484,7 +3484,7 @@ fn plan_replica_config(
             compute_addresses,
             workers,
         ) => {
-            scx.require_feature_flag(&vars::ENABLE_UNMANAGED_CLUSTER_REPLICAS)?;
+            scx.require_feature_flag(&vars::ENABLE_UNORCHESTRATED_CLUSTER_REPLICAS)?;
 
             // When manually testing Materialize in unsafe mode, it's easy to
             // accidentally omit one of these options, so we try to produce
@@ -3520,10 +3520,10 @@ fn plan_replica_config(
             }
 
             if disk_in.is_some() {
-                sql_bail!("DISK can't be specified for unmanaged clusters");
+                sql_bail!("DISK can't be specified for unorchestrated clusters");
             }
 
-            Ok(ReplicaConfig::Unmanaged {
+            Ok(ReplicaConfig::Unorchestrated {
                 storagectl_addrs,
                 storage_addrs,
                 computectl_addrs,
@@ -3535,7 +3535,7 @@ fn plan_replica_config(
         _ => {
             // We don't bother trying to produce a more helpful error message
             // here because no user is likely to hit this path.
-            sql_bail!("invalid mixture of managed and unmanaged replica options");
+            sql_bail!("invalid mixture of orchestrated and unorchestrated replica options");
         }
     }
 }
@@ -3594,7 +3594,7 @@ pub fn plan_create_cluster_replica(
 
     let config = plan_replica_config(scx, options)?;
 
-    if let ReplicaConfig::Managed { internal: true, .. } = &config {
+    if let ReplicaConfig::Orchestrated { internal: true, .. } = &config {
         if MANAGED_REPLICA_PATTERN.is_match(name.as_str()) {
             return Err(PlanError::MangedReplicaName(name.into_string()));
         }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1919,8 +1919,8 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_unmanaged_cluster_replicas,
-        desc: "unmanaged cluster replicas",
+        name: enable_unorchestrated_cluster_replicas,
+        desc: "unorchestrated cluster replicas",
         default: false,
         internal: true,
         enable_for_item_parsing: true,

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -631,7 +631,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             c.up("redpanda", "materialized", "postgres", "clusterd")
 
             c.sql(
-                "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+                "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
                 port=6877,
                 user="mz_system",
             )

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -231,7 +231,7 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         c.up(*[n.name for n in nodes])
 
         c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
             port=6877,
             user="mz_system",
         )

--- a/test/cluster/blue-green-deployment/setup.td
+++ b/test/cluster/blue-green-deployment/setup.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;
 
 > DROP CLUSTER IF EXISTS prod CASCADE
 > DROP CLUSTER IF EXISTS prod_deploy CASCADE

--- a/test/cluster/cluster-drop-concurrent/setup.td
+++ b/test/cluster/cluster-drop-concurrent/setup.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;
 
 > DROP CLUSTER IF EXISTS drop CASCADE
 > CREATE CLUSTER drop REPLICAS (replica1 (

--- a/test/cluster/github-cloud-7998/setup.td
+++ b/test/cluster/github-cloud-7998/setup.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;
 
 # Create a cluster that we can make unavailable.
 > CREATE CLUSTER compute REPLICAS (

--- a/test/cluster/index-source-stuck/run.td
+++ b/test/cluster/index-source-stuck/run.td
@@ -11,7 +11,7 @@
 # in sqllogictest.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;
 
 > DROP CLUSTER IF EXISTS cluster1 CASCADE;
 > DROP CLUSTER IF EXISTS cluster2 CASCADE;

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -102,7 +102,7 @@ def workflow_test_smoke(c: Composition, parser: WorkflowArgumentParser) -> None:
     # between testdrive runs.
     c.sql(
         """
-        ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
+        ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;
 
         DROP CLUSTER IF EXISTS cluster1 CASCADE;
 
@@ -130,7 +130,7 @@ def workflow_test_smoke(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     c.sql(
         """
-        ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
+        ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;
 
         CREATE CLUSTER REPLICA cluster1.replica2
             STORAGECTL ADDRESSES ['clusterd3:2100', 'clusterd4:2100'],
@@ -166,7 +166,7 @@ def workflow_test_invalid_compute_reuse(c: Composition) -> None:
     c.up("clusterd2")
     c.sql("DROP CLUSTER IF EXISTS cluster1 CASCADE;")
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )
@@ -303,7 +303,7 @@ def workflow_test_github_15531(c: Composition) -> None:
         )
 
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )
@@ -408,7 +408,7 @@ def workflow_test_github_15535(c: Composition) -> None:
     c.up("clusterd1")
 
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )
@@ -470,7 +470,7 @@ def workflow_test_github_15799(c: Composition) -> None:
     c.up("clusterd2")
 
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )
@@ -524,7 +524,7 @@ def workflow_test_github_15930(c: Composition) -> None:
         c.up("clusterd1")
 
         c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
             port=6877,
             user="mz_system",
         )
@@ -628,7 +628,7 @@ def workflow_test_github_15496(c: Composition) -> None:
         c.up("clusterd_nopanic")
 
         c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
             port=6877,
             user="mz_system",
         )
@@ -701,7 +701,7 @@ def workflow_test_github_17177(c: Composition) -> None:
         c.up("clusterd1")
 
         c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
             port=6877,
             user="mz_system",
         )
@@ -780,7 +780,7 @@ def workflow_test_github_17510(c: Composition) -> None:
         c.up("clusterd1")
 
         c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
             port=6877,
             user="mz_system",
         )
@@ -954,7 +954,7 @@ def workflow_test_github_17509(c: Composition) -> None:
         c.up("clusterd_nopanic")
 
         c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
             port=6877,
             user="mz_system",
         )
@@ -1048,7 +1048,7 @@ def workflow_test_github_19610(c: Composition) -> None:
         c.up("clusterd_nopanic")
 
         c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
             port=6877,
             user="mz_system",
         )
@@ -1156,7 +1156,7 @@ def workflow_test_single_time_monotonicity_enforcers(c: Composition) -> None:
         c.up("clusterd_nopanic")
 
         c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
             port=6877,
             user="mz_system",
         )
@@ -1480,7 +1480,7 @@ def workflow_test_replica_targeted_subscribe_abort(c: Composition) -> None:
     c.up("clusterd2")
 
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )
@@ -1569,7 +1569,7 @@ def workflow_test_replica_targeted_select_abort(c: Composition) -> None:
     c.up("clusterd2")
 
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )
@@ -1686,7 +1686,7 @@ def workflow_test_compute_reconciliation_reuse(c: Composition) -> None:
     c.up("clusterd1")
 
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )
@@ -1778,7 +1778,7 @@ def workflow_test_compute_reconciliation_no_errors(c: Composition) -> None:
     c.up("clusterd1")
 
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )
@@ -1862,7 +1862,7 @@ def workflow_test_mz_subscriptions(c: Composition) -> None:
     c.up("materialized", "clusterd1")
 
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )
@@ -1961,7 +1961,7 @@ def workflow_test_mv_source_sink(c: Composition) -> None:
     c.up("clusterd1")
 
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )
@@ -2032,7 +2032,7 @@ def workflow_test_clusterd_death_detection(c: Composition) -> None:
         input=dedent(
             """
             $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-            ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+            ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
             $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
             {
@@ -2215,7 +2215,7 @@ def workflow_test_replica_metrics(c: Composition) -> None:
         return Metrics(resp)
 
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )

--- a/test/cluster/pg-snapshot-partial-failure/02-create-sources.td
+++ b/test/cluster/pg-snapshot-partial-failure/02-create-sources.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 > DROP SOURCE IF EXISTS mz_source CASCADE;
 > DROP SECRET IF EXISTS pgpass CASCADE;

--- a/test/cluster/pg-snapshot-resumption/02-create-sources.td
+++ b/test/cluster/pg-snapshot-resumption/02-create-sources.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 > DROP SOURCE IF EXISTS mz_source CASCADE;
 > DROP SECRET IF EXISTS pgpass CASCADE;

--- a/test/cluster/sink-failure/01-configure-sinks.td
+++ b/test/cluster/sink-failure/01-configure-sinks.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 > DROP SOURCE IF EXISTS mz_source CASCADE;
 > DROP SECRET IF EXISTS pgpass CASCADE;

--- a/test/cluster/storage/01-create-sources.td
+++ b/test/cluster/storage/01-create-sources.td
@@ -11,7 +11,7 @@
 $ set-sql-timeout duration=180s
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 # Create sources and verify they can ingest data while `environmentd` is online.
 

--- a/test/kafka-resumption/source-resumption/setup.td
+++ b/test/kafka-resumption/source-resumption/setup.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 $ kafka-create-topic topic=topic
 

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1459,7 +1459,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         c.up(*[n.name for n in nodes])
 
         c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
             port=6877,
             user="mz_system",
         )
@@ -1635,7 +1635,7 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
                     )
 
                 c.sql(
-                    "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+                    "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
                     port=6877,
                     user="mz_system",
                 )

--- a/test/mysql-cdc/correctness-property-2.td
+++ b/test/mysql-cdc/correctness-property-2.td
@@ -12,7 +12,7 @@ $ set-max-tries max-tries=20
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_mysql_source = true
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 $ set count=10000
 

--- a/test/pg-cdc/correctness-property-2.td
+++ b/test/pg-cdc/correctness-property-2.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 $ set count=10000
 

--- a/test/pg-cdc/max-slot-wal-keep-size.td
+++ b/test/pg-cdc/max-slot-wal-keep-size.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER USER postgres WITH replication;

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -221,7 +221,7 @@ def restart_environmentd(c: Composition) -> None:
 def drop_create_replica(c: Composition) -> None:
 
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )
@@ -242,7 +242,7 @@ def drop_create_replica(c: Composition) -> None:
 
 def create_invalid_replica(c: Composition) -> None:
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )
@@ -424,7 +424,7 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         c.up("materialized", *[n.name for n in nodes])
 
         c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
             port=6877,
             user="mz_system",
         )

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -15,7 +15,7 @@ mode cockroach
 reset-server
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = on;
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = on;
 ----
 COMPLETE 0
 
@@ -100,13 +100,13 @@ quickstart
 
 # Test invalid option combinations.
 
-statement error invalid mixture of managed and unmanaged replica options
+statement error invalid mixture of orchestrated and unorchestrated replica options
 CREATE CLUSTER baz REPLICAS (r1 (COMPUTE ADDRESSES ['localhost:1234'], SIZE 'small'))
 
-statement error invalid mixture of managed and unmanaged replica options
+statement error invalid mixture of orchestrated and unorchestrated replica options
 CREATE CLUSTER baz REPLICAS (r1 (SIZE '2', WORKERS 1))
 
-statement error invalid mixture of managed and unmanaged replica options
+statement error invalid mixture of orchestrated and unorchestrated replica options
 CREATE CLUSTER baz REPLICAS (r1 (SIZE '2', COMPUTE ADDRESSES ['localhost:1234']))
 
 statement error COMPUTECTL ADDRESSES and COMPUTE ADDRESSES must have the same length
@@ -622,13 +622,13 @@ CREATE CLUSTER REPLICA quickstart.replica SIZE '1', AVAILABILITY ZONE 'a'
 statement error AVAILABILITY ZONE specified more than once
 CREATE CLUSTER REPLICA quickstart.replica AVAILABILITY ZONE 'a', AVAILABILITY ZONE 'b'
 
-statement error invalid mixture of managed and unmanaged replica options
+statement error invalid mixture of orchestrated and unorchestrated replica options
 CREATE CLUSTER REPLICA quickstart.replica STORAGECTL ADDRESSES ['host'], AVAILABILITY ZONE 'a'
 
-statement error invalid mixture of managed and unmanaged replica options
+statement error invalid mixture of orchestrated and unorchestrated replica options
 CREATE CLUSTER REPLICA quickstart.replica STORAGECTL ADDRESSES ['host'], AVAILABILITY ZONE 'a'
 
-statement error invalid mixture of managed and unmanaged replica options
+statement error invalid mixture of orchestrated and unorchestrated replica options
 CREATE CLUSTER REPLICA quickstart.replica AVAILABILITY ZONE 'a', STORAGECTL ADDRESSES ['host']
 
 # Test that the contents of mz_cluster_replicas look sensible

--- a/test/sqllogictest/github-11568.slt
+++ b/test/sqllogictest/github-11568.slt
@@ -12,7 +12,7 @@
 mode cockroach
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;
 ----
 COMPLETE 0
 

--- a/test/sqllogictest/show_clusters.slt
+++ b/test/sqllogictest/show_clusters.slt
@@ -15,7 +15,7 @@ mode standard
 reset-server
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = on;
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = on;
 ----
 COMPLETE 0
 

--- a/test/ssh-connection/setup.td
+++ b/test/ssh-connection/setup.td
@@ -11,7 +11,7 @@
 # Done here instead of in the workflow to ensure the state is reset.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 ALTER SYSTEM SET enable_connection_validation_syntax = true
 ALTER SYSTEM SET enable_default_kafka_ssh_tunnel = true
 

--- a/test/testdrive/cc_cluster_sizes.td
+++ b/test/testdrive/cc_cluster_sizes.td
@@ -20,7 +20,7 @@ contains:unknown cluster replica size 512C
 
 # Nor can we create an unmanaged replica directly
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 ! CREATE CLUSTER c REPLICAS (r1 (SIZE '1cc'))
 contains:unknown cluster replica size 1cc

--- a/test/testdrive/correctness-property-2.td
+++ b/test/testdrive/correctness-property-2.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 $ set keyschema={
     "type": "record",

--- a/test/testdrive/source-sink-clusters.td
+++ b/test/testdrive/source-sink-clusters.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 # Clean up cluster manually, since testdrive does not automatically clean up
 # clusters.

--- a/test/testdrive/statistics-deletion.td
+++ b/test/testdrive/statistics-deletion.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 > CREATE CLUSTER cluster1 REPLICAS (r1 (SIZE '2'))
 

--- a/test/testdrive/statistics-maintenance.td
+++ b/test/testdrive/statistics-maintenance.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true
+ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 ALTER SYSTEM SET kafka_default_metadata_fetch_interval = 1000
 ALTER SYSTEM SET storage_statistics_collection_interval = 1000
 ALTER SYSTEM SET storage_statistics_interval = 2000

--- a/test/tracing/mzcompose.py
+++ b/test/tracing/mzcompose.py
@@ -142,7 +142,7 @@ def workflow_clusterd(c: Composition) -> None:
     port = c.port("clusterd", 6878)
 
     c.sql(
-        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
         port=6877,
         user="mz_system",
     )

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -35,7 +35,7 @@ SERVICES = [
         ],
         additional_system_parameter_defaults={
             "disk_cluster_replicas_default": "true",
-            "enable_unmanaged_cluster_replicas": "true",
+            "enable_unorchestrated_cluster_replicas": "true",
             "storage_dataflow_delay_sources_past_rehydration": "true",
         },
         environment_extra=materialized_environment_extra,
@@ -166,7 +166,7 @@ def workflow_rehydration(c: Composition) -> None:
                     "--orchestrator-process-scratch-directory=/scratch",
                 ],
                 additional_system_parameter_defaults={
-                    "enable_unmanaged_cluster_replicas": "true",
+                    "enable_unorchestrated_cluster_replicas": "true",
                     "disk_cluster_replicas_default": "true",
                     "enable_disk_cluster_replicas": "true",
                     # Force backpressure to be enabled.
@@ -195,7 +195,7 @@ def workflow_rehydration(c: Composition) -> None:
                     "--orchestrator-process-scratch-directory=/scratch",
                 ],
                 additional_system_parameter_defaults={
-                    "enable_unmanaged_cluster_replicas": "true",
+                    "enable_unorchestrated_cluster_replicas": "true",
                     # Force backpressure to be enabled.
                     "storage_dataflow_max_inflight_bytes": "1",
                     "storage_dataflow_max_inflight_bytes_to_cluster_size_fraction": "0.01",
@@ -430,7 +430,7 @@ def workflow_autospill(c: Composition) -> None:
                 "disk_cluster_replicas_default": "true",
                 "upsert_rocksdb_auto_spill_to_disk": "true",
                 "upsert_rocksdb_auto_spill_threshold_bytes": "200",
-                "enable_unmanaged_cluster_replicas": "true",
+                "enable_unorchestrated_cluster_replicas": "true",
                 "storage_dataflow_delay_sources_past_rehydration": "true",
             },
         ),

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -172,7 +172,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         c.up("materialized")
 
         c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
             port=6877,
             user="mz_system",
         )


### PR DESCRIPTION
Unmanaged replicas are an internal-only feature used for testing Materialize with finer control than going through the orchestrator would allow. But the name of the feature clashes badly with the name of a user-facing feature added later: unmanaged and managed clusters.

So, rename the unmanaged replica feature in the codebase from to "unorchestrated replicas". It's just a better name overall, as what you avoid with unorchestrated replicas is Materialize using its "Orchestrator".

Fix #20167.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Should be just internal code and test renaming. No user visible impact. Not all that important, but it's been bugging me for a long while.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
