### PR TITLE
storage: support order keys in upsert state api

### DIFF
--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -566,7 +566,10 @@ where
     let shutdown_button = builder.build(move |caps| async move {
         let [mut output_cap, health_cap]: [_; 2] = caps.try_into().unwrap();
 
-        let mut state = UpsertState::new(
+        // The order key of the `UpsertState` is `Option<FromTime>`, which implements `Default`
+        // (as required for `merge_snapshot_chunk`), with slightly more efficient serialization
+        // than a default `Partitioned`.
+        let mut state = UpsertState::<_, Option<FromTime>>::new(
             state().await,
             upsert_shared_metrics,
             &upsert_metrics,

--- a/src/storage/src/render/upsert/autospill.rs
+++ b/src/storage/src/render/upsert/autospill.rs
@@ -7,6 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! An `UpsertStateBackend` that starts in memory and spills to RocksDB
+//! when the total size passes some threshold.
+
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -99,6 +102,8 @@ where
     where
         P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<O>>)>,
     {
+        // Note that we never revert back to memory if the size shrinks below the threshold.
+        // That case is considered rare and not worth the complexity.
         match &mut self.backend_type {
             BackendType::InMemory(map) => {
                 let mut put_stats = map.multi_put(puts).await?;

--- a/src/storage/src/render/upsert/memory.rs
+++ b/src/storage/src/render/upsert/memory.rs
@@ -7,9 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Allow usage of `std::collections::HashMap`.
-//! We need to iterate through all the values in the map, so we can't use `mz_ore` wrapper.
-//! Also, we don't need any ordering for the values fetched, so using std HashMap.
+//! An `UpsertStateBackend` that stores values in memory.
+
+// Allow usage of `std::collections::HashMap`.
+// We need to iterate through all the values in the map, so we can't use `mz_ore` wrapper.
+// Also, we don't need any ordering for the values fetched, so using std HashMap.
 #![allow(clippy::disallowed_types)]
 
 use std::collections::hash_map::Drain;

--- a/src/storage/src/render/upsert/rocksdb.rs
+++ b/src/storage/src/render/upsert/rocksdb.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! An `UpsertStateBackend` that stores values in RocksDB.
+
 use mz_rocksdb::RocksDBInstance;
 use serde::{de::DeserializeOwned, Serialize};
 

--- a/src/storage/src/render/upsert/types.rs
+++ b/src/storage/src/render/upsert/types.rs
@@ -859,6 +859,8 @@ where
 
         self.stats.update_bytes_indexed_by(stats.size_diff);
         self.stats.update_records_indexed_by(stats.values_diff);
+        self.stats
+            .update_envelope_state_tombstones_by(stats.tombstones_diff);
 
         Ok(())
     }

--- a/test/upsert/autospill/01-setup.td
+++ b/test/upsert/autospill/01-setup.td
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET kafka_default_metadata_fetch_interval = 1000
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
+
 > DROP CLUSTER IF EXISTS storage_cluster CASCADE;
 
 > CREATE CLUSTER storage_cluster REPLICAS (

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -428,7 +428,7 @@ def workflow_autospill(c: Composition) -> None:
             additional_system_parameter_defaults={
                 "disk_cluster_replicas_default": "true",
                 "upsert_rocksdb_auto_spill_to_disk": "true",
-                "upsert_rocksdb_auto_spill_threshold_bytes": "200",
+                "upsert_rocksdb_auto_spill_threshold_bytes": "250",
                 "enable_unorchestrated_cluster_replicas": "true",
                 "storage_dataflow_delay_sources_past_rehydration": "true",
             },


### PR DESCRIPTION
This is broken out of: https://github.com/MaterializeInc/materialize/pull/24663

Fundamentally, fixing https://github.com/MaterializeInc/materialize/issues/23998 requires that the upsert state backends are able to _ingest data that arrives before a progress update_. This requires we store and _order key_ alongside that data, so that we can order values for the same key that occurred at the same _source time_, but within the same mz timestamp. This includes tombstones for keys that were deleted. This pr adds this functionality to the upsert state backend, but does not make use of it yet.

Tombstones unfortunately take up permanent space in the state. There is no easy way around this (other than doing a full range scan of the state on `Progress` updates), and our choice to avoid doing so will be discussed in the next pr (24663)


### Motivation

  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
