### PR TITLE
test: Re-enable test-version-skips catalog test

### DIFF
--- a/test/persist-catalog-migration/mzcompose.py
+++ b/test/persist-catalog-migration/mzcompose.py
@@ -30,9 +30,6 @@ def workflow_default(c: Composition) -> None:
     for i, name in enumerate(c.workflows):
         if name == "default":
             continue
-        # TODO: Reenable when #25499 is fixed
-        if name == "test-version-skips":
-            continue
         with c.test_case(name):
             c.workflow(name)
 


### PR DESCRIPTION
The test-version-skips catalog test was fixed in
cfc43bbbd8d240ac5f467dad3536bce358ec67ad65fac804d3fbe8122200020eL21 but never re-enabled. This commit re-enables it.

Fixes #25499

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
