### PR TITLE
storage/mysql: Set MySQL source to running on render

### DIFF
--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -262,9 +262,8 @@ utf8_table            subsource <null>  <null>
 # "space table"         subsource <null>  <null>
 # таблица               subsource <null>  <null>
 
-# TODO: #25416 (source status remains "starting")
-# > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
-# running
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
+running
 
 > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source_progress';
 running

--- a/test/mysql-cdc/schema-restart/after-restart.td
+++ b/test/mysql-cdc/schema-restart/after-restart.td
@@ -8,11 +8,10 @@
 # by the Apache License, Version 2.0.
 
 
-# Primary source is starting because of snapshot error in one subsource
 > SELECT true
     FROM mz_internal.mz_source_statuses
     WHERE
-        name = 'schema_test' AND status = 'starting';
+        name = 'schema_test' AND status = 'running';
 true
 
 # dummy subsource is put into error state


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Seed the mysql source health status as running to avoid user confusion.
This PR is the same implementation as the corresponding postgres source PR: https://github.com/MaterializeInc/materialize/pull/24471

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/materialize/issues/25416


<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
