### PR TITLE
Canonicalize MFPs below Negates

### DIFF
--- a/src/transform/src/canonicalize_mfp.rs
+++ b/src/transform/src/canonicalize_mfp.rs
@@ -62,9 +62,17 @@ impl CanonicalizeMfp {
         indexes: &dyn IndexOracle,
     ) -> Result<(), crate::TransformError> {
         let mut mfp = MapFilterProject::extract_non_errors_from_expr_mut(relation);
-        relation.try_visit_mut_children(|e| self.action(e, indexes))?;
         mfp.optimize(); // Optimize MFP, e.g., perform CSE
-        Self::rebuild_mfp(mfp, relation);
+                        // Push MFPs through `Negate` operators, if encountered.
+                        // This is a first steps toward a `CanonicalizeLinear`,
+                        // which puts linear operators in a canonical representation.
+        if let MirRelationExpr::Negate { input } = relation {
+            Self::rebuild_mfp(mfp, &mut **input);
+            relation.try_visit_mut_children(|e| self.action(e, indexes))?;
+        } else {
+            relation.try_visit_mut_children(|e| self.action(e, indexes))?;
+            Self::rebuild_mfp(mfp, relation);
+        }
         Ok(())
     }
 

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -414,10 +414,10 @@ Explained Query:
                     Get l0 // { types: "(integer?, integer)" }
               Map (false) // { types: "(integer?, integer, boolean)" }
                 Union // { types: "(integer?, integer)" }
