### PR TITLE
dbt-materialize: extract await logic from deploy_wait

### DIFF
--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_await.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_await.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro deploy_wait(poll_interval=15) %}
+{% macro deploy_await(poll_interval=15) %}
 {#
   Waits for all objects within the deployment clusters to be fully hydrated,
   polling the cluster's readiness status at a specified interval.

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
@@ -24,7 +24,7 @@
 
   ## Arguments
   - `wait` (boolean, optional): Waits for the deployment to be fully hyrated.
-      Defaults to false. It is recommended you call `deploy_wait` manually and
+      Defaults to false. It is recommended you call `deploy_await` manually and
       run additional validation checks before promoting a deployment to production.
   - `poll_interval` (integer): The interval, in seconds, between each readiness check.
 
@@ -103,7 +103,7 @@
 {% endfor %}
 
 {% if wait %}
-    {{ deploy_wait(poll_interval) }}
+    {{ deploy_await(poll_interval) }}
 {% endif %}
 
 {% call statement('swap', fetch_result=True, auto_begin=False) -%}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_wait.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_wait.sql
@@ -39,14 +39,6 @@
 
 {% for cluster in clusters %}
     {% set deploy_cluster = cluster ~ "_dbt_deploy" %}
-    {% for i in range(1, 100000) %}
-        {% if is_cluster_ready(deploy_cluster) %}
-            {{ return(true) }}
-        {% endif %}
-        -- Hydration takes time. Be a good
-        -- citizen and don't overwhelm mz_introspection
-        {{ adapter.sleep(poll_interval) }}
-    {% endfor %}
-    {{ exceptions.raise_compiler_error("Cluster " ~ deploy_cluster ~ " failed to hydrate within a reasonable amount of time") }}
+    {{ await_cluster_ready(deploy_cluster, poll_interval) }}
 {% endfor %}
 {% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/await_cluster_ready.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/await_cluster_ready.sql
@@ -1,0 +1,27 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{% macro await_cluster_ready(cluster, poll_interval=15) %}
+
+{% for i in range(1, 100000) %}
+    {% if is_cluster_ready(cluster) %}
+        {{ return(true) }}
+    {% endif %}
+    -- Hydration takes time. Be a good
+    -- citizen and don't overwhelm mz_introspection
+    {{ adapter.sleep(poll_interval) }}
+{% endfor %}
+{{ exceptions.raise_compiler_error("Cluster " ~ deploy_cluster ~ " failed to hydrate within a reasonable amount of time") }}
+{% endmacro %}

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -42,6 +42,11 @@ class TestRunWithDeploy:
             "test_view_index.sql": test_view_index,
         }
 
+    @pytest.fixture(autouse=True)
+    def cleanup(self, project):
+        project.run_sql("DROP CLUSTER IF EXISTS quickstart_dbt_deploy CASCADE")
+        project.run_sql("DROP SCHEMA IF EXISTS public_dbt_deploy CASCADE")
+
     def test_deployment_run(self, project):
         # the test runner overrides schemas
         # so we can only validate the cluster
@@ -94,6 +99,11 @@ class TestSourceFail:
             "test_source.sql": test_source,
         }
 
+    @pytest.fixture(autouse=True)
+    def cleanup(self, project):
+        project.run_sql("DROP CLUSTER IF EXISTS quickstart_dbt_deploy CASCADE")
+        project.run_sql("DROP SCHEMA IF EXISTS public_dbt_deploy CASCADE")
+
     def test_source_fails(self, project):
         run_dbt(["run-operation", "deploy_init"])
         run_dbt(["run", "--vars", "deploy: True"], expect_pass=False)
@@ -117,6 +127,11 @@ class TestSinkFail:
             "test_materialized_view.sql": test_materialized_view,
             "test_sink.sql": test_sink,
         }
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self, project):
+        project.run_sql("DROP CLUSTER IF EXISTS quickstart_dbt_deploy CASCADE")
+        project.run_sql("DROP SCHEMA IF EXISTS public_dbt_deploy CASCADE")
 
     def test_source_fails(self, project):
         run_dbt(["run-operation", "deploy_init"])


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Extract the await logic from `deploy_wait` to it's own macro. I also added some test cleanups to remove flakes. 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
