### PR TITLE
remove unused features from deps in aws-util

### DIFF
--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -20,9 +20,9 @@ bytes = "1.3.0"
 bytesize = "1.1.0"
 http = "0.2.8"
 hyper-tls = { version = "0.5.0" }
-mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes_", "region"] }
+mz-ore = { path = "../ore", default-features = false }
 thiserror = "1.0.37"
-tokio = { version = "1.32.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
+tokio = { version = "1.32.0", default-features = false, features = ["macros"] }
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 


### PR DESCRIPTION
Remove unused features from deps in aws-util.

### Motivation

  * This PR fixes a previously unreported bug.
Things are pulling extra unused stuff. This causes problems for the cloud repo, when trying to bump our submodule.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No user-facing behavior changes.
