### PR TITLE
tests: testdrive in cloudtests: capture output for error extraction

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/api/k8s_resource.py
+++ b/misc/python/materialize/cloudtest/k8s/api/k8s_resource.py
@@ -38,7 +38,9 @@ class K8sResource:
         ]
 
         if suppress_command_error_output:
-            subprocess.run(cmd, text=True, input=input, check=True)
+            subprocess.run(
+                cmd, text=True, input=input, check=True, capture_output=capture_output
+            )
         else:
             run_process_with_error_information(
                 cmd, input, capture_output=capture_output

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -166,7 +166,16 @@ class TestdrivePod(K8sPod, TestdriveBase):
                 print(e.stdout, end="")
             if e.stderr is not None:
                 print(e.stderr, file=sys.stderr, end="")
-            error_chunks = extract_error_chunks_from_output(e.stderr or e.stdout)
+
+            output = e.stderr or e.stdout
+            if output is None and suppress_command_error_output:
+                output = "(not captured)"
+
+            assert (
+                output is not None
+            ), f"Missing stdout and stderr when running '{e.cmd}' without success"
+
+            error_chunks = extract_error_chunks_from_output(output)
             error_text = "\n".join(error_chunks)
             raise CommandFailureCausedUIError(
                 f"Running {' '.join(command)} in testdrive failed with:\n{error_text}",

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -157,6 +157,8 @@ class TestdrivePod(K8sPod, TestdriveBase):
                 "--",
                 *command,
                 input=input,
+                # needed to extract errors
+                capture_output=True,
                 suppress_command_error_output=suppress_command_error_output,
             )
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/6627#018debd5-c1bd-4a12-8bac-19cc5efa7368:

```
Traceback (most recent call last):
  File "/var/lib/buildkite-agent/builds/buildkite-aarch64-b9f4a11-i-0a856e4a363f16ab9-1/materialize/nightlies/test/cloudtest/test_full_testdrive.py", line 29, in test_full_testdrive
    mz.testdrive.run(f"testdrive/{file_pattern}")
  File "/var/lib/buildkite-agent/builds/buildkite-aarch64-b9f4a11-i-0a856e4a363f16ab9-1/materialize/nightlies/misc/python/materialize/cloudtest/k8s/testdrive.py", line 82, in run
    self._run_internal(
  File "/var/lib/buildkite-agent/builds/buildkite-aarch64-b9f4a11-i-0a856e4a363f16ab9-1/materialize/nightlies/misc/python/materialize/cloudtest/k8s/testdrive.py", line 167, in _run_internal
    error_chunks = extract_error_chunks_from_output(e.stderr or e.stdout)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/buildkite-agent/builds/buildkite-aarch64-b9f4a11-i-0a856e4a363f16ab9-1/materialize/nightlies/misc/python/materialize/mzcompose/test_result.py", line 122, in extract_error_chunks_from_output
    if "+++ !!! Error Report" not in output:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```