### PR TITLE
Don't acquire read holds when EXPLAINing a REFRESH MV

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -200,7 +200,7 @@ impl Coordinator {
         plan: plan::CreateMaterializedViewPlan,
         resolved_ids: ResolvedIds,
         // An optional context set iff the state machine is initiated from
-        // sequencing an EXPALIN for this statement.
+        // sequencing an EXPLAIN for this statement.
         explain_ctx: ExplainContext,
     ) -> Result<CreateMaterializedViewStage, AdapterError> {
         let plan::CreateMaterializedViewPlan {
@@ -252,7 +252,7 @@ impl Coordinator {
         // the REFRESH AT expressions have been evaluated, so we can handle something like
         // `mz_now()::text::int8 + 10000`;
         if let Some(refresh_schedule) = refresh_schedule {
-            if !refresh_schedule.ats.is_empty() {
+            if !refresh_schedule.ats.is_empty() && matches!(explain_ctx, ExplainContext::None) {
                 let ids = self
                     .index_oracle(*cluster_id)
                     .sufficient_collections(resolved_ids.0.iter());

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1077,3 +1077,23 @@ NULL
 30
 70
 100
+
+## EXPLAIN shouldn't try to grab read holds in `create_materialized_view_validate`
+
+statement ok
+CREATE TABLE t3(x int);
+
+statement ok
+INSERT INTO t3 VALUES (5), (6);
+
+statement ok
+CREATE MATERIALIZED VIEW mv8 WITH (REFRESH AT CREATION) AS
+SELECT DISTINCT x-x FROM t3;
+
+# Sleep until we could no longer grab read holds at the original creation time.
+statement ok
+SELECT mz_unsafe.mz_sleep(2);
+
+# This would fail to get read holds if it attempted to do so.
+statement ok
+EXPLAIN REPLAN MATERIALIZED VIEW mv8;


### PR DESCRIPTION
There is no need to acquire any read holds when EXPLAINing a materialized view. In fact, it was causing a problem when using `EXPLAIN REPLAN`: For MVs with `REFRESH AT CREATION`, we tried to acquire a read hold at the original creation time, which was not possible, and therefore we were failing the `EXPLAIN REPLAN`.

Note that the read hold acquisition in `resolve_mz_now_for_create_materialized_view` already had this behavior that it's not acquiring read holds if we are in an EXPLAIN, so this PR just modifies `create_materialized_view_validate` to have the same behavior.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
