### PR TITLE
webhooks: Bump default limit to 500 concurrent requests

### DIFF
--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -306,7 +306,7 @@ Webhook sources apply the following limits to received requests:
 
 * The maximum size of the request body is **`2MB`**. Requests larger than this
   will fail with `413 Payload Too Large`.
-* The maximum number of concurrent connections is **250**, across all webhook
+* The maximum number of concurrent connections is **500**, across all webhook
   sources. Trying to connect when the server is at the capacity will return
   `429 Too Many Requests`.
 * Requests that contain a header name specified more than once will be rejected

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -124,7 +124,7 @@ macro_rules! sql_err {
 pub const DEFAULT_SCHEMA: &str = "public";
 
 /// The number of concurrent requests we allow at once for webhook sources.
-pub const WEBHOOK_CONCURRENCY_LIMIT: usize = 250;
+pub const WEBHOOK_CONCURRENCY_LIMIT: usize = 500;
 
 pub mod ast;
 pub mod catalog;


### PR DESCRIPTION
This PR increase the default limit for concurrent webhook requests to 500. Note, I'll also make this change via LaunchDarkly so the docs can get updated immediately.

### Motivation

We've made perf improvements since releasing webhooks and this is a reasonable limit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Increases the rate limit at which users can send us webhook requests
