### PR TITLE
Lower `Filter` with `Map`'s variadic method

### DIFF
--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1160,9 +1160,11 @@ Explained Query:
         Project (#0..=#3) // { arity: 4 }
           Join on=(#0 = #4) type=differential // { arity: 5 }
             implementation
-              %0:l0[#0]K » %1[#0]K
+              %0:l0[#0]Kf » %1[#0]Kf
             ArrangeBy keys=[[#0]] // { arity: 4 }
-              Get l0 // { arity: 4 }
+              Project (#1, #3..=#5) // { arity: 4 }
+                Filter (#0 = #2) AND NOT(like["zz%"](padchar(#5))) // { arity: 6 }
+                  Get l0 // { arity: 6 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
@@ -1180,25 +1182,21 @@ Explained Query:
     With
       cte l1 =
         Distinct project=[#0] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Get l0 // { arity: 4 }
+          Project (#1) // { arity: 1 }
+            Get l0 // { arity: 6 }
       cte l0 =
-        Project (#17, #19..=#21) // { arity: 4 }
-          Join on=(#0 = #18) type=differential // { arity: 22 }
-            implementation
-              %1:item[#0]UKf » %0:stock[#0]KAf
-            ArrangeBy keys=[[#0]] // { arity: 18 }
-              ReadIndex on=stock fk_stock_item=[differential join] // { arity: 18 }
-            ArrangeBy keys=[[#0]] // { arity: 4 }
-              Project (#0, #2..=#4) // { arity: 4 }
-                Filter NOT(like["zz%"](padchar(#4))) // { arity: 5 }
-                  ReadStorage materialize.public.item // { arity: 5 }
-
-Source materialize.public.item
-  filter=(NOT(like["zz%"](padchar(#4))))
+        CrossJoin type=differential // { arity: 6 }
+          implementation
+            %0:stock[×] » %1:item[×]
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Project (#0, #17) // { arity: 2 }
+              ReadIndex on=stock fk_stock_warehouse=[*** full scan ***] // { arity: 18 }
+          ArrangeBy keys=[[]] // { arity: 4 }
+            Project (#0, #2..=#4) // { arity: 4 }
+              ReadStorage materialize.public.item // { arity: 5 }
 
 Used Indexes:
-  - materialize.public.fk_stock_item (differential join)
+  - materialize.public.fk_stock_warehouse (*** full scan ***)
   - materialize.public.fk_supplier_nationkey (*** full scan ***)
 
 EOF
@@ -1402,9 +1400,11 @@ Explained Query:
       Project (#1, #2) // { arity: 2 }
         Join on=(#0 = #3) type=differential // { arity: 4 }
           implementation
-            %1[#0]UKA » %0:l0[#0]UK
+            %1[#0]UKA » %0:l0[#0]Kef
           ArrangeBy keys=[[#0]] // { arity: 3 }
-            Get l0 // { arity: 3 }
+            Project (#0..=#2) // { arity: 3 }
+              Filter (#5 = "GERMANY") AND (#3 = #4) // { arity: 6 }
+                Get l0 // { arity: 6 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Distinct project=[#0] // { arity: 1 }
               Project (#0) // { arity: 1 }
@@ -1414,13 +1414,14 @@ Explained Query:
                       Filter (#1) IS NOT NULL AND (date_to_timestamp(#10) > 2010-05-23 12:00:00) // { arity: 15 }
                         Join on=(#0 = ((#1 * #2) % 10000) AND #1 = #8 = #14) type=delta // { arity: 15 }
                           implementation
-                            %0:l0 » %1:stock[((#0 * #1) % 10000)]K » %3:item[#0]UKlf » %2:orderline[#4]KAif
-                            %1:stock » %3:item[#0]UKlf » %0:l0[#0]UK » %2:orderline[#4]KAif
-                            %2:orderline » %3:item[#0]UKlf » %1:stock[#0]KA » %0:l0[#0]UK
-                            %3:item » %2:orderline[#4]KAif » %1:stock[#0]KA » %0:l0[#0]UK
+                            %0 » %1:stock[((#0 * #1) % 10000)]K » %3:item[#0]UKlf » %2:orderline[#4]KAif
+                            %1:stock » %0[#0]UKA » %3:item[#0]UKlf » %2:orderline[#4]KAif
+                            %2:orderline » %3:item[#0]UKlf » %1:stock[#0]KA » %0[#0]UKA
+                            %3:item » %2:orderline[#4]KAif » %1:stock[#0]KA » %0[#0]UKA
                           ArrangeBy keys=[[#0]] // { arity: 1 }
-                            Project (#0) // { arity: 1 }
-                              Get l0 // { arity: 3 }
+                            Distinct project=[#0] // { arity: 1 }
+                              Project (#0) // { arity: 1 }
+                                Get l0 // { arity: 6 }
                           ArrangeBy keys=[[#0], [((#0 * #1) % 10000)]] // { arity: 3 }
                             Project (#0..=#2) // { arity: 3 }
                               ReadIndex on=stock fk_stock_warehouse=[*** full scan ***] // { arity: 18 }
@@ -1432,16 +1433,15 @@ Explained Query:
                                 ReadStorage materialize.public.item // { arity: 5 }
     With
       cte l0 =
-        Project (#0..=#2) // { arity: 3 }
-          Join on=(#3 = #7) type=differential // { arity: 8 }
-            implementation
-              %1:nation[#0]UKef » %0:supplier[#3]KAef
-            ArrangeBy keys=[[#3]] // { arity: 7 }
-              ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Filter (#1 = "GERMANY") // { arity: 4 }
-                  ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
+        CrossJoin type=differential // { arity: 6 }
+          implementation
+            %0:supplier[×] » %1:nation[×]
+          ArrangeBy keys=[[]] // { arity: 4 }
+            Project (#0..=#3) // { arity: 4 }
+              ReadIndex on=supplier fk_supplier_nationkey=[*** full scan ***] // { arity: 7 }
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
 
 Source materialize.public.item
   filter=(like["co%"](padchar(#4)))
@@ -1450,7 +1450,7 @@ Used Indexes:
   - materialize.public.fk_orderline_item (delta join lookup)
   - materialize.public.fk_stock_warehouse (*** full scan ***)
   - materialize.public.fk_nation_regionkey (*** full scan ***)
-  - materialize.public.fk_supplier_nationkey (differential join)
+  - materialize.public.fk_supplier_nationkey (*** full scan ***)
 
 EOF
 
@@ -1488,9 +1488,11 @@ Explained Query:
         Project (#0) // { arity: 1 }
           Join on=(#1 = #5 AND #2 = #6 AND #3 = #7 AND #4 = #8) type=differential // { arity: 9 }
             implementation
-              %0:l0[#1..=#4]KKKK » %1[#0..=#3]KKKK
+              %0:l0[#1..=#4]KKKKef » %1[#0..=#3]KKKKef
             ArrangeBy keys=[[#1..=#4]] // { arity: 5 }
-              Get l0 // { arity: 5 }
+              Project (#1, #3..=#5, #7) // { arity: 5 }
+                Filter (#16 = "GERMANY") AND (#0 = #14) AND (#2 = #15) AND (#3 = #8) AND (#4 = #9) AND (#5 = #10) AND (#5 = #13) AND (#6 = #12) AND (#10 = #13) AND (#7 > #11) // { arity: 17 }
+                  Get l0 // { arity: 17 }
             ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
               Union // { arity: 4 }
                 Negate // { arity: 4 }
@@ -1508,35 +1510,31 @@ Explained Query:
     With
       cte l1 =
         Distinct project=[#0..=#3] // { arity: 4 }
-          Project (#1..=#4) // { arity: 4 }
-            Get l0 // { arity: 5 }
+          Project (#3..=#5, #7) // { arity: 4 }
+            Get l0 // { arity: 17 }
       cte l0 =
-        Project (#1, #3..=#5, #7) // { arity: 5 }
-          Filter (#7 > #11) // { arity: 16 }
-            Join on=(#0 = #14 AND #2 = #15 AND #3 = #8 AND #4 = #9 AND #5 = #10 = #13 AND #6 = #12) type=delta // { arity: 16 }
-              implementation
-                %0:supplier » %4:nation[#0]UKef » %3:stock[#2]KA » %1:orderline[#2, #3]KK » %2:order[#0..=#2]UKKK
-                %1:orderline » %2:order[#0..=#2]UKKK » %3:stock[#0, #1]UKK » %0:supplier[#0]UK » %4:nation[#0]UKef
-                %2:order » %1:orderline[#2, #1, #0]KKKA » %3:stock[#0, #1]UKK » %0:supplier[#0]UK » %4:nation[#0]UKef
-                %3:stock » %0:supplier[#0]UK » %4:nation[#0]UKef » %1:orderline[#2, #3]KK » %2:order[#0..=#2]UKKK
-                %4:nation » %0:supplier[#2]KA » %3:stock[#2]KA » %1:orderline[#2, #3]KK » %2:order[#0..=#2]UKKK
-              ArrangeBy keys=[[#0], [#2]] // { arity: 3 }
-                Project (#0, #1, #3) // { arity: 3 }
-                  ReadIndex on=supplier fk_supplier_nationkey=[*** full scan ***] // { arity: 7 }
-              ArrangeBy keys=[[#2, #1, #0], [#2, #3]] // { arity: 5 }
-                Project (#0..=#2, #4, #6) // { arity: 5 }
-                  Filter (#4) IS NOT NULL // { arity: 10 }
-                    ReadIndex on=orderline fk_orderline_order=[*** full scan ***] // { arity: 10 }
-              ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                Project (#0..=#2, #4) // { arity: 4 }
-                  ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }
-              ArrangeBy keys=[[#0, #1], [#2]] // { arity: 3 }
-                Project (#0, #1, #17) // { arity: 3 }
-                  ReadIndex on=stock fk_stock_warehouse=[*** full scan ***] // { arity: 18 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Filter (#1 = "GERMANY") // { arity: 4 }
-                    ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
+        CrossJoin type=delta // { arity: 17 }
+          implementation
+            %0:supplier » %1:orderline[×] » %2:order[×] » %3:stock[×] » %4:nation[×]
+            %1:orderline » %0:supplier[×] » %2:order[×] » %3:stock[×] » %4:nation[×]
+            %2:order » %0:supplier[×] » %1:orderline[×] » %3:stock[×] » %4:nation[×]
+            %3:stock » %0:supplier[×] » %1:orderline[×] » %2:order[×] » %4:nation[×]
+            %4:nation » %0:supplier[×] » %1:orderline[×] » %2:order[×] » %3:stock[×]
+          ArrangeBy keys=[[]] // { arity: 3 }
+            Project (#0, #1, #3) // { arity: 3 }
+              ReadIndex on=supplier fk_supplier_nationkey=[*** full scan ***] // { arity: 7 }
+          ArrangeBy keys=[[]] // { arity: 5 }
+            Project (#0..=#2, #4, #6) // { arity: 5 }
+              ReadIndex on=orderline fk_orderline_order=[*** full scan ***] // { arity: 10 }
+          ArrangeBy keys=[[]] // { arity: 4 }
+            Project (#0..=#2, #4) // { arity: 4 }
+              ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }
+          ArrangeBy keys=[[]] // { arity: 3 }
+            Project (#0, #1, #17) // { arity: 3 }
+              ReadIndex on=stock fk_stock_warehouse=[*** full scan ***] // { arity: 18 }
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.fk_order_customer (*** full scan ***)
@@ -1575,37 +1573,13 @@ Explained Query:
     Return // { arity: 3 }
       Reduce group_by=[substr(char_to_text(#0), 1, 1)] aggregates=[count(*), sum(#1)] // { arity: 3 }
         Project (#3, #4) // { arity: 2 }
-          Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 8 }
-            implementation
-              %0:l1[#0..=#2]UKKK » %1[#0..=#2]KKK
-            ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-              Get l1 // { arity: 5 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Union // { arity: 3 }
-                Negate // { arity: 3 }
-                  Project (#0..=#2) // { arity: 3 }
-                    Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
-                      implementation
-                        %1[#0..=#2]UKKKA » %0:l2[#0..=#2]UKKK
-                      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                        Get l2 // { arity: 3 }
-                      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                        Distinct project=[#2, #0, #1] // { arity: 3 }
-                          Project (#1..=#3) // { arity: 3 }
-                            Filter (#3) IS NOT NULL // { arity: 8 }
-                              ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }
-                Get l2 // { arity: 3 }
-    With
-      cte l2 =
-        Project (#0..=#2) // { arity: 3 }
-          Get l1 // { arity: 5 }
-      cte l1 =
-        Project (#0..=#4) // { arity: 5 }
-          Filter (#4 > (#5 / bigint_to_numeric(case when (#6 = 0) then null else #6 end))) // { arity: 7 }
-            CrossJoin type=differential // { arity: 7 }
+          Filter (#4 > (#5 / bigint_to_numeric(case when (#6 = 0) then null else #6 end))) // { arity: 10 }
+            Join on=(#0 = #7 AND #1 = #8 AND #2 = #9) type=delta // { arity: 10 }
               implementation
-                %1[×]UA » %0:l0[×]ef
-              ArrangeBy keys=[[]] // { arity: 5 }
+                %0:l0 » %1[×]UA » %2[#0..=#2]KKK
+                %1 » %0:l0[×]ef » %2[#0..=#2]KKK
+                %2 » %0:l0[#0..=#2]UKKKef » %1[×]UA
+              ArrangeBy keys=[[], [#0..=#2]] // { arity: 5 }
                 Project (#0..=#2, #9, #16) // { arity: 5 }
                   Filter ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
                     Get l0 // { arity: 23 }
@@ -1614,6 +1588,25 @@ Explained Query:
                   Project (#16) // { arity: 1 }
                     Filter (#16 > 0) AND ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
                       Get l0 // { arity: 23 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                Union // { arity: 3 }
+                  Negate // { arity: 3 }
+                    Project (#0..=#2) // { arity: 3 }
+                      Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                        implementation
+                          %1[#0..=#2]UKKKA » %0:l1[#0..=#2]UKKK
+                        ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                          Get l1 // { arity: 3 }
+                        ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                          Distinct project=[#2, #0, #1] // { arity: 3 }
+                            Project (#1..=#3) // { arity: 3 }
+                              Filter (#3) IS NOT NULL // { arity: 8 }
+                                ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }
+                  Get l1 // { arity: 3 }
+    With
+      cte l1 =
+        Project (#0..=#2) // { arity: 3 }
+          ReadIndex on=customer fk_customer_district=[*** full scan ***] // { arity: 22 }
       cte l0 =
         Map (substr(char_to_text(#11), 1, 1)) // { arity: 23 }
           ReadIndex on=customer fk_customer_district=[*** full scan ***] // { arity: 22 }

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -429,37 +429,39 @@ Return // { arity: 3 }
               Project (#0, #2) // { arity: 2 }
                 Map (#0) // { arity: 3 }
                   Project (#0, #1) // { arity: 2 }
-                    Filter (#2 > 0) // { arity: 3 }
-                      Project (#0, #1, #3) // { arity: 3 }
-                        Join on=(#0 = #2) // { arity: 4 }
-                          Get l4 // { arity: 2 }
-                          Union // { arity: 2 }
-                            Get l7 // { arity: 2 }
-                            CrossJoin // { arity: 2 }
-                              Project (#0) // { arity: 1 }
-                                Join on=(#0 = #1) // { arity: 2 }
-                                  Union // { arity: 1 }
-                                    Negate // { arity: 1 }
+                    Filter true AND (#4 > 0) // { arity: 5 }
+                      Join on=(#0 = #2 AND #1 = #3) // { arity: 5 }
+                        Get l4 // { arity: 2 }
+                        Project (#0, #1, #3) // { arity: 3 }
+                          Join on=(#0 = #2) // { arity: 4 }
+                            Get l5 // { arity: 2 }
+                            Union // { arity: 2 }
+                              Get l8 // { arity: 2 }
+                              CrossJoin // { arity: 2 }
+                                Project (#0) // { arity: 1 }
+                                  Join on=(#0 = #1) // { arity: 2 }
+                                    Union // { arity: 1 }
+                                      Negate // { arity: 1 }
+                                        Distinct project=[#0] // { arity: 1 }
+                                          Get l8 // { arity: 2 }
                                       Distinct project=[#0] // { arity: 1 }
-                                        Get l7 // { arity: 2 }
-                                    Distinct project=[#0] // { arity: 1 }
-                                      Get l5 // { arity: 1 }
-                                  Get l5 // { arity: 1 }
-                              Constant // { arity: 1 }
-                                - (null)
+                                        Get l6 // { arity: 1 }
+                                    Get l6 // { arity: 1 }
+                                Constant // { arity: 1 }
+                                  - (null)
 With
-  cte l7 =
+  cte l8 =
     Union // { arity: 2 }
-      Get l6 // { arity: 2 }
+      Get l7 // { arity: 2 }
       Map (error("more than one record produced in subquery")) // { arity: 2 }
         Project (#0) // { arity: 1 }
           Filter (#1 > 1) // { arity: 2 }
             Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-              Get l6 // { arity: 2 }
-  cte l6 =
+              Get l7 // { arity: 2 }
+  cte l7 =
     Project (#0, #2) // { arity: 2 }
       Join on=(#0 = #1) // { arity: 3 }
-        Get l5 // { arity: 1 }
+        Get l6 // { arity: 1 }
         Union // { arity: 2 }
           Get l2 // { arity: 2 }
           CrossJoin // { arity: 2 }
@@ -474,15 +476,17 @@ With
                 Get l1 // { arity: 1 }
             Constant // { arity: 1 }
               - (null)
-  cte l5 =
+  cte l6 =
     Distinct project=[#0] // { arity: 1 }
+      Get l5 // { arity: 2 }
+  cte l5 =
+    Distinct project=[#0, #1] // { arity: 2 }
       Get l4 // { arity: 2 }
   cte l4 =
-    Filter true // { arity: 2 }
-      CrossJoin // { arity: 2 }
-        Distinct project=[#1] // { arity: 1 }
-          Get l3 // { arity: 2 }
-        Get materialize.public.x // { arity: 1 }
+    CrossJoin // { arity: 2 }
+      Distinct project=[#1] // { arity: 1 }
+        Get l3 // { arity: 2 }
+      Get materialize.public.x // { arity: 1 }
   cte l3 =
     CrossJoin // { arity: 2 }
       Get l1 // { arity: 1 }

--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -373,52 +373,78 @@ SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
           "Map": {
             "input": {
               "Let": {
-                "id": 1,
+                "id": 2,
                 "value": {
                   "Filter": {
                     "input": {
-                      "Join": {
-                        "inputs": [
-                          {
-                            "Get": {
-                              "id": {
-                                "Local": 0
-                              },
-                              "typ": {
-                                "column_types": [],
-                                "keys": [
-                                  []
-                                ]
-                              },
-                              "access_strategy": "UnknownOrLocal"
-                            }
-                          },
-                          {
-                            "Get": {
-                              "id": {
-                                "Global": {
-                                  "User": 5
+                      "Let": {
+                        "id": 1,
+                        "value": {
+                          "Join": {
+                            "inputs": [
+                              {
+                                "Get": {
+                                  "id": {
+                                    "Local": 0
+                                  },
+                                  "typ": {
+                                    "column_types": [],
+                                    "keys": [
+                                      []
+                                    ]
+                                  },
+                                  "access_strategy": "UnknownOrLocal"
                                 }
                               },
-                              "typ": {
-                                "column_types": [
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": false
+                              {
+                                "Get": {
+                                  "id": {
+                                    "Global": {
+                                      "User": 5
+                                    }
                                   },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ],
-                                "keys": []
-                              },
-                              "access_strategy": "UnknownOrLocal"
-                            }
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": false
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      }
+                                    ],
+                                    "keys": []
+                                  },
+                                  "access_strategy": "UnknownOrLocal"
+                                }
+                              }
+                            ],
+                            "equivalences": [],
+                            "implementation": "Unimplemented"
                           }
-                        ],
-                        "equivalences": [],
-                        "implementation": "Unimplemented"
+                        },
+                        "body": {
+                          "Get": {
+                            "id": {
+                              "Local": 1
+                            },
+                            "typ": {
+                              "column_types": [
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": false
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                }
+                              ],
+                              "keys": []
+                            },
+                            "access_strategy": "UnknownOrLocal"
+                          }
+                        }
                       }
                     },
                     "predicates": [
@@ -519,7 +545,7 @@ SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
                 "body": {
                   "Get": {
                     "id": {
-                      "Local": 1
+                      "Local": 2
                     },
                     "typ": {
                       "column_types": [
@@ -1693,361 +1719,378 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
           "Filter": {
             "input": {
               "Let": {
-                "id": 4,
+                "id": 1,
                 "value": {
-                  "Project": {
-                    "input": {
-                      "Filter": {
-                        "input": {
-                          "Let": {
-                            "id": 1,
-                            "value": {
-                              "Filter": {
-                                "input": {
-                                  "Join": {
-                                    "inputs": [
+                  "Join": {
+                    "inputs": [
+                      {
+                        "Get": {
+                          "id": {
+                            "Local": 0
+                          },
+                          "typ": {
+                            "column_types": [],
+                            "keys": [
+                              []
+                            ]
+                          },
+                          "access_strategy": "UnknownOrLocal"
+                        }
+                      },
+                      {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "typ": {
+                            "column_types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ],
+                            "keys": []
+                          },
+                          "access_strategy": "UnknownOrLocal"
+                        }
+                      }
+                    ],
+                    "equivalences": [],
+                    "implementation": "Unimplemented"
+                  }
+                },
+                "body": {
+                  "Join": {
+                    "inputs": [
+                      {
+                        "Get": {
+                          "id": {
+                            "Local": 1
+                          },
+                          "typ": {
+                            "column_types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ],
+                            "keys": []
+                          },
+                          "access_strategy": "UnknownOrLocal"
+                        }
+                      },
+                      {
+                        "Let": {
+                          "id": 2,
+                          "value": {
+                            "Reduce": {
+                              "input": {
+                                "Get": {
+                                  "id": {
+                                    "Local": 1
+                                  },
+                                  "typ": {
+                                    "column_types": [
                                       {
-                                        "Get": {
-                                          "id": {
-                                            "Local": 0
-                                          },
-                                          "typ": {
-                                            "column_types": [],
-                                            "keys": [
-                                              []
-                                            ]
-                                          },
-                                          "access_strategy": "UnknownOrLocal"
-                                        }
+                                        "scalar_type": "Int32",
+                                        "nullable": true
                                       },
                                       {
-                                        "Get": {
-                                          "id": {
-                                            "Global": {
-                                              "User": 1
-                                            }
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              }
-                                            ],
-                                            "keys": []
-                                          },
-                                          "access_strategy": "UnknownOrLocal"
-                                        }
+                                        "scalar_type": "Int32",
+                                        "nullable": true
                                       }
                                     ],
-                                    "equivalences": [],
-                                    "implementation": "Unimplemented"
-                                  }
+                                    "keys": []
+                                  },
+                                  "access_strategy": "UnknownOrLocal"
+                                }
+                              },
+                              "group_key": [
+                                {
+                                  "Column": 0
                                 },
-                                "predicates": [
-                                  {
-                                    "CallVariadic": {
-                                      "func": "And",
-                                      "exprs": [
-                                        {
-                                          "Literal": [
-                                            {
-                                              "Ok": {
-                                                "data": [
-                                                  2
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "scalar_type": "Bool",
-                                              "nullable": false
-                                            }
+                                {
+                                  "Column": 1
+                                }
+                              ],
+                              "aggregates": [],
+                              "monotonic": false,
+                              "expected_group_size": null
+                            }
+                          },
+                          "body": {
+                            "Let": {
+                              "id": 3,
+                              "value": {
+                                "Reduce": {
+                                  "input": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 2
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": [
+                                          [
+                                            0,
+                                            1
                                           ]
-                                        },
-                                        {
-                                          "Literal": [
-                                            {
-                                              "Ok": {
-                                                "data": [
-                                                  2
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "scalar_type": "Bool",
-                                              "nullable": false
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                        ]
+                                      },
+                                      "access_strategy": "UnknownOrLocal"
                                     }
-                                  }
-                                ]
-                              }
-                            },
-                            "body": {
-                              "Let": {
-                                "id": 2,
-                                "value": {
-                                  "Reduce": {
-                                    "input": {
-                                      "Get": {
-                                        "id": {
-                                          "Local": 1
-                                        },
-                                        "typ": {
-                                          "column_types": [
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
+                                  },
+                                  "group_key": [
+                                    {
+                                      "Column": 0
+                                    }
+                                  ],
+                                  "aggregates": [],
+                                  "monotonic": false,
+                                  "expected_group_size": null
+                                }
+                              },
+                              "body": {
+                                "Project": {
+                                  "input": {
+                                    "Join": {
+                                      "inputs": [
+                                        {
+                                          "Get": {
+                                            "id": {
+                                              "Local": 2
                                             },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            }
-                                          ],
-                                          "keys": []
+                                            "typ": {
+                                              "column_types": [
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                },
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                }
+                                              ],
+                                              "keys": [
+                                                [
+                                                  0,
+                                                  1
+                                                ]
+                                              ]
+                                            },
+                                            "access_strategy": "UnknownOrLocal"
+                                          }
                                         },
-                                        "access_strategy": "UnknownOrLocal"
-                                      }
-                                    },
-                                    "group_key": [
-                                      {
-                                        "Column": 0
-                                      }
-                                    ],
-                                    "aggregates": [],
-                                    "monotonic": false,
-                                    "expected_group_size": null
-                                  }
-                                },
-                                "body": {
-                                  "Project": {
-                                    "input": {
-                                      "Join": {
-                                        "inputs": [
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 1
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": []
-                                              },
-                                              "access_strategy": "UnknownOrLocal"
-                                            }
-                                          },
-                                          {
-                                            "Let": {
-                                              "id": 3,
-                                              "value": {
-                                                "Map": {
-                                                  "input": {
-                                                    "Reduce": {
-                                                      "input": {
-                                                        "Filter": {
-                                                          "input": {
-                                                            "Join": {
-                                                              "inputs": [
-                                                                {
-                                                                  "Get": {
-                                                                    "id": {
-                                                                      "Local": 2
-                                                                    },
-                                                                    "typ": {
-                                                                      "column_types": [
-                                                                        {
-                                                                          "scalar_type": "Int32",
-                                                                          "nullable": true
-                                                                        }
-                                                                      ],
-                                                                      "keys": [
-                                                                        [
-                                                                          0
+                                        {
+                                          "Let": {
+                                            "id": 5,
+                                            "value": {
+                                              "Map": {
+                                                "input": {
+                                                  "Reduce": {
+                                                    "input": {
+                                                      "Filter": {
+                                                        "input": {
+                                                          "Let": {
+                                                            "id": 4,
+                                                            "value": {
+                                                              "Join": {
+                                                                "inputs": [
+                                                                  {
+                                                                    "Get": {
+                                                                      "id": {
+                                                                        "Local": 3
+                                                                      },
+                                                                      "typ": {
+                                                                        "column_types": [
+                                                                          {
+                                                                            "scalar_type": "Int32",
+                                                                            "nullable": true
+                                                                          }
+                                                                        ],
+                                                                        "keys": [
+                                                                          [
+                                                                            0
+                                                                          ]
                                                                         ]
-                                                                      ]
-                                                                    },
-                                                                    "access_strategy": "UnknownOrLocal"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "Get": {
-                                                                    "id": {
-                                                                      "Global": {
-                                                                        "User": 5
-                                                                      }
-                                                                    },
-                                                                    "typ": {
-                                                                      "column_types": [
-                                                                        {
-                                                                          "scalar_type": "Int32",
-                                                                          "nullable": false
-                                                                        },
-                                                                        {
-                                                                          "scalar_type": "Int32",
-                                                                          "nullable": true
+                                                                      },
+                                                                      "access_strategy": "UnknownOrLocal"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "Get": {
+                                                                      "id": {
+                                                                        "Global": {
+                                                                          "User": 5
                                                                         }
-                                                                      ],
-                                                                      "keys": []
-                                                                    },
-                                                                    "access_strategy": "UnknownOrLocal"
+                                                                      },
+                                                                      "typ": {
+                                                                        "column_types": [
+                                                                          {
+                                                                            "scalar_type": "Int32",
+                                                                            "nullable": false
+                                                                          },
+                                                                          {
+                                                                            "scalar_type": "Int32",
+                                                                            "nullable": true
+                                                                          }
+                                                                        ],
+                                                                        "keys": []
+                                                                      },
+                                                                      "access_strategy": "UnknownOrLocal"
+                                                                    }
                                                                   }
-                                                                }
-                                                              ],
-                                                              "equivalences": [],
-                                                              "implementation": "Unimplemented"
-                                                            }
-                                                          },
-                                                          "predicates": [
-                                                            {
-                                                              "CallBinary": {
-                                                                "func": "Lt",
-                                                                "expr1": {
-                                                                  "Column": 0
+                                                                ],
+                                                                "equivalences": [],
+                                                                "implementation": "Unimplemented"
+                                                              }
+                                                            },
+                                                            "body": {
+                                                              "Get": {
+                                                                "id": {
+                                                                  "Local": 4
                                                                 },
-                                                                "expr2": {
-                                                                  "Column": 1
-                                                                }
+                                                                "typ": {
+                                                                  "column_types": [
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": true
+                                                                    },
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": false
+                                                                    },
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": true
+                                                                    }
+                                                                  ],
+                                                                  "keys": []
+                                                                },
+                                                                "access_strategy": "UnknownOrLocal"
                                                               }
                                                             }
+                                                          }
+                                                        },
+                                                        "predicates": [
+                                                          {
+                                                            "CallBinary": {
+                                                              "func": "Lt",
+                                                              "expr1": {
+                                                                "Column": 0
+                                                              },
+                                                              "expr2": {
+                                                                "Column": 1
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "group_key": [
+                                                      {
+                                                        "Column": 0
+                                                      }
+                                                    ],
+                                                    "aggregates": [],
+                                                    "monotonic": false,
+                                                    "expected_group_size": null
+                                                  }
+                                                },
+                                                "scalars": [
+                                                  {
+                                                    "Literal": [
+                                                      {
+                                                        "Ok": {
+                                                          "data": [
+                                                            2
                                                           ]
                                                         }
                                                       },
-                                                      "group_key": [
+                                                      {
+                                                        "scalar_type": "Bool",
+                                                        "nullable": false
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "body": {
+                                              "Union": {
+                                                "base": {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 5
+                                                    },
+                                                    "typ": {
+                                                      "column_types": [
                                                         {
-                                                          "Column": 0
-                                                        }
-                                                      ],
-                                                      "aggregates": [],
-                                                      "monotonic": false,
-                                                      "expected_group_size": null
-                                                    }
-                                                  },
-                                                  "scalars": [
-                                                    {
-                                                      "Literal": [
-                                                        {
-                                                          "Ok": {
-                                                            "data": [
-                                                              2
-                                                            ]
-                                                          }
+                                                          "scalar_type": "Int32",
+                                                          "nullable": false
                                                         },
                                                         {
                                                           "scalar_type": "Bool",
                                                           "nullable": false
                                                         }
-                                                      ]
-                                                    }
-                                                  ]
-                                                }
-                                              },
-                                              "body": {
-                                                "Union": {
-                                                  "base": {
-                                                    "Get": {
-                                                      "id": {
-                                                        "Local": 3
-                                                      },
-                                                      "typ": {
-                                                        "column_types": [
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": false
-                                                          },
-                                                          {
-                                                            "scalar_type": "Bool",
-                                                            "nullable": false
-                                                          }
-                                                        ],
-                                                        "keys": [
-                                                          [
-                                                            0
-                                                          ]
+                                                      ],
+                                                      "keys": [
+                                                        [
+                                                          0
                                                         ]
-                                                      },
-                                                      "access_strategy": "UnknownOrLocal"
-                                                    }
-                                                  },
-                                                  "inputs": [
-                                                    {
-                                                      "Join": {
-                                                        "inputs": [
-                                                          {
-                                                            "Project": {
-                                                              "input": {
-                                                                "Join": {
-                                                                  "inputs": [
-                                                                    {
-                                                                      "Union": {
-                                                                        "base": {
-                                                                          "Negate": {
-                                                                            "input": {
-                                                                              "Reduce": {
-                                                                                "input": {
-                                                                                  "Get": {
-                                                                                    "id": {
-                                                                                      "Local": 3
-                                                                                    },
-                                                                                    "typ": {
-                                                                                      "column_types": [
-                                                                                        {
-                                                                                          "scalar_type": "Int32",
-                                                                                          "nullable": false
-                                                                                        },
-                                                                                        {
-                                                                                          "scalar_type": "Bool",
-                                                                                          "nullable": false
-                                                                                        }
-                                                                                      ],
-                                                                                      "keys": [
-                                                                                        [
-                                                                                          0
-                                                                                        ]
-                                                                                      ]
-                                                                                    },
-                                                                                    "access_strategy": "UnknownOrLocal"
-                                                                                  }
-                                                                                },
-                                                                                "group_key": [
-                                                                                  {
-                                                                                    "Column": 0
-                                                                                  }
-                                                                                ],
-                                                                                "aggregates": [],
-                                                                                "monotonic": false,
-                                                                                "expected_group_size": null
-                                                                              }
-                                                                            }
-                                                                          }
-                                                                        },
-                                                                        "inputs": [
-                                                                          {
+                                                      ]
+                                                    },
+                                                    "access_strategy": "UnknownOrLocal"
+                                                  }
+                                                },
+                                                "inputs": [
+                                                  {
+                                                    "Join": {
+                                                      "inputs": [
+                                                        {
+                                                          "Project": {
+                                                            "input": {
+                                                              "Join": {
+                                                                "inputs": [
+                                                                  {
+                                                                    "Union": {
+                                                                      "base": {
+                                                                        "Negate": {
+                                                                          "input": {
                                                                             "Reduce": {
                                                                               "input": {
                                                                                 "Get": {
                                                                                   "id": {
-                                                                                    "Local": 2
+                                                                                    "Local": 5
                                                                                   },
                                                                                   "typ": {
                                                                                     "column_types": [
                                                                                       {
                                                                                         "scalar_type": "Int32",
-                                                                                        "nullable": true
+                                                                                        "nullable": false
+                                                                                      },
+                                                                                      {
+                                                                                        "scalar_type": "Bool",
+                                                                                        "nullable": false
                                                                                       }
                                                                                     ],
                                                                                     "keys": [
@@ -2069,167 +2112,154 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                                               "expected_group_size": null
                                                                             }
                                                                           }
-                                                                        ]
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "Get": {
-                                                                        "id": {
-                                                                          "Local": 2
-                                                                        },
-                                                                        "typ": {
-                                                                          "column_types": [
-                                                                            {
-                                                                              "scalar_type": "Int32",
-                                                                              "nullable": true
-                                                                            }
-                                                                          ],
-                                                                          "keys": [
-                                                                            [
-                                                                              0
-                                                                            ]
-                                                                          ]
-                                                                        },
-                                                                        "access_strategy": "UnknownOrLocal"
-                                                                      }
-                                                                    }
-                                                                  ],
-                                                                  "equivalences": [
-                                                                    [
-                                                                      {
-                                                                        "Column": 0
+                                                                        }
                                                                       },
-                                                                      {
-                                                                        "Column": 1
-                                                                      }
-                                                                    ]
-                                                                  ],
-                                                                  "implementation": "Unimplemented"
-                                                                }
-                                                              },
-                                                              "outputs": [
-                                                                0
-                                                              ]
-                                                            }
-                                                          },
-                                                          {
-                                                            "Constant": {
-                                                              "rows": {
-                                                                "Ok": [
-                                                                  [
-                                                                    {
-                                                                      "data": [
-                                                                        1
+                                                                      "inputs": [
+                                                                        {
+                                                                          "Reduce": {
+                                                                            "input": {
+                                                                              "Get": {
+                                                                                "id": {
+                                                                                  "Local": 3
+                                                                                },
+                                                                                "typ": {
+                                                                                  "column_types": [
+                                                                                    {
+                                                                                      "scalar_type": "Int32",
+                                                                                      "nullable": true
+                                                                                    }
+                                                                                  ],
+                                                                                  "keys": [
+                                                                                    [
+                                                                                      0
+                                                                                    ]
+                                                                                  ]
+                                                                                },
+                                                                                "access_strategy": "UnknownOrLocal"
+                                                                              }
+                                                                            },
+                                                                            "group_key": [
+                                                                              {
+                                                                                "Column": 0
+                                                                              }
+                                                                            ],
+                                                                            "aggregates": [],
+                                                                            "monotonic": false,
+                                                                            "expected_group_size": null
+                                                                          }
+                                                                        }
                                                                       ]
-                                                                    },
-                                                                    1
-                                                                  ]
-                                                                ]
-                                                              },
-                                                              "typ": {
-                                                                "column_types": [
+                                                                    }
+                                                                  },
                                                                   {
-                                                                    "scalar_type": "Bool",
-                                                                    "nullable": false
+                                                                    "Get": {
+                                                                      "id": {
+                                                                        "Local": 3
+                                                                      },
+                                                                      "typ": {
+                                                                        "column_types": [
+                                                                          {
+                                                                            "scalar_type": "Int32",
+                                                                            "nullable": true
+                                                                          }
+                                                                        ],
+                                                                        "keys": [
+                                                                          [
+                                                                            0
+                                                                          ]
+                                                                        ]
+                                                                      },
+                                                                      "access_strategy": "UnknownOrLocal"
+                                                                    }
                                                                   }
                                                                 ],
-                                                                "keys": []
+                                                                "equivalences": [
+                                                                  [
+                                                                    {
+                                                                      "Column": 0
+                                                                    },
+                                                                    {
+                                                                      "Column": 1
+                                                                    }
+                                                                  ]
+                                                                ],
+                                                                "implementation": "Unimplemented"
                                                               }
+                                                            },
+                                                            "outputs": [
+                                                              0
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "Constant": {
+                                                            "rows": {
+                                                              "Ok": [
+                                                                [
+                                                                  {
+                                                                    "data": [
+                                                                      1
+                                                                    ]
+                                                                  },
+                                                                  1
+                                                                ]
+                                                              ]
+                                                            },
+                                                            "typ": {
+                                                              "column_types": [
+                                                                {
+                                                                  "scalar_type": "Bool",
+                                                                  "nullable": false
+                                                                }
+                                                              ],
+                                                              "keys": []
                                                             }
                                                           }
-                                                        ],
-                                                        "equivalences": [],
-                                                        "implementation": "Unimplemented"
-                                                      }
+                                                        }
+                                                      ],
+                                                      "equivalences": [],
+                                                      "implementation": "Unimplemented"
                                                     }
-                                                  ]
-                                                }
+                                                  }
+                                                ]
                                               }
                                             }
                                           }
-                                        ],
-                                        "equivalences": [
-                                          [
-                                            {
-                                              "Column": 0
-                                            },
-                                            {
-                                              "Column": 2
-                                            }
-                                          ]
-                                        ],
-                                        "implementation": "Unimplemented"
-                                      }
-                                    },
-                                    "outputs": [
-                                      0,
-                                      1,
-                                      3
-                                    ]
-                                  }
+                                        }
+                                      ],
+                                      "equivalences": [
+                                        [
+                                          {
+                                            "Column": 0
+                                          },
+                                          {
+                                            "Column": 2
+                                          }
+                                        ]
+                                      ],
+                                      "implementation": "Unimplemented"
+                                    }
+                                  },
+                                  "outputs": [
+                                    0,
+                                    1,
+                                    3
+                                  ]
                                 }
                               }
                             }
                           }
-                        },
-                        "predicates": [
-                          {
-                            "Column": 2
-                          }
-                        ]
-                      }
-                    },
-                    "outputs": [
-                      0,
-                      1
-                    ]
-                  }
-                },
-                "body": {
-                  "Let": {
-                    "id": 5,
-                    "value": {
-                      "Reduce": {
-                        "input": {
-                          "Get": {
-                            "id": {
-                              "Local": 4
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": []
-                            },
-                            "access_strategy": "UnknownOrLocal"
-                          }
-                        },
-                        "group_key": [
-                          {
-                            "Column": 1
-                          }
-                        ],
-                        "aggregates": [],
-                        "monotonic": false,
-                        "expected_group_size": null
-                      }
-                    },
-                    "body": {
-                      "Project": {
-                        "input": {
-                          "Join": {
-                            "inputs": [
-                              {
+                        }
+                      },
+                      {
+                        "Let": {
+                          "id": 6,
+                          "value": {
+                            "Reduce": {
+                              "input": {
                                 "Get": {
                                   "id": {
-                                    "Local": 4
+                                    "Local": 1
                                   },
                                   "typ": {
                                     "column_types": [
@@ -2247,197 +2277,110 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                   "access_strategy": "UnknownOrLocal"
                                 }
                               },
-                              {
-                                "Let": {
-                                  "id": 6,
-                                  "value": {
-                                    "Map": {
-                                      "input": {
-                                        "Reduce": {
-                                          "input": {
-                                            "Filter": {
-                                              "input": {
-                                                "Join": {
-                                                  "inputs": [
-                                                    {
-                                                      "Get": {
-                                                        "id": {
-                                                          "Local": 5
-                                                        },
-                                                        "typ": {
-                                                          "column_types": [
-                                                            {
-                                                              "scalar_type": "Int32",
-                                                              "nullable": true
-                                                            }
-                                                          ],
-                                                          "keys": [
-                                                            [
-                                                              0
-                                                            ]
-                                                          ]
-                                                        },
-                                                        "access_strategy": "UnknownOrLocal"
-                                                      }
-                                                    },
-                                                    {
-                                                      "Get": {
-                                                        "id": {
-                                                          "Global": {
-                                                            "User": 5
-                                                          }
-                                                        },
-                                                        "typ": {
-                                                          "column_types": [
-                                                            {
-                                                              "scalar_type": "Int32",
-                                                              "nullable": false
-                                                            },
-                                                            {
-                                                              "scalar_type": "Int32",
-                                                              "nullable": true
-                                                            }
-                                                          ],
-                                                          "keys": []
-                                                        },
-                                                        "access_strategy": "UnknownOrLocal"
-                                                      }
-                                                    }
-                                                  ],
-                                                  "equivalences": [],
-                                                  "implementation": "Unimplemented"
-                                                }
-                                              },
-                                              "predicates": [
-                                                {
-                                                  "CallBinary": {
-                                                    "func": "Gt",
-                                                    "expr1": {
-                                                      "Column": 0
-                                                    },
-                                                    "expr2": {
-                                                      "Column": 2
-                                                    }
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          },
-                                          "group_key": [
-                                            {
-                                              "Column": 0
-                                            }
-                                          ],
-                                          "aggregates": [],
-                                          "monotonic": false,
-                                          "expected_group_size": null
-                                        }
+                              "group_key": [
+                                {
+                                  "Column": 0
+                                },
+                                {
+                                  "Column": 1
+                                }
+                              ],
+                              "aggregates": [],
+                              "monotonic": false,
+                              "expected_group_size": null
+                            }
+                          },
+                          "body": {
+                            "Let": {
+                              "id": 7,
+                              "value": {
+                                "Reduce": {
+                                  "input": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 6
                                       },
-                                      "scalars": [
-                                        {
-                                          "Literal": [
-                                            {
-                                              "Ok": {
-                                                "data": [
-                                                  2
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "scalar_type": "Bool",
-                                              "nullable": false
-                                            }
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": [
+                                          [
+                                            0,
+                                            1
                                           ]
-                                        }
-                                      ]
+                                        ]
+                                      },
+                                      "access_strategy": "UnknownOrLocal"
                                     }
                                   },
-                                  "body": {
-                                    "Union": {
-                                      "base": {
-                                        "Get": {
-                                          "id": {
-                                            "Local": 6
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": false
-                                              },
-                                              {
-                                                "scalar_type": "Bool",
-                                                "nullable": false
-                                              }
-                                            ],
-                                            "keys": [
-                                              [
-                                                0
-                                              ]
-                                            ]
-                                          },
-                                          "access_strategy": "UnknownOrLocal"
-                                        }
-                                      },
+                                  "group_key": [
+                                    {
+                                      "Column": 1
+                                    }
+                                  ],
+                                  "aggregates": [],
+                                  "monotonic": false,
+                                  "expected_group_size": null
+                                }
+                              },
+                              "body": {
+                                "Project": {
+                                  "input": {
+                                    "Join": {
                                       "inputs": [
                                         {
-                                          "Join": {
-                                            "inputs": [
-                                              {
-                                                "Project": {
-                                                  "input": {
-                                                    "Join": {
-                                                      "inputs": [
-                                                        {
-                                                          "Union": {
-                                                            "base": {
-                                                              "Negate": {
-                                                                "input": {
-                                                                  "Reduce": {
-                                                                    "input": {
-                                                                      "Get": {
-                                                                        "id": {
-                                                                          "Local": 6
-                                                                        },
-                                                                        "typ": {
-                                                                          "column_types": [
-                                                                            {
-                                                                              "scalar_type": "Int32",
-                                                                              "nullable": false
-                                                                            },
-                                                                            {
-                                                                              "scalar_type": "Bool",
-                                                                              "nullable": false
-                                                                            }
-                                                                          ],
-                                                                          "keys": [
-                                                                            [
-                                                                              0
-                                                                            ]
-                                                                          ]
-                                                                        },
-                                                                        "access_strategy": "UnknownOrLocal"
-                                                                      }
-                                                                    },
-                                                                    "group_key": [
-                                                                      {
-                                                                        "Column": 0
-                                                                      }
-                                                                    ],
-                                                                    "aggregates": [],
-                                                                    "monotonic": false,
-                                                                    "expected_group_size": null
-                                                                  }
-                                                                }
-                                                              }
-                                                            },
-                                                            "inputs": [
-                                                              {
-                                                                "Reduce": {
-                                                                  "input": {
+                                          "Get": {
+                                            "id": {
+                                              "Local": 6
+                                            },
+                                            "typ": {
+                                              "column_types": [
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                },
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                }
+                                              ],
+                                              "keys": [
+                                                [
+                                                  0,
+                                                  1
+                                                ]
+                                              ]
+                                            },
+                                            "access_strategy": "UnknownOrLocal"
+                                          }
+                                        },
+                                        {
+                                          "Let": {
+                                            "id": 9,
+                                            "value": {
+                                              "Map": {
+                                                "input": {
+                                                  "Reduce": {
+                                                    "input": {
+                                                      "Filter": {
+                                                        "input": {
+                                                          "Let": {
+                                                            "id": 8,
+                                                            "value": {
+                                                              "Join": {
+                                                                "inputs": [
+                                                                  {
                                                                     "Get": {
                                                                       "id": {
-                                                                        "Local": 5
+                                                                        "Local": 7
                                                                       },
                                                                       "typ": {
                                                                         "column_types": [
@@ -2455,122 +2398,394 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                                       "access_strategy": "UnknownOrLocal"
                                                                     }
                                                                   },
-                                                                  "group_key": [
+                                                                  {
+                                                                    "Get": {
+                                                                      "id": {
+                                                                        "Global": {
+                                                                          "User": 5
+                                                                        }
+                                                                      },
+                                                                      "typ": {
+                                                                        "column_types": [
+                                                                          {
+                                                                            "scalar_type": "Int32",
+                                                                            "nullable": false
+                                                                          },
+                                                                          {
+                                                                            "scalar_type": "Int32",
+                                                                            "nullable": true
+                                                                          }
+                                                                        ],
+                                                                        "keys": []
+                                                                      },
+                                                                      "access_strategy": "UnknownOrLocal"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "equivalences": [],
+                                                                "implementation": "Unimplemented"
+                                                              }
+                                                            },
+                                                            "body": {
+                                                              "Get": {
+                                                                "id": {
+                                                                  "Local": 8
+                                                                },
+                                                                "typ": {
+                                                                  "column_types": [
                                                                     {
-                                                                      "Column": 0
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": true
+                                                                    },
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": false
+                                                                    },
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": true
                                                                     }
                                                                   ],
-                                                                  "aggregates": [],
-                                                                  "monotonic": false,
-                                                                  "expected_group_size": null
-                                                                }
+                                                                  "keys": []
+                                                                },
+                                                                "access_strategy": "UnknownOrLocal"
                                                               }
-                                                            ]
+                                                            }
                                                           }
                                                         },
-                                                        {
-                                                          "Get": {
-                                                            "id": {
-                                                              "Local": 5
-                                                            },
-                                                            "typ": {
-                                                              "column_types": [
-                                                                {
-                                                                  "scalar_type": "Int32",
-                                                                  "nullable": true
-                                                                }
-                                                              ],
-                                                              "keys": [
-                                                                [
-                                                                  0
-                                                                ]
-                                                              ]
-                                                            },
-                                                            "access_strategy": "UnknownOrLocal"
-                                                          }
-                                                        }
-                                                      ],
-                                                      "equivalences": [
-                                                        [
+                                                        "predicates": [
                                                           {
-                                                            "Column": 0
-                                                          },
-                                                          {
-                                                            "Column": 1
+                                                            "CallBinary": {
+                                                              "func": "Gt",
+                                                              "expr1": {
+                                                                "Column": 0
+                                                              },
+                                                              "expr2": {
+                                                                "Column": 2
+                                                              }
+                                                            }
                                                           }
                                                         ]
-                                                      ],
-                                                      "implementation": "Unimplemented"
-                                                    }
-                                                  },
-                                                  "outputs": [
-                                                    0
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "Constant": {
-                                                  "rows": {
-                                                    "Ok": [
-                                                      [
-                                                        {
+                                                      }
+                                                    },
+                                                    "group_key": [
+                                                      {
+                                                        "Column": 0
+                                                      }
+                                                    ],
+                                                    "aggregates": [],
+                                                    "monotonic": false,
+                                                    "expected_group_size": null
+                                                  }
+                                                },
+                                                "scalars": [
+                                                  {
+                                                    "Literal": [
+                                                      {
+                                                        "Ok": {
                                                           "data": [
-                                                            1
+                                                            2
                                                           ]
-                                                        },
-                                                        1
-                                                      ]
-                                                    ]
-                                                  },
-                                                  "typ": {
-                                                    "column_types": [
+                                                        }
+                                                      },
                                                       {
                                                         "scalar_type": "Bool",
                                                         "nullable": false
                                                       }
-                                                    ],
-                                                    "keys": []
+                                                    ]
                                                   }
-                                                }
+                                                ]
                                               }
-                                            ],
-                                            "equivalences": [],
-                                            "implementation": "Unimplemented"
+                                            },
+                                            "body": {
+                                              "Union": {
+                                                "base": {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 9
+                                                    },
+                                                    "typ": {
+                                                      "column_types": [
+                                                        {
+                                                          "scalar_type": "Int32",
+                                                          "nullable": false
+                                                        },
+                                                        {
+                                                          "scalar_type": "Bool",
+                                                          "nullable": false
+                                                        }
+                                                      ],
+                                                      "keys": [
+                                                        [
+                                                          0
+                                                        ]
+                                                      ]
+                                                    },
+                                                    "access_strategy": "UnknownOrLocal"
+                                                  }
+                                                },
+                                                "inputs": [
+                                                  {
+                                                    "Join": {
+                                                      "inputs": [
+                                                        {
+                                                          "Project": {
+                                                            "input": {
+                                                              "Join": {
+                                                                "inputs": [
+                                                                  {
+                                                                    "Union": {
+                                                                      "base": {
+                                                                        "Negate": {
+                                                                          "input": {
+                                                                            "Reduce": {
+                                                                              "input": {
+                                                                                "Get": {
+                                                                                  "id": {
+                                                                                    "Local": 9
+                                                                                  },
+                                                                                  "typ": {
+                                                                                    "column_types": [
+                                                                                      {
+                                                                                        "scalar_type": "Int32",
+                                                                                        "nullable": false
+                                                                                      },
+                                                                                      {
+                                                                                        "scalar_type": "Bool",
+                                                                                        "nullable": false
+                                                                                      }
+                                                                                    ],
+                                                                                    "keys": [
+                                                                                      [
+                                                                                        0
+                                                                                      ]
+                                                                                    ]
+                                                                                  },
+                                                                                  "access_strategy": "UnknownOrLocal"
+                                                                                }
+                                                                              },
+                                                                              "group_key": [
+                                                                                {
+                                                                                  "Column": 0
+                                                                                }
+                                                                              ],
+                                                                              "aggregates": [],
+                                                                              "monotonic": false,
+                                                                              "expected_group_size": null
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "inputs": [
+                                                                        {
+                                                                          "Reduce": {
+                                                                            "input": {
+                                                                              "Get": {
+                                                                                "id": {
+                                                                                  "Local": 7
+                                                                                },
+                                                                                "typ": {
+                                                                                  "column_types": [
+                                                                                    {
+                                                                                      "scalar_type": "Int32",
+                                                                                      "nullable": true
+                                                                                    }
+                                                                                  ],
+                                                                                  "keys": [
+                                                                                    [
+                                                                                      0
+                                                                                    ]
+                                                                                  ]
+                                                                                },
+                                                                                "access_strategy": "UnknownOrLocal"
+                                                                              }
+                                                                            },
+                                                                            "group_key": [
+                                                                              {
+                                                                                "Column": 0
+                                                                              }
+                                                                            ],
+                                                                            "aggregates": [],
+                                                                            "monotonic": false,
+                                                                            "expected_group_size": null
+                                                                          }
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "Get": {
+                                                                      "id": {
+                                                                        "Local": 7
+                                                                      },
+                                                                      "typ": {
+                                                                        "column_types": [
+                                                                          {
+                                                                            "scalar_type": "Int32",
+                                                                            "nullable": true
+                                                                          }
+                                                                        ],
+                                                                        "keys": [
+                                                                          [
+                                                                            0
+                                                                          ]
+                                                                        ]
+                                                                      },
+                                                                      "access_strategy": "UnknownOrLocal"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "equivalences": [
+                                                                  [
+                                                                    {
+                                                                      "Column": 0
+                                                                    },
+                                                                    {
+                                                                      "Column": 1
+                                                                    }
+                                                                  ]
+                                                                ],
+                                                                "implementation": "Unimplemented"
+                                                              }
+                                                            },
+                                                            "outputs": [
+                                                              0
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "Constant": {
+                                                            "rows": {
+                                                              "Ok": [
+                                                                [
+                                                                  {
+                                                                    "data": [
+                                                                      1
+                                                                    ]
+                                                                  },
+                                                                  1
+                                                                ]
+                                                              ]
+                                                            },
+                                                            "typ": {
+                                                              "column_types": [
+                                                                {
+                                                                  "scalar_type": "Bool",
+                                                                  "nullable": false
+                                                                }
+                                                              ],
+                                                              "keys": []
+                                                            }
+                                                          }
+                                                        }
+                                                      ],
+                                                      "equivalences": [],
+                                                      "implementation": "Unimplemented"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
                                           }
                                         }
-                                      ]
+                                      ],
+                                      "equivalences": [
+                                        [
+                                          {
+                                            "Column": 1
+                                          },
+                                          {
+                                            "Column": 2
+                                          }
+                                        ]
+                                      ],
+                                      "implementation": "Unimplemented"
                                     }
-                                  }
+                                  },
+                                  "outputs": [
+                                    0,
+                                    1,
+                                    3
+                                  ]
                                 }
                               }
-                            ],
-                            "equivalences": [
-                              [
-                                {
-                                  "Column": 1
-                                },
-                                {
-                                  "Column": 2
-                                }
-                              ]
-                            ],
-                            "implementation": "Unimplemented"
+                            }
                           }
-                        },
-                        "outputs": [
-                          0,
-                          1,
-                          3
-                        ]
+                        }
                       }
-                    }
+                    ],
+                    "equivalences": [
+                      [
+                        {
+                          "Column": 0
+                        },
+                        {
+                          "Column": 2
+                        },
+                        {
+                          "Column": 5
+                        }
+                      ],
+                      [
+                        {
+                          "Column": 1
+                        },
+                        {
+                          "Column": 3
+                        },
+                        {
+                          "Column": 6
+                        }
+                      ]
+                    ],
+                    "implementation": "Unimplemented"
                   }
                 }
               }
             },
             "predicates": [
               {
-                "Column": 2
+                "Column": 4
+              },
+              {
+                "Column": 7
+              },
+              {
+                "CallVariadic": {
+                  "func": "And",
+                  "exprs": [
+                    {
+                      "Literal": [
+                        {
+                          "Ok": {
+                            "data": [
+                              2
+                            ]
+                          }
+                        },
+                        {
+                          "scalar_type": "Bool",
+                          "nullable": false
+                        }
+                      ]
+                    },
+                    {
+                      "Literal": [
+                        {
+                          "Ok": {
+                            "data": [
+                              2
+                            ]
+                          }
+                        },
+                        {
+                          "scalar_type": "Bool",
+                          "nullable": false
+                        }
+                      ]
+                    }
+                  ]
+                }
               }
             ]
           }
@@ -2800,10 +3015,10 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                         },
                                         {
                                           "Let": {
-                                            "id": 5,
+                                            "id": 6,
                                             "value": {
                                               "Let": {
-                                                "id": 4,
+                                                "id": 5,
                                                 "value": {
                                                   "Project": {
                                                     "input": {
@@ -2811,55 +3026,85 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                         "input": {
                                                           "Filter": {
                                                             "input": {
-                                                              "Join": {
-                                                                "inputs": [
-                                                                  {
-                                                                    "Get": {
-                                                                      "id": {
-                                                                        "Local": 3
-                                                                      },
-                                                                      "typ": {
-                                                                        "column_types": [
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          }
-                                                                        ],
-                                                                        "keys": [
-                                                                          [
-                                                                            0
-                                                                          ]
-                                                                        ]
-                                                                      },
-                                                                      "access_strategy": "UnknownOrLocal"
-                                                                    }
-                                                                  },
-                                                                  {
-                                                                    "Get": {
-                                                                      "id": {
-                                                                        "Global": {
-                                                                          "User": 3
+                                                              "Let": {
+                                                                "id": 4,
+                                                                "value": {
+                                                                  "Join": {
+                                                                    "inputs": [
+                                                                      {
+                                                                        "Get": {
+                                                                          "id": {
+                                                                            "Local": 3
+                                                                          },
+                                                                          "typ": {
+                                                                            "column_types": [
+                                                                              {
+                                                                                "scalar_type": "Int32",
+                                                                                "nullable": true
+                                                                              }
+                                                                            ],
+                                                                            "keys": [
+                                                                              [
+                                                                                0
+                                                                              ]
+                                                                            ]
+                                                                          },
+                                                                          "access_strategy": "UnknownOrLocal"
                                                                         }
                                                                       },
-                                                                      "typ": {
-                                                                        "column_types": [
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": false
+                                                                      {
+                                                                        "Get": {
+                                                                          "id": {
+                                                                            "Global": {
+                                                                              "User": 3
+                                                                            }
                                                                           },
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          }
-                                                                        ],
-                                                                        "keys": []
-                                                                      },
-                                                                      "access_strategy": "UnknownOrLocal"
-                                                                    }
+                                                                          "typ": {
+                                                                            "column_types": [
+                                                                              {
+                                                                                "scalar_type": "Int32",
+                                                                                "nullable": false
+                                                                              },
+                                                                              {
+                                                                                "scalar_type": "Int32",
+                                                                                "nullable": true
+                                                                              }
+                                                                            ],
+                                                                            "keys": []
+                                                                          },
+                                                                          "access_strategy": "UnknownOrLocal"
+                                                                        }
+                                                                      }
+                                                                    ],
+                                                                    "equivalences": [],
+                                                                    "implementation": "Unimplemented"
                                                                   }
-                                                                ],
-                                                                "equivalences": [],
-                                                                "implementation": "Unimplemented"
+                                                                },
+                                                                "body": {
+                                                                  "Get": {
+                                                                    "id": {
+                                                                      "Local": 4
+                                                                    },
+                                                                    "typ": {
+                                                                      "column_types": [
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        },
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": false
+                                                                        },
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        }
+                                                                      ],
+                                                                      "keys": []
+                                                                    },
+                                                                    "access_strategy": "UnknownOrLocal"
+                                                                  }
+                                                                }
                                                               }
                                                             },
                                                             "predicates": [
@@ -2913,7 +3158,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                     "base": {
                                                       "Get": {
                                                         "id": {
-                                                          "Local": 4
+                                                          "Local": 5
                                                         },
                                                         "typ": {
                                                           "column_types": [
@@ -2947,7 +3192,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                       "input": {
                                                                         "Get": {
                                                                           "id": {
-                                                                            "Local": 4
+                                                                            "Local": 5
                                                                           },
                                                                           "typ": {
                                                                             "column_types": [
@@ -3057,7 +3302,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                 "base": {
                                                   "Get": {
                                                     "id": {
-                                                      "Local": 5
+                                                      "Local": 6
                                                     },
                                                     "typ": {
                                                       "column_types": [
@@ -3093,7 +3338,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                               "input": {
                                                                                 "Get": {
                                                                                   "id": {
-                                                                                    "Local": 5
+                                                                                    "Local": 6
                                                                                   },
                                                                                   "typ": {
                                                                                     "column_types": [
@@ -3262,7 +3507,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                       },
                       {
                         "Let": {
-                          "id": 6,
+                          "id": 7,
                           "value": {
                             "Reduce": {
                               "input": {
@@ -3301,13 +3546,13 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                           },
                           "body": {
                             "Let": {
-                              "id": 7,
+                              "id": 8,
                               "value": {
                                 "Reduce": {
                                   "input": {
                                     "Get": {
                                       "id": {
-                                        "Local": 6
+                                        "Local": 7
                                       },
                                       "typ": {
                                         "column_types": [
@@ -3348,7 +3593,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                         {
                                           "Get": {
                                             "id": {
-                                              "Local": 6
+                                              "Local": 7
                                             },
                                             "typ": {
                                               "column_types": [
@@ -3373,10 +3618,10 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                         },
                                         {
                                           "Let": {
-                                            "id": 9,
+                                            "id": 11,
                                             "value": {
                                               "Let": {
-                                                "id": 8,
+                                                "id": 10,
                                                 "value": {
                                                   "Project": {
                                                     "input": {
@@ -3384,55 +3629,85 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                         "input": {
                                                           "Filter": {
                                                             "input": {
-                                                              "Join": {
-                                                                "inputs": [
-                                                                  {
-                                                                    "Get": {
-                                                                      "id": {
-                                                                        "Local": 7
-                                                                      },
-                                                                      "typ": {
-                                                                        "column_types": [
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          }
-                                                                        ],
-                                                                        "keys": [
-                                                                          [
-                                                                            0
-                                                                          ]
-                                                                        ]
-                                                                      },
-                                                                      "access_strategy": "UnknownOrLocal"
-                                                                    }
-                                                                  },
-                                                                  {
-                                                                    "Get": {
-                                                                      "id": {
-                                                                        "Global": {
-                                                                          "User": 5
+                                                              "Let": {
+                                                                "id": 9,
+                                                                "value": {
+                                                                  "Join": {
+                                                                    "inputs": [
+                                                                      {
+                                                                        "Get": {
+                                                                          "id": {
+                                                                            "Local": 8
+                                                                          },
+                                                                          "typ": {
+                                                                            "column_types": [
+                                                                              {
+                                                                                "scalar_type": "Int32",
+                                                                                "nullable": true
+                                                                              }
+                                                                            ],
+                                                                            "keys": [
+                                                                              [
+                                                                                0
+                                                                              ]
+                                                                            ]
+                                                                          },
+                                                                          "access_strategy": "UnknownOrLocal"
                                                                         }
                                                                       },
-                                                                      "typ": {
-                                                                        "column_types": [
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": false
+                                                                      {
+                                                                        "Get": {
+                                                                          "id": {
+                                                                            "Global": {
+                                                                              "User": 5
+                                                                            }
                                                                           },
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          }
-                                                                        ],
-                                                                        "keys": []
-                                                                      },
-                                                                      "access_strategy": "UnknownOrLocal"
-                                                                    }
+                                                                          "typ": {
+                                                                            "column_types": [
+                                                                              {
+                                                                                "scalar_type": "Int32",
+                                                                                "nullable": false
+                                                                              },
+                                                                              {
+                                                                                "scalar_type": "Int32",
+                                                                                "nullable": true
+                                                                              }
+                                                                            ],
+                                                                            "keys": []
+                                                                          },
+                                                                          "access_strategy": "UnknownOrLocal"
+                                                                        }
+                                                                      }
+                                                                    ],
+                                                                    "equivalences": [],
+                                                                    "implementation": "Unimplemented"
                                                                   }
-                                                                ],
-                                                                "equivalences": [],
-                                                                "implementation": "Unimplemented"
+                                                                },
+                                                                "body": {
+                                                                  "Get": {
+                                                                    "id": {
+                                                                      "Local": 9
+                                                                    },
+                                                                    "typ": {
+                                                                      "column_types": [
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        },
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": false
+                                                                        },
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        }
+                                                                      ],
+                                                                      "keys": []
+                                                                    },
+                                                                    "access_strategy": "UnknownOrLocal"
+                                                                  }
+                                                                }
                                                               }
                                                             },
                                                             "predicates": [
@@ -3486,7 +3761,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                     "base": {
                                                       "Get": {
                                                         "id": {
-                                                          "Local": 8
+                                                          "Local": 10
                                                         },
                                                         "typ": {
                                                           "column_types": [
@@ -3520,7 +3795,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                       "input": {
                                                                         "Get": {
                                                                           "id": {
-                                                                            "Local": 8
+                                                                            "Local": 10
                                                                           },
                                                                           "typ": {
                                                                             "column_types": [
@@ -3630,7 +3905,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                 "base": {
                                                   "Get": {
                                                     "id": {
-                                                      "Local": 9
+                                                      "Local": 11
                                                     },
                                                     "typ": {
                                                       "column_types": [
@@ -3666,7 +3941,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                               "input": {
                                                                                 "Get": {
                                                                                   "id": {
-                                                                                    "Local": 9
+                                                                                    "Local": 11
                                                                                   },
                                                                                   "typ": {
                                                                                     "column_types": [
@@ -3702,7 +3977,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                             "input": {
                                                                               "Get": {
                                                                                 "id": {
-                                                                                  "Local": 7
+                                                                                  "Local": 8
                                                                                 },
                                                                                 "typ": {
                                                                                   "column_types": [
@@ -3736,7 +4011,7 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                                                   {
                                                                     "Get": {
                                                                       "id": {
-                                                                        "Local": 7
+                                                                        "Local": 8
                                                                       },
                                                                       "typ": {
                                                                         "column_types": [
@@ -4426,58 +4701,13 @@ WHERE t1.b = t2.b AND t2.b = t3.b
           "Filter": {
             "input": {
               "Let": {
-                "id": 4,
+                "id": 7,
                 "value": {
                   "Let": {
-                    "id": 1,
+                    "id": 4,
                     "value": {
-                      "Join": {
-                        "inputs": [
-                          {
-                            "Get": {
-                              "id": {
-                                "Local": 0
-                              },
-                              "typ": {
-                                "column_types": [],
-                                "keys": [
-                                  []
-                                ]
-                              },
-                              "access_strategy": "UnknownOrLocal"
-                            }
-                          },
-                          {
-                            "Get": {
-                              "id": {
-                                "Global": {
-                                  "User": 1
-                                }
-                              },
-                              "typ": {
-                                "column_types": [
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ],
-                                "keys": []
-                              },
-                              "access_strategy": "UnknownOrLocal"
-                            }
-                          }
-                        ],
-                        "equivalences": [],
-                        "implementation": "Unimplemented"
-                      }
-                    },
-                    "body": {
                       "Let": {
-                        "id": 2,
+                        "id": 1,
                         "value": {
                           "Join": {
                             "inputs": [
@@ -4525,7 +4755,222 @@ WHERE t1.b = t2.b AND t2.b = t3.b
                         },
                         "body": {
                           "Let": {
-                            "id": 3,
+                            "id": 2,
+                            "value": {
+                              "Join": {
+                                "inputs": [
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "typ": {
+                                        "column_types": [],
+                                        "keys": [
+                                          []
+                                        ]
+                                      },
+                                      "access_strategy": "UnknownOrLocal"
+                                    }
+                                  },
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Global": {
+                                          "User": 1
+                                        }
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      },
+                                      "access_strategy": "UnknownOrLocal"
+                                    }
+                                  }
+                                ],
+                                "equivalences": [],
+                                "implementation": "Unimplemented"
+                              }
+                            },
+                            "body": {
+                              "Let": {
+                                "id": 3,
+                                "value": {
+                                  "Filter": {
+                                    "input": {
+                                      "Project": {
+                                        "input": {
+                                          "Join": {
+                                            "inputs": [
+                                              {
+                                                "Get": {
+                                                  "id": {
+                                                    "Local": 1
+                                                  },
+                                                  "typ": {
+                                                    "column_types": [
+                                                      {
+                                                        "scalar_type": "Int32",
+                                                        "nullable": true
+                                                      },
+                                                      {
+                                                        "scalar_type": "Int32",
+                                                        "nullable": true
+                                                      }
+                                                    ],
+                                                    "keys": []
+                                                  },
+                                                  "access_strategy": "UnknownOrLocal"
+                                                }
+                                              },
+                                              {
+                                                "Get": {
+                                                  "id": {
+                                                    "Local": 2
+                                                  },
+                                                  "typ": {
+                                                    "column_types": [
+                                                      {
+                                                        "scalar_type": "Int32",
+                                                        "nullable": true
+                                                      },
+                                                      {
+                                                        "scalar_type": "Int32",
+                                                        "nullable": true
+                                                      }
+                                                    ],
+                                                    "keys": []
+                                                  },
+                                                  "access_strategy": "UnknownOrLocal"
+                                                }
+                                              }
+                                            ],
+                                            "equivalences": [],
+                                            "implementation": "Unimplemented"
+                                          }
+                                        },
+                                        "outputs": [
+                                          0,
+                                          1,
+                                          2,
+                                          3
+                                        ]
+                                      }
+                                    },
+                                    "predicates": [
+                                      {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                2
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "Bool",
+                                            "nullable": false
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "body": {
+                                  "Get": {
+                                    "id": {
+                                      "Local": 3
+                                    },
+                                    "typ": {
+                                      "column_types": [
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        }
+                                      ],
+                                      "keys": []
+                                    },
+                                    "access_strategy": "UnknownOrLocal"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "body": {
+                      "Let": {
+                        "id": 5,
+                        "value": {
+                          "Join": {
+                            "inputs": [
+                              {
+                                "Get": {
+                                  "id": {
+                                    "Local": 0
+                                  },
+                                  "typ": {
+                                    "column_types": [],
+                                    "keys": [
+                                      []
+                                    ]
+                                  },
+                                  "access_strategy": "UnknownOrLocal"
+                                }
+                              },
+                              {
+                                "Get": {
+                                  "id": {
+                                    "Global": {
+                                      "User": 1
+                                    }
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      }
+                                    ],
+                                    "keys": []
+                                  },
+                                  "access_strategy": "UnknownOrLocal"
+                                }
+                              }
+                            ],
+                            "equivalences": [],
+                            "implementation": "Unimplemented"
+                          }
+                        },
+                        "body": {
+                          "Let": {
+                            "id": 6,
                             "value": {
                               "Filter": {
                                 "input": {
@@ -4536,10 +4981,18 @@ WHERE t1.b = t2.b AND t2.b = t3.b
                                           {
                                             "Get": {
                                               "id": {
-                                                "Local": 1
+                                                "Local": 4
                                               },
                                               "typ": {
                                                 "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  },
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  },
                                                   {
                                                     "scalar_type": "Int32",
                                                     "nullable": true
@@ -4557,7 +5010,7 @@ WHERE t1.b = t2.b AND t2.b = t3.b
                                           {
                                             "Get": {
                                               "id": {
-                                                "Local": 2
+                                                "Local": 5
                                               },
                                               "typ": {
                                                 "column_types": [
@@ -4584,7 +5037,9 @@ WHERE t1.b = t2.b AND t2.b = t3.b
                                       0,
                                       1,
                                       2,
-                                      3
+                                      3,
+                                      4,
+                                      5
                                     ]
                                   }
                                 },
@@ -4610,10 +5065,18 @@ WHERE t1.b = t2.b AND t2.b = t3.b
                             "body": {
                               "Get": {
                                 "id": {
-                                  "Local": 3
+                                  "Local": 6
                                 },
                                 "typ": {
                                   "column_types": [
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    },
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    },
                                     {
                                       "scalar_type": "Int32",
                                       "nullable": true
@@ -4643,186 +5106,40 @@ WHERE t1.b = t2.b AND t2.b = t3.b
                   }
                 },
                 "body": {
-                  "Let": {
-                    "id": 5,
-                    "value": {
-                      "Join": {
-                        "inputs": [
-                          {
-                            "Get": {
-                              "id": {
-                                "Local": 0
-                              },
-                              "typ": {
-                                "column_types": [],
-                                "keys": [
-                                  []
-                                ]
-                              },
-                              "access_strategy": "UnknownOrLocal"
-                            }
-                          },
-                          {
-                            "Get": {
-                              "id": {
-                                "Global": {
-                                  "User": 1
-                                }
-                              },
-                              "typ": {
-                                "column_types": [
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ],
-                                "keys": []
-                              },
-                              "access_strategy": "UnknownOrLocal"
-                            }
-                          }
-                        ],
-                        "equivalences": [],
-                        "implementation": "Unimplemented"
-                      }
+                  "Get": {
+                    "id": {
+                      "Local": 7
                     },
-                    "body": {
-                      "Let": {
-                        "id": 6,
-                        "value": {
-                          "Filter": {
-                            "input": {
-                              "Project": {
-                                "input": {
-                                  "Join": {
-                                    "inputs": [
-                                      {
-                                        "Get": {
-                                          "id": {
-                                            "Local": 4
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              }
-                                            ],
-                                            "keys": []
-                                          },
-                                          "access_strategy": "UnknownOrLocal"
-                                        }
-                                      },
-                                      {
-                                        "Get": {
-                                          "id": {
-                                            "Local": 5
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              }
-                                            ],
-                                            "keys": []
-                                          },
-                                          "access_strategy": "UnknownOrLocal"
-                                        }
-                                      }
-                                    ],
-                                    "equivalences": [],
-                                    "implementation": "Unimplemented"
-                                  }
-                                },
-                                "outputs": [
-                                  0,
-                                  1,
-                                  2,
-                                  3,
-                                  4,
-                                  5
-                                ]
-                              }
-                            },
-                            "predicates": [
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        2
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Bool",
-                                    "nullable": false
-                                  }
-                                ]
-                              }
-                            ]
-                          }
+                    "typ": {
+                      "column_types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
                         },
-                        "body": {
-                          "Get": {
-                            "id": {
-                              "Local": 6
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": []
-                            },
-                            "access_strategy": "UnknownOrLocal"
-                          }
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
                         }
-                      }
-                    }
+                      ],
+                      "keys": []
+                    },
+                    "access_strategy": "UnknownOrLocal"
                   }
                 }
               }
@@ -7904,402 +8221,60 @@ FROM
                                 "Filter": {
                                   "input": {
                                     "Let": {
-                                      "id": 5,
+                                      "id": 8,
                                       "value": {
-                                        "Reduce": {
+                                        "Filter": {
                                           "input": {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 4
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
+                                            "Let": {
+                                              "id": 5,
+                                              "value": {
+                                                "Reduce": {
+                                                  "input": {
+                                                    "Get": {
+                                                      "id": {
+                                                        "Local": 4
+                                                      },
+                                                      "typ": {
+                                                        "column_types": [
+                                                          {
+                                                            "scalar_type": "Int32",
+                                                            "nullable": true
+                                                          },
+                                                          {
+                                                            "scalar_type": "Int32",
+                                                            "nullable": true
+                                                          }
+                                                        ],
+                                                        "keys": []
+                                                      },
+                                                      "access_strategy": "UnknownOrLocal"
+                                                    }
                                                   },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": []
+                                                  "group_key": [
+                                                    {
+                                                      "Column": 1
+                                                    },
+                                                    {
+                                                      "Column": 0
+                                                    }
+                                                  ],
+                                                  "aggregates": [],
+                                                  "monotonic": false,
+                                                  "expected_group_size": null
+                                                }
                                               },
-                                              "access_strategy": "UnknownOrLocal"
-                                            }
-                                          },
-                                          "group_key": [
-                                            {
-                                              "Column": 1
-                                            },
-                                            {
-                                              "Column": 0
-                                            }
-                                          ],
-                                          "aggregates": [],
-                                          "monotonic": false,
-                                          "expected_group_size": null
-                                        }
-                                      },
-                                      "body": {
-                                        "Project": {
-                                          "input": {
-                                            "Join": {
-                                              "inputs": [
-                                                {
-                                                  "Get": {
-                                                    "id": {
-                                                      "Local": 4
-                                                    },
-                                                    "typ": {
-                                                      "column_types": [
+                                              "body": {
+                                                "Project": {
+                                                  "input": {
+                                                    "Join": {
+                                                      "inputs": [
                                                         {
-                                                          "scalar_type": "Int32",
-                                                          "nullable": true
-                                                        },
-                                                        {
-                                                          "scalar_type": "Int32",
-                                                          "nullable": true
-                                                        }
-                                                      ],
-                                                      "keys": []
-                                                    },
-                                                    "access_strategy": "UnknownOrLocal"
-                                                  }
-                                                },
-                                                {
-                                                  "Let": {
-                                                    "id": 7,
-                                                    "value": {
-                                                      "Let": {
-                                                        "id": 6,
-                                                        "value": {
-                                                          "Reduce": {
-                                                            "input": {
-                                                              "Join": {
-                                                                "inputs": [
-                                                                  {
-                                                                    "Get": {
-                                                                      "id": {
-                                                                        "Local": 5
-                                                                      },
-                                                                      "typ": {
-                                                                        "column_types": [
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          },
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          }
-                                                                        ],
-                                                                        "keys": [
-                                                                          [
-                                                                            0,
-                                                                            1
-                                                                          ]
-                                                                        ]
-                                                                      },
-                                                                      "access_strategy": "UnknownOrLocal"
-                                                                    }
-                                                                  },
-                                                                  {
-                                                                    "Get": {
-                                                                      "id": {
-                                                                        "Global": {
-                                                                          "User": 1
-                                                                        }
-                                                                      },
-                                                                      "typ": {
-                                                                        "column_types": [
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          },
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          }
-                                                                        ],
-                                                                        "keys": []
-                                                                      },
-                                                                      "access_strategy": "UnknownOrLocal"
-                                                                    }
-                                                                  }
-                                                                ],
-                                                                "equivalences": [],
-                                                                "implementation": "Unimplemented"
-                                                              }
-                                                            },
-                                                            "group_key": [
-                                                              {
-                                                                "Column": 0
-                                                              },
-                                                              {
-                                                                "Column": 1
-                                                              }
-                                                            ],
-                                                            "aggregates": [
-                                                              {
-                                                                "func": "MaxInt32",
-                                                                "expr": {
-                                                                  "CallBinary": {
-                                                                    "func": "MulInt32",
-                                                                    "expr1": {
-                                                                      "Column": 1
-                                                                    },
-                                                                    "expr2": {
-                                                                      "Column": 2
-                                                                    }
-                                                                  }
-                                                                },
-                                                                "distinct": false
-                                                              }
-                                                            ],
-                                                            "monotonic": false,
-                                                            "expected_group_size": null
-                                                          }
-                                                        },
-                                                        "body": {
-                                                          "Union": {
-                                                            "base": {
-                                                              "Get": {
-                                                                "id": {
-                                                                  "Local": 6
-                                                                },
-                                                                "typ": {
-                                                                  "column_types": [
-                                                                    {
-                                                                      "scalar_type": "Int32",
-                                                                      "nullable": true
-                                                                    },
-                                                                    {
-                                                                      "scalar_type": "Int32",
-                                                                      "nullable": true
-                                                                    },
-                                                                    {
-                                                                      "scalar_type": "Int32",
-                                                                      "nullable": true
-                                                                    }
-                                                                  ],
-                                                                  "keys": [
-                                                                    [
-                                                                      0,
-                                                                      1
-                                                                    ]
-                                                                  ]
-                                                                },
-                                                                "access_strategy": "UnknownOrLocal"
-                                                              }
-                                                            },
-                                                            "inputs": [
-                                                              {
-                                                                "Join": {
-                                                                  "inputs": [
-                                                                    {
-                                                                      "Project": {
-                                                                        "input": {
-                                                                          "Join": {
-                                                                            "inputs": [
-                                                                              {
-                                                                                "Union": {
-                                                                                  "base": {
-                                                                                    "Negate": {
-                                                                                      "input": {
-                                                                                        "Reduce": {
-                                                                                          "input": {
-                                                                                            "Get": {
-                                                                                              "id": {
-                                                                                                "Local": 6
-                                                                                              },
-                                                                                              "typ": {
-                                                                                                "column_types": [
-                                                                                                  {
-                                                                                                    "scalar_type": "Int32",
-                                                                                                    "nullable": true
-                                                                                                  },
-                                                                                                  {
-                                                                                                    "scalar_type": "Int32",
-                                                                                                    "nullable": true
-                                                                                                  },
-                                                                                                  {
-                                                                                                    "scalar_type": "Int32",
-                                                                                                    "nullable": true
-                                                                                                  }
-                                                                                                ],
-                                                                                                "keys": [
-                                                                                                  [
-                                                                                                    0,
-                                                                                                    1
-                                                                                                  ]
-                                                                                                ]
-                                                                                              },
-                                                                                              "access_strategy": "UnknownOrLocal"
-                                                                                            }
-                                                                                          },
-                                                                                          "group_key": [
-                                                                                            {
-                                                                                              "Column": 0
-                                                                                            },
-                                                                                            {
-                                                                                              "Column": 1
-                                                                                            }
-                                                                                          ],
-                                                                                          "aggregates": [],
-                                                                                          "monotonic": false,
-                                                                                          "expected_group_size": null
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  },
-                                                                                  "inputs": [
-                                                                                    {
-                                                                                      "Reduce": {
-                                                                                        "input": {
-                                                                                          "Get": {
-                                                                                            "id": {
-                                                                                              "Local": 5
-                                                                                            },
-                                                                                            "typ": {
-                                                                                              "column_types": [
-                                                                                                {
-                                                                                                  "scalar_type": "Int32",
-                                                                                                  "nullable": true
-                                                                                                },
-                                                                                                {
-                                                                                                  "scalar_type": "Int32",
-                                                                                                  "nullable": true
-                                                                                                }
-                                                                                              ],
-                                                                                              "keys": [
-                                                                                                [
-                                                                                                  0,
-                                                                                                  1
-                                                                                                ]
-                                                                                              ]
-                                                                                            },
-                                                                                            "access_strategy": "UnknownOrLocal"
-                                                                                          }
-                                                                                        },
-                                                                                        "group_key": [
-                                                                                          {
-                                                                                            "Column": 0
-                                                                                          },
-                                                                                          {
-                                                                                            "Column": 1
-                                                                                          }
-                                                                                        ],
-                                                                                        "aggregates": [],
-                                                                                        "monotonic": false,
-                                                                                        "expected_group_size": null
-                                                                                      }
-                                                                                    }
-                                                                                  ]
-                                                                                }
-                                                                              },
-                                                                              {
-                                                                                "Get": {
-                                                                                  "id": {
-                                                                                    "Local": 5
-                                                                                  },
-                                                                                  "typ": {
-                                                                                    "column_types": [
-                                                                                      {
-                                                                                        "scalar_type": "Int32",
-                                                                                        "nullable": true
-                                                                                      },
-                                                                                      {
-                                                                                        "scalar_type": "Int32",
-                                                                                        "nullable": true
-                                                                                      }
-                                                                                    ],
-                                                                                    "keys": [
-                                                                                      [
-                                                                                        0,
-                                                                                        1
-                                                                                      ]
-                                                                                    ]
-                                                                                  },
-                                                                                  "access_strategy": "UnknownOrLocal"
-                                                                                }
-                                                                              }
-                                                                            ],
-                                                                            "equivalences": [
-                                                                              [
-                                                                                {
-                                                                                  "Column": 0
-                                                                                },
-                                                                                {
-                                                                                  "Column": 2
-                                                                                }
-                                                                              ],
-                                                                              [
-                                                                                {
-                                                                                  "Column": 1
-                                                                                },
-                                                                                {
-                                                                                  "Column": 3
-                                                                                }
-                                                                              ]
-                                                                            ],
-                                                                            "implementation": "Unimplemented"
-                                                                          }
-                                                                        },
-                                                                        "outputs": [
-                                                                          0,
-                                                                          1
-                                                                        ]
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "Constant": {
-                                                                        "rows": {
-                                                                          "Ok": [
-                                                                            [
-                                                                              {
-                                                                                "data": [
-                                                                                  0
-                                                                                ]
-                                                                              },
-                                                                              1
-                                                                            ]
-                                                                          ]
-                                                                        },
-                                                                        "typ": {
-                                                                          "column_types": [
-                                                                            {
-                                                                              "scalar_type": "Int32",
-                                                                              "nullable": true
-                                                                            }
-                                                                          ],
-                                                                          "keys": []
-                                                                        }
-                                                                      }
-                                                                    }
-                                                                  ],
-                                                                  "equivalences": [],
-                                                                  "implementation": "Unimplemented"
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
-                                                        }
-                                                      }
-                                                    },
-                                                    "body": {
-                                                      "Filter": {
-                                                        "input": {
                                                           "Get": {
                                                             "id": {
-                                                              "Local": 7
+                                                              "Local": 4
                                                             },
                                                             "typ": {
                                                               "column_types": [
-                                                                {
-                                                                  "scalar_type": "Int32",
-                                                                  "nullable": true
-                                                                },
                                                                 {
                                                                   "scalar_type": "Int32",
                                                                   "nullable": true
@@ -8314,101 +8289,479 @@ FROM
                                                             "access_strategy": "UnknownOrLocal"
                                                           }
                                                         },
-                                                        "predicates": [
-                                                          {
-                                                            "CallVariadic": {
-                                                              "func": "And",
-                                                              "exprs": [
-                                                                {
-                                                                  "CallBinary": {
-                                                                    "func": "Eq",
-                                                                    "expr1": {
-                                                                      "Column": 1
+                                                        {
+                                                          "Let": {
+                                                            "id": 7,
+                                                            "value": {
+                                                              "Let": {
+                                                                "id": 6,
+                                                                "value": {
+                                                                  "Reduce": {
+                                                                    "input": {
+                                                                      "Join": {
+                                                                        "inputs": [
+                                                                          {
+                                                                            "Get": {
+                                                                              "id": {
+                                                                                "Local": 5
+                                                                              },
+                                                                              "typ": {
+                                                                                "column_types": [
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": true
+                                                                                  },
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": true
+                                                                                  }
+                                                                                ],
+                                                                                "keys": [
+                                                                                  [
+                                                                                    0,
+                                                                                    1
+                                                                                  ]
+                                                                                ]
+                                                                              },
+                                                                              "access_strategy": "UnknownOrLocal"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "Get": {
+                                                                              "id": {
+                                                                                "Global": {
+                                                                                  "User": 1
+                                                                                }
+                                                                              },
+                                                                              "typ": {
+                                                                                "column_types": [
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": true
+                                                                                  },
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": true
+                                                                                  }
+                                                                                ],
+                                                                                "keys": []
+                                                                              },
+                                                                              "access_strategy": "UnknownOrLocal"
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "equivalences": [],
+                                                                        "implementation": "Unimplemented"
+                                                                      }
                                                                     },
-                                                                    "expr2": {
-                                                                      "Column": 0
-                                                                    }
+                                                                    "group_key": [
+                                                                      {
+                                                                        "Column": 0
+                                                                      },
+                                                                      {
+                                                                        "Column": 1
+                                                                      }
+                                                                    ],
+                                                                    "aggregates": [
+                                                                      {
+                                                                        "func": "MaxInt32",
+                                                                        "expr": {
+                                                                          "CallBinary": {
+                                                                            "func": "MulInt32",
+                                                                            "expr1": {
+                                                                              "Column": 1
+                                                                            },
+                                                                            "expr2": {
+                                                                              "Column": 2
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "distinct": false
+                                                                      }
+                                                                    ],
+                                                                    "monotonic": false,
+                                                                    "expected_group_size": null
                                                                   }
                                                                 },
-                                                                {
-                                                                  "CallBinary": {
-                                                                    "func": "Gt",
-                                                                    "expr1": {
-                                                                      "Column": 2
-                                                                    },
-                                                                    "expr2": {
-                                                                      "Literal": [
-                                                                        {
-                                                                          "Ok": {
-                                                                            "data": [
-                                                                              42,
-                                                                              5
+                                                                "body": {
+                                                                  "Union": {
+                                                                    "base": {
+                                                                      "Get": {
+                                                                        "id": {
+                                                                          "Local": 6
+                                                                        },
+                                                                        "typ": {
+                                                                          "column_types": [
+                                                                            {
+                                                                              "scalar_type": "Int32",
+                                                                              "nullable": true
+                                                                            },
+                                                                            {
+                                                                              "scalar_type": "Int32",
+                                                                              "nullable": true
+                                                                            },
+                                                                            {
+                                                                              "scalar_type": "Int32",
+                                                                              "nullable": true
+                                                                            }
+                                                                          ],
+                                                                          "keys": [
+                                                                            [
+                                                                              0,
+                                                                              1
                                                                             ]
-                                                                          }
+                                                                          ]
+                                                                        },
+                                                                        "access_strategy": "UnknownOrLocal"
+                                                                      }
+                                                                    },
+                                                                    "inputs": [
+                                                                      {
+                                                                        "Join": {
+                                                                          "inputs": [
+                                                                            {
+                                                                              "Project": {
+                                                                                "input": {
+                                                                                  "Join": {
+                                                                                    "inputs": [
+                                                                                      {
+                                                                                        "Union": {
+                                                                                          "base": {
+                                                                                            "Negate": {
+                                                                                              "input": {
+                                                                                                "Reduce": {
+                                                                                                  "input": {
+                                                                                                    "Get": {
+                                                                                                      "id": {
+                                                                                                        "Local": 6
+                                                                                                      },
+                                                                                                      "typ": {
+                                                                                                        "column_types": [
+                                                                                                          {
+                                                                                                            "scalar_type": "Int32",
+                                                                                                            "nullable": true
+                                                                                                          },
+                                                                                                          {
+                                                                                                            "scalar_type": "Int32",
+                                                                                                            "nullable": true
+                                                                                                          },
+                                                                                                          {
+                                                                                                            "scalar_type": "Int32",
+                                                                                                            "nullable": true
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        "keys": [
+                                                                                                          [
+                                                                                                            0,
+                                                                                                            1
+                                                                                                          ]
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      "access_strategy": "UnknownOrLocal"
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "group_key": [
+                                                                                                    {
+                                                                                                      "Column": 0
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "Column": 1
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "aggregates": [],
+                                                                                                  "monotonic": false,
+                                                                                                  "expected_group_size": null
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "inputs": [
+                                                                                            {
+                                                                                              "Reduce": {
+                                                                                                "input": {
+                                                                                                  "Get": {
+                                                                                                    "id": {
+                                                                                                      "Local": 5
+                                                                                                    },
+                                                                                                    "typ": {
+                                                                                                      "column_types": [
+                                                                                                        {
+                                                                                                          "scalar_type": "Int32",
+                                                                                                          "nullable": true
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "scalar_type": "Int32",
+                                                                                                          "nullable": true
+                                                                                                        }
+                                                                                                      ],
+                                                                                                      "keys": [
+                                                                                                        [
+                                                                                                          0,
+                                                                                                          1
+                                                                                                        ]
+                                                                                                      ]
+                                                                                                    },
+                                                                                                    "access_strategy": "UnknownOrLocal"
+                                                                                                  }
+                                                                                                },
+                                                                                                "group_key": [
+                                                                                                  {
+                                                                                                    "Column": 0
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "Column": 1
+                                                                                                  }
+                                                                                                ],
+                                                                                                "aggregates": [],
+                                                                                                "monotonic": false,
+                                                                                                "expected_group_size": null
+                                                                                              }
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      },
+                                                                                      {
+                                                                                        "Get": {
+                                                                                          "id": {
+                                                                                            "Local": 5
+                                                                                          },
+                                                                                          "typ": {
+                                                                                            "column_types": [
+                                                                                              {
+                                                                                                "scalar_type": "Int32",
+                                                                                                "nullable": true
+                                                                                              },
+                                                                                              {
+                                                                                                "scalar_type": "Int32",
+                                                                                                "nullable": true
+                                                                                              }
+                                                                                            ],
+                                                                                            "keys": [
+                                                                                              [
+                                                                                                0,
+                                                                                                1
+                                                                                              ]
+                                                                                            ]
+                                                                                          },
+                                                                                          "access_strategy": "UnknownOrLocal"
+                                                                                        }
+                                                                                      }
+                                                                                    ],
+                                                                                    "equivalences": [
+                                                                                      [
+                                                                                        {
+                                                                                          "Column": 0
+                                                                                        },
+                                                                                        {
+                                                                                          "Column": 2
+                                                                                        }
+                                                                                      ],
+                                                                                      [
+                                                                                        {
+                                                                                          "Column": 1
+                                                                                        },
+                                                                                        {
+                                                                                          "Column": 3
+                                                                                        }
+                                                                                      ]
+                                                                                    ],
+                                                                                    "implementation": "Unimplemented"
+                                                                                  }
+                                                                                },
+                                                                                "outputs": [
+                                                                                  0,
+                                                                                  1
+                                                                                ]
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "Constant": {
+                                                                                "rows": {
+                                                                                  "Ok": [
+                                                                                    [
+                                                                                      {
+                                                                                        "data": [
+                                                                                          0
+                                                                                        ]
+                                                                                      },
+                                                                                      1
+                                                                                    ]
+                                                                                  ]
+                                                                                },
+                                                                                "typ": {
+                                                                                  "column_types": [
+                                                                                    {
+                                                                                      "scalar_type": "Int32",
+                                                                                      "nullable": true
+                                                                                    }
+                                                                                  ],
+                                                                                  "keys": []
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ],
+                                                                          "equivalences": [],
+                                                                          "implementation": "Unimplemented"
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            "body": {
+                                                              "Filter": {
+                                                                "input": {
+                                                                  "Get": {
+                                                                    "id": {
+                                                                      "Local": 7
+                                                                    },
+                                                                    "typ": {
+                                                                      "column_types": [
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
                                                                         },
                                                                         {
                                                                           "scalar_type": "Int32",
-                                                                          "nullable": false
+                                                                          "nullable": true
+                                                                        },
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        }
+                                                                      ],
+                                                                      "keys": []
+                                                                    },
+                                                                    "access_strategy": "UnknownOrLocal"
+                                                                  }
+                                                                },
+                                                                "predicates": [
+                                                                  {
+                                                                    "CallVariadic": {
+                                                                      "func": "And",
+                                                                      "exprs": [
+                                                                        {
+                                                                          "CallBinary": {
+                                                                            "func": "Eq",
+                                                                            "expr1": {
+                                                                              "Column": 1
+                                                                            },
+                                                                            "expr2": {
+                                                                              "Column": 0
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "CallBinary": {
+                                                                            "func": "Gt",
+                                                                            "expr1": {
+                                                                              "Column": 2
+                                                                            },
+                                                                            "expr2": {
+                                                                              "Literal": [
+                                                                                {
+                                                                                  "Ok": {
+                                                                                    "data": [
+                                                                                      42,
+                                                                                      5
+                                                                                    ]
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "scalar_type": "Int32",
+                                                                                  "nullable": false
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          }
                                                                         }
                                                                       ]
                                                                     }
                                                                   }
-                                                                }
-                                                              ]
+                                                                ]
+                                                              }
                                                             }
                                                           }
+                                                        }
+                                                      ],
+                                                      "equivalences": [
+                                                        [
+                                                          {
+                                                            "Column": 1
+                                                          },
+                                                          {
+                                                            "Column": 2
+                                                          }
+                                                        ],
+                                                        [
+                                                          {
+                                                            "Column": 0
+                                                          },
+                                                          {
+                                                            "Column": 3
+                                                          }
                                                         ]
-                                                      }
+                                                      ],
+                                                      "implementation": "Unimplemented"
                                                     }
-                                                  }
+                                                  },
+                                                  "outputs": [
+                                                    0,
+                                                    1,
+                                                    4
+                                                  ]
                                                 }
-                                              ],
-                                              "equivalences": [
-                                                [
-                                                  {
-                                                    "Column": 1
-                                                  },
-                                                  {
-                                                    "Column": 2
-                                                  }
-                                                ],
-                                                [
-                                                  {
-                                                    "Column": 0
-                                                  },
-                                                  {
-                                                    "Column": 3
-                                                  }
-                                                ]
-                                              ],
-                                              "implementation": "Unimplemented"
+                                              }
                                             }
                                           },
-                                          "outputs": [
-                                            0,
-                                            1,
-                                            4
+                                          "predicates": [
+                                            {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      2
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "Bool",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
                                           ]
+                                        }
+                                      },
+                                      "body": {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 8
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          },
+                                          "access_strategy": "UnknownOrLocal"
                                         }
                                       }
                                     }
                                   },
                                   "predicates": [
-                                    {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              2
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "Bool",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    },
                                     {
                                       "CallBinary": {
                                         "func": "NotEq",

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -217,71 +217,75 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
 ----
 Return
   Project (#0, #1)
-    Filter #2
-      Project (#0, #1, #3)
-        Join on=(#1 = #2)
-          Get l3
-          Union
-            Get l5
-            CrossJoin
-              Project (#0)
-                Join on=(#0 = #1)
-                  Union
-                    Negate
-                      Distinct project=[#0]
-                        Get l5
-                    Distinct project=[#0]
-                      Get l4
-                  Get l4
-              Constant
-                - (false)
-With
-  cte l5 =
-    Map (true)
-      Distinct project=[#0]
-        Filter (#0 > #2)
-          CrossJoin
-            Get l4
-            Get materialize.public.mv
-  cte l4 =
-    Distinct project=[#1]
-      Get l3
-  cte l3 =
-    Project (#0, #1)
-      Filter #2
+    Filter #4 AND #7 AND (true AND true)
+      Join on=(#0 = #2 = #5 AND #1 = #3 = #6)
+        Get l0
         Project (#0, #1, #3)
           Join on=(#0 = #2)
-            Get l0
+            Get l1
             Union
-              Get l2
+              Get l3
               CrossJoin
                 Project (#0)
                   Join on=(#0 = #1)
                     Union
                       Negate
                         Distinct project=[#0]
-                          Get l2
+                          Get l3
                       Distinct project=[#0]
-                        Get l1
-                    Get l1
+                        Get l2
+                    Get l2
                 Constant
                   - (false)
-  cte l2 =
+        Project (#0, #1, #3)
+          Join on=(#1 = #2)
+            Get l4
+            Union
+              Get l6
+              CrossJoin
+                Project (#0)
+                  Join on=(#0 = #1)
+                    Union
+                      Negate
+                        Distinct project=[#0]
+                          Get l6
+                      Distinct project=[#0]
+                        Get l5
+                    Get l5
+                Constant
+                  - (false)
+With
+  cte l6 =
+    Map (true)
+      Distinct project=[#0]
+        Filter (#0 > #2)
+          CrossJoin
+            Get l5
+            Get materialize.public.mv
+  cte l5 =
+    Distinct project=[#1]
+      Get l4
+  cte l4 =
+    Distinct project=[#0, #1]
+      Get l0
+  cte l3 =
     Map (true)
       Distinct project=[#0]
         Filter (#0 < #1)
           CrossJoin
-            Get l1
+            Get l2
             Get materialize.public.mv
-  cte l1 =
+  cte l2 =
     Distinct project=[#0]
+      Get l1
+  cte l1 =
+    Distinct project=[#0, #1]
       Get l0
   cte l0 =
-    Filter (true AND true)
-      CrossJoin
-        Constant
-          - ()
-        Get materialize.public.t
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
 
 EOF
 
@@ -691,25 +695,26 @@ Return
     Project (#0, #1, #3, #4)
       Join on=(#0 = #2)
         Get l0
-        Filter true AND (#0 != #0)
-          Project (#0, #1, #4)
-            Join on=(#1 = #2 AND #0 = #3)
-              Get l3
-              Filter ((#1 = #0) AND (#2 > 5))
-                Union
-                  Get l5
-                  CrossJoin
-                    Project (#0, #1)
-                      Join on=(#0 = #2 AND #1 = #3)
-                        Union
-                          Negate
+        Filter (#0 != #0)
+          Filter true
+            Project (#0, #1, #4)
+              Join on=(#1 = #2 AND #0 = #3)
+                Get l3
+                Filter ((#1 = #0) AND (#2 > 5))
+                  Union
+                    Get l5
+                    CrossJoin
+                      Project (#0, #1)
+                        Join on=(#0 = #2 AND #1 = #3)
+                          Union
+                            Negate
+                              Distinct project=[#0, #1]
+                                Get l5
                             Distinct project=[#0, #1]
-                              Get l5
-                          Distinct project=[#0, #1]
-                            Get l4
-                        Get l4
-                    Constant
-                      - (null)
+                              Get l4
+                          Get l4
+                      Constant
+                        - (null)
 With
   cte l5 =
     Reduce group_by=[#0, #1] aggregates=[max((#1 * #2))]

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -1308,141 +1308,95 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
     {
       "id": "Explained Query",
       "plan": {
-        "Let": {
-          "id": 0,
-          "value": {
-            "Project": {
-              "input": {
-                "Join": {
-                  "inputs": [
-                    {
-                      "ArrangeBy": {
-                        "input": {
-                          "Get": {
-                            "id": {
-                              "Global": {
-                                "User": 1
-                              }
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": []
-                            },
-                            "access_strategy": {
-                              "Index": [
-                                [
-                                  {
-                                    "User": 4
-                                  },
-                                  "DifferentialJoin"
-                                ]
-                              ]
-                            }
+        "Project": {
+          "input": {
+            "Join": {
+              "inputs": [
+                {
+                  "ArrangeBy": {
+                    "input": {
+                      "Get": {
+                        "id": {
+                          "Global": {
+                            "User": 1
                           }
                         },
-                        "keys": [
-                          [
+                        "typ": {
+                          "column_types": [
                             {
-                              "Column": 0
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
                             }
+                          ],
+                          "keys": []
+                        },
+                        "access_strategy": {
+                          "Index": [
+                            [
+                              {
+                                "User": 4
+                              },
+                              {
+                                "DeltaJoin": true
+                              }
+                            ],
+                            [
+                              {
+                                "User": 4
+                              },
+                              "FullScan"
+                            ]
                           ]
-                        ]
+                        }
                       }
                     },
-                    {
-                      "ArrangeBy": {
+                    "keys": [
+                      [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      [
+                        {
+                          "Column": 1
+                        }
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "ArrangeBy": {
+                    "input": {
+                      "Reduce": {
                         "input": {
-                          "Reduce": {
+                          "Project": {
                             "input": {
-                              "Project": {
+                              "Filter": {
                                 "input": {
-                                  "Filter": {
-                                    "input": {
-                                      "Join": {
-                                        "inputs": [
-                                          {
-                                            "ArrangeBy": {
-                                              "input": {
-                                                "Reduce": {
-                                                  "input": {
-                                                    "Project": {
-                                                      "input": {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Global": {
-                                                              "User": 1
-                                                            }
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              },
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              }
-                                                            ],
-                                                            "keys": []
-                                                          },
-                                                          "access_strategy": {
-                                                            "Index": [
-                                                              [
-                                                                {
-                                                                  "User": 4
-                                                                },
-                                                                "FullScan"
-                                                              ]
-                                                            ]
-                                                          }
-                                                        }
-                                                      },
-                                                      "outputs": [
-                                                        0
-                                                      ]
-                                                    }
-                                                  },
-                                                  "group_key": [
-                                                    {
-                                                      "Column": 0
-                                                    }
-                                                  ],
-                                                  "aggregates": [],
-                                                  "monotonic": false,
-                                                  "expected_group_size": null
-                                                }
-                                              },
-                                              "keys": [
-                                                []
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "ArrangeBy": {
+                                  "Join": {
+                                    "inputs": [
+                                      {
+                                        "ArrangeBy": {
+                                          "input": {
+                                            "Reduce": {
                                               "input": {
                                                 "Project": {
                                                   "input": {
                                                     "Get": {
                                                       "id": {
                                                         "Global": {
-                                                          "User": 8
+                                                          "User": 1
                                                         }
                                                       },
                                                       "typ": {
                                                         "column_types": [
                                                           {
                                                             "scalar_type": "Int32",
-                                                            "nullable": false
+                                                            "nullable": true
                                                           },
                                                           {
                                                             "scalar_type": "Int32",
@@ -1451,7 +1405,16 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                         ],
                                                         "keys": []
                                                       },
-                                                      "access_strategy": "Persist"
+                                                      "access_strategy": {
+                                                        "Index": [
+                                                          [
+                                                            {
+                                                              "User": 4
+                                                            },
+                                                            "FullScan"
+                                                          ]
+                                                        ]
+                                                      }
                                                     }
                                                   },
                                                   "outputs": [
@@ -1459,276 +1422,172 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                   ]
                                                 }
                                               },
-                                              "keys": [
-                                                []
+                                              "group_key": [
+                                                {
+                                                  "Column": 0
+                                                }
+                                              ],
+                                              "aggregates": [],
+                                              "monotonic": false,
+                                              "expected_group_size": null
+                                            }
+                                          },
+                                          "keys": [
+                                            []
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "ArrangeBy": {
+                                          "input": {
+                                            "Project": {
+                                              "input": {
+                                                "Get": {
+                                                  "id": {
+                                                    "Global": {
+                                                      "User": 8
+                                                    }
+                                                  },
+                                                  "typ": {
+                                                    "column_types": [
+                                                      {
+                                                        "scalar_type": "Int32",
+                                                        "nullable": false
+                                                      },
+                                                      {
+                                                        "scalar_type": "Int32",
+                                                        "nullable": true
+                                                      }
+                                                    ],
+                                                    "keys": []
+                                                  },
+                                                  "access_strategy": "Persist"
+                                                }
+                                              },
+                                              "outputs": [
+                                                0
                                               ]
                                             }
-                                          }
-                                        ],
-                                        "equivalences": [],
-                                        "implementation": {
-                                          "Differential": [
-                                            [
-                                              0,
-                                              [],
-                                              {
-                                                "unique_key": false,
-                                                "key_length": 0,
-                                                "arranged": false,
-                                                "cardinality": null,
-                                                "filters": {
-                                                  "literal_equality": false,
-                                                  "like": false,
-                                                  "is_null": false,
-                                                  "literal_inequality": 0,
-                                                  "any_filter": false
-                                                },
-                                                "input": 0
-                                              }
-                                            ],
-                                            [
-                                              [
-                                                1,
-                                                [],
-                                                {
-                                                  "unique_key": false,
-                                                  "key_length": 0,
-                                                  "arranged": false,
-                                                  "cardinality": null,
-                                                  "filters": {
-                                                    "literal_equality": false,
-                                                    "like": false,
-                                                    "is_null": false,
-                                                    "literal_inequality": 0,
-                                                    "any_filter": false
-                                                  },
-                                                  "input": 1
-                                                }
-                                              ]
-                                            ]
+                                          },
+                                          "keys": [
+                                            []
                                           ]
                                         }
                                       }
-                                    },
-                                    "predicates": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "Lt",
-                                          "expr1": {
-                                            "Column": 0
-                                          },
-                                          "expr2": {
-                                            "Column": 1
+                                    ],
+                                    "equivalences": [],
+                                    "implementation": {
+                                      "Differential": [
+                                        [
+                                          0,
+                                          [],
+                                          {
+                                            "unique_key": false,
+                                            "key_length": 0,
+                                            "arranged": false,
+                                            "cardinality": null,
+                                            "filters": {
+                                              "literal_equality": false,
+                                              "like": false,
+                                              "is_null": false,
+                                              "literal_inequality": 0,
+                                              "any_filter": false
+                                            },
+                                            "input": 0
                                           }
-                                        }
-                                      }
-                                    ]
+                                        ],
+                                        [
+                                          [
+                                            1,
+                                            [],
+                                            {
+                                              "unique_key": false,
+                                              "key_length": 0,
+                                              "arranged": false,
+                                              "cardinality": null,
+                                              "filters": {
+                                                "literal_equality": false,
+                                                "like": false,
+                                                "is_null": false,
+                                                "literal_inequality": 0,
+                                                "any_filter": false
+                                              },
+                                              "input": 1
+                                            }
+                                          ]
+                                        ]
+                                      ]
+                                    }
                                   }
                                 },
-                                "outputs": [
-                                  0
+                                "predicates": [
+                                  {
+                                    "CallBinary": {
+                                      "func": "Lt",
+                                      "expr1": {
+                                        "Column": 0
+                                      },
+                                      "expr2": {
+                                        "Column": 1
+                                      }
+                                    }
+                                  }
                                 ]
                               }
                             },
-                            "group_key": [
-                              {
-                                "Column": 0
-                              }
-                            ],
-                            "aggregates": [],
-                            "monotonic": false,
-                            "expected_group_size": null
+                            "outputs": [
+                              0
+                            ]
                           }
                         },
-                        "keys": [
-                          [
-                            {
-                              "Column": 0
-                            }
-                          ]
-                        ]
-                      }
-                    }
-                  ],
-                  "equivalences": [
-                    [
-                      {
-                        "Column": 0
-                      },
-                      {
-                        "Column": 2
-                      }
-                    ]
-                  ],
-                  "implementation": {
-                    "Differential": [
-                      [
-                        1,
-                        [
+                        "group_key": [
                           {
                             "Column": 0
                           }
                         ],
-                        {
-                          "unique_key": true,
-                          "key_length": 1,
-                          "arranged": true,
-                          "cardinality": null,
-                          "filters": {
-                            "literal_equality": false,
-                            "like": false,
-                            "is_null": false,
-                            "literal_inequality": 0,
-                            "any_filter": false
-                          },
-                          "input": 1
-                        }
-                      ],
+                        "aggregates": [],
+                        "monotonic": false,
+                        "expected_group_size": null
+                      }
+                    },
+                    "keys": [
                       [
-                        [
-                          0,
-                          [
-                            {
-                              "Column": 0
-                            }
-                          ],
-                          {
-                            "unique_key": false,
-                            "key_length": 1,
-                            "arranged": true,
-                            "cardinality": null,
-                            "filters": {
-                              "literal_equality": false,
-                              "like": false,
-                              "is_null": false,
-                              "literal_inequality": 0,
-                              "any_filter": false
-                            },
-                            "input": 0
-                          }
-                        ]
+                        {
+                          "Column": 0
+                        }
                       ]
                     ]
                   }
-                }
-              },
-              "outputs": [
-                0,
-                1
-              ]
-            }
-          },
-          "body": {
-            "Project": {
-              "input": {
-                "Join": {
-                  "inputs": [
-                    {
-                      "ArrangeBy": {
+                },
+                {
+                  "ArrangeBy": {
+                    "input": {
+                      "Reduce": {
                         "input": {
-                          "Get": {
-                            "id": {
-                              "Local": 0
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": false
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": []
-                            },
-                            "access_strategy": "UnknownOrLocal"
-                          }
-                        },
-                        "keys": [
-                          [
-                            {
-                              "Column": 1
-                            }
-                          ]
-                        ]
-                      }
-                    },
-                    {
-                      "ArrangeBy": {
-                        "input": {
-                          "Reduce": {
+                          "Project": {
                             "input": {
-                              "Project": {
+                              "Filter": {
                                 "input": {
-                                  "Filter": {
-                                    "input": {
-                                      "Join": {
-                                        "inputs": [
-                                          {
-                                            "ArrangeBy": {
-                                              "input": {
-                                                "Reduce": {
-                                                  "input": {
-                                                    "Project": {
-                                                      "input": {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Local": 0
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": false
-                                                              },
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              }
-                                                            ],
-                                                            "keys": []
-                                                          },
-                                                          "access_strategy": "UnknownOrLocal"
-                                                        }
-                                                      },
-                                                      "outputs": [
-                                                        1
-                                                      ]
-                                                    }
-                                                  },
-                                                  "group_key": [
-                                                    {
-                                                      "Column": 0
-                                                    }
-                                                  ],
-                                                  "aggregates": [],
-                                                  "monotonic": false,
-                                                  "expected_group_size": null
-                                                }
-                                              },
-                                              "keys": [
-                                                []
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "ArrangeBy": {
+                                  "Join": {
+                                    "inputs": [
+                                      {
+                                        "ArrangeBy": {
+                                          "input": {
+                                            "Reduce": {
                                               "input": {
                                                 "Project": {
                                                   "input": {
                                                     "Get": {
                                                       "id": {
                                                         "Global": {
-                                                          "User": 8
+                                                          "User": 1
                                                         }
                                                       },
                                                       "typ": {
                                                         "column_types": [
                                                           {
                                                             "scalar_type": "Int32",
-                                                            "nullable": false
+                                                            "nullable": true
                                                           },
                                                           {
                                                             "scalar_type": "Int32",
@@ -1737,7 +1596,16 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                         ],
                                                         "keys": []
                                                       },
-                                                      "access_strategy": "Persist"
+                                                      "access_strategy": {
+                                                        "Index": [
+                                                          [
+                                                            {
+                                                              "User": 4
+                                                            },
+                                                            "FullScan"
+                                                          ]
+                                                        ]
+                                                      }
                                                     }
                                                   },
                                                   "outputs": [
@@ -1745,165 +1613,310 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                   ]
                                                 }
                                               },
-                                              "keys": [
-                                                []
+                                              "group_key": [
+                                                {
+                                                  "Column": 0
+                                                }
+                                              ],
+                                              "aggregates": [],
+                                              "monotonic": false,
+                                              "expected_group_size": null
+                                            }
+                                          },
+                                          "keys": [
+                                            []
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "ArrangeBy": {
+                                          "input": {
+                                            "Project": {
+                                              "input": {
+                                                "Get": {
+                                                  "id": {
+                                                    "Global": {
+                                                      "User": 8
+                                                    }
+                                                  },
+                                                  "typ": {
+                                                    "column_types": [
+                                                      {
+                                                        "scalar_type": "Int32",
+                                                        "nullable": false
+                                                      },
+                                                      {
+                                                        "scalar_type": "Int32",
+                                                        "nullable": true
+                                                      }
+                                                    ],
+                                                    "keys": []
+                                                  },
+                                                  "access_strategy": "Persist"
+                                                }
+                                              },
+                                              "outputs": [
+                                                1
                                               ]
                                             }
-                                          }
-                                        ],
-                                        "equivalences": [],
-                                        "implementation": {
-                                          "Differential": [
-                                            [
-                                              0,
-                                              [],
-                                              {
-                                                "unique_key": false,
-                                                "key_length": 0,
-                                                "arranged": false,
-                                                "cardinality": null,
-                                                "filters": {
-                                                  "literal_equality": false,
-                                                  "like": false,
-                                                  "is_null": false,
-                                                  "literal_inequality": 0,
-                                                  "any_filter": false
-                                                },
-                                                "input": 0
-                                              }
-                                            ],
-                                            [
-                                              [
-                                                1,
-                                                [],
-                                                {
-                                                  "unique_key": false,
-                                                  "key_length": 0,
-                                                  "arranged": false,
-                                                  "cardinality": null,
-                                                  "filters": {
-                                                    "literal_equality": false,
-                                                    "like": false,
-                                                    "is_null": false,
-                                                    "literal_inequality": 0,
-                                                    "any_filter": false
-                                                  },
-                                                  "input": 1
-                                                }
-                                              ]
-                                            ]
+                                          },
+                                          "keys": [
+                                            []
                                           ]
                                         }
                                       }
-                                    },
-                                    "predicates": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "Gt",
-                                          "expr1": {
-                                            "Column": 0
-                                          },
-                                          "expr2": {
-                                            "Column": 1
+                                    ],
+                                    "equivalences": [],
+                                    "implementation": {
+                                      "Differential": [
+                                        [
+                                          0,
+                                          [],
+                                          {
+                                            "unique_key": false,
+                                            "key_length": 0,
+                                            "arranged": false,
+                                            "cardinality": null,
+                                            "filters": {
+                                              "literal_equality": false,
+                                              "like": false,
+                                              "is_null": false,
+                                              "literal_inequality": 0,
+                                              "any_filter": false
+                                            },
+                                            "input": 0
                                           }
-                                        }
-                                      }
-                                    ]
+                                        ],
+                                        [
+                                          [
+                                            1,
+                                            [],
+                                            {
+                                              "unique_key": false,
+                                              "key_length": 0,
+                                              "arranged": false,
+                                              "cardinality": null,
+                                              "filters": {
+                                                "literal_equality": false,
+                                                "like": false,
+                                                "is_null": false,
+                                                "literal_inequality": 0,
+                                                "any_filter": false
+                                              },
+                                              "input": 1
+                                            }
+                                          ]
+                                        ]
+                                      ]
+                                    }
                                   }
                                 },
-                                "outputs": [
-                                  0
+                                "predicates": [
+                                  {
+                                    "CallBinary": {
+                                      "func": "Gt",
+                                      "expr1": {
+                                        "Column": 0
+                                      },
+                                      "expr2": {
+                                        "Column": 1
+                                      }
+                                    }
+                                  }
                                 ]
                               }
                             },
-                            "group_key": [
-                              {
-                                "Column": 0
-                              }
-                            ],
-                            "aggregates": [],
-                            "monotonic": false,
-                            "expected_group_size": null
+                            "outputs": [
+                              0
+                            ]
                           }
                         },
-                        "keys": [
-                          [
-                            {
-                              "Column": 0
-                            }
-                          ]
-                        ]
-                      }
-                    }
-                  ],
-                  "equivalences": [
-                    [
-                      {
-                        "Column": 1
-                      },
-                      {
-                        "Column": 2
-                      }
-                    ]
-                  ],
-                  "implementation": {
-                    "Differential": [
-                      [
-                        1,
-                        [
+                        "group_key": [
                           {
                             "Column": 0
                           }
                         ],
-                        {
-                          "unique_key": true,
-                          "key_length": 1,
-                          "arranged": true,
-                          "cardinality": null,
-                          "filters": {
-                            "literal_equality": false,
-                            "like": false,
-                            "is_null": false,
-                            "literal_inequality": 0,
-                            "any_filter": false
-                          },
-                          "input": 1
-                        }
-                      ],
+                        "aggregates": [],
+                        "monotonic": false,
+                        "expected_group_size": null
+                      }
+                    },
+                    "keys": [
                       [
-                        [
-                          0,
-                          [
-                            {
-                              "Column": 1
-                            }
-                          ],
-                          {
-                            "unique_key": false,
-                            "key_length": 1,
-                            "arranged": false,
-                            "cardinality": null,
-                            "filters": {
-                              "literal_equality": false,
-                              "like": false,
-                              "is_null": false,
-                              "literal_inequality": 0,
-                              "any_filter": false
-                            },
-                            "input": 0
-                          }
-                        ]
+                        {
+                          "Column": 0
+                        }
                       ]
                     ]
                   }
                 }
-              },
-              "outputs": [
-                0,
-                1
-              ]
+              ],
+              "equivalences": [
+                [
+                  {
+                    "Column": 0
+                  },
+                  {
+                    "Column": 2
+                  }
+                ],
+                [
+                  {
+                    "Column": 1
+                  },
+                  {
+                    "Column": 3
+                  }
+                ]
+              ],
+              "implementation": {
+                "DeltaQuery": [
+                  [
+                    [
+                      1,
+                      [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      {
+                        "unique_key": true,
+                        "key_length": 1,
+                        "arranged": true,
+                        "cardinality": null,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
+                        },
+                        "input": 1
+                      }
+                    ],
+                    [
+                      2,
+                      [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      {
+                        "unique_key": true,
+                        "key_length": 1,
+                        "arranged": true,
+                        "cardinality": null,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
+                        },
+                        "input": 2
+                      }
+                    ]
+                  ],
+                  [
+                    [
+                      0,
+                      [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      {
+                        "unique_key": false,
+                        "key_length": 1,
+                        "arranged": true,
+                        "cardinality": null,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
+                        },
+                        "input": 0
+                      }
+                    ],
+                    [
+                      2,
+                      [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      {
+                        "unique_key": true,
+                        "key_length": 1,
+                        "arranged": true,
+                        "cardinality": null,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
+                        },
+                        "input": 2
+                      }
+                    ]
+                  ],
+                  [
+                    [
+                      0,
+                      [
+                        {
+                          "Column": 1
+                        }
+                      ],
+                      {
+                        "unique_key": false,
+                        "key_length": 1,
+                        "arranged": false,
+                        "cardinality": null,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
+                        },
+                        "input": 0
+                      }
+                    ],
+                    [
+                      1,
+                      [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      {
+                        "unique_key": true,
+                        "key_length": 1,
+                        "arranged": true,
+                        "cardinality": null,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
+                        },
+                        "input": 1
+                      }
+                    ]
+                  ]
+                ]
+              }
             }
-          }
+          },
+          "outputs": [
+            0,
+            1
+          ]
         }
       }
     }

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -257,44 +257,37 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
 Explained Query:
-  Return
-    Project (#0, #1)
-      Join on=(#1 = #2) type=differential
-        ArrangeBy keys=[[#1]]
-          Get l0
-        ArrangeBy keys=[[#0]]
-          Distinct project=[#0]
-            Project (#0)
-              Filter (#0 > #1)
-                CrossJoin type=differential
-                  ArrangeBy keys=[[]]
-                    Distinct project=[#0]
-                      Project (#1)
-                        Get l0
-                  ArrangeBy keys=[[]]
+  Project (#0, #1)
+    Join on=(#0 = #2 AND #1 = #3) type=delta
+      ArrangeBy keys=[[#0], [#1]]
+        ReadIndex on=t t_a_idx=[*** full scan ***, delta join 1st input (full scan)]
+      ArrangeBy keys=[[#0]]
+        Distinct project=[#0]
+          Project (#0)
+            Filter (#0 < #1)
+              CrossJoin type=differential
+                ArrangeBy keys=[[]]
+                  Distinct project=[#0]
+                    Project (#0)
+                      ReadIndex on=t t_a_idx=[*** full scan ***]
+                ArrangeBy keys=[[]]
+                  Project (#0)
+                    ReadStorage materialize.public.mv
+      ArrangeBy keys=[[#0]]
+        Distinct project=[#0]
+          Project (#0)
+            Filter (#0 > #1)
+              CrossJoin type=differential
+                ArrangeBy keys=[[]]
+                  Distinct project=[#0]
                     Project (#1)
-                      ReadStorage materialize.public.mv
-  With
-    cte l0 =
-      Project (#0, #1)
-        Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            ReadIndex on=t t_a_idx=[differential join]
-          ArrangeBy keys=[[#0]]
-            Distinct project=[#0]
-              Project (#0)
-                Filter (#0 < #1)
-                  CrossJoin type=differential
-                    ArrangeBy keys=[[]]
-                      Distinct project=[#0]
-                        Project (#0)
-                          ReadIndex on=t t_a_idx=[*** full scan ***]
-                    ArrangeBy keys=[[]]
-                      Project (#0)
-                        ReadStorage materialize.public.mv
+                      ReadIndex on=t t_a_idx=[*** full scan ***]
+                ArrangeBy keys=[[]]
+                  Project (#1)
+                    ReadStorage materialize.public.mv
 
 Used Indexes:
-  - materialize.public.t_a_idx (*** full scan ***, differential join)
+  - materialize.public.t_a_idx (*** full scan ***, delta join 1st input (full scan))
 
 EOF
 

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -217,44 +217,37 @@ EXPLAIN OPTIMIZED PLAN WITH(humanized expressions, redacted) AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
 Explained Query:
-  Return
-    Project (#0, #1)
-      Join on=(#1{b} = #2{b}) type=differential
-        ArrangeBy keys=[[#1{b}]]
-          Get l0
-        ArrangeBy keys=[[#0{b}]]
-          Distinct project=[#0{b}]
-            Project (#0)
-              Filter (#0{b} > #1{b})
-                CrossJoin type=differential
-                  ArrangeBy keys=[[]]
-                    Distinct project=[#0{b}]
-                      Project (#1)
-                        Get l0
-                  ArrangeBy keys=[[]]
+  Project (#0, #1)
+    Join on=(#0{a} = #2{a} AND #1{b} = #3{b}) type=delta
+      ArrangeBy keys=[[#0{a}], [#1{b}]]
+        ReadIndex on=t t_a_idx=[*** full scan ***, delta join 1st input (full scan)]
+      ArrangeBy keys=[[#0{a}]]
+        Distinct project=[#0{a}]
+          Project (#0)
+            Filter (#0{a} < #1{a})
+              CrossJoin type=differential
+                ArrangeBy keys=[[]]
+                  Distinct project=[#0{a}]
+                    Project (#0)
+                      ReadIndex on=t t_a_idx=[*** full scan ***]
+                ArrangeBy keys=[[]]
+                  Project (#0)
+                    ReadStorage materialize.public.mv
+      ArrangeBy keys=[[#0{b}]]
+        Distinct project=[#0{b}]
+          Project (#0)
+            Filter (#0{b} > #1{b})
+              CrossJoin type=differential
+                ArrangeBy keys=[[]]
+                  Distinct project=[#0{b}]
                     Project (#1)
-                      ReadStorage materialize.public.mv
-  With
-    cte l0 =
-      Project (#0, #1)
-        Join on=(#0{a} = #2{a}) type=differential
-          ArrangeBy keys=[[#0{a}]]
-            ReadIndex on=t t_a_idx=[differential join]
-          ArrangeBy keys=[[#0{a}]]
-            Distinct project=[#0{a}]
-              Project (#0)
-                Filter (#0{a} < #1{a})
-                  CrossJoin type=differential
-                    ArrangeBy keys=[[]]
-                      Distinct project=[#0{a}]
-                        Project (#0)
-                          ReadIndex on=t t_a_idx=[*** full scan ***]
-                    ArrangeBy keys=[[]]
-                      Project (#0)
-                        ReadStorage materialize.public.mv
+                      ReadIndex on=t t_a_idx=[*** full scan ***]
+                ArrangeBy keys=[[]]
+                  Project (#1)
+                    ReadStorage materialize.public.mv
 
 Used Indexes:
-  - materialize.public.t_a_idx (*** full scan ***, differential join)
+  - materialize.public.t_a_idx (*** full scan ***, delta join 1st input (full scan))
 
 EOF
 

--- a/test/sqllogictest/github-9147.slt
+++ b/test/sqllogictest/github-9147.slt
@@ -18,16 +18,15 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE 1 in (SELECT 1 
 ----
 Explained Query:
   Project (#0, #1) // { arity: 2 }
-    Join on=(#0 = #2) type=differential // { arity: 3 }
+    Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
       implementation
-        %1[#0]UKA » %0:t1[#0]K
-      ArrangeBy keys=[[#0]] // { arity: 2 }
+        %1[#0, #1]UKKA » %0:t1[#0, #1]KK
+      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
         ReadStorage materialize.public.t1 // { arity: 2 }
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Distinct project=[#0] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Filter (#0 > 1) // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
+      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+        Distinct project=[#0, #1] // { arity: 2 }
+          Filter (#0 > 1) // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
 
 EOF
 

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -269,66 +269,67 @@ materialize.public.q02:
     Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
       Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10) type=differential // { arity: 11 }
         implementation
-          %1[#0, #1]UKK » %0:l4[#0, #7]KK
+          %1[#0, #1]UKK » %0:l0[#0, #7]KKelf
         ArrangeBy keys=[[#0{p_partkey}, #7{ps_supplycost}]] // { arity: 9 }
-          Get l4 // { arity: 9 }
+          Project (#0, #1, #5, #6, #8..=#10, #13, #15) // { arity: 9 }
+            Filter (#3{p_size} = 15) AND (#18{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#2{p_type})) AND (#0{p_partkey} = #11{ps_partkey}) AND (#4{s_suppkey} = #12{ps_suppkey}) AND (#7{s_nationkey} = #14{n_nationkey}) AND (#16{n_regionkey} = #17{r_regionkey}) // { arity: 19 }
+              Get l0 // { arity: 19 }
         ArrangeBy keys=[[#0{p_partkey}, #1]] // { arity: 2 }
           Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
             Project (#0, #4) // { arity: 2 }
               Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
                 Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                   implementation
-                    %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                    %1:l1 » %0[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                    %2:l0 » %1:l1[#1]KA » %0[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
-                    %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
-                    %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
+                    %0 » %1:partsupp[#0]KA » %2:supplier[#0]KA » %3:nation[#0]KA » %4:region[#0]KAef
+                    %1:partsupp » %0[#0]UKA » %2:supplier[#0]KA » %3:nation[#0]KA » %4:region[#0]KAef
+                    %2:supplier » %1:partsupp[#1]KA » %0[#0]UKA » %3:nation[#0]KA » %4:region[#0]KAef
+                    %3:nation » %4:region[#0]KAef » %2:supplier[#3]KA » %1:partsupp[#1]KA » %0[#0]UKA
+                    %4:region » %3:nation[#2]KA » %2:supplier[#3]KA » %1:partsupp[#1]KA » %0[#0]UKA
                   ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
                     Distinct project=[#0{p_partkey}] // { arity: 1 }
                       Project (#0) // { arity: 1 }
-                        Get l4 // { arity: 9 }
-                  Get l1 // { arity: 5 }
-                  Get l0 // { arity: 7 }
-                  Get l2 // { arity: 4 }
-                  Get l3 // { arity: 3 }
+                        Get l0 // { arity: 19 }
+                  ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
+                    ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
+                  ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
+                    ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+                  ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
+                    ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
+                  ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
+                    ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
   With
-    cte l4 =
-      Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-        Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#23{n_regionkey}) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
-          Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
-            implementation
-              %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-              %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
-              %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-              %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-              %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-            Get l0 // { arity: 7 }
-            Get l1 // { arity: 5 }
-            Get l2 // { arity: 4 }
-            Get l3 // { arity: 3 }
-    cte l3 =
-      ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
-        ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
-    cte l2 =
-      ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
-        ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
-    cte l1 =
-      ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
-        ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
     cte l0 =
-      ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-        ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+      CrossJoin type=delta // { arity: 19 }
+        implementation
+          %0:part » %1:supplier[×] » %2:partsupp[×] » %3:nation[×] » %4:region[×]
+          %1:supplier » %0:part[×] » %2:partsupp[×] » %3:nation[×] » %4:region[×]
+          %2:partsupp » %0:part[×] » %1:supplier[×] » %3:nation[×] » %4:region[×]
+          %3:nation » %0:part[×] » %1:supplier[×] » %2:partsupp[×] » %4:region[×]
+          %4:region » %0:part[×] » %1:supplier[×] » %2:partsupp[×] » %3:nation[×]
+        ArrangeBy keys=[[]] // { arity: 4 }
+          Project (#0, #2, #4, #5) // { arity: 4 }
+            Filter (#0{p_partkey}) IS NOT NULL // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
+        ArrangeBy keys=[[]] // { arity: 7 }
+          ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#0, #1, #3) // { arity: 3 }
+            ReadIndex on=partsupp fk_partsupp_partkey=[*** full scan ***] // { arity: 5 }
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            ReadIndex on=nation pk_nation_nationkey=[*** full scan ***] // { arity: 4 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            ReadIndex on=region pk_region_regionkey=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_nation_nationkey (*** full scan ***, delta join lookup)
   - materialize.public.fk_nation_regionkey (delta join lookup)
-  - materialize.public.pk_region_regionkey (delta join lookup)
-  - materialize.public.pk_part_partkey (delta join 1st input (full scan))
-  - materialize.public.pk_supplier_suppkey (delta join lookup)
+  - materialize.public.pk_region_regionkey (*** full scan ***, delta join lookup)
+  - materialize.public.pk_part_partkey (*** full scan ***)
+  - materialize.public.pk_supplier_suppkey (*** full scan ***, delta join lookup)
   - materialize.public.fk_supplier_nationkey (delta join lookup)
-  - materialize.public.fk_partsupp_partkey (delta join lookup)
+  - materialize.public.fk_partsupp_partkey (*** full scan ***, delta join lookup)
   - materialize.public.fk_partsupp_suppkey (delta join lookup)
 
 EOF
@@ -445,7 +446,7 @@ materialize.public.q04:
           ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
             Distinct project=[#0{o_orderkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
+                Filter (#0{o_orderkey}) IS NOT NULL // { arity: 9 }
                   ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
             Distinct project=[#0{l_orderkey}] // { arity: 1 }
@@ -1352,9 +1353,11 @@ materialize.public.q16:
       Project (#0..=#3) // { arity: 4 }
         Join on=(#0{ps_suppkey} = #4{ps_suppkey}) type=differential // { arity: 5 }
           implementation
-            %0:l0[#0]K » %1[#0]K
+            %0:l0[#0]Kef » %1[#0]Kef
           ArrangeBy keys=[[#0{ps_suppkey}]] // { arity: 4 }
-            Get l0 // { arity: 4 }
+            Project (#1, #3..=#5) // { arity: 4 }
+              Filter (#3{p_brand} != "Brand#45") AND (#0{ps_partkey} = #2{p_partkey}) AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#4{p_type}))) AND ((#5{p_size} = 3) OR (#5{p_size} = 9) OR (#5{p_size} = 14) OR (#5{p_size} = 19) OR (#5{p_size} = 23) OR (#5{p_size} = 36) OR (#5{p_size} = 45) OR (#5{p_size} = 49)) // { arity: 6 }
+                Get l0 // { arity: 6 }
           ArrangeBy keys=[[#0{ps_suppkey}]] // { arity: 1 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
@@ -1374,23 +1377,23 @@ materialize.public.q16:
   With
     cte l1 =
       Distinct project=[#0{ps_suppkey}] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l0 // { arity: 4 }
+        Project (#1) // { arity: 1 }
+          Get l0 // { arity: 6 }
     cte l0 =
-      Project (#1, #8..=#10) // { arity: 4 }
-        Filter (#8{p_brand} != "Brand#45") AND (#0{ps_partkey}) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
-          Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
-            implementation
-              %1:part[#0]KAef » %0:partsupp[#0]KAef
-            ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
-              ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+      CrossJoin type=differential // { arity: 6 }
+        implementation
+          %0:partsupp[×] » %1:part[×]
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
+        ArrangeBy keys=[[]] // { arity: 4 }
+          Project (#0, #3..=#5) // { arity: 4 }
+            ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
 
 Used Indexes:
-  - materialize.public.pk_part_partkey (differential join)
+  - materialize.public.pk_part_partkey (*** full scan ***)
   - materialize.public.pk_supplier_suppkey (*** full scan ***)
-  - materialize.public.fk_partsupp_partkey (differential join)
+  - materialize.public.pk_partsupp_partkey_suppkey (*** full scan ***)
 
 EOF
 
@@ -1431,51 +1434,53 @@ materialize.public.q17:
     Project (#1) // { arity: 1 }
       Map ((#0 / 7)) // { arity: 2 }
         Union // { arity: 1 }
-          Get l2 // { arity: 1 }
+          Get l1 // { arity: 1 }
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
               Negate // { arity: 0 }
                 Project () // { arity: 0 }
-                  Get l2 // { arity: 1 }
+                  Get l1 // { arity: 1 }
               Constant // { arity: 0 }
                 - ()
   With
-    cte l2 =
+    cte l1 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
           Filter (#1{l_quantity} < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
-            Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
+            Join on=(#0{l_partkey} = #3{p_partkey}) type=differential // { arity: 6 }
               implementation
-                %1[#0]UKA » %0:l1[#0]K
+                %1[#0]UKA » %0:l0[#0]Kef
               ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
-                Get l1 // { arity: 3 }
-              ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
-                Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
+                Project (#0..=#2) // { arity: 3 }
+                  Filter (#4{p_brand} = "Brand#23") AND (#5{p_container} = "MED BOX") AND (#0{l_partkey} = #3{p_partkey}) // { arity: 6 }
+                    Get l0 // { arity: 6 }
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 3 }
+                Reduce group_by=[#0{p_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
                   Project (#0, #5) // { arity: 2 }
-                    Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
+                    Join on=(#0{p_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
                       implementation
-                        %0[#0]UKA » %1:l0[#1]KA
-                      ArrangeBy keys=[[#0{l_partkey}]] // { arity: 1 }
-                        Distinct project=[#0{l_partkey}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
-                            Get l1 // { arity: 3 }
-                      Get l0 // { arity: 16 }
-    cte l1 =
-      Project (#1, #4, #5) // { arity: 3 }
-        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") AND (#1{l_partkey}) IS NOT NULL // { arity: 25 }
-          Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
-            implementation
-              %1:part[#0]KAef » %0:l0[#1]KAef
-            Get l0 // { arity: 16 }
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+                        %0[#0]UKA » %1:lineitem[#1]KA
+                      ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+                        Distinct project=[#0{p_partkey}] // { arity: 1 }
+                          Project (#3) // { arity: 1 }
+                            Get l0 // { arity: 6 }
+                      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
+                        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
     cte l0 =
-      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
-        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
+      CrossJoin type=differential // { arity: 6 }
+        implementation
+          %0:lineitem[×] » %1:part[×]
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#1, #4, #5) // { arity: 3 }
+            ReadIndex on=lineitem fk_lineitem_partkey=[*** full scan ***] // { arity: 16 }
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#0, #3, #6) // { arity: 3 }
+            Filter (#0{p_partkey}) IS NOT NULL // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
 
 Used Indexes:
-  - materialize.public.pk_part_partkey (differential join)
-  - materialize.public.fk_lineitem_partkey (differential join)
+  - materialize.public.pk_part_partkey (*** full scan ***)
+  - materialize.public.fk_lineitem_partkey (*** full scan ***, differential join)
 
 EOF
 
@@ -1533,43 +1538,45 @@ materialize.public.q18:
         Filter (#7 > 300) // { arity: 8 }
           Join on=(#2{o_orderkey} = #6{o_orderkey}) type=differential // { arity: 8 }
             implementation
-              %1[#0]UKAif » %0:l1[#2]Kif
+              %1[#0]UKAif » %0:l0[#2]Kif
             ArrangeBy keys=[[#2{o_orderkey}]] // { arity: 6 }
-              Get l1 // { arity: 6 }
+              Project (#0..=#2, #4, #5, #7) // { arity: 6 }
+                Filter (#0{c_custkey} = #3{o_custkey}) AND (#2{o_orderkey} = #6{l_orderkey}) // { arity: 8 }
+                  Get l0 // { arity: 8 }
             ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 2 }
               Reduce group_by=[#0{o_orderkey}] aggregates=[sum(#1{l_quantity})] // { arity: 2 }
                 Project (#0, #5) // { arity: 2 }
                   Join on=(#0{o_orderkey} = #1{l_orderkey}) type=differential // { arity: 17 }
                     implementation
-                      %0[#0]UKA » %1:l0[#0]KA
+                      %0[#0]UKA » %1:lineitem[#0]KA
                     ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
                       Distinct project=[#0{o_orderkey}] // { arity: 1 }
                         Project (#2) // { arity: 1 }
-                          Get l1 // { arity: 6 }
-                    Get l0 // { arity: 16 }
+                          Get l0 // { arity: 8 }
+                    ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
+                      ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
   With
-    cte l1 =
-      Project (#0, #1, #8, #11, #12, #21) // { arity: 6 }
-        Filter (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
-          Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
-            implementation
-              %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
-              %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
-              %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
-              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
-              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-            Get l0 // { arity: 16 }
     cte l0 =
-      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
-        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
+      CrossJoin type=delta // { arity: 8 }
+        implementation
+          %0:customer » %1:orders[×] » %2:lineitem[×]
+          %1:orders » %0:customer[×] » %2:lineitem[×]
+          %2:lineitem » %0:customer[×] » %1:orders[×]
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+        ArrangeBy keys=[[]] // { arity: 4 }
+          Project (#0, #1, #3, #4) // { arity: 4 }
+            Filter (#0{o_orderkey}) IS NOT NULL // { arity: 9 }
+              ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #4) // { arity: 2 }
+            ReadIndex on=lineitem fk_lineitem_orderkey=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
-  - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
-  - materialize.public.pk_orders_orderkey (delta join lookup)
-  - materialize.public.fk_orders_custkey (delta join lookup)
-  - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
+  - materialize.public.pk_customer_custkey (*** full scan ***)
+  - materialize.public.pk_orders_orderkey (*** full scan ***)
+  - materialize.public.fk_lineitem_orderkey (*** full scan ***, differential join)
 
 EOF
 
@@ -1711,70 +1718,69 @@ materialize.public.q20:
     Project (#1, #2) // { arity: 2 }
       Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
         implementation
-          %1[#0]UKA » %0:l0[#0]K
+          %1[#0]UKA » %0:l0[#0]Kef
         ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 3 }
-          Get l0 // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Filter (#5{n_name} = "CANADA") AND (#3{s_nationkey} = #4{n_nationkey}) // { arity: 6 }
+              Get l0 // { arity: 6 }
         ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 1 }
           Distinct project=[#0{s_suppkey}] // { arity: 1 }
             Project (#0) // { arity: 1 }
-              Filter (integer_to_numeric(#2{ps_availqty}) > #5) // { arity: 6 }
-                Join on=(#0{s_suppkey} = #4{ps_suppkey} AND #1{ps_partkey} = #3{ps_partkey}) type=differential // { arity: 6 }
+              Filter (integer_to_numeric(#2{ps_availqty}) > (0.5 * #6)) // { arity: 7 }
+                Join on=(#0{s_suppkey} = #5{ps_suppkey} AND #1{ps_partkey} = #3{p_partkey} = #4{ps_partkey}) type=delta // { arity: 7 }
                   implementation
-                    %1[#1, #0]UKK » %0:l1[#0, #1]KKf
-                  ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
+                    %0:l1 » %2[#0, #1]UKKA » %1[#0]UKA
+                    %1 » %0:l1[#1]Kf » %2[#0, #1]UKKA
+                    %2 » %1[#0]UKA » %0:l1[#0, #1]KKf
+                  ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}], [#1{ps_partkey}]] // { arity: 3 }
                     Project (#0, #1, #3) // { arity: 3 }
                       Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                         Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
-                    Project (#0, #1, #3) // { arity: 3 }
-                      Map ((0.5 * #2)) // { arity: 4 }
-                        Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
-                          Project (#0, #1, #6) // { arity: 3 }
-                            Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
-                              Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
-                                implementation
-                                  %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
-                                ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
-                                  Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
-                                    Project (#1, #2) // { arity: 2 }
-                                      Get l1 // { arity: 4 }
-                                ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
-                                  ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
+                  ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+                    Distinct project=[#0{p_partkey}] // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
+                          ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
+                  ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 3 }
+                    Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
+                      Project (#0, #1, #6) // { arity: 3 }
+                        Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
+                          Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
+                            implementation
+                              %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
+                            ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
+                              Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
+                                Project (#1, #2) // { arity: 2 }
+                                  Get l1 // { arity: 4 }
+                            ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
+                              ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
   With
     cte l1 =
-      Project (#0..=#3) // { arity: 4 }
-        Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
-          implementation
-            %0 » %1:partsupp[×] » %2[#0]UKA
-            %1:partsupp » %2[#0]UKA » %0[×]
-            %2 » %1:partsupp[#0]KA » %0[×]
-          ArrangeBy keys=[[]] // { arity: 1 }
-            Distinct project=[#0{s_suppkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Get l0 // { arity: 3 }
-          ArrangeBy keys=[[], [#0{ps_partkey}]] // { arity: 3 }
-            Project (#0..=#2) // { arity: 3 }
-              ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
-          ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
-            Distinct project=[#0{p_partkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
-                  ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
+      CrossJoin type=differential // { arity: 4 }
+        implementation
+          %0[×] » %1:partsupp[×]
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Distinct project=[#0{s_suppkey}] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Get l0 // { arity: 6 }
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
     cte l0 =
-      Project (#0..=#2) // { arity: 3 }
-        Filter (#8{n_name} = "CANADA") AND (#3{s_nationkey}) IS NOT NULL // { arity: 11 }
-          Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
-            implementation
-              %1:nation[#0]KAef » %0:supplier[#3]KAef
-            ArrangeBy keys=[[#3{s_nationkey}]] // { arity: 7 }
-              ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
-            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-              ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
+      CrossJoin type=differential // { arity: 6 }
+        implementation
+          %0:supplier[×] » %1:nation[×]
+        ArrangeBy keys=[[]] // { arity: 4 }
+          Project (#0..=#3) // { arity: 4 }
+            ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            ReadIndex on=nation pk_nation_nationkey=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (differential join)
+  - materialize.public.pk_nation_nationkey (*** full scan ***)
   - materialize.public.pk_part_partkey (*** full scan ***)
-  - materialize.public.fk_supplier_nationkey (differential join)
+  - materialize.public.pk_supplier_suppkey (*** full scan ***)
   - materialize.public.pk_partsupp_partkey_suppkey (*** full scan ***)
   - materialize.public.fk_lineitem_partsuppkey (differential join)
 
@@ -1838,76 +1844,72 @@ materialize.public.q21:
   Return // { arity: 2 }
     Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
       Project (#1) // { arity: 1 }
-        Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
+        Join on=(#0{s_suppkey} = #4{l_suppkey} = #6{l_suppkey} AND #2{l_orderkey} = #3{l_orderkey} = #5{l_orderkey}) type=delta // { arity: 7 }
           implementation
-            %0:l2[#2, #0]KK » %1[#0, #1]KK
-          ArrangeBy keys=[[#2{l_orderkey}, #0{s_suppkey}]] // { arity: 3 }
-            Get l2 // { arity: 3 }
-          ArrangeBy keys=[[#0{l_orderkey}, #1{s_suppkey}]] // { arity: 2 }
-            Union // { arity: 2 }
-              Negate // { arity: 2 }
-                Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
-                    Filter (#1{s_suppkey} != #4{l_suppkey}) AND (#14{l_receiptdate} > #13{l_commitdate}) // { arity: 18 }
-                      Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
-                        implementation
-                          %1:l1[#0]KAf » %0:l3[#0]Kf
-                        ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
-                          Get l3 // { arity: 2 }
-                        Get l1 // { arity: 16 }
-              Get l3 // { arity: 2 }
-  With
-    cte l3 =
-      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-        Project (#0, #2) // { arity: 2 }
-          Get l2 // { arity: 3 }
-    cte l2 =
-      Project (#0..=#2) // { arity: 3 }
-        Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
-          implementation
-            %1[#1, #0]UKK » %0:l0[#0, #2]KK
+            %0:l0 » %1[#0, #1]UKKA » %2[#0, #1]KK
+            %1 » %0:l0[#0, #2]KKef » %2[#0, #1]KK
+            %2 » %1[#0, #1]UKKA » %0:l0[#0, #2]KKef
           ArrangeBy keys=[[#0{s_suppkey}, #2{l_orderkey}]] // { arity: 3 }
-            Get l0 // { arity: 3 }
-          ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
-            Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
+            Project (#0, #1, #3) // { arity: 3 }
+              Filter (#8{o_orderstatus} = "F") AND (#10{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey} = #4{l_suppkey}) AND (#2{s_nationkey} = #9{n_nationkey}) AND (#3{l_orderkey} = #7{o_orderkey}) AND (#6{l_receiptdate} > #5{l_commitdate}) // { arity: 11 }
+                Get l0 // { arity: 11 }
+          ArrangeBy keys=[[#0{l_orderkey}, #1{l_suppkey}]] // { arity: 2 }
+            Distinct project=[#0{l_orderkey}, #1{l_suppkey}] // { arity: 2 }
               Project (#0, #1) // { arity: 2 }
-                Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
+                Filter (#1{l_suppkey} != #4{l_suppkey}) // { arity: 18 }
                   Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                     implementation
-                      %1:l1[#0]KA » %0[#0]K
-                    ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
-                      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-                        Project (#0, #2) // { arity: 2 }
-                          Get l0 // { arity: 3 }
-                    Get l1 // { arity: 16 }
-    cte l1 =
+                      %1:l3[#0]KA » %0:l2[#0]K
+                    Get l2 // { arity: 2 }
+                    Get l3 // { arity: 16 }
+          ArrangeBy keys=[[#0{l_orderkey}, #1{l_suppkey}]] // { arity: 2 }
+            Union // { arity: 2 }
+              Negate // { arity: 2 }
+                Distinct project=[#0{l_orderkey}, #1{l_suppkey}] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Filter (#1{l_suppkey} != #4{l_suppkey}) AND (#14{l_receiptdate} > #13{l_commitdate}) // { arity: 18 }
+                      Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
+                        implementation
+                          %1:l3[#0]KAf » %0:l2[#0]Kf
+                        Get l2 // { arity: 2 }
+                        Get l3 // { arity: 16 }
+              Get l1 // { arity: 2 }
+  With
+    cte l3 =
       ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
+    cte l2 =
+      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
+        Get l1 // { arity: 2 }
+    cte l1 =
+      Distinct project=[#0{l_orderkey}, #1{l_suppkey}] // { arity: 2 }
+        Project (#3, #4) // { arity: 2 }
+          Get l0 // { arity: 11 }
     cte l0 =
-      Project (#0, #1, #7) // { arity: 3 }
-        Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
-          Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
-            implementation
-              %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-              %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
-              %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
-              %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-            ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-              ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
-            ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
-              ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
-              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-              ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+      CrossJoin type=delta // { arity: 11 }
+        implementation
+          %0:supplier » %1:lineitem[×] » %2:orders[×] » %3:nation[×]
+          %1:lineitem » %0:supplier[×] » %2:orders[×] » %3:nation[×]
+          %2:orders » %0:supplier[×] » %1:lineitem[×] » %3:nation[×]
+          %3:nation » %0:supplier[×] » %1:lineitem[×] » %2:orders[×]
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#0, #1, #3) // { arity: 3 }
+            ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
+        ArrangeBy keys=[[]] // { arity: 4 }
+          Project (#0, #2, #11, #12) // { arity: 4 }
+            ReadIndex on=lineitem fk_lineitem_orderkey=[*** full scan ***] // { arity: 16 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #2) // { arity: 2 }
+            ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            ReadIndex on=nation pk_nation_nationkey=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join lookup)
-  - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
-  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
-  - materialize.public.pk_orders_orderkey (delta join lookup)
-  - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
-  - materialize.public.fk_lineitem_suppkey (delta join lookup)
+  - materialize.public.pk_nation_nationkey (*** full scan ***)
+  - materialize.public.pk_supplier_suppkey (*** full scan ***)
+  - materialize.public.pk_orders_orderkey (*** full scan ***)
+  - materialize.public.fk_lineitem_orderkey (*** full scan ***, differential join)
 
 EOF
 
@@ -1977,49 +1979,44 @@ materialize.public.q22:
   Return // { arity: 3 }
     Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
       Project (#1, #2) // { arity: 2 }
-        Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
-          implementation
-            %0:l1[#0]K » %1[#0]K
-          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 3 }
-            Get l1 // { arity: 3 }
-          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
-                    Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
-                      implementation
-                        %0:l2[#0]UKA » %1[#0]UKA
-                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                        Get l2 // { arity: 1 }
-                      ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
-                        Distinct project=[#0{o_custkey}] // { arity: 1 }
-                          Project (#1) // { arity: 1 }
-                            ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
-              Get l2 // { arity: 1 }
-  With
-    cte l2 =
-      Distinct project=[#0{c_custkey}] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l1 // { arity: 3 }
-    cte l1 =
-      Project (#0..=#2) // { arity: 3 }
-        Filter (#2{c_acctbal} > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
-          CrossJoin type=differential // { arity: 5 }
+        Filter (#2{c_acctbal} > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 6 }
+          Join on=(#0{c_custkey} = #5{c_custkey}) type=delta // { arity: 6 }
             implementation
-              %1[×]UA » %0:l0[×]ef
-            ArrangeBy keys=[[]] // { arity: 3 }
+              %0:l1 » %1[×]UA » %2[#0]K
+              %1 » %0:l1[×]ef » %2[#0]K
+              %2 » %1[×]UA » %0:l1[#0]KAef
+            ArrangeBy keys=[[], [#0{c_custkey}]] // { arity: 3 }
               Project (#0, #4, #5) // { arity: 3 }
                 Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                  Get l0 // { arity: 9 }
+                  Get l1 // { arity: 9 }
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
                 Project (#5) // { arity: 1 }
                   Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                    Get l0 // { arity: 9 }
-    cte l0 =
+                    Get l1 // { arity: 9 }
+            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+              Union // { arity: 1 }
+                Negate // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
+                      Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
+                        implementation
+                          %0:l0[#0]UKA » %1[#0]UKA
+                        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                          Get l0 // { arity: 1 }
+                        ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
+                          Distinct project=[#0{o_custkey}] // { arity: 1 }
+                            Project (#1) // { arity: 1 }
+                              ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+                Get l0 // { arity: 1 }
+  With
+    cte l1 =
       Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
         ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+    cte l0 =
+      Distinct project=[#0{c_custkey}] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (*** full scan ***)

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -248,66 +248,67 @@ materialize.public.q02:
     Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
       Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10) type=differential // { arity: 11 }
         implementation
-          %1[#0, #1]UKK » %0:l4[#0, #7]KK
+          %1[#0, #1]UKK » %0:l0[#0, #7]KKelf
         ArrangeBy keys=[[#0{p_partkey}, #7{ps_supplycost}]] // { arity: 9 }
-          Get l4 // { arity: 9 }
+          Project (#0, #1, #5, #6, #8..=#10, #13, #15) // { arity: 9 }
+            Filter (#3{p_size} = 15) AND (#18{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#2{p_type})) AND (#0{p_partkey} = #11{ps_partkey}) AND (#4{s_suppkey} = #12{ps_suppkey}) AND (#7{s_nationkey} = #14{n_nationkey}) AND (#16{n_regionkey} = #17{r_regionkey}) // { arity: 19 }
+              Get l0 // { arity: 19 }
         ArrangeBy keys=[[#0{p_partkey}, #1]] // { arity: 2 }
           Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
             Project (#0, #4) // { arity: 2 }
               Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
                 Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                   implementation
-                    %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                    %1:l1 » %0[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                    %2:l0 » %1:l1[#1]KA » %0[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
-                    %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
-                    %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
+                    %0 » %1:partsupp[#0]KA » %2:supplier[#0]KA » %3:nation[#0]KA » %4:region[#0]KAef
+                    %1:partsupp » %0[#0]UKA » %2:supplier[#0]KA » %3:nation[#0]KA » %4:region[#0]KAef
+                    %2:supplier » %1:partsupp[#1]KA » %0[#0]UKA » %3:nation[#0]KA » %4:region[#0]KAef
+                    %3:nation » %4:region[#0]KAef » %2:supplier[#3]KA » %1:partsupp[#1]KA » %0[#0]UKA
+                    %4:region » %3:nation[#2]KA » %2:supplier[#3]KA » %1:partsupp[#1]KA » %0[#0]UKA
                   ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
                     Distinct project=[#0{p_partkey}] // { arity: 1 }
                       Project (#0) // { arity: 1 }
-                        Get l4 // { arity: 9 }
-                  Get l1 // { arity: 5 }
-                  Get l0 // { arity: 7 }
-                  Get l2 // { arity: 4 }
-                  Get l3 // { arity: 3 }
+                        Get l0 // { arity: 19 }
+                  ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
+                    ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
+                  ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
+                    ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+                  ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
+                    ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
+                  ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
+                    ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
   With
-    cte l4 =
-      Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-        Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#23{n_regionkey}) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
-          Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
-            implementation
-              %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-              %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
-              %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-              %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-              %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-            Get l0 // { arity: 7 }
-            Get l1 // { arity: 5 }
-            Get l2 // { arity: 4 }
-            Get l3 // { arity: 3 }
-    cte l3 =
-      ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
-        ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
-    cte l2 =
-      ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
-        ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
-    cte l1 =
-      ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
-        ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
     cte l0 =
-      ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-        ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+      CrossJoin type=delta // { arity: 19 }
+        implementation
+          %0:part » %1:supplier[×] » %2:partsupp[×] » %3:nation[×] » %4:region[×]
+          %1:supplier » %0:part[×] » %2:partsupp[×] » %3:nation[×] » %4:region[×]
+          %2:partsupp » %0:part[×] » %1:supplier[×] » %3:nation[×] » %4:region[×]
+          %3:nation » %0:part[×] » %1:supplier[×] » %2:partsupp[×] » %4:region[×]
+          %4:region » %0:part[×] » %1:supplier[×] » %2:partsupp[×] » %3:nation[×]
+        ArrangeBy keys=[[]] // { arity: 4 }
+          Project (#0, #2, #4, #5) // { arity: 4 }
+            Filter (#0{p_partkey}) IS NOT NULL // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
+        ArrangeBy keys=[[]] // { arity: 7 }
+          ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#0, #1, #3) // { arity: 3 }
+            ReadIndex on=partsupp fk_partsupp_partkey=[*** full scan ***] // { arity: 5 }
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            ReadIndex on=nation pk_nation_nationkey=[*** full scan ***] // { arity: 4 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            ReadIndex on=region pk_region_regionkey=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_nation_nationkey (*** full scan ***, delta join lookup)
   - materialize.public.fk_nation_regionkey (delta join lookup)
-  - materialize.public.pk_region_regionkey (delta join lookup)
-  - materialize.public.pk_part_partkey (delta join 1st input (full scan))
-  - materialize.public.pk_supplier_suppkey (delta join lookup)
+  - materialize.public.pk_region_regionkey (*** full scan ***, delta join lookup)
+  - materialize.public.pk_part_partkey (*** full scan ***)
+  - materialize.public.pk_supplier_suppkey (*** full scan ***, delta join lookup)
   - materialize.public.fk_supplier_nationkey (delta join lookup)
-  - materialize.public.fk_partsupp_partkey (delta join lookup)
+  - materialize.public.fk_partsupp_partkey (*** full scan ***, delta join lookup)
   - materialize.public.fk_partsupp_suppkey (delta join lookup)
 
 EOF
@@ -406,7 +407,7 @@ materialize.public.q04:
           ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
             Distinct project=[#0{o_orderkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
+                Filter (#0{o_orderkey}) IS NOT NULL // { arity: 9 }
                   ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
             Distinct project=[#0{l_orderkey}] // { arity: 1 }
@@ -1208,9 +1209,11 @@ materialize.public.q16:
       Project (#0..=#3) // { arity: 4 }
         Join on=(#0{ps_suppkey} = #4{ps_suppkey}) type=differential // { arity: 5 }
           implementation
-            %0:l0[#0]K » %1[#0]K
+            %0:l0[#0]Kef » %1[#0]Kef
           ArrangeBy keys=[[#0{ps_suppkey}]] // { arity: 4 }
-            Get l0 // { arity: 4 }
+            Project (#1, #3..=#5) // { arity: 4 }
+              Filter (#3{p_brand} != "Brand#45") AND (#0{ps_partkey} = #2{p_partkey}) AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#4{p_type}))) AND ((#5{p_size} = 3) OR (#5{p_size} = 9) OR (#5{p_size} = 14) OR (#5{p_size} = 19) OR (#5{p_size} = 23) OR (#5{p_size} = 36) OR (#5{p_size} = 45) OR (#5{p_size} = 49)) // { arity: 6 }
+                Get l0 // { arity: 6 }
           ArrangeBy keys=[[#0{ps_suppkey}]] // { arity: 1 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
@@ -1230,23 +1233,23 @@ materialize.public.q16:
   With
     cte l1 =
       Distinct project=[#0{ps_suppkey}] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l0 // { arity: 4 }
+        Project (#1) // { arity: 1 }
+          Get l0 // { arity: 6 }
     cte l0 =
-      Project (#1, #8..=#10) // { arity: 4 }
-        Filter (#8{p_brand} != "Brand#45") AND (#0{ps_partkey}) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
-          Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
-            implementation
-              %1:part[#0]KAef » %0:partsupp[#0]KAef
-            ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
-              ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+      CrossJoin type=differential // { arity: 6 }
+        implementation
+          %0:partsupp[×] » %1:part[×]
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
+        ArrangeBy keys=[[]] // { arity: 4 }
+          Project (#0, #3..=#5) // { arity: 4 }
+            ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
 
 Used Indexes:
-  - materialize.public.pk_part_partkey (differential join)
+  - materialize.public.pk_part_partkey (*** full scan ***)
   - materialize.public.pk_supplier_suppkey (*** full scan ***)
-  - materialize.public.fk_partsupp_partkey (differential join)
+  - materialize.public.pk_partsupp_partkey_suppkey (*** full scan ***)
 
 EOF
 
@@ -1278,51 +1281,53 @@ materialize.public.q17:
     Project (#1) // { arity: 1 }
       Map ((#0 / 7)) // { arity: 2 }
         Union // { arity: 1 }
-          Get l2 // { arity: 1 }
+          Get l1 // { arity: 1 }
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
               Negate // { arity: 0 }
                 Project () // { arity: 0 }
-                  Get l2 // { arity: 1 }
+                  Get l1 // { arity: 1 }
               Constant // { arity: 0 }
                 - ()
   With
-    cte l2 =
+    cte l1 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
           Filter (#1{l_quantity} < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
-            Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
+            Join on=(#0{l_partkey} = #3{p_partkey}) type=differential // { arity: 6 }
               implementation
-                %1[#0]UKA » %0:l1[#0]K
+                %1[#0]UKA » %0:l0[#0]Kef
               ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
-                Get l1 // { arity: 3 }
-              ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
-                Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
+                Project (#0..=#2) // { arity: 3 }
+                  Filter (#4{p_brand} = "Brand#23") AND (#5{p_container} = "MED BOX") AND (#0{l_partkey} = #3{p_partkey}) // { arity: 6 }
+                    Get l0 // { arity: 6 }
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 3 }
+                Reduce group_by=[#0{p_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
                   Project (#0, #5) // { arity: 2 }
-                    Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
+                    Join on=(#0{p_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
                       implementation
-                        %0[#0]UKA » %1:l0[#1]KA
-                      ArrangeBy keys=[[#0{l_partkey}]] // { arity: 1 }
-                        Distinct project=[#0{l_partkey}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
-                            Get l1 // { arity: 3 }
-                      Get l0 // { arity: 16 }
-    cte l1 =
-      Project (#1, #4, #5) // { arity: 3 }
-        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") AND (#1{l_partkey}) IS NOT NULL // { arity: 25 }
-          Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
-            implementation
-              %1:part[#0]KAef » %0:l0[#1]KAef
-            Get l0 // { arity: 16 }
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+                        %0[#0]UKA » %1:lineitem[#1]KA
+                      ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+                        Distinct project=[#0{p_partkey}] // { arity: 1 }
+                          Project (#3) // { arity: 1 }
+                            Get l0 // { arity: 6 }
+                      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
+                        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
     cte l0 =
-      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
-        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
+      CrossJoin type=differential // { arity: 6 }
+        implementation
+          %0:lineitem[×] » %1:part[×]
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#1, #4, #5) // { arity: 3 }
+            ReadIndex on=lineitem fk_lineitem_partkey=[*** full scan ***] // { arity: 16 }
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#0, #3, #6) // { arity: 3 }
+            Filter (#0{p_partkey}) IS NOT NULL // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
 
 Used Indexes:
-  - materialize.public.pk_part_partkey (differential join)
-  - materialize.public.fk_lineitem_partkey (differential join)
+  - materialize.public.pk_part_partkey (*** full scan ***)
+  - materialize.public.fk_lineitem_partkey (*** full scan ***, differential join)
 
 EOF
 
@@ -1371,43 +1376,45 @@ materialize.public.q18:
         Filter (#7 > 300) // { arity: 8 }
           Join on=(#2{o_orderkey} = #6{o_orderkey}) type=differential // { arity: 8 }
             implementation
-              %1[#0]UKAif » %0:l1[#2]Kif
+              %1[#0]UKAif » %0:l0[#2]Kif
             ArrangeBy keys=[[#2{o_orderkey}]] // { arity: 6 }
-              Get l1 // { arity: 6 }
+              Project (#0..=#2, #4, #5, #7) // { arity: 6 }
+                Filter (#0{c_custkey} = #3{o_custkey}) AND (#2{o_orderkey} = #6{l_orderkey}) // { arity: 8 }
+                  Get l0 // { arity: 8 }
             ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 2 }
               Reduce group_by=[#0{o_orderkey}] aggregates=[sum(#1{l_quantity})] // { arity: 2 }
                 Project (#0, #5) // { arity: 2 }
                   Join on=(#0{o_orderkey} = #1{l_orderkey}) type=differential // { arity: 17 }
                     implementation
-                      %0[#0]UKA » %1:l0[#0]KA
+                      %0[#0]UKA » %1:lineitem[#0]KA
                     ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
                       Distinct project=[#0{o_orderkey}] // { arity: 1 }
                         Project (#2) // { arity: 1 }
-                          Get l1 // { arity: 6 }
-                    Get l0 // { arity: 16 }
+                          Get l0 // { arity: 8 }
+                    ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
+                      ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
   With
-    cte l1 =
-      Project (#0, #1, #8, #11, #12, #21) // { arity: 6 }
-        Filter (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
-          Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
-            implementation
-              %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
-              %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
-              %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
-              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
-              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-            Get l0 // { arity: 16 }
     cte l0 =
-      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
-        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
+      CrossJoin type=delta // { arity: 8 }
+        implementation
+          %0:customer » %1:orders[×] » %2:lineitem[×]
+          %1:orders » %0:customer[×] » %2:lineitem[×]
+          %2:lineitem » %0:customer[×] » %1:orders[×]
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+        ArrangeBy keys=[[]] // { arity: 4 }
+          Project (#0, #1, #3, #4) // { arity: 4 }
+            Filter (#0{o_orderkey}) IS NOT NULL // { arity: 9 }
+              ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #4) // { arity: 2 }
+            ReadIndex on=lineitem fk_lineitem_orderkey=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
-  - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
-  - materialize.public.pk_orders_orderkey (delta join lookup)
-  - materialize.public.fk_orders_custkey (delta join lookup)
-  - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
+  - materialize.public.pk_customer_custkey (*** full scan ***)
+  - materialize.public.pk_orders_orderkey (*** full scan ***)
+  - materialize.public.fk_lineitem_orderkey (*** full scan ***, differential join)
 
 EOF
 
@@ -1531,70 +1538,69 @@ materialize.public.q20:
     Project (#1, #2) // { arity: 2 }
       Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
         implementation
-          %1[#0]UKA » %0:l0[#0]K
+          %1[#0]UKA » %0:l0[#0]Kef
         ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 3 }
-          Get l0 // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Filter (#5{n_name} = "CANADA") AND (#3{s_nationkey} = #4{n_nationkey}) // { arity: 6 }
+              Get l0 // { arity: 6 }
         ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 1 }
           Distinct project=[#0{s_suppkey}] // { arity: 1 }
             Project (#0) // { arity: 1 }
-              Filter (integer_to_numeric(#2{ps_availqty}) > #5) // { arity: 6 }
-                Join on=(#0{s_suppkey} = #4{ps_suppkey} AND #1{ps_partkey} = #3{ps_partkey}) type=differential // { arity: 6 }
+              Filter (integer_to_numeric(#2{ps_availqty}) > (0.5 * #6)) // { arity: 7 }
+                Join on=(#0{s_suppkey} = #5{ps_suppkey} AND #1{ps_partkey} = #3{p_partkey} = #4{ps_partkey}) type=delta // { arity: 7 }
                   implementation
-                    %1[#1, #0]UKK » %0:l1[#0, #1]KKf
-                  ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
+                    %0:l1 » %2[#0, #1]UKKA » %1[#0]UKA
+                    %1 » %0:l1[#1]Kf » %2[#0, #1]UKKA
+                    %2 » %1[#0]UKA » %0:l1[#0, #1]KKf
+                  ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}], [#1{ps_partkey}]] // { arity: 3 }
                     Project (#0, #1, #3) // { arity: 3 }
                       Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                         Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
-                    Project (#0, #1, #3) // { arity: 3 }
-                      Map ((0.5 * #2)) // { arity: 4 }
-                        Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
-                          Project (#0, #1, #6) // { arity: 3 }
-                            Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
-                              Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
-                                implementation
-                                  %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
-                                ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
-                                  Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
-                                    Project (#1, #2) // { arity: 2 }
-                                      Get l1 // { arity: 4 }
-                                ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
-                                  ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
+                  ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+                    Distinct project=[#0{p_partkey}] // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
+                          ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
+                  ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 3 }
+                    Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
+                      Project (#0, #1, #6) // { arity: 3 }
+                        Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
+                          Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
+                            implementation
+                              %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
+                            ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
+                              Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
+                                Project (#1, #2) // { arity: 2 }
+                                  Get l1 // { arity: 4 }
+                            ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
+                              ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
   With
     cte l1 =
-      Project (#0..=#3) // { arity: 4 }
-        Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
-          implementation
-            %0 » %1:partsupp[×] » %2[#0]UKA
-            %1:partsupp » %2[#0]UKA » %0[×]
-            %2 » %1:partsupp[#0]KA » %0[×]
-          ArrangeBy keys=[[]] // { arity: 1 }
-            Distinct project=[#0{s_suppkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Get l0 // { arity: 3 }
-          ArrangeBy keys=[[], [#0{ps_partkey}]] // { arity: 3 }
-            Project (#0..=#2) // { arity: 3 }
-              ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
-          ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
-            Distinct project=[#0{p_partkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
-                  ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
+      CrossJoin type=differential // { arity: 4 }
+        implementation
+          %0[×] » %1:partsupp[×]
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Distinct project=[#0{s_suppkey}] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Get l0 // { arity: 6 }
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
     cte l0 =
-      Project (#0..=#2) // { arity: 3 }
-        Filter (#8{n_name} = "CANADA") AND (#3{s_nationkey}) IS NOT NULL // { arity: 11 }
-          Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
-            implementation
-              %1:nation[#0]KAef » %0:supplier[#3]KAef
-            ArrangeBy keys=[[#3{s_nationkey}]] // { arity: 7 }
-              ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
-            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-              ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
+      CrossJoin type=differential // { arity: 6 }
+        implementation
+          %0:supplier[×] » %1:nation[×]
+        ArrangeBy keys=[[]] // { arity: 4 }
+          Project (#0..=#3) // { arity: 4 }
+            ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            ReadIndex on=nation pk_nation_nationkey=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (differential join)
+  - materialize.public.pk_nation_nationkey (*** full scan ***)
   - materialize.public.pk_part_partkey (*** full scan ***)
-  - materialize.public.fk_supplier_nationkey (differential join)
+  - materialize.public.pk_supplier_suppkey (*** full scan ***)
   - materialize.public.pk_partsupp_partkey_suppkey (*** full scan ***)
   - materialize.public.fk_lineitem_partsuppkey (differential join)
 
@@ -1649,76 +1655,72 @@ materialize.public.q21:
   Return // { arity: 2 }
     Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
       Project (#1) // { arity: 1 }
-        Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
+        Join on=(#0{s_suppkey} = #4{l_suppkey} = #6{l_suppkey} AND #2{l_orderkey} = #3{l_orderkey} = #5{l_orderkey}) type=delta // { arity: 7 }
           implementation
-            %0:l2[#2, #0]KK » %1[#0, #1]KK
-          ArrangeBy keys=[[#2{l_orderkey}, #0{s_suppkey}]] // { arity: 3 }
-            Get l2 // { arity: 3 }
-          ArrangeBy keys=[[#0{l_orderkey}, #1{s_suppkey}]] // { arity: 2 }
-            Union // { arity: 2 }
-              Negate // { arity: 2 }
-                Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
-                    Filter (#1{s_suppkey} != #4{l_suppkey}) AND (#14{l_receiptdate} > #13{l_commitdate}) // { arity: 18 }
-                      Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
-                        implementation
-                          %1:l1[#0]KAf » %0:l3[#0]Kf
-                        ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
-                          Get l3 // { arity: 2 }
-                        Get l1 // { arity: 16 }
-              Get l3 // { arity: 2 }
-  With
-    cte l3 =
-      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-        Project (#0, #2) // { arity: 2 }
-          Get l2 // { arity: 3 }
-    cte l2 =
-      Project (#0..=#2) // { arity: 3 }
-        Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
-          implementation
-            %1[#1, #0]UKK » %0:l0[#0, #2]KK
+            %0:l0 » %1[#0, #1]UKKA » %2[#0, #1]KK
+            %1 » %0:l0[#0, #2]KKef » %2[#0, #1]KK
+            %2 » %1[#0, #1]UKKA » %0:l0[#0, #2]KKef
           ArrangeBy keys=[[#0{s_suppkey}, #2{l_orderkey}]] // { arity: 3 }
-            Get l0 // { arity: 3 }
-          ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
-            Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
+            Project (#0, #1, #3) // { arity: 3 }
+              Filter (#8{o_orderstatus} = "F") AND (#10{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey} = #4{l_suppkey}) AND (#2{s_nationkey} = #9{n_nationkey}) AND (#3{l_orderkey} = #7{o_orderkey}) AND (#6{l_receiptdate} > #5{l_commitdate}) // { arity: 11 }
+                Get l0 // { arity: 11 }
+          ArrangeBy keys=[[#0{l_orderkey}, #1{l_suppkey}]] // { arity: 2 }
+            Distinct project=[#0{l_orderkey}, #1{l_suppkey}] // { arity: 2 }
               Project (#0, #1) // { arity: 2 }
-                Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
+                Filter (#1{l_suppkey} != #4{l_suppkey}) // { arity: 18 }
                   Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                     implementation
-                      %1:l1[#0]KA » %0[#0]K
-                    ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
-                      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-                        Project (#0, #2) // { arity: 2 }
-                          Get l0 // { arity: 3 }
-                    Get l1 // { arity: 16 }
-    cte l1 =
+                      %1:l3[#0]KA » %0:l2[#0]K
+                    Get l2 // { arity: 2 }
+                    Get l3 // { arity: 16 }
+          ArrangeBy keys=[[#0{l_orderkey}, #1{l_suppkey}]] // { arity: 2 }
+            Union // { arity: 2 }
+              Negate // { arity: 2 }
+                Distinct project=[#0{l_orderkey}, #1{l_suppkey}] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Filter (#1{l_suppkey} != #4{l_suppkey}) AND (#14{l_receiptdate} > #13{l_commitdate}) // { arity: 18 }
+                      Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
+                        implementation
+                          %1:l3[#0]KAf » %0:l2[#0]Kf
+                        Get l2 // { arity: 2 }
+                        Get l3 // { arity: 16 }
+              Get l1 // { arity: 2 }
+  With
+    cte l3 =
       ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
+    cte l2 =
+      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
+        Get l1 // { arity: 2 }
+    cte l1 =
+      Distinct project=[#0{l_orderkey}, #1{l_suppkey}] // { arity: 2 }
+        Project (#3, #4) // { arity: 2 }
+          Get l0 // { arity: 11 }
     cte l0 =
-      Project (#0, #1, #7) // { arity: 3 }
-        Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
-          Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
-            implementation
-              %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-              %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
-              %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
-              %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-            ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-              ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
-            ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
-              ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
-              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-              ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+      CrossJoin type=delta // { arity: 11 }
+        implementation
+          %0:supplier » %1:lineitem[×] » %2:orders[×] » %3:nation[×]
+          %1:lineitem » %0:supplier[×] » %2:orders[×] » %3:nation[×]
+          %2:orders » %0:supplier[×] » %1:lineitem[×] » %3:nation[×]
+          %3:nation » %0:supplier[×] » %1:lineitem[×] » %2:orders[×]
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#0, #1, #3) // { arity: 3 }
+            ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
+        ArrangeBy keys=[[]] // { arity: 4 }
+          Project (#0, #2, #11, #12) // { arity: 4 }
+            ReadIndex on=lineitem fk_lineitem_orderkey=[*** full scan ***] // { arity: 16 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #2) // { arity: 2 }
+            ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            ReadIndex on=nation pk_nation_nationkey=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join lookup)
-  - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
-  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
-  - materialize.public.pk_orders_orderkey (delta join lookup)
-  - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
-  - materialize.public.fk_lineitem_suppkey (delta join lookup)
+  - materialize.public.pk_nation_nationkey (*** full scan ***)
+  - materialize.public.pk_supplier_suppkey (*** full scan ***)
+  - materialize.public.pk_orders_orderkey (*** full scan ***)
+  - materialize.public.fk_lineitem_orderkey (*** full scan ***, differential join)
 
 EOF
 
@@ -1779,49 +1781,44 @@ materialize.public.q22:
   Return // { arity: 3 }
     Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
       Project (#1, #2) // { arity: 2 }
-        Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
-          implementation
-            %0:l1[#0]K » %1[#0]K
-          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 3 }
-            Get l1 // { arity: 3 }
-          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
-                    Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
-                      implementation
-                        %0:l2[#0]UKA » %1[#0]UKA
-                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                        Get l2 // { arity: 1 }
-                      ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
-                        Distinct project=[#0{o_custkey}] // { arity: 1 }
-                          Project (#1) // { arity: 1 }
-                            ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
-              Get l2 // { arity: 1 }
-  With
-    cte l2 =
-      Distinct project=[#0{c_custkey}] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l1 // { arity: 3 }
-    cte l1 =
-      Project (#0..=#2) // { arity: 3 }
-        Filter (#2{c_acctbal} > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
-          CrossJoin type=differential // { arity: 5 }
+        Filter (#2{c_acctbal} > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 6 }
+          Join on=(#0{c_custkey} = #5{c_custkey}) type=delta // { arity: 6 }
             implementation
-              %1[×]UA » %0:l0[×]ef
-            ArrangeBy keys=[[]] // { arity: 3 }
+              %0:l1 » %1[×]UA » %2[#0]K
+              %1 » %0:l1[×]ef » %2[#0]K
+              %2 » %1[×]UA » %0:l1[#0]KAef
+            ArrangeBy keys=[[], [#0{c_custkey}]] // { arity: 3 }
               Project (#0, #4, #5) // { arity: 3 }
                 Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                  Get l0 // { arity: 9 }
+                  Get l1 // { arity: 9 }
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
                 Project (#5) // { arity: 1 }
                   Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                    Get l0 // { arity: 9 }
-    cte l0 =
+                    Get l1 // { arity: 9 }
+            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+              Union // { arity: 1 }
+                Negate // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
+                      Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
+                        implementation
+                          %0:l0[#0]UKA » %1[#0]UKA
+                        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                          Get l0 // { arity: 1 }
+                        ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
+                          Distinct project=[#0{o_custkey}] // { arity: 1 }
+                            Project (#1) // { arity: 1 }
+                              ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+                Get l0 // { arity: 1 }
+  With
+    cte l1 =
       Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
         ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+    cte l0 =
+      Distinct project=[#0{c_custkey}] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (*** full scan ***)

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -247,66 +247,67 @@ Explained Query:
       Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
         Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10) type=differential // { arity: 11 }
           implementation
-            %1[#0, #1]UKK » %0:l4[#0, #7]KK
+            %1[#0, #1]UKK » %0:l0[#0, #7]KKelf
           ArrangeBy keys=[[#0{p_partkey}, #7{ps_supplycost}]] // { arity: 9 }
-            Get l4 // { arity: 9 }
+            Project (#0, #1, #5, #6, #8..=#10, #13, #15) // { arity: 9 }
+              Filter (#3{p_size} = 15) AND (#18{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#2{p_type})) AND (#0{p_partkey} = #11{ps_partkey}) AND (#4{s_suppkey} = #12{ps_suppkey}) AND (#7{s_nationkey} = #14{n_nationkey}) AND (#16{n_regionkey} = #17{r_regionkey}) // { arity: 19 }
+                Get l0 // { arity: 19 }
           ArrangeBy keys=[[#0{p_partkey}, #1]] // { arity: 2 }
             Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
               Project (#0, #4) // { arity: 2 }
                 Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
                   Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                     implementation
-                      %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                      %1:l1 » %0[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                      %2:l0 » %1:l1[#1]KA » %0[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
-                      %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
-                      %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
+                      %0 » %1:partsupp[#0]KA » %2:supplier[#0]KA » %3:nation[#0]KA » %4:region[#0]KAef
+                      %1:partsupp » %0[#0]UKA » %2:supplier[#0]KA » %3:nation[#0]KA » %4:region[#0]KAef
+                      %2:supplier » %1:partsupp[#1]KA » %0[#0]UKA » %3:nation[#0]KA » %4:region[#0]KAef
+                      %3:nation » %4:region[#0]KAef » %2:supplier[#3]KA » %1:partsupp[#1]KA » %0[#0]UKA
+                      %4:region » %3:nation[#2]KA » %2:supplier[#3]KA » %1:partsupp[#1]KA » %0[#0]UKA
                     ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
                       Distinct project=[#0{p_partkey}] // { arity: 1 }
                         Project (#0) // { arity: 1 }
-                          Get l4 // { arity: 9 }
-                    Get l1 // { arity: 5 }
-                    Get l0 // { arity: 7 }
-                    Get l2 // { arity: 4 }
-                    Get l3 // { arity: 3 }
+                          Get l0 // { arity: 19 }
+                    ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
+                      ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
+                    ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
+                      ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+                    ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
+                      ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
+                    ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
+                      ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
     With
-      cte l4 =
-        Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-          Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#23{n_regionkey}) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
-            Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
-              implementation
-                %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
-                %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-                %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-                ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-              Get l0 // { arity: 7 }
-              Get l1 // { arity: 5 }
-              Get l2 // { arity: 4 }
-              Get l3 // { arity: 3 }
-      cte l3 =
-        ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
-          ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
-      cte l2 =
-        ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
-          ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
-      cte l1 =
-        ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
-          ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
       cte l0 =
-        ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-          ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+        CrossJoin type=delta // { arity: 19 }
+          implementation
+            %0:part » %1:supplier[×] » %2:partsupp[×] » %3:nation[×] » %4:region[×]
+            %1:supplier » %0:part[×] » %2:partsupp[×] » %3:nation[×] » %4:region[×]
+            %2:partsupp » %0:part[×] » %1:supplier[×] » %3:nation[×] » %4:region[×]
+            %3:nation » %0:part[×] » %1:supplier[×] » %2:partsupp[×] » %4:region[×]
+            %4:region » %0:part[×] » %1:supplier[×] » %2:partsupp[×] » %3:nation[×]
+          ArrangeBy keys=[[]] // { arity: 4 }
+            Project (#0, #2, #4, #5) // { arity: 4 }
+              Filter (#0{p_partkey}) IS NOT NULL // { arity: 9 }
+                ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
+          ArrangeBy keys=[[]] // { arity: 7 }
+            ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
+          ArrangeBy keys=[[]] // { arity: 3 }
+            Project (#0, #1, #3) // { arity: 3 }
+              ReadIndex on=partsupp fk_partsupp_partkey=[*** full scan ***] // { arity: 5 }
+          ArrangeBy keys=[[]] // { arity: 3 }
+            Project (#0..=#2) // { arity: 3 }
+              ReadIndex on=nation pk_nation_nationkey=[*** full scan ***] // { arity: 4 }
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              ReadIndex on=region pk_region_regionkey=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_nation_nationkey (*** full scan ***, delta join lookup)
   - materialize.public.fk_nation_regionkey (delta join lookup)
-  - materialize.public.pk_region_regionkey (delta join lookup)
-  - materialize.public.pk_part_partkey (delta join 1st input (full scan))
-  - materialize.public.pk_supplier_suppkey (delta join lookup)
+  - materialize.public.pk_region_regionkey (*** full scan ***, delta join lookup)
+  - materialize.public.pk_part_partkey (*** full scan ***)
+  - materialize.public.pk_supplier_suppkey (*** full scan ***, delta join lookup)
   - materialize.public.fk_supplier_nationkey (delta join lookup)
-  - materialize.public.fk_partsupp_partkey (delta join lookup)
+  - materialize.public.fk_partsupp_partkey (*** full scan ***, delta join lookup)
   - materialize.public.fk_partsupp_suppkey (delta join lookup)
 
 EOF
@@ -405,7 +406,7 @@ Explained Query:
             ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
               Distinct project=[#0{o_orderkey}] // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
+                  Filter (#0{o_orderkey}) IS NOT NULL // { arity: 9 }
                     ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
             ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
               Distinct project=[#0{l_orderkey}] // { arity: 1 }
@@ -1205,9 +1206,11 @@ Explained Query:
         Project (#0..=#3) // { arity: 4 }
           Join on=(#0{ps_suppkey} = #4{ps_suppkey}) type=differential // { arity: 5 }
             implementation
-              %0:l0[#0]K » %1[#0]K
+              %0:l0[#0]Kef » %1[#0]Kef
             ArrangeBy keys=[[#0{ps_suppkey}]] // { arity: 4 }
-              Get l0 // { arity: 4 }
+              Project (#1, #3..=#5) // { arity: 4 }
+                Filter (#3{p_brand} != "Brand#45") AND (#0{ps_partkey} = #2{p_partkey}) AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#4{p_type}))) AND ((#5{p_size} = 3) OR (#5{p_size} = 9) OR (#5{p_size} = 14) OR (#5{p_size} = 19) OR (#5{p_size} = 23) OR (#5{p_size} = 36) OR (#5{p_size} = 45) OR (#5{p_size} = 49)) // { arity: 6 }
+                  Get l0 // { arity: 6 }
             ArrangeBy keys=[[#0{ps_suppkey}]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
@@ -1227,23 +1230,23 @@ Explained Query:
     With
       cte l1 =
         Distinct project=[#0{ps_suppkey}] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Get l0 // { arity: 4 }
+          Project (#1) // { arity: 1 }
+            Get l0 // { arity: 6 }
       cte l0 =
-        Project (#1, #8..=#10) // { arity: 4 }
-          Filter (#8{p_brand} != "Brand#45") AND (#0{ps_partkey}) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
-            Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
-              implementation
-                %1:part[#0]KAef » %0:partsupp[#0]KAef
-              ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
-                ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-                ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+        CrossJoin type=differential // { arity: 6 }
+          implementation
+            %0:partsupp[×] » %1:part[×]
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
+          ArrangeBy keys=[[]] // { arity: 4 }
+            Project (#0, #3..=#5) // { arity: 4 }
+              ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
 
 Used Indexes:
-  - materialize.public.pk_part_partkey (differential join)
+  - materialize.public.pk_part_partkey (*** full scan ***)
   - materialize.public.pk_supplier_suppkey (*** full scan ***)
-  - materialize.public.fk_partsupp_partkey (differential join)
+  - materialize.public.pk_partsupp_partkey_suppkey (*** full scan ***)
 
 EOF
 
@@ -1274,51 +1277,53 @@ Explained Query:
     Project (#1) // { arity: 1 }
       Map ((#0 / 7)) // { arity: 2 }
         Union // { arity: 1 }
-          Get l2 // { arity: 1 }
+          Get l1 // { arity: 1 }
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
               Negate // { arity: 0 }
                 Project () // { arity: 0 }
-                  Get l2 // { arity: 1 }
+                  Get l1 // { arity: 1 }
               Constant // { arity: 0 }
                 - ()
   With
-    cte l2 =
+    cte l1 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
           Filter (#1{l_quantity} < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
-            Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
+            Join on=(#0{l_partkey} = #3{p_partkey}) type=differential // { arity: 6 }
               implementation
-                %1[#0]UKA » %0:l1[#0]K
+                %1[#0]UKA » %0:l0[#0]Kef
               ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
-                Get l1 // { arity: 3 }
-              ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
-                Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
+                Project (#0..=#2) // { arity: 3 }
+                  Filter (#4{p_brand} = "Brand#23") AND (#5{p_container} = "MED BOX") AND (#0{l_partkey} = #3{p_partkey}) // { arity: 6 }
+                    Get l0 // { arity: 6 }
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 3 }
+                Reduce group_by=[#0{p_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
                   Project (#0, #5) // { arity: 2 }
-                    Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
+                    Join on=(#0{p_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
                       implementation
-                        %0[#0]UKA » %1:l0[#1]KA
-                      ArrangeBy keys=[[#0{l_partkey}]] // { arity: 1 }
-                        Distinct project=[#0{l_partkey}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
-                            Get l1 // { arity: 3 }
-                      Get l0 // { arity: 16 }
-    cte l1 =
-      Project (#1, #4, #5) // { arity: 3 }
-        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") AND (#1{l_partkey}) IS NOT NULL // { arity: 25 }
-          Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
-            implementation
-              %1:part[#0]KAef » %0:l0[#1]KAef
-            Get l0 // { arity: 16 }
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
-              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+                        %0[#0]UKA » %1:lineitem[#1]KA
+                      ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+                        Distinct project=[#0{p_partkey}] // { arity: 1 }
+                          Project (#3) // { arity: 1 }
+                            Get l0 // { arity: 6 }
+                      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
+                        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
     cte l0 =
-      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
-        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
+      CrossJoin type=differential // { arity: 6 }
+        implementation
+          %0:lineitem[×] » %1:part[×]
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#1, #4, #5) // { arity: 3 }
+            ReadIndex on=lineitem fk_lineitem_partkey=[*** full scan ***] // { arity: 16 }
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#0, #3, #6) // { arity: 3 }
+            Filter (#0{p_partkey}) IS NOT NULL // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
 
 Used Indexes:
-  - materialize.public.pk_part_partkey (differential join)
-  - materialize.public.fk_lineitem_partkey (differential join)
+  - materialize.public.pk_part_partkey (*** full scan ***)
+  - materialize.public.fk_lineitem_partkey (*** full scan ***, differential join)
 
 EOF
 
@@ -1367,43 +1372,45 @@ Explained Query:
           Filter (#7 > 300) // { arity: 8 }
             Join on=(#2{o_orderkey} = #6{o_orderkey}) type=differential // { arity: 8 }
               implementation
-                %1[#0]UKAif » %0:l1[#2]Kif
+                %1[#0]UKAif » %0:l0[#2]Kif
               ArrangeBy keys=[[#2{o_orderkey}]] // { arity: 6 }
-                Get l1 // { arity: 6 }
+                Project (#0..=#2, #4, #5, #7) // { arity: 6 }
+                  Filter (#0{c_custkey} = #3{o_custkey}) AND (#2{o_orderkey} = #6{l_orderkey}) // { arity: 8 }
+                    Get l0 // { arity: 8 }
               ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 2 }
                 Reduce group_by=[#0{o_orderkey}] aggregates=[sum(#1{l_quantity})] // { arity: 2 }
                   Project (#0, #5) // { arity: 2 }
                     Join on=(#0{o_orderkey} = #1{l_orderkey}) type=differential // { arity: 17 }
                       implementation
-                        %0[#0]UKA » %1:l0[#0]KA
+                        %0[#0]UKA » %1:lineitem[#0]KA
                       ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
                         Distinct project=[#0{o_orderkey}] // { arity: 1 }
                           Project (#2) // { arity: 1 }
-                            Get l1 // { arity: 6 }
-                      Get l0 // { arity: 16 }
+                            Get l0 // { arity: 8 }
+                      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
+                        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
     With
-      cte l1 =
-        Project (#0, #1, #8, #11, #12, #21) // { arity: 6 }
-          Filter (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
-            Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
-              implementation
-                %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
-                %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
-                %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-              ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
-                ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-              ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
-                ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-              Get l0 // { arity: 16 }
       cte l0 =
-        ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
-          ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
+        CrossJoin type=delta // { arity: 8 }
+          implementation
+            %0:customer » %1:orders[×] » %2:lineitem[×]
+            %1:orders » %0:customer[×] » %2:lineitem[×]
+            %2:lineitem » %0:customer[×] » %1:orders[×]
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+          ArrangeBy keys=[[]] // { arity: 4 }
+            Project (#0, #1, #3, #4) // { arity: 4 }
+              Filter (#0{o_orderkey}) IS NOT NULL // { arity: 9 }
+                ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Project (#0, #4) // { arity: 2 }
+              ReadIndex on=lineitem fk_lineitem_orderkey=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
-  - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
-  - materialize.public.pk_orders_orderkey (delta join lookup)
-  - materialize.public.fk_orders_custkey (delta join lookup)
-  - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
+  - materialize.public.pk_customer_custkey (*** full scan ***)
+  - materialize.public.pk_orders_orderkey (*** full scan ***)
+  - materialize.public.fk_lineitem_orderkey (*** full scan ***, differential join)
 
 EOF
 
@@ -1526,70 +1533,69 @@ Explained Query:
       Project (#1, #2) // { arity: 2 }
         Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
           implementation
-            %1[#0]UKA » %0:l0[#0]K
+            %1[#0]UKA » %0:l0[#0]Kef
           ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 3 }
-            Get l0 // { arity: 3 }
+            Project (#0..=#2) // { arity: 3 }
+              Filter (#5{n_name} = "CANADA") AND (#3{s_nationkey} = #4{n_nationkey}) // { arity: 6 }
+                Get l0 // { arity: 6 }
           ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 1 }
             Distinct project=[#0{s_suppkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (integer_to_numeric(#2{ps_availqty}) > #5) // { arity: 6 }
-                  Join on=(#0{s_suppkey} = #4{ps_suppkey} AND #1{ps_partkey} = #3{ps_partkey}) type=differential // { arity: 6 }
+                Filter (integer_to_numeric(#2{ps_availqty}) > (0.5 * #6)) // { arity: 7 }
+                  Join on=(#0{s_suppkey} = #5{ps_suppkey} AND #1{ps_partkey} = #3{p_partkey} = #4{ps_partkey}) type=delta // { arity: 7 }
                     implementation
-                      %1[#1, #0]UKK » %0:l1[#0, #1]KKf
-                    ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
+                      %0:l1 » %2[#0, #1]UKKA » %1[#0]UKA
+                      %1 » %0:l1[#1]Kf » %2[#0, #1]UKKA
+                      %2 » %1[#0]UKA » %0:l1[#0, #1]KKf
+                    ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}], [#1{ps_partkey}]] // { arity: 3 }
                       Project (#0, #1, #3) // { arity: 3 }
                         Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                           Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
-                      Project (#0, #1, #3) // { arity: 3 }
-                        Map ((0.5 * #2)) // { arity: 4 }
-                          Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
-                            Project (#0, #1, #6) // { arity: 3 }
-                              Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
-                                Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
-                                  implementation
-                                    %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
-                                  ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
-                                    Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
-                                      Project (#1, #2) // { arity: 2 }
-                                        Get l1 // { arity: 4 }
-                                  ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
-                                    ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
+                    ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+                      Distinct project=[#0{p_partkey}] // { arity: 1 }
+                        Project (#0) // { arity: 1 }
+                          Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
+                            ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
+                    ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 3 }
+                      Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
+                        Project (#0, #1, #6) // { arity: 3 }
+                          Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
+                            Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
+                              implementation
+                                %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
+                              ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
+                                Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
+                                  Project (#1, #2) // { arity: 2 }
+                                    Get l1 // { arity: 4 }
+                              ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
+                                ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
     With
       cte l1 =
-        Project (#0..=#3) // { arity: 4 }
-          Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
-            implementation
-              %0 » %1:partsupp[×] » %2[#0]UKA
-              %1:partsupp » %2[#0]UKA » %0[×]
-              %2 » %1:partsupp[#0]KA » %0[×]
-            ArrangeBy keys=[[]] // { arity: 1 }
-              Distinct project=[#0{s_suppkey}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Get l0 // { arity: 3 }
-            ArrangeBy keys=[[], [#0{ps_partkey}]] // { arity: 3 }
-              Project (#0..=#2) // { arity: 3 }
-                ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
-            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
-              Distinct project=[#0{p_partkey}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
-                    ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
+        CrossJoin type=differential // { arity: 4 }
+          implementation
+            %0[×] » %1:partsupp[×]
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Distinct project=[#0{s_suppkey}] // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l0 // { arity: 6 }
+          ArrangeBy keys=[[]] // { arity: 3 }
+            Project (#0..=#2) // { arity: 3 }
+              ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
       cte l0 =
-        Project (#0..=#2) // { arity: 3 }
-          Filter (#8{n_name} = "CANADA") AND (#3{s_nationkey}) IS NOT NULL // { arity: 11 }
-            Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
-              implementation
-                %1:nation[#0]KAef » %0:supplier[#3]KAef
-              ArrangeBy keys=[[#3{s_nationkey}]] // { arity: 7 }
-                ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
-              ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-                ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
+        CrossJoin type=differential // { arity: 6 }
+          implementation
+            %0:supplier[×] » %1:nation[×]
+          ArrangeBy keys=[[]] // { arity: 4 }
+            Project (#0..=#3) // { arity: 4 }
+              ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              ReadIndex on=nation pk_nation_nationkey=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (differential join)
+  - materialize.public.pk_nation_nationkey (*** full scan ***)
   - materialize.public.pk_part_partkey (*** full scan ***)
-  - materialize.public.fk_supplier_nationkey (differential join)
+  - materialize.public.pk_supplier_suppkey (*** full scan ***)
   - materialize.public.pk_partsupp_partkey_suppkey (*** full scan ***)
   - materialize.public.fk_lineitem_partsuppkey (differential join)
 
@@ -1644,76 +1650,72 @@ Explained Query:
     Return // { arity: 2 }
       Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
-          Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
+          Join on=(#0{s_suppkey} = #4{l_suppkey} = #6{l_suppkey} AND #2{l_orderkey} = #3{l_orderkey} = #5{l_orderkey}) type=delta // { arity: 7 }
             implementation
-              %0:l2[#2, #0]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[#2{l_orderkey}, #0{s_suppkey}]] // { arity: 3 }
-              Get l2 // { arity: 3 }
-            ArrangeBy keys=[[#0{l_orderkey}, #1{s_suppkey}]] // { arity: 2 }
-              Union // { arity: 2 }
-                Negate // { arity: 2 }
-                  Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
-                    Project (#0, #1) // { arity: 2 }
-                      Filter (#1{s_suppkey} != #4{l_suppkey}) AND (#14{l_receiptdate} > #13{l_commitdate}) // { arity: 18 }
-                        Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
-                          implementation
-                            %1:l1[#0]KAf » %0:l3[#0]Kf
-                          ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
-                            Get l3 // { arity: 2 }
-                          Get l1 // { arity: 16 }
-                Get l3 // { arity: 2 }
-    With
-      cte l3 =
-        Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-          Project (#0, #2) // { arity: 2 }
-            Get l2 // { arity: 3 }
-      cte l2 =
-        Project (#0..=#2) // { arity: 3 }
-          Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
-            implementation
-              %1[#1, #0]UKK » %0:l0[#0, #2]KK
+              %0:l0 » %1[#0, #1]UKKA » %2[#0, #1]KK
+              %1 » %0:l0[#0, #2]KKef » %2[#0, #1]KK
+              %2 » %1[#0, #1]UKKA » %0:l0[#0, #2]KKef
             ArrangeBy keys=[[#0{s_suppkey}, #2{l_orderkey}]] // { arity: 3 }
-              Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
-              Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
+              Project (#0, #1, #3) // { arity: 3 }
+                Filter (#8{o_orderstatus} = "F") AND (#10{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey} = #4{l_suppkey}) AND (#2{s_nationkey} = #9{n_nationkey}) AND (#3{l_orderkey} = #7{o_orderkey}) AND (#6{l_receiptdate} > #5{l_commitdate}) // { arity: 11 }
+                  Get l0 // { arity: 11 }
+            ArrangeBy keys=[[#0{l_orderkey}, #1{l_suppkey}]] // { arity: 2 }
+              Distinct project=[#0{l_orderkey}, #1{l_suppkey}] // { arity: 2 }
                 Project (#0, #1) // { arity: 2 }
-                  Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
+                  Filter (#1{l_suppkey} != #4{l_suppkey}) // { arity: 18 }
                     Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                       implementation
-                        %1:l1[#0]KA » %0[#0]K
-                      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
-                        Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-                          Project (#0, #2) // { arity: 2 }
-                            Get l0 // { arity: 3 }
-                      Get l1 // { arity: 16 }
-      cte l1 =
+                        %1:l3[#0]KA » %0:l2[#0]K
+                      Get l2 // { arity: 2 }
+                      Get l3 // { arity: 16 }
+            ArrangeBy keys=[[#0{l_orderkey}, #1{l_suppkey}]] // { arity: 2 }
+              Union // { arity: 2 }
+                Negate // { arity: 2 }
+                  Distinct project=[#0{l_orderkey}, #1{l_suppkey}] // { arity: 2 }
+                    Project (#0, #1) // { arity: 2 }
+                      Filter (#1{l_suppkey} != #4{l_suppkey}) AND (#14{l_receiptdate} > #13{l_commitdate}) // { arity: 18 }
+                        Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
+                          implementation
+                            %1:l3[#0]KAf » %0:l2[#0]Kf
+                          Get l2 // { arity: 2 }
+                          Get l3 // { arity: 16 }
+                Get l1 // { arity: 2 }
+    With
+      cte l3 =
         ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
           ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
+      cte l2 =
+        ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
+          Get l1 // { arity: 2 }
+      cte l1 =
+        Distinct project=[#0{l_orderkey}, #1{l_suppkey}] // { arity: 2 }
+          Project (#3, #4) // { arity: 2 }
+            Get l0 // { arity: 11 }
       cte l0 =
-        Project (#0, #1, #7) // { arity: 3 }
-          Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
-            Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
-              implementation
-                %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-                %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
-                %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
-                %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-              ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-                ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
-              ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
-                ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-              ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
-                ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-              ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
-                ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+        CrossJoin type=delta // { arity: 11 }
+          implementation
+            %0:supplier » %1:lineitem[×] » %2:orders[×] » %3:nation[×]
+            %1:lineitem » %0:supplier[×] » %2:orders[×] » %3:nation[×]
+            %2:orders » %0:supplier[×] » %1:lineitem[×] » %3:nation[×]
+            %3:nation » %0:supplier[×] » %1:lineitem[×] » %2:orders[×]
+          ArrangeBy keys=[[]] // { arity: 3 }
+            Project (#0, #1, #3) // { arity: 3 }
+              ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
+          ArrangeBy keys=[[]] // { arity: 4 }
+            Project (#0, #2, #11, #12) // { arity: 4 }
+              ReadIndex on=lineitem fk_lineitem_orderkey=[*** full scan ***] // { arity: 16 }
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Project (#0, #2) // { arity: 2 }
+              ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              ReadIndex on=nation pk_nation_nationkey=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join lookup)
-  - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
-  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
-  - materialize.public.pk_orders_orderkey (delta join lookup)
-  - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
-  - materialize.public.fk_lineitem_suppkey (delta join lookup)
+  - materialize.public.pk_nation_nationkey (*** full scan ***)
+  - materialize.public.pk_supplier_suppkey (*** full scan ***)
+  - materialize.public.pk_orders_orderkey (*** full scan ***)
+  - materialize.public.fk_lineitem_orderkey (*** full scan ***, differential join)
 
 EOF
 
@@ -1774,49 +1776,44 @@ Explained Query:
     Return // { arity: 3 }
       Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
         Project (#1, #2) // { arity: 2 }
-          Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
-            implementation
-              %0:l1[#0]K » %1[#0]K
-            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 3 }
-              Get l1 // { arity: 3 }
-            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-              Union // { arity: 1 }
-                Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
-                    Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
-                      Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
-                        implementation
-                          %0:l2[#0]UKA » %1[#0]UKA
-                        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                          Get l2 // { arity: 1 }
-                        ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
-                          Distinct project=[#0{o_custkey}] // { arity: 1 }
-                            Project (#1) // { arity: 1 }
-                              ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
-                Get l2 // { arity: 1 }
-    With
-      cte l2 =
-        Distinct project=[#0{c_custkey}] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Get l1 // { arity: 3 }
-      cte l1 =
-        Project (#0..=#2) // { arity: 3 }
-          Filter (#2{c_acctbal} > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
-            CrossJoin type=differential // { arity: 5 }
+          Filter (#2{c_acctbal} > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 6 }
+            Join on=(#0{c_custkey} = #5{c_custkey}) type=delta // { arity: 6 }
               implementation
-                %1[×]UA » %0:l0[×]ef
-              ArrangeBy keys=[[]] // { arity: 3 }
+                %0:l1 » %1[×]UA » %2[#0]K
+                %1 » %0:l1[×]ef » %2[#0]K
+                %2 » %1[×]UA » %0:l1[#0]KAef
+              ArrangeBy keys=[[], [#0{c_custkey}]] // { arity: 3 }
                 Project (#0, #4, #5) // { arity: 3 }
                   Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                    Get l0 // { arity: 9 }
+                    Get l1 // { arity: 9 }
               ArrangeBy keys=[[]] // { arity: 2 }
                 Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
                   Project (#5) // { arity: 1 }
                     Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                      Get l0 // { arity: 9 }
-      cte l0 =
+                      Get l1 // { arity: 9 }
+              ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
+                        Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
+                          implementation
+                            %0:l0[#0]UKA » %1[#0]UKA
+                          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                            Get l0 // { arity: 1 }
+                          ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
+                            Distinct project=[#0{o_custkey}] // { arity: 1 }
+                              Project (#1) // { arity: 1 }
+                                ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+                  Get l0 // { arity: 1 }
+    With
+      cte l1 =
         Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
           ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+      cte l0 =
+        Distinct project=[#0{c_custkey}] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey (*** full scan ***)

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -638,38 +638,33 @@ explain with(arity, join implementations) select min(a) from t_pk where a betwee
 Explained Query:
   Return // { arity: 1 }
     Union // { arity: 1 }
-      Get l1 // { arity: 1 }
+      Get l0 // { arity: 1 }
       Map (null) // { arity: 1 }
         Union // { arity: 0 }
           Negate // { arity: 0 }
             Project () // { arity: 0 }
-              Get l1 // { arity: 1 }
+              Get l0 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
   With
-    cte l1 =
+    cte l0 =
       Reduce aggregates=[min(#0)] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Join on=(#0 = #1) type=differential // { arity: 2 }
             implementation
-              %0:t_pk[#0]UKiif » %1[#0]Kiif
+              %0:t_pk[#0]UKiif » %1[#0]UKiif
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (#0 <= 195) AND (#0 >= 38) // { arity: 2 }
                   ReadStorage materialize.public.t_pk // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
-              Union // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Get l0 // { arity: 2 }
-                Map (error("more than one record produced in subquery")) // { arity: 1 }
-                  Project () // { arity: 0 }
-                    Filter (#0 > 1) // { arity: 1 }
-                      Reduce aggregates=[count(*)] // { arity: 1 }
-                        Project () // { arity: 0 }
-                          Get l0 // { arity: 2 }
-    cte l0 =
-      Filter (#0 = 1308) // { arity: 2 }
-        ReadStorage materialize.public.t // { arity: 2 }
+              Map (error("more than one record produced in subquery")) // { arity: 1 }
+                Project () // { arity: 0 }
+                  Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
+                    Reduce aggregates=[count(*)] // { arity: 1 }
+                      Project () // { arity: 0 }
+                        Filter (#0 = 1308) // { arity: 2 }
+                          ReadStorage materialize.public.t // { arity: 2 }
 
 Source materialize.public.t
   filter=((#0 = 1308))
@@ -684,38 +679,33 @@ explain with(arity, join implementations) select min(a) from t where a between 3
 Explained Query:
   Return // { arity: 1 }
     Union // { arity: 1 }
-      Get l1 // { arity: 1 }
+      Get l0 // { arity: 1 }
       Map (null) // { arity: 1 }
         Union // { arity: 0 }
           Negate // { arity: 0 }
             Project () // { arity: 0 }
-              Get l1 // { arity: 1 }
+              Get l0 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
   With
-    cte l1 =
+    cte l0 =
       Reduce aggregates=[min(#0)] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Join on=(#0 = #1) type=differential // { arity: 2 }
             implementation
-              %0:t[#0]Kiif » %1[#0]Kiif
+              %1[#0]UK » %0:t[#0]Kiif
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (#0 <= 195) AND (#0 >= 38) // { arity: 2 }
                   ReadStorage materialize.public.t // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
-              Union // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Get l0 // { arity: 2 }
-                Map (error("more than one record produced in subquery")) // { arity: 1 }
-                  Project () // { arity: 0 }
-                    Filter (#0 > 1) // { arity: 1 }
-                      Reduce aggregates=[count(*)] // { arity: 1 }
-                        Project () // { arity: 0 }
-                          Get l0 // { arity: 2 }
-    cte l0 =
-      Filter (#0 = 1308) // { arity: 2 }
-        ReadStorage materialize.public.t // { arity: 2 }
+              Map (error("more than one record produced in subquery")) // { arity: 1 }
+                Project () // { arity: 0 }
+                  Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
+                    Reduce aggregates=[count(*)] // { arity: 1 }
+                      Project () // { arity: 0 }
+                        Filter (#0 = 1308) // { arity: 2 }
+                          ReadStorage materialize.public.t // { arity: 2 }
 
 EOF
 

--- a/test/sqllogictest/transform/predicate_reduction.slt
+++ b/test/sqllogictest/transform/predicate_reduction.slt
@@ -82,11 +82,13 @@ NULL
 query T multiline
 EXPLAIN DECORRELATED PLAN WITH(arity) FOR SELECT * FROM t1 WHERE (f1 is null)::int - 1 = 0 and ((f1 is null) or ((f1 is null)::int - 1 = 0))
 ----
-Filter (((boolean_to_integer((#0) IS NULL) - 1) = 0) AND ((#0) IS NULL OR ((boolean_to_integer((#0) IS NULL) - 1) = 0))) // { arity: 2 }
-  CrossJoin // { arity: 2 }
-    Constant // { arity: 0 }
-      - ()
-    Get materialize.public.t1 // { arity: 2 }
+Project (#0, #1) // { arity: 2 }
+  Filter (#3 AND (#2 OR #3)) // { arity: 4 }
+    Map ((#0) IS NULL, ((boolean_to_integer(#2) - 1) = 0)) // { arity: 4 }
+      CrossJoin // { arity: 2 }
+        Constant // { arity: 0 }
+          - ()
+        Get materialize.public.t1 // { arity: 2 }
 
 EOF
 

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -153,34 +153,27 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1) AND f2 = (SELECT f1 FROM t1);
 ----
 Explained Query:
-  Return // { arity: 2 }
-    Project (#0, #1) // { arity: 2 }
-      Join on=(#0 = #2 AND #1 = #3) type=delta // { arity: 4 }
+  Project (#0, #1) // { arity: 2 }
+    Filter (#0 = #1) // { arity: 3 }
+      Join on=(#0 = #2) type=differential // { arity: 3 }
         implementation
-          %0:t1 » %1:l0[#0]K » %2:l0[#0]K
-          %1:l0 » %0:t1[#0]KA » %2:l0[#0]K
-          %2:l0 » %0:t1[#1]K » %1:l0[#0]K
-        ArrangeBy keys=[[#0], [#1]] // { arity: 2 }
-          Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
-            ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
-        Get l0 // { arity: 1 }
-        Get l0 // { arity: 1 }
-  With
-    cte l0 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Union // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
-          Map (error("more than one record produced in subquery")) // { arity: 1 }
-            Project () // { arity: 0 }
-              Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-                Reduce aggregates=[count(*)] // { arity: 1 }
-                  Project () // { arity: 0 }
-                    ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+          %0:t1[#0]KAf » %1[#0]Kf
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          ReadIndex on=t1 i1=[differential join] // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Union // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#0) IS NOT NULL // { arity: 2 }
+                ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+            Map (error("more than one record produced in subquery")) // { arity: 1 }
+              Project () // { arity: 0 }
+                Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
+                  Reduce aggregates=[count(*)] // { arity: 1 }
+                    Project () // { arity: 0 }
+                      ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
 
 Used Indexes:
-  - materialize.public.i1 (*** full scan ***)
+  - materialize.public.i1 (*** full scan ***, differential join)
 
 EOF
 
@@ -190,33 +183,30 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE f1 = (SELECT f1
 Explained Query:
   Return // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
-      Join on=(#0 = #2 AND #1 = #3) type=delta // { arity: 4 }
-        implementation
-          %0:t1 » %1:l1[#0]K » %2:l1[#0]K
-          %1:l1 » %0:t1[#0]KA » %2:l1[#0]K
-          %2:l1 » %0:t1[#1]K » %1:l1[#0]K
-        ArrangeBy keys=[[#0], [#1]] // { arity: 2 }
-          Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
-            ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
-        Get l1 // { arity: 1 }
-        Get l1 // { arity: 1 }
+      Filter (#0 = #1) // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 3 }
+          implementation
+            %0:l0[#0]KAf » %1[#0]Kf
+          Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Union // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l1 // { arity: 3 }
+              Map (error("more than one record produced in subquery")) // { arity: 1 }
+                Project () // { arity: 0 }
+                  Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
+                    Reduce aggregates=[count(*)] // { arity: 1 }
+                      Project () // { arity: 0 }
+                        Get l1 // { arity: 3 }
   With
     cte l1 =
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Union // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Get l0 // { arity: 3 }
-          Map (error("more than one record produced in subquery")) // { arity: 1 }
-            Project () // { arity: 0 }
-              Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-                Reduce aggregates=[count(*)] // { arity: 1 }
-                  Project () // { arity: 0 }
-                    Get l0 // { arity: 3 }
-    cte l0 =
       ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadIndex on=t1 i1=[differential join, lookup] // { arity: 2 }
 
 Used Indexes:
-  - materialize.public.i1 (*** full scan ***, lookup)
+  - materialize.public.i1 (differential join, lookup)
 
 EOF
 
@@ -254,29 +244,24 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE f1 = (SELECT f1
 Explained Query:
   Return // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
-      Filter ((#0 = #2) OR (#1 = #3)) // { arity: 4 }
-        CrossJoin type=delta // { arity: 4 }
+      Filter ((#0 = #2) OR (#1 = #2)) // { arity: 3 }
+        CrossJoin type=differential // { arity: 3 }
           implementation
-            %0:t1 » %1:l1[×] » %2:l1[×]
-            %1:l1 » %0:t1[×] » %2:l1[×]
-            %2:l1 » %0:t1[×] » %1:l1[×]
+            %0:t1[×] » %1[×]
           ArrangeBy keys=[[]] // { arity: 2 }
             ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
-          Get l1 // { arity: 1 }
-          Get l1 // { arity: 1 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Union // { arity: 1 }
+              Get l0 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Distinct project=[] // { arity: 0 }
+                      Project () // { arity: 0 }
+                        Get l0 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
   With
-    cte l1 =
-      ArrangeBy keys=[[]] // { arity: 1 }
-        Union // { arity: 1 }
-          Get l0 // { arity: 1 }
-          Map (null) // { arity: 1 }
-            Union // { arity: 0 }
-              Negate // { arity: 0 }
-                Distinct project=[] // { arity: 0 }
-                  Project () // { arity: 0 }
-                    Get l0 // { arity: 1 }
-              Constant // { arity: 0 }
-                - ()
     cte l0 =
       Union // { arity: 1 }
         Project (#0) // { arity: 1 }

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -173,26 +173,28 @@ WHERE f1 IN (SELECT ROW_NUMBER() OVER () FROM t2);
 ----
 Return // { arity: 1 }
   Project (#0) // { arity: 1 }
-    Filter #2 // { arity: 3 }
-      Project (#0, #1, #3) // { arity: 3 }
-        Join on=(#0 = #2) // { arity: 4 }
-          Get l0 // { arity: 2 }
-          Union // { arity: 2 }
-            Get l2 // { arity: 2 }
-            CrossJoin // { arity: 2 }
-              Project (#0) // { arity: 1 }
-                Join on=(#0 = #1) // { arity: 2 }
-                  Union // { arity: 1 }
-                    Negate // { arity: 1 }
+    Filter #4 AND true // { arity: 5 }
+      Join on=(#0 = #2 AND #1 = #3) // { arity: 5 }
+        Get l0 // { arity: 2 }
+        Project (#0, #1, #3) // { arity: 3 }
+          Join on=(#0 = #2) // { arity: 4 }
+            Get l1 // { arity: 2 }
+            Union // { arity: 2 }
+              Get l3 // { arity: 2 }
+              CrossJoin // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Join on=(#0 = #1) // { arity: 2 }
+                    Union // { arity: 1 }
+                      Negate // { arity: 1 }
+                        Distinct project=[#0] // { arity: 1 }
+                          Get l3 // { arity: 2 }
                       Distinct project=[#0] // { arity: 1 }
-                        Get l2 // { arity: 2 }
-                    Distinct project=[#0] // { arity: 1 }
-                      Get l1 // { arity: 1 }
-                  Get l1 // { arity: 1 }
-              Constant // { arity: 1 }
-                - (false)
+                        Get l2 // { arity: 1 }
+                    Get l2 // { arity: 1 }
+                Constant // { arity: 1 }
+                  - (false)
 With
-  cte l2 =
+  cte l3 =
     Map (true) // { arity: 2 }
       Distinct project=[#0] // { arity: 1 }
         Filter (integer_to_bigint(#0) = #1) // { arity: 2 }
@@ -203,17 +205,19 @@ With
                   FlatMap unnest_list(#1) // { arity: 3 }
                     Reduce group_by=[#0] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 2 }
                       CrossJoin // { arity: 3 }
-                        Get l1 // { arity: 1 }
+                        Get l2 // { arity: 1 }
                         Get materialize.public.t2 // { arity: 2 }
-  cte l1 =
+  cte l2 =
     Distinct project=[#0] // { arity: 1 }
+      Get l1 // { arity: 2 }
+  cte l1 =
+    Distinct project=[#0, #1] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
-    Filter true // { arity: 2 }
-      CrossJoin // { arity: 2 }
-        Constant // { arity: 0 }
-          - ()
-        Get materialize.public.t1 // { arity: 2 }
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.t1 // { arity: 2 }
 
 EOF
 


### PR DESCRIPTION
This PR changes how we lower `HIR::Filter`, by mapping the predicate expressions and then filtering based on them and projecting them away. This allows filter to use map's variadic lowering, rather than sequencing the lowering. This dramatically improves the lowering of queries like 
```sql
SELECT * FROM t1 AS a1 
WHERE f1 IN (SELECT * FROM t1 WHERE f1 = a1.f1 AND f1 <= 1)
  AND f1 IN (SELECT * FROM t1 WHERE f1 = a1.f1 AND f1 <= 2)
  AND f1 IN (SELECT * FROM t1 WHERE f1 = a1.f1 AND f1 <= 3)
  AND f1 IN (SELECT * FROM t1 WHERE f1 = a1.f1 AND f1 <= 4)
  AND f1 IN (SELECT * FROM t1 WHERE f1 = a1.f1 AND f1 <= 5)
```
(( taken from @aalexandrov )). Without the PR, each subquery is lowered in sequence, resulting in a large sequential dataflow with many horrible joins. With the PR, it is one join:
```
                    Optimized Plan                    
------------------------------------------------------
 Explained Query:                                    +
   Project (#0)                                      +
     Join on=(#0 = #1 = #2 = #3 = #4 = #5) type=delta+
       ArrangeBy keys=[[#0]]                         +
         ReadStorage materialize.public.t1           +
       ArrangeBy keys=[[#0]]                         +
         Distinct project=[#0]                       +
           Filter (#0 <= 1) AND (#0 = #0)            +
             ReadStorage materialize.public.t1       +
       ArrangeBy keys=[[#0]]                         +
         Distinct project=[#0]                       +
           Filter (#0 <= 2) AND (#0 = #0)            +
             ReadStorage materialize.public.t1       +
       ArrangeBy keys=[[#0]]                         +
         Distinct project=[#0]                       +
           Filter (#0 <= 3) AND (#0 = #0)            +
             ReadStorage materialize.public.t1       +
       ArrangeBy keys=[[#0]]                         +
         Distinct project=[#0]                       +
           Filter (#0 <= 4) AND (#0 = #0)            +
             ReadStorage materialize.public.t1       +
       ArrangeBy keys=[[#0]]                         +
         Distinct project=[#0]                       +
           Filter (#0 <= 5) AND (#0 = #0)            +
             ReadStorage materialize.public.t1       +
 ```
There are still some quirks in there it seems, but it is a much better plan.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
