### PR TITLE
explain,sql: support `EXPLAIN ... VIEW` variants

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1915,7 +1915,7 @@ impl Coordinator {
         };
 
         let explain = match stage {
-            ExplainStage::OptimizedPlan => {
+            ExplainStage::GlobalPlan => {
                 let Some(plan) = self.catalog().try_get_optimized_plan(&id).cloned() else {
                     tracing::error!("cannot find {stage} for materialized view {id} in catalog");
                     coord_bail!("cannot find {stage} for materialized view in catalog");
@@ -1974,7 +1974,7 @@ impl Coordinator {
         };
 
         let explain = match stage {
-            ExplainStage::OptimizedPlan => {
+            ExplainStage::GlobalPlan => {
                 let Some(plan) = self.catalog().try_get_optimized_plan(&id).cloned() else {
                     tracing::error!("cannot find {stage} for index {id} in catalog");
                     coord_bail!("cannot find {stage} for index in catalog");

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1861,6 +1861,10 @@ impl Coordinator {
     ) {
         match &plan.explainee {
             plan::Explainee::Statement(stmt) => match stmt {
+                plan::ExplaineeStatement::CreateView { .. } => {
+                    let msg = "EXPLAIN CREATE VIEW is currently not supported";
+                    ctx.retire(Err(AdapterError::Unsupported(msg)));
+                }
                 plan::ExplaineeStatement::CreateMaterializedView { .. } => {
                     self.explain_create_materialized_view(ctx, plan).await;
                 }
@@ -1871,6 +1875,10 @@ impl Coordinator {
                     self.explain_peek(ctx, plan, target_cluster).await;
                 }
             },
+            plan::Explainee::View(_) => {
+                let msg = "EXPLAIN VIEW is currently not supported";
+                ctx.retire(Err(AdapterError::Unsupported(msg)));
+            }
             plan::Explainee::MaterializedView(_) => {
                 let result = self.explain_materialized_view(&ctx, plan);
                 ctx.retire(result);
@@ -1878,6 +1886,10 @@ impl Coordinator {
             plan::Explainee::Index(_) => {
                 let result = self.explain_index(&ctx, plan);
                 ctx.retire(result);
+            }
+            plan::Explainee::ReplanView(_) => {
+                let msg = "EXPLAIN REPLAN VIEW is currently not supported";
+                ctx.retire(Err(AdapterError::Unsupported(msg)));
             }
             plan::Explainee::ReplanMaterializedView(_) => {
                 self.explain_replan_materialized_view(ctx, plan).await;

--- a/src/repr/src/explain/tracing.rs
+++ b/src/repr/src/explain/tracing.rs
@@ -321,8 +321,8 @@ impl PlanTrace<UsedIndexes> {
         // Compute the path from which we are going to lookup the `UsedIndexes`
         // instance from the requested path.
         let path = match NamedPlan::of_path(plan_path) {
-            Some(NamedPlan::Optimized) => Some(NamedPlan::Optimized),
-            Some(NamedPlan::Physical) => Some(NamedPlan::Optimized),
+            Some(NamedPlan::Global) => Some(NamedPlan::Global),
+            Some(NamedPlan::Physical) => Some(NamedPlan::Global),
             Some(NamedPlan::FastPath) => Some(NamedPlan::FastPath),
             _ => None,
         };

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -232,6 +232,7 @@ Linear
 List
 Load
 Local
+Locally
 Log
 Logical
 Login

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3552,8 +3552,8 @@ pub enum ExplainStage {
     RawPlan,
     /// The mz_expr::MirRelationExpr after decorrelation
     DecorrelatedPlan,
-    /// The mz_expr::MirRelationExpr after optimization
-    OptimizedPlan,
+    /// The mz_expr::MirRelationExpr after global optimization
+    GlobalPlan,
     /// The mz_compute_types::plan::Plan
     PhysicalPlan,
     /// The complete trace of the plan through the optimizer
@@ -3567,7 +3567,7 @@ impl ExplainStage {
         match self {
             Self::RawPlan => Some(Raw.path()),
             Self::DecorrelatedPlan => Some(Decorrelated.path()),
-            Self::OptimizedPlan => Some(Optimized.path()),
+            Self::GlobalPlan => Some(Global.path()),
             Self::PhysicalPlan => Some(Physical.path()),
             Self::Trace => None,
         }
@@ -3579,7 +3579,7 @@ impl ExplainStage {
         match self {
             Self::RawPlan => false,
             Self::DecorrelatedPlan => false,
-            Self::OptimizedPlan => true,
+            Self::GlobalPlan => true,
             Self::PhysicalPlan => true,
             Self::Trace => false,
         }
@@ -3591,7 +3591,7 @@ impl AstDisplay for ExplainStage {
         match self {
             Self::RawPlan => f.write_str("RAW PLAN"),
             Self::DecorrelatedPlan => f.write_str("DECORRELATED PLAN"),
-            Self::OptimizedPlan => f.write_str("OPTIMIZED PLAN"),
+            Self::GlobalPlan => f.write_str("OPTIMIZED PLAN"),
             Self::PhysicalPlan => f.write_str("PHYSICAL PLAN"),
             Self::Trace => f.write_str("OPTIMIZER TRACE"),
         }
@@ -3604,7 +3604,7 @@ impl_display!(ExplainStage);
 pub enum NamedPlan {
     Raw,
     Decorrelated,
-    Optimized,
+    Global,
     Physical,
     FastPath,
 }
@@ -3615,7 +3615,7 @@ impl NamedPlan {
         match value {
             "optimize/raw" => Some(Self::Raw),
             "optimize/hir_to_mir" => Some(Self::Decorrelated),
-            "optimize/global" => Some(Self::Optimized),
+            "optimize/global" => Some(Self::Global),
             "optimize/finalize_dataflow" => Some(Self::Physical),
             "optimize/fast_path" => Some(Self::FastPath),
             _ => None,
@@ -3628,7 +3628,7 @@ impl NamedPlan {
         match self {
             Self::Raw => "optimize/raw",
             Self::Decorrelated => "optimize/hir_to_mir",
-            Self::Optimized => "optimize/global",
+            Self::Global => "optimize/global",
             Self::Physical => "optimize/finalize_dataflow",
             Self::FastPath => "optimize/fast_path",
         }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -7329,39 +7329,42 @@ impl<'a> Parser<'a> {
     /// Parse an `EXPLAIN ... PLAN` statement, assuming that the `EXPLAIN` token
     /// has already been consumed.
     fn parse_explain_plan(&mut self) -> Result<Statement<Raw>, ParserError> {
-        let stage = match self.parse_one_of_keywords(&[
-            PLAN,
+        let (has_stage, stage) = match self.parse_one_of_keywords(&[
             RAW,
             DECORRELATED,
             OPTIMIZED,
             PHYSICAL,
             OPTIMIZER,
+            PLAN,
         ]) {
-            Some(PLAN) => {
-                // EXPLAIN PLAN = EXPLAIN OPTIMIZED PLAN
-                Some(ExplainStage::OptimizedPlan)
-            }
             Some(RAW) => {
                 self.expect_keyword(PLAN)?;
-                Some(ExplainStage::RawPlan)
+                (true, Some(ExplainStage::RawPlan))
             }
             Some(DECORRELATED) => {
                 self.expect_keyword(PLAN)?;
-                Some(ExplainStage::DecorrelatedPlan)
+                (true, Some(ExplainStage::DecorrelatedPlan))
             }
             Some(OPTIMIZED) => {
                 self.expect_keyword(PLAN)?;
-                Some(ExplainStage::OptimizedPlan)
+                (true, Some(ExplainStage::GlobalPlan))
             }
             Some(PHYSICAL) => {
                 self.expect_keyword(PLAN)?;
-                Some(ExplainStage::PhysicalPlan)
+                (true, Some(ExplainStage::PhysicalPlan))
             }
             Some(OPTIMIZER) => {
                 self.expect_keyword(TRACE)?;
-                Some(ExplainStage::Trace)
+                (true, Some(ExplainStage::Trace))
             }
-            None => None,
+            Some(PLAN) => {
+                // Use the default plan for the explainee.
+                (true, None)
+            }
+            None => {
+                // Use the default plan for the explainee.
+                (false, None)
+            }
             _ => unreachable!(),
         };
 
@@ -7390,14 +7393,14 @@ impl<'a> Parser<'a> {
             ExplainFormat::Text
         };
 
-        if stage.is_some() {
+        if has_stage {
             self.expect_keyword(FOR)?;
         }
 
         let explainee = self.parse_explainee()?;
 
         Ok(Statement::ExplainPlan(ExplainPlanStatement {
-            stage: stage.unwrap_or(ExplainStage::OptimizedPlan),
+            stage: stage.unwrap_or_else(|| ExplainStage::GlobalPlan),
             with_options,
             format,
             explainee,

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -23,7 +23,7 @@ EXPLAIN SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN RAW PLAN FOR SELECT 665
@@ -44,7 +44,7 @@ EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN PHYSICAL PLAN FOR SELECT 665
@@ -58,77 +58,77 @@ EXPLAIN SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR MATERIALIZED VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR MATERIALIZED VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: MaterializedView(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: MaterializedView(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR INDEX foo
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR INDEX foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: Index(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Index(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR REPLAN VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR REPLAN VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: ReplanView(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: ReplanView(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR REPLAN MATERIALIZED VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR REPLAN MATERIALIZED VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: ReplanMaterializedView(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: ReplanMaterializedView(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR REPLAN INDEX foo
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR REPLAN INDEX foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: ReplanIndex(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: ReplanIndex(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN WITH(types) FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN WITH (TYPES) AS TEXT FOR VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [ExplainPlanOption { name: Types, value: None }], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [ExplainPlanOption { name: Types, value: None }], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN WITH(arity, types) FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN WITH (ARITY, TYPES) AS TEXT FOR VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [ExplainPlanOption { name: Arity, value: None }, ExplainPlanOption { name: Types, value: None }], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [ExplainPlanOption { name: Arity, value: None }, ExplainPlanOption { name: Types, value: None }], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN ((SELECT 1))
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 1
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 # regression test for #16029
 parse-statement
@@ -136,7 +136,7 @@ EXPLAIN WITH a AS (SELECT 1) SELECT * FROM a
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN TIMESTAMP FOR SELECT 1
@@ -150,7 +150,7 @@ EXPLAIN AS JSON SELECT * FROM foo
 ----
 EXPLAIN OPTIMIZED PLAN AS JSON FOR SELECT * FROM foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Json, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Json, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN OPTIMIZER TRACE WITH (types) AS TEXT FOR BROKEN SELECT 1 + 1
@@ -166,28 +166,28 @@ EXPLAIN WITH (humanized expressions) CREATE MATERIALIZED VIEW mv AS SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN WITH (HUMANIZED EXPRESSIONS) AS TEXT FOR CREATE MATERIALIZED VIEW mv AS SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [ExplainPlanOption { name: HumanizedExpressions, value: None }], format: Text, explainee: CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("mv")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [] }, false) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [ExplainPlanOption { name: HumanizedExpressions, value: None }], format: Text, explainee: CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("mv")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [] }, false) })
 
 parse-statement
 EXPLAIN BROKEN CREATE MATERIALIZED VIEW mv AS SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR BROKEN CREATE MATERIALIZED VIEW mv AS SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("mv")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [] }, true) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("mv")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [] }, true) })
 
 parse-statement
 EXPLAIN BROKEN CREATE DEFAULT INDEX ON q1
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR BROKEN CREATE DEFAULT INDEX ON q1
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedItemName([Ident("q1")])), key_parts: None, with_options: [], if_not_exists: false }, true) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedItemName([Ident("q1")])), key_parts: None, with_options: [], if_not_exists: false }, true) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR CREATE INDEX ON v(auction_id)
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR CREATE INDEX ON v (auction_id)
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedItemName([Ident("v")])), key_parts: Some([Identifier([Ident("auction_id")])]), with_options: [], if_not_exists: false }, false) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedItemName([Ident("v")])), key_parts: Some([Identifier([Ident("auction_id")])]), with_options: [], if_not_exists: false }, false) })
 
 parse-statement
 EXPLAIN VALUE SCHEMA AS TEXT FOR CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE UPSERT
@@ -222,7 +222,7 @@ EXPLAIN SELECT 665 AS OF 3
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 665 AS OF 3
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Value(Number("3")))) }, false) })
+ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Value(Number("3")))) }, false) })
 
 parse-statement
 EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM numbers where value > 10

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -89,6 +89,20 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR REPLAN VIEW foo
 ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: ReplanView(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR REPLAN VIEW foo
+----
+EXPLAIN LOCALLY OPTIMIZED PLAN AS TEXT FOR REPLAN VIEW foo
+=>
+ExplainPlan(ExplainPlanStatement { stage: LocalPlan, with_options: [], format: Text, explainee: ReplanView(Name(UnresolvedItemName([Ident("foo")]))) })
+
+parse-statement
+EXPLAIN PLAN FOR REPLAN VIEW foo
+----
+error: EXPLAIN statement for a view needs an explicit stage
+EXPLAIN PLAN FOR REPLAN VIEW foo
+        ^
+
+parse-statement
 EXPLAIN OPTIMIZED PLAN FOR REPLAN MATERIALIZED VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR REPLAN MATERIALIZED VIEW foo
@@ -101,6 +115,20 @@ EXPLAIN OPTIMIZED PLAN FOR REPLAN INDEX foo
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR REPLAN INDEX foo
 =>
 ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: ReplanIndex(Name(UnresolvedItemName([Ident("foo")]))) })
