### PR TITLE
mysql tests: Add in data-ingest and parallel-workload test frameworks

### DIFF
--- a/misc/python/materialize/data_ingest/data_type.py
+++ b/misc/python/materialize/data_ingest/data_type.py
@@ -366,4 +366,7 @@ DATA_TYPES_FOR_AVRO = sorted(
     list(set(DATA_TYPES) - {TextTextMap, Jsonb, Bytea, Boolean}), key=repr
 )
 
+# MySQL doesn't support keys of unlimited size
+DATA_TYPES_FOR_KEY = sorted(list(set(DATA_TYPES_FOR_AVRO) - {Text, Bytea}), key=repr)
+
 NUMBER_TYPES = [SmallInt, Int, Long, Float, Double]

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import confluent_kafka  # type: ignore
 import pg8000
+import pymysql
 from confluent_kafka.admin import AdminClient  # type: ignore
 from confluent_kafka.schema_registry import Schema, SchemaRegistryClient  # type: ignore
 from confluent_kafka.schema_registry.avro import AvroSerializer  # type: ignore
@@ -28,6 +29,7 @@ from materialize.data_ingest.field import Field, formatted_value
 from materialize.data_ingest.query_error import QueryError
 from materialize.data_ingest.row import Operation
 from materialize.data_ingest.transaction import Transaction
+from materialize.mzcompose.services.mysql import MySql
 
 
 class Executor:
@@ -274,6 +276,129 @@ class KafkaExecutor(Executor):
                 else:
                     raise ValueError(f"Unexpected operation {row.operation}")
         self.producer.flush()
+
+
+class MySqlExecutor(Executor):
+    mysql_conn: pymysql.Connection
+    table: str
+    source: str
+    num: int
+
+    def __init__(
+        self,
+        num: int,
+        ports: dict[str, int],
+        fields: list[Field],
+        database: str,
+        schema: str = "public",
+        cluster: str | None = None,
+    ):
+        super().__init__(ports, fields, database, schema, cluster)
+        self.table = f"mytable{num}"
+        self.source = f"mysql_source{num}"
+        self.num = num
+
+    def create(self) -> None:
+        self.mysql_conn = pymysql.connect(
+            host="localhost",
+            user="root",
+            password=MySql.DEFAULT_ROOT_PASSWORD,
+            database="mysql",
+            port=self.ports["mysql"],
+        )
+
+        values = [
+            f"{identifier(field.name)} {str(field.data_type.name(Backend.POSTGRES)).lower()}"
+            for field in self.fields
+        ]
+        keys = [field.name for field in self.fields if field.is_key]
+
+        self.mysql_conn.autocommit(True)
+        with self.mysql_conn.cursor() as cur:
+            self.execute(cur, f"DROP TABLE IF EXISTS {identifier(self.table)};")
+            primary_key = (
+                f", PRIMARY KEY ({', '.join([identifier(key) for key in keys])})"
+                if keys
+                else ""
+            )
+            self.execute(
+                cur,
+                f"CREATE TABLE {identifier(self.table)} ({', '.join(values)} {primary_key});",
+            )
+        self.mysql_conn.autocommit(False)
+
+        self.mz_conn.autocommit = True
+        with self.mz_conn.cursor() as cur:
+            self.execute(
+                cur,
+                f"CREATE SECRET IF NOT EXISTS mypass AS '{MySql.DEFAULT_ROOT_PASSWORD}'",
+            )
+            self.execute(
+                cur,
+                f"""CREATE CONNECTION mysql{self.num} FOR MYSQL
+                    HOST 'mysql',
+                    USER root,
+                    PASSWORD SECRET mypass""",
+            )
+            self.execute(
+                cur,
+                f"""CREATE SOURCE {identifier(self.database)}.{identifier(self.schema)}.{identifier(self.source)}
+                    {f"IN CLUSTER {identifier(self.cluster)}" if self.cluster else ""}
+                    FROM MYSQL CONNECTION mysql{self.num}
+                    FOR TABLES (mysql.{identifier(self.table)} AS {identifier(self.table)})""",
+            )
+        self.mz_conn.autocommit = False
+
+    def run(self, transaction: Transaction) -> None:
+        with self.mysql_conn.cursor() as cur:
+            for row_list in transaction.row_lists:
+                for row in row_list.rows:
+                    if row.operation == Operation.INSERT:
+                        values_str = ", ".join(
+                            str(formatted_value(value)) for value in row.values
+                        )
+                        self.execute(
+                            cur,
+                            f"""INSERT INTO {identifier(self.table)}
+                                VALUES ({values_str})
+                            """,
+                        )
+                    elif row.operation == Operation.UPSERT:
+                        values_str = ", ".join(
+                            str(formatted_value(value)) for value in row.values
+                        )
+                        ", ".join(
+                            identifier(field.name)
+                            for field in row.fields
+                            if field.is_key
+                        )
+                        update_str = ", ".join(
+                            f"{identifier(field.name)} = VALUES({identifier(field.name)})"
+                            for field in row.fields
+                        )
+                        self.execute(
+                            cur,
+                            f"""INSERT INTO {identifier(self.table)}
+                                VALUES ({values_str})
+                                ON DUPLICATE KEY
+                                UPDATE {update_str}
+                            """,
+                        )
+                    elif row.operation == Operation.DELETE:
+                        cond_str = " AND ".join(
+                            f"{identifier(field.name)} = {formatted_value(value)}"
+                            for field, value in zip(row.fields, row.values)
+                            if field.is_key
+                        )
+                        self.execute(
+                            cur,
+                            f"""DELETE FROM {identifier(self.table)}
+                                WHERE {cond_str}
+                            """,
+                        )
+                    else:
+                        raise ValueError(f"Unexpected operation {row.operation}")
+        self.mysql_conn.commit()
 
 
 class PgExecutor(Executor):

