### PR TITLE
ci: improve exception name extraction

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -561,7 +561,7 @@ class Composition:
             ui.header(f"mzcompose: test case {name} succeeded")
         except Exception as e:
             end_time = time.time()
-            error_message = f"{str(type(e))}: {e}"
+            error_message = f"{e.__class__.__module__}.{e.__class__.__name__}: {e}"
             ui.header(f"mzcompose: test case {name} failed: {error_message}")
             errors = self.extract_test_errors(e, error_message)
 


### PR DESCRIPTION
`str(type(e))` resulted in `<class pg8000.exceptions.InterfaceError>`, which is suppressed by Buildkite due to the angle brackets as can be seen in

<img width="417" alt="Bildschirmfoto 2024-03-01 um 10 38 23" src="https://github.com/MaterializeInc/materialize/assets/129728240/7777f352-dd67-4ff6-9185-d9cbf06fe383">

This change should improve the output.