### PR TITLE
test: Fix broken upgrade tests

### DIFF
--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -44,6 +44,7 @@ INVALID_VERSIONS = {
     MzVersion.parse_mz("v0.81.0"),  # incompatible for upgrades
     MzVersion.parse_mz("v0.81.1"),  # incompatible for upgrades
     MzVersion.parse_mz("v0.81.2"),  # incompatible for upgrades
+    MzVersion.parse_mz("v0.89.7"),
 }
 
 _SKIP_IMAGE_CHECK_BELOW_THIS_VERSION = MzVersion.parse_mz("v0.77.0")
@@ -423,7 +424,7 @@ def get_commits_of_accepted_regressions_between_versions(
 
 
 class VersionsFromDocs:
-    """Materialize versions as listed in doc/user/content/versions
+    """Materialize versions as listed in doc/user/content/releases
 
     Only versions that declare `versiond: true` in their
     frontmatter are considered.


### PR DESCRIPTION
This commit marks version v0.89.7 as broken since CI failed and it was never deployed on docker.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
