### PR TITLE
explain,coord: implement `EXPLAIN ... VIEW` variants

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -434,10 +434,10 @@ pub struct PeekStageValidate {
     /// sequencing a COPY TO statement.
     ///
     /// Will result in creating and using [`optimize::copy_to::Optimizer`] in
-    /// the `opimizer` field of all subsequent stages.
+    /// the `optimizer` field of all subsequent stages.
     copy_to_ctx: Option<CopyToContext>,
     /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
+    /// sequencing an EXPLAIN for this statement.
     explain_ctx: ExplainContext,
 }
 
@@ -450,7 +450,7 @@ pub struct PeekStageLinearizeTimestamp {
     timeline_context: TimelineContext,
     optimizer: Either<optimize::peek::Optimizer, optimize::copy_to::Optimizer>,
     /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
+    /// sequencing an EXPLAIN for this statement.
     explain_ctx: ExplainContext,
 }
 
@@ -464,7 +464,7 @@ pub struct PeekStageRealTimeRecency {
     oracle_read_ts: Option<Timestamp>,
     optimizer: Either<optimize::peek::Optimizer, optimize::copy_to::Optimizer>,
     /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
+    /// sequencing an EXPLAIN for this statement.
     explain_ctx: ExplainContext,
 }
 
@@ -479,7 +479,7 @@ pub struct PeekStageTimestampReadHold {
     real_time_recency_ts: Option<mz_repr::Timestamp>,
     optimizer: Either<optimize::peek::Optimizer, optimize::copy_to::Optimizer>,
     /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
+    /// sequencing an EXPLAIN for this statement.
     explain_ctx: ExplainContext,
 }
 
@@ -493,7 +493,7 @@ pub struct PeekStageOptimize {
     determination: TimestampDetermination<mz_repr::Timestamp>,
     optimizer: Either<optimize::peek::Optimizer, optimize::copy_to::Optimizer>,
     /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
+    /// sequencing an EXPLAIN for this statement.
     explain_ctx: ExplainContext,
 }
 
@@ -538,7 +538,7 @@ pub struct CreateIndexOptimize {
     plan: plan::CreateIndexPlan,
     resolved_ids: ResolvedIds,
     /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
+    /// sequencing an EXPLAIN for this statement.
     explain_ctx: ExplainContext,
 }
 
