### PR TITLE
parallel-workload: Remove mz_sleeps again

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -216,9 +216,6 @@ class SelectAction(Action):
         else:
             expressions = "*"
 
-        if self.rng.choice([True, False]):
-            expressions += f", mz_unsafe.mz_sleep({self.rng.randint(1, 5)})"
-
         query = f"SELECT {expressions} FROM {obj_name} "
 
         if join:

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -252,7 +252,6 @@ class View(DBObject):
     rename: int
     schema: Schema
     refresh: str | None
-    sleep: int
 
     def __init__(
         self,
@@ -308,8 +307,6 @@ class View(DBObject):
             else None
         )
 
-        self.sleep = rng.randint(0, 5)
-
         if base_object2:
             self.join_column = rng.choice(base_object.columns)
             self.join_column2 = None
@@ -338,9 +335,6 @@ class View(DBObject):
             f"{source_column} AS {column.name(True)}"
             for source_column, column in zip(self.source_columns, self.columns)
         )
-
-        if self.sleep:
-            columns_str += f", mz_unsafe.mz_sleep({self.sleep})"
 
         query += f" {self}"
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