--- a/misc/python/materialize/data_ingest/workload.py
+++ b/misc/python/materialize/data_ingest/workload.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import pg8000
 
-from materialize.data_ingest.data_type import DATA_TYPES_FOR_AVRO
+from materialize.data_ingest.data_type import DATA_TYPES_FOR_AVRO, DATA_TYPES_FOR_KEY
 from materialize.data_ingest.definition import (
     Delete,
     Insert,
@@ -157,7 +157,7 @@ def execute_workload(
     fields = []
 
     for i in range(random.randint(1, 10)):
-        fields.append(Field(f"key{i}", random.choice(DATA_TYPES_FOR_AVRO), True))
+        fields.append(Field(f"key{i}", random.choice(DATA_TYPES_FOR_KEY), True))
     for i in range(random.randint(0, 20)):
         fields.append(Field(f"value{i}", random.choice(DATA_TYPES_FOR_AVRO), False))
     print(f"With fields: {fields}")

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -34,6 +34,7 @@ from materialize.parallel_workload.database import (
     MAX_INDEXES,
     MAX_KAFKA_SINKS,
     MAX_KAFKA_SOURCES,
+    MAX_MYSQL_SOURCES,
     MAX_POSTGRES_SOURCES,
     MAX_ROLES,
     MAX_ROWS,
@@ -48,6 +49,7 @@ from materialize.parallel_workload.database import (
     Index,
     KafkaSink,
     KafkaSource,
+    MySqlSource,
     PostgresSource,
     Role,
     Schema,
@@ -1391,6 +1393,72 @@ class DropKafkaSourceAction(Action):
         return True
 
 
+class CreateMySqlSourceAction(Action):
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
+        result = super().errors_to_ignore(exe)
+        if exe.db.scenario in (Scenario.Kill, Scenario.TogglePersistTxn):
+            result.extend(
+                ["cannot create source in cluster with more than one replica"]
+            )
+        return result
+
+    def run(self, exe: Executor) -> bool:
+        # TODO: Reenable when #22770 is fixed
+        if exe.db.scenario == Scenario.BackupRestore:
+            return False
+
+        with exe.db.lock:
+            if len(exe.db.mysql_sources) >= MAX_MYSQL_SOURCES:
+                return False
+            source_id = exe.db.mysql_source_id
+            exe.db.mysql_source_id += 1
+            potential_clusters = [c for c in exe.db.clusters if len(c.replicas) == 1]
+            schema = self.rng.choice(exe.db.schemas)
+            cluster = self.rng.choice(potential_clusters)
+        with schema.lock, cluster.lock:
+            if schema not in exe.db.schemas:
+                return False
+            if cluster not in exe.db.clusters or len(cluster.replicas) != 1:
+                return False
+
+            try:
+                source = MySqlSource(
+                    source_id,
+                    cluster,
+                    schema,
+                    exe.db.ports,
+                    self.rng,
+                )
+                source.create(exe)
+                exe.db.mysql_sources.append(source)
+            except:
+                if exe.db.scenario not in (Scenario.Kill, Scenario.TogglePersistTxn):
+                    raise
+        return True
+
+
+class DropMySqlSourceAction(Action):
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
+        return [
+            "still depended upon by",
+        ] + super().errors_to_ignore(exe)
+
+    def run(self, exe: Executor) -> bool:
+        with exe.db.lock:
+            if not exe.db.mysql_sources:
+                return False
+            source = self.rng.choice(exe.db.mysql_sources)
+        with source.lock:
+            # Was dropped while we were acquiring lock
+            if source not in exe.db.mysql_sources:
+                return False
+
+            query = f"DROP SOURCE {source.executor.source}"
+            exe.execute(query)
+            exe.db.mysql_sources.remove(source)
+        return True
+
+
 class CreatePostgresSourceAction(Action):
     def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
@@ -1680,6 +1748,8 @@ ddl_action_list = ActionList(
         (DropKafkaSinkAction, 1),
         (CreateKafkaSourceAction, 4),
         (DropKafkaSourceAction, 1),
+        (CreateMySqlSourceAction, 4),
+        (DropMySqlSourceAction, 1),
         (CreatePostgresSourceAction, 4),
         (DropPostgresSourceAction, 1),
         (GrantPrivilegesAction, 4),

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -18,6 +18,7 @@ from pg8000.native import identifier, literal
 from materialize.data_ingest.data_type import (
     DATA_TYPES,
     DATA_TYPES_FOR_AVRO,
+    DATA_TYPES_FOR_KEY,
     Bytea,
     DataType,
     Jsonb,
@@ -25,11 +26,12 @@ from materialize.data_ingest.data_type import (
     TextTextMap,
 )
 from materialize.data_ingest.definition import Insert
-from materialize.data_ingest.executor import KafkaExecutor, PgExecutor
+from materialize.data_ingest.executor import KafkaExecutor, MySqlExecutor, PgExecutor
 from materialize.data_ingest.field import Field
 from materialize.data_ingest.transaction import Transaction
 from materialize.data_ingest.workload import WORKLOADS
 from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.services.mysql import MySql
 from materialize.parallel_workload.executor import Executor
 from materialize.parallel_workload.settings import Complexity, Scenario
 from materialize.util import naughty_strings
@@ -47,6 +49,7 @@ MAX_INDEXES = 100
 MAX_ROLES = 100
 MAX_WEBHOOK_SOURCES = 20
 MAX_KAFKA_SOURCES = 20
+MAX_MYSQL_SOURCES = 20
 MAX_POSTGRES_SOURCES = 20
 MAX_KAFKA_SINKS = 20
 
@@ -58,6 +61,7 @@ MAX_INITIAL_VIEWS = 10
 MAX_INITIAL_ROLES = 3
 MAX_INITIAL_WEBHOOK_SOURCES = 3
 MAX_INITIAL_KAFKA_SOURCES = 3
+MAX_INITIAL_MYSQL_SOURCES = 3
 MAX_INITIAL_POSTGRES_SOURCES = 3
 MAX_INITIAL_KAFKA_SINKS = 3
 
@@ -593,6 +597,74 @@ class KafkaSink(DBObject):
         exe.execute(query)
 
 
+class MySqlColumn(Column):
+    def __init__(
+        self, name: str, data_type: type[DataType], nullable: bool, db_object: DBObject
+    ):
+        self.raw_name = name
+        self.data_type = data_type
+        self.nullable = nullable
+        self.db_object = db_object
+
+    def name(self, in_query: bool = False) -> str:
+        return identifier(self.raw_name) if in_query else self.raw_name
+
+
+class MySqlSource(DBObject):
+    source_id: int
+    cluster: "Cluster"
+    executor: MySqlExecutor
+    generator: Iterator[Transaction]
+    lock: threading.Lock
+    columns: list[MySqlColumn]
+    schema: Schema
+    num_rows: int
+
+    def __init__(
+        self,
+        source_id: int,
+        cluster: "Cluster",
+        schema: Schema,
+        ports: dict[str, int],
+        rng: random.Random,
+    ):
+        super().__init__()
+        self.source_id = source_id
+        self.cluster = cluster
+        self.schema = schema
+        self.num_rows = 0
+        fields = []
+        for i in range(rng.randint(1, 10)):
+            fields.append(
+                # naughtify: MySql column identifiers are escaped differently for MySql sources: key3_ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏА gets "", but pg8000.native.identifier() doesn't
+                Field(f"key{i}", rng.choice(DATA_TYPES_FOR_KEY), True)
+            )
+        for i in range(rng.randint(0, 20)):
+            fields.append(Field(f"value{i}", rng.choice(DATA_TYPES_FOR_AVRO), False))
+        self.columns = [
+            MySqlColumn(field.name, field.data_type, False, self) for field in fields
+        ]
+        self.executor = MySqlExecutor(
+            self.source_id,
+            ports,
+            fields,
+            schema.db.name(),
+            schema.name(),
+            cluster.name(),
+        )
+        self.generator = rng.choice(list(WORKLOADS))(None).generate(fields)
+        self.lock = threading.Lock()
+
+    def name(self) -> str:
+        return self.executor.table
+
+    def __str__(self) -> str:
+        return f"{self.schema}.{self.name()}"
+
+    def create(self, exe: Executor) -> None:
+        self.executor.create()
+
+
 class PostgresColumn(Column):
     def __init__(
         self, name: str, data_type: type[DataType], nullable: bool, db_object: DBObject
@@ -793,6 +865,8 @@ class Database:
     webhook_source_id: int
     kafka_sources: list[KafkaSource]
     kafka_source_id: int
+    mysql_sources: list[MySqlSource]
+    mysql_source_id: int
     postgres_sources: list[PostgresSource]
     postgres_source_id: int
     kafka_sinks: list[KafkaSink]
@@ -866,6 +940,7 @@ class Database:
         ]
         self.webhook_source_id = len(self.webhook_sources)
         self.kafka_sources = []
+        self.mysql_sources = []
         self.postgres_sources = []
         self.kafka_sinks = []
         if not self.fast_startup:
@@ -879,6 +954,20 @@ class Database:
                 )
                 for i in range(rng.randint(0, MAX_INITIAL_KAFKA_SOURCES))
             ]
+            # TODO: Reenable when #22770 is fixed
+            if self.scenario == Scenario.BackupRestore:
+                self.mysql_sources = []
+            else:
+                self.mysql_sources = [
+                    MySqlSource(
+                        i,
+                        rng.choice(self.clusters),
+                        rng.choice(self.schemas),
+                        ports,
+                        rng,
+                    )
+                    for i in range(rng.randint(0, MAX_INITIAL_MYSQL_SOURCES))
+                ]
             # TODO: Reenable when #22770 is fixed
             if self.scenario == Scenario.BackupRestore:
                 self.postgres_sources = []
@@ -904,6 +993,7 @@ class Database:
                 for i in range(rng.randint(0, MAX_INITIAL_KAFKA_SINKS))
             ]
         self.kafka_source_id = len(self.kafka_sources)
+        self.mysql_source_id = len(self.mysql_sources)
         self.postgres_source_id = len(self.postgres_sources)
         self.kafka_sink_id = len(self.kafka_sinks)
         self.lock = threading.Lock()
@@ -911,18 +1001,23 @@ class Database:
 
     def db_objects(
         self,
-    ) -> list[WebhookSource | PostgresSource | KafkaSource | View | Table]:
+    ) -> list[
+        WebhookSource | MySqlSource | PostgresSource | KafkaSource | View | Table
+    ]:
         return (
             self.tables
             + self.views
             + self.kafka_sources
+            + self.mysql_sources
             + self.postgres_sources
             + self.webhook_sources
         )
 
     def db_objects_without_views(
         self,
-    ) -> list[WebhookSource | PostgresSource | KafkaSource | View | Table]:
+    ) -> list[
+        WebhookSource | MySqlSource | PostgresSource | KafkaSource | View | Table
+    ]:
         return [
             obj for obj in self.db_objects() if type(obj) != View or obj.materialized
         ]
@@ -957,6 +1052,11 @@ class Database:
         exe.execute("CREATE SECRET pgpass AS 'postgres'")
         exe.execute(
             "CREATE CONNECTION postgres_conn FOR POSTGRES HOST 'postgres', DATABASE postgres, USER postgres, PASSWORD SECRET pgpass"
+        )
+
+        exe.execute(f"CREATE SECRET mypass AS '{MySql.DEFAULT_ROOT_PASSWORD}'")
+        exe.execute(
+            "CREATE CONNECTION mysql_conn FOR MYSQL HOST 'mysql', USER root, PASSWORD SECRET mypass"
         )
 
         for relation in self:

--- a/test/data-ingest/mzcompose.py
+++ b/test/data-ingest/mzcompose.py
@@ -10,19 +10,25 @@
 import random
 import time
 
-from materialize.data_ingest.executor import KafkaExecutor, KafkaRoundtripExecutor
+from materialize.data_ingest.executor import (
+    KafkaExecutor,
+    KafkaRoundtripExecutor,
+    MySqlExecutor,
+)
 from materialize.data_ingest.workload import *  # noqa: F401 F403
 from materialize.data_ingest.workload import WORKLOADS, execute_workload
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.zookeeper import Zookeeper
 
 SERVICES = [
     Postgres(),
+    MySql(),
     Zookeeper(),
     Kafka(
         auto_create_topics=False,
@@ -69,7 +75,14 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     print(f"--- Random seed is {args.seed}")
 
-    services = ("materialized", "zookeeper", "kafka", "schema-registry", "postgres")
+    services = (
+        "materialized",
+        "zookeeper",
+        "kafka",
+        "schema-registry",
+        "postgres",
+        "mysql",
+    )
     c.up(*services)
 
     conn = c.sql_connection()
@@ -87,7 +100,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     conn.autocommit = False
     conn.close()
 
-    executor_classes = [KafkaRoundtripExecutor, KafkaExecutor]
+    executor_classes = [MySqlExecutor, KafkaRoundtripExecutor, KafkaExecutor]
     ports = {s: c.default_port(s) for s in services}
 
     for i, workload_class in enumerate(workloads):

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -18,6 +18,7 @@ from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc, Minio
+from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.toxiproxy import Toxiproxy
@@ -28,6 +29,7 @@ from materialize.parallel_workload.settings import Complexity, Scenario
 SERVICES = [
     Cockroach(setup_materialize=True),
     Postgres(),
+    MySql(),
     Zookeeper(),
     Kafka(
         auto_create_topics=False,
@@ -59,6 +61,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     service_names = [
         "cockroach",
         "postgres",
+        "mysql",
         "zookeeper",
         "kafka",
         "schema-registry",


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/24927

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
