### PR TITLE
webhooks: Make batch interval configurable via LaunchDarkly

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -185,6 +185,8 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             wait_for_count: config.pg_source_snapshot_wait_for_count(),
         },
         enable_dependency_read_hold_asserts: config.enable_dependency_read_hold_asserts(),
+        user_storage_managed_collections_batch_duration: config
+            .user_storage_managed_collections_batch_duration(),
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1113,6 +1113,7 @@ impl SystemVars {
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL_STAGGER,
+            &USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION,
         ];
 
         let persist_configs = mz_dyncfgs::all_dyncfgs();
@@ -2004,6 +2005,11 @@ impl SystemVars {
         *self.expect_value(&ENABLE_DEPENDENCY_READ_HOLD_ASSERTS)
     }
 
+    /// Returns the `user_storage_managed_collections_batch_duration` configuration parameter.
+    pub fn user_storage_managed_collections_batch_duration(&self) -> Duration {
+        *self.expect_value(&USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION)
+    }
+
     /// Returns whether the named variable is a compute configuration parameter
     /// (things that go in `ComputeParameters` and are sent to replicas via `UpdateConfiguration`
     /// commands).
@@ -2048,6 +2054,7 @@ impl SystemVars {
             || name == STORAGE_RECORD_SOURCE_SINK_NAMESPACED_ERRORS.name()
             || name == STORAGE_STATISTICS_INTERVAL.name()
             || name == STORAGE_STATISTICS_COLLECTION_INTERVAL.name()
+            || name == USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION.name()
             || is_upsert_rocksdb_config_var(name)
             || self.is_persist_config_var(name)
             || is_tracing_var(name)

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -25,6 +25,7 @@ use mz_repr::bytes::ByteSize;
 use mz_sql_parser::ast::Ident;
 use mz_sql_parser::ident;
 use mz_storage_types::controller::PersistTxnTablesImpl;
+use mz_storage_types::parameters::STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT;
 use mz_tracing::{CloneableEnvFilter, SerializableDirective};
 use once_cell::sync::Lazy;
 use uncased::UncasedStr;
@@ -1442,6 +1443,13 @@ pub static WEBHOOK_CONCURRENT_REQUEST_LIMIT: VarDefinition = VarDefinition::new(
     "webhook_concurrent_request_limit",
     value!(usize; WEBHOOK_CONCURRENCY_LIMIT),
     "Maximum number of concurrent requests for appending to a webhook source.",
+    true,
+);
+
+pub static USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION: VarDefinition = VarDefinition::new(
+    "user_storage_managed_collections_batch_duration",
+    value!(Duration; STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT),
+    "Duration which we'll wait to collect a batch of events for a webhook source.",
     true,
 );
 

--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -11,6 +11,7 @@
 //! collections.
 
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use differential_dataflow::lattice::Lattice;
@@ -25,6 +26,7 @@ use mz_persist_types::Codec64;
 use mz_repr::{Diff, GlobalId, Row, TimestampManipulation};
 use mz_storage_client::client::TimestamplessUpdate;
 use mz_storage_client::controller::MonotonicAppender;
+use mz_storage_types::parameters::STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT;
 use timely::progress::Timestamp;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Duration, Instant};
@@ -34,8 +36,8 @@ use crate::{persist_handles, StorageError};
 
 // Note(parkmycar): The capacity here was chosen arbitrarily.
 const CHANNEL_CAPACITY: usize = 4096;
-// Default rate at which we append data and advance the uppers of managed collections.
-const DEFAULT_TICK: Duration = Duration::from_secs(1);
+// Default rate at which we advance the uppers of managed collections.
+const DEFAULT_TICK_MS: u64 = 1_000;
 
 type WriteChannel = mpsc::Sender<(Vec<(Row, Diff)>, oneshot::Sender<Result<(), StorageError>>)>;
 type WriteTask = AbortOnDropHandle<()>;
@@ -48,6 +50,9 @@ where
 {
     collections: Arc<Mutex<BTreeMap<GlobalId, (WriteChannel, WriteTask, ShutdownSender)>>>,
     write_handle: persist_handles::PersistMonotonicWriteWorker<T>,
+    /// Amount of time we'll wait before sending a batch of inserts to Persist, for user
+    /// collections.
+    user_batch_duration_ms: Arc<AtomicU64>,
     now: NowFn,
 }
 
@@ -68,11 +73,23 @@ where
         write_handle: persist_handles::PersistMonotonicWriteWorker<T>,
         now: NowFn,
     ) -> CollectionManager<T> {
+        let batch_duration_ms: u64 = STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT
+            .as_millis()
+            .try_into()
+            .expect("known to fit");
         CollectionManager {
             collections: Arc::new(Mutex::new(BTreeMap::new())),
             write_handle,
+            user_batch_duration_ms: Arc::new(AtomicU64::new(batch_duration_ms)),
             now,
         }
+    }
+
+    /// Updates the duration we'll wait to batch events for user owned collections.
+    pub fn update_user_batch_duration(&self, duration: Duration) {
+        tracing::info!(?duration, "updating user batch duration");
+        let millis: u64 = duration.as_millis().try_into().unwrap_or(u64::MAX);
+        self.user_batch_duration_ms.store(millis, Ordering::Relaxed);
     }
 
     /// Registers the collection as one that `CollectionManager` will:
@@ -93,7 +110,12 @@ where
         }
 
         // Spawns a new task so we can write to this collection.
-        let writer_and_handle = write_task(id, self.write_handle.clone(), self.now.clone());
+        let writer_and_handle = write_task(
+            id,
+            self.write_handle.clone(),
+            Arc::clone(&self.user_batch_duration_ms),
+            self.now.clone(),
+        );
         let prev = guard.insert(id, writer_and_handle);
 
         // Double check the previous task was actually finished.
@@ -176,6 +198,7 @@ where
 fn write_task<T>(
     id: GlobalId,
     write_handle: persist_handles::PersistMonotonicWriteWorker<T>,
+    user_batch_duration_ms: Arc<AtomicU64>,
     now: NowFn,
 ) -> (WriteChannel, WriteTask, ShutdownSender)
 where
@@ -187,7 +210,7 @@ where
     let handle = mz_ore::task::spawn(
         || format!("CollectionManager-write_task-{id}"),
         async move {
-            let mut interval = tokio::time::interval(DEFAULT_TICK);
+            let mut interval = tokio::time::interval(Duration::from_millis(DEFAULT_TICK_MS));
 
             'run: loop {
                 tokio::select! {
@@ -232,7 +255,20 @@ where
                         if let Some(batch) = cmd {
                             // To rate limit appends to persist we add artifical latency, and will
                             // finish no sooner than this instant.
-                            let min_time_to_complete = Instant::now() + DEFAULT_TICK;
+                            let batch_duration_ms = match id {
+                                GlobalId::User(_) => Duration::from_millis(user_batch_duration_ms.load(Ordering::Relaxed)),
+                                // For non-user collections, always just use the default.
+                                _ => STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT,
+                            };
+                            let use_batch_now = Instant::now();
+                            let min_time_to_complete = use_batch_now + batch_duration_ms;
+
+                            tracing::debug!(
+                                ?use_batch_now,
+                                ?batch_duration_ms,
+                                ?min_time_to_complete,
+                                "batch duration",
+                            );
 
                             // Reset the interval which is used to periodically bump the uppers
                             // because the uppers will get bumped with the following update. This

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -265,6 +265,11 @@ where
         self.config.update(config_params);
         self.statistics_interval_sender
             .send_replace(self.config.parameters.statistics_interval);
+        self.collection_manager.update_user_batch_duration(
+            self.config
+                .parameters
+                .user_storage_managed_collections_batch_duration,
+        );
     }
 
     /// Get the current configuration

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -41,6 +41,7 @@ message ProtoStorageParameters {
     mz_proto.ProtoDuration statistics_collection_interval = 23;
     ProtoPgSourceSnapshotConfig pg_snapshot_config = 24;
     bool enable_dependency_read_hold_asserts = 27;
+    mz_proto.ProtoDuration user_storage_managed_collections_batch_duration = 28;
 }
 
 

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -73,10 +73,13 @@ pub struct StorageParameters {
     pub statistics_collection_interval: Duration,
     pub pg_snapshot_config: PgSourceSnapshotConfig,
     pub enable_dependency_read_hold_asserts: bool,
+    /// Duration that we wait to batch rows for user owned, storage managed, collections.
+    pub user_storage_managed_collections_batch_duration: Duration,
 }
 
 pub const STATISTICS_INTERVAL_DEFAULT: Duration = Duration::from_secs(60);
 pub const STATISTICS_COLLECTION_INTERVAL_DEFAULT: Duration = Duration::from_secs(10);
+pub const STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT: Duration = Duration::from_secs(1);
 
 // Implement `Default` manually, so that the default can match the
 // LD default. This is not strictly necessary, but improves clarity.
@@ -104,6 +107,8 @@ impl Default for StorageParameters {
             statistics_collection_interval: STATISTICS_COLLECTION_INTERVAL_DEFAULT,
             pg_snapshot_config: Default::default(),
             enable_dependency_read_hold_asserts: true,
+            user_storage_managed_collections_batch_duration:
+                STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT,
         }
     }
 }
@@ -201,6 +206,7 @@ impl StorageParameters {
             statistics_collection_interval,
             pg_snapshot_config,
             enable_dependency_read_hold_asserts,
+            user_storage_managed_collections_batch_duration,
         }: StorageParameters,
     ) {
         self.persist.update(persist);
@@ -227,6 +233,8 @@ impl StorageParameters {
         self.statistics_collection_interval = statistics_collection_interval;
         self.pg_snapshot_config = pg_snapshot_config;
         self.enable_dependency_read_hold_asserts = enable_dependency_read_hold_asserts;
+        self.user_storage_managed_collections_batch_duration =
+            user_storage_managed_collections_batch_duration;
     }
 }
 
@@ -266,6 +274,10 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             statistics_collection_interval: Some(self.statistics_collection_interval.into_proto()),
             pg_snapshot_config: Some(self.pg_snapshot_config.into_proto()),
             enable_dependency_read_hold_asserts: self.enable_dependency_read_hold_asserts,
+            user_storage_managed_collections_batch_duration: Some(
+                self.user_storage_managed_collections_batch_duration
+                    .into_proto(),
+            ),
         }
     }
 
@@ -330,6 +342,11 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
                 .pg_snapshot_config
                 .into_rust_if_some("ProtoStorageParameters::pg_snapshot_config")?,
             enable_dependency_read_hold_asserts: proto.enable_dependency_read_hold_asserts,
+            user_storage_managed_collections_batch_duration: proto
+                .user_storage_managed_collections_batch_duration
+                .into_rust_if_some(
+                    "ProtoStorageParameters::user_storage_managed_collections_batch_duration",
+                )?,
         })
     }
 }


### PR DESCRIPTION
The storage controller manages the collections that back webhooks, as well as some system collections, e.g. builtin sources. These collections each have a `tokio::task` that pulls updates off of a channel and then pushes the writes to a Persist handle. We currently have a "batch interval" where we'll wait 1 second from the start of a write before pulling more updates off the channel. This PR makes that interval configurable for user owned collections, which currently are just webhooks.

Note: we only apply this dynamic interval to user collections because there is currently no need to decrease the latency for system collections.

### Motivation

Have the ability to reduce latency for webhooks, with the tradeoff of increased CRDB traffic.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Gives us a knob to tune webhook latency
