### PR TITLE
timely-util: safe fallible operator API

### DIFF
--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -27,10 +27,10 @@ use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_persist_types::{Codec, Codec64};
 use mz_timely_util::builder_async::{
-    Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+    AsyncCapabilitySet, Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
 use timely::dataflow::channels::pact::Exchange;
-use timely::dataflow::operators::{CapabilitySet, ConnectLoop, Enter, Feedback, Leave};
+use timely::dataflow::operators::{ConnectLoop, Enter, Feedback, Leave};
 use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, Stream};
 use timely::order::TotalOrder;
@@ -240,7 +240,7 @@ where
 
     #[allow(clippy::await_holding_refcell_ref)]
     let shutdown_button = builder.build(move |caps| async move {
-        let mut cap_set = CapabilitySet::from_elem(caps.into_element());
+        let mut cap_set = AsyncCapabilitySet::from_elem(caps.into_element());
 
         // Only one worker is responsible for distributing parts
         if worker_index != chosen_worker {

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -36,7 +36,7 @@ use mz_storage_types::sources::SourceData;
 use mz_storage_types::stats::RelationPartStats;
 use mz_timely_util::buffer::ConsolidateBuffer;
 use mz_timely_util::builder_async::{
-    Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+    AsyncCapabilitySet, Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
 use mz_timely_util::probe::ProbeNotify;
 use serde::{Deserialize, Serialize};
@@ -45,7 +45,7 @@ use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::channels::Bundle;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::{Capability, Leave, OkErr};
-use timely::dataflow::operators::{CapabilitySet, ConnectLoop, Feedback};
+use timely::dataflow::operators::{ConnectLoop, Feedback};
 use timely::dataflow::scopes::Child;
 use timely::dataflow::ScopeParent;
 use timely::dataflow::{Scope, Stream};
@@ -754,7 +754,7 @@ where
     });
     let shutdown_button = builder.build(move |caps| async move {
         // The output capability.
-        let mut cap_set = CapabilitySet::from_elem(caps.into_element());
+        let mut cap_set = AsyncCapabilitySet::from_elem(caps.into_element());
 
         // The frontier of our output. This matches the `CapabilitySet` above.
         let mut output_frontier = Antichain::from_elem(TimelyTimestamp::minimum());

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -96,7 +96,7 @@ use mz_storage_types::sinks::{
 };
 use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{
-    Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+    AsyncCapabilitySet, Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
 use rdkafka::error::KafkaError;
 use rdkafka::message::{Header, OwnedHeaders};
@@ -104,7 +104,7 @@ use rdkafka::metadata::Metadata;
 use rdkafka::producer::{BaseProducer, BaseRecord, Producer};
 use rdkafka::types::RDKafkaErrorCode;
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
-use timely::dataflow::operators::{CapabilitySet, Concatenate, Map, ToStream};
+use timely::dataflow::operators::{Concatenate, Map, ToStream};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp as _};
 use timely::PartialOrder;
@@ -735,7 +735,7 @@ fn encode_collection<G: Scope>(
             // point. This is a temporary workaround of build_fallible's bad interaction of owned
             // capabilities and errors.
             // TODO(petrosagg): Make the fallible async operator safe
-            *capset = CapabilitySet::new();
+            *capset = AsyncCapabilitySet::new();
 
             while let Some(event) = input.next().await {
                 if let Event::Data(cap, rows) = event {

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -30,7 +30,9 @@ use mz_storage_types::errors::ContextCreationError;
 use mz_storage_types::sources::kafka::{KafkaMetadataKind, KafkaSourceConnection, RangeBound};
 use mz_storage_types::sources::{MzOffset, SourceTimestamp};
 use mz_timely_util::antichain::AntichainExt;
-use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
+use mz_timely_util::builder_async::{
+    AsyncCapability, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+};
 use mz_timely_util::order::Partitioned;
 use rdkafka::client::Client;
 use rdkafka::consumer::base_consumer::PartitionQueue;
@@ -40,7 +42,6 @@ use rdkafka::message::{BorrowedMessage, Headers};
 use rdkafka::statistics::Statistics;
 use rdkafka::topic_partition_list::Offset;
 use rdkafka::{ClientContext, Message, TopicPartitionList};
-use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 use timely::progress::Timestamp;
@@ -112,9 +113,9 @@ struct PartialProgressStatistics {
 
 struct PartitionCapability {
     /// The capability of the data produced
-    data: Capability<Partitioned<RangeBound<PartitionId>, MzOffset>>,
+    data: AsyncCapability<Partitioned<RangeBound<PartitionId>, MzOffset>>,
     /// The capability of the progress stream
-    progress: Capability<Partitioned<RangeBound<PartitionId>, MzOffset>>,
+    progress: AsyncCapability<Partitioned<RangeBound<PartitionId>, MzOffset>>,
 }
 
 /// Represents the low and high watermark offsets of a Kafka partition.

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -58,7 +58,7 @@ use std::rc::Rc;
 use differential_dataflow::Collection;
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pushers::TeeCore;
-use timely::dataflow::operators::{CapabilitySet, Concat, Map};
+use timely::dataflow::operators::{Concat, Map};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 use uuid::Uuid;
@@ -73,7 +73,7 @@ use mz_sql_parser::ast::{Ident, UnresolvedItemName};
 use mz_storage_types::errors::SourceErrorDetails;
 use mz_storage_types::sources::mysql::{GtidPartition, GtidState};
 use mz_storage_types::sources::{MySqlSourceConnection, SourceTimestamp};
-use mz_timely_util::builder_async::{AsyncOutputHandle, PressOnDropButton};
+use mz_timely_util::builder_async::{AsyncCapabilitySet, AsyncOutputHandle, PressOnDropButton};
 use mz_timely_util::order::Extrema;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
@@ -281,13 +281,13 @@ async fn return_definite_error(
         Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>,
         TeeCore<GtidPartition, Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>>,
     >,
-    data_cap_set: &CapabilitySet<GtidPartition>,
+    data_cap_set: &AsyncCapabilitySet<GtidPartition>,
     definite_error_handle: &mut AsyncOutputHandle<
         GtidPartition,
         Vec<ReplicationError>,
         TeeCore<GtidPartition, Vec<ReplicationError>>,
     >,
-    definite_error_cap_set: &CapabilitySet<GtidPartition>,
+    definite_error_cap_set: &AsyncCapabilitySet<GtidPartition>,
 ) -> () {
     for output_index in outputs {
         let update = (

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -92,7 +92,7 @@ use futures::TryStreamExt;
 use mysql_async::prelude::Queryable;
 use mysql_async::{IsolationLevel, Row as MySqlRow, TxOpts};
 use mz_timely_util::antichain::AntichainExt;
-use timely::dataflow::operators::{CapabilitySet, Concat, Map};
+use timely::dataflow::operators::{Concat, Map};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp};
 use tracing::{error, trace};
@@ -105,7 +105,9 @@ use mz_sql_parser::ast::UnresolvedItemName;
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_storage_types::sources::mysql::{gtid_set_frontier, GtidPartition};
 use mz_storage_types::sources::MySqlSourceConnection;
-use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
+use mz_timely_util::builder_async::{
+    AsyncCapabilitySet, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+};
 
 use crate::metrics::source::mysql::MySqlSnapshotMetrics;
 use crate::source::types::ProgressStatisticsUpdate;
@@ -397,7 +399,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                     };
                     rewinds_handle.give(&rewind_cap_set[0], req).await;
                 }
-                *rewind_cap_set = CapabilitySet::new();
+                *rewind_cap_set = AsyncCapabilitySet::new();
 
                 // Read the snapshot data from the tables
                 let mut final_row = Row::default();

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -89,8 +89,8 @@ use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_ssh_util::tunnel_manager::SshTunnelManager;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
 use mz_timely_util::builder_async::{
-    AsyncOutputHandle, Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder,
-    PressOnDropButton,
+    AsyncCapability, AsyncOutputHandle, Event as AsyncEvent,
+    OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
 use mz_timely_util::operator::StreamExt as TimelyStreamExt;
 use once_cell::sync::Lazy;
@@ -100,7 +100,6 @@ use postgres_protocol::message::backend::{
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::channels::pushers::TeeCore;
-use timely::dataflow::operators::Capability;
 use timely::dataflow::operators::{Concat, Map};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
@@ -464,7 +463,7 @@ async fn raw_stream<'a>(
         Vec<ProgressStatisticsUpdate>,
         TeeCore<MzOffset, Vec<ProgressStatisticsUpdate>>,
     >,
-    stats_cap: &'a Capability<MzOffset>,
+    stats_cap: &'a AsyncCapability<MzOffset>,
 ) -> Result<
     Result<
         impl AsyncStream<

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -54,14 +54,15 @@ use mz_storage_types::errors::SourceError;
 use mz_storage_types::sources::{SourceConnection, SourceExport, SourceTimestamp};
 use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{
-    Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+    AsyncCapabilitySet, Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder,
+    PressOnDropButton,
 };
 use mz_timely_util::capture::UnboundedTokioCapture;
 use mz_timely_util::operator::StreamExt as _;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::capture::capture::Capture;
 use timely::dataflow::operators::capture::Event;
-use timely::dataflow::operators::{Broadcast, CapabilitySet, Concat, Leave, Partition};
+use timely::dataflow::operators::{Broadcast, Concat, Leave, Partition};
 use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::frontier::MutableAntichain;
@@ -453,7 +454,7 @@ where
             return;
         }
 
-        let mut cap_set = CapabilitySet::from_elem(capabilities.into_element());
+        let mut cap_set = AsyncCapabilitySet::from_elem(capabilities.into_element());
 
         let remap_handle = crate::source::reclock::compat::PersistHandle::<FromTime, _>::new(
             Arc::clone(&persist_clients),
@@ -609,7 +610,7 @@ where
 
     reclock_op.build(move |capabilities| async move {
         // The capability of the output after reclocking the source frontier
-        let mut cap_set = CapabilitySet::from_elem(capabilities.into_element());
+        let mut cap_set = AsyncCapabilitySet::from_elem(capabilities.into_element());
 
         let source_metrics = metrics.get_source_metrics(&name, id, worker_id);
 

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -29,7 +29,7 @@ use timely::{Data, ExchangeData, PartialOrder};
 
 use crate::buffer::ConsolidateBuffer;
 use crate::builder_async::{
-    AsyncInputHandle, AsyncOutputHandle, ConnectedToOne, Disconnected,
+    AsyncCapability, AsyncInputHandle, AsyncOutputHandle, ConnectedToOne, Disconnected,
     OperatorBuilder as OperatorBuilderAsync,
 };
 
@@ -77,7 +77,7 @@ where
     where
         D2: Data,
         B: FnOnce(
-            Capability<G::Timestamp>,
+            AsyncCapability<G::Timestamp>,
             OperatorInfo,
             AsyncInputHandle<G::Timestamp, Vec<D1>, ConnectedToOne>,
             AsyncOutputHandle<G::Timestamp, Vec<D2>, Tee<G::Timestamp, D2>>,
@@ -100,7 +100,7 @@ where
         D2: Data,
         D3: Data,
         B: FnOnce(
-            Capability<G::Timestamp>,
+            AsyncCapability<G::Timestamp>,
             OperatorInfo,
             AsyncInputHandle<G::Timestamp, Vec<D1>, ConnectedToOne>,
             AsyncInputHandle<G::Timestamp, Vec<D2>, ConnectedToOne>,
@@ -297,7 +297,7 @@ where
     where
         D2: Data,
         B: FnOnce(
-            Capability<G::Timestamp>,
+            AsyncCapability<G::Timestamp>,
             OperatorInfo,
             AsyncInputHandle<G::Timestamp, Vec<D1>, ConnectedToOne>,
             AsyncOutputHandle<G::Timestamp, Vec<D2>, Tee<G::Timestamp, D2>>,
@@ -332,7 +332,7 @@ where
         D2: Data,
         D3: Data,
         B: FnOnce(
-            Capability<G::Timestamp>,
+            AsyncCapability<G::Timestamp>,
             OperatorInfo,
             AsyncInputHandle<G::Timestamp, Vec<D1>, ConnectedToOne>,
             AsyncInputHandle<G::Timestamp, Vec<D2>, ConnectedToOne>,
@@ -617,7 +617,7 @@ pub fn source_async<G: Scope, D, B, BFut>(scope: &G, name: String, constructor: 
 where
     D: Data,
     B: FnOnce(
-        Capability<G::Timestamp>,
+        AsyncCapability<G::Timestamp>,
         OperatorInfo,
         AsyncOutputHandle<G::Timestamp, Vec<D>, Tee<G::Timestamp, D>>,
     ) -> BFut,

--- a/src/timely-util/src/probe.rs
+++ b/src/timely-util/src/probe.rs
@@ -17,14 +17,14 @@ use std::cell::RefCell;
 use std::convert::Infallible;
 use std::rc::Rc;
 
-use timely::dataflow::operators::{CapabilitySet, InspectCore};
+use timely::dataflow::operators::InspectCore;
 use timely::dataflow::{Scope, Stream, StreamCore};
 use timely::progress::frontier::{Antichain, AntichainRef, MutableAntichain};
 use timely::progress::Timestamp;
 use timely::{Container, PartialOrder};
 use tokio::sync::Notify;
 
-use crate::builder_async::OperatorBuilder as AsyncOperatorBuilder;
+use crate::builder_async::{AsyncCapabilitySet, OperatorBuilder as AsyncOperatorBuilder};
 
 /// Monitors progress at a `Stream`.
 pub trait ProbeNotify<G: Scope> {
@@ -166,7 +166,7 @@ where
     let (_output, output_stream) = builder.new_output();
 
     builder.build(move |capabilities| async move {
-        let mut cap_set = CapabilitySet::from(capabilities);
+        let mut cap_set = AsyncCapabilitySet::from(capabilities);
         let mut frontier = Antichain::from_elem(T::minimum());
 
         let mut downgrade_capability = |f: AntichainRef<T>| {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
