### PR TITLE
webhooks: Add some basic tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4287,6 +4287,7 @@ dependencies = [
  "mz-orchestrator-process",
  "mz-orchestrator-tracing",
  "mz-ore",
+ "mz-ore-instrument-macro",
  "mz-persist-client",
  "mz-pgrepr",
  "mz-pgtest",

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
+use mz_ore::instrument;
 use mz_repr::{Datum, Diff, Row, RowArena};
 use mz_secrets::cache::CachingSecretsReader;
 use mz_secrets::SecretsReader;
@@ -256,6 +257,7 @@ impl WebhookAppender {
     }
 
     /// Appends updates to the linked webhook source.
+    #[instrument(level = "debug", target = "webhook")]
     pub async fn append(&self, updates: Vec<(Row, Diff)>) -> Result<(), AppendWebhookError> {
         if self.is_closed() {
             return Err(AppendWebhookError::ChannelClosed);

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -59,6 +59,7 @@ mz-orchestrator-kubernetes = { path = "../orchestrator-kubernetes" }
 mz-orchestrator-process = { path = "../orchestrator-process" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 mz-ore = { path = "../ore", features = ["async", "tracing_"] }
+mz-ore-instrument-macro = { path = "../ore-instrument-macro" }
 mz-persist-client = { path = "../persist-client" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-pgwire = { path = "../pgwire" }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -25,6 +25,7 @@ use async_trait::async_trait;
 use differential_dataflow::lattice::Lattice;
 use mz_cluster_client::client::ClusterReplicaLocation;
 use mz_cluster_client::ReplicaId;
+use mz_ore::instrument;
 use mz_persist_client::read::{Cursor, ReadHandle};
 use mz_persist_client::stats::SnapshotStats;
 use mz_persist_types::Codec64;
@@ -664,6 +665,7 @@ impl MonotonicAppender {
         MonotonicAppender { tx }
     }
 
+    #[instrument(level = "debug")]
     pub async fn append(&self, updates: Vec<(Row, Diff)>) -> Result<(), StorageError> {
         let (tx, rx) = oneshot::channel();
 


### PR DESCRIPTION
This PR adds some basic `debug` level tracing to webhook handling.

### Motivation

Get an idea what takes a long time in webhook handling

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