+
+parse-statement
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR VIEW foo
+----
+EXPLAIN LOCALLY OPTIMIZED PLAN AS TEXT FOR VIEW foo
+=>
+ExplainPlan(ExplainPlanStatement { stage: LocalPlan, with_options: [], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
+
+parse-statement
+EXPLAIN PLAN FOR VIEW foo
+----
+error: EXPLAIN statement for a view needs an explicit stage
+EXPLAIN PLAN FOR VIEW foo
+        ^
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN WITH(types) FOR VIEW foo
@@ -159,7 +187,26 @@ EXPLAIN OPTIMIZER TRACE WITH (TYPES) AS TEXT FOR BROKEN SELECT 1 + 1
 =>
 ExplainPlan(ExplainPlanStatement { stage: Trace, with_options: [ExplainPlanOption { name: Types, value: None }], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, true) })
 
-# TODO (aalexandrov): Add negative tests for new explain API.
+parse-statement
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR CREATE VIEW mv AS SELECT 665
+----
+EXPLAIN LOCALLY OPTIMIZED PLAN AS TEXT FOR CREATE VIEW mv AS SELECT 665
+=>
+ExplainPlan(ExplainPlanStatement { stage: LocalPlan, with_options: [], format: Text, explainee: CreateView(CreateViewStatement { if_exists: Error, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("mv")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } }, false) })
+
+parse-statement
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR CREATE OR REPLACE VIEW mv AS SELECT 665
+----
+EXPLAIN LOCALLY OPTIMIZED PLAN AS TEXT FOR CREATE OR REPLACE VIEW mv AS SELECT 665
+=>
+ExplainPlan(ExplainPlanStatement { stage: LocalPlan, with_options: [], format: Text, explainee: CreateView(CreateViewStatement { if_exists: Replace, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("mv")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } }, false) })
+
+parse-statement
+EXPLAIN CREATE VIEW mv AS SELECT 665
+----
+error: EXPLAIN statement for a view needs an explicit stage
+EXPLAIN CREATE VIEW mv AS SELECT 665
+        ^
 
 parse-statement
 EXPLAIN WITH (humanized expressions) CREATE MATERIALIZED VIEW mv AS SELECT 665

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -255,20 +255,21 @@ pub fn describe_explain_plan(
 
     match stage {
         ExplainStage::RawPlan => {
-            relation_desc =
-                relation_desc.with_column("Raw Plan", ScalarType::String.nullable(false));
+            let name = "Raw Plan";
+            relation_desc = relation_desc.with_column(name, ScalarType::String.nullable(false));
         }
         ExplainStage::DecorrelatedPlan => {
-            relation_desc =
-                relation_desc.with_column("Decorrelated Plan", ScalarType::String.nullable(false));
+            let name = "Decorrelated Plan";
+            relation_desc = relation_desc.with_column(name, ScalarType::String.nullable(false));
         }
-        ExplainStage::OptimizedPlan => {
-            relation_desc =
-                relation_desc.with_column("Optimized Plan", ScalarType::String.nullable(false));
+        }
+        ExplainStage::GlobalPlan => {
+            let name = "Optimized Plan";
+            relation_desc = relation_desc.with_column(name, ScalarType::String.nullable(false));
         }
         ExplainStage::PhysicalPlan => {
-            relation_desc =
-                relation_desc.with_column("Physical Plan", ScalarType::String.nullable(false));
+            let name = "Physical Plan";
+            relation_desc = relation_desc.with_column(name, ScalarType::String.nullable(false));
         }
         ExplainStage::Trace => {
             relation_desc = relation_desc

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -262,6 +262,9 @@ pub fn describe_explain_plan(
             let name = "Decorrelated Plan";
             relation_desc = relation_desc.with_column(name, ScalarType::String.nullable(false));
         }
+        ExplainStage::LocalPlan => {
+            let name = "Locally Optimized Plan";
+            relation_desc = relation_desc.with_column(name, ScalarType::String.nullable(false));
         }
         ExplainStage::GlobalPlan => {
             let name = "Optimized Plan";
@@ -405,16 +408,20 @@ fn plan_explainee(
 
     let is_replan = matches!(
         explainee,
-        Explainee::ReplanView(_) | Explainee::ReplanMaterializedView(_) | Explainee::ReplanIndex(_),
+        Explainee::ReplanView(_) | Explainee::ReplanMaterializedView(_) | Explainee::ReplanIndex(_)
     );
 
     let explainee = match explainee {
-        Explainee::View(_) | Explainee::ReplanView(_) => {
-            bail_never_supported!(
-                "EXPLAIN ... VIEW <view_name>",
-                "sql/explain-plan",
-                "Use `EXPLAIN ... SELECT * FROM <view_name>` (if the view is not indexed) or `EXPLAIN ... INDEX <idx_name>` (if the view is indexed) instead."
-            );
+        Explainee::View(name) | Explainee::ReplanView(name) => {
+            let item = scx.get_item_by_resolved_name(&name)?;
+            let item_type = item.item_type();
+            if item_type != CatalogItemType::View {
+                sql_bail!("Expected {name} to be a view, not a {item_type}");
+            }
+            match is_replan {
+                true => crate::plan::Explainee::ReplanView(item.id()),
+                false => crate::plan::Explainee::View(item.id()),
+            }
         }
         Explainee::MaterializedView(name) | Explainee::ReplanMaterializedView(name) => {
             let item = scx.get_item_by_resolved_name(&name)?;
@@ -439,14 +446,31 @@ fn plan_explainee(
             }
         }
         Explainee::Select(select, broken) => {
-            let copy_to = None;
-            let (plan, desc) = plan_select_inner(scx, *select, params, copy_to)?;
-
+            let (plan, desc) = plan_select_inner(scx, *select, params, None)?;
             if broken {
                 scx.require_feature_flag(&vars::ENABLE_EXPLAIN_BROKEN)?;
             }
-
             crate::plan::Explainee::Statement(ExplaineeStatement::Select { broken, plan, desc })
+        }
+        Explainee::CreateView(mut stmt, broken) => {
+            if stmt.if_exists != IfExistsBehavior::Skip {
+                // If we don't force this parameter to Skip planning will
+                // fail for names that already exist in the catalog. This
+                // can happen even in `Replace` mode if the existing item
+                // has dependencies.
+                stmt.if_exists = IfExistsBehavior::Skip;
+            } else {
+                sql_bail!(
+                    "Cannot EXPLAIN a CREATE VIEW that explictly sets IF NOT EXISTS \
+                     (the behavior is implied within the scope of an enclosing EXPLAIN)"
+                );
+            }
+
+            let Plan::CreateView(plan) = ddl::plan_create_view(scx, *stmt, params)? else {
+                sql_bail!("expected CreateViewPlan plan");
+            };
+
+            crate::plan::Explainee::Statement(ExplaineeStatement::CreateView { broken, plan })
         }
         Explainee::CreateMaterializedView(mut stmt, broken) => {
             if stmt.if_exists != IfExistsBehavior::Skip {

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -767,8 +767,10 @@ fn generate_rbac_requirements(
         })
         | Plan::ExplainPushdown(plan::ExplainPushdownPlan { explainee }) => RbacRequirements {
             privileges: match explainee {
-                Explainee::MaterializedView(id)
+                Explainee::View(id)
+                | Explainee::MaterializedView(id)
                 | Explainee::Index(id)
+                | Explainee::ReplanView(id)
                 | Explainee::ReplanMaterializedView(id)
                 | Explainee::ReplanIndex(id) => {
                     let item = catalog.get_item(id);
@@ -786,8 +788,10 @@ fn generate_rbac_requirements(
                     .collect(),
             },
             item_usage: match explainee {
-                Explainee::MaterializedView(..)
+                Explainee::View(..)
+                | Explainee::MaterializedView(..)
                 | Explainee::Index(..)
+                | Explainee::ReplanView(..)
                 | Explainee::ReplanMaterializedView(..)
                 | Explainee::ReplanIndex(..) => &EMPTY_ITEM_USAGE,
                 Explainee::Statement(_) => &DEFAULT_ITEM_USAGE,

--- a/test/sqllogictest/explain/bad_explain_statements.slt
+++ b/test/sqllogictest/explain/bad_explain_statements.slt
@@ -7,11 +7,5 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-statement ok
-CREATE VIEW v as SELECT (1, 2)
-
-statement error db error: ERROR: EXPLAIN \.\.\. VIEW <view_name> is not supported, for more information consult the documentation at https://materialize\.com/docs/sql/explain\-plan
-EXPLAIN VIEW v
-
-statement error db error: ERROR: a valid `EXPLAIN` option
+statement error db error: ERROR: a valid explain plan option name
 EXPLAIN RAW PLAN WITH (foo, types) AS TEXT FOR SELECT 1


### PR DESCRIPTION
Add parser and planner support for the following `EXPLAIN ... VIEW` statements:
    
- `EXPLAIN CREATE VIEW ...`
- `EXPLAIN REPLAN VIEW ...`
- `EXPLAIN VIEW ...`

### Motivation

  * This PR adds a known-desirable feature.

https://github.com/MaterializeInc/materialize/issues/25273

### Tips for reviewer
    
As part of the changes I:

1. Rename `ExplainStage::{OptimizedPlan ⇒ GlobalPlan}` and `NamedPlan::{Optimized ⇒ Global}`.
1. Introduce new enum variants `ExplainStage::LocalPlan` and `NamedPlan::Local` that correspond to the `optimize/local` stage and teach the parser to support this stage for the variants introduced above.

The implementations will be included in a follow-up PR.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
