### PR TITLE
storage/statistics: fix rehydration latency being multiplied by 1000

### DIFF
--- a/src/storage-client/src/statistics.rs
+++ b/src/storage-client/src/statistics.rs
@@ -554,7 +554,7 @@ impl PackableStats for SourceStatisticsUpdate {
             rehydration_latency_ms: Gauge::gauge(
                 <Option<mz_repr::adt::interval::Interval>>::try_from(iter.next().unwrap())
                     .unwrap()
-                    .map(|int| int.micros),
+                    .map(|int| int.micros / 1000),
             ),
             snapshot_records_known: Gauge::gauge(
                 <Option<u64>>::try_from(iter.next().unwrap()).unwrap(),

--- a/test/cluster/gh-25633/01-create-source.td
+++ b/test/cluster/gh-25633/01-create-source.td
@@ -1,0 +1,27 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET kafka_default_metadata_fetch_interval = 1000
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
+
+> DROP CLUSTER IF EXISTS test_cluster CASCADE;
+> CREATE CLUSTER test_cluster (SIZE '1');
+
+> CREATE SOURCE count IN CLUSTER test_cluster FROM LOAD GENERATOR COUNTER
+
+> SELECT
+    u.rehydration_latency IS NOT NULL
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('count')
+true
+
+> ALTER CLUSTER test_cluster SET (REPLICATION FACTOR = 0)

--- a/test/cluster/gh-25633/02-after-environmentd-restart.td
+++ b/test/cluster/gh-25633/02-after-environmentd-restart.td
@@ -1,0 +1,21 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Verify that the data ingested before `environmentd` was killed is still
+# present, then try ingesting more data.
+
+> SELECT
+    (u.rehydration_latency)::text = '${arg.rehydration-latency}'
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('count')
+true
+
+> DROP SOURCE IF EXISTS count
+> DROP CLUSTER IF EXISTS test_cluster CASCADE


### PR DESCRIPTION
When we unpack `rehydration_latency_ms`, we accidentally don't divide it back into micros. _This means everytime envd restarts, we multiply the rehydration latency by 1000._ This is overridden by the next time a source is rehydrated.

This is not unsafe because:
- It doesn't cause negative multiplicities or break the 
- In release mode, we won't panic after restarting enough times and overflowing during multiplication

For this reason I don't think we need a backport, but we do want to fix this before the next release. Working on a test now.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/25633

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
