### PR TITLE
output consistency: special date values

### DIFF
--- a/misc/python/materialize/output_consistency/input_data/types/date_time_types_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/date_time_types_provider.py
@@ -63,7 +63,7 @@ DATE_TYPE = DateTimeDataType(
     # BC, AD not working, see: https://github.com/MaterializeInc/materialize/issues/19637
     "0001-01-01",
     "99999-12-31",
-    ["2023-06-01"],
+    ["2023-06-01", "2024-02-29"],
     is_max_value_pg_compatible=False,
 )
 TIME_TYPE = DateTimeDataType(
@@ -75,7 +75,7 @@ TIMESTAMP_TYPE = DateTimeDataType(
     # BC, AD not working, see: https://github.com/MaterializeInc/materialize/issues/19637
     "0001-01-01 00:00:00",
     "99999-12-31 23:59:59",
-    ["2023-06-01 11:22:33.44444"],
+    ["2023-02-28 11:22:33.44444", "2024-02-29 23:50:00"],
     is_max_value_pg_compatible=False,
 )
 TIMESTAMPTZ_TYPE = DateTimeDataType(
@@ -84,7 +84,12 @@ TIMESTAMPTZ_TYPE = DateTimeDataType(
     # BC, AD not working, see: https://github.com/MaterializeInc/materialize/issues/19637
     "0001-01-01 00:00:00",
     "99999-12-31 23:59:59",
-    ["2023-06-01 11:22:33.44444", "2023-09-01 14:00:02.46464646"],
+    [
+        "2023-06-01 11:22:33.44444",
+        # leap year
+        "2024-02-29 11:50:00 EST",
+        "2024-02-28 19:50:00 America/Los_Angeles",
+    ],
     has_time_zone=True,
     is_max_value_pg_compatible=False,
 )

--- a/misc/python/materialize/output_consistency/input_data/types/date_time_types_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/date_time_types_provider.py
@@ -89,6 +89,10 @@ TIMESTAMPTZ_TYPE = DateTimeDataType(
         # leap year
         "2024-02-29 11:50:00 EST",
         "2024-02-28 19:50:00 America/Los_Angeles",
+        # change to DST
+        "2024-03-31 01:20:00 Europe/Vienna",
+        "2024-03-31 02:20:00 Europe/Vienna",
+        "2024-03-31 03:20:00 Europe/Vienna",
     ],
     has_time_zone=True,
     is_max_value_pg_compatible=False,
@@ -98,7 +102,13 @@ INTERVAL_TYPE = DateTimeDataType(
     "INTERVAL",
     "-178956970 years -8 months -2147483648 days -2562047788:00:54.775808",
     "178956970 years 7 months 2147483647 days 2562047788:00:54.775807",
-    ["2 years 3 months 4 days 11:22:33.456789", "100 months 100 days", "44:45:45"],
+    [
+        "2 years 3 months 4 days 11:22:33.456789",
+        "100 months 100 days",
+        "44:45:45",
+        "45 minutes",
+        "70 minutes",
+    ],
     # type is compatible but causes too many issues for now
     is_pg_compatible=False,
     is_max_value_pg_compatible=True,

--- a/misc/python/materialize/output_consistency/input_data/types/date_time_types_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/date_time_types_provider.py
@@ -27,6 +27,7 @@ class DateTimeDataType(DataType):
         min_value: str,
         max_value: str,
         further_values: list[str],
+        further_values_with_fixed_timezone: list[str] = [],
         has_time_zone: bool = False,
         is_pg_compatible: bool = True,
         is_max_value_pg_compatible: bool = True,
@@ -40,6 +41,7 @@ class DateTimeDataType(DataType):
         self.min_value = min_value
         self.max_value = max_value
         self.further_values = further_values
+        self.further_values_with_fixed_timezone = further_values_with_fixed_timezone
         self.has_time_zone = has_time_zone
         self.is_max_value_pg_compatible = is_max_value_pg_compatible
 
@@ -84,8 +86,8 @@ TIMESTAMPTZ_TYPE = DateTimeDataType(
     # BC, AD not working, see: https://github.com/MaterializeInc/materialize/issues/19637
     "0001-01-01 00:00:00",
     "99999-12-31 23:59:59",
-    [
-        "2023-06-01 11:22:33.44444",
+    further_values=["2023-06-01 11:22:33.44444"],
+    further_values_with_fixed_timezone=[
         # leap year
         "2024-02-29 11:50:00 EST",
         "2024-02-28 19:50:00 America/Los_Angeles",

--- a/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
+++ b/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
@@ -95,9 +95,9 @@ class PostgresResultComparator(ResultComparator):
             value1 = value1.replace(", ", ",").replace(": ", ":")
             value2 = value2.replace(", ", ",").replace(": ", ":")
 
-        # Postgres uses 'mons' instead of 'months'
-        value1 = value1.replace(" mons", " months")
-        value2 = value2.replace(" mons", " months")
+        # Postgres uses 'mon' / 'mons' instead of 'month' / 'months'
+        value1 = value1.replace(" month", " mon")
+        value2 = value2.replace(" month", " mon")
 
         return value1 == value2
 


### PR DESCRIPTION
> 02e3d4b6e1 output consistency: date-time: add leap year values
3fe5153054 output consistency: date-time: DST values


Inspired by https://github.com/MaterializeInc/materialize/issues/25642.

Nightly: https://buildkite.com/materialize/nightlies/builds/6716