-                  Map (1) // { types: "(integer?, integer)" }
-                    Negate // { types: "(integer?)" }
-                      Project (#0) // { types: "(integer?)" }
-                        Filter (#1 = 1) // { types: "(integer?, integer)" }
+                  Negate // { types: "(integer?, integer)" }
+                    Project (#0, #2) // { types: "(integer?, integer)" }
+                      Filter (#1 = 1) // { types: "(integer?, integer, integer)" }
+                        Map (1) // { types: "(integer?, integer, integer)" }
                           Get l0 // { types: "(integer?, integer)" }
                   Get l0 // { types: "(integer?, integer)" }
   With
@@ -698,10 +698,10 @@ Explained Query:
                   Get l1 // { types: "(integer?, integer)" }
             Map (false) // { types: "(integer?, integer, boolean)" }
               Union // { types: "(integer?, integer)" }
-                Map (1) // { types: "(integer?, integer)" }
-                  Negate // { types: "(integer?)" }
-                    Project (#0) // { types: "(integer?)" }
-                      Filter (#1 = 1) // { types: "(integer?, integer)" }
+                Negate // { types: "(integer?, integer)" }
+                  Project (#0, #2) // { types: "(integer?, integer)" }
+                    Filter (#1 = 1) // { types: "(integer?, integer, integer)" }
+                      Map (1) // { types: "(integer?, integer, integer)" }
                         Get l1 // { types: "(integer?, integer)" }
                 Get l1 // { types: "(integer?, integer)" }
         ArrangeBy keys=[[#0]] // { types: "(integer?, boolean?)" }

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -408,17 +408,14 @@ Explained Query:
             ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
           ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer, boolean)" }
             Union // { types: "(integer?, integer, boolean)" }
-              Project (#0, #2, #3) // { types: "(integer?, integer, boolean)" }
-                Filter (#1 = 1) // { types: "(integer?, integer, integer, boolean)" }
-                  Map (1, true) // { types: "(integer?, integer, integer, boolean)" }
-                    Get l0 // { types: "(integer?, integer)" }
+              Filter (#1 = 1) // { types: "(integer?, integer, boolean)" }
+                Map (true) // { types: "(integer?, integer, boolean)" }
+                  Get l0 // { types: "(integer?, integer)" }
               Map (false) // { types: "(integer?, integer, boolean)" }
                 Union // { types: "(integer?, integer)" }
                   Negate // { types: "(integer?, integer)" }
-                    Project (#0, #2) // { types: "(integer?, integer)" }
-                      Filter (#1 = 1) // { types: "(integer?, integer, integer)" }
-                        Map (1) // { types: "(integer?, integer, integer)" }
-                          Get l0 // { types: "(integer?, integer)" }
+                    Filter (#1 = 1) // { types: "(integer?, integer)" }
+                      Get l0 // { types: "(integer?, integer)" }
                   Get l0 // { types: "(integer?, integer)" }
   With
     cte l0 =
@@ -692,17 +689,14 @@ Explained Query:
                   - ()
         ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer, boolean)" }
           Union // { types: "(integer?, integer, boolean)" }
-            Project (#0, #2, #3) // { types: "(integer?, integer, boolean)" }
-              Filter (#1 = 1) // { types: "(integer?, integer, integer, boolean)" }
-                Map (1, true) // { types: "(integer?, integer, integer, boolean)" }
-                  Get l1 // { types: "(integer?, integer)" }
+            Filter (#1 = 1) // { types: "(integer?, integer, boolean)" }
+              Map (true) // { types: "(integer?, integer, boolean)" }
+                Get l1 // { types: "(integer?, integer)" }
             Map (false) // { types: "(integer?, integer, boolean)" }
               Union // { types: "(integer?, integer)" }
                 Negate // { types: "(integer?, integer)" }
-                  Project (#0, #2) // { types: "(integer?, integer)" }
-                    Filter (#1 = 1) // { types: "(integer?, integer, integer)" }
-                      Map (1) // { types: "(integer?, integer, integer)" }
-                        Get l1 // { types: "(integer?, integer)" }
+                  Filter (#1 = 1) // { types: "(integer?, integer)" }
+                    Get l1 // { types: "(integer?, integer)" }
                 Get l1 // { types: "(integer?, integer)" }
         ArrangeBy keys=[[#0]] // { types: "(integer?, boolean?)" }
           Union // { types: "(integer?, boolean?)" }

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -827,8 +827,8 @@ Explained Query:
                         %0[#0, #1]KK » %1:t3[#0, #1]KK
                       ArrangeBy keys=[[#0, #1]] // { arity: 2 }
                         Union // { arity: 2 }
-                          Map (6) // { arity: 2 }
-                            Negate // { arity: 1 }
+                          Negate // { arity: 2 }
+                            Map (6) // { arity: 2 }
                               Distinct project=[#0] // { arity: 1 }
                                 Project (#1) // { arity: 1 }
                                   Get l0 // { arity: 2 }

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -450,19 +450,8 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t4 AS a1 LEFT JOIN t4 AS a2 USING (f1, f2) WHERE a1.f1 = 123 AND a1.f2 = 234;
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Union // { arity: 2 }
-      Negate // { arity: 2 }
-        Project (#2, #3) // { arity: 2 }
-          Filter (#0 = 123) AND (#1 = 234) // { arity: 4 }
-            Map (123, 234) // { arity: 4 }
-              ReadStorage materialize.public.t4 // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
-  With
-    cte l0 =
-      Filter (#0 = 123) AND (#1 = 234) // { arity: 2 }
-        ReadStorage materialize.public.t4 // { arity: 2 }
+  Filter (#0 = 123) AND (#1 = 234) // { arity: 2 }
+    ReadStorage materialize.public.t4 // { arity: 2 }
 
 Source materialize.public.t4
   filter=((#0 = 123) AND (#1 = 234))

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -452,10 +452,11 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t4 AS a1 LEFT JOIN t4 AS
 Explained Query:
   Return // { arity: 2 }
     Union // { arity: 2 }
-      Map (123, 234) // { arity: 2 }
-        Negate // { arity: 0 }
-          Project () // { arity: 0 }
-            Get l0 // { arity: 2 }
+      Negate // { arity: 2 }
+        Project (#2, #3) // { arity: 2 }
+          Filter (#0 = 123) AND (#1 = 234) // { arity: 4 }
+            Map (123, 234) // { arity: 4 }
+              ReadStorage materialize.public.t4 // { arity: 2 }
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
   With

--- a/test/sqllogictest/transform/is_null_propagation.slt
+++ b/test/sqllogictest/transform/is_null_propagation.slt
@@ -62,14 +62,11 @@ Explained Query:
                 Filter (#0 = bigint_to_double(#1)) // { arity: 2 }
                   Get l2 // { arity: 2 }
               Negate // { arity: 1 }
-                Project (#2) // { arity: 1 }
-                  Filter (#0 = 0) // { arity: 3 }
-                    Map (0) // { arity: 3 }
-                      Get l2 // { arity: 2 }
-              Project (#1) // { arity: 1 }
-                Filter (#0 = 0) // { arity: 2 }
-                  Map (0) // { arity: 2 }
-                    Get l1 // { arity: 1 }
+                Project (#0) // { arity: 1 }
+                  Filter (#0 = 0) // { arity: 2 }
+                    Get l2 // { arity: 2 }
+              Filter (#0 = 0) // { arity: 1 }
+                Get l1 // { arity: 1 }
   With
     cte l2 =
       Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }

--- a/test/sqllogictest/transform/is_null_propagation.slt
+++ b/test/sqllogictest/transform/is_null_propagation.slt
@@ -61,10 +61,10 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Filter (#0 = bigint_to_double(#1)) // { arity: 2 }
                   Get l2 // { arity: 2 }
-              Map (0) // { arity: 1 }
-                Negate // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Filter (#0 = 0) // { arity: 2 }
+              Negate // { arity: 1 }
+                Project (#2) // { arity: 1 }
+                  Filter (#0 = 0) // { arity: 3 }
+                    Map (0) // { arity: 3 }
                       Get l2 // { arity: 2 }
               Project (#1) // { arity: 1 }
                 Filter (#0 = 0) // { arity: 2 }

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -76,10 +76,10 @@ Explained Query:
   Union // { non_negative: false }
     Project (#0) // { non_negative: true }
       ReadStorage materialize.public.people // { non_negative: true }
-    Map (5) // { non_negative: false }
-      Negate // { non_negative: false }
-        Project () // { non_negative: true }
-          Filter (#0 = 5) // { non_negative: true }
+    Negate // { non_negative: false }
+      Project (#4) // { non_negative: true }
+        Filter (#0 = 5) // { non_negative: true }
+          Map (5) // { non_negative: true }
             ReadStorage materialize.public.people // { non_negative: true }
 
 EOF

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -77,10 +77,9 @@ Explained Query:
     Project (#0) // { non_negative: true }
       ReadStorage materialize.public.people // { non_negative: true }
     Negate // { non_negative: false }
-      Project (#4) // { non_negative: true }
+      Project (#0) // { non_negative: true }
         Filter (#0 = 5) // { non_negative: true }
-          Map (5) // { non_negative: true }
-            ReadStorage materialize.public.people // { non_negative: true }
+          ReadStorage materialize.public.people // { non_negative: true }
 
 EOF
 

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -120,9 +120,9 @@ Explained Query:
       Threshold // { arity: 2 }
         Union // { arity: 2 }
           ReadStorage materialize.public.t1 // { arity: 2 }
-          Map (null) // { arity: 2 }
-            Negate // { arity: 1 }
-              Project (#0) // { arity: 1 }
+          Negate // { arity: 2 }
+            Project (#0, #2) // { arity: 2 }
+              Map (null) // { arity: 3 }
                 ReadStorage materialize.public.t3 // { arity: 2 }
 
 EOF

--- a/test/testdrive/primary-key-optimizations.td
+++ b/test/testdrive/primary-key-optimizations.td
@@ -80,7 +80,7 @@ $ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys
 "Explained Query (fast path):  ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 > EXPLAIN WITH(no notices) SELECT key1, key2 FROM t1 GROUP BY key1, key2 HAVING key1 = 'a';
-"Explained Query (fast path):  Project (#3, #1)    Filter (#0 = \"a\")      Map (\"a\")        ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
+"Explained Query (fast path):  Project (#0, #1)    Filter (#0 = \"a\")      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 # Optimization not possible - explicit distinct is present in planFor certain types of tests the 
 
@@ -192,7 +192,7 @@ $ kafka-ingest format=avro topic=t1-pkne schema=${schema}
 "Explained Query (fast path):  ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
 > EXPLAIN WITH(no notices) SELECT key1, key2 FROM t1_pkne GROUP BY key1, key2 HAVING key1 = 'a';
-"Explained Query (fast path):  Project (#3, #1)    Filter (#0 = \"a\")      Map (\"a\")        ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
+"Explained Query (fast path):  Project (#0, #1)    Filter (#0 = \"a\")      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
 # Optimization not possible - explicit distinct is present in plan
 


### PR DESCRIPTION
This PR modifies MFP canonicalization, pushing them through Negate (and often lifting the Negate to a Union). This should come at no cost, as Negate does not modify the collection of records, and the intent is to open up better MFP reasoning by consolidating more together.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
