### PR TITLE
data-ingest: Accept logger from parallel-workload

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -384,7 +384,7 @@ class SourceInsertAction(Action):
                         source.num_rows += 1
                     elif row.operation == Operation.DELETE:
                         source.num_rows -= 1
-            source.executor.run(transaction)
+            source.executor.run(transaction, logging_exe=exe)
         return True
 
 

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -538,7 +538,7 @@ class KafkaSource(DBObject):
         return f"{self.schema}.{self.name()}"
 
     def create(self, exe: Executor) -> None:
-        self.executor.create()
+        self.executor.create(logging_exe=exe)
 
 
 class KafkaSink(DBObject):
@@ -662,7 +662,7 @@ class MySqlSource(DBObject):
         return f"{self.schema}.{self.name()}"
 
     def create(self, exe: Executor) -> None:
-        self.executor.create()
+        self.executor.create(logging_exe=exe)
 
 
 class PostgresColumn(Column):
@@ -730,7 +730,7 @@ class PostgresSource(DBObject):
         return f"{self.schema}.{self.name()}"
 
     def create(self, exe: Executor) -> None:
-        self.executor.create()
+        self.executor.create(logging_exe=exe)
 
 
 class Index:
@@ -1039,7 +1039,7 @@ class Database:
 
         exe.execute("SELECT name FROM mz_roles WHERE name LIKE 'r%'")
         for row in exe.cur.fetchall():
-            exe.execute(f"DROP ROLE {identifier(row[0])}")
+            exe.execute(f"DROP ROLE {identifier(row[0])} CASCADE")
 
         exe.execute(
             "CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER 'kafka:9092', SECURITY PROTOCOL PLAINTEXT"


### PR DESCRIPTION
Noticed here that we are missing some data-ingest logs: https://materializeinc.slack.com/archives/C01LKF361MZ/p1709222602231569

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
