### PR TITLE
compute: add JSON explain output for bin/mzexplore (take 2)

### DIFF
--- a/bin/mzexplore
+++ b/bin/mzexplore
@@ -9,6 +9,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# dashboard-clean - Clean the dashboard model json to be fit for public consumption
+# mzexplore - Extract definitions and plans from the cloud
 
 exec "$(dirname "$0")"/pyactivate -m materialize.cli.mzexplore "$@"

--- a/bin/mzexplore
+++ b/bin/mzexplore
@@ -9,6 +9,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# mzexplore - Extract definitions and plans from the cloud
+# mzexplore - Extract definitions and plans from a Materialize instance using pgwire.
 
 exec "$(dirname "$0")"/pyactivate -m materialize.cli.mzexplore "$@"

--- a/misc/python/materialize/cli/mzexplore.py
+++ b/misc/python/materialize/cli/mzexplore.py
@@ -179,7 +179,7 @@ def defs(
 @click.option("--with", "-w", "explain_flags", **Opt.explain_flags)
 @click.option("--stage", "-s", "explain_stages", **Opt.explain_stage)
 @click.option("--suffix", **Opt.explain_suffix)
-@is_documented_by(api.extract.defs)
+@is_documented_by(api.extract.plans)
 def plans(
     target: Path,
     database: str,

--- a/misc/python/materialize/cli/mzexplore.py
+++ b/misc/python/materialize/cli/mzexplore.py
@@ -109,6 +109,14 @@ class Opt:
         metavar="SUFFIX",
     )
 
+    explain_format = dict(
+        type=click.Choice([str(v.name.lower()) for v in list(api.ExplainFormat)]),
+        default=["TEXT"],
+        callback=lambda ctx, param, v: api.ExplainFormat[v.upper()],
+        help="AS ... clause to pass to the EXPLAIN command.",
+        metavar="FORMAT",
+    )
+
 
 def is_documented_by(original: Any) -> Any:
     def wrapper(target):
@@ -178,6 +186,7 @@ def defs(
 @click.option("--explainee-type", "-t", **Opt.explainee_type)
 @click.option("--with", "-w", "explain_flags", **Opt.explain_flags)
 @click.option("--stage", "-s", "explain_stages", **Opt.explain_stage)
+@click.option("--format", "-f", "explain_format", **Opt.explain_format)
 @click.option("--suffix", **Opt.explain_suffix)
 @is_documented_by(api.extract.plans)
 def plans(
@@ -193,6 +202,7 @@ def plans(
     explainee_type: api.ExplaineeType,
     explain_flags: list[api.ExplainFlag],
     explain_stages: set[api.ExplainStage],
+    explain_format: api.ExplainFormat,
     suffix: str | None = None,
 ) -> None:
     try:
@@ -209,6 +219,7 @@ def plans(
             explainee_type,
             explain_flags,
             explain_stages,
+            explain_format,
             suffix,
         )
     except Exception as e:

--- a/misc/python/materialize/cli/mzexplore.py
+++ b/misc/python/materialize/cli/mzexplore.py
@@ -113,7 +113,7 @@ class Opt:
         type=click.Choice([str(v.name.lower()) for v in list(api.ExplainFormat)]),
         default=["TEXT"],
         callback=lambda ctx, param, v: api.ExplainFormat[v.upper()],
-        help="AS ... clause to pass to the EXPLAIN command.",
+        help="AS [FORMAT] clause to pass to the EXPLAIN command.",
         metavar="FORMAT",
     )
 

--- a/misc/python/materialize/mzexplore/__init__.py
+++ b/misc/python/materialize/mzexplore/__init__.py
@@ -12,5 +12,6 @@ from materialize.mzexplore import extract  # noqa: F401
 from materialize.mzexplore.common import (
     ExplaineeType,  # noqa: F401
     ExplainFlag,  # noqa: F401
+    ExplainFormat,  # noqa: F401
     ExplainStage,  # noqa: F401
 )

--- a/misc/python/materialize/mzexplore/common.py
+++ b/misc/python/materialize/mzexplore/common.py
@@ -27,6 +27,20 @@ class ExplaineeType(Enum):
         return (self.value & other.value) > 0
 
 
+class ExplainFormat(Enum):
+    TEXT = "TEXT"
+    JSON = "JSON"
+
+    def __str__(self):
+        return self.name
+
+    def suffix(self):
+        if self == ExplainFormat.JSON:
+            return "json"
+
+        return "txt"
+
+
 class ExplainStage(str, Enum):
     RAW_PLAN = "RAW PLAN"
     DECORRELATED_PLAN = "DECORRELATED PLAN"

--- a/misc/python/materialize/mzexplore/extract.py
+++ b/misc/python/materialize/mzexplore/extract.py
@@ -236,7 +236,7 @@ def plans(
                     info(f"Explaining {stage} for CREATE {fqname} in `{file_name}`")
                     try:
                         plans[file_name] = explain(
-                            db, stage, explainee, explain_flags, explain_format
+                            db, stage, explainee, explain_flags, explain_format,
                         )
                     except DatabaseError as e:
                         warn(f"Cannot explain {stage} for CREATE {fqname}: {e}")

--- a/misc/python/materialize/mzexplore/extract.py
+++ b/misc/python/materialize/mzexplore/extract.py
@@ -236,7 +236,11 @@ def plans(
                     info(f"Explaining {stage} for CREATE {fqname} in `{file_name}`")
                     try:
                         plans[file_name] = explain(
-                            db, stage, explainee, explain_flags, explain_format,
+                            db,
+                            stage,
+                            explainee,
+                            explain_flags,
+                            explain_format,
                         )
                     except DatabaseError as e:
                         warn(f"Cannot explain {stage} for CREATE {fqname}: {e}")

--- a/test/persist-catalog-migration/mzcompose.py
+++ b/test/persist-catalog-migration/mzcompose.py
@@ -15,7 +15,7 @@ from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.ui import UIError
 from materialize.version_list import (
-    get_previous_mz_version,
+    get_previous_published_version,
 )
 
 mz_options: dict[MzVersion, str] = {}
@@ -418,8 +418,8 @@ def workflow_test_version_skips(c: Composition) -> None:
 
     # If the current version is `v0.X.0-dev`, two_minor_releases_before will be `v0.X-2.Y`.
     # where Y is the most recent patch version of the minor version.
-    two_minor_releases_before = get_previous_mz_version(
-        get_previous_mz_version(current_version, previous_minor=True),
+    two_minor_releases_before = get_previous_published_version(
+        get_previous_published_version(current_version, previous_minor=True),
         previous_minor=True,
     )
 


### PR DESCRIPTION
`bin/mzexplore` can extract `EXPLAIN PLAN` output as text.

This PR adds a flag `--format [FORMAT]` that lets you get JSON output.

Along the way, there are a few minor bugfixes.

This is take 2; I messed up the history of #25435.

### Motivation

  * This PR fixes a previously unreported bug.

See the first two commits: there was a copypasta mistake in docs; the help text for `bin/mzexplore extract --help` gave incorrect output for `plans`. The third commit and also fixes an issue that led to `..txt` suffixes in generated plans.

  * This PR adds a feature that has not yet been specified.

Running `bin/mzexplore extract plans --format json ...` will extract plans in JSON format.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
