### PR TITLE
storage/mysql: Alter table fixes; don't error if ignored column is detected

### DIFF
--- a/src/mysql-util/src/decoding.rs
+++ b/src/mysql-util/src/decoding.rs
@@ -44,12 +44,9 @@ pub fn pack_mysql_row(
                     table_desc.name
                 )))?
             }
-            EitherOrBoth::Right(value) => {
-                tracing::error!("mysql: extra value {value:?} for table {}", table_desc.name);
-                Err(MySqlError::DecodeError(format!(
-                    "extra value found: {value:?} for table {}",
-                    table_desc.name
-                )))?
+            EitherOrBoth::Right(_) => {
+                // If there are extra columns on the upstream table we can safely ignore them
+                break;
             }
         };
         let datum = match val_to_datum(value, col_desc, &mut temp_strs, &mut temp_bytes) {

--- a/test/mysql-cdc/alter-table-after-source.td
+++ b/test/mysql-cdc/alter-table-after-source.td
@@ -118,9 +118,8 @@ $ mysql-execute name=mysql
 ALTER TABLE remove_column DROP COLUMN f2;
 INSERT INTO remove_column VALUES (3);
 
-# TODO: #25451 (schema change not detected)
-# ! select * from remove_column;
-# contains:incompatible schema change
+! select * from remove_column;
+contains:incompatible schema change
 
 
 #
@@ -134,9 +133,8 @@ UPDATE alter_column SET f2 = '12';
 ALTER TABLE alter_column MODIFY f2 int;
 INSERT INTO alter_column VALUES (3, 23);
 
-# TODO: #25451 (schema change not detected)
-# ! select * from alter_column;
-# contains:incompatible schema change
+! select * from alter_column;
+contains:incompatible schema change
 
 
 #
@@ -149,9 +147,8 @@ $ mysql-execute name=mysql
 ALTER TABLE alter_drop_nullability MODIFY f1 INTEGER;
 INSERT INTO alter_drop_nullability VALUES (NULL);
 
-# TODO: #25451 (schema change not detected)
-# ! SELECT * FROM alter_drop_nullability WHERE f1 IS NOT NULL;
-# contains:incompatible schema change
+! SELECT * FROM alter_drop_nullability WHERE f1 IS NOT NULL;
+contains:incompatible schema change
 
 # We have guaranteed that this column is not null so the optimizer eagerly
 # returns the empty set.
@@ -220,9 +217,8 @@ ALTER TABLE alter_cycle_pk DROP PRIMARY KEY;
 ALTER TABLE alter_cycle_pk ADD PRIMARY KEY(f1);
 INSERT INTO alter_cycle_pk VALUES (2);
 
-# TODO: #25451 (schema change not detected)
-# ! SELECT * FROM alter_cycle_pk;
-# contains:incompatible schema change
+! SELECT * FROM alter_cycle_pk;
+contains:incompatible schema change
 
 #
 # Cycle PK off (no pk, pk, no pk)
@@ -252,9 +248,8 @@ $ mysql-execute name=mysql
 ALTER TABLE alter_drop_unique DROP INDEX f1;
 INSERT INTO alter_drop_unique VALUES (1);
 
-# TODO: #25451 (schema change not detected)
-# ! SELECT f1 FROM alter_drop_unique;
-# contains:incompatible schema change
+! SELECT f1 FROM alter_drop_unique;
+contains:incompatible schema change
 
 
 #
@@ -283,21 +278,20 @@ $ mysql-execute name=mysql
 ALTER TABLE alter_extend_column MODIFY f1 VARCHAR(20);
 INSERT INTO alter_extend_column VALUES ('abcd');
 
-# TODO: #25451 (schema change not detected)
-# ! SELECT * FROM alter_extend_column;
-# contains:incompatible schema change
+! SELECT * FROM alter_extend_column;
+contains:incompatible schema change
 
 #
 # Alter decimal
 > SELECT * from alter_decimal
 123.45
 
-# $ mysql-execute name=mysql
-# ALTER TABLE alter_decimal ALTER COLUMN f1 TYPE DECIMAL(6,1);
-# INSERT INTO alter_decimal VALUES (12345.6);
+$ mysql-execute name=mysql
+ALTER TABLE alter_decimal MODIFY COLUMN f1 DECIMAL(6,1);
+INSERT INTO alter_decimal VALUES (12345.6);
 
-# ! SELECT * FROM alter_decimal;
-# contains:altered
+! SELECT * FROM alter_decimal;
+contains:altered
 
 
 #
@@ -310,9 +304,8 @@ $ mysql-execute name=mysql
 ALTER TABLE alter_table_rename RENAME TO alter_table_renamed;
 INSERT INTO alter_table_renamed VALUES (2);
 
-# TODO: #25451 (schema change not detected)
-# ! SELECT * FROM alter_table_rename;
-# contains:table was dropped
+! SELECT * FROM alter_table_rename;
+contains:table was dropped
 
 $ mysql-execute name=mysql
 INSERT INTO alter_table_renamed VALUES (3);
@@ -333,9 +326,8 @@ ALTER TABLE alter_table_rename_column RENAME COLUMN f2 TO f1;
 ALTER TABLE alter_table_rename_column RENAME COLUMN f3 TO f2;
 INSERT INTO alter_table_rename_column (f1, f2) VALUES ('f1_renamed', 'f2_renamed');
 
-# TODO: #25451 (schema change not detected)
-# ! SELECT * FROM alter_table_rename_column;
-# contains:incompatible schema change
+! SELECT * FROM alter_table_rename_column;
+contains:incompatible schema change
 
 
 #
@@ -350,9 +342,8 @@ ALTER TABLE alter_table_change_attnum DROP COLUMN f2;
 ALTER TABLE alter_table_change_attnum ADD COLUMN f2 VARCHAR(10);
 INSERT INTO alter_table_change_attnum (f1, f2) VALUES ('f1_changed', 'f2_changed');
 
-# TODO: #25451 (schema change not detected)
-# ! SELECT * FROM alter_table_change_attnum;
-# contains:incompatible schema change
+! SELECT * FROM alter_table_change_attnum;
+contains:incompatible schema change
 
 > SELECT * from alter_table_supported;
 1 1
@@ -385,9 +376,8 @@ $ mysql-execute name=mysql
 ALTER TABLE alter_table_supported DROP COLUMN f2;
 INSERT INTO alter_table_supported (f1) VALUES (1);
 
-# TODO: #25451 (schema change not detected)
-# ! SELECT * from alter_table_supported;
-# contains:incompatible schema change
+! SELECT * from alter_table_supported;
+contains:incompatible schema change
 
 
 #
@@ -412,14 +402,12 @@ TRUNCATE truncate_table;
 $ mysql-execute name=mysql
 DROP TABLE drop_table;
 
-# TODO: #25451 (schema change not detected)
-# > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'drop_table';
-# ceased
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'drop_table';
+ceased
 
 # this should not brick the whole source
-# TODO: #25451 (schema change not detected)
-# > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
-# running
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
+running
 
 # TODO: #25365 (source bricked after restart)
 > DROP SOURCE mz_source CASCADE;

--- a/test/mysql-cdc/alter-table-irrelevant.td
+++ b/test/mysql-cdc/alter-table-irrelevant.td
@@ -70,39 +70,37 @@ INSERT INTO irrelevant_table VALUES ('ab');
   FOR ALL TABLES;
 
 # Check the first view still works
-# TODO: #25066 (irrelevant table breaks source)
-# > SELECT * FROM base_table;
-# 1
-# 2
+> SELECT * FROM base_table;
+1
+2
 
 # Confirm the second table now has a corresponding view and it has the expected data
-# TODO: #25066 (irrelevant table breaks source)
-# > SELECT * FROM irrelevant_table
-# <null>
-# ab
+> SELECT * FROM irrelevant_table
+<null>
+ab
 
 # Alter the irrelevant_table now that it is relevant
 $ mysql-execute name=mysql
 ALTER TABLE irrelevant_table ADD COLUMN f3 char(2);
 INSERT INTO irrelevant_table VALUES ('bc', 'de');
 
-# TODO: #25066 (irrelevant table breaks source)
-# > SELECT * FROM base_table;
-# 1
-# 2
+> SELECT * FROM base_table;
+1
+2
 
-# TODO: #25066 (irrelevant table breaks source)
-# > SELECT * FROM irrelevant_table
-# <null>
-# ab
-# bc
+> SELECT * FROM irrelevant_table
+<null>
+ab
+bc
 
 # Alter in an incompatible way and ensure replication error does not occur
 $ mysql-execute name=mysql
 ALTER TABLE irrelevant_table DROP COLUMN f2;
 INSERT INTO irrelevant_table VALUES ('gh');
 
-# TODO: #25066 (irrelevant table breaks source)
-# > SELECT * FROM base_table;
-# 1
-# 2
+> SELECT * FROM base_table;
+1
+2
+
+# Drop source since sanity check restart requires it is in a good state
+> DROP SOURCE mz_source


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes: https://github.com/MaterializeInc/materialize/issues/25066 and https://github.com/MaterializeInc/materialize/issues/25451

@nrainer-materialize I uncommented all the test cases that correspond to those 2 issues ^. The first one is fixed by the code change here to ignore additional columns that we don't need to ingest, and the other seemed to work once I uncommented it too.

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
