### PR TITLE
Port frontegg-mock to axum, and implement features needed for kind tests in the cloud repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4530,6 +4530,7 @@ name = "mz-frontegg-mock"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "axum",
  "clap",
  "hyper",
  "jsonwebtoken",

--- a/misc/python/materialize/cloudtest/util/jwt_key.py
+++ b/misc/python/materialize/cloudtest/util/jwt_key.py
@@ -7,70 +7,20 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-import datetime
 import logging
-import uuid
 from textwrap import dedent
 
-import jwt
 import requests
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 
 from materialize.cloudtest.util.common import retry
 
 LOGGER = logging.getLogger(__name__)
 
 
-def _generate_jwt_keys() -> tuple[rsa.RSAPrivateKey, bytes]:
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    public_key = private_key.public_key()
-    public_key_bytes = public_key.public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-    return private_key, public_key_bytes
-
-
-JWK_PRIVATE_KEY, JWK_PUBLIC_KEY = _generate_jwt_keys()
-
-
-def make_jwt(tenant_id: str) -> str:
-    """
-    Build a JWT to authenticate to the environment controller. (This must be
-    done dynamically in the test so that the token has a valid, recent
-    timestamp).
-
-    NOTE that the following constraints are assumed:
-    - `email` must end with `materialize[dot]com`
-    - `roles` must include `MaterializeAdmin`
-    - `iss` must match the environment controller's `FRONTEGG_URL` variable
-    """
-    # JWTs expect UNIX timestamps
-    now = int(datetime.datetime.now().timestamp())
-    payload = {
-        "sub": str(uuid.uuid4()),
-        "email": "test@materialize.com",
-        "roles": [
-            "MaterializeAdmin",
-        ],
-        "permissions": [
-            "materialize.environment.read",
-            "materialize.environment.write",
-        ],
-        "tenantId": tenant_id,
-        "iss": "https://admin.cloud.materialize.com",
-        "iat": now,
-        "exp": now + 3600,
-    }
-    tok: str = jwt.encode(payload, JWK_PRIVATE_KEY, algorithm="RS256")
-    return tok
-
-
-def fetch_jwt(email: str, password: str, host: str) -> str:
+def fetch_jwt(email: str, password: str, host: str, scheme: str) -> str:
     def fetch():
         res = requests.post(
-            f"https://{host}/frontegg/identity/resources/auth/v1/user",
+            f"{scheme}://{host}/identity/resources/auth/v1/user",
             json={"email": email, "password": password},
             timeout=10,
         )

--- a/misc/python/materialize/mzcompose/services/frontegg.py
+++ b/misc/python/materialize/mzcompose/services/frontegg.py
@@ -18,11 +18,12 @@ from materialize.ui import UIError
 class FronteggMock(Service):
     def __init__(
         self,
-        tenant_id: str,
         users: str,
-        roles: str,
+        issuer: str,
         encoding_key: str | None = None,
         encoding_key_file: str | None = None,
+        decoding_key: str | None = None,
+        decoding_key_file: str | None = None,
         name: str = "frontegg-mock",
         mzbuild: str = "frontegg-mock",
         volumes: list[str] = [],
@@ -30,12 +31,10 @@ class FronteggMock(Service):
     ) -> None:
         command = [
             "--listen-addr=0.0.0.0:6880",
-            "--tenant-id",
-            tenant_id,
             "--users",
             users,
-            "--roles",
-            roles,
+            "--issuer",
+            issuer,
         ]
         if encoding_key:
             command += ["--encoding-key", encoding_key]
@@ -43,6 +42,13 @@ class FronteggMock(Service):
             command += ["--encoding-key-file", encoding_key_file]
         else:
             raise UIError("FronteggMock service must specify encoding-key[-file]")
+
+        if decoding_key:
+            command += ["--decoding-key", decoding_key]
+        elif decoding_key_file:
+            command += ["--decoding-key-file", decoding_key_file]
+        else:
+            raise UIError("FronteggMock service must specify decoding-key[-file]")
 
         depends_graph: dict[str, ServiceDependency] = {
             s: {"condition": "service_started"} for s in depends_on

--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -527,6 +527,7 @@ fn continuously_refresh(
 pub struct Claims {
     pub exp: i64,
     pub email: String,
+    pub iss: String,
     pub sub: Uuid,
     pub user_id: Option<Uuid>,
     pub tenant_id: Uuid,

--- a/src/frontegg-mock/Cargo.toml
+++ b/src/frontegg-mock/Cargo.toml
@@ -11,11 +11,12 @@ workspace = true
 
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
+axum = { version = "0.6.20", features = ["headers"] }
 clap = { version = "3.2.24", features = ["derive", "env"] }
 hyper = { version = "0.14.23", features = ["http1", "server"] }
 jsonwebtoken = "9.2.0"
 mz-frontegg-auth = { path = "../frontegg-auth" }
-mz-ore = { path = "../ore", default-features = false }
+mz-ore = { path = "../ore", default-features = false, features = ["cli"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 tokio = { version = "1.24.2", default-features = false }

--- a/src/frontegg-mock/src/lib.rs
+++ b/src/frontegg-mock/src/lib.rs
@@ -9,24 +9,37 @@
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::convert::Infallible;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{body, Body, Request, Response, Server as HyperServer};
-use jsonwebtoken::EncodingKey;
-use mz_frontegg_auth::{ApiTokenArgs, ApiTokenResponse, Claims, RefreshToken, REFRESH_SUFFIX};
+use axum::extract::State;
+use axum::headers::authorization::Bearer;
+use axum::headers::Authorization;
+use axum::http::{Request, StatusCode};
+use axum::middleware;
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router, TypedHeader};
+use jsonwebtoken::{DecodingKey, EncodingKey, TokenData};
+use mz_frontegg_auth::{ApiTokenResponse, Claims};
 use mz_ore::now::NowFn;
 use mz_ore::retry::Retry;
 use mz_ore::task::JoinHandle;
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use uuid::Uuid;
 
+const AUTH_API_TOKEN_PATH: &str = "/identity/resources/auth/v1/api-token";
+const AUTH_USER_PATH: &str = "/identity/resources/auth/v1/user";
+const AUTH_API_TOKEN_REFRESH_PATH: &str = "/identity/resources/auth/v1/api-token/token/refresh";
+const USERS_ME_PATH: &str = "/identity/resources/users/v2/me";
+const USERS_API_TOKENS_PATH: &str = "/identity/resources/users/api-tokens/v1";
+
 pub struct FronteggMockServer {
-    pub url: String,
+    pub base_url: String,
     pub refreshes: Arc<Mutex<u64>>,
     pub enable_refresh: Arc<AtomicBool>,
     pub auth_requests: Arc<Mutex<u64>>,
@@ -36,139 +49,81 @@ pub struct FronteggMockServer {
 
 impl FronteggMockServer {
     /// Starts a [`FronteggMockServer`], must be started from within a [`tokio::runtime::Runtime`].
-    ///
-    /// Users is a mapping from (client, secret) -> email address.
     pub fn start(
         addr: Option<&SocketAddr>,
+        issuer: String,
         encoding_key: EncodingKey,
-        tenant_id: Uuid,
-        users: BTreeMap<(String, String), String>,
-        roles: BTreeMap<String, Vec<String>>,
+        decoding_key: DecodingKey,
+        users: BTreeMap<String, UserConfig>,
         now: NowFn,
         expires_in_secs: i64,
         latency: Option<Duration>,
     ) -> Result<FronteggMockServer, anyhow::Error> {
         let (role_updates_tx, role_updates_rx) = unbounded_channel();
+
         let refreshes = Arc::new(Mutex::new(0u64));
         let enable_refresh = Arc::new(AtomicBool::new(true));
         let auth_requests = Arc::new(Mutex::new(0u64));
-        let context = Context {
+
+        let user_api_tokens: BTreeMap<UserApiToken, String> = users
+            .iter()
+            .map(|(email, user)| {
+                user.initial_api_tokens
+                    .iter()
+                    .map(|token| (token.clone(), email.clone()))
+            })
+            .flatten()
+            .collect();
+
+        let context = Arc::new(Context {
+            issuer,
             encoding_key,
-            tenant_id,
-            users,
-            roles,
-            role_updates_rx: Arc::new(Mutex::new(role_updates_rx)),
+            decoding_key,
+            users: Mutex::new(users),
+            user_api_tokens: Mutex::new(user_api_tokens),
+            role_updates_rx: Mutex::new(role_updates_rx),
             now,
             expires_in_secs,
             latency,
-            refresh_tokens: Arc::new(Mutex::new(BTreeMap::new())),
+            refresh_tokens: Mutex::new(BTreeMap::new()),
             refreshes: Arc::clone(&refreshes),
             enable_refresh: Arc::clone(&enable_refresh),
             auth_requests: Arc::clone(&auth_requests),
-        };
-
-        let service = make_service_fn(move |_conn| {
-            let mut context = context.clone();
-            let service = service_fn(move |req| {
-                while let Ok((email, roles)) = context.role_updates_rx.lock().unwrap().try_recv() {
-                    context.roles.insert(email, roles);
-                }
-                Self::handle(context.clone(), req)
-            });
-            async move { Ok::<_, Infallible>(service) }
         });
+
+        let router = Router::new()
+            .route(AUTH_API_TOKEN_PATH, post(handle_post_auth_api_token))
+            .route(AUTH_USER_PATH, post(handle_post_auth_user))
+            .route(AUTH_API_TOKEN_REFRESH_PATH, post(handle_post_token_refresh))
+            .route(USERS_ME_PATH, get(handle_get_user_profile))
+            .route(USERS_API_TOKENS_PATH, post(handle_post_user_api_token))
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&context),
+                latency_middleware,
+            ))
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&context),
+                role_update_middleware,
+            ))
+            .with_state(context);
+
         let addr = match addr {
             Some(addr) => Cow::Borrowed(addr),
             None => Cow::Owned(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)),
         };
-        let server = HyperServer::bind(&addr).serve(service);
-        let url = format!("http://{}/", server.local_addr());
+        let server = axum::Server::bind(&addr)
+            .serve(router.into_make_service_with_connect_info::<SocketAddr>());
+        let base_url = format!("http://{}", server.local_addr());
         let handle = mz_ore::task::spawn(|| "mzcloud-mock-server", server);
 
         Ok(FronteggMockServer {
-            url,
+            base_url,
             refreshes,
             enable_refresh,
             auth_requests,
             role_updates_tx,
             handle,
         })
-    }
-
-    async fn handle(context: Context, req: Request<Body>) -> Result<Response<Body>, Infallible> {
-        // In some cases we want to add latency to test de-duplicating results.
-        if let Some(latency) = context.latency {
-            tokio::time::sleep(latency).await;
-        }
-
-        let (parts, body) = req.into_parts();
-        let body = body::to_bytes(body).await.unwrap();
-        let email: String = if parts.uri.path().ends_with(REFRESH_SUFFIX) {
-            // Always count refresh attempts, even if enable_refresh is false.
-            *context.refreshes.lock().unwrap() += 1;
-            let args: RefreshToken = serde_json::from_slice(&body).unwrap();
-            match (
-                context
-                    .refresh_tokens
-                    .lock()
-                    .unwrap()
-                    .remove(args.refresh_token),
-                context.enable_refresh.load(Ordering::Relaxed),
-            ) {
-                (Some(email), true) => email.to_string(),
-                _ => {
-                    return Ok(Response::builder()
-                        .status(400)
-                        .body(Body::from("unknown refresh token"))
-                        .unwrap())
-                }
-            }
-        } else {
-            *context.auth_requests.lock().unwrap() += 1;
-            let args: ApiTokenArgs = serde_json::from_slice(&body).unwrap();
-            match context
-                .users
-                .get(&(args.client_id.to_string(), args.secret.to_string()))
-            {
-                Some(email) => email.to_string(),
-                None => {
-                    return Ok(Response::builder()
-                        .status(400)
-                        .body(Body::from("unknown user"))
-                        .unwrap())
-                }
-            }
-        };
-        let roles = context.roles.get(&email).cloned().unwrap_or_default();
-        let refresh_token = Uuid::new_v4().to_string();
-        context
-            .refresh_tokens
-            .lock()
-            .unwrap()
-            .insert(refresh_token.clone(), email.clone());
-        let access_token = jsonwebtoken::encode(
-            &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
-            &Claims {
-                exp: context.now.as_secs() + context.expires_in_secs,
-                email,
-                sub: Uuid::new_v4(),
-                user_id: None,
-                tenant_id: context.tenant_id,
-                roles,
-                permissions: Vec::new(),
-            },
-            &context.encoding_key,
-        )
-        .unwrap();
-        let resp = ApiTokenResponse {
-            expires: "".to_string(),
-            expires_in: context.expires_in_secs,
-            access_token,
-            refresh_token,
-        };
-        Ok(Response::new(Body::from(
-            serde_json::to_vec(&resp).unwrap(),
-        )))
     }
 
     pub fn wait_for_refresh(&self, expires_in_secs: u64) {
@@ -189,20 +144,259 @@ impl FronteggMockServer {
             })
             .unwrap();
     }
+
+    pub fn auth_api_token_url(&self) -> String {
+        format!("{}{}", &self.base_url, AUTH_API_TOKEN_PATH)
+    }
 }
 
-#[derive(Clone)]
-struct Context {
-    encoding_key: EncodingKey,
+fn decode_access_token(
+    context: &Context,
+    token: &str,
+) -> Result<TokenData<Claims>, jsonwebtoken::errors::Error> {
+    jsonwebtoken::decode(
+        token,
+        &context.decoding_key,
+        &jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256),
+    )
+}
+
+fn generate_access_token(
+    context: &Context,
+    email: String,
     tenant_id: Uuid,
-    users: BTreeMap<(String, String), String>,
-    roles: BTreeMap<String, Vec<String>>,
-    role_updates_rx: Arc<Mutex<UnboundedReceiver<(String, Vec<String>)>>>,
+    roles: Vec<String>,
+) -> String {
+    let mut permissions = Vec::new();
+    if roles
+        .iter()
+        .any(|r| r.as_str() == "MaterializePlatformAdmin")
+    {
+        permissions.push("materialize.environment.write".to_owned());
+        permissions.push("materialize.invoice.read".to_owned());
+    }
+    if roles.iter().any(|r| r.as_str() == "MaterializePlatform") {
+        permissions.push("materialize.environment.read".to_owned());
+    }
+    jsonwebtoken::encode(
+        &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
+        &Claims {
+            exp: context.now.as_secs() + context.expires_in_secs,
+            email,
+            iss: context.issuer.clone(),
+            sub: Uuid::new_v4(),
+            user_id: None,
+            tenant_id,
+            roles,
+            permissions,
+        },
+        &context.encoding_key,
+    )
+    .unwrap()
+}
+
+fn generate_refresh_token(context: &Context, email: String) -> String {
+    let refresh_token = Uuid::new_v4().to_string();
+    context
+        .refresh_tokens
+        .lock()
+        .unwrap()
+        .insert(refresh_token.clone(), email);
+    refresh_token
+}
+
+async fn latency_middleware<B>(
+    State(context): State<Arc<Context>>,
+    request: Request<B>,
+    next: Next<B>,
+) -> impl IntoResponse {
+    // In some cases we want to add latency to test de-duplicating results.
+    if let Some(latency) = context.latency {
+        tokio::time::sleep(latency).await;
+    }
+    next.run(request).await
+}
+
+async fn role_update_middleware<B>(
+    State(context): State<Arc<Context>>,
+    request: Request<B>,
+    next: Next<B>,
+) -> impl IntoResponse {
+    {
+        let mut role_updates_rx = context.role_updates_rx.lock().unwrap();
+        while let Ok((email, roles)) = role_updates_rx.try_recv() {
+            let mut users = context.users.lock().unwrap();
+            users.get_mut(&email).unwrap().roles = roles;
+        }
+    }
+    next.run(request).await
+}
+
+async fn handle_post_auth_api_token(
+    State(context): State<Arc<Context>>,
+    Json(request): Json<UserApiToken>,
+) -> Result<Json<ApiTokenResponse>, StatusCode> {
+    *context.auth_requests.lock().unwrap() += 1;
+    let user_api_tokens = context.user_api_tokens.lock().unwrap();
+    let (email, user) = match user_api_tokens.get(&request) {
+        Some(email) => {
+            let users = context.users.lock().unwrap();
+            let user = users
+                .get(email)
+                .expect("API tokens are only created by logged in valid users.");
+            (email, user.to_owned())
+        }
+        None => return Err(StatusCode::UNAUTHORIZED),
+    };
+    let refresh_token = generate_refresh_token(&context, email.clone());
+    let access_token = generate_access_token(
+        &context,
+        email.to_owned(),
+        user.tenant_id,
+        user.roles.clone(),
+    );
+    Ok(Json(ApiTokenResponse {
+        expires: "".to_string(),
+        expires_in: context.expires_in_secs,
+        access_token,
+        refresh_token,
+    }))
+}
+
+async fn handle_post_auth_user(
+    State(context): State<Arc<Context>>,
+    Json(request): Json<AuthUserRequest>,
+) -> Result<Json<ApiTokenResponse>, StatusCode> {
+    *context.auth_requests.lock().unwrap() += 1;
+    let users = context.users.lock().unwrap();
+    let user = match users.get(&request.email) {
+        Some(user) if request.password == user.password => user.to_owned(),
+        _ => return Err(StatusCode::UNAUTHORIZED),
+    };
+    let refresh_token = generate_refresh_token(&context, request.email.clone());
+    let access_token =
+        generate_access_token(&context, request.email, user.tenant_id, user.roles.clone());
+    Ok(Json(ApiTokenResponse {
+        expires: "".to_string(),
+        expires_in: context.expires_in_secs,
+        access_token,
+        refresh_token,
+    }))
+}
+
+async fn handle_post_token_refresh(
+    State(context): State<Arc<Context>>,
+    Json(previous_refresh_token): Json<RefreshTokenRequest>,
+) -> Result<Json<ApiTokenResponse>, StatusCode> {
+    // Always count refresh attempts, even if enable_refresh is false.
+    *context.refreshes.lock().unwrap() += 1;
+    let email = match (
+        context
+            .refresh_tokens
+            .lock()
+            .unwrap()
+            .remove(&previous_refresh_token.refresh_token),
+        context.enable_refresh.load(Ordering::Relaxed),
+    ) {
+        (Some(email), true) => email.to_string(),
+        _ => return Err(StatusCode::UNAUTHORIZED),
+    };
+    let users = context.users.lock().unwrap();
+    let user = match users.get(&email) {
+        Some(user) => user.to_owned(),
+        None => return Err(StatusCode::UNAUTHORIZED),
+    };
+    let refresh_token = generate_refresh_token(&context, email.clone());
+    let access_token = generate_access_token(&context, email, user.tenant_id, user.roles.clone());
+    Ok(Json(ApiTokenResponse {
+        expires: "".to_string(),
+        expires_in: context.expires_in_secs,
+        access_token,
+        refresh_token,
+    }))
+}
+
+// https://docs.frontegg.com/reference/userscontrollerv2_getuserprofile
+async fn handle_get_user_profile<'a>(
+    State(context): State<Arc<Context>>,
+    TypedHeader(authorization): TypedHeader<Authorization<Bearer>>,
+) -> Result<Json<UserProfileResponse>, StatusCode> {
+    let claims: Claims = match decode_access_token(&context, authorization.token()) {
+        Ok(TokenData { claims, .. }) => claims,
+        Err(_) => return Err(StatusCode::UNAUTHORIZED),
+    };
+    Ok(Json(UserProfileResponse {
+        tenant_id: claims.tenant_id,
+    }))
+}
+
+// https://docs.frontegg.com/reference/userapitokensv1controller_createtenantapitoken
+async fn handle_post_user_api_token<'a>(
+    State(context): State<Arc<Context>>,
+    TypedHeader(authorization): TypedHeader<Authorization<Bearer>>,
+) -> Result<Json<UserApiToken>, StatusCode> {
+    let claims: Claims = match decode_access_token(&context, authorization.token()) {
+        Ok(TokenData { claims, .. }) => claims,
+        Err(_) => return Err(StatusCode::UNAUTHORIZED),
+    };
+    let mut tokens = context.user_api_tokens.lock().unwrap();
+    let new_token = UserApiToken {
+        client_id: Uuid::new_v4(),
+        secret: Uuid::new_v4(),
+    };
+    tokens.insert(new_token.clone(), claims.email);
+    Ok(Json(new_token))
+}
+
+#[derive(Deserialize)]
+struct AuthUserRequest {
+    email: String,
+    password: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshTokenRequest {
+    refresh_token: String,
+}
+
+// We only use this for the tenant ID, so ignoring all other fields,
+// even required ones.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct UserProfileResponse {
+    tenant_id: Uuid,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub struct UserApiToken {
+    #[serde(alias = "client_id")]
+    pub client_id: Uuid,
+    pub secret: Uuid,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct UserConfig {
+    pub email: String,
+    pub password: String,
+    pub tenant_id: Uuid,
+    pub initial_api_tokens: Vec<UserApiToken>,
+    pub roles: Vec<String>,
+}
+
+struct Context {
+    issuer: String,
+    encoding_key: EncodingKey,
+    decoding_key: DecodingKey,
+    users: Mutex<BTreeMap<String, UserConfig>>,
+    user_api_tokens: Mutex<BTreeMap<UserApiToken, String>>,
+    role_updates_rx: Mutex<UnboundedReceiver<(String, Vec<String>)>>,
     now: NowFn,
     expires_in_secs: i64,
     latency: Option<Duration>,
     // Uuid -> email
-    refresh_tokens: Arc<Mutex<BTreeMap<String, String>>>,
+    refresh_tokens: Mutex<BTreeMap<String, String>>,
     refreshes: Arc<Mutex<u64>>,
     enable_refresh: Arc<AtomicBool>,
     auth_requests: Arc<Mutex<u64>>,

--- a/src/frontegg-mock/src/main.rs
+++ b/src/frontegg-mock/src/main.rs
@@ -16,13 +16,11 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use anyhow::Context;
-use jsonwebtoken::EncodingKey;
-use mz_frontegg_mock::FronteggMockServer;
+use jsonwebtoken::{DecodingKey, EncodingKey};
+use mz_frontegg_mock::{FronteggMockServer, UserConfig};
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::error::ErrorExt;
 use mz_ore::now::SYSTEM_TIME;
-use serde::Deserialize;
-use uuid::Uuid;
 
 #[derive(Debug, clap::Parser)]
 #[clap(about = "Frontegg mock server", long_about = None)]
@@ -30,21 +28,25 @@ struct Args {
     /// Listen address for the server; supports DNS names.
     #[clap(long, value_name = "HOST:PORT")]
     listen_addr: String,
+    /// Issuer to include in generated JWTs.
+    #[clap(long)]
+    issuer: String,
     /// RSA private key in PEM format for JWT encoding.
     #[clap(long)]
     encoding_key: Option<String>,
     /// File path for RSA private key in PEM format for JWT encoding.
     #[clap(long)]
     encoding_key_file: Option<PathBuf>,
+    /// RSA public key in PEM format for JWT decoding.
     #[clap(long)]
-    /// Tenant id.
-    tenant_id: Uuid,
+    decoding_key: Option<String>,
+    /// File path for RSA public key in PEM format for JWT decoding.
     #[clap(long)]
-    /// Users and their client ids and passwords. JSON of the form: `{"u1": {"client": "client_id", "password": "password"}, "u2": {..}}`
+    decoding_key_file: Option<PathBuf>,
+    /// User information.
+    /// JSON of the form: `[{"email": "...", "password": "...", "tenant_id": "...", initial_api_tokens: [{"client_id": "...", "secret": "..."}], "roles": ["role1", "role2"]}]`
+    #[clap(long)]
     users: String,
-    /// Roles to which users belong. JSON of the form: `{"u1": ["role1", "role2"], "u2": [..]}`
-    #[clap(long)]
-    roles: String,
 }
 
 #[tokio::main]
@@ -74,33 +76,35 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         }
         _ => anyhow::bail!("exactly one of --encoding-key or --encoding-key-file expected"),
     };
-    let users: BTreeMap<String, User> =
-        serde_json::from_str(&args.users).with_context(|| "decoding --users")?;
-    let users: BTreeMap<(String, String), String> = users
+    let decoding_key = match (args.decoding_key, args.decoding_key_file) {
+        (None, Some(path)) => {
+            let key = std::fs::read(path)?;
+            DecodingKey::from_rsa_pem(&key).with_context(|| "decoding --decoding-key-file")?
+        }
+        (Some(key), None) => {
+            DecodingKey::from_rsa_pem(key.as_bytes()).with_context(|| "decoding --decoding-key")?
+        }
+        _ => anyhow::bail!("exactly one of --decoding-key or --decoding-key-file expected"),
+    };
+    let users: BTreeMap<String, UserConfig> = serde_json::from_str::<Vec<UserConfig>>(&args.users)
+        .with_context(|| "decoding --users")?
         .into_iter()
-        .map(|(name, u)| ((u.client, u.password), name))
+        .map(|user| (user.email.clone(), user))
         .collect();
-    let roles = serde_json::from_str(&args.roles).with_context(|| "decoding --roles")?;
     let server = FronteggMockServer::start(
         Some(&addr),
+        args.issuer,
         encoding_key,
-        args.tenant_id,
+        decoding_key,
         users,
-        roles,
         SYSTEM_TIME.clone(),
         500,
         None,
     )?;
 
     println!("frontegg-mock listening...");
-    println!(" HTTP address: {}", server.url);
+    println!(" HTTP address: {}", server.base_url);
 
     server.handle.await??;
     anyhow::bail!("serving tasks unexpectedly exited");
-}
-
-#[derive(Deserialize)]
-struct User {
-    client: String,
-    password: String,
 }


### PR DESCRIPTION
* Ports frontegg-mock to axum.
* Adds support for more frontegg endpoints, which are used by the cloud repo's tests.
* Adds support for verifying TLS against a different hostname, which will be used in the cloud repo tests.
* Improves consistency between Kind and non-Kind configurations.

### Motivation


  * This PR adds a known-desirable feature.
Pre-requisites for tests in the cloud repo.
https://github.com/MaterializeInc/cloud/issues/7522

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  Not a release blocker, but is required for the tests in https://github.com/MaterializeInc/cloud/pull/8824
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - no user-facing behavior changes.
