### PR TITLE
balancerd: use configmap-based cancellation scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,6 +3767,7 @@ dependencies = [
  "prometheus",
  "reqwest",
  "semver",
+ "tempfile",
  "tokio",
  "tokio-openssl",
  "tokio-postgres",

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -46,6 +46,7 @@ mz-environmentd = { path = "../environmentd", features = ["test"] }
 mz-frontegg-mock = { path = "../frontegg-mock" }
 postgres = "0.19.5"
 reqwest = "0.11.24"
+tempfile = "3.8.1"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/balancerd/src/service.rs
+++ b/src/balancerd/src/service.rs
@@ -52,11 +52,13 @@ pub struct Args {
     /// destinaiton.
     #[clap(long, value_name = "HOST.{}.NAME:PORT")]
     https_resolver_template: String,
-    /// Cancellation DNS resolver address. `{}` is replaced with the org id part of the incoming
-    /// connection id (the 12 bits after (and excluding) the first bit) converted to a 3-char UUID
-    /// string. The cancellation request will be mirrored to all IPs this address resolves to.
-    #[clap(long, value_name = "HOST.{}.NAME:PORT")]
-    cancellation_resolver_template: Option<String>,
+    /// Cancellation resolver configmap directory. The org id part of the incoming connection id
+    /// (the 12 bits after (and excluding) the first bit) converted to a 3-char UUID string is
+    /// appended to this to make a file path. That file is read, and every newline-delimited line
+    /// there is DNS resolved, and all returned IPs get a mirrored cancellation request. The lines
+    /// in the file must be of the form `host:port`.
+    #[clap(long, value_name = "/path/to/configmap/dir/")]
+    cancellation_resolver_dir: Option<PathBuf>,
 
     /// JWK used to validate JWTs during Frontegg authentication as a PEM public
     /// key. Can optionally be base64 encoded with the URL-safe alphabet.
@@ -143,7 +145,7 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         args.internal_http_listen_addr,
         args.pgwire_listen_addr,
         args.https_listen_addr,
-        args.cancellation_resolver_template,
+        args.cancellation_resolver_dir,
         resolver,
         args.https_resolver_template,
         args.tls.into_config()?,


### PR DESCRIPTION
Use a specified directory to which files containing DNS addresses will be written for cancellation.

See https://github.com/MaterializeInc/materialize/issues/24081#issuecomment-1942928294

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a