### PR TITLE
storage/mysql: Support special characters in mysql table names

### DIFF
--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -65,7 +65,6 @@ use mz_mysql_util::{
 use mz_ore::cast::CastFrom;
 use mz_ore::result::ResultExt;
 use mz_repr::{Diff, GlobalId, Row};
-use mz_sql_parser::ast::UnresolvedItemName;
 use mz_storage_types::sources::mysql::{gtid_set_frontier, GtidPartition, GtidState};
 use mz_storage_types::sources::MySqlSourceConnection;
 use mz_timely_util::builder_async::{
@@ -77,8 +76,8 @@ use crate::source::types::SourceReaderError;
 use crate::source::RawSourceCreationConfig;
 
 use super::{
-    return_definite_error, validate_mysql_repl_settings, DefiniteError, ReplicationError,
-    RewindRequest, TransientError,
+    return_definite_error, validate_mysql_repl_settings, DefiniteError, MySqlTableName,
+    ReplicationError, RewindRequest, TransientError,
 };
 
 mod context;
@@ -102,7 +101,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
     config: RawSourceCreationConfig,
     connection: MySqlSourceConnection,
     subsource_resume_uppers: BTreeMap<GlobalId, Antichain<GtidPartition>>,
-    table_info: BTreeMap<UnresolvedItemName, (usize, MySqlTableDesc)>,
+    table_info: BTreeMap<MySqlTableName, (usize, MySqlTableDesc)>,
     rewind_stream: &Stream<G, RewindRequest>,
     metrics: MySqlSourceMetrics,
 ) -> (

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -106,6 +106,9 @@ CREATE TABLE escaped_text_table (f1 TEXT, f2 TEXT);
 INSERT INTO escaped_text_table VALUES ('escaped\\ntext\\twith\\nnewlines\\tand\\ntabs', 'more\\tescaped\\ntext');
 INSERT INTO escaped_text_table VALUES ('second\\nrow\\twith\\tmore\\ttabs', 'and\\nmore\\n\\nnewlines\\n');
 
+CREATE TABLE mixED_CAse (spECialCase INTEGER);
+INSERT INTO mixED_CAse VALUES (1), (2);
+
 CREATE TABLE conflict_table (f1 INTEGER);
 INSERT INTO conflict_table VALUES (123);
 
@@ -249,19 +252,20 @@ contains: CREATE SOURCE specifies DETAILS option
     public."nulls_table",
     public."utf8_table",
     public."escaped_text_table",
+    public."mixED_CAse",
     conflict_schema.conflict_table AS public.conflict_table,
-    public."create"
+    public."create",
+    public."space table",
+    public."таблица",
+    public."""literal_quotes"""
   );
-# TODO: #25415 (tables with special characters)
-#    public."space table",
-#    public."таблица",
-#    public."""literal_quotes""",
 
 > SHOW SOURCES
 conflict_table        subsource <null>  <null>
 create                subsource <null>  <null>
 escaped_text_table    subsource <null>  <null>
 large_text            subsource <null>  <null>
+mixED_CAse            subsource <null>  <null>
 multipart_pk          subsource <null>  <null>
 mz_source             mysql  ${arg.default-replica-size}  cdc_cluster
 mz_source_progress    progress  <null>  <null>
@@ -272,10 +276,9 @@ trailing_space_nopk   subsource <null>  <null>
 trailing_space_pk     subsource <null>  <null>
 types_table           subsource <null>  <null>
 utf8_table            subsource <null>  <null>
-# TODO: #25415 (tables with special characters)
-# "\"literal_quotes\""  subsource <null>  <null>
-# "space table"         subsource <null>  <null>
-# таблица               subsource <null>  <null>
+"\"literal_quotes\""  subsource <null>  <null>
+"space table"         subsource <null>  <null>
+таблица               subsource <null>  <null>
 
 > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
 running
@@ -337,9 +340,8 @@ contains: SOURCE "conflict_table" is a subsource and must be dropped with ALTER 
 > SELECT * FROM utf8_table;
 "това е текст" "това \'е\' \"текст\""
 
-# TODO: #25415 (tables with special characters)
-# > SELECT * FROM "таблица";
-# стойност
+> SELECT * FROM "таблица";
+стойност
 
 > SELECT * FROM escaped_text_table;
 "escaped\\ntext\\twith\\nnewlines\\tand\\ntabs" "more\\tescaped\\ntext"
@@ -348,12 +350,15 @@ contains: SOURCE "conflict_table" is a subsource and must be dropped with ALTER 
 > SELECT * FROM conflict_table;
 234
 
-# TODO: #25415 (tables with special characters)
-# > SELECT * FROM """literal_quotes"""
-# v
+> SELECT * FROM """literal_quotes"""
+v
 
 > SELECT * FROM "create"
 v
+
+> SELECT * FROM "mixED_CAse"
+1
+2
 
 #
 # Confirm that the new sources can be used to build upon
@@ -418,8 +423,9 @@ UPDATE nulls_table SET f2 = NULL WHERE f2 = 2;
 INSERT INTO utf8_table VALUES ('това е текст 2', 'това ''е'' "текст" 2');
 UPDATE utf8_table SET f1 = concat(f1, f1), f2 = concat(f2, f2);
 
-# TODO: #25415 (tables with special characters)
-# INSERT INTO "таблица" SELECT * FROM "таблица";
+INSERT INTO `таблица` SELECT * FROM `таблица`;
+
+INSERT INTO mixED_CAse SELECT * FROM mixED_CAse;
 
 #
 # Check the updated data on the Materialize side
@@ -465,10 +471,15 @@ UPDATE utf8_table SET f1 = concat(f1, f1), f2 = concat(f2, f2);
 "това е текст 2това е текст 2" "това \'е\' \"текст\" 2това \'е\' \"текст\" 2"
 "това е тексттова е текст" "това \'е\' \"текст\"това \'е\' \"текст\""
 
-# TODO: #25415 (tables with special characters)
-# > SELECT * FROM "таблица";
-# стойност
-# стойност
+> SELECT * FROM "таблица";
+стойност
+стойност
+
+> SELECT * FROM "mixED_CAse";
+1
+2
+1
+2
 
 > SELECT * FROM join_view;
 "2" "two_two" "2" "2"
@@ -523,9 +534,8 @@ DELETE FROM multipart_pk;
 DELETE FROM nulls_table;
 DELETE FROM utf8_table;
 DELETE FROM conflict_schema.conflict_table;
-
-# TODO: #25415 (tables with special characters)
-# DELETE FROM "таблица";
+DELETE FROM `таблица`;
+DELETE FROM mixED_CAse;
 
 #
 # Check that all data sources empty out on the Materialize side
@@ -558,9 +568,11 @@ DELETE FROM conflict_schema.conflict_table;
 > SELECT COUNT(*) FROM join_view;
 0
 
-# TODO: #25415 (tables with special characters)
-# > SELECT COUNT(*) FROM "таблица";
-# 0
+> SELECT COUNT(*) FROM "таблица";
+0
+
+> SELECT COUNT(*) FROM "mixED_CAse";
+0
 
 > SELECT COUNT(*) FROM conflict_table;
 0


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/materialize/issues/25415

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

In MySQL backticks ` are used to quote system identifiers with special characters, unlike Postgres/MZ which uses double-quotes ".

I originally tried to implement a fix using the `mz_sql_parser::ast` `Ident` and `UnresolvedItemName` types but found it difficult to modify the behavior to support the different quoting style and realized that we don't need a lot of the functionality provided by those types. To keep things simple, I switched to a mysql-specific type for describing and serializing the schema/table names.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