@@ -565,6 +565,7 @@ pub struct CreateIndexExplain {
 pub enum CreateViewStage {
     Optimize(CreateViewOptimize),
     Finish(CreateViewFinish),
+    Explain(CreateViewExplain),
 }
 
 #[derive(Debug)]
@@ -572,6 +573,9 @@ pub struct CreateViewOptimize {
     validity: PlanValidity,
     plan: plan::CreateViewPlan,
     resolved_ids: ResolvedIds,
+    /// An optional context set iff the state machine is initiated from
+    /// sequencing an EXPLAIN for this statement.
+    explain_ctx: ExplainContext,
 }
 
 #[derive(Debug)]
@@ -581,6 +585,14 @@ pub struct CreateViewFinish {
     plan: plan::CreateViewPlan,
     resolved_ids: ResolvedIds,
     optimized_expr: OptimizedMirRelationExpr,
+}
+
+#[derive(Debug)]
+pub struct CreateViewExplain {
+    validity: PlanValidity,
+    id: GlobalId,
+    plan: plan::CreateViewPlan,
+    explain_ctx: ExplainPlanContext,
 }
 
 #[derive(Debug)]
@@ -630,7 +642,7 @@ pub struct CreateMaterializedViewOptimize {
     plan: plan::CreateMaterializedViewPlan,
     resolved_ids: ResolvedIds,
     /// An optional context set iff the state machine is initiated from
-    /// sequencing an EXPALIN for this statement.
+    /// sequencing an EXPLAIN for this statement.
     explain_ctx: ExplainContext,
 }
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -33,7 +33,7 @@ use mz_repr::explain::json::json_string;
 use mz_repr::explain::{ExplainFormat, ExprHumanizer};
 use mz_repr::role_id::RoleId;
 use mz_repr::{Datum, Diff, GlobalId, Row, RowArena, Timestamp};
-use mz_sql::ast::{ExplainStage, IndexOptionName};
+use mz_sql::ast::IndexOptionName;
 use mz_sql::catalog::{
     CatalogCluster, CatalogClusterReplica, CatalogDatabase, CatalogError,
     CatalogItem as SqlCatalogItem, CatalogItemType, CatalogRole, CatalogSchema, CatalogTypeDetails,
@@ -87,7 +87,6 @@ use crate::coord::{
     RealTimeRecencyContext, StageResult, Staged, TargetCluster,
 };
 use crate::error::AdapterError;
-use crate::explain::explain_dataflow;
 use crate::notice::{AdapterNotice, DroppedInUseIndex};
 use crate::optimize::dataflows::{prep_scalar_expr, EvalTime, ExprPrepStyle};
 use crate::optimize::{self, Optimize};
@@ -1890,65 +1889,6 @@ impl Coordinator {
                 self.explain_replan_index(ctx, plan).await;
             }
         };
-    }
-
-    fn explain_index(
-        &mut self,
-        ctx: &ExecuteContext,
-        plan::ExplainPlanPlan {
-            stage,
-            format,
-            config,
-            explainee,
-        }: plan::ExplainPlanPlan,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        let plan::Explainee::Index(id) = explainee else {
-            unreachable!() // Asserted in `sequence_explain_plan`.
-        };
-        let CatalogItem::Index(_) = self.catalog().get_entry(&id).item() else {
-            unreachable!() // Asserted in `plan_explain_plan`.
-        };
-
-        let Some(dataflow_metainfo) = self.catalog().try_get_dataflow_metainfo(&id) else {
-            tracing::error!("cannot find dataflow metainformation for index {id} in catalog");
-            coord_bail!("cannot find dataflow metainformation for index {id} in catalog");
-        };
-
-        let explain = match stage {
-            ExplainStage::GlobalPlan => {
-                let Some(plan) = self.catalog().try_get_optimized_plan(&id).cloned() else {
-                    tracing::error!("cannot find {stage} for index {id} in catalog");
-                    coord_bail!("cannot find {stage} for index in catalog");
-                };
-                explain_dataflow(
-                    plan,
-                    format,
-                    &config,
-                    &self.catalog().for_session(ctx.session()),
-                    dataflow_metainfo,
-                )?
-            }
-            ExplainStage::PhysicalPlan => {
-                let Some(plan) = self.catalog().try_get_physical_plan(&id).cloned() else {
-                    tracing::error!("cannot find {stage} for index {id} in catalog");
-                    coord_bail!("cannot find {stage} for index in catalog");
-                };
-                explain_dataflow(
-                    plan,
-                    format,
-                    &config,
-                    &self.catalog().for_session(ctx.session()),
-                    dataflow_metainfo,
-                )?
-            }
-            _ => {
-                coord_bail!("cannot EXPLAIN {} FOR INDEX", stage);
-            }
-        };
-
-        let rows = vec![Row::pack_slice(&[Datum::from(explain.as_str())])];
-
-        Ok(Self::send_immediate_rows(rows))
     }
 
     #[instrument]

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1892,69 +1892,6 @@ impl Coordinator {
         };
     }
 
