### PR TITLE
storage/mysql: Fix zippy MySqlInsert action row counting

### DIFF
--- a/misc/python/materialize/zippy/mysql_actions.py
+++ b/misc/python/materialize/zippy/mysql_actions.py
@@ -146,8 +146,8 @@ class MySqlInsert(MySqlDML):
 
                 $ mysql-execute name=mysql
                 USE public;
-                SET @i:={prev_max + 1};
-                INSERT INTO {self.mysql_table.name} SELECT @i:=@i+1 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT {self.mysql_table.watermarks.max - (prev_max + 1)};
+                SET @i:={prev_max};
+                INSERT INTO {self.mysql_table.name} SELECT @i:=@i+1 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT {self.mysql_table.watermarks.max - prev_max};
                 """
             )
         )


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

As I was trying to debug a related issue #25582 I hit an error which indicated that the zippy action was mis-counting how many expected rows should be in a mysql sub-source table.

The output from that failed test run is here: https://gist.github.com/rjobanp/23eaee0d22e6e1fc36e20c4b24a95be5
In that gist `table8` is instantiated with one row of value `0`, then later a delete is performed that doesn't affect any rows `DELETE FROM table8 WHERE f1 > 0;`, and eventually an insert of `6286` rows is done. After that, the zippy test fails since it was expecting `6288` rows to exist. Comparing the actual table in mysql and materialize show the correct count of `6287` rows.

I was able to replicate and verify the fix of the issue with this zippy configuration

```
class MySqlCdc(Scenario):
    """A Zippy test using MySQL CDC exclusively."""

    def bootstrap(self) -> list[ActionOrFactory]:
        return super().bootstrap() + [MySqlStart]

    def actions_with_weight(self) -> dict[ActionOrFactory, float]:
        return {
            CreateMySqlTable: 2,
            CreateMySqlCdcTable: 2,
            KillClusterd: 1,
            StoragedKill: 1,
            StoragedStart: 1,
            MySqlRestart: 1,
            CreateViewParameterized(): 1,
            ValidateView: 2,
            MySqlDML: 1,
        }
```

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
