### PR TITLE
ore: fix error locations with mz_ore::instrument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4903,6 +4903,8 @@ dependencies = [
 name = "mz-ore-instrument-macro"
 version = "0.0.0"
 dependencies = [
+ "proc-macro2",
+ "quote",
  "tracing",
  "workspace-hack",
 ]

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -105,7 +105,7 @@ impl Coordinator {
             replication_factor,
             size,
             disk,
-            optimizer_feature_overrides,
+            optimizer_feature_overrides: _,
         }: CreateClusterManagedPlan,
         cluster_id: ClusterId,
         mut ops: Vec<catalog::Op>,

--- a/src/ore-instrument-macro/Cargo.toml
+++ b/src/ore-instrument-macro/Cargo.toml
@@ -10,6 +10,8 @@ publish = false
 workspace = true
 
 [dependencies]
+quote = "1.0.28"
+proc-macro2 = "1.0.60"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2361,7 +2361,7 @@ where
     #[instrument(level = "info", fields(from_id, storage_dependencies, read_capability))]
     fn install_read_capabilities(
         &mut self,
-        from_id: GlobalId,
+        _from_id: GlobalId,
         storage_dependencies: &[GlobalId],
         read_capability: Antichain<T>,
     ) -> Result<(), StorageError> {


### PR DESCRIPTION
Uses `quote!` to make sure we get good error locations

tested with a real compilation error locally, as well as ensured with `cargo expand` that `fields()` get kept

@mjibson we probably want to add an assert on a field value being passed through in your tracing testing pr!

### Motivation

  * This PR fixes a recognized bug.
 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