-    fn explain_materialized_view(
-        &mut self,
-        ctx: &ExecuteContext,
-        plan::ExplainPlanPlan {
-            stage,
-            format,
-            config,
-            explainee,
-        }: plan::ExplainPlanPlan,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        let plan::Explainee::MaterializedView(id) = explainee else {
-            unreachable!() // Asserted in `sequence_explain_plan`.
-        };
-        let CatalogItem::MaterializedView(_) = self.catalog().get_entry(&id).item() else {
-            unreachable!() // Asserted in `plan_explain_plan`.
-        };
-
-        let Some(dataflow_metainfo) = self.catalog().try_get_dataflow_metainfo(&id) else {
-            tracing::error!(
-                "cannot find dataflow metainformation for materialized view {id} in catalog"
-            );
-            coord_bail!(
-                "cannot find dataflow metainformation for materialized view {id} in catalog"
-            );
-        };
-
-        let explain = match stage {
-            ExplainStage::GlobalPlan => {
-                let Some(plan) = self.catalog().try_get_optimized_plan(&id).cloned() else {
-                    tracing::error!("cannot find {stage} for materialized view {id} in catalog");
-                    coord_bail!("cannot find {stage} for materialized view in catalog");
-                };
-                explain_dataflow(
-                    plan,
-                    format,
-                    &config,
-                    &self.catalog().for_session(ctx.session()),
-                    dataflow_metainfo,
-                )?
-            }
-            ExplainStage::PhysicalPlan => {
-                let Some(plan) = self.catalog().try_get_physical_plan(&id).cloned() else {
-                    tracing::error!("cannot find {stage} for materialized view {id} in catalog");
-                    coord_bail!("cannot find {stage} for materialized view in catalog");
-                };
-                explain_dataflow(
-                    plan,
-                    format,
-                    &config,
-                    &self.catalog().for_session(ctx.session()),
-                    dataflow_metainfo,
-                )?
-            }
-            _ => {
-                coord_bail!("cannot EXPLAIN {} FOR MATERIALIZED VIEW", stage);
-            }
-        };
-
-        let rows = vec![Row::pack_slice(&[Datum::from(explain.as_str())])];
-
-        Ok(Self::send_immediate_rows(rows))
-    }
-
     fn explain_index(
         &mut self,
         ctx: &ExecuteContext,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1856,8 +1856,7 @@ impl Coordinator {
         match &plan.explainee {
             plan::Explainee::Statement(stmt) => match stmt {
                 plan::ExplaineeStatement::CreateView { .. } => {
-                    let msg = "EXPLAIN CREATE VIEW is currently not supported";
-                    ctx.retire(Err(AdapterError::Unsupported(msg)));
+                    self.explain_create_view(ctx, plan).await;
                 }
                 plan::ExplaineeStatement::CreateMaterializedView { .. } => {
                     self.explain_create_materialized_view(ctx, plan).await;
@@ -1870,8 +1869,8 @@ impl Coordinator {
                 }
             },
             plan::Explainee::View(_) => {
-                let msg = "EXPLAIN VIEW is currently not supported";
-                ctx.retire(Err(AdapterError::Unsupported(msg)));
+                let result = self.explain_view(&ctx, plan);
+                ctx.retire(result);
             }
             plan::Explainee::MaterializedView(_) => {
                 let result = self.explain_materialized_view(&ctx, plan);
@@ -1882,8 +1881,7 @@ impl Coordinator {
                 ctx.retire(result);
             }
             plan::Explainee::ReplanView(_) => {
-                let msg = "EXPLAIN REPLAN VIEW is currently not supported";
-                ctx.retire(Err(AdapterError::Unsupported(msg)));
+                self.explain_replan_view(ctx, plan).await;
             }
             plan::Explainee::ReplanMaterializedView(_) => {
                 self.explain_replan_materialized_view(ctx, plan).await;

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -174,7 +174,7 @@ impl Coordinator {
     }
 
     // `explain_ctx` is an optional context set iff the state machine is initiated from
-    // sequencing an EXPALIN for this statement.
+    // sequencing an EXPLAIN for this statement.
     #[instrument]
     fn create_index_validate(
         &mut self,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -16,6 +16,9 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::instrument;
 use mz_ore::soft_panic_or_log;
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
+use mz_repr::Datum;
+use mz_repr::Row;
+use mz_sql::ast::ExplainStage;
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::{ObjectId, ResolvedIds};
 use mz_sql::plan;
@@ -33,6 +36,7 @@ use crate::coord::{
     ExplainPlanContext, Message, PlanValidity, StageResult, Staged,
 };
 use crate::error::AdapterError;
+use crate::explain::explain_dataflow;
 use crate::explain::optimizer_trace::OptimizerTrace;
 use crate::optimize::dataflows::dataflow_import_id_bundle;
 use crate::optimize::{self, Optimize, OverrideFrom};
@@ -137,7 +141,7 @@ impl Coordinator {
             optimizer_trace,
         });
         let stage = return_if_err!(
-            self.create_materialized_view_validate(ctx.session(), plan, resolved_ids, explain_ctx,),
+            self.create_materialized_view_validate(ctx.session(), plan, resolved_ids, explain_ctx),
             ctx
         );
         self.sequence_staged(ctx, Span::current(), stage).await;
@@ -191,6 +195,70 @@ impl Coordinator {
             ctx
         );
         self.sequence_staged(ctx, Span::current(), stage).await;
+    }
+
+    #[instrument]
+    pub(super) fn explain_materialized_view(
+        &mut self,
+        ctx: &ExecuteContext,
+        plan::ExplainPlanPlan {
+            stage,
+            format,
+            config,
+            explainee,
+        }: plan::ExplainPlanPlan,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        let plan::Explainee::MaterializedView(id) = explainee else {
+            unreachable!() // Asserted in `sequence_explain_plan`.
+        };
+        let CatalogItem::MaterializedView(_) = self.catalog().get_entry(&id).item() else {
+            unreachable!() // Asserted in `plan_explain_plan`.
+        };
+
+        let Some(dataflow_metainfo) = self.catalog().try_get_dataflow_metainfo(&id) else {
+            tracing::error!(
+                "cannot find dataflow metainformation for materialized view {id} in catalog"
+            );
+            coord_bail!(
+                "cannot find dataflow metainformation for materialized view {id} in catalog"
+            );
+        };
+
+        let explain = match stage {
+            ExplainStage::GlobalPlan => {
+                let Some(plan) = self.catalog().try_get_optimized_plan(&id).cloned() else {
+                    tracing::error!("cannot find {stage} for materialized view {id} in catalog");
+                    coord_bail!("cannot find {stage} for materialized view in catalog");
+                };
+                explain_dataflow(
+                    plan,
+                    format,
+                    &config,
+                    &self.catalog().for_session(ctx.session()),
+                    dataflow_metainfo,
+                )?
+            }
+            ExplainStage::PhysicalPlan => {
+                let Some(plan) = self.catalog().try_get_physical_plan(&id).cloned() else {
+                    tracing::error!("cannot find {stage} for materialized view {id} in catalog");
+                    coord_bail!("cannot find {stage} for materialized view in catalog");
+                };
+                explain_dataflow(
+                    plan,
+                    format,
+                    &config,
+                    &self.catalog().for_session(ctx.session()),
+                    dataflow_metainfo,
+                )?
+            }
+            _ => {
+                coord_bail!("cannot EXPLAIN {} FOR MATERIALIZED VIEW", stage);
+            }
+        };
+
+        let rows = vec![Row::pack_slice(&[Datum::from(explain.as_str())])];
+
+        Ok(Self::send_immediate_rows(rows))
     }
 
     #[instrument]
@@ -338,22 +406,22 @@ impl Coordinator {
             move || {
                 span.in_scope(|| {
                     let mut pipeline = || -> Result<(
-                    optimize::materialized_view::LocalMirPlan,
-                    optimize::materialized_view::GlobalMirPlan,
-                    optimize::materialized_view::GlobalLirPlan,
-                ), AdapterError> {
-                    let _dispatch_guard = explain_ctx.dispatch_guard();
+                        optimize::materialized_view::LocalMirPlan,
+                        optimize::materialized_view::GlobalMirPlan,
+                        optimize::materialized_view::GlobalLirPlan,
+                    ), AdapterError> {
+                        let _dispatch_guard = explain_ctx.dispatch_guard();
 
-                    let raw_expr = plan.materialized_view.expr.clone();
+                        let raw_expr = plan.materialized_view.expr.clone();
 
-                    // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local and global)
-                    let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
-                    let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan.clone())?;
-                    // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                    let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan.clone())?;
+                        // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local and global)
+                        let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
+                        let global_mir_plan = optimizer.catch_unwind_optimize(local_mir_plan.clone())?;
+                        // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
+                        let global_lir_plan = optimizer.catch_unwind_optimize(global_mir_plan.clone())?;
 
-                    Ok((local_mir_plan, global_mir_plan, global_lir_plan))
-                };
+                        Ok((local_mir_plan, global_mir_plan, global_lir_plan))
+                    };
 
                     let stage = match pipeline() {
                         Ok((local_mir_plan, global_mir_plan, global_lir_plan)) => {

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -7,10 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use maplit::btreemap;
 use mz_catalog::memory::objects::{CatalogItem, View};
 use mz_expr::CollectionPlan;
 use mz_ore::instrument;
-use mz_repr::RelationDesc;
+use mz_repr::explain::{ExprHumanizerExt, TransientItem};
+use mz_repr::{Datum, RelationDesc, Row};
+use mz_sql::ast::ExplainStage;
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::{ObjectId, ResolvedIds};
 use mz_sql::plan::{self};
@@ -19,11 +22,13 @@ use tracing::Span;
 use crate::command::ExecuteResponse;
 use crate::coord::sequencer::inner::return_if_err;
 use crate::coord::{
-    Coordinator, CreateViewFinish, CreateViewOptimize, CreateViewStage, Message, PlanValidity,
-    StageResult, Staged,
+    Coordinator, CreateViewExplain, CreateViewFinish, CreateViewOptimize, CreateViewStage,
+    ExplainContext, ExplainPlanContext, Message, PlanValidity, StageResult, Staged,
 };
 use crate::error::AdapterError;
-use crate::optimize::{self, Optimize};
+use crate::explain::explain_plan;
+use crate::explain::optimizer_trace::OptimizerTrace;
+use crate::optimize::{self, Optimize, OverrideFrom};
 use crate::session::Session;
 use crate::{catalog, AdapterNotice, ExecuteContext};
 
@@ -32,6 +37,7 @@ impl Staged for CreateViewStage {
         match self {
             Self::Optimize(stage) => &mut stage.validity,
             Self::Finish(stage) => &mut stage.validity,
+            Self::Explain(stage) => &mut stage.validity,
         }
     }
 
@@ -43,6 +49,7 @@ impl Staged for CreateViewStage {
         match self {
             CreateViewStage::Optimize(stage) => coord.create_view_optimize(stage).await,
             CreateViewStage::Finish(stage) => coord.create_view_finish(ctx.session(), stage).await,
+            CreateViewStage::Explain(stage) => coord.create_view_explain(ctx.session(), stage),
         }
     }
 
@@ -63,10 +70,146 @@ impl Coordinator {
         resolved_ids: ResolvedIds,
     ) {
         let stage = return_if_err!(
-            self.create_view_validate(ctx.session(), plan, resolved_ids),
+            self.create_view_validate(ctx.session(), plan, resolved_ids, ExplainContext::None),
             ctx
         );
         self.sequence_staged(ctx, Span::current(), stage).await;
+    }
+
+    #[instrument]
+    pub(crate) async fn explain_create_view(
+        &mut self,
+        ctx: ExecuteContext,
+        plan::ExplainPlanPlan {
+            stage,
+            format,
+            config,
+            explainee,
+        }: plan::ExplainPlanPlan,
+    ) {
+        let plan::Explainee::Statement(stmt) = explainee else {
+            // This is currently asserted in the `sequence_explain_plan` code that
+            // calls this method.
+            unreachable!()
+        };
+        let plan::ExplaineeStatement::CreateView { broken, plan } = stmt else {
+            // This is currently asserted in the `sequence_explain_plan` code that
+            // calls this method.
+            unreachable!()
+        };
+
+        // Create an OptimizerTrace instance to collect plans emitted when
+        // executing the optimizer pipeline.
+        let optimizer_trace = OptimizerTrace::new(broken, stage.path());
+
+        // Not used in the EXPLAIN path so it's OK to generate a dummy value.
+        let resolved_ids = ResolvedIds(Default::default());
+
+        let explain_ctx = ExplainContext::Plan(ExplainPlanContext {
+            broken,
+            config,
+            format,
+            stage,
+            replan: None,
+            desc: None,
+            optimizer_trace,
+        });
+        let stage = return_if_err!(
+            self.create_view_validate(ctx.session(), plan, resolved_ids, explain_ctx),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
+    }
+
+    #[instrument]
+    pub(crate) async fn explain_replan_view(
+        &mut self,
+        ctx: ExecuteContext,
+        plan::ExplainPlanPlan {
+            stage,
+            format,
+            config,
+            explainee,
+        }: plan::ExplainPlanPlan,
+    ) {
+        let plan::Explainee::ReplanView(id) = explainee else {
+            unreachable!() // Asserted in `sequence_explain_plan`.
+        };
+        let CatalogItem::View(item) = self.catalog().get_entry(&id).item() else {
+            unreachable!() // Asserted in `plan_explain_plan`.
+        };
+
+        let state = self.catalog().state();
+        let plan_result = state.deserialize_plan(id, item.create_sql.clone(), true);
+        let (plan, resolved_ids) = return_if_err!(plan_result, ctx);
+
+        let plan::Plan::CreateView(plan) = plan else {
+            unreachable!() // We are parsing the `create_sql` of a `View` item.
+        };
+
+        // It is safe to assume that query optimization will always succeed, so
+        // for now we statically assume `broken = false`.
+        let broken = false;
+
+        // Create an OptimizerTrace instance to collect plans emitted when
+        // executing the optimizer pipeline.
+        let optimizer_trace = OptimizerTrace::new(broken, stage.path());
+
+        let explain_ctx = ExplainContext::Plan(ExplainPlanContext {
+            broken,
+            config,
+            format,
+            stage,
+            replan: Some(id),
+            desc: None,
+            optimizer_trace,
+        });
+        let stage = return_if_err!(
+            self.create_view_validate(ctx.session(), plan, resolved_ids, explain_ctx),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
+    }
+
+    #[instrument]
+    pub(crate) fn explain_view(
+        &mut self,
+        ctx: &ExecuteContext,
+        plan::ExplainPlanPlan {
+            stage,
+            format,
+            config,
+            explainee,
+        }: plan::ExplainPlanPlan,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        let plan::Explainee::View(id) = explainee else {
+            unreachable!() // Asserted in `sequence_explain_plan`.
+        };
+        let CatalogItem::View(view) = self.catalog().get_entry(&id).item() else {
+            unreachable!() // Asserted in `plan_explain_plan`.
+        };
+
+        let explain = match stage {
+            ExplainStage::RawPlan => explain_plan(
+                view.raw_expr.clone(),
+                format,
+                &config,
+                &self.catalog().for_session(ctx.session()),
+            )?,
+            ExplainStage::LocalPlan => explain_plan(
+                view.optimized_expr.as_inner().clone(),
+                format,
+                &config,
+                &self.catalog().for_session(ctx.session()),
+            )?,
+            _ => {
+                coord_bail!("cannot EXPLAIN {} FOR VIEW", stage);
+            }
+        };
+
+        let rows = vec![Row::pack_slice(&[Datum::from(explain.as_str())])];
+
+        Ok(Self::send_immediate_rows(rows))
     }
 
     #[instrument]
@@ -75,6 +218,9 @@ impl Coordinator {
         session: &Session,
         plan: plan::CreateViewPlan,
         resolved_ids: ResolvedIds,
+        // An optional context set iff the state machine is initiated from
+        // sequencing an EXPLAIN for this statement.
+        explain_ctx: ExplainContext,
     ) -> Result<CreateViewStage, AdapterError> {
         let plan::CreateViewPlan {
             view: plan::View { expr, .. },
@@ -102,6 +248,7 @@ impl Coordinator {
             validity,
             plan,
             resolved_ids,
+            explain_ctx,
         }))
     }
 
@@ -112,30 +259,80 @@ impl Coordinator {
             validity,
             plan,
             resolved_ids,
+            explain_ctx,
         }: CreateViewOptimize,
     ) -> Result<StageResult<Box<CreateViewStage>>, AdapterError> {
         let id = self.catalog_mut().allocate_user_id().await?;
 
         // Collect optimizer parameters.
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
+        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
+            .override_from(&explain_ctx);
+
+        // Build an optimizer for this VIEW.
+        let mut optimizer = optimize::view::Optimizer::new(optimizer_config);
 
         let span = Span::current();
         Ok(StageResult::Handle(mz_ore::task::spawn_blocking(
             || "optimize create view",
             move || {
                 span.in_scope(|| {
-                    // Build an optimizer for this VIEW.
-                    let mut optimizer = optimize::view::Optimizer::new(optimizer_config);
-                    // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
-                    let raw_expr = plan.view.expr.clone();
-                    let optimized_expr = optimizer.catch_unwind_optimize(raw_expr)?;
-                    Ok(Box::new(CreateViewStage::Finish(CreateViewFinish {
-                        validity,
-                        id,
-                        plan,
-                        optimized_expr,
-                        resolved_ids,
-                    })))
+                    let mut pipeline =
+                        || -> Result<mz_expr::OptimizedMirRelationExpr, AdapterError> {
+                            let _dispatch_guard = explain_ctx.dispatch_guard();
+
+                            // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
+                            let raw_expr = plan.view.expr.clone();
+                            let optimized_expr = optimizer.catch_unwind_optimize(raw_expr)?;
+
+                            Ok(optimized_expr)
+                        };
+
+                    let stage = match pipeline() {
+                        Ok(optimized_expr) => {
+                            if let ExplainContext::Plan(explain_ctx) = explain_ctx {
+                                CreateViewStage::Explain(CreateViewExplain {
+                                    validity,
+                                    id,
+                                    plan,
+                                    explain_ctx,
+                                })
+                            } else {
+                                CreateViewStage::Finish(CreateViewFinish {
+                                    validity,
+                                    id,
+                                    plan,
+                                    optimized_expr,
+                                    resolved_ids,
+                                })
+                            }
+                        }
+                        // Internal optimizer errors are handled differently
+                        // depending on the caller.
+                        Err(err) => {
+                            let ExplainContext::Plan(explain_ctx) = explain_ctx else {
+                                // In `sequence_~` contexts, immediately return the error.
+                                return Err(err.into());
+                            };
+
+                            if explain_ctx.broken {
+                                // In `EXPLAIN BROKEN` contexts, just log the error
+                                // and move to the next stage with default
+                                // parameters.
+                                tracing::error!("error while handling EXPLAIN statement: {}", err);
+                                CreateViewStage::Explain(CreateViewExplain {
+                                    validity,
+                                    id,
+                                    plan,
+                                    explain_ctx,
+                                })
+                            } else {
+                                // In regular `EXPLAIN` contexts, immediately return the error.
+                                return Err(err.into());
+                            }
+                        }
+                    };
+
+                    Ok(Box::new(stage))
                 })
             },
         )))
@@ -205,5 +402,59 @@ impl Coordinator {
             }
             Err(err) => Err(err),
         }
+    }
+
+    #[instrument]
+    fn create_view_explain(
+        &mut self,
+        session: &Session,
+        CreateViewExplain {
+            id,
+            plan:
+                plan::CreateViewPlan {
+                    name,
+                    view: plan::View { column_names, .. },
+                    ..
+                },
+            explain_ctx:
+                ExplainPlanContext {
+                    broken,
+                    config,
+                    format,
+                    stage,
+                    optimizer_trace,
+                    ..
+                },
+            ..
+        }: CreateViewExplain,
+    ) -> Result<StageResult<Box<CreateViewStage>>, AdapterError> {
+        let session_catalog = self.catalog().for_session(session);
+        let expr_humanizer = {
+            let full_name = self.catalog().resolve_full_name(&name, None);
+            let transient_items = btreemap! {
+                id => TransientItem::new(
+                    Some(full_name.to_string()),
+                    Some(full_name.item.to_string()),
+                    Some(column_names.iter().map(|c| c.to_string()).collect()),
+                )
+            };
+            ExprHumanizerExt::new(transient_items, &session_catalog)
+        };
+
+        let rows = optimizer_trace.into_rows(
+            format,
+            &config,
+            &expr_humanizer,
+            None,
+            Default::default(),
+            stage,
+            plan::ExplaineeStatementKind::CreateView,
+        )?;
+
+        if broken {
+            tracing_core::callsite::rebuild_interest_cache();
+        }
+
+        Ok(StageResult::Response(Self::send_immediate_rows(rows)))
     }
 }

--- a/src/adapter/src/explain/mod.rs
+++ b/src/adapter/src/explain/mod.rs
@@ -74,3 +74,31 @@ where
 
     Ok(Explainable::new(&mut plan).explain(&format, &context)?)
 }
+
+/// Convenience method to explain a single plan.
+///
+/// In the long term, this method and [`explain_dataflow`] should be unified. In
+/// order to do that, however, we first need to generalize the role
+/// [`DataflowMetainfo`] as a carrier of metainformation for the optimization
+/// pass in general, and not for a specific strucutre representing an
+/// intermediate result.
+pub(crate) fn explain_plan<T>(
+    mut plan: T,
+    format: ExplainFormat,
+    config: &ExplainConfig,
+    humanizer: &dyn ExprHumanizer,
+) -> Result<String, AdapterError>
+where
+    for<'a> Explainable<'a, T>: Explain<'a, Context = ExplainContext<'a>>,
+{
+    let context = ExplainContext {
+        config,
+        humanizer,
+        used_indexes: Default::default(),
+        finishing: Default::default(),
+        duration: Default::default(),
+        optimizer_notices: Default::default(),
+    };
+
+    Ok(Explainable::new(&mut plan).explain(&format, &context)?)
+}

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -13,7 +13,7 @@ use mz_expr::OptimizedMirRelationExpr;
 use mz_sql::plan::HirRelationExpr;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
 
-use crate::optimize::{optimize_mir_local, Optimize, OptimizerConfig, OptimizerError};
+use crate::optimize::{optimize_mir_local, trace_plan, Optimize, OptimizerConfig, OptimizerError};
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.
@@ -35,6 +35,9 @@ impl Optimize<HirRelationExpr> for Optimizer {
     type To = OptimizedMirRelationExpr;
 
     fn optimize(&mut self, expr: HirRelationExpr) -> Result<Self::To, OptimizerError> {
+        // Trace the pipeline input under `optimize/raw`.
+        trace_plan!(at: "raw", &expr);
+
         // HIR ⇒ MIR lowering and decorrelation
         let expr = expr.lower(&self.config)?;
 

--- a/test/sqllogictest/explain/view.slt
+++ b/test/sqllogictest/explain/view.slt
@@ -1,0 +1,224 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_new_outer_join_lowering TO false;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE accounts(id int, balance int);
+
+# Use `id bigint` instead of `id int` to force differences in planning based on
+# the `enable_new_outer_join_lowering` feature flag value.
+statement ok
+CREATE TABLE account_details(id bigint, address string);
+
+statement ok
+CREATE OR REPLACE VIEW v AS
+SELECT
+  *
+FROM
+  accounts a
+  LEFT JOIN account_details ad USING(id)
+WHERE
+  balance = 100;
+
+mode cockroach
+
+# Must explain the "Raw Plan".
+query T multiline
+EXPLAIN RAW PLAN FOR
+VIEW v;
+----
+Project (#0, #1, #3)
+  Filter (#1 = 100)
+    LeftOuterJoin (true AND (integer_to_bigint(#0) = #2))
+      Get materialize.public.accounts
+      Get materialize.public.account_details
+
+EOF
+
+# Must explain the "Locally Optimized Plan".
+query T multiline
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR
+VIEW v;
+----
+Return
+  Project (#0, #1, #3)
+    Union
+      Get l0
+      Project (#0, #3..=#5)
+        Map (100, null, null)
+          Join on=(#0 = #1)
+            Union
+              Negate
+                Distinct project=[#0]
+                  Get l0
+              Distinct project=[#0]
+                Get l1
+            Get l1
+With
+  cte l1 =
+    Filter (#1 = 100)
+      Get materialize.public.accounts
+  cte l0 =
+    Join on=(#2 = integer_to_bigint(#0))
+      Filter (#0) IS NOT NULL AND (#1 = 100)
+        Get materialize.public.accounts
+      Filter (#0) IS NOT NULL
+        Get materialize.public.account_details
+
+EOF
+
+# Must explain the "Locally Optimized Plan" (same as above).
+query T multiline
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR
+REPLAN VIEW v;
+----
+Return
+  Project (#0, #1, #3)
+    Union
+      Get l0
+      Project (#0, #3..=#5)
+        Map (100, null, null)
+          Join on=(#0 = #1)
+            Union
+              Negate
+                Distinct project=[#0]
+                  Get l0
+              Distinct project=[#0]
+                Get l1
+            Get l1
+With
+  cte l1 =
+    Filter (#1 = 100)
+      Get materialize.public.accounts
+  cte l0 =
+    Join on=(#2 = integer_to_bigint(#0))
+      Filter (#0) IS NOT NULL AND (#1 = 100)
+        Get materialize.public.accounts
+      Filter (#0) IS NOT NULL
+        Get materialize.public.account_details
+
+EOF
+
+# Must explain the "Locally Optimized Plan" after changing the feature flag
+# (same as below).
+query T multiline
+EXPLAIN LOCALLY OPTIMIZED PLAN WITH(ENABLE NEW OUTER JOIN LOWERING = TRUE) FOR
+REPLAN VIEW v;
+----
+Return
+  Project (#0, #1, #3)
+    Union
+      Map (null, null)
+        Union
+          Project (#0, #1)
+            Negate
+              Join on=(#2 = integer_to_bigint(#0))
+                Get l1
+                Distinct project=[integer_to_bigint(#0)]
+                  Get l0
+          Get l1
+      Filter (#1 = 100)
+        Get l0
+With
+  cte l1 =
+    Filter (#1 = 100)
+      Get materialize.public.accounts
+  cte l0 =
+    Join on=(#2 = integer_to_bigint(#0))
+      Filter (#0) IS NOT NULL
+        Get materialize.public.accounts
+      Filter (#0) IS NOT NULL
+        Get materialize.public.account_details
+
+EOF
+
+# Change the feature flag value
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_new_outer_join_lowering TO true;
+----
+COMPLETE 0
+
+# Must be planning with the feature flag turned on.
+statement ok
+CREATE OR REPLACE VIEW v AS
+SELECT
+  *
+FROM
+  accounts a
+  LEFT JOIN account_details ad USING(id)
+WHERE
+  balance = 100;
+
+# Ensure that flag whas used during planning.
+query T multiline
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR
+VIEW v;
+----
+Return
+  Project (#0, #1, #3)
+    Union
+      Map (null, null)
+        Union
+          Project (#0, #1)
+            Negate
+              Join on=(#2 = integer_to_bigint(#0))
+                Get l1
+                Distinct project=[integer_to_bigint(#0)]
+                  Get l0
+          Get l1
+      Filter (#1 = 100)
+        Get l0
+With
+  cte l1 =
+    Filter (#1 = 100)
+      Get materialize.public.accounts
+  cte l0 =
+    Join on=(#2 = integer_to_bigint(#0))
+      Filter (#0) IS NOT NULL
+        Get materialize.public.accounts
+      Filter (#0) IS NOT NULL
+        Get materialize.public.account_details
+
+EOF
+
+# Must be re-planning with the feature flag turned off.
+query T multiline
+EXPLAIN LOCALLY OPTIMIZED PLAN WITH(ENABLE NEW OUTER JOIN LOWERING = FALSE) FOR
+REPLAN VIEW v;
+----
+Return
+  Project (#0, #1, #3)
+    Union
+      Get l0
+      Project (#0, #3..=#5)
+        Map (100, null, null)
+          Join on=(#0 = #1)
+            Union
+              Negate
+                Distinct project=[#0]
+                  Get l0
+              Distinct project=[#0]
+                Get l1
+            Get l1
+With
+  cte l1 =
+    Filter (#1 = 100)
+      Get materialize.public.accounts
+  cte l0 =
+    Join on=(#2 = integer_to_bigint(#0))
+      Filter (#0) IS NOT NULL AND (#1 = 100)
+        Get materialize.public.accounts
+      Filter (#0) IS NOT NULL
+        Get materialize.public.account_details
+
+EOF


### PR DESCRIPTION
Add coordinator support for sequencing the following `EXPLAIN ... VIEW`
statements:

- `EXPLAIN CREATE VIEW ...`
- `EXPLAIN REPLAN VIEW ...`
- `EXPLAIN VIEW ...`

### Motivation

  * This PR adds a known-desirable feature.

Part of #25273.

### Tips for reviewer

Review one commit at a time. The bulk of the work for this PR is in the first commit, followed by three commits that move code around and expand the set of stages supported by `EXPLAIN MATERIALIZED VIEW`. The final commit adds an `EXPLAIN VIEW` test.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Added support for explaining view-related statements: `EXPLAIN ... VIEW`, `EXPLAIN ... REPLAN VIEW`, `EXPLAIN ... CREATE VIEW`.
