### PR TITLE
Lifecycle logging: reduce opportunities for timestamp inconsistency

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -403,11 +403,12 @@ impl Coordinator {
                 }
             }
             ControllerResponse::WatchSetFinished(sets) => {
+                let now = self.now();
                 for set in sets {
                     let (id, ev) = set
                         .downcast_ref::<(StatementLoggingId, StatementLifecycleEvent)>()
                         .expect("we currently log all watch sets with this type");
-                    self.record_statement_lifecycle_event(id, ev);
+                    self.record_statement_lifecycle_event(id, ev, now);
                 }
             }
         }

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -350,12 +350,11 @@ impl Coordinator {
         reason: StatementEndedExecutionReason,
     ) {
         let StatementLoggingId(uuid) = id;
-        let now = self.now_datetime();
-        let now_millis = now.timestamp_millis().try_into().expect("sane system time");
+        let now = self.now();
         let ended_record = StatementEndedExecutionRecord {
             id: uuid,
             reason,
-            ended_at: now_millis,
+            ended_at: now,
         };
 
         let began_record = self
@@ -372,7 +371,11 @@ impl Coordinator {
                 .pending_statement_execution_events
                 .push((row, diff));
         }
-        self.record_statement_lifecycle_event(&id, &StatementLifecycleEvent::ExecutionFinished);
+        self.record_statement_lifecycle_event(
+            &id,
+            &StatementLifecycleEvent::ExecutionFinished,
+            now,
+        );
     }
 
     fn pack_statement_execution_inner(
@@ -648,9 +651,11 @@ impl Coordinator {
         let (ps_record, ps_uuid) = self.log_prepared_statement(session, logging)?;
 
         let ev_id = Uuid::new_v4();
+        let now = self.now();
         self.record_statement_lifecycle_event(
             &StatementLoggingId(ev_id),
             &StatementLifecycleEvent::ExecutionBegan,
+            now,
         );
 
         let params = std::iter::zip(params.types.iter(), params.datums.iter())
@@ -728,13 +733,13 @@ impl Coordinator {
         &mut self,
         id: &StatementLoggingId,
         event: &StatementLifecycleEvent,
+        when: EpochMillis,
     ) {
         if self
             .catalog()
             .system_config()
             .enable_statement_lifecycle_logging()
         {
-            let when = self.now();
             let row = Self::pack_statement_lifecycle_event(id, event, when);
             self.statement_logging
                 .pending_statement_lifecycle_events


### PR DESCRIPTION
This PR ensures that:

* If the coordinator detects that several "watch sets" finished at the same time, then they are recorded at the same time
* A statement ended execution event is recorded at the same time as the corresponding `finished_at` time in the activity log

### Motivation

  * This PR fixes a previously unreported bug.

    Possibly inconsistent timestamps between various statement events


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None
