### PR TITLE
 cloudtests: enable MySql tests in upgrade test 

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -257,7 +257,7 @@ steps:
         label: Full Testdrive in Cloudtest (K8s)
         timeout_in_minutes: 300
         agents:
-          queue: linux-aarch64
+          queue: linux-aarch64-large
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~

--- a/misc/python/materialize/cloudtest/app/materialize_application.py
+++ b/misc/python/materialize/cloudtest/app/materialize_application.py
@@ -27,6 +27,7 @@ from materialize.cloudtest.k8s.environmentd import (
     MaterializedAliasService,
 )
 from materialize.cloudtest.k8s.minio import Minio
+from materialize.cloudtest.k8s.mysql import mysql_resources
 from materialize.cloudtest.k8s.persist_pubsub import PersistPubSubService
 from materialize.cloudtest.k8s.postgres import postgres_resources
 from materialize.cloudtest.k8s.redpanda import redpanda_resources
@@ -70,6 +71,7 @@ class MaterializeApplication(CloudtestApplicationBase):
         return [
             *cockroach_resources(apply_node_selectors=self.apply_node_selectors),
             *postgres_resources(apply_node_selectors=self.apply_node_selectors),
+            *mysql_resources(apply_node_selectors=self.apply_node_selectors),
             *redpanda_resources(apply_node_selectors=self.apply_node_selectors),
             *debezium_resources(apply_node_selectors=self.apply_node_selectors),
             *ssh_resources(apply_node_selectors=self.apply_node_selectors),

--- a/misc/python/materialize/cloudtest/k8s/api/k8s_resource.py
+++ b/misc/python/materialize/cloudtest/k8s/api/k8s_resource.py
@@ -71,10 +71,18 @@ class K8sResource:
         assert False
 
     def image(
-        self, service: str, tag: str | None = None, release_mode: bool = True
+        self,
+        service: str,
+        tag: str | None = None,
+        release_mode: bool = True,
+        org: str | None = "materialize",
     ) -> str:
         if tag is not None:
-            return f"materialize/{service}:{tag}"
+            image_name = f"{service}:{tag}"
+            if org is not None:
+                image_name = f"{org}/{image_name}"
+
+            return image_name
         else:
             coverage = ui.env_is_truthy("CI_COVERAGE_ENABLED")
             repo = mzbuild.Repository(

--- a/misc/python/materialize/cloudtest/k8s/mysql.py
+++ b/misc/python/materialize/cloudtest/k8s/mysql.py
@@ -1,0 +1,103 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from kubernetes.client import (
+    V1Container,
+    V1ContainerPort,
+    V1Deployment,
+    V1DeploymentSpec,
+    V1EnvVar,
+    V1LabelSelector,
+    V1ObjectMeta,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1Service,
+    V1ServicePort,
+    V1ServiceSpec,
+)
+
+from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
+from materialize.cloudtest.k8s.api.k8s_deployment import K8sDeployment
+from materialize.cloudtest.k8s.api.k8s_resource import K8sResource
+from materialize.cloudtest.k8s.api.k8s_service import K8sService
+
+
+class MySqlService(K8sService):
+    def __init__(
+        self,
+        namespace: str,
+    ) -> None:
+        super().__init__(namespace)
+        service_port = V1ServicePort(name="sql", port=3306)
+
+        self.service = V1Service(
+            api_version="v1",
+            kind="Service",
+            metadata=V1ObjectMeta(
+                name="mysql", namespace=namespace, labels={"app": "mysql"}
+            ),
+            spec=V1ServiceSpec(
+                type="NodePort",
+                ports=[service_port],
+                selector={"app": "mysql"},
+            ),
+        )
+
+
+class MySqlDeployment(K8sDeployment):
+    def __init__(self, namespace: str, apply_node_selectors: bool) -> None:
+        super().__init__(namespace)
+        env = [
+            V1EnvVar(name="MYSQL_ROOT_PASSWORD", value="p@ssw0rd"),
+        ]
+        ports = [V1ContainerPort(container_port=3306, name="sql")]
+        container = V1Container(
+            name="mysql",
+            image=self.image("mysql", tag=None, release_mode=True),
+            args=[
+                "--log-bin=mysql-bin",
+                "--gtid_mode=ON",
+                "--enforce_gtid_consistency=ON",
+                "--binlog-format=row",
+                "--log-slave-updates",
+                "--binlog-row-image=full",
+                "--server-id=1",
+            ],
+            env=env,
+            ports=ports,
+        )
+
+        node_selector = None
+        if apply_node_selectors:
+            node_selector = {"supporting-services": "true"}
+
+        template = V1PodTemplateSpec(
+            metadata=V1ObjectMeta(namespace=namespace, labels={"app": "mysql"}),
+            spec=V1PodSpec(containers=[container], node_selector=node_selector),
+        )
+
+        selector = V1LabelSelector(match_labels={"app": "mysql"})
+
+        spec = V1DeploymentSpec(replicas=1, template=template, selector=selector)
+
+        self.deployment = V1Deployment(
+            api_version="apps/v1",
+            kind="Deployment",
+            metadata=V1ObjectMeta(name="mysql", namespace=namespace),
+            spec=spec,
+        )
+
+
+def mysql_resources(
+    namespace: str = DEFAULT_K8S_NAMESPACE, apply_node_selectors: bool = False
+) -> list[K8sResource]:
+    return [
+        MySqlService(namespace),
+        MySqlDeployment(namespace, apply_node_selectors),
+    ]

--- a/misc/python/materialize/cloudtest/k8s/mysql.py
+++ b/misc/python/materialize/cloudtest/k8s/mysql.py
@@ -59,7 +59,7 @@ class MySqlDeployment(K8sDeployment):
         ports = [V1ContainerPort(container_port=3306, name="sql")]
         container = V1Container(
             name="mysql",
-            image=self.image("mysql", tag="8.0.35", release_mode=True),
+            image=self.image("mysql", tag="8.0.35", release_mode=True, org=None),
             args=[
                 "--log-bin=mysql-bin",
                 "--gtid_mode=ON",

--- a/misc/python/materialize/cloudtest/k8s/mysql.py
+++ b/misc/python/materialize/cloudtest/k8s/mysql.py
@@ -59,7 +59,7 @@ class MySqlDeployment(K8sDeployment):
         ports = [V1ContainerPort(container_port=3306, name="sql")]
         container = V1Container(
             name="mysql",
-            image=self.image("mysql", tag=None, release_mode=True),
+            image=self.image("mysql", tag="8.0.35", release_mode=True),
             args=[
                 "--log-bin=mysql-bin",
                 "--gtid_mode=ON",

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -20,11 +20,6 @@ from materialize.checks.all_checks.alter_connection import (
     AlterConnectionToSsh,
 )
 from materialize.checks.all_checks.kafka_protocols import KafkaProtocols
-from materialize.checks.all_checks.mysql_cdc import (
-    MySqlCdc,
-    MySqlCdcMzNow,
-    MySqlCdcNoWait,
-)
 from materialize.checks.checks import Check
 from materialize.checks.cloudtest_actions import (
     ReplaceEnvironmentdStatefulSet,
@@ -83,7 +78,6 @@ def test_upgrade(aws_region: str | None, log_filter: str | None, dev: bool) -> N
     executor = CloudtestExecutor(application=mz, version=last_released_version)
     # KafkaProtocols: No shared secrets directory
     # AlterConnection*: No second SSH host (other_ssh_bastion) set up
-    # MySqlCdc*: Needs MySql to be added to cloudtests
     checks = list(
         all_subclasses(Check)
         - {
@@ -91,9 +85,6 @@ def test_upgrade(aws_region: str | None, log_filter: str | None, dev: bool) -> N
             AlterConnectionToSsh,
             AlterConnectionToNonSsh,
             AlterConnectionHost,
-            MySqlCdc,
-            MySqlCdcNoWait,
-            MySqlCdcMzNow,
         }
     )
     scenario = CloudtestUpgrade(checks=checks, executor=executor)

--- a/test/mysql/Dockerfile
+++ b/test/mysql/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+MZFROM test-certs as certs
+
+FROM mysql:8.3.0
+
+ENV MYSQL_ROOT_PASSWORD=p@ssw0rd

--- a/test/mysql/mzbuild.yml
+++ b/test/mysql/mzbuild.yml
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: mysql


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/24927.

Nightly: https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Atests%2Fmysql-platform-in-cloudtests