### PR TITLE
tests: sqlsmith: add ignore for NaN timestamp

### DIFF
--- a/misc/python/materialize/sqlsmith.py
+++ b/misc/python/materialize/sqlsmith.py
@@ -130,4 +130,5 @@ known_errors = [
     "aggregate functions are not allowed in LIMIT",
     "nested aggregate functions are not allowed",
     "function map_build(text list) does not exist",
+    "timestamp cannot be NaN",
 ]


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/6630#018ded1f-b19b-4996-a09f-9603a652c86c.

Reduced to
```
materialize=> SELECT pg_catalog.to_timestamp('NaN'::float8);
ERROR:  timestamp cannot be NaN
```

Same behavior in Postgres:
```
postgres=# SELECT pg_catalog.to_timestamp('NaN'::float8);
ERROR:  timestamp cannot be NaN
```