### PR TITLE
platform-checks: Remove scenario that skips a version

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -701,17 +701,6 @@ steps:
               composition: platform-checks
               args: [--scenario=PreflightCheckRollback]
 
-      - id: checks-upgrade-entire-mz-previous-version
-        label: "Checks upgrade from previous version, whole-Mz restart"
-        timeout_in_minutes: 60
-        agents:
-          queue: linux-aarch64-large
-        artifact_paths: junit_*.xml
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: platform-checks
-              args: [--scenario=UpgradeEntireMzPreviousVersion]
-
       - id: checks-upgrade-entire-mz-two-versions
         label: "Checks upgrade across two versions"
         timeout_in_minutes: 60

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -77,13 +77,6 @@ class UpgradeEntireMz(Scenario):
         ]
 
 
-class UpgradeEntireMzPreviousVersion(UpgradeEntireMz):
-    """Upgrade the entire Mz instance from the previous released version."""
-
-    def base_version(self) -> MzVersion:
-        return get_previous_version()
-
-
 class UpgradeEntireMzTwoVersions(Scenario):
     """Upgrade the entire Mz instance starting from the previous
     released version and passing through the last released version."""


### PR DESCRIPTION
As noted by @jkosh44 in https://github.com/MaterializeInc/materialize/pull/25636

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
