### PR TITLE
transform: plumb through `OptimizerFeatures`

### DIFF
--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -147,7 +147,10 @@ impl Optimize<HirRelationExpr> for Optimizer {
         let expr = expr.lower(&self.config)?;
 
         // MIR ⇒ MIR optimization (local)
-        let expr = optimize_mir_local(expr, &self.typecheck_ctx)?.into_inner();
+        let mut df_meta = DataflowMetainfo::default();
+        let mut transform_ctx =
+            TransformCtx::local(&self.config.features, &self.typecheck_ctx, &mut df_meta);
+        let expr = optimize_mir_local(expr, &mut transform_ctx)?.into_inner();
 
         // Return the (sealed) plan at the end of this optimization step.
         Ok(LocalMirPlan {

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -27,7 +27,7 @@ use mz_storage_types::sinks::S3UploadInfo;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::normalize_lets::normalize_lets;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
-use mz_transform::StatisticsOracle;
+use mz_transform::{StatisticsOracle, TransformCtx};
 use timely::progress::Antichain;
 use tracing::warn;
 
@@ -279,12 +279,17 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
             }
         }
 
-        let df_meta = mz_transform::optimize_dataflow(
-            &mut df_desc,
+        // Construct TransformCtx for global optimization.
+        let mut df_meta = DataflowMetainfo::default();
+        let mut transform_ctx = TransformCtx::global(
             &df_builder,
             &*stats,
             &self.config.features,
-        )?;
+            &self.typecheck_ctx,
+            &mut df_meta,
+        );
+        // Run global optimization.
+        mz_transform::optimize_dataflow(&mut df_desc, &mut transform_ctx)?;
 
         if self.config.mode == OptimizeMode::Explain {
             // Collect the list of indexes used by the dataflow at this point.

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -159,7 +159,10 @@ impl Optimize<HirRelationExpr> for Optimizer {
         let expr = expr.lower(&self.config)?;
 
         // MIR ⇒ MIR optimization (local)
-        let expr = optimize_mir_local(expr, &self.typecheck_ctx)?.into_inner();
+        let mut df_meta = DataflowMetainfo::default();
+        let mut transform_ctx =
+            TransformCtx::local(&self.config.features, &self.typecheck_ctx, &mut df_meta);
+        let expr = optimize_mir_local(expr, &mut transform_ctx)?.into_inner();
 
         // Return the (sealed) plan at the end of this optimization step.
         Ok(LocalMirPlan { expr })

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -37,6 +37,7 @@ use mz_sql::plan::HirRelationExpr;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::normalize_lets::normalize_lets;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
+use mz_transform::TransformCtx;
 use timely::progress::Antichain;
 
 use crate::catalog::Catalog;
@@ -225,12 +226,17 @@ impl Optimize<LocalMirPlan> for Optimizer {
             |s| prep_scalar_expr(s, style),
         )?;
 
-        let df_meta = mz_transform::optimize_dataflow(
-            &mut df_desc,
+        // Construct TransformCtx for global optimization.
+        let mut df_meta = DataflowMetainfo::default();
+        let mut transform_ctx = TransformCtx::global(
             &df_builder,
             &mz_transform::EmptyStatisticsOracle, // TODO: wire proper stats
             &self.config.features,
-        )?;
+            &self.typecheck_ctx,
+            &mut df_meta,
+        );
+        // Run global optimization.
+        mz_transform::optimize_dataflow(&mut df_desc, &mut transform_ctx)?;
 
         if self.config.mode == OptimizeMode::Explain {
             // Collect the list of indexes used by the dataflow at this point.

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -340,7 +340,7 @@ fn optimize_mir_local(
     ctx: &mut TransformCtx,
 ) -> Result<OptimizedMirRelationExpr, OptimizerError> {
     #[allow(deprecated)]
-    let optimizer = mz_transform::Optimizer::logical_optimizer(ctx.typecheck_ctx);
+    let optimizer = mz_transform::Optimizer::logical_optimizer(ctx);
     let expr = optimizer.optimize(expr, ctx)?;
 
     // Trace the result of this phase.

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -71,8 +71,9 @@ use mz_repr::optimize::{OptimizerFeatureOverrides, OptimizerFeatures, OverrideFr
 use mz_repr::GlobalId;
 use mz_sql::plan::PlanError;
 use mz_sql::session::vars::SystemVars;
+use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::typecheck::SharedContext as TypecheckContext;
-use mz_transform::TransformError;
+use mz_transform::{TransformCtx, TransformError};
 
 // Alias types
 // -----------
@@ -340,9 +341,13 @@ fn optimize_mir_local(
     expr: MirRelationExpr,
     typecheck_ctx: &TypecheckContext,
 ) -> Result<OptimizedMirRelationExpr, OptimizerError> {
+    let features = OptimizerFeatures::default();
+    let mut df_meta = DataflowMetainfo::default();
+    let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta);
+
     #[allow(deprecated)]
     let optimizer = mz_transform::Optimizer::logical_optimizer(typecheck_ctx);
-    let expr = optimizer.optimize(expr)?;
+    let expr = optimizer.optimize(expr, &mut transform_ctx)?;
 
     // Trace the result of this phase.
     mz_repr::explain::trace_plan(expr.as_inner());

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -155,7 +155,10 @@ impl Optimize<HirRelationExpr> for Optimizer {
         let expr = expr.lower(&self.config)?;
 
         // MIR ⇒ MIR optimization (local)
-        let expr = optimize_mir_local(expr, &self.typecheck_ctx)?.into_inner();
+        let mut df_meta = DataflowMetainfo::default();
+        let mut transform_ctx =
+            TransformCtx::local(&self.config.features, &self.typecheck_ctx, &mut df_meta);
+        let expr = optimize_mir_local(expr, &mut transform_ctx)?.into_inner();
 
         // Return the (sealed) plan at the end of this optimization step.
         Ok(LocalMirPlan {

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -219,7 +219,10 @@ impl Optimize<SubscribeFrom> for Optimizer {
                 // let expr = expr.lower(&self.config)?;
 
                 // MIR ⇒ MIR optimization (local)
-                let expr = optimize_mir_local(expr, &self.typecheck_ctx)?;
+                let mut df_meta = DataflowMetainfo::default();
+                let mut transform_ctx =
+                    TransformCtx::local(&self.config.features, &self.typecheck_ctx, &mut df_meta);
+                let expr = optimize_mir_local(expr, &mut transform_ctx)?;
 
                 df_builder.import_view_into_dataflow(&self.view_id, &expr, &mut df_desc)?;
                 df_builder.maybe_reoptimize_imported_views(&mut df_desc, &self.config)?;

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -52,7 +52,7 @@ pub fn optimize_dataflow(
     optimize_dataflow_relations(
         dataflow,
         #[allow(deprecated)]
-        &Optimizer::logical_optimizer(transform_ctx.typecheck_ctx),
+        &Optimizer::logical_optimizer(transform_ctx),
         transform_ctx,
     )?;
 
@@ -69,14 +69,14 @@ pub fn optimize_dataflow(
     // pushed down across views.
     optimize_dataflow_relations(
         dataflow,
-        &Optimizer::logical_cleanup_pass(transform_ctx.typecheck_ctx, false),
+        &Optimizer::logical_cleanup_pass(transform_ctx, false),
         transform_ctx,
     )?;
 
     // Physical optimization pass
     optimize_dataflow_relations(
         dataflow,
-        &Optimizer::physical_optimizer(transform_ctx.typecheck_ctx),
+        &Optimizer::physical_optimizer(transform_ctx),
         transform_ctx,
     )?;
 

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -221,7 +221,7 @@ fn optimize_dataflow_relations(
     stats: &dyn StatisticsOracle,
     features: &OptimizerFeatures,
     optimizer: &Optimizer,
-    dataflow_metainfo: &mut DataflowMetainfo,
+    df_meta: &mut DataflowMetainfo,
 ) -> Result<(), TransformError> {
     // Re-optimize each dataflow
     // TODO(mcsherry): we should determine indexes from the optimized representation
@@ -231,13 +231,7 @@ fn optimize_dataflow_relations(
         // Re-run all optimizations on the composite views.
         optimizer.transform(
             object.plan.as_inner_mut(),
-            &mut TransformCtx::with_config_and_metainfo(
-                indexes,
-                stats,
-                &object.id,
-                features.enable_eager_delta_joins,
-                dataflow_metainfo,
-            ),
+            &mut TransformCtx::global(indexes, stats, &object.id, &features, df_meta),
         )?;
     }
 

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -68,7 +68,7 @@ impl crate::Transform for JoinImplementation {
             relation,
             &mut IndexMap::new(ctx.indexes),
             ctx.stats,
-            ctx.enable_eager_delta_joins,
+            ctx.features.enable_eager_delta_joins,
         );
         mz_repr::explain::trace_plan(&*relation);
         result

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -102,8 +102,13 @@ pub struct TransformCtx<'a> {
 }
 
 impl<'a> TransformCtx<'a> {
-    /// Generates a dummy [`TransformCtx`] instance for crate tests.
-    pub fn dummy(
+    /// Generates a [`TransformCtx`] instance for the local MIR optimization
+    /// stage.
+    ///
+    /// Used to call [`Optimizer::optimize`] on a
+    /// [`Optimizer::logical_optimizer`] in order to transform a stand-alone
+    /// [`MirRelationExpr`].
+    pub fn local(
         features: &'a OptimizerFeatures,
         typecheck_ctx: &'a typecheck::SharedContext,
         df_meta: &'a mut DataflowMetainfo,
@@ -670,7 +675,7 @@ impl Optimizer {
         let features = OptimizerFeatures::default();
         let typecheck_ctx = typecheck::empty_context();
         let mut df_meta = DataflowMetainfo::default();
-        let mut transform_ctx = TransformCtx::dummy(&features, &typecheck_ctx, &mut df_meta);
+        let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta);
         let transform_result = self.transform(&mut relation, &mut transform_ctx);
 
         // Make sure we are not swallowing any notice.

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -671,19 +671,16 @@ impl Optimizer {
     pub fn optimize(
         &self,
         mut relation: MirRelationExpr,
+        ctx: &mut TransformCtx,
     ) -> Result<mz_expr::OptimizedMirRelationExpr, TransformError> {
-        let features = OptimizerFeatures::default();
-        let typecheck_ctx = typecheck::empty_context();
-        let mut df_meta = DataflowMetainfo::default();
-        let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta);
-        let transform_result = self.transform(&mut relation, &mut transform_ctx);
+        let transform_result = self.transform(&mut relation, ctx);
 
         // Make sure we are not swallowing any notice.
         // TODO: we should actually wire up notices that come from here. This is not urgent, because
         // currently notices can only come from the physical MIR optimizer (specifically,
         // `LiteralConstraints`), and callers of this method are running the logical MIR optimizer.
         soft_assert_or_log!(
-            df_meta.optimizer_notices.is_empty(),
+            ctx.df_meta.optimizer_notices.is_empty(),
             "logical MIR optimization unexpectedly produced notices"
         );
 

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -87,7 +87,7 @@ macro_rules! any {
 #[derive(Debug)]
 pub struct TransformCtx<'a> {
     /// The global ID for this query (if it exists).
-    pub global_id: Option<&'a GlobalId>,
+    pub global_id: Option<GlobalId>,
     /// The indexes accessible.
     pub indexes: &'a dyn IndexOracle,
     /// Statistical estimates.
@@ -117,17 +117,24 @@ impl<'a> TransformCtx<'a> {
     pub fn global(
         indexes: &'a dyn IndexOracle,
         stats: &'a dyn StatisticsOracle,
-        global_id: &'a GlobalId,
         features: &'a OptimizerFeatures,
         df_meta: &'a mut DataflowMetainfo,
     ) -> Self {
         Self {
             indexes,
             stats,
-            global_id: Some(global_id),
+            global_id: None,
             features,
             df_meta,
         }
+    }
+
+    fn set_global_id(&mut self, global_id: GlobalId) {
+        self.global_id = Some(global_id);
+    }
+
+    fn reset_global_id(&mut self) {
+        self.global_id = None;
     }
 }
 

--- a/src/transform/src/literal_constraints.rs
+++ b/src/transform/src/literal_constraints.rs
@@ -327,7 +327,7 @@ impl LiteralConstraints {
                                 .into_iter()
                                 .collect_vec();
 
-                            transform_ctx.dataflow_metainfo.push_optimizer_notice_dedup(
+                            transform_ctx.df_meta.push_optimizer_notice_dedup(
                                 IndexTooWideForLiteralConstraints {
                                     index_id,
                                     index_key,

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -66,8 +66,15 @@
 //!   indexes: &mz_transform::EmptyIndexOracle,
 //!   stats: &mz_transform::EmptyStatisticsOracle,
 //!   global_id: None,
-//!   enable_eager_delta_joins: false,
-//!   dataflow_metainfo: &mut DataflowMetainfo::default(),
+//!   features: &mz_repr::optimizer::OptimizerFeatures {
+//!       enable_consolidate_after_union_negate: false,
+//!       enable_eager_delta_joins: false,
+//!       enable_new_outer_join_lowering: false,
+//!       enable_reduce_mfp_fusion: false,
+//!       persist_fast_path_limit: 0,
+//!       reoptimize_imported_views: false,
+//!   },
+//!   df_meta: &mut DataflowMetainfo::default(),
 //! });
 //!
 //! let predicate00 = MirScalarExpr::column(0).call_binary(MirScalarExpr::column(0), BinaryFunc::AddInt64);

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -1168,7 +1168,7 @@ impl crate::Transform for Typecheck {
 
         let expected = transform_ctx
             .global_id
-            .map_or_else(|| None, |id| typecheck_ctx.get(&Id::Global(*id)));
+            .map_or_else(|| None, |id| typecheck_ctx.get(&Id::Global(id)));
 
         if let Some(id) = transform_ctx.global_id {
             if self.disallow_new_globals
@@ -1213,7 +1213,7 @@ impl crate::Transform for Typecheck {
             }
             (Ok(got), None) => {
                 if let Some(id) = transform_ctx.global_id {
-                    typecheck_ctx.insert(Id::Global(*id), got);
+                    typecheck_ctx.insert(Id::Global(id), got);
                 }
             }
             (Err(err), _) => {

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -168,7 +168,7 @@ mod tests {
         let features = OptimizerFeatures::default();
         let typecheck_ctx = typecheck::empty_context();
         let mut df_meta = DataflowMetainfo::default();
-        let mut transform_ctx = TransformCtx::dummy(&features, &typecheck_ctx, &mut df_meta);
+        let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta);
         let mut rel = parse_relation(s, cat, args)?;
         for t in args.get("apply").cloned().unwrap_or_else(Vec::new).iter() {
             get_transform(t)?.transform(&mut rel, &mut transform_ctx)?;

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -234,7 +234,7 @@ fn apply_transform<T: mz_transform::Transform>(
     let typecheck_ctx = mz_transform::typecheck::empty_context();
     let mut df_meta = DataflowMetainfo::default();
     let mut transform_ctx =
-        mz_transform::TransformCtx::dummy(&features, &typecheck_ctx, &mut df_meta);
+        mz_transform::TransformCtx::local(&features, &typecheck_ctx, &mut df_meta);
 
     // Apply the transformation, returning early on TransformError.
     transform

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -230,19 +230,15 @@ fn apply_transform<T: mz_transform::Transform>(
     // Parse the relation, returning early on parse error.
     let mut relation = try_parse_mir(catalog, input)?;
 
-    let mut df_meta = DataflowMetainfo::default();
     let features = mz_repr::optimize::OptimizerFeatures::default();
-    let mut ctx: mz_transform::TransformCtx = mz_transform::TransformCtx {
-        indexes: &mz_transform::EmptyIndexOracle,
-        stats: &mz_transform::EmptyStatisticsOracle,
-        global_id: None,
-        features: &features,
-        df_meta: &mut df_meta,
-    };
+    let typecheck_ctx = mz_transform::typecheck::empty_context();
+    let mut df_meta = DataflowMetainfo::default();
+    let mut transform_ctx =
+        mz_transform::TransformCtx::dummy(&features, &typecheck_ctx, &mut df_meta);
 
     // Apply the transformation, returning early on TransformError.
     transform
-        .transform(&mut relation, &mut ctx)
+        .transform(&mut relation, &mut transform_ctx)
         .map_err(|e| format!("{}\n", e.to_string().trim()))?;
 
     // Serialize and return the transformed relation.

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -230,18 +230,19 @@ fn apply_transform<T: mz_transform::Transform>(
     // Parse the relation, returning early on parse error.
     let mut relation = try_parse_mir(catalog, input)?;
 
-    let mut dataflow_metainfo = DataflowMetainfo::default();
-    let mut empty_args: mz_transform::TransformCtx = mz_transform::TransformCtx {
+    let mut df_meta = DataflowMetainfo::default();
+    let features = mz_repr::optimize::OptimizerFeatures::default();
+    let mut ctx: mz_transform::TransformCtx = mz_transform::TransformCtx {
         indexes: &mz_transform::EmptyIndexOracle,
         stats: &mz_transform::EmptyStatisticsOracle,
         global_id: None,
-        enable_eager_delta_joins: false,
-        dataflow_metainfo: &mut dataflow_metainfo,
+        features: &features,
+        df_meta: &mut df_meta,
     };
 
     // Apply the transformation, returning early on TransformError.
     transform
-        .transform(&mut relation, &mut empty_args)
+        .transform(&mut relation, &mut ctx)
         .map_err(|e| format!("{}\n", e.to_string().trim()))?;
 
     // Serialize and return the transformed relation.


### PR DESCRIPTION
Make `OptimizerConfig` available in all parts of the MIR optimizations defined in `mz_transform` (local and global).

### Motivation

  * This PR adds a known-desirable feature.

Part of #25273.

### Tips for reviewer

To follow what is happening it's best to review this one commit at a time.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. (Relying on the large body of existing tests).
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
