### PR TITLE
doc/user: improve guides by removing stale mentions

### DIFF
--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -201,8 +201,8 @@ fraudulent accounts.
     CREATE TABLE fraud_accounts (id bigint);
     ```
 
-1. In a new browser window, side-by-side with this one, navigate to the [Materialize console]
-(https://console.materialize.com/), and pop open another SQL Shell.
+1. In a new browser window, side-by-side with this one, navigate to the [Materialize console](https://console.materialize.com/),
+   and pop open another SQL Shell.
 
 1. To see results change over time, let's `SUBSCRIBE` to a query that returns
 the Top 5 auction winners, overall.

--- a/doc/user/content/ingest-data/amazon-eventbridge.md
+++ b/doc/user/content/ingest-data/amazon-eventbridge.md
@@ -20,7 +20,12 @@ Ensure that you have:
 
 ## Step 1. (Optional) Create a cluster
 
-If you already have a cluster for your webhook sources, you can skip this step.
+{{< note >}}
+If you are prototyping and already have a cluster to host your webhook
+source (e.g. `quickstart`), **you can skip this step**. For production
+scenarios, we recommend separating your workloads into multiple clusters for
+[resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
+{{< /note >}}
 
 To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/create-cluster):
 

--- a/doc/user/content/ingest-data/amazon-eventbridge.md
+++ b/doc/user/content/ingest-data/amazon-eventbridge.md
@@ -26,6 +26,8 @@ To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/crea
 
 ```sql
 CREATE CLUSTER webhooks_cluster (SIZE = '3xsmall');
+
+SET CLUSTER = webhooks_cluster;
 ```
 
 ## Step 2. Create a secret
@@ -42,11 +44,13 @@ a secure location.
 
 ## Step 3. Set up a webhook source
 
-Using the secret from **Step 2.**, create a [webhook source](/sql/create-source/webhook/)
-in Materialize to ingest data from Amazon EventBridge.
+Using the secret from the previous step, create a [webhook source](/sql/create-source/webhook/)
+in Materialize to ingest data from Amazon EventBridge. By default, the source
+will be created in the active cluster; to use a different cluster, use the `IN
+CLUSTER` clause.
 
 ```sql
-CREATE SOURCE eventbridge_source IN CLUSTER webhooks_cluster
+CREATE SOURCE eventbridge_source
 FROM WEBHOOK
   BODY FORMAT JSON
   -- Include all headers, but filter out the secret.

--- a/doc/user/content/ingest-data/amazon-msk.md
+++ b/doc/user/content/ingest-data/amazon-msk.md
@@ -196,7 +196,8 @@ The process to connect Materialize to Amazon MSK consists of the following steps
 
     c. Copy the url under **Private endpoint** and against **SASL/SCRAM**. This will be your `<broker-url>` going forward.
 
-    d. From a `psql` terminal, connect to Materialize.
+    d. Connect to Materialize using the [SQL Shell](https://console.materialize.com/),
+       or your preferred SQL client.
 
     e. Create a connection using the command below. The broker URL is what you copied in step c of this subsection. The `<topic-name>` is the name of the topic you created in Step 4. The `<your-username>` and `<your-password>` is from _Store a new secret_ under Step 2.
 

--- a/doc/user/content/ingest-data/amazon-msk.md
+++ b/doc/user/content/ingest-data/amazon-msk.md
@@ -220,8 +220,10 @@ The process to connect Materialize to Amazon MSK consists of the following steps
 
 ## Creating a source
 
-The Kafka connection created in the previous section can then be reused across multiple [`CREATE SOURCE`](/sql/create-source/kafka/)
-statements:
+The Kafka connection created in the previous section can then be reused across
+multiple [`CREATE SOURCE`](/sql/create-source/kafka/) statements. By default,
+the source will be created in the active cluster; to use a different cluster,
+use the `IN CLUSTER` clause.
 
 ```sql
 CREATE SOURCE json_source

--- a/doc/user/content/ingest-data/cdc-mysql.md
+++ b/doc/user/content/ingest-data/cdc-mysql.md
@@ -13,15 +13,24 @@ menu:
     weight: 10
 ---
 
-Change Data Capture (CDC) allows you to track and propagate changes in a MySQL database to downstream consumers based on its binary log (`binlog`). In this guide, we'll cover how to use Materialize to create and efficiently maintain real-time materialized views on top of CDC data.
+Change Data Capture (CDC) allows you to track and propagate changes in a MySQL
+database to downstream consumers based on its binary log (`binlog`). In this
+guide, we'll cover how to use Materialize to create and efficiently maintain
+real-time materialized views on top of CDC data.
 
 ## Kafka + Debezium
 
-You can use [Debezium](https://debezium.io/) and the [Kafka source](/sql/create-source/kafka/#using-debezium) to propagate CDC data from MySQL to Materialize. Debezium captures row-level changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the upstream database and publishes them as events to Kafka using Kafka Connect-compatible connectors.
+You can use [Debezium](https://debezium.io/) and the [Kafka source](/sql/create-source/kafka/#using-debezium)
+to propagate CDC data from MySQL to Materialize. Debezium captures row-level
+changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the
+upstream database and publishes them as events to Kafka using Kafka
+Connect-compatible connectors.
 
 ### Database setup
 
-Before deploying a Debezium connector, you need to ensure that the upstream database is configured to support [row-based replication](https://dev.mysql.com/doc/refman/8.0/en/replication-rbr-usage.html). As _root_:
+Before deploying a Debezium connector, you need to ensure that the upstream
+database is configured to support [row-based replication](https://dev.mysql.com/doc/refman/8.0/en/replication-rbr-usage.html).
+As _root_:
 
 1. Check the `log_bin` and `binlog_format` settings:
 
@@ -30,11 +39,17 @@ Before deploying a Debezium connector, you need to ensure that the upstream data
     WHERE variable_name IN ('log_bin', 'binlog_format');
     ```
 
-    For CDC, binary logging must be enabled and use the `row` format. If your settings differ, you can adjust the database configuration file (`/etc/mysql/my.cnf`) to use `log_bin=mysql-bin` and `binlog_format=row`. Keep in mind that changing these settings requires a restart of the MySQL instance and can [affect database performance](https://dev.mysql.com/doc/refman/8.0/en/replication-sbr-rbr.html#replication-sbr-rbr-rbr-disadvantages).
+    For CDC, binary logging must be enabled and use the `row` format. If your
+    settings differ, you can adjust the database configuration file
+    (`/etc/mysql/my.cnf`) to use `log_bin=mysql-bin` and `binlog_format=row`.
+    Keep in mind that changing these settings requires a restart of the MySQL
+    instance and can [affect database performance](https://dev.mysql.com/doc/refman/8.0/en/replication-sbr-rbr.html#replication-sbr-rbr-rbr-disadvantages).
 
-    **Note:** Additional steps may be required if you're using MySQL on [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.MySQL.BinaryFormat.html).
+    **Note:** Additional steps may be required if you're using MySQL on
+      [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.MySQL.BinaryFormat.html).
 
-1. Grant enough privileges to the replication user to ensure Debezium can operate in the database:
+1. Grant enough privileges to the replication user to ensure Debezium can
+   operate in the database:
 
     ```sql
     GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO "user";
@@ -46,11 +61,14 @@ Before deploying a Debezium connector, you need to ensure that the upstream data
 
 **Minimum requirements:** Debezium 1.5+
 
-Debezium is deployed as a set of Kafka Connect-compatible
-connectors, so you first need to define a MySQL connector configuration and then start the connector by adding it to Kafka Connect.
+Debezium is deployed as a set of Kafka Connect-compatible connectors, so you
+first need to define a MySQL connector configuration and then start the
+connector by adding it to Kafka Connect.
 
 {{< warning >}}
-If you deploy the MySQL Debezium connector in [Confluent Cloud](https://docs.confluent.io/cloud/current/connectors/cc-mysql-source-cdc-debezium.html), you **must** override the default value of `After-state only` to `false`.
+
+If you deploy the MySQL Debezium connector in [Confluent Cloud](https://docs.confluent.io/cloud/current/connectors/cc-mysql-source-cdc-debezium.html),
+you **must** override the default value of `After-state only` to `false`.
 {{</ warning >}}
 
 {{< tabs >}}
@@ -79,12 +97,16 @@ If you deploy the MySQL Debezium connector in [Confluent Cloud](https://docs.con
     }
     ```
 
-    You can read more about each configuration property in the [Debezium documentation](https://debezium.io/documentation/reference/connectors/mysql.html#mysql-connector-properties).
+    You can read more about each configuration property in the
+    [Debezium documentation](https://debezium.io/documentation/reference/connectors/mysql.html#mysql-connector-properties).
 
 {{< /tab >}}
 {{< tab "Debezium 2.0+">}}
 
-1. From Debezium 2.0, Confluent Schema Registry (CSR) support is not bundled in Debezium containers. To enable CSR, you must install the following Confluent Avro converter JAR files into the Kafka Connect plugin directory (by default, `/kafka/connect`):
+1. From Debezium 2.0, Confluent Schema Registry (CSR) support is not bundled in
+   Debezium containers. To enable CSR, you must install the following Confluent
+   Avro converter JAR files into the Kafka Connect plugin directory (by default,
+   `/kafka/connect`):
 
     * `kafka-connect-avro-converter`
     * `kafka-connect-avro-data`
@@ -125,7 +147,10 @@ If you deploy the MySQL Debezium connector in [Confluent Cloud](https://docs.con
     }
     ```
 
-    You can read more about each configuration property in the [Debezium documentation](https://debezium.io/documentation/reference/2.4/connectors/mysql.html). By default, the connector writes events for each table to a Kafka topic named `serverName.databaseName.tableName`.
+    You can read more about each configuration property in the
+    [Debezium documentation](https://debezium.io/documentation/reference/2.4/connectors/mysql.html).
+    By default, the connector writes events for each table to a Kafka topic
+    named `serverName.databaseName.tableName`.
 
 {{< /tab >}}
 {{< /tabs >}}
@@ -144,7 +169,11 @@ If you deploy the MySQL Debezium connector in [Confluent Cloud](https://docs.con
     curl http://$CURRENT_HOST:8083/connectors/your-connector/status
     ```
 
-    The first time it connects to a MySQL server, Debezium takes a [consistent snapshot](https://debezium.io/documentation/reference/connectors/mysql.html#mysql-snapshots) of the tables selected for replication, so you should see that the pre-existing records in the replicated table are initially pushed into your Kafka topic:
+    The first time it connects to a MySQL server, Debezium takes a
+    [consistent snapshot](https://debezium.io/documentation/reference/connectors/mysql.html#mysql-snapshots)
+    of the tables selected for replication, so you should see that the
+    pre-existing records in the replicated table are initially pushed into your
+    Kafka topic:
 
     ```bash
     /usr/bin/kafka-avro-console-consumer \
@@ -157,7 +186,10 @@ If you deploy the MySQL Debezium connector in [Confluent Cloud](https://docs.con
 
 {{< debezium-json >}}
 
-Debezium emits change events using an envelope that contains detailed information about upstream database operations, like the `before` and `after` values for each record. To create a source that interprets the [Debezium envelope](/sql/create-source/kafka/#using-debezium) in Materialize:
+Debezium emits change events using an envelope that contains detailed
+information about upstream database operations, like the `before` and `after`
+values for each record. To create a source that interprets the
+[Debezium envelope](/sql/create-source/kafka/#using-debezium) in Materialize:
 
 ```sql
 CREATE SOURCE kafka_repl
@@ -166,13 +198,20 @@ CREATE SOURCE kafka_repl
     ENVELOPE DEBEZIUM;
 ```
 
+By default, the source will be created in the active cluster; to use a different
+cluster, use the `IN CLUSTER` clause.
+
 #### Transaction support
 
-Debezium provides [transaction metadata](https://debezium.io/documentation/reference/connectors/mysql.html#mysql-transaction-metadata) that can be used to preserve transactional boundaries downstream. We are working on using this topic to support transaction-aware processing in Materialize ([#7537](https://github.com/MaterializeInc/materialize/issues/7537))!
+Debezium provides [transaction metadata](https://debezium.io/documentation/reference/connectors/mysql.html#mysql-transaction-metadata)
+that can be used to preserve transactional boundaries downstream. We are working
+on using this topic to support transaction-aware processing in [Materialize #7537](https://github.com/MaterializeInc/materialize/issues/7537)!
 
 ### Create a materialized view
 
-Any materialized view defined on top of this source will be incrementally updated as new change events stream in through Kafka, as a result of `INSERT`, `UPDATE` and `DELETE` operations in the original MySQL database.
+Any materialized view defined on top of this source will be incrementally
+updated as new change events stream in through Kafka, as a result of `INSERT`,
+`UPDATE` and `DELETE` operations in the original MySQL database.
 
 ```sql
 CREATE MATERIALIZED VIEW cnt_table1 AS

--- a/doc/user/content/ingest-data/cdc-postgres-kafka-debezium.md
+++ b/doc/user/content/ingest-data/cdc-postgres-kafka-debezium.md
@@ -11,28 +11,38 @@ menu:
     weight: 50
 ---
 
-Change Data Capture (CDC) allows you to track and propagate changes in a Postgres database to downstream consumers based on its Write-Ahead Log (WAL).
+Change Data Capture (CDC) allows you to track and propagate changes in a
+Postgres database to downstream consumers based on its Write-Ahead Log (WAL).
 
-This guide shows you how to use [Debezium](https://debezium.io/) and [Kafka](/sql/create-source/kafka/#using-debezium) to propagate CDC data from Postgres to Materialize. Debezium captures row-level changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the upstream database and publishes them as events to Kafka using Kafka Connect-compatible connectors.
+This guide shows you how to use [Debezium](https://debezium.io/) and [Kafka](/sql/create-source/kafka/#using-debezium)
+to propagate CDC data from Postgres to Materialize. Debezium captures row-level
+changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the
+upstream database and publishes them as events to Kafka using Kafka
+Connect-compatible connectors.
 
 ### Database setup
 
 **Minimum requirements:** PostgreSQL 11+
 
-Before deploying a Debezium connector, you need to ensure that the upstream database is configured to support [logical replication](https://www.postgresql.org/docs/current/logical-replication.html).
+Before deploying a Debezium connector, you need to ensure that the upstream
+database is configured to support [logical replication](https://www.postgresql.org/docs/current/logical-replication.html).
 
 {{< tabs >}}
 {{< tab "Self-hosted">}}
 
 As a _superuser_:
 
-1. Check the [`wal_level` configuration](https://www.postgresql.org/docs/current/wal-configuration.html) setting:
+1. Check the [`wal_level` configuration](https://www.postgresql.org/docs/current/wal-configuration.html)
+   setting:
 
     ```sql
     SHOW wal_level;
     ```
 
-    The default value is `replica`. For CDC, you'll need to set it to `logical` in the database configuration file (`postgresql.conf`). Keep in mind that changing the `wal_level` requires a restart of the Postgres instance and can affect database performance.
+    The default value is `replica`. For CDC, you'll need to set it to `logical`
+    in the database configuration file (`postgresql.conf`). Keep in mind that
+    changing the `wal_level` requires a restart of the Postgres instance and
+    can affect database performance.
 
 1. Restart the database so all changes can take effect.
 
@@ -40,15 +50,21 @@ As a _superuser_:
 
 {{< tab "AWS RDS">}}
 
-We recommend following the [AWS RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication) documentation for detailed information on logical replication configuration and best practices.
+We recommend following the [AWS RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication)
+documentation for detailed information on logical replication configuration and
+best practices.
 
 As a _superuser_ (`rds_superuser`):
 
-1. Create a custom RDS parameter group and associate it with your instance. You will not be able to set custom parameters on the default RDS parameter groups.
+1. Create a custom RDS parameter group and associate it with your instance. You
+   will not be able to set custom parameters on the default RDS parameter groups.
 
-1. In the custom RDS parameter group, set the `rds.logical_replication` static parameter to `1`.
+1. In the custom RDS parameter group, set the `rds.logical_replication` static
+   parameter to `1`.
 
-1. Add the egress IP addresses associated with your Materialize region to the security group of the RDS instance. You can find these addresses by querying the `mz_egress_ips` table in Materialize.
+1. Add the egress IP addresses associated with your Materialize region to the
+   security group of the RDS instance. You can find these addresses by querying
+   the `mz_egress_ips` table in Materialize.
 
 1. Restart the database so all changes can take effect.
 
@@ -57,24 +73,34 @@ As a _superuser_ (`rds_superuser`):
 {{< tab "AWS Aurora">}}
 
 {{< note >}}
-Aurora Serverless (v1) [does **not** support](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html#aurora-serverless.limitations) logical replication, so it's not possible to use this service with Materialize.
+Aurora Serverless (v1) [does **not** support](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html#aurora-serverless.limitations)
+logical replication, so it's not possible to use this service with
+Materialize.
 {{</ note >}}
 
-We recommend following the [AWS Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Replication.Logical.html#AuroraPostgreSQL.Replication.Logical.Configure) documentation for detailed information on logical replication configuration and best practices.
+We recommend following the [AWS Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Replication.Logical.html#AuroraPostgreSQL.Replication.Logical.Configure)
+documentation for detailed information on logical replication configuration and
+best practices.
 
 As a _superuser_:
 
-1. Create a DB cluster parameter group for your instance using the following settings:
+1. Create a DB cluster parameter group for your instance using the following
+   settings:
 
     Set **Parameter group family** to your version of Aurora PostgreSQL.
 
     Set **Type** to **DB Cluster Parameter Group**.
 
-1. In the DB cluster parameter group, set the `rds.logical_replication` static parameter to `1`.
+1. In the DB cluster parameter group, set the `rds.logical_replication` static
+   parameter to `1`.
 
-1. In the DB cluster parameter group, set reasonable values for `max_replication_slots`, `max_wal_senders`, `max_logical_replication_workers`, and `max_worker_processes parameters`  based on your expected usage.
+1. In the DB cluster parameter group, set reasonable values for
+   `max_replication_slots`, `max_wal_senders`, `max_logical_replication_workers`,
+   and `max_worker_processes parameters`  based on your expected usage.
 
-1. Add the egress IP addresses associated with your Materialize region to the security group of the DB instance. You can find these addresses by querying the `mz_egress_ips` table in Materialize.
+1. Add the egress IP addresses associated with your Materialize region to the
+   security group of the DB instance. You can find these addresses by querying the
+   `mz_egress_ips` table in Materialize.
 
 1. Restart the database so all changes can take effect.
 
@@ -82,11 +108,16 @@ As a _superuser_:
 
 {{< tab "Azure DB">}}
 
-We recommend following the [Azure DB for PostgreSQL](https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-logical#pre-requisites-for-logical-replication-and-logical-decoding) documentation for detailed information on logical replication configuration and best practices.
+We recommend following the [Azure DB for PostgreSQL](https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-logical#pre-requisites-for-logical-replication-and-logical-decoding)
+documentation for detailed information on logical replication configuration and
+best practices.
 
-1. In the Azure portal, or using the Azure CLI, [enable logical replication](https://docs.microsoft.com/en-us/azure/postgresql/concepts-logical#set-up-your-server) for the PostgreSQL instance.
+1. In the Azure portal, or using the Azure CLI, [enable logical replication](https://docs.microsoft.com/en-us/azure/postgresql/concepts-logical#set-up-your-server)
+   for the PostgreSQL instance.
 
-1. Add the egress IP addresses associated with your Materialize region to the list of allowed IP addresses under the "Connections security" menu. You can find these addresses by querying the `mz_egress_ips` table in Materialize.
+1. Add the egress IP addresses associated with your Materialize region to the
+   list of allowed IP addresses under the "Connections security" menu. You can
+   find these addresses by querying the `mz_egress_ips` table in Materialize.
 
 1. Restart the database so all changes can take effect.
 
@@ -94,13 +125,18 @@ We recommend following the [Azure DB for PostgreSQL](https://docs.microsoft.com/
 
 {{< tab "Cloud SQL">}}
 
-We recommend following the [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/replication/configure-logical-replication#configuring-your-postgresql-instance) documentation for detailed information on logical replication configuration and best practices.
+We recommend following the [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/replication/configure-logical-replication#configuring-your-postgresql-instance)
+documentation for detailed information on logical replication configuration and
+best practices.
 
 As a _superuser_ (`cloudsqlsuperuser`):
 
-1. In the Google Cloud Console, enable logical replication by setting the `cloudsql.logical_decoding` configuration parameter to `on`.
+1. In the Google Cloud Console, enable logical replication by setting the
+`cloudsql.logical_decoding` configuration parameter to `on`.
 
-1. Add the egress IP addresses associated with your Materialize region to the list of allowed IP addresses. You can find these addresses by querying the `mz_egress_ips` table in Materialize.
+1. Add the egress IP addresses associated with your Materialize region to the
+list of allowed IP addresses. You can find these addresses by querying the
+`mz_egress_ips` table in Materialize.
 
 1. Restart the database so all changes can take effect.
 
@@ -110,26 +146,39 @@ As a _superuser_ (`cloudsqlsuperuser`):
 
 Once logical replication is enabled:
 
-1. Grant enough privileges to ensure Debezium can operate in the database. The specific privileges will depend on how much control you want to give to the replication user, so we recommend following the [Debezium documentation](https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-replication-user-privileges).
+1. Grant enough privileges to ensure Debezium can operate in the database. The
+   specific privileges will depend on how much control you want to give to the
+   replication user, so we recommend following the [Debezium documentation](https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-replication-user-privileges).
 
-1. If a table that you want to replicate has a **primary key** defined, you can use your default replica identity value. If a table you want to replicate has **no primary key** defined, you must set the replica identity value to `FULL`:
+1. If a table that you want to replicate has a **primary key** defined, you can
+   use your default replica identity value. If a table you want to replicate
+   has **no primary key** defined, you must set the replica identity value to
+   `FULL`:
 
     ```sql
     ALTER TABLE repl_table REPLICA IDENTITY FULL;
     ```
 
-    This setting determines the amount of information that is written to the WAL in `UPDATE` and `DELETE` operations. Setting it to `FULL` will include the previous values of all the table’s columns in the change events.
+    This setting determines the amount of information that is written to the WAL
+    in `UPDATE` and `DELETE` operations. Setting it to `FULL` will include the
+    previous values of all the table’s columns in the change events.
 
-    As a heads up, you should expect a performance hit in the database from increased CPU usage. For more information, see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/logical-replication-publication.html).
+    As a heads up, you should expect a performance hit in the database from
+    increased CPU usage. For more information, see the
+    [PostgreSQL documentation](https://www.postgresql.org/docs/current/logical-replication-publication.html).
 
 ### Deploy Debezium
 
 **Minimum requirements:** Debezium 1.5+
 
-Debezium is deployed as a set of Kafka Connect-compatible connectors, so you first need to define a Postgres connector configuration and then start the connector by adding it to Kafka Connect.
+Debezium is deployed as a set of Kafka Connect-compatible connectors, so you
+first need to define a Postgres connector configuration and then start the
+connector by adding it to Kafka Connect.
 
 {{< warning >}}
-If you deploy the PostgreSQL Debezium connector in [Confluent Cloud](https://docs.confluent.io/cloud/current/connectors/cc-mysql-source-cdc-debezium.html), you **must** override the default value of `After-state only` to `false`.
+If you deploy the PostgreSQL Debezium connector in [Confluent Cloud](https://docs.confluent.io/cloud/current/connectors/cc-mysql-source-cdc-debezium.html),
+you **must** override the default value of `After-state only` to `false`.
+
 {{</ warning >}}
 
 {{< tabs >}}
@@ -159,13 +208,18 @@ If you deploy the PostgreSQL Debezium connector in [Confluent Cloud](https://doc
     }
     ```
 
-    You can read more about each configuration property in the [Debezium documentation](https://debezium.io/documentation/reference/1.6/connectors/postgresql.html#postgresql-connector-properties). By default, the connector writes events for each table to a Kafka topic named `serverName.schemaName.tableName`.
+    You can read more about each configuration property in the [Debezium documentation](https://debezium.io/documentation/reference/1.6/connectors/postgresql.html#postgresql-connector-properties).
+    By default, the connector writes events for each table to a Kafka topic
+    named `serverName.schemaName.tableName`.
 
 
 {{< /tab >}}
 {{< tab "Debezium 2.0+">}}
 
-1. Beginning with Debezium 2.0.0, Confluent Schema Registry support is not included in the Debezium containers. To enable the Confluent Schema Registry for a Debezium container, install the following Confluent Avro converter JAR files into the Connect plugin directory:
+1. Beginning with Debezium 2.0.0, Confluent Schema Registry support is not
+   included in the Debezium containers. To enable the Confluent Schema Registry
+   for a Debezium container, install the following Confluent Avro converter JAR
+   files into the Connect plugin directory:
 
     * `kafka-connect-avro-converter`
     * `kafka-connect-avro-data`
@@ -177,7 +231,8 @@ If you deploy the PostgreSQL Debezium connector in [Confluent Cloud](https://doc
 
     You can read more about this in the [Debezium documentation](https://debezium.io/documentation/reference/stable/configuration/avro.html#deploying-confluent-schema-registry-with-debezium-containers).
 
-1. Create a connector configuration file and save it as `register-postgres.json`:
+1. Create a connector configuration file and save it as
+   `register-postgres.json`:
 
     ```json
     {
@@ -204,7 +259,9 @@ If you deploy the PostgreSQL Debezium connector in [Confluent Cloud](https://doc
     }
     ```
 
-    You can read more about each configuration property in the [Debezium documentation](https://debezium.io/documentation/reference/2.4/connectors/postgresql.html#postgresql-connector-properties). By default, the connector writes events for each table to a Kafka topic named `serverName.schemaName.tableName`.
+    You can read more about each configuration property in the [Debezium documentation](https://debezium.io/documentation/reference/2.4/connectors/postgresql.html#postgresql-connector-properties).
+    By default, the connector writes events for each table to a Kafka topic
+    named `serverName.schemaName.tableName`.
 
 {{< /tab >}}
 {{< /tabs >}}
@@ -224,7 +281,11 @@ If you deploy the PostgreSQL Debezium connector in [Confluent Cloud](https://doc
     curl http://$CURRENT_HOST:8083/connectors/your-connector/status
     ```
 
-    The first time it connects to a Postgres server, Debezium takes a [consistent snapshot](https://debezium.io/documentation/reference/1.6/connectors/postgresql.html#postgresql-snapshots) of the tables selected for replication, so you should see that the pre-existing records in the replicated table are initially pushed into your Kafka topic:
+    The first time it connects to a Postgres server, Debezium takes a
+    [consistent snapshot](https://debezium.io/documentation/reference/1.6/connectors/postgresql.html#postgresql-snapshots)
+    of the tables selected for replication, so you should see that the
+    pre-existing records in the replicated table are initially pushed into your
+    Kafka topic:
 
     ```bash
     /usr/bin/kafka-avro-console-consumer \
@@ -237,7 +298,10 @@ If you deploy the PostgreSQL Debezium connector in [Confluent Cloud](https://doc
 
 {{< debezium-json >}}
 
-Debezium emits change events using an envelope that contains detailed information about upstream database operations, like the `before` and `after` values for each record. To create a source that interprets the [Debezium envelope](/sql/create-source/kafka/#using-debezium) in Materialize:
+Debezium emits change events using an envelope that contains detailed
+information about upstream database operations, like the `before` and `after`
+values for each record. To create a source that interprets the
+[Debezium envelope](/sql/create-source/kafka/#using-debezium) in Materialize:
 
 ```sql
 CREATE SOURCE kafka_repl
@@ -246,15 +310,24 @@ CREATE SOURCE kafka_repl
     ENVELOPE DEBEZIUM;
 ```
 
-This allows you to replicate tables with `REPLICA IDENTITY DEFAULT`, `INDEX`, or `FULL`.
+By default, the source will be created in the active cluster; to use a different
+cluster, use the `IN CLUSTER` clause.
+
+This allows you to replicate tables with `REPLICA IDENTITY DEFAULT`, `INDEX`, or
+`FULL`.
 
 #### Transaction support
 
-Debezium provides [transaction metadata](https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-transaction-metadata) that can be used to preserve transactional boundaries downstream. We are working on using this topic to support transaction-aware processing in Materialize ([#7537](https://github.com/MaterializeInc/materialize/issues/7537))!
+Debezium provides [transaction metadata](https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-transaction-metadata)
+that can be used to preserve transactional boundaries downstream. We are
+working on using this topic to support transaction-aware processing in
+[Materialize #7537](https://github.com/MaterializeInc/materialize/issues/7537)!
 
 ### Create a materialized view
 
-Any materialized view defined on top of this source will be incrementally updated as new change events stream in through Kafka, as a result of `INSERT`, `UPDATE` and `DELETE` operations in the original Postgres database.
+Any materialized view defined on top of this source will be incrementally
+updated as new change events stream in through Kafka, as a result of `INSERT`,
+`UPDATE` and `DELETE` operations in the original Postgres database.
 
 ```sql
 CREATE MATERIALIZED VIEW cnt_table1 AS

--- a/doc/user/content/ingest-data/cdc-sql-server.md
+++ b/doc/user/content/ingest-data/cdc-sql-server.md
@@ -28,7 +28,8 @@ Connect-compatible connectors.
 
 ### Database setup
 
-Before deploying a Debezium connector, ensure that the upstream database is configured to support CDC.
+Before deploying a Debezium connector, ensure that the upstream database is
+configured to support CDC.
 
 1.  Enable CDC on the SQL Server instance and database:
 
@@ -44,7 +45,9 @@ Before deploying a Debezium connector, ensure that the upstream database is conf
 
 **Minimum requirements:** Debezium 1.5+
 
-Debezium is deployed as a set of Kafka Connect-compatible connectors. First, define a SQL Server connector configuration, then start the connector by adding it to Kafka Connect.
+Debezium is deployed as a set of Kafka Connect-compatible connectors. First,
+define a SQL Server connector configuration, then start the connector by adding
+it to Kafka Connect.
 
 {{< tabs >}}
 {{< tab "Debezium 1.5+">}}
@@ -79,7 +82,11 @@ Debezium is deployed as a set of Kafka Connect-compatible connectors. First, def
 {{< /tab >}}
 {{< tab "Debezium 2.0+">}}
 
-1. Beginning with Debezium 2.0.0, Confluent Schema Registry support is not included in the Debezium containers. To enable the Confluent Schema Registry for a Debezium container, install the following Confluent Avro converter JAR files into the Connect plugin directory:
+1. Beginning with Debezium 2.0.0, Confluent Schema Registry support is not
+   included in the Debezium containers. To enable the Confluent Schema Registry
+   for a Debezium container, install the following Confluent Avro converter JAR
+   files into the Connect plugin directory:
+
     * `kafka-connect-avro-converter`
     * `kafka-connect-avro-data`
     * `kafka-avro-serializer`
@@ -115,7 +122,10 @@ Debezium is deployed as a set of Kafka Connect-compatible connectors. First, def
     }
     ```
 
-    You can read more about each configuration property in the [Debezium documentation](https://debezium.io/documentation/reference/2.4/connectors/sqlserver.html). By default, the connector writes events for each table to a Kafka topic named `serverName.databaseName.tableName`.
+    You can read more about each configuration property in the
+    [Debezium documentation](https://debezium.io/documentation/reference/2.4/connectors/sqlserver.html).
+    By default, the connector writes events for each table to a Kafka topic
+    named `serverName.databaseName.tableName`.
 
 {{< /tab >}}
 {{< /tabs >}}
@@ -134,11 +144,15 @@ Debezium is deployed as a set of Kafka Connect-compatible connectors. First, def
     curl http://$CURRENT_HOST:8083/connectors/inventory-connector/status
     ```
 
-Now, Debezium will capture changes from the SQL Server database and publish them to Kafka.
+Now, Debezium will capture changes from the SQL Server database and publish them
+to Kafka.
 
 ### Create a source
 
-Debezium emits change events using an envelope that contains detailed information about upstream database operations, like the `before` and `after` values for each record. To create a source that interprets the [Debezium envelope](/sql/create-source/kafka/#using-debezium) in Materialize:
+Debezium emits change events using an envelope that contains detailed
+information about upstream database operations, like the `before` and `after`
+values for each record. To create a source that interprets the
+[Debezium envelope](/sql/create-source/kafka/#using-debezium) in Materialize:
 
 ```sql
 CREATE SOURCE kafka_repl
@@ -147,13 +161,21 @@ CREATE SOURCE kafka_repl
     ENVELOPE DEBEZIUM;
 ```
 
+By default, the source will be created in the active cluster; to use a different
+cluster, use the `IN CLUSTER` clause.
+
 #### Transaction support
 
-Debezium provides [transaction metadata](https://debezium.io/documentation/reference/connectors/sqlserver.html#sqlserver-transaction-metadata) that can be used to preserve transactional boundaries downstream. Work is in progress to utilize this topic to support transaction-aware processing in Materialize ([#7537](https://github.com/MaterializeInc/materialize/issues/7537))!
+Debezium provides [transaction metadata](https://debezium.io/documentation/reference/connectors/sqlserver.html#sqlserver-transaction-metadata)
+that can be used to preserve transactional boundaries downstream. Work is in
+progress to utilize this topic to support transaction-aware processing in
+[Materialize #7537](https://github.com/MaterializeInc/materialize/issues/7537)!
 
 ### Create a materialized view
 
-Any materialized view defined on top of this source will be incrementally updated as new change events stream in through Kafka, resulting from `INSERT`, `UPDATE`, and `DELETE` operations in the original SQL Server database.
+Any materialized view defined on top of this source will be incrementally
+updated as new change events stream in through Kafka, resulting from `INSERT`,
+`UPDATE`, and `DELETE` operations in the original SQL Server database.
 
 ```sql
 CREATE MATERIALIZED VIEW cnt_table AS
@@ -182,4 +204,5 @@ initial snapshot for all tables has been completed.
 
 ##### Supported types
 
-`DATETIMEOFFSET` columns are replicated as `text` {{% gh 8017 %}}, and `DATETIME2` columns are replicated as `bigint` {{% gh 8041 %}} in Materialize.
+`DATETIMEOFFSET` columns are replicated as `text` {{% gh 8017 %}}, and
+`DATETIME2` columns are replicated as `bigint` {{% gh 8041 %}} in Materialize.

--- a/doc/user/content/ingest-data/confluent-cloud.md
+++ b/doc/user/content/ingest-data/confluent-cloud.md
@@ -73,17 +73,20 @@ of the following steps:
 
 4. #### Create a source in Materialize
 
-    a. Open the [Confluent Cloud dashboard](https://confluent.cloud/) and select your cluster
+    a. Open the [Confluent Cloud dashboard](https://confluent.cloud/) and select your cluster.
 
-    b. Click on **Overview** and select **Cluster settings**
+    b. Click on **Overview** and select **Cluster settings**.
 
-    c. Copy the URL under **Bootstrap server**. This will be your `<broker-url>` going forward
+    c. Copy the URL under **Bootstrap server**. This will be your `<broker-url>` going forward.
 
-    d. From the _psql_ terminal, run the following command. Replace
-    `<confluent_cloud>` with whatever you want to name your source. The broker
-    URL is what you copied in step c of this subsection. The `<topic-name>` is
-    the name of the topic you created in Step 4. The `<your-api-key>` and
-    `<your-api-secret>` are from the _Create an API Key_ step.
+    d. Connect to Materialize using the [SQL Shell](https://console.materialize.com/),
+       or your preferred SQL client.
+
+    e. Run the following command. Replace `<confluent_cloud>` with whatever you
+    want to name your source. The broker URL is what you copied in step c of
+    this subsection. The `<topic-name>` is the name of the topic you created in
+    Step 4. The `<your-api-key>` and `<your-api-secret>` are from the _Create
+    an API Key_ step.
 
     ```sql
       CREATE SECRET confluent_username AS '<your-api-key>';
@@ -103,7 +106,7 @@ of the following steps:
     By default, the source will be created in the active cluster; to use a different
     cluster, use the `IN CLUSTER` clause.
 
-    e. If the command executes without an error and outputs _CREATE SOURCE_, it
+    f. If the command executes without an error and outputs _CREATE SOURCE_, it
     means that you have successfully connected Materialize to your Confluent
     Cloud Kafka cluster.
 

--- a/doc/user/content/ingest-data/confluent-cloud.md
+++ b/doc/user/content/ingest-data/confluent-cloud.md
@@ -13,26 +13,37 @@ menu:
 [//]: # "TODO(morsapaes) The Kafka guides need to be rewritten for consistency
 with the Postgres ones. We should include spill to disk in the guidance then."
 
-This guide goes through the required steps to connect Materialize to a Confluent Cloud Kafka cluster.
+This guide goes through the required steps to connect Materialize to a Confluent
+Cloud Kafka cluster.
 
-If you already have a Confluent Cloud Kafka cluster, you can skip step 1 and directly move on to [Create an API Key](#create-an-api-key). You can also skip step 3 if you already have a Confluent Cloud Kafka cluster up and running, and have created a topic that you want to create a source for.
+If you already have a Confluent Cloud Kafka cluster, you can skip step 1 and
+directly move on to [Create an API Key](#create-an-api-key). You can also skip
+step 3 if you already have a Confluent Cloud Kafka cluster up and running, and
+have created a topic that you want to create a source for.
 
-The process to connect Materialize to a Confluent Cloud Kafka cluster consists of the following steps:
+The process to connect Materialize to a Confluent Cloud Kafka cluster consists
+of the following steps:
+
 1. #### Create a Confluent Cloud Kafka cluster
-    If you already have a Confluent Cloud Kafka cluster set up, then you can skip this step.
+
+    If you already have a Confluent Cloud Kafka cluster set up, then you can
+    skip this step.
 
     a. Sign in to [Confluent Cloud](https://confluent.cloud/)
 
     b. Choose **Create a new cluster**
 
-    c. Select the cluster type, and specify the rest of the settings based on your needs
+    c. Select the cluster type, and specify the rest of the settings based on
+    your needs
 
     d. Choose **Create cluster**
 
     **Note:** This creation can take about 10 minutes. For more information on the cluster creation, see [Confluent Cloud documentation](https://docs.confluent.io/cloud/current/get-started/index.html#step-1-create-a-ak-cluster-in-ccloud).
 
 2. #### Create an API Key
+
     ##### API Key
+
     a. Navigate to the [Confluent Cloud dashboard](https://confluent.cloud/)
 
     b. Choose the Confluent Cloud Kafka cluster you just created in Step 1
@@ -41,25 +52,39 @@ The process to connect Materialize to a Confluent Cloud Kafka cluster consists o
 
     d. In the **API Keys** section, choose **Add Key**
 
-    e. Specify the scope for the API key and then click **Create Key**. If you choose to create a _granular access_ API key, make sure to create a [service account](https://docs.confluent.io/cloud/current/access-management/identity/service-accounts.html#create-a-service-account-using-the-ccloud-console) and add an [ACL](https://docs.confluent.io/cloud/current/access-management/access-control/acl.html#use-access-control-lists-acls-for-ccloud) with `Read` access to the topic you want to create a source for.
+    e. Specify the scope for the API key and then click **Create Key**. If you
+    choose to create a _granular access_ API key, make sure to create a
+    [service account](https://docs.confluent.io/cloud/current/access-management/identity/service-accounts.html#create-a-service-account-using-the-ccloud-console)
+    and add an [ACL](https://docs.confluent.io/cloud/current/access-management/access-control/acl.html#use-access-control-lists-acls-for-ccloud)
+    with `Read` access to the topic you want to create a source for.
 
-    Take note of the API Key you just created, as well as the API Key secret key; you'll need them later on. Keep in mind that the API Key secret key contains sensitive information, and you should store it somewhere safe!
+    Take note of the API Key you just created, as well as the API Key secret
+    key; you'll need them later on. Keep in mind that the API Key secret key
+    contains sensitive information, and you should store it somewhere safe!
 
 3. #### Create a topic
-    To start using Materialize with Confluent Cloud, you need to point it to an existing Kafka topic you want to read data from.
+
+    To start using Materialize with Confluent Cloud, you need to point it to an
+    existing Kafka topic you want to read data from.
 
     If you already have a topic created, you can skip this step.
 
     Otherwise, you can find more information about how to do that [here](https://docs.confluent.io/cloud/current/get-started/index.html#step-2-create-a-ak-topic).
 
 4. #### Create a source in Materialize
+
     a. Open the [Confluent Cloud dashboard](https://confluent.cloud/) and select your cluster
 
     b. Click on **Overview** and select **Cluster settings**
 
     c. Copy the URL under **Bootstrap server**. This will be your `<broker-url>` going forward
 
-    d. From the _psql_ terminal, run the following command. Replace `<confluent_cloud>` with whatever you want to name your source. The broker URL is what you copied in step c of this subsection. The `<topic-name>` is the name of the topic you created in Step 4. The `<your-api-key>` and `<your-api-secret>` are from the _Create an API Key_ step.
+    d. From the _psql_ terminal, run the following command. Replace
+    `<confluent_cloud>` with whatever you want to name your source. The broker
+    URL is what you copied in step c of this subsection. The `<topic-name>` is
+    the name of the topic you created in Step 4. The `<your-api-key>` and
+    `<your-api-secret>` are from the _Create an API Key_ step.
+
     ```sql
       CREATE SECRET confluent_username AS '<your-api-key>';
       CREATE SECRET confluent_password AS '<your-api-secret>';
@@ -75,6 +100,8 @@ The process to connect Materialize to a Confluent Cloud Kafka cluster consists o
         FROM KAFKA CONNECTION confluent_cloud (TOPIC '<topic-name>')
         FORMAT JSON;
     ```
+    By default, the source will be created in the active cluster; to use a different
+    cluster, use the `IN CLUSTER` clause.
 
     e. If the command executes without an error and outputs _CREATE SOURCE_, it
     means that you have successfully connected Materialize to your Confluent

--- a/doc/user/content/ingest-data/hubspot.md
+++ b/doc/user/content/ingest-data/hubspot.md
@@ -18,7 +18,12 @@ Ensure that you have:
 
 ## Step 1. (Optional) Create a cluster
 
-If you already have a cluster for your webhook sources, you can skip this step.
+{{< note >}}
+If you are prototyping and already have a cluster to host your webhook
+source (e.g. `quickstart`), **you can skip this step**. For production
+scenarios, we recommend separating your workloads into multiple clusters for
+[resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
+{{< /note >}}
 
 To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/create-cluster):
 

--- a/doc/user/content/ingest-data/hubspot.md
+++ b/doc/user/content/ingest-data/hubspot.md
@@ -24,6 +24,8 @@ To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/crea
 
 ```sql
 CREATE CLUSTER webhooks_cluster (SIZE = '3xsmall');
+
+SET CLUSTER = webhooks_cluster;
 ```
 
 ## Step 2. Create a secret
@@ -39,11 +41,13 @@ a secure location.
 
 ## Step 3. Set up a webhook source
 
-Using the secret from the previous step, create a [webhook source](/sql/create-source/webhook/)
-in Materialize to ingest data from HubSpot:
+Using the secret the previous step, create a [webhook source](/sql/create-source/webhook/)
+in Materialize to ingest data from HubSpot. By default, the source will be
+created in the active cluster; to use a different cluster, use the `IN
+CLUSTER` clause.
 
 ```sql
-CREATE SOURCE hubspot_source IN CLUSTER webhooks_cluster
+CREATE SOURCE hubspot_source
   FROM WEBHOOK
     BODY FORMAT JSON
     CHECK (

--- a/doc/user/content/ingest-data/kafka-self-hosted.md
+++ b/doc/user/content/ingest-data/kafka-self-hosted.md
@@ -14,7 +14,8 @@ menu:
 [//]: # "TODO(morsapaes) The Kafka guides need to be rewritten for consistency
 with the Postgres ones. We should include spill to disk in the guidance then."
 
-This guide goes through the required steps to connect Materialize to a self-hosted Kafka cluster.
+This guide goes through the required steps to connect Materialize to a
+self-hosted Kafka cluster.
 
 ## Before you begin
 
@@ -25,13 +26,18 @@ Before you begin, you must have:
 
 ## Configure network security
 
-There are various ways to configure your Kafka network to allow Materialize to connect:
+There are various ways to configure your Kafka network to allow Materialize to
+connect:
 
-- **Use AWS PrivateLink**: If your Kafka cluster is running on AWS, you can use AWS PrivateLink to connect Materialize to the cluster.
+- **Use AWS PrivateLink**: If your Kafka cluster is running on AWS, you can use
+    AWS PrivateLink to connect Materialize to the cluster.
 
-- **Use an SSH tunnel**: If your Kafka cluster is running in a private network, you can use an SSH tunnel to connect Materialize to the cluster.
+- **Use an SSH tunnel**: If your Kafka cluster is running in a private network,
+    you can use an SSH tunnel to connect Materialize to the cluster.
 
-- **Allow Materialize IPs**: If your Kafka cluster is publicly accessible, you can configure your firewall to allow connections from a set of static Materialize IP addresses.
+- **Allow Materialize IPs**: If your Kafka cluster is publicly accessible, you
+    can configure your firewall to allow connections from a set of static
+    Materialize IP addresses.
 
 Select the option that works best for you.
 
@@ -40,8 +46,12 @@ Select the option that works best for you.
 {{< tab "Privatelink">}}
 
 {{< note >}}
-Materialize provides Terraform modules for both [Amazon MSK clusters](https://github.com/MaterializeInc/terraform-aws-msk-privatelink) and [self-managed Kafka clusters](https://github.com/MaterializeInc/terraform-aws-kafka-privatelink) which can be used to create the target groups for each Kafka broker (step 1), the network load balancer (step 2),
-the TCP listeners (step 3) and the VPC endpoint service (step 5).
+Materialize provides Terraform modules for both [Amazon MSK clusters](https://github.com/MaterializeInc/terraform-aws-msk-privatelink)
+and [self-managed Kafka clusters](https://github.com/MaterializeInc/terraform-aws-kafka-privatelink)
+which can be used to create the target groups for each Kafka broker (step 1),
+the network load balancer (step 2), the TCP listeners (step 3) and the VPC
+endpoint service (step 5).
+
 {{< /note >}}
 
 {{% network-security/privatelink-kafka %}}
@@ -54,7 +64,8 @@ the TCP listeners (step 3) and the VPC endpoint service (step 5).
 
 ## Create a source connection
 
-In Materialize, create a source connection that uses the SSH tunnel connection you configured in the previous section:
+In Materialize, create a source connection that uses the SSH tunnel connection
+you configured in the previous section:
 
 ```sql
 CREATE CONNECTION kafka_connection TO KAFKA (
@@ -67,15 +78,18 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 
 {{< tab "Allow Materialize IPs">}}
 
-1. In the `psql` shell connected to Materialize, find the static egress IP addresses for the Materialize region you are running in:
+1. In the `psql` shell connected to Materialize, find the static egress IP
+   addresses for the Materialize region you are running in:
 
     ```sql
     SELECT * FROM mz_egress_ips;
     ```
 
-1. Update your Kafka cluster firewall rules to allow traffic from each IP address from the previous step.
+1. Update your Kafka cluster firewall rules to allow traffic from each IP
+   address from the previous step.
 
-1. Create a [`KAFKA`](/sql/create-connection/#kafka) connection that references your Kafka cluster:
+1. Create a [Kafka connection](/sql/create-connection/#kafka) that references
+   your Kafka cluster:
 
     ```sql
     CREATE SECRET kafka_password AS '<your-password>';
@@ -94,14 +108,17 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 
 ## Creating a source
 
-The Kafka connection created in the previous section can then be reused across multiple [`CREATE SOURCE`](/sql/create-source/kafka/)
-statements:
+The Kafka connection created in the previous section can then be reused across
+multiple [`CREATE SOURCE`](/sql/create-source/kafka/) statements:
 
 ```sql
 CREATE SOURCE json_source
   FROM KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
   FORMAT JSON;
 ```
+
+By default, the source will be created in the active cluster; to use a different
+cluster, use the `IN CLUSTER` clause.
 
 ## Related pages
 

--- a/doc/user/content/ingest-data/kafka-self-hosted.md
+++ b/doc/user/content/ingest-data/kafka-self-hosted.md
@@ -78,8 +78,9 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 
 {{< tab "Allow Materialize IPs">}}
 
-1. In the `psql` shell connected to Materialize, find the static egress IP
-   addresses for the Materialize region you are running in:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, find the static egress IP addresses for the
+   Materialize region you are running in:
 
     ```sql
     SELECT * FROM mz_egress_ips;

--- a/doc/user/content/ingest-data/postgres-alloydb.md
+++ b/doc/user/content/ingest-data/postgres-alloydb.md
@@ -8,19 +8,24 @@ menu:
     weight: 25
 ---
 
-This page shows you how to stream data from [AlloyDB](https://cloud.google.com/alloydb) to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
+This page shows you how to stream data from [AlloyDB](https://cloud.google.com/alloydb)
+to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
 
 ## Before you begin
 
 {{% postgres-direct/before-you-begin %}}
 
-If you don't already have an AlloyDB instance, creating one involves several steps, including configuring your cluster and setting up network connections. For detailed instructions, refer to the [AlloyDB documentation](https://cloud.google.com/alloydb/docs).
+If you don't already have an AlloyDB instance, creating one involves several
+steps, including configuring your cluster and setting up network connections.
+For detailed instructions, refer to the [AlloyDB documentation](https://cloud.google.com/alloydb/docs).
 
 ## Step 1. Enable logical replication
 
-Materialize uses PostgreSQL's [logical replication](https://www.postgresql.org/docs/current/logical-replication.html) protocol to track changes in your database and propagate them to Materialize.
+Materialize uses PostgreSQL's [logical replication](https://www.postgresql.org/docs/current/logical-replication.html)
+protocol to track changes in your database and propagate them to Materialize.
 
-For guidance on enabling logical replication in AlloyDB, see the [AlloyDB documentation](https://cloud.google.com/datastream/docs/configure-your-source-postgresql-database#configure_alloydb_for_replication).
+For guidance on enabling logical replication in AlloyDB, see the
+[AlloyDB documentation](https://cloud.google.com/datastream/docs/configure-your-source-postgresql-database#configure_alloydb_for_replication).
 
 ## Step 2. Create a publication
 
@@ -28,60 +33,84 @@ For guidance on enabling logical replication in AlloyDB, see the [AlloyDB docume
 
 ## Step 3. Configure network security
 
-To establish authorized and secure connections to an AlloyDB instance, an authentication proxy is necessary. The Google Cloud Platform offers a guide [here](https://cloud.google.com/alloydb/docs/auth-proxy/connect) to assist you in setting up this proxy and generating a connection string that can be utilized with Materialize. Further down, we will provide you with a tailored approach specific to integrating Materialize.
+To establish authorized and secure connections to an AlloyDB instance, an
+authentication proxy is necessary. Google Cloud Platform provides [a guide](https://cloud.google.com/alloydb/docs/auth-proxy/connect)
+to assist you in setting up this proxy and generating a connection string that
+can be utilized with Materialize. Further down, we will provide you with a
+tailored approach specific to integrating Materialize.
 
-Next, choose the best network configuration for your setup to connect Materialize with AlloyDB:
+Next, choose the best network configuration for your setup to connect
+Materialize with AlloyDB:
 
-- **Allow Materialize IPs:** If your AlloyDB instance is publicly accessible, configure your firewall to allow connections from Materialize IP addresses.
-- **Use an SSH tunnel:** For private networks, use an SSH tunnel to connect Materialize to AlloyDB.
+- **Allow Materialize IPs:** If your AlloyDB instance is publicly accessible,
+    configure your firewall to allow connections from Materialize IP
+    addresses.
+- **Use an SSH tunnel:** For private networks, use an SSH tunnel to connect
+    Materialize to AlloyDB.
 
 {{< tabs >}}
 
 {{< tab "Allow Materialize IPs">}}
 
-1. In the `psql` shell connected to Materialize, find the static egress IP addresses for the Materialize region you are running in:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, find the static egress IP addresses for the
+   Materialize region you are running in:
 
     ```sql
     SELECT * FROM mz_egress_ips;
     ```
 
-1. Update your Google Cloud firewall rules to allow traffic to your AlloyDB auth proxy instance from each IP address from the previous step.
+1. Update your Google Cloud firewall rules to allow traffic to your AlloyDB auth
+   proxy instance from each IP address from the previous step.
 
 {{< /tab >}}
 
 {{< tab "Use an SSH tunnel">}}
 
-To create an SSH tunnel from Materialize to your database, you launch an instance to serve as an SSH bastion host, configure the bastion host to allow traffic only from Materialize, and then configure your database's private network to allow traffic from the bastion host.
+To create an SSH tunnel from Materialize to your database, you launch an
+instance to serve as an SSH bastion host, configure the bastion host to allow
+traffic only from Materialize, and then configure your database's private
+network to allow traffic from the bastion host.
 
-1. [Launch a GCE instance](https://cloud.google.com/compute/docs/instances/create-start-instance) to serve as your SSH bastion host.
+1. [Launch a GCE instance](https://cloud.google.com/compute/docs/instances/create-start-instance) to
+    serve as your SSH bastion host.
 
-    - Make sure the instance is publicly accessible and in the same VPC as your database.
-    - Add a key pair and note the username. You'll use this username when connecting Materialize to your bastion host.
-    - Make sure the VM has a [static public IP address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address). You'll use this IP address when connecting Materialize to your bastion host.
+    - Make sure the instance is publicly accessible and in the same VPC as your
+      database.
+    - Add a key pair and note the username. You'll use this username when
+      connecting Materialize to your bastion host.
+    - Make sure the VM has a [static public IP address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address).
+      You'll use this IP address when connecting Materialize to your bastion
+      host.
 
 1. Configure the SSH bastion host to allow traffic only from Materialize.
 
-    1. In the `psql` shell connected to Materialize, get the static egress IP addresses for the Materialize region you are running in:
+    1. In the [SQL Shell](https://console.materialize.com/), or your preferred
+       SQL client connected to Materialize, get the static egress IP addresses for
+       the Materialize region you are running in:
 
-        ```sql
-        SELECT * FROM mz_egress_ips;
-        ```
+       ```sql
+       SELECT * FROM mz_egress_ips;
+       ```
 
-    1. Update your SSH bastion host's firewall rules to allow traffic from each IP address from the previous step.
+    1. Update your SSH bastion host's firewall rules to allow traffic from each
+       IP address from the previous step.
 
-1. Update your Google Cloud firewall rules to allow traffic to your AlloyDB auth proxy instance from the SSH bastion host.
+1. Update your Google Cloud firewall rules to allow traffic to your AlloyDB auth
+   proxy instance from the SSH bastion host.
 
 {{< /tab >}}
 
 {{< /tabs >}}
 
-## Step 5. Create an ingestion cluster
+## Step 5. (Optional) Create a cluster
 
 {{% postgres-direct/create-an-ingestion-cluster %}}
 
 ## Step 6. Start ingesting data
 
-With the network configured and an ingestion pipeline in place, connect Materialize to your AlloyDB instance and begin the data ingestion process.
+With the network configured and an ingestion pipeline in place, connect
+Materialize to your AlloyDB instance and begin the data ingestion process.
 
 {{< tabs >}}
 

--- a/doc/user/content/ingest-data/postgres-alloydb.md
+++ b/doc/user/content/ingest-data/postgres-alloydb.md
@@ -105,7 +105,14 @@ network to allow traffic from the bastion host.
 
 ## Step 5. (Optional) Create a cluster
 
-{{% postgres-direct/create-an-ingestion-cluster %}}
+{{< note >}}
+If you are prototyping and already have a cluster to host your PostgreSQL
+source (e.g. `quickstart`), **you can skip this step**. For production
+scenarios, we recommend separating your workloads into multiple clusters for
+[resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
+{{< /note >}}
+
+{{% postgres-direct/create-a-cluster %}}
 
 ## Step 6. Start ingesting data
 

--- a/doc/user/content/ingest-data/postgres-amazon-aurora.md
+++ b/doc/user/content/ingest-data/postgres-amazon-aurora.md
@@ -225,7 +225,14 @@ configuration of resources for an SSH tunnel. For more details, see the
 
 ## Step 4. (Optional) Create a cluster
 
-{{% postgres-direct/create-an-ingestion-cluster %}}
+{{< note >}}
+If you are prototyping and already have a cluster to host your PostgreSQL
+source (e.g. `quickstart`), **you can skip this step**. For production
+scenarios, we recommend separating your workloads into multiple clusters for
+[resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
+{{< /note >}}
+
+{{% postgres-direct/create-a-cluster %}}
 
 ## Step 5. Start ingesting data
 

--- a/doc/user/content/ingest-data/postgres-amazon-aurora.md
+++ b/doc/user/content/ingest-data/postgres-amazon-aurora.md
@@ -8,7 +8,8 @@ menu:
     weight: 10
 ---
 
-This page shows you how to stream data from [Amazon Aurora for PostgreSQL](https://aws.amazon.com/rds/aurora/) to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
+This page shows you how to stream data from [Amazon Aurora for PostgreSQL](https://aws.amazon.com/rds/aurora/)
+to Materialize using the[PostgreSQL source](/sql/create-source/postgres/).
 
 ## Before you begin
 
@@ -16,12 +17,16 @@ This page shows you how to stream data from [Amazon Aurora for PostgreSQL](https
 
 ## Step 1. Enable logical replication
 
-Materialize uses PostgreSQL's [logical replication](https://www.postgresql.org/docs/current/logical-replication.html) protocol to track changes in your database and propagate them to Materialize.
+Materialize uses PostgreSQL's [logical replication](https://www.postgresql.org/docs/current/logical-replication.html)
+protocol to track changes in your database and propagate them to Materialize.
 
-For guidance on enabling logical replication in Aurora, see the [Aurora documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Replication.Logical.html#AuroraPostgreSQL.Replication.Logical.Configure).
+For guidance on enabling logical replication in Aurora, see the
+[Aurora documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Replication.Logical.html#AuroraPostgreSQL.Replication.Logical.Configure).
 
 {{< note >}}
-Aurora Serverless (v1) [does **not** support](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html#aurora-serverless.limitations) logical replication, so it's not possible to use this service with Materialize.
+Aurora Serverless (v1) [does **not** support](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html#aurora-serverless.limitations)
+logical replication, so it's not possible to use this service with
+Materialize.
 {{</ note >}}
 
 ## Step 2. Create a publication
@@ -30,11 +35,16 @@ Aurora Serverless (v1) [does **not** support](https://docs.aws.amazon.com/Amazon
 
 ## Step 3. Configure network security
 
-There are various ways to configure your database's network to allow Materialize to connect:
+There are various ways to configure your database's network to allow Materialize
+to connect:
 
-- **Allow Materialize IPs:** If your database is publicly accessible, you can configure your database's security group to allow connections from a set of static Materialize IP addresses.
+- **Allow Materialize IPs:** If your database is publicly accessible, you can
+    configure your database's security group to allow connections from a set of
+    static Materialize IP addresses.
 
-- **Use AWS PrivateLink** or **Use an SSH tunnel:** If your database is running in a private network, you can use either [AWS PrivateLink](https://aws.amazon.com/privatelink/) or an SSH tunnel to connect Materialize to the database.
+- **Use AWS PrivateLink** or **Use an SSH tunnel:** If your database is running
+    in a private network, you can use either [AWS PrivateLink](https://aws.amazon.com/privatelink/)
+    or an SSH tunnel to connect Materialize to the database.
 
 Select the option that works best for you.
 
@@ -42,13 +52,16 @@ Select the option that works best for you.
 
 {{< tab "Allow Materialize IPs">}}
 
-1. In the `psql` shell connected to Materialize, find the static egress IP addresses for the Materialize region you are running in:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, find the static egress IP addresses for the
+   Materialize region you are running in:
 
     ```sql
     SELECT * FROM mz_egress_ips;
     ```
 
-1. [Add an inbound rule to your Aurora security group](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Overview.RDSSecurityGroups.html) for each IP address from the previous step.
+1. [Add an inbound rule to your Aurora security group](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Overview.RDSSecurityGroups.html)
+    for each IP address from the previous step.
 
     In each rule:
 
@@ -61,25 +74,33 @@ Select the option that works best for you.
 
 {{< public-preview />}}
 
-[AWS PrivateLink](https://aws.amazon.com/privatelink/) lets you connect Materialize to your Aurora instance without exposing traffic to the public internet. To use AWS PrivateLink, you create a network load balancer in the same VPC as your Aurora instance and a VPC endpoint service that Materialize connects to. The VPC endpoint service then routes requests from Materialize to Aurora via the network load balancer.
+[AWS PrivateLink](https://aws.amazon.com/privatelink/) lets you connect
+Materialize to your Aurora instance without exposing traffic to the public
+internet. To use AWS PrivateLink, you create a network load balancer in the
+same VPC as your Aurora instance and a VPC endpoint service that Materialize
+connects to. The VPC endpoint service then routes requests from Materialize to
+Aurora via the network load balancer.
 
 {{< note >}}
-Materialize provides a Terraform module that automates the creation and configuration of AWS resources for a PrivateLink connection. For more details, see the [Terraform module repository](https://github.com/MaterializeInc/terraform-aws-rds-privatelink).
+Materialize provides a Terraform module that automates the creation and
+configuration of AWS resources for a PrivateLink connection. For more details,
+see the [Terraform module repository](https://github.com/MaterializeInc/terraform-aws-rds-privatelink).
 {{</ note >}}
 
 1. Get the IP address of your Aurora instance.
 
-    You'll need this address to register your Aurora instance as the target for the network load balancer in the next step.
+    You'll need this address to register your Aurora instance as the target for
+    the network load balancer in the next step.
 
     To get the IP address of your database instance:
 
-    1. Select your database in the RDS Console.
-    1. Find your Aurora endpoint under **Connectivity & security**.
-    1. Use the `dig` or `nslooklup` command to find the IP address that the endpoint resolves to:
+    1. Select your database in the RDS Console. 1. Find your Aurora endpoint
+    under **Connectivity & security**. 1. Use the `dig` or `nslooklup` command
+    to find the IP address that the endpoint resolves to:
 
-        ```sh
-        dig +short <AURORA_ENDPOINT>
-        ```
+       ```sh
+       dig +short <AURORA_ENDPOINT>
+       ```
 
 1. [Create a dedicated target group for your Aurora instance](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-target-group.html).
 
@@ -89,93 +110,146 @@ Materialize provides a Terraform module that automates the creation and configur
 
     - Choose the same VPC as your RDS instance.
 
-    - Use the IP address from the previous step to register your Aurora instance as the target.
+    - Use the IP address from the previous step to register your Aurora instance
+      as the target.
 
-    **Warning:** The IP address of your Aurora instance can change without notice. For this reason, it's best to set up automation to regularly check the IP of the instance and update your target group accordingly. You can use a lambda function to automate this process - see Materialize's [Terraform module for AWS PrivateLink](https://github.com/MaterializeInc/terraform-aws-rds-privatelink/blob/main/lambda_function.py) for an example. Another approach is to [configure an EC2 instance as an RDS router](https://aws.amazon.com/blogs/database/how-to-use-amazon-rds-and-amazon-aurora-with-a-static-ip-address/) for your network load balancer.
+    **Warning:** The IP address of your Aurora instance can change without
+      notice. For this reason, it's best to set up automation to regularly
+      check the IP of the instance and update your target group accordingly.
+      You can use a lambda function to automate this process - see
+      Materialize's [Terraform module for AWS PrivateLink](https://github.com/MaterializeInc/terraform-aws-rds-privatelink/blob/main/lambda_function.py)
+      for an example. Another approach is to [configure an EC2 instance as an
+      RDS router](https://aws.amazon.com/blogs/database/how-to-use-amazon-rds-and-amazon-aurora-with-a-static-ip-address/)
+      for your network load balancer.
 
 1. [Create a network load balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-network-load-balancer.html).
 
-    - For **Network mapping**, choose the same VPC as your RDS instance and select all of the availability zones and subnets that you RDS instance is in.
+    - For **Network mapping**, choose the same VPC as your RDS instance and
+      select all of the availability zones and subnets that you RDS instance is
+      in.
 
-    - For **Listeners and routing**, set the protocol and port to **TCP** and **5432** and select the target group you created in the previous step.
+    - For **Listeners and routing**, set the protocol and port to **TCP**
+      and **5432** and select the target group you created in the previous
+      step.
 
-1. In the security group of your Aurora instance, [allow traffic from the the network load balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html).
+1. In the security group of your Aurora instance, [allow traffic from the the
+   network load balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html).
 
-    If [client IP preservation](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#client-ip-preservation) is disabled, the easiest approach is to add an inbound rule with the VPC CIDR of the network load balancer. If you don't want to grant access to the entire VPC CIDR, you can add inbound rules for the private IP addresses of the load balancer subnets.
+    If [client IP preservation](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#client-ip-preservation)
+    is disabled, the easiest approach is to add an inbound rule with the VPC
+    CIDR of the network load balancer. If you don't want to grant access to the
+    entire VPC CIDR, you can add inbound rules for the private IP addresses of
+    the load balancer subnets.
 
-    - To find the VPC CIDR, go to the network load balancer and look under **Network mapping**.
-    - To find the private IP addresses of the load balancer subnets, go to **Network Interfaces**, search for the name of the network load balancer, and look on the **Details** tab for each matching network interface.
+    - To find the VPC CIDR, go to the network load balancer and look
+      under **Network mapping**.
+
+    - To find the private IP addresses of the load balancer subnets, go
+      to **Network Interfaces**, search for the name of the network load
+      balancer, and look on the **Details** tab for each matching network
+      interface.
 
 1. [Create a VPC endpoint service](https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html).
 
-    - For **Load balancer type**, choose **Network** and then select the network load balancer you created in the previous step.
+    - For **Load balancer type**, choose **Network** and then select the network
+      load balancer you created in the previous step.
 
-    - After creating the VPC endpoint service, note its **Service name**. You'll use this service name when connecting Materialize later.
+    - After creating the VPC endpoint service, note its **Service name**. You'll
+      use this service name when connecting Materialize later.
 
-    **Remarks**
-    By disabling [Acceptance Required](https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests), while still strictly managing who can view your endpoint via IAM, Materialze will be able to seamlessly recreate and migrate endpoints as we work to stabilize this feature.
+    **Remarks** By disabling [Acceptance Required](https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests),
+      while still strictly managing who can view your endpoint via IAM,
+      Materialze will be able to seamlessly recreate and migrate endpoints as
+      we work to stabilize this feature.
 
-1. Go back to the target group you created for the network load balancer and make sure that the [health checks](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html) are reporting the targets as healthy.
+1. Go back to the target group you created for the network load balancer and
+   make sure that the [health checks](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html)
+   are reporting the targets as healthy.
 
 {{< /tab >}}
 
 {{< tab "Use an SSH tunnel">}}
 
-To create an SSH tunnel from Materialize to your database, you launch an instance to serve as an SSH bastion host, configure the bastion host to allow traffic only from Materialize, and then configure your database's private network to allow traffic from the bastion host.
+To create an SSH tunnel from Materialize to your database, you launch an
+instance to serve as an SSH bastion host, configure the bastion host to allow
+traffic only from Materialize, and then configure your database's private
+network to allow traffic from the bastion host.
 
 {{< note >}}
-Materialize provides a Terraform module that automates the creation and configuration of resources for an SSH tunnel. For more details, see the [Terraform module repository](https://github.com/MaterializeInc/terraform-aws-ec2-ssh-bastion).
+Materialize provides a Terraform module that automates the creation and
+configuration of resources for an SSH tunnel. For more details, see the
+[Terraform module repository](https://github.com/MaterializeInc/terraform-aws-ec2-ssh-bastion).
 {{</ note >}}
 
-1. [Launch an EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/LaunchingAndUsingInstances.html) to serve as your SSH bastion host.
+1. [Launch an EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/LaunchingAndUsingInstances.html)
+    to serve as your SSH bastion host.
 
-    - Make sure the instance is publicly accessible and in the same VPC as your RDS instance.
-    - Add a key pair and note the username. You'll use this username when connecting Materialize to your bastion host.
+    - Make sure the instance is publicly accessible and in the same VPC as your
+      RDS instance.
 
-    **Warning:** Auto-assigned public IP addresses can change in [certain cases](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-public-addresses). For this reason, it's best to associate an [elastic IP address](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#ip-addressing-eips) to your bastion host.
+    - Add a key pair and note the username. You'll use this username when
+      connecting Materialize to your bastion host.
+
+    **Warning:** Auto-assigned public IP addresses can change in [certain cases](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-public-addresses).
+      For this reason, it's best to associate an [elastic IP address](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#ip-addressing-eips)
+      to your bastion host.
 
 1. Configure the SSH bastion host to allow traffic only from Materialize.
 
-    1. In the `psql` shell connected to Materialize, get the static egress IP addresses for the Materialize region you are running in:
+    1. In the [SQL Shell](https://console.materialize.com/), or your preferred
+       SQL client connected to Materialize, get the static egress IP addresses for
+       the Materialize region you are running in:
 
-        ```sql
-        SELECT * FROM mz_egress_ips;
-        ```
+       ```sql
+       SELECT * FROM mz_egress_ips;
+       ```
 
-    1. For each static egress IP, [add an inbound rule](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html) to your SSH bastion host's security group.
+    1. For each static egress IP, [add an inbound rule](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html)
+       to your SSH bastion host's security group.
 
         In each rule:
+
         - Set **Type** to **PostgreSQL**.
         - Set **Source** to the IP address in CIDR notation.
 
-1. In the security group of your RDS instance, [add an inbound rule](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html) to allow traffic from the SSH bastion host.
+1. In the security group of your RDS instance, [add an inbound rule](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html)
+   to allow traffic from the SSH bastion host.
 
     - Set **Type** to **All TCP**.
-    - Set **Source** to **Custom** and select the bastion host's security group.
+    - Set **Source** to **Custom** and select the bastion host's security
+      group.
 
 {{< /tab >}}
 
 {{< /tabs >}}
 
-## Step 4. Create an ingestion cluster
+## Step 4. (Optional) Create a cluster
 
 {{% postgres-direct/create-an-ingestion-cluster %}}
 
 ## Step 5. Start ingesting data
 
-Now that you've configured your database network and created an ingestion cluster, you can connect Materialize to your PostgreSQL database and start ingesting data. The exact steps depend on your networking configuration, so start by selecting the relevant option.
+Now that you've configured your database network and created an ingestion
+cluster, you can connect Materialize to your PostgreSQL database and start
+ingesting data. The exact steps depend on your networking configuration, so
+start by selecting the relevant option.
 
 {{< tabs >}}
 
 {{< tab "Allow Materialize IPs">}}
 
-1. In the `psql` shell connected to Materialize, use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, use the [`CREATE SECRET`](/sql/create-secret/)
+   command to securely store the password for the `materialize` PostgreSQL user you
+   created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
-1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create a connection object with access and authentication details for Materialize to use:
+1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create a
+   connection object with access and authentication details for Materialize to
+   use:
 
     ```sql
     CREATE CONNECTION pg_connection TO POSTGRES (
@@ -188,16 +262,22 @@ Now that you've configured your database network and created an ingestion cluste
       );
     ```
 
-    - Replace `<host>` with the **Writer** endpoint for your Aurora database. To find the endpoint, select your database in the RDS Console, then click the **Connectivity & security** tab and look for the endpoint with type **Writer**.
+    - Replace `<host>` with the **Writer** endpoint for your Aurora database. To
+      find the endpoint, select your database in the RDS Console, then click
+      the **Connectivity & security** tab and look for the endpoint with
+      type **Writer**.
 
         <div class="warning">
             <strong class="gutter">WARNING!</strong>
             You must use the <strong>Writer</strong> endpoint for the database. Using a <strong>Reader</strong> endpoint will not work.
         </div>
 
-    - Replace `<database>` with the name of the database containing the tables you want to replicate to Materialize.
+    - Replace `<database>` with the name of the database containing the tables
+      you want to replicate to Materialize.
 
-1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your Aurora instance and start ingesting data from the publication you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize
+   to your Aurora instance and start ingesting data from the publication you
+   created [earlier](#step-2-create-a-publication).
 
     ```sql
     CREATE SOURCE mz_source
@@ -206,15 +286,23 @@ Now that you've configured your database network and created an ingestion cluste
       FOR ALL TABLES;
     ```
 
-    To ingest data from specific schemas or tables in your publication, use `FOR SCHEMAS (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR ALL TABLES`.
+    By default, the source will be created in the active cluster; to use a
+    different cluster, use the `IN CLUSTER` clause. To ingest data from
+    specific schemas or tables in your publication, use `FOR SCHEMAS
+    (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR
+    ALL TABLES`.
 
-1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes) for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP} SUBSOURCE`](/sql/alter-source/#context) syntax.
+1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
+   for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP} SUBSOURCE`](/sql/alter-source/#context)
+   syntax.
 
 {{< /tab >}}
 
 {{< tab "Use AWS PrivateLink">}}
 
-1. In the `psql` shell connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#aws-privatelink) command to create an AWS PrivateLink connection:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#aws-privatelink)
+   command to create an AWS PrivateLink connection:
 
     ```sql
     CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
@@ -225,9 +313,13 @@ Now that you've configured your database network and created an ingestion cluste
 
     - Replace the `SERVICE NAME` value with the service name you noted [earlier](#step-3-configure-network-security).
 
-    - Replace the `AVAILABILITY ZONES` list with the IDs of the availability zones in your AWS account.
+    - Replace the `AVAILABILITY ZONES` list with the IDs of the availability
+      zones in your AWS account.
 
-      To find your availability zone IDs, select your database in the RDS Console and click the subnets under **Connectivity & security**. For each subnet, look for **Availability Zone ID** (e.g., `use1-az6`), not **Availability Zone** (e.g., `us-east-1d`).
+      To find your availability zone IDs, select your database in the RDS
+      Console and click the subnets under **Connectivity & security**. For each
+      subnet, look for **Availability Zone ID** (e.g., `use1-az6`),
+      not **Availability Zone** (e.g., `us-east-1d`).
 
 1. Retrieve the AWS principal for the AWS PrivateLink connection you just created:
 
@@ -245,13 +337,16 @@ Now that you've configured your database network and created an ingestion cluste
      u1     | arn:aws:iam::664411391173:role/mz_20273b7c-2bbe-42b8-8c36-8cc179e9bbc3_u1
     ```
 
-1. [Update your VPC endpoint service to accept connections from the AWS principal](https://docs.aws.amazon.com/vpc/latest/privatelink/add-endpoint-service-permissions.html).
+1. Update your VPC endpoint service to [accept connections from the AWS principal](https://docs.aws.amazon.com/vpc/latest/privatelink/add-endpoint-service-permissions.html).
 
-1. If your AWS PrivateLink service is configured to require acceptance of connection requests, [manually approve the connection request from Materialize](https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests).
+1. If your AWS PrivateLink service is configured to require acceptance of
+   connection requests, [manually approve the connection request from Materialize](https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests).
 
-    **Note:** It can take some time for the connection request to show up. Do not move on to the next step until you've approved the connection.
+    **Note:** It can take some time for the connection request to show up. Do
+      not move on to the next step until you've approved the connection.
 
-1. Validate the AWS PrivateLink connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
+1. Validate the AWS PrivateLink connection you created using the
+   [`VALIDATE CONNECTION`](/sql/validate-connection) command:
 
     ```sql
     VALIDATE CONNECTION privatelink_svc;
@@ -259,13 +354,16 @@ Now that you've configured your database network and created an ingestion cluste
 
     If no validation error is returned, move to the next step.
 
-1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the
+   password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
-1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create another connection object, this time with database access and authentication details for Materialize to use:
+1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create
+another connection object, this time with database access and authentication
+details for Materialize to use:
 
     ```sql
     CREATE CONNECTION pg_connection TO POSTGRES (
@@ -278,11 +376,16 @@ Now that you've configured your database network and created an ingestion cluste
       );
     ```
 
-    - Replace `<host>` with your Aurora endpoint. To find your Aurora endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+    - Replace `<host>` with your Aurora endpoint. To find your Aurora endpoint,
+      select your database in the RDS Console, and look under **Connectivity &
+      security**.
 
-    - Replace `<database>` with the name of the database containing the tables you want to replicate to Materialize.
+    - Replace `<database>` with the name of the database containing the tables
+      you want to replicate to Materialize.
 
-1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your Aurora instance via AWS PrivateLink and start ingesting data from the publication you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize
+   to your Aurora instance via AWS PrivateLink and start ingesting data from the
+   publication you created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SOURCE mz_source
@@ -291,13 +394,19 @@ Now that you've configured your database network and created an ingestion cluste
       FOR ALL TABLES;
     ```
 
-    To ingest data from specific schemas or tables in your publication, use `FOR SCHEMAS (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR ALL TABLES`.
+    By default, the source will be created in the active cluster; to use a
+    different cluster, use the `IN CLUSTER` clause. To ingest data from
+    specific schemas or tables in your publication, use `FOR SCHEMAS
+    (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR
+    ALL TABLES`.
 
 {{< /tab >}}
 
 {{< tab "Use an SSH tunnel">}}
 
-1. In the `psql` shell connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel) command to create an SSH tunnel connection:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel)
+   command to create an SSH tunnel connection:
 
     ```sql
     CREATE CONNECTION ssh_connection TO SSH TUNNEL (
@@ -307,10 +416,14 @@ Now that you've configured your database network and created an ingestion cluste
     );
     ```
 
-    - Replace `<SSH_BASTION_HOST>` and `<SSH_BASTION_PORT`> with the public IP address and port of the SSH bastion host you created [earlier](#step-3-configure-network-security).
-    - Replace `<SSH_BASTION_USER>` with the username for the key pair you created for your SSH bastion host.
+    - Replace `<SSH_BASTION_HOST>` and `<SSH_BASTION_PORT`> with the public IP
+      address and port of the SSH bastion host you created [earlier](#step-3-configure-network-security).
 
-1. Get Materialize's public keys for the SSH tunnel connection you just created:
+    - Replace `<SSH_BASTION_USER>` with the username for the key pair you
+      created for your SSH bastion host.
+
+1. Get Materialize's public keys for the SSH tunnel connection you just
+   created:
 
     ```sql
     SELECT
@@ -324,7 +437,8 @@ Now that you've configured your database network and created an ingestion cluste
         mz_connections.name = 'ssh_connection';
     ```
 
-1. Log in to your SSH bastion host and add Materialize's public keys to the `authorized_keys` file, for example:
+1. Log in to your SSH bastion host and add Materialize's public keys to the
+   `authorized_keys` file, for example:
 
     ```sh
     # Command for Linux
@@ -332,7 +446,9 @@ Now that you've configured your database network and created an ingestion cluste
     echo "ssh-ed25519 AAAA...hLYV materialize" >> ~/.ssh/authorized_keys
     ```
 
-1. Back in the `psql` shell connected to Materialize, validate the SSH tunnel connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
+1. Back in the SQL client connected to Materialize, validate the SSH tunnel
+   connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection)
+   command:
 
     ```sql
     VALIDATE CONNECTION ssh_connection;
@@ -340,13 +456,16 @@ Now that you've configured your database network and created an ingestion cluste
 
     If no validation error is returned, move to the next step.
 
-1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the
+password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
-1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create another connection object, this time with database access and authentication details for Materialize to use:
+1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create
+   another connection object, this time with database access and authentication
+   details for Materialize to use:
 
     ```sql
     CREATE CONNECTION pg_connection TO POSTGRES (
@@ -359,11 +478,16 @@ Now that you've configured your database network and created an ingestion cluste
       );
     ```
 
-    - Replace `<host>` with your Aurora endpoint. To find your Aurora endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+    - Replace `<host>` with your Aurora endpoint. To find your Aurora endpoint,
+      select your database in the RDS Console, and look under **Connectivity &
+      security**.
 
-    - Replace `<database>` with the name of the database containing the tables you want to replicate to Materialize.
+    - Replace `<database>` with the name of the database containing the tables
+      you want to replicate to Materialize.
 
-1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your Aurora instance and start ingesting data from the publication you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize
+   to your Aurora instance and start ingesting data from the publication you
+   created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SOURCE mz_source
@@ -372,7 +496,11 @@ Now that you've configured your database network and created an ingestion cluste
       FOR ALL TABLES;
     ```
 
-    To ingest data from specific schemas or tables in your publication, use `FOR SCHEMAS (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR ALL TABLES`.
+    By default, the source will be created in the active cluster; to use a
+    different cluster, use the `IN CLUSTER` clause. To ingest data from
+    specific schemas or tables in your publication, use `FOR SCHEMAS
+    (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR
+    ALL TABLES`.
 
 {{< /tab >}}
 

--- a/doc/user/content/ingest-data/postgres-amazon-rds.md
+++ b/doc/user/content/ingest-data/postgres-amazon-rds.md
@@ -278,9 +278,16 @@ configuration of resources for an SSH tunnel. For more details, see the
 
 {{< /tabs >}}
 
-## Step 4. Create an ingestion cluster
+## Step 4. (Optional) Create a cluster
 
-{{% postgres-direct/create-an-ingestion-cluster %}}
+{{< note >}}
+If you are prototyping and already have a cluster to host your PostgreSQL
+source (e.g. `quickstart`), **you can skip this step**. For production
+scenarios, we recommend separating your workloads into multiple clusters for
+[resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
+{{< /note >}}
+
+{{% postgres-direct/create-a-cluster %}}
 
 ## Step 5. Start ingesting data
 

--- a/doc/user/content/ingest-data/postgres-amazon-rds.md
+++ b/doc/user/content/ingest-data/postgres-amazon-rds.md
@@ -12,7 +12,8 @@ menu:
     weight: 5
 ---
 
-This page shows you how to stream data from [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/) to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
+This page shows you how to stream data from [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/)
+to Materialize using the[PostgreSQL source](/sql/create-source/postgres/).
 
 ## Before you begin
 
@@ -20,11 +21,13 @@ This page shows you how to stream data from [Amazon RDS for PostgreSQL](https://
 
 ## Step 1. Enable logical replication
 
-Materialize uses PostgreSQL's [logical replication](https://www.postgresql.org/docs/current/logical-replication.html) protocol to track changes in your database and propagate them to Materialize.
+Materialize uses PostgreSQL's [logical replication](https://www.postgresql.org/docs/current/logical-replication.html)
+protocol to track changes in your database and propagate them to Materialize.
 
 As a first step, you need to make sure logical replication is enabled.
 
-1. As a user with the `rds_superuser` role, use `psql` to connect to your database.
+1. As a user with the `rds_superuser` role, use `psql` (or your preferred SQL
+   client) to connect to your database.
 
 1. Check if logical replication is enabled:
 
@@ -51,15 +54,20 @@ As a first step, you need to make sure logical replication is enabled.
     - Set **Parameter group family** to your PostgreSQL version.
     - Set **Type** to **DB Parameter Group**.
 
-1. Edit the new parameter group and set the `rds.logical_replication` parameter to `1`.
+1. Edit the new parameter group and set the `rds.logical_replication` parameter
+   to `1`.
 
 1. [Associate the RDS parameter group to your database](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithDBInstanceParamGroups.html#USER_WorkingWithParamGroups.Associating).
 
-    Use the **Apply Immediately** option. The database must be rebooted in order for the parameter group association to take effect. Keep in mind that rebooting the RDS instance can affect database performance.
+    Use the **Apply Immediately** option. The database must be rebooted in order
+    for the parameter group association to take effect. Keep in mind that
+    rebooting the RDS instance can affect database performance.
 
-    Do not move on to the next step until the database **Status** is **Available** in the RDS Console.
+    Do not move on to the next step until the database **Status**
+    is **Available** in the RDS Console.
 
-1. Back in your `psql` shell, verify that replication is now enabled:
+1. Back in the SQL client connected to Materialize, verify that replication is
+   now enabled:
 
     ``` sql
     SELECT name, setting
@@ -83,11 +91,16 @@ As a first step, you need to make sure logical replication is enabled.
 
 ## Step 3. Configure network security
 
-There are various ways to configure your database's network to allow Materialize to connect:
+There are various ways to configure your database's network to allow Materialize
+to connect:
 
-- **Allow Materialize IPs:** If your database is publicly accessible, you can configure your database's security group to allow connections from a set of static Materialize IP addresses.
+- **Allow Materialize IPs:** If your database is publicly accessible, you can
+    configure your database's security group to allow connections from a set of
+    static Materialize IP addresses.
 
-- **Use AWS PrivateLink** or **Use an SSH tunnel:** If your database is running in a private network, you can use either [AWS PrivateLink](https://aws.amazon.com/privatelink/) or an SSH tunnel to connect Materialize to the database.
+- **Use AWS PrivateLink** or **Use an SSH tunnel:** If your database is running
+    in a private network, you can use either [AWS PrivateLink](https://aws.amazon.com/privatelink/)
+    or an SSH tunnel to connect Materialize to the database.
 
 Select the option that works best for you.
 
@@ -95,13 +108,16 @@ Select the option that works best for you.
 
 {{< tab "Allow Materialize IPs">}}
 
-1. In the `psql` shell connected to Materialize, find the static egress IP addresses for the Materialize region you are running in:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, find the static egress IP addresses for the
+   Materialize region you are running in:
 
     ```sql
     SELECT * FROM mz_egress_ips;
     ```
 
-1. In the RDS Console, [add an inbound rule to your RDS security group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/working-with-security-groups.html#adding-security-group-rule) for each IP address from the previous step.
+1. In the RDS Console, [add an inbound rule to your RDS security group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/working-with-security-groups.html#adding-security-group-rule)
+   for each IP address from the previous step.
 
     In each rule:
 
@@ -114,23 +130,35 @@ Select the option that works best for you.
 
 {{< public-preview />}}
 
-[AWS PrivateLink](https://aws.amazon.com/privatelink/) lets you connect Materialize to your RDS instance without exposing traffic to the public internet. To use AWS PrivateLink, you create a network load balancer in the same VPC as your RDS instance and a VPC endpoint service that Materialize connects to. The VPC endpoint service then routes requests from Materialize to RDS via the network load balancer.
+[AWS PrivateLink](https://aws.amazon.com/privatelink/) lets you connect
+Materialize to your RDS instance without exposing traffic to the public
+internet. To use AWS PrivateLink, you create a network load balancer in the
+same VPC as your RDS instance and a VPC endpoint service that Materialize
+connects to. The VPC endpoint service then routes requests from Materialize to
+RDS via the network load balancer.
 
 {{< note >}}
-Materialize provides a Terraform module that automates the creation and configuration of AWS resources for a PrivateLink connection. For more details, see the [Terraform module repository](https://github.com/MaterializeInc/terraform-aws-rds-privatelink).
+Materialize provides a Terraform module that automates the creation and
+configuration of AWS resources for a PrivateLink connection. For more details,
+see the [Terraform module repository](https://github.com/MaterializeInc/terraform-aws-rds-privatelink).
 {{</ note >}}
 
-1. Get the IP address of your RDS instance. You'll need this address to register your RDS instance as the target for the network load balancer in the next step.
+1. Get the IP address of your RDS instance. You'll need this address to register
+   your RDS instance as the target for the network load balancer in the next
+   step.
 
     To get the IP address of your RDS instance:
 
     1. Select your database in the RDS Console.
-    1. Find your RDS endpoint under **Connectivity & security**.
-    1. Use the `dig` or `nslooklup` command to find the IP address that the endpoint resolves to:
 
-        ```sh
-        dig +short <RDS_ENDPOINT>
-        ```
+    1. Find your RDS endpoint under **Connectivity & security**.
+
+    1. Use the `dig` or `nslooklup` command to find the IP address that the
+    endpoint resolves to:
+
+       ```sh
+       dig +short <RDS_ENDPOINT>
+       ```
 
 1. [Create a dedicated target group for your RDS instance](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-target-group.html).
 
@@ -140,69 +168,111 @@ Materialize provides a Terraform module that automates the creation and configur
 
     - Choose the same VPC as your RDS instance.
 
-    - Use the IP address from the previous step to register your RDS instance as the target.
+    - Use the IP address from the previous step to register your RDS instance as
+      the target.
 
-    **Warning:** The IP address of your RDS instance can change without notice. For this reason, it's best to set up automation to regularly check the IP of the instance and update your target group accordingly. You can use a lambda function to automate this process - see Materialize's [Terraform module for AWS PrivateLink](https://github.com/MaterializeInc/terraform-aws-rds-privatelink/blob/main/lambda_function.py) for an example. Another approach is to [configure an EC2 instance as an RDS router](https://aws.amazon.com/blogs/database/how-to-use-amazon-rds-and-amazon-aurora-with-a-static-ip-address/) for your network load balancer.
+    **Warning:** The IP address of your RDS instance can change without notice.
+      For this reason, it's best to set up automation to regularly check the IP
+      of the instance and update your target group accordingly. You can use a
+      lambda function to automate this process - see Materialize's
+      [Terraform module for AWS PrivateLink](https://github.com/MaterializeInc/terraform-aws-rds-privatelink/blob/main/lambda_function.py)
+      for an example. Another approach is to [configure an EC2 instance as an
+      RDS router](https://aws.amazon.com/blogs/database/how-to-use-amazon-rds-and-amazon-aurora-with-a-static-ip-address/)
+      for your network load balancer.
 
 1. [Create a network load balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-network-load-balancer.html).
 
-    - For **Network mapping**, choose the same VPC as your RDS instance and select all of the availability zones and subnets that you RDS instance is in.
+    - For **Network mapping**, choose the same VPC as your RDS instance and
+      select all of the availability zones and subnets that you RDS instance is
+      in.
 
-    - For **Listeners and routing**, set the protocol and port to **TCP** and **5432** and select the target group you created in the previous step.
+    - For **Listeners and routing**, set the protocol and port to **TCP**
+      and **5432** and select the target group you created in the previous
+      step.
 
 1. In the security group of your RDS instance, [allow traffic from the the network load balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html).
 
-    If [client IP preservation](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#client-ip-preservation) is disabled, the easiest approach is to add an inbound rule with the VPC CIDR of the network load balancer. If you don't want to grant access to the entire VPC CIDR, you can add inbound rules for the private IP addresses of the load balancer subnets.
+    If [client IP preservation](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#client-ip-preservation)
+    is disabled, the easiest approach is to add an inbound rule with the VPC
+    CIDR of the network load balancer. If you don't want to grant access to the
+    entire VPC CIDR, you can add inbound rules for the private IP addresses of
+    the load balancer subnets.
 
-    - To find the VPC CIDR, go to your network load balancer and look under **Network mapping**.
-    - To find the private IP addresses of the load balancer subnets, go to **Network Interfaces**, search for the name of the network load balancer, and look on the **Details** tab for each matching network interface.
+    - To find the VPC CIDR, go to your network load balancer and look
+      under **Network mapping**.
+    - To find the private IP addresses of the load balancer subnets, go
+      to **Network Interfaces**, search for the name of the network load
+      balancer, and look on the **Details** tab for each matching network
+      interface.
 
 1. [Create a VPC endpoint service](https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html).
 
-    - For **Load balancer type**, choose **Network** and then select the network load balancer you created in the previous step.
+    - For **Load balancer type**, choose **Network** and then select the network
+      load balancer you created in the previous step.
 
-    - After creating the VPC endpoint service, note its **Service name**. You'll use this service name when connecting Materialize later.
+    - After creating the VPC endpoint service, note its **Service name**. You'll
+      use this service name when connecting Materialize later.
 
-    **Remarks**:
-    By disabling [Acceptance Required](https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests), while still strictly managing who can view your endpoint via IAM, Materialze will be able to seamlessly recreate and migrate endpoints as we work to stabilize this feature.
+    **Remarks**: By disabling [Acceptance Required](https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests),
+      while still strictly managing who can view your endpoint via IAM,
+      Materialze will be able to seamlessly recreate and migrate endpoints as
+      we work to stabilize this feature.
 
-1. Go back to the target group you created for the network load balancer and make sure that the [health checks](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html) are reporting the targets as healthy.
+1. Go back to the target group you created for the network load balancer and
+   make sure that the [health checks](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html)
+   are reporting the targets as healthy.
 
 {{< /tab >}}
 
 {{< tab "Use an SSH tunnel">}}
 
-To create an SSH tunnel from Materialize to your database, you launch an instance to serve as an SSH bastion host, configure the bastion host to allow traffic only from Materialize, and then configure your database's private network to allow traffic from the bastion host.
+To create an SSH tunnel from Materialize to your database, you launch an
+instance to serve as an SSH bastion host, configure the bastion host to allow
+traffic only from Materialize, and then configure your database's private
+network to allow traffic from the bastion host.
 
 {{< note >}}
-Materialize provides a Terraform module that automates the creation and configuration of resources for an SSH tunnel. For more details, see the [Terraform module repository](https://github.com/MaterializeInc/terraform-aws-ec2-ssh-bastion).
+Materialize provides a Terraform module that automates the creation and
+configuration of resources for an SSH tunnel. For more details, see the
+[Terraform module repository](https://github.com/MaterializeInc/terraform-aws-ec2-ssh-bastion).
 {{</ note >}}
 
-1. [Launch an EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/LaunchingAndUsingInstances.html) to serve as your SSH bastion host.
+1. [Launch an EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/LaunchingAndUsingInstances.html)
+   to serve as your SSH bastion host.
 
-    - Make sure the instance is publicly accessible and in the same VPC as your RDS instance.
-    - Add a key pair and note the username. You'll use this username when connecting Materialize to your bastion host.
+    - Make sure the instance is publicly accessible and in the same VPC as your
+      RDS instance.
+    - Add a key pair and note the username. You'll use this username when
+      connecting Materialize to your bastion host.
 
-    **Warning:** Auto-assigned public IP addresses can change in [certain cases](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-public-addresses). For this reason, it's best to associate an [elastic IP address](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#ip-addressing-eips) to your bastion host.
+    **Warning:** Auto-assigned public IP addresses can change in [certain cases](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-public-addresses).
+
+    For this reason, it's best to associate an [elastic IP address](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#ip-addressing-eips)
+    to your bastion host.
 
 1. Configure the SSH bastion host to allow traffic only from Materialize.
 
-    1. In the `psql` shell connected to Materialize, get the static egress IP addresses for the Materialize region you are running in:
+    1. In the [SQL Shell](https://console.materialize.com/), or your preferred
+       SQL client connected to Materialize, get the static egress IP addresses for
+       the Materialize region you are running in:
 
-        ```sql
-        SELECT * FROM mz_egress_ips;
-        ```
+       ```sql
+       SELECT * FROM mz_egress_ips;
+       ```
 
-    1. For each static egress IP, [add an inbound rule](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html) to your SSH bastion host's security group.
+    1. For each static egress IP, [add an inbound rule](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html)
+       to your SSH bastion host's security group.
 
         In each rule:
         - Set **Type** to **PostgreSQL**.
         - Set **Source** to the IP address in CIDR notation.
 
-1. In the security group of your RDS instance, [add an inbound rule](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html) to allow traffic from the SSH bastion host.
+1. In the security group of your RDS instance, [add an inbound rule](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html)
+   to allow traffic from the SSH bastion host.
 
     - Set **Type** to **All TCP**.
-    - Set **Source** to **Custom** and select the bastion host's security group.
+    - Set **Source** to **Custom** and select the bastion host's security
+      group.
 
 {{< /tab >}}
 
@@ -214,19 +284,27 @@ Materialize provides a Terraform module that automates the creation and configur
 
 ## Step 5. Start ingesting data
 
-Now that you've configured your database network and created an ingestion cluster, you can connect Materialize to your PostgreSQL database and start ingesting data. The exact steps depend on your networking configuration, so start by selecting the relevant option.
+Now that you've configured your database network and created an ingestion
+cluster, you can connect Materialize to your PostgreSQL database and start
+ingesting data. The exact steps depend on your networking configuration, so
+start by selecting the relevant option.
 
 {{< tabs >}}
 
 {{< tab "Allow Materialize IPs">}}
 
-1. In the `psql` shell connected to Materialize, use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, use the [`CREATE SECRET`](/sql/create-secret/)
+   command to securely store the password for the `materialize` PostgreSQL user you
+   created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
-1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create a connection object with access and authentication details for Materialize to use:
+1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create a
+   connection object with access and authentication details for Materialize to
+   use:
 
     ```sql
     CREATE CONNECTION pg_connection TO POSTGRES (
@@ -239,11 +317,16 @@ Now that you've configured your database network and created an ingestion cluste
       );
     ```
 
-    - Replace `<host>` with your RDS endpoint. To find your RDS endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+    - Replace `<host>` with your RDS endpoint. To find your RDS endpoint, select
+      your database in the RDS Console, and look under **Connectivity &
+      security**.
 
-    - Replace `<database>` with the name of the database containing the tables you want to replicate to Materialize.
+    - Replace `<database>` with the name of the database containing the tables
+      you want to replicate to Materialize.
 
-1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your RDS instance and start ingesting data from the publication you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize
+   to your RDS instance and start ingesting data from the publication you created
+   [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SOURCE mz_source
@@ -252,15 +335,23 @@ Now that you've configured your database network and created an ingestion cluste
       FOR ALL TABLES;
     ```
 
-    To ingest data from specific schemas or tables in your publication, use `FOR SCHEMAS (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR ALL TABLES`.
+    By default, the source will be created in the active cluster; to use a
+    different cluster, use the `IN CLUSTER` clause. To ingest data from
+    specific schemas or tables in your publication, use `FOR SCHEMAS
+    (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR
+    ALL TABLES`.
 
-1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes) for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP} SUBSOURCE`](/sql/alter-source/#context) syntax.
+1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
+   for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP} SUBSOURCE`](/sql/alter-source/#context)
+   syntax.
 
 {{< /tab >}}
 
 {{< tab "Use AWS PrivateLink">}}
 
-1. In the `psql` shell connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#aws-privatelink) command to create an AWS PrivateLink connection:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#aws-privatelink)
+   command to create an AWS PrivateLink connection:
 
     ```sql
     CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
@@ -271,11 +362,16 @@ Now that you've configured your database network and created an ingestion cluste
 
     - Replace the `SERVICE NAME` value with the service name you noted [earlier](#step-3-configure-network-security).
 
-    - Replace the `AVAILABILITY ZONES` list with the IDs of the availability zones in your AWS account.
+    - Replace the `AVAILABILITY ZONES` list with the IDs of the availability
+      zones in your AWS account.
 
-      To find your availability zone IDs, select your database in the RDS Console and click the subnets under **Connectivity & security**. For each subnet, look for **Availability Zone ID** (e.g., `use1-az6`), not **Availability Zone** (e.g., `us-east-1d`).
+      To find your availability zone IDs, select your database in the RDS
+      Console and click the subnets under **Connectivity & security**. For each
+      subnet, look for **Availability Zone ID** (e.g., `use1-az6`),
+      not **Availability Zone** (e.g., `us-east-1d`).
 
-1. Retrieve the AWS principal for the AWS PrivateLink connection you just created:
+1. Retrieve the AWS principal for the AWS PrivateLink connection you just
+   created:
 
     ```sql
     SELECT principal
@@ -291,13 +387,16 @@ Now that you've configured your database network and created an ingestion cluste
      u1     | arn:aws:iam::664411391173:role/mz_20273b7c-2bbe-42b8-8c36-8cc179e9bbc3_u1
     ```
 
-1. [Update your VPC endpoint service to accept connections from the AWS principal](https://docs.aws.amazon.com/vpc/latest/privatelink/add-endpoint-service-permissions.html).
+1. Update your VPC endpoint service to [accept connections from the AWS principal](https://docs.aws.amazon.com/vpc/latest/privatelink/add-endpoint-service-permissions.html).
 
-1. If your AWS PrivateLink service is configured to require acceptance of connection requests, [manually approve the connection request from Materialize](https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests).
+1. If your AWS PrivateLink service is configured to require acceptance of
+   connection requests, [manually approve the connection request from Materialize](https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#accept-reject-connection-requests).
 
-    **Note:** It can take some time for the connection request to show up. Do not move on to the next step until you've approved the connection.
+    **Note:** It can take some time for the connection request to show up. Do
+      not move on to the next step until you've approved the connection.
 
-1. Validate the AWS PrivateLink connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
+1. Validate the AWS PrivateLink connection you created using the
+   [`VALIDATE CONNECTION`](/sql/validate-connection) command:
 
     ```sql
     VALIDATE CONNECTION privatelink_svc;
@@ -305,13 +404,16 @@ Now that you've configured your database network and created an ingestion cluste
 
     If no validation error is returned, move to the next step.
 
-1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the
+   password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
-1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create another connection object, this time with database access and authentication details for Materialize to use:
+1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create
+   another connection object, this time with database access and authentication
+   details for Materialize to use:
 
     ```sql
     CREATE CONNECTION pg_connection TO POSTGRES (
@@ -324,11 +426,16 @@ Now that you've configured your database network and created an ingestion cluste
       );
     ```
 
-    - Replace `<host>` with your RDS endpoint. To find your RDS endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+    - Replace `<host>` with your RDS endpoint. To find your RDS endpoint, select
+      your database in the RDS Console, and look under **Connectivity &
+      security**.
 
-    - Replace `<database>` with the name of the database containing the tables you want to replicate to Materialize.
+    - Replace `<database>` with the name of the database containing the tables
+      you want to replicate to Materialize.
 
-1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your RDS instance via AWS PrivateLink and start ingesting data from the publication you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize
+   to your RDS instance via AWS PrivateLink and start ingesting data from the
+   publication you created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SOURCE mz_source
@@ -337,13 +444,19 @@ Now that you've configured your database network and created an ingestion cluste
       FOR ALL TABLES;
     ```
 
-    To ingest data from specific schemas or tables in your publication, use `FOR SCHEMAS (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR ALL TABLES`.
+    By default, the source will be created in the active cluster; to use a
+    different cluster, use the `IN CLUSTER` clause. To ingest data from
+    specific schemas or tables in your publication, use `FOR SCHEMAS
+    (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR
+    ALL TABLES`.
 
 {{< /tab >}}
 
 {{< tab "Use an SSH tunnel">}}
 
-1. In the `psql` shell connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel) command to create an SSH tunnel connection:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel)
+   command to create an SSH tunnel connection:
 
     ```sql
     CREATE CONNECTION ssh_connection TO SSH TUNNEL (
@@ -353,10 +466,14 @@ Now that you've configured your database network and created an ingestion cluste
     );
     ```
 
-    - Replace `<SSH_BASTION_HOST>` and `<SSH_BASTION_PORT`> with the public IP address and port of the SSH bastion host you created [earlier](#step-3-configure-network-security).
-    - Replace `<SSH_BASTION_USER>` with the username for the key pair you created for your SSH bastion host.
+    - Replace `<SSH_BASTION_HOST>` and `<SSH_BASTION_PORT`> with the public IP
+      address and port of the SSH bastion host you created [earlier](#step-3-configure-network-security).
 
-1. Get Materialize's public keys for the SSH tunnel connection you just created:
+    - Replace `<SSH_BASTION_USER>` with the username for the key pair you
+      created for your SSH bastion host.
+
+1. Get Materialize's public keys for the SSH tunnel connection you just
+   created:
 
     ```sql
     SELECT
@@ -369,7 +486,8 @@ Now that you've configured your database network and created an ingestion cluste
         mz_connections.name = 'ssh_connection';
     ```
 
-1. Log in to your SSH bastion host and add Materialize's public keys to the `authorized_keys` file, for example:
+1. Log in to your SSH bastion host and add Materialize's public keys to the
+   `authorized_keys` file, for example:
 
     ```sh
     # Command for Linux
@@ -377,7 +495,8 @@ Now that you've configured your database network and created an ingestion cluste
     echo "ssh-ed25519 AAAA...hLYV materialize" >> ~/.ssh/authorized_keys
     ```
 
-1. Back in the `psql` shell connected to Materialize, validate the SSH tunnel connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
+1. Back in the SQL client connected to Materialize, validate the SSH tunnel
+   connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
 
     ```sql
     VALIDATE CONNECTION ssh_connection;
@@ -385,13 +504,16 @@ Now that you've configured your database network and created an ingestion cluste
 
     If no validation error is returned, move to the next step.
 
-1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the
+   password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
-1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create another connection object, this time with database access and authentication details for Materialize to use:
+1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create
+   another connection object, this time with database access and authentication
+   details for Materialize to use:
 
     ```sql
     CREATE CONNECTION pg_connection TO POSTGRES (
@@ -404,11 +526,16 @@ Now that you've configured your database network and created an ingestion cluste
       );
     ```
 
-    - Replace `<host>` with your RDS endpoint. To find your RDS endpoint, select your database in the RDS Console, and look under **Connectivity & security**.
+    - Replace `<host>` with your RDS endpoint. To find your RDS endpoint, select
+      your database in the RDS Console, and look under **Connectivity &
+      security**.
 
-    - Replace `<database>` with the name of the database containing the tables you want to replicate to Materialize.
+    - Replace `<database>` with the name of the database containing the tables
+      you want to replicate to Materialize.
 
-1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your RDS instance and start ingesting data from the publication you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize
+   to your RDS instance and start ingesting data from the publication you created
+   [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SOURCE mz_source
@@ -417,7 +544,11 @@ Now that you've configured your database network and created an ingestion cluste
       FOR ALL TABLES;
     ```
 
-    To ingest data from specific schemas or tables in your publication, use `FOR SCHEMAS (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR ALL TABLES`.
+    By default, the source will be created in the active cluster; to use a
+    different cluster, use the `IN CLUSTER` clause. To ingest data from
+    specific schemas or tables in your publication, use `FOR SCHEMAS
+    (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR
+    ALL TABLES`.
 
 {{< /tab >}}
 

--- a/doc/user/content/ingest-data/postgres-azure-db.md
+++ b/doc/user/content/ingest-data/postgres-azure-db.md
@@ -95,9 +95,16 @@ to serve as your SSH bastion host.
 
 {{< /tabs >}}
 
-## Step 4. Create an ingestion cluster
+## Step 4. (Optional) Create a cluster
 
-{{% postgres-direct/create-an-ingestion-cluster %}}
+{{< note >}}
+If you are prototyping and already have a cluster to host your PostgreSQL
+source (e.g. `quickstart`), **you can skip this step**. For production
+scenarios, we recommend separating your workloads into multiple clusters for
+[resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
+{{< /note >}}
+
+{{% postgres-direct/create-a-cluster %}}
 
 ## Step 5. Start ingesting data
 

--- a/doc/user/content/ingest-data/postgres-azure-db.md
+++ b/doc/user/content/ingest-data/postgres-azure-db.md
@@ -8,7 +8,8 @@ menu:
     weight: 15
 ---
 
-This page shows you how to stream data from [Azure DB for PostgreSQL](https://azure.microsoft.com/en-us/products/postgresql) to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
+This page shows you how to stream data from [Azure DB for PostgreSQL](https://azure.microsoft.com/en-us/products/postgresql)
+to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
 
 ## Before you begin
 
@@ -16,9 +17,11 @@ This page shows you how to stream data from [Azure DB for PostgreSQL](https://az
 
 ## Step 1. Enable logical replication
 
-Materialize uses PostgreSQL's [logical replication](https://www.postgresql.org/docs/current/logical-replication.html) protocol to track changes in your database and propagate them to Materialize.
+Materialize uses PostgreSQL's [logical replication](https://www.postgresql.org/docs/current/logical-replication.html)
+protocol to track changes in your database and propagate them to Materialize.
 
-For guidance on enabling logical replication in Azure DB, see the [Azure documentation](https://learn.microsoft.com/en-us/azure/postgresql/single-server/concepts-logical#set-up-your-server).
+For guidance on enabling logical replication in Azure DB, see the
+[Azure documentation](https://learn.microsoft.com/en-us/azure/postgresql/single-server/concepts-logical#set-up-your-server).
 
 ## Step 2. Create a publication
 
@@ -26,11 +29,15 @@ For guidance on enabling logical replication in Azure DB, see the [Azure documen
 
 ## Step 3. Configure network security
 
-There are various ways to configure your database's network to allow Materialize to connect:
+There are various ways to configure your database's network to allow Materialize
+to connect:
 
-- **Allow Materialize IPs:** If your database is publicly accessible, you can configure your database's firewall to allow connections from a set of static Materialize IP addresses.
+- **Allow Materialize IPs:** If your database is publicly accessible, you can
+    configure your database's firewall to allow connections from a set of
+    static Materialize IP addresses.
 
-- **Use an SSH tunnel:** If your database is running in a private network, you can use an SSH tunnel to connect Materialize to the database.
+- **Use an SSH tunnel:** If your database is running in a private network, you
+    can use an SSH tunnel to connect Materialize to the database.
 
 Select the option that works best for you.
 
@@ -38,36 +45,51 @@ Select the option that works best for you.
 
 {{< tab "Allow Materialize IPs">}}
 
-1. In the `psql` shell connected to Materialize, find the static egress IP addresses for the Materialize region you are running in:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, find the static egress IP addresses for the
+   Materialize region you are running in:
 
     ```sql
     SELECT * FROM mz_egress_ips;
     ```
 
-1. Update your [Azure DB firewall rules](https://learn.microsoft.com/en-us/azure/azure-sql/database/firewall-configure?view=azuresql) to allow traffic from each IP address from the previous step.
+1. Update your [Azure DB firewall rules](https://learn.microsoft.com/en-us/azure/azure-sql/database/firewall-configure?view=azuresql)
+   to allow traffic from each IP address from the previous step.
+
 {{< /tab >}}
 
 {{< tab "Use an SSH tunnel">}}
 
-To create an SSH tunnel from Materialize to your database, you launch an instance to serve as an SSH bastion host, configure the bastion host to allow traffic only from Materialize, and then configure your database's private network to allow traffic from the bastion host.
+To create an SSH tunnel from Materialize to your database, you launch an
+instance to serve as an SSH bastion host, configure the bastion host to allow
+traffic only from Materialize, and then configure your database's private
+network to allow traffic from the bastion host.
 
-1. [Launch an Azure VM with a static public IP address](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/virtual-network-deploy-static-pip-arm-portal?toc=%2Fazure%2Fvirtual-machines%2Ftoc.json) to serve as your SSH bastion host.
+1. [Launch an Azure VM with a static public IP address](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/virtual-network-deploy-static-pip-arm-portal?toc=%2Fazure%2Fvirtual-machines%2Ftoc.json)
+to serve as your SSH bastion host.
 
-    - Make sure the VM is publicly accessible and in the same VPC as your database.
-    - Add a key pair and note the username. You'll use this username when connecting Materialize to your bastion host.
-    - Make sure the VM has a static public IP address. You'll use this IP address when connecting Materialize to your bastion host.
+    - Make sure the VM is publicly accessible and in the same VPC as your
+      database.
+    - Add a key pair and note the username. You'll use this username when
+      connecting Materialize to your bastion host.
+    - Make sure the VM has a static public IP address. You'll use this IP
+      address when connecting Materialize to your bastion host.
 
 1. Configure the SSH bastion host to allow traffic only from Materialize.
 
-    1. In the `psql` shell connected to Materialize, get the static egress IP addresses for the Materialize region you are running in:
+    1. In the [SQL Shell](https://console.materialize.com/), or your preferred
+       SQL client connected to Materialize, get the static egress IP addresses for
+       the Materialize region you are running in:
 
-        ```sql
-        SELECT * FROM mz_egress_ips;
-        ```
+       ```sql
+       SELECT * FROM mz_egress_ips;
+       ```
 
-    1. Update your SSH bastion host's [firewall rules](https://learn.microsoft.com/en-us/azure/virtual-network/tutorial-filter-network-traffic?toc=%2Fazure%2Fvirtual-machines%2Ftoc.json) to allow traffic from each IP address from the previous step.
+    1. Update your SSH bastion host's [firewall rules](https://learn.microsoft.com/en-us/azure/virtual-network/tutorial-filter-network-traffic?toc=%2Fazure%2Fvirtual-machines%2Ftoc.json)
+    to allow traffic from each IP address from the previous step.
 
-1. Update your [Azure DB firewall rules](https://learn.microsoft.com/en-us/azure/azure-sql/database/firewall-configure?view=azuresql) to allow traffic from the SSH bastion host.
+1. Update your [Azure DB firewall rules](https://learn.microsoft.com/en-us/azure/azure-sql/database/firewall-configure?view=azuresql)
+   to allow traffic from the SSH bastion host.
 
 {{< /tab >}}
 
@@ -79,19 +101,27 @@ To create an SSH tunnel from Materialize to your database, you launch an instanc
 
 ## Step 5. Start ingesting data
 
-Now that you've configured your database network and created an ingestion cluster, you can connect Materialize to your PostgreSQL database and start ingesting data. The exact steps depend on your networking configuration, so start by selecting the relevant option.
+Now that you've configured your database network and created an ingestion
+cluster, you can connect Materialize to your PostgreSQL database and start
+ingesting data. The exact steps depend on your networking configuration, so
+start by selecting the relevant option.
 
 {{< tabs >}}
 
 {{< tab "Allow Materialize IPs">}}
 
-1. In the `psql` shell connected to Materialize, use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, use the [`CREATE SECRET`](/sql/create-secret/)
+   command to securely store the password for the `materialize` PostgreSQL user
+   you created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
-1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create a connection object with access and authentication details for Materialize to use:
+1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create a
+   connection object with access and authentication details for Materialize to
+   use:
 
     ```sql
     CREATE CONNECTION pg_connection TO POSTGRES (
@@ -106,9 +136,12 @@ Now that you've configured your database network and created an ingestion cluste
 
     - Replace `<host>` with your Azure DB endpoint.
 
-    - Replace `<database>` with the name of the database containing the tables you want to replicate to Materialize.
+    - Replace `<database>` with the name of the database containing the tables
+      you want to replicate to Materialize.
 
-1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your Azure instance and start ingesting data from the publication you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize
+to your Azure instance and start ingesting data from the publication you
+created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SOURCE mz_source
@@ -117,15 +150,23 @@ Now that you've configured your database network and created an ingestion cluste
       FOR ALL TABLES;
     ```
 
-    To ingest data from specific schemas or tables in your publication, use `FOR SCHEMAS (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR ALL TABLES`.
+    By default, the source will be created in the active cluster; to use a
+    different cluster, use the `IN CLUSTER` clause. To ingest data from
+    specific schemas or tables in your publication, use `FOR SCHEMAS
+    (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR
+    ALL TABLES`.
 
-1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes) for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP} SUBSOURCE`](/sql/alter-source/#context) syntax.
+1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
+   for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP} SUBSOURCE`](/sql/alter-source/#context)
+   syntax.
 
 {{< /tab >}}
 
 {{< tab "Use an SSH tunnel">}}
 
-1. In the `psql` shell connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel) command to create an SSH tunnel connection:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel)
+   command to create an SSH tunnel connection:
 
     ```sql
     CREATE CONNECTION ssh_connection TO SSH TUNNEL (
@@ -135,10 +176,14 @@ Now that you've configured your database network and created an ingestion cluste
     );
     ```
 
-    - Replace `<SSH_BASTION_HOST>` and `<SSH_BASTION_PORT`> with the public IP address and port of the SSH bastion host you created [earlier](#step-3-configure-network-security).
-    - Replace `<SSH_BASTION_USER>` with the username for the key pair you created for your SSH bastion host.
+    - Replace `<SSH_BASTION_HOST>` and `<SSH_BASTION_PORT`> with the public IP
+      address and port of the SSH bastion host you created [earlier](#step-3-configure-network-security).
 
-1. Get Materialize's public keys for the SSH tunnel connection you just created:
+    - Replace `<SSH_BASTION_USER>` with the username for the key pair you
+      created for your SSH bastion host.
+
+1. Get Materialize's public keys for the SSH tunnel connection you just
+   created:
 
     ```sql
     SELECT
@@ -151,7 +196,8 @@ Now that you've configured your database network and created an ingestion cluste
         mz_connections.name = 'ssh_connection';
     ```
 
-1. Log in to your SSH bastion host and add Materialize's public keys to the `authorized_keys` file, for example:
+1. Log in to your SSH bastion host and add Materialize's public keys to the
+`authorized_keys` file, for example:
 
     ```sh
     # Command for Linux
@@ -159,7 +205,9 @@ Now that you've configured your database network and created an ingestion cluste
     echo "ssh-ed25519 AAAA...hLYV materialize" >> ~/.ssh/authorized_keys
     ```
 
-1. Back in the `psql` shell connected to Materialize, validate the SSH tunnel connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
+1. Back in the SQL client connected to Materialize, validate the SSH tunnel
+   connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection)
+   command:
 
     ```sql
     VALIDATE CONNECTION ssh_connection;
@@ -167,13 +215,16 @@ Now that you've configured your database network and created an ingestion cluste
 
     If no validation error is returned, move to the next step.
 
-1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the
+   password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
-1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create another connection object, this time with database access and authentication details for Materialize to use:
+1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create
+   another connection object, this time with database access and authentication
+   details for Materialize to use:
 
     ```sql
     CREATE CONNECTION pg_connection TO POSTGRES (
@@ -188,9 +239,12 @@ Now that you've configured your database network and created an ingestion cluste
 
     - Replace `<host>` with your Azure DB endpoint.
 
-    - Replace `<database>` with the name of the database containing the tables you want to replicate to Materialize.
+    - Replace `<database>` with the name of the database containing the tables
+      you want to replicate to Materialize.
 
-1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your Azure instance and start ingesting data from the publication you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize
+to your Azure instance and start ingesting data from the publication you
+created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SOURCE mz_source
@@ -199,7 +253,11 @@ Now that you've configured your database network and created an ingestion cluste
       FOR ALL TABLES;
     ```
 
-    To ingest data from specific schemas or tables in your publication, use `FOR SCHEMAS (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR ALL TABLES`.
+    By default, the source will be created in the active cluster; to use a
+    different cluster, use the `IN CLUSTER` clause. To ingest data from
+    specific schemas or tables in your publication, use `FOR SCHEMAS
+    (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR
+    ALL TABLES`.
 
 {{< /tab >}}
 

--- a/doc/user/content/ingest-data/postgres-google-cloud-sql.md
+++ b/doc/user/content/ingest-data/postgres-google-cloud-sql.md
@@ -8,7 +8,8 @@ menu:
     weight: 20
 ---
 
-This page shows you how to stream data from [Google Cloud SQL for PostgreSQL](https://cloud.google.com/sql/postgresql) to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
+This page shows you how to stream data from [Google Cloud SQL for PostgreSQL](https://cloud.google.com/sql/postgresql)
+to Materialize using the[PostgreSQL source](/sql/create-source/postgres/).
 
 ## Before you begin
 
@@ -16,9 +17,11 @@ This page shows you how to stream data from [Google Cloud SQL for PostgreSQL](ht
 
 ## Step 1. Enable logical replication
 
-Materialize uses PostgreSQL's [logical replication](https://www.postgresql.org/docs/current/logical-replication.html) protocol to track changes in your database and propagate them to Materialize.
+Materialize uses PostgreSQL's [logical replication](https://www.postgresql.org/docs/current/logical-replication.html)
+protocol to track changes in your database and propagate them to Materialize.
 
-For guidance on enabling logical replication in Cloud SQL, see the [Cloud SQL documentation](https://cloud.google.com/sql/docs/postgres/replication/configure-logical-replication#configuring-your-postgresql-instance).
+For guidance on enabling logical replication in Cloud SQL, see the [Cloud SQL
+documentation](https://cloud.google.com/sql/docs/postgres/replication/configure-logical-replication#configuring-your-postgresql-instance).
 
 ## Step 2. Create a publication
 
@@ -26,11 +29,15 @@ For guidance on enabling logical replication in Cloud SQL, see the [Cloud SQL do
 
 ## Step 3. Configure network security
 
-There are various ways to configure your database's network to allow Materialize to connect:
+There are various ways to configure your database's network to allow Materialize
+to connect:
 
-- **Allow Materialize IPs:** If your database is publicly accessible, you can configure your database's firewall to allow connections from a set of static Materialize IP addresses.
+- **Allow Materialize IPs:** If your database is publicly accessible, you can
+    configure your database's firewall to allow connections from a set of
+    static Materialize IP addresses.
 
-- **Use an SSH tunnel:** If your database is running in a private network, you can use an SSH tunnel to connect Materialize to the database.
+- **Use an SSH tunnel:** If your database is running in a private network, you
+    can use an SSH tunnel to connect Materialize to the database.
 
 Select the option that works best for you.
 
@@ -38,37 +45,51 @@ Select the option that works best for you.
 
 {{< tab "Allow Materialize IPs">}}
 
-1. In the `psql` shell connected to Materialize, find the static egress IP addresses for the Materialize region you are running in:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, find the static egress IP addresses for the
+   Materialize region you are running in:
 
     ```sql
     SELECT * FROM mz_egress_ips;
     ```
 
-1. Update your Google Cloud SQL firewall rules to allow traffic from each IP address from the previous step.
+1. Update your Google Cloud SQL firewall rules to allow traffic from each IP
+   address from the previous step.
 
 {{< /tab >}}
 
 {{< tab "Use an SSH tunnel">}}
 
-To create an SSH tunnel from Materialize to your database, you launch an instance to serve as an SSH bastion host, configure the bastion host to allow traffic only from Materialize, and then configure your database's private network to allow traffic from the bastion host.
+To create an SSH tunnel from Materialize to your database, you launch an
+instance to serve as an SSH bastion host, configure the bastion host to allow
+traffic only from Materialize, and then configure your database's private
+network to allow traffic from the bastion host.
 
 1. [Launch a GCE instance](https://cloud.google.com/compute/docs/instances/create-start-instance) to serve as your SSH bastion host.
 
-    - Make sure the instance is publicly accessible and in the same VPC as your database.
-    - Add a key pair and note the username. You'll use this username when connecting Materialize to your bastion host.
-    - Make sure the VM has a [static public IP address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address). You'll use this IP address when connecting Materialize to your bastion host.
+    - Make sure the instance is publicly accessible and in the same VPC as your
+      database.
+    - Add a key pair and note the username. You'll use this username when
+      connecting Materialize to your bastion host.
+    - Make sure the VM has a [static public IP address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address).
+      You'll use this IP address when connecting Materialize to your bastion
+      host.
 
 1. Configure the SSH bastion host to allow traffic only from Materialize.
 
-    1. In the `psql` shell connected to Materialize, get the static egress IP addresses for the Materialize region you are running in:
+    1. In the [SQL Shell](https://console.materialize.com/), or your preferred
+       SQL client connected to Materialize, get the static egress IP addresses for
+       the Materialize region you are running in:
 
-        ```sql
-        SELECT * FROM mz_egress_ips;
-        ```
+       ```sql
+       SELECT * FROM mz_egress_ips;
+       ```
 
-    1. Update your SSH bastion host's firewall rules to allow traffic from each IP address from the previous step.
+    1. Update your SSH bastion host's firewall rules to allow traffic from each
+    IP address from the previous step.
 
-1. Update your Google Cloud SQL firewall rules to allow traffic from the SSH bastion host.
+1. Update your Google Cloud SQL firewall rules to allow traffic from the SSH
+bastion host.
 
 {{< /tab >}}
 
@@ -80,7 +101,10 @@ To create an SSH tunnel from Materialize to your database, you launch an instanc
 
 ## Step 5. Start ingesting data
 
-Now that you've configured your database network and created an ingestion cluster, you can connect Materialize to your PostgreSQL database and start ingesting data. The exact steps depend on your networking configuration, so start by selecting the relevant option.
+Now that you've configured your database network and created an ingestion
+cluster, you can connect Materialize to your PostgreSQL database and start
+ingesting data. The exact steps depend on your networking configuration, so
+start by selecting the relevant option.
 
 {{< tabs >}}
 

--- a/doc/user/content/ingest-data/postgres-google-cloud-sql.md
+++ b/doc/user/content/ingest-data/postgres-google-cloud-sql.md
@@ -95,9 +95,16 @@ bastion host.
 
 {{< /tabs >}}
 
-## Step 4. Create an ingestion cluster
+## Step 4. (Optional) Create a cluster
 
-{{% postgres-direct/create-an-ingestion-cluster %}}
+{{< note >}}
+If you are prototyping and already have a cluster to host your PostgreSQL
+source (e.g. `quickstart`), **you can skip this step**. For production
+scenarios, we recommend separating your workloads into multiple clusters for
+[resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
+{{< /note >}}
+
+{{% postgres-direct/create-a-cluster %}}
 
 ## Step 5. Start ingesting data
 

--- a/doc/user/content/ingest-data/postgres-self-hosted.md
+++ b/doc/user/content/ingest-data/postgres-self-hosted.md
@@ -1,5 +1,5 @@
 ---
-title: "Ingest data from Self-hosted PostgreSQL"
+title: "Ingest data from self-hosted PostgreSQL"
 description: "How to stream data from self-hosted PostgreSQL database to Materialize"
 menu:
   main:
@@ -235,9 +235,16 @@ traffic from the bastion host.
 
 {{< /tabs >}}
 
-## Step 4. Create an ingestion cluster
+## Step 4. (Optional) Create a cluster
 
-{{% postgres-direct/create-an-ingestion-cluster %}}
+{{< note >}}
+If you are prototyping and already have a cluster to host your PostgreSQL
+source (e.g. `quickstart`), **you can skip this step**. For production
+scenarios, we recommend separating your workloads into multiple clusters for
+[resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
+{{< /note >}}
+
+{{% postgres-direct/create-a-cluster %}}
 
 ## Step 5. Start ingesting data
 

--- a/doc/user/content/ingest-data/redpanda-cloud.md
+++ b/doc/user/content/ingest-data/redpanda-cloud.md
@@ -108,7 +108,7 @@ start by selecting the relevant option.
 1. Copy the URL under **Cluster hosts**. This will be your
 `<redpanda-broker-url>` going forward.
 
-1. [In the Materialize SQL shell](https://console.materialize.com/), or your
+1. In the Materialize [SQL shell](https://console.materialize.com/), or your
 preferred SQL client, create a connection with your Redpanda Cloud cluster
 access and authentication details using the [`CREATE CONNECTION`](/sql/create-connection/)
 command:
@@ -130,8 +130,9 @@ command:
     ```
 
 1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize
-to your Redpanda Cloud cluster and start ingesting data from your target
-topic:
+   to your Redpanda Cloud cluster and start ingesting data from your target topic.
+   By default, the source will be created in the active cluster; to use a
+   different cluster, use the `IN CLUSTER` clause.
 
     ```sql
     CREATE SOURCE rp_source
@@ -214,7 +215,7 @@ in a region supported by Materialize: `us-east-1`,`us-west-2`, or `eu-west-1`.
         '.private_link'
     ```
 
-1. [In the Materialize SQL shell](https://console.materialize.com/), or your
+1. In the Materialize [SQL shell](https://console.materialize.com/), or your
 preferred SQL client, create a [PrivateLink connection](/ingest-data/network-security/privatelink/)
 using the service name from the previous step. Be sure to specify **all
 availability zones** of your Redpanda Cloud cluster.

--- a/doc/user/content/ingest-data/rudderstack.md
+++ b/doc/user/content/ingest-data/rudderstack.md
@@ -25,6 +25,8 @@ To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/crea
 
 ```sql
 CREATE CLUSTER webhooks_cluster (SIZE = '3xsmall');
+
+SET CLUSTER = webhooks_cluster;
 ```
 
 ## Step 2. Create a secret
@@ -39,10 +41,13 @@ Change the `<secret_value>` to a unique value that only you know and store it in
 
 ## Step 3. Set up a webhook source
 
-Using the secret from **Step 2.**, create a [webhook source](/sql/create-source/webhook/) in Materialize to ingest data from RudderStack:
+Using the secret from the previous step, create a [webhook source](/sql/create-source/webhook/)
+in Materialize to ingest data from RudderStack. By default, the source will be
+created in the active cluster; to use a different cluster, use the `IN
+CLUSTER` clause.
 
 ```sql
-CREATE SOURCE rudderstack_source IN CLUSTER webhooks_cluster
+CREATE SOURCE rudderstack_source
   FROM WEBHOOK
     BODY FORMAT JSON
     CHECK (

--- a/doc/user/content/ingest-data/rudderstack.md
+++ b/doc/user/content/ingest-data/rudderstack.md
@@ -19,7 +19,12 @@ Ensure that you have:
 
 ## Step 1. (Optional) Create a cluster
 
-If you already have a cluster for your webhook sources, you can skip this step.
+{{< note >}}
+If you are prototyping and already have a cluster to host your webhook
+source (e.g. `quickstart`), **you can skip this step**. For production
+scenarios, we recommend separating your workloads into multiple clusters for
+[resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
+{{< /note >}}
 
 To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/create-cluster):
 

--- a/doc/user/content/ingest-data/segment.md
+++ b/doc/user/content/ingest-data/segment.md
@@ -20,7 +20,12 @@ Ensure that you have:
 
 ## Step 1. (Optional) Create a cluster
 
-If you already have a cluster for your webhook sources, you can skip this step.
+{{< note >}}
+If you are prototyping and already have a cluster to host your webhook
+source (e.g. `quickstart`), **you can skip this step**. For production
+scenarios, we recommend separating your workloads into multiple clusters for
+[resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
+{{< /note >}}
 
 To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/create-cluster):
 

--- a/doc/user/content/ingest-data/segment.md
+++ b/doc/user/content/ingest-data/segment.md
@@ -26,6 +26,8 @@ To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/crea
 
 ```sql
 CREATE CLUSTER webhooks_cluster (SIZE = '3xsmall');
+
+SET CLUSTER = webhooks_cluster;
 ```
 
 ## Step 2. Create a secret
@@ -41,7 +43,9 @@ Change the `<secret_value>` to a unique value that only you know and store it in
 ## Step 3. Set up a webhook source
 
 Using the secret from the previous step, create a [webhook source](/sql/create-source/webhook/)
-in Materialize to ingest data from Segment:
+in Materialize to ingest data from Segment. By default, the source will be
+created in the active cluster; to use a different cluster, use the `IN
+CLUSTER` clause.
 
 ```sql
 CREATE SOURCE segment_source IN CLUSTER webhooks_cluster FROM WEBHOOK

--- a/doc/user/content/ingest-data/snowcatcloud.md
+++ b/doc/user/content/ingest-data/snowcatcloud.md
@@ -25,6 +25,8 @@ To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/crea
 
 ```sql
 CREATE CLUSTER webhooks_cluster (SIZE = '3xsmall');
+
+SET CLUSTER = webhooks_cluster;
 ```
 
 ## Step 2. Create a secret
@@ -40,7 +42,9 @@ Change the `<secret_value>` to a unique value that only you know and store it in
 ## Step 3. Set up a webhook source
 
 Using the secret from the previous step, create a [webhook source](/sql/create-source/webhook/)
-in Materialize to ingest data from SnowcatCloud:
+in Materialize to ingest data from SnowcatCloud. By default, the source will be
+created in the active cluster; to use a different cluster, use the `IN
+CLUSTER` clause.
 
 ```sql
 CREATE SOURCE snowcat_source IN CLUSTER webhooks_cluster

--- a/doc/user/content/ingest-data/snowcatcloud.md
+++ b/doc/user/content/ingest-data/snowcatcloud.md
@@ -14,7 +14,7 @@ into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
 Ensure that you have:
 
-- [ [SnowcatCloud account](https://app.snowcatcloud.com/register)
+- A [SnowcatCloud account](https://app.snowcatcloud.com/register)
 - A Snowplow or Analytics.js compatible pipeline set up and running.
 
 ## Step 1. (Optional) Create a cluster

--- a/doc/user/content/ingest-data/snowcatcloud.md
+++ b/doc/user/content/ingest-data/snowcatcloud.md
@@ -19,7 +19,12 @@ Ensure that you have:
 
 ## Step 1. (Optional) Create a cluster
 
-If you already have a cluster for your webhook sources, you can skip this step.
+{{< note >}}
+If you are prototyping and already have a cluster to host your webhook
+source (e.g. `quickstart`), **you can skip this step**. For production
+scenarios, we recommend separating your workloads into multiple clusters for
+[resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
+{{< /note >}}
 
 To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/create-cluster):
 

--- a/doc/user/content/ingest-data/stripe.md
+++ b/doc/user/content/ingest-data/stripe.md
@@ -18,7 +18,12 @@ Ensure that you have a Stripe account.
 
 ## Step 1. (Optional) Create a cluster
 
-If you already have a cluster for your webhook sources, you can skip this step.
+{{< note >}}
+If you are prototyping and already have a cluster to host your webhook
+source (e.g. `quickstart`), **you can skip this step**. For production
+scenarios, we recommend separating your workloads into multiple clusters for
+[resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
+{{< /note >}}
 
 To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/create-cluster):
 

--- a/doc/user/content/ingest-data/stripe.md
+++ b/doc/user/content/ingest-data/stripe.md
@@ -24,6 +24,8 @@ To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/crea
 
 ```sql
 CREATE CLUSTER webhooks_cluster (SIZE = '3xsmall');
+
+SET CLUSTER = webhooks_cluster;
 ```
 
 ## Step 2. Create a secret
@@ -38,8 +40,10 @@ Change the `<secret_value>` to a unique value that only you know and store it in
 
 ## Step 3. Set up a webhook source
 
-Using the secret from **Step 2.**, create a [webhook source](/sql/create-source/webhook/)
-in Materialize to ingest data from Stripe.
+Using the secret from the previous step, create a [webhook source](/sql/create-source/webhook/)
+in Materialize to ingest data from Stripe. By default, the source will be
+created in the active cluster; to use a different cluster, use the `IN
+CLUSTER` clause.
 
 ```sql
 CREATE SOURCE stripe_source IN CLUSTER webhooks_cluster

--- a/doc/user/content/ingest-data/upstash-kafka.md
+++ b/doc/user/content/ingest-data/upstash-kafka.md
@@ -13,69 +13,99 @@ menu:
 [//]: # "TODO(morsapaes) The Kafka guides need to be rewritten for consistency
 with the Postgres ones. We should include spill to disk in the guidance then."
 
-This guide goes through the required steps to connect Materialize to an Upstash Kafka cluster.
+This guide goes through the required steps to connect Materialize to an Upstash
+Kafka cluster.
 
-If you already have an Upstash Kafka cluster, you can skip steps 1 and 2 and directly move on to [Create a topic](#create-a-topic). You can also skip step 3 if you already have an Upstash Kafka cluster up and running, and have created a topic that you want to create a source for.
+If you already have an Upstash Kafka cluster, you can skip steps 1 and 2 and
+directly move on to [Create a topic](#create-a-topic). You can also skip step 3
+if you already have an Upstash Kafka cluster up and running, and have created a
+topic that you want to create a source for.
 
-The process to connect Materialize to Upstash Kafka consists of the following steps:
+The process to connect Materialize to Upstash Kafka consists of the following
+steps:
+
 1. #### Create an Upstash Kafka cluster
+
     If you already have an Upstash Kafka cluster set up, then you can skip this step.
 
-    a. Sign in to the [Upstash console](https://console.upstash.com/login)
+    a. Sign in to the [Upstash console](https://console.upstash.com/login).
 
-    b. Choose **Kafka** and then click the **Create Cluster** button
+    b. Choose **Kafka** and then click the **Create Cluster** button.
 
-    c. Enter a cluster name, and specify the rest of the settings based on your needs
+    c. Enter a cluster name, and specify the rest of the settings based on your
+    needs.
 
-    d. Choose **Create**
+    d. Choose **Create**.
 
-    e. Create your first topic by specifying a topic name and the number of partitions
+    e. Create your first topic by specifying a topic name and the number of
+    partitions.
 
-    f. Click **Create**
+    f. Click **Create**.
 
     **Note:** This creation process should take only a few seconds.
 
 2. #### Create new credentials
 
-    By default, Upstash provides a default credential that you can use to connect to your cluster. It's important to note that this default has full access to all topics in your cluster. For a more restricted setup, you can create a new credential with limited access to specific topics. If you want to use the default credential, skip this step.
+    By default, Upstash provides a default credential that you can use to
+    connect to your cluster. It's important to note that this default has full
+    access to all topics in your cluster. For a more restricted setup, you can
+    create a new credential with limited access to specific topics. If you want
+    to use the default credential, skip this step.
 
-    a. Navigate to the [Upstash console](https://console.upstash.com/login)
+    a. Navigate to the [Upstash console](https://console.upstash.com/login).
 
-    b. Choose the Upstash Kafka cluster you just created in Step 1
+    b. Choose the Upstash Kafka cluster you just created in the previous step.
 
-    c. Click on the **Credentials** tab
+    c. Click on the **Credentials** tab.
 
-    d. In the **Credentials** section, choose **New Credentials**
+    d. In the **Credentials** section, choose **New Credentials**.
 
-    e. Specify a name for the credentials
+    e. Specify a name for the credentials.
 
-    f. List the topics you want to grant access to
+    f. List the topics you want to grant access to.
 
-    g. Choose the **Permissions** you want to grant to the credentials
+    g. Choose the **Permissions** you want to grant to the credentials.
 
-    h. Click **Create**
+    h. Click **Create**.
 
-    If you want to create a [source](/sql/create-source/kafka/) in Materialize, you'll need to grant the **Read** permission. To create a [sink](/sql/create-sink/kafka/), you'll need to grant the **Read** and **Write** permissions.
+    If you want to create a [source](/sql/create-source/kafka/) in Materialize,
+    you'll need to grant the **Read** permission. To create a [sink](/sql/create-sink/kafka/),
+    you'll need to grant the **Read** and **Write** permissions.
 
-    Take note of the credentials you just created, you'll need them later on. Keep in mind that the credentials contain sensitive information, and you should store them somewhere safe!
+    Take note of the credentials you just created, you'll need them later on.
+    Keep in mind that the credentials contain sensitive information, and you
+    should store them somewhere safe!
 
 3. #### Create a topic
-    To start using Materialize with Upstash, you need to point it to an existing Upstash Kafka topic you want to read data from.
+
+    To start using Materialize with Upstash, you need to point it to an existing
+    Upstash Kafka topic you want to read data from.
 
     If you already have a topic created, you can skip this step.
 
-    Otherwise, you can follow the steps [here](https://docs.upstash.com/kafka#create-a-topic) to create a topic.
+    Otherwise, you can follow [these steps](https://docs.upstash.com/kafka#create-a-topic)
+    to create a topic.
 
-    Once you have a topic, you can produce a message to it by clicking on the topic name and then clicking on the **Messages** tab, and then clicking on the **Produce** button.
+    Once you have a topic, you can produce a message to it by clicking on the
+    topic name and then clicking on the **Messages** tab, and then clicking on
+    the **Produce** button.
 
 4. #### Create a source in Materialize
-    a. Open the [Upstash console](https://console.upstash.com/login) and select your cluster
 
-    b. Click on **Details**
+    a. Open the [Upstash console](https://console.upstash.com/login) and select
+    your cluster.
 
-    c. Copy the URL under **Endpoint**. This will be your `<upstash-broker-url>` going forward
+    b. Click on **Details**.
 
-    d. From the _psql_ terminal, run the following command. Replace `<upstash_kafka>` with whatever you want to name your source. The broker URL is what you copied in step c of this subsection. The `<topic-name>` is the name of the topic you created in Step 3. The `<your-username>` and `<your-password>` are from the _Create new credentials_ step.
+    c. Copy the URL under **Endpoint**. This will be your `<upstash-broker-url>`
+    going forward.
+
+    d. In the [SQL Shell](https://console.materialize.com/), or your preferred
+    SQL client connected to Materialize, run the following command. Replace
+    `<upstash_kafka>` with whatever you want to name your source. The broker
+    URL is what you copied in step c of this subsection. The `<topic-name>` is
+    the name of the topic you created in Step 3. The `<your-username>` and
+    `<your-password>` are from the _Create new credentials_ step.
 
     ```sql
       CREATE SECRET upstash_username AS '<your-username>';
@@ -93,6 +123,9 @@ The process to connect Materialize to Upstash Kafka consists of the following st
         FORMAT JSON;
     ```
 
+    By default, the source will be created in the active cluster; to use a
+    different cluster, use the `IN CLUSTER` clause.
+
     e. If the command executes without an error and outputs _CREATE SOURCE_, it
     means that you have successfully connected Materialize to your Upstash
     Kafka cluster.
@@ -108,9 +141,10 @@ The process to connect Materialize to Upstash Kafka consists of the following st
 
 5. #### Create a sink in Materialize
 
-    A [sink](/sql/create-sink) is a way to write data from Materialize to an external system like a Kafka cluster.
+    A [sink](/sql/create-sink) is a way to write data from Materialize to an
+    external system like a Kafka cluster.
 
-    To create a sink, from the _psql_ terminal, run the following command:
+    To create a sink, run the following command:
 
     ```sql
       CREATE SINK <sink-name>
@@ -120,6 +154,16 @@ The process to connect Materialize to Upstash Kafka consists of the following st
         ENVELOPE DEBEZIUM;
     ```
 
-    The generated schema will have a Debezium-style diff envelope to capture changes in the input view or source as we defined in the `ENVELOPE` clause. You can find more details about the various different supported formats and possible configurations [here](/sql/create-sink/kafka/).
+    By default, the sink will be created in the active cluster; to use a
+    different cluster, use the `IN CLUSTER` clause.
 
-    Once you have created the sink, you can go to the [Upstash console](https://console.upstash.com/login) and click on the topic you defined in the `CREATE SINK` statement. You will see the messages that were written to the topic. Materialize will produce messages to the topic every time the underlying source, table, or materialized view has new changes.
+    The generated schema will have a Debezium-style diff envelope to capture
+    changes in the input view or source as we defined in the `ENVELOPE` clause.
+    You can find more details about the various different supported formats and
+    possible configurations [here](/sql/create-sink/kafka/).
+
+    Once you have created the sink, you can go to the [Upstash console](https://console.upstash.com/login)
+    and click on the topic you defined in the `CREATE SINK` statement. You will
+    see the messages that were written to the topic. Materialize will produce
+    messages to the topic every time the underlying source, table, or
+    materialized view has new changes.

--- a/doc/user/content/ingest-data/warpstream.md
+++ b/doc/user/content/ingest-data/warpstream.md
@@ -13,28 +13,38 @@ menu:
 [//]: # "TODO(morsapaes) The Kafka guides need to be rewritten for consistency
 with the Postgres ones. We should include spill to disk in the guidance then."
 
-This guide goes through the necessary steps to connect Materialize to [WarpStream](https://www.warpstream.com/), an Apache Kafka® protocol compatible data streaming platform.
+This guide goes through the necessary steps to connect Materialize to
+[WarpStream](https://www.warpstream.com/), an Apache Kafka® protocol compatible
+data streaming platform.
 
-WarpStream runs on commodity object stores (e.g., Amazon S3, Google Cloud Storage, Azure Blob Storage) and offers benefits such as no inter-AZ bandwidth costs and no local disks management. This guide highlights its integration with Materialize using [Fly.io](https://fly.io/).
+WarpStream runs on commodity object stores (e.g., Amazon S3, Google Cloud
+Storage, Azure Blob Storage) and offers benefits such as no inter-AZ bandwidth
+costs and no local disks management. This guide highlights its integration with
+Materialize using [Fly.io](https://fly.io/).
 
 #### Before you begin
 
 Ensure you have the following:
 
--   WarpStream account: [Register here](https://console.warpstream.com/signup)
--   Fly.io account: Used for deploying a WarpStream cluster with TLS termination and SASL authentication.
+-   [A WarpStream account](https://console.warpstream.com/signup)
+-   A Fly.io account: used for deploying a WarpStream cluster with TLS termination
+    and SASL authentication.
 
 1. #### Set up WarpStream
 
     If you already have a WarpStream cluster, you can skip this step.
 
-    a. Begin by registering for a WarpStream account or logging in to your existing account.
+    a. Begin by registering for a WarpStream account or logging in to your
+    existing account.
 
-    b. Follow [this guide](https://github.com/warpstreamlabs/warpstream-fly-io-template) to deploy your WarpStream cluster on Fly.io.
+    b. Follow [this guide](https://github.com/warpstreamlabs/warpstream-fly-io-template)
+    to deploy your WarpStream cluster on Fly.io.
 
-    c. Post deployment, [create credentials](https://docs.warpstream.com/warpstream/how-to/configure-the-warpstream-agent-for-production/configure-authentication-for-the-warpstream-agent#sasl-authentication) for connecting to your WarpStream cluster.
+    c. Post deployment, [create credentials](https://docs.warpstream.com/warpstream/how-to/configure-the-warpstream-agent-for-production/configure-authentication-for-the-warpstream-agent#sasl-authentication)
+    for connecting to your WarpStream cluster.
 
-    d. Use the provided credentials to connect to the WarpStream cluster on Fly.io. Test this connection using [the WarpStream CLI](https://docs.warpstream.com/warpstream/install-the-warpstream-agent):
+    d. Use the provided credentials to connect to the WarpStream cluster on
+    Fly.io. Test this connection using [the WarpStream CLI](https://docs.warpstream.com/warpstream/install-the-warpstream-agent):
 
     ```bash
     warpstream kcmd -type diagnose-connection \
@@ -43,7 +53,8 @@ Ensure you have the following:
                     -password ccp_XXXXXXXXXX
     ```
 
-    Change the `bootstrap-host` to the name of your WarpStream cluster on Fly.io.
+    Change the `bootstrap-host` to the name of your WarpStream cluster on
+    Fly.io.
 
     e. Create the `materialize_click_streams` topic:
 
@@ -70,7 +81,9 @@ Ensure you have the following:
 
 2. #### Integrate with Materialize
 
-    To integrate WarpStream with Materialize, you need to set up a connection to the WarpStream broker and create a source in Materialize to consume the data.
+    To integrate WarpStream with Materialize, you need to set up a connection to
+    the WarpStream broker and create a source in Materialize to consume the
+    data.
 
     Head over to the Materialize console and follow the steps below:
 
@@ -92,7 +105,9 @@ Ensure you have the following:
     );
     ```
 
-    c. Create a source in Materialize to consume messages:
+    c. Create a source in Materialize to consume messages. By default, the
+    source will be created in the active cluster; to use a different cluster,
+    use the `IN CLUSTER` clause.
 
     ```sql
     CREATE SOURCE warpstream_click_stream_source
@@ -137,4 +152,6 @@ Ensure you have the following:
 
 ---
 
-By following the steps outlined above, you will have successfully set up a connection between WarpStream and Materialize. You can now use Materialize to query the data ingested from WarpStream.
+By following the steps outlined above, you will have successfully set up a
+connection between WarpStream and Materialize. You can now use Materialize to
+query the data ingested from WarpStream.

--- a/doc/user/content/integrations/http-api.md
+++ b/doc/user/content/integrations/http-api.md
@@ -20,9 +20,9 @@ https://<MZ host address>/api/sql
 
 The API:
 
-- Requires username/password authentication, just as connecting via `psql`.
-  Materialize provides you the username and password upon setting up your
-  account.
+- Requires username/password authentication, just as connecting via a SQL
+  client (e.g. `psql`). Materialize provides you the username and password upon
+  setting up your account.
 - Requires that you provide the entirety of your request. The API does not
   provide session-like semantics, so there is no way to e.g. interactively use
   transactions.
@@ -60,7 +60,7 @@ The HTTP API provides two modes with slightly different transactional semantics 
 https://<MZ host address>/api/sql
 ```
 
-Accessing the endpoint requires [basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). Reuse the same credentials as with `psql`:
+Accessing the endpoint requires [basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). Reuse the same credentials as with a SQL client (e.g. `psql`):
 
 * **User ID:** Your email to access Materialize.
 * **Password:** Your app password.

--- a/doc/user/content/integrations/websocket-api.md
+++ b/doc/user/content/integrations/websocket-api.md
@@ -22,9 +22,9 @@ wss://<MZ host address>/api/experimental/sql
 
 The API:
 
-- Requires username/password authentication, just as connecting via `psql`.
-  Materialize provides you the username and password upon setting up your
-  account.
+- Requires username/password authentication, just as connecting via a SQL
+  client (e.g. `psql`). Materialize provides you the username and password upon
+  setting up your account.
 - Maintains an interactive session.
 - Does not support some statements:
     - `CLOSE`

--- a/doc/user/content/manage/access-control/rbac-tutorial.md
+++ b/doc/user/content/manage/access-control/rbac-tutorial.md
@@ -24,8 +24,6 @@ production cluster.
 
 ## Before you begin
 
-* Make sure you have `psql` or another client installed locally.
-
 * Make sure you have a [Materialize account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation) and already have a password to connect with.
 
 ## Step 1. Invite a new user
@@ -41,11 +39,8 @@ example.
 
 ## Step 2. Create a new role
 
-1. In the Materialize UI, go to the **Connect** screen and copy the `psql` command or external tool information.
-
-1. Open a new terminal window, run the `psql` command or use the external tool connection information, and enter your app password.
-
-1. Now that you're logged in, you can create a new role:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, create a new role:
 
     ```sql
     CREATE ROLE dev_role;
@@ -89,8 +84,8 @@ example.
 Your `dev_role` has the default system-level permissions and needs object-level privileges. RBAC allows you to apply granular privileges to objects in the SQL hierarchy. Let's create some example objects in the system and determine what
 privileges the role needs.
 
-1. In your `psql` terminal, create a new example cluster to avoid impacting
-   other environments:
+1. In the SQL client connected to Materialize, create a new example cluster to
+avoid impacting other environments:
 
    ```sql
    CREATE CLUSTER dev_cluster (SIZE = '3xsmall');

--- a/doc/user/content/manage/dbt.md
+++ b/doc/user/content/manage/dbt.md
@@ -382,26 +382,24 @@ SELECT NULL AS col_with_constraints,
 
     This command generates **executable SQL code** from any model files under the specified directory and runs it in the target environment. You can find the compiled statements under `/target/run` and `target/compiled` in the dbt project folder.
 
-1. Using a new terminal window, [connect](/integrations/psql/) to Materialize to double-check that all objects have been created:
-
-    ```bash
-    psql "postgres://<user>:<password>@<host>:6875/materialize"
-    ```
+1. Using the [SQL Shell](https://console.materialize.com/), or your preferred
+   SQL client connected to Materialize, double-check that all objects have been
+   created:
 
     ```sql
-    materialize=> SHOW SOURCES [FROM database.schema];
+    SHOW SOURCES [FROM database.schema];
            name
     -------------------
      postgres_table_a
      postgres_table_b
      kafka_topic_a
 
-     materialize=> SHOW VIEWS;
+    SHOW VIEWS;
            name
     -------------------
      view_a
 
-     materialize=> SHOW MATERIALIZED VIEWS;
+     SHOW MATERIALIZED VIEWS;
            name
     -------------------
      materialized_view_a
@@ -458,20 +456,18 @@ Using dbt in a streaming context means that you're able to run data quality and 
 
     This guarantees that your tests keep running in the background as views that are automatically updated as soon as an assertion fails.
 
-1. Using a new terminal window, [connect](/integrations/psql/) to Materialize to double-check that the schema storing the tests has been created, as well as the test materialized views:
-
-    ```bash
-    psql "postgres://<user>:<password>@<host>:6875/materialize"
-    ```
+1. Using the [SQL Shell](https://console.materialize.com/), or your preferred
+   SQL client connected to Materialize, that the schema storing the tests has been
+   created, as well as the test materialized views:
 
     ```sql
-    materialize=> SHOW SCHEMAS;
+    SHOW SCHEMAS;
            name
     -------------------
      public
      public_etl_failure
 
-     materialize=> SHOW MATERIALIZED VIEWS FROM public_etl_failure;;
+    SHOW MATERIALIZED VIEWS FROM public_etl_failure;;
            name
     -------------------
      not_null_col_a

--- a/doc/user/content/sql/recursive-ctes.md
+++ b/doc/user/content/sql/recursive-ctes.md
@@ -75,7 +75,10 @@ However, introducing recursive CTEs complicates the situation as follows:
 
 ## Examples
 
-Let's consider a very simple schema consisting of `users` that belong to a hierarchy of geographical `areas` and exchange `transfers` between each other.
+Let's consider a very simple schema consisting of `users` that belong to a
+hierarchy of geographical `areas` and exchange `transfers` between each other.
+Use the [SQL Shell](https://console.materialize.com/) to run the sequence of
+commands below.
 
 
 ### Example schema
@@ -134,12 +137,16 @@ WITH MUTUALLY RECURSIVE
 SELECT src_id, dst_id FROM connected;
 ```
 
-You can insert [the example data](#example-data) and observe how the materialized view contents change over time from the `psql` with the `\watch` command:
+To see results change over time, you can [`SUBSCRIBE`](/sql/subscribe/) to the
+materialized view and then use a different SQL Shell session to insert
+some sample data into the base tables used in the view:
 
 ```sql
-SELECT * FROM connected;
-\watch 1
+SUBSCRIBE(SELECT * FROM connected) WITH (SNAPSHOT = FALSE);
 ```
+
+You'll see results change as new data is inserted. When you’re done, cancel out
+of the `SUBSCRIBE` using **Stop streaming**.
 
 {{< note >}}
 Depending on your base data, the number of records in the `connected` result might get close to the square of the number of `users`.
@@ -171,12 +178,14 @@ CREATE MATERIALIZED VIEW strongly_connected_components AS
   GROUP BY u.id;
 ```
 
-Again, you can insert [the example data](#example-data) and observe how the materialized view contents change over time from the `psql` with the `\watch` command:
+Again, you can insert some sample data into the base tables and observe how the
+materialized view contents change over time using `SUBSCRIBE`:
 
 ```sql
-SELECT * FROM strongly_connected_components;
-\watch 1
+SUBSCRIBE(SELECT * FROM strongly_connected_components) WITH (SNAPSHOT = FALSE);
 ```
+
+When you’re done, cancel out of the `SUBSCRIBE` using **Stop streaming**.
 
 {{< note >}}
 The `strongly_connected_components` definition given above is not recursive, but relies on the recursive CTEs from the `connected` definition.

--- a/doc/user/layouts/shortcodes/postgres-direct/before-you-begin.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/before-you-begin.html
@@ -1,5 +1,7 @@
 - Make sure you are running PostgreSQL 11 or higher.
 
-- Make sure you have access to your PostgreSQL instance via a SQL client (e.g. [`psql`](https://www.postgresql.org/docs/current/app-psql.html)).
+- Make sure you have access to your PostgreSQL instance via [`psql`](https://www.postgresql.org/docs/current/app-psql.html),
+  or your preferred SQL client.
 
-You'll use the [Materialize SQL shell](https://console.materialize.com/), or your preferred SQL client, to interact with Materialize.
+You'll use the [SQL Shell](https://console.materialize.com/), or your preferred
+SQL client, to interact with Materialize.

--- a/doc/user/layouts/shortcodes/postgres-direct/before-you-begin.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/before-you-begin.html
@@ -2,6 +2,3 @@
 
 - Make sure you have access to your PostgreSQL instance via [`psql`](https://www.postgresql.org/docs/current/app-psql.html),
   or your preferred SQL client.
-
-You'll use the [SQL Shell](https://console.materialize.com/), or your preferred
-SQL client, to interact with Materialize.

--- a/doc/user/layouts/shortcodes/postgres-direct/check-the-ingestion-status.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/check-the-ingestion-status.html
@@ -1,8 +1,13 @@
-Before it starts consuming the replication stream, Materialize takes a snapshot of the relevant tables in your publication. Until this snapshot is complete, Materialize won't have the same view of your data as your PostgreSQL database.
+Before it starts consuming the replication stream, Materialize takes a snapshot
+of the relevant tables in your publication. Until this snapshot is complete,
+Materialize won't have the same view of your data as your PostgreSQL database.
 
-In this step, you'll first verify that the source is running and then check the status of the snapshotting process.
+In this step, you'll first verify that the source is running and then check the
+status of the snapshotting process.
 
-1. Back in the SQL client connected to Materialize, use the [`mz_source_statuses`](/sql/system-catalog/mz_internal/#mz_source_statuses) table to check the overall status of your source:
+1. Back in the SQL client connected to Materialize, use the
+   [`mz_source_statuses`](/sql/system-catalog/mz_internal/#mz_source_statuses)
+   table to check the overall status of your source:
 
     ```sql
     WITH
@@ -23,9 +28,14 @@ In this step, you'll first verify that the source is running and then check the 
         ON mz_source_statuses.id = sources.referenced_object_id;
     ```
 
-    For each `subsource`, make sure the `status` is `running`. If you see `stalled` or `failed`, there's likely a configuration issue for you to fix. Check the `error` field for details and fix the issue before moving on. Also, if the `status` of any subsource is `starting` for more than a few minutes, [contact our team](/support/).
+    For each `subsource`, make sure the `status` is `running`. If you see
+    `stalled` or `failed`, there's likely a configuration issue for you to fix.
+    Check the `error` field for details and fix the issue before moving on.
+    Also, if the `status` of any subsource is `starting` for more than a few
+    minutes, [contact our team](/support/).
 
-2. Once the source is running, use the [`mz_source_statistics`](/sql/system-catalog/mz_internal/#mz_source_statistics) table to check the status of the initial snapshot:
+2. Once the source is running, use the [`mz_source_statistics`](/sql/system-catalog/mz_internal/#mz_source_statistics)
+   table to check the status of the initial snapshot:
 
     ```sql
     WITH
@@ -55,4 +65,6 @@ In this step, you'll first verify that the source is running and then check the 
     (1 row)
     ```
 
-    Once `snapshot_commited` is `t`, move on to the next step. Snapshotting can take between a few minutes to several hours, depending on the size of your dataset and the size of the cluster replica you chose for your `ingest_postgres` cluster.
+    Once `snapshot_commited` is `t`, move on to the next step. Snapshotting can
+    take between a few minutes to several hours, depending on the size of your
+    dataset and the size of the cluster the source is running in.

--- a/doc/user/layouts/shortcodes/postgres-direct/create-a-cluster.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/create-a-cluster.html
@@ -5,7 +5,7 @@ work you need the cluster to do, whether ingesting data from a source,
 computing always-up-to-date query results, serving results to clients, or a
 combination.
 
-In this case, you'll create 1 new `small` cluster for ingesting source data from
+In this case, you'll create a dedicated cluster for ingesting source data from
 your PostgreSQL database.
 
 1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL

--- a/doc/user/layouts/shortcodes/postgres-direct/create-a-publication-aws.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/create-a-publication-aws.html
@@ -1,8 +1,13 @@
-Once logical replication is enabled, create a publication with the tables that you want to replicate to Materialize. You'll also need a user for Materialize with sufficient privileges to manage replication.
+Once logical replication is enabled, create a publication with the tables that
+you want to replicate to Materialize. You'll also need a user for Materialize
+with sufficient privileges to manage replication.
 
-1. As a _superuser_, use `psql` to connect to your database.
+1. As a _superuser_, use `psql` (or your preferred SQL client) to connect to
+   your database.
 
-1. For each table that you want to replicate to Materialize, set the [replica identity](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY) to `FULL`:
+1. For each table that you want to replicate to Materialize, set the
+   [replica identity](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY)
+   to `FULL`:
 
     ```sql
     ALTER TABLE <table1> REPLICA IDENTITY FULL;
@@ -12,9 +17,14 @@ Once logical replication is enabled, create a publication with the tables that y
     ALTER TABLE <table2> REPLICA IDENTITY FULL;
     ```
 
-    `REPLICA IDENTITY FULL` ensures that the replication stream includes the previous data of changed rows, in the case of `UPDATE` and `DELETE` operations. This setting enables Materialize to ingest PostgreSQL data with minimal in-memory state. However, you should expect increased disk usage in your PostgreSQL database.
+    `REPLICA IDENTITY FULL` ensures that the replication stream includes the
+    previous data of changed rows, in the case of `UPDATE` and `DELETE`
+    operations. This setting enables Materialize to ingest PostgreSQL data with
+    minimal in-memory state. However, you should expect increased disk usage in
+    your PostgreSQL database.
 
-1. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate:
+1. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html)
+   with the tables you want to replicate:
 
     _For specific tables:_
 
@@ -28,9 +38,13 @@ Once logical replication is enabled, create a publication with the tables that y
     CREATE PUBLICATION mz_source FOR ALL TABLES;
     ```
 
-    The `mz_source` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream.
+    The `mz_source` publication will contain the set of change events generated
+    from the specified tables, and will later be used to ingest the replication
+    stream.
 
-    Be sure to include only the tables you need. If the publication includes additional tables, Materialize will waste resources on ingesting and then immediately discarding the data.
+    Be sure to include only the tables you need. If the publication includes
+    additional tables, Materialize will waste resources on ingesting and then
+    immediately discarding the data.
 
 1. Create a user for Materialize, if you don't already have one:
 
@@ -62,9 +76,12 @@ Once logical replication is enabled, create a publication with the tables that y
     GRANT SELECT ON <table2> TO materialize;
     ```
 
-    Once connected to your database, Materialize will take an initial snapshot of the tables in your publication. `SELECT` privileges are required for this initial snapshot.
+    Once connected to your database, Materialize will take an initial snapshot
+    of the tables in your publication. `SELECT` privileges are required for
+    this initial snapshot.
 
-    If you expect to add tables to your publication, you can grant `SELECT` on all tables in the schema instead of naming the specific tables:
+    If you expect to add tables to your publication, you can grant `SELECT` on
+    all tables in the schema instead of naming the specific tables:
 
     ```sql
     GRANT SELECT ON ALL TABLES IN SCHEMA <schema> TO materialize;

--- a/doc/user/layouts/shortcodes/postgres-direct/create-a-publication-other.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/create-a-publication-other.html
@@ -1,6 +1,10 @@
-Once logical replication is enabled, the next step is to create a publication with the tables that you want to replicate to Materialize. You'll also need a user for Materialize with sufficient privileges to manage replication.
+Once logical replication is enabled, the next step is to create a publication
+with the tables that you want to replicate to Materialize. You'll also need a
+user for Materialize with sufficient privileges to manage replication.
 
-1. For each table that you want to replicate to Materialize, set the [replica identity](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY) to `FULL`:
+1. For each table that you want to replicate to Materialize, set the
+   [replica identity](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY)
+   to `FULL`:
 
     ```sql
     ALTER TABLE <table1> REPLICA IDENTITY FULL;
@@ -10,9 +14,14 @@ Once logical replication is enabled, the next step is to create a publication wi
     ALTER TABLE <table2> REPLICA IDENTITY FULL;
     ```
 
-    `REPLICA IDENTITY FULL` ensures that the replication stream includes the previous data of changed rows, in the case of `UPDATE` and `DELETE` operations. This setting enables Materialize to ingest PostgreSQL data with minimal in-memory state. However, you should expect increased disk usage in your PostgreSQL database.
+    `REPLICA IDENTITY FULL` ensures that the replication stream includes the
+    previous data of changed rows, in the case of `UPDATE` and `DELETE`
+    operations. This setting enables Materialize to ingest PostgreSQL data with
+    minimal in-memory state. However, you should expect increased disk usage in
+    your PostgreSQL database.
 
-1. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) with the tables you want to replicate:
+1. Create a [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html)
+   with the tables you want to replicate:
 
     _For specific tables:_
 
@@ -26,9 +35,13 @@ Once logical replication is enabled, the next step is to create a publication wi
     CREATE PUBLICATION mz_source FOR ALL TABLES;
     ```
 
-    The `mz_source` publication will contain the set of change events generated from the specified tables, and will later be used to ingest the replication stream.
+    The `mz_source` publication will contain the set of change events generated
+    from the specified tables, and will later be used to ingest the replication
+    stream.
 
-    Be sure to include only the tables you need. If the publication includes additional tables, Materialize will waste resources on ingesting and then immediately discarding the data.
+    Be sure to include only the tables you need. If the publication includes
+    additional tables, Materialize will waste resources on ingesting and then
+    immediately discarding the data.
 
 1. Create a user for Materialize, if you don't already have one:
 
@@ -60,9 +73,12 @@ Once logical replication is enabled, the next step is to create a publication wi
     GRANT SELECT ON <table2> TO materialize;
     ```
 
-    Once connected to your database, Materialize will take an initial snapshot of the tables in your publication. `SELECT` privileges are required for this initial snapshot.
+    Once connected to your database, Materialize will take an initial snapshot
+    of the tables in your publication. `SELECT` privileges are required for
+    this initial snapshot.
 
-    If you expect to add tables to your publication, you can grant `SELECT` on all tables in the schema instead of naming the specific tables:
+    If you expect to add tables to your publication, you can grant `SELECT` on
+    all tables in the schema instead of naming the specific tables:
 
     ```sql
     GRANT SELECT ON ALL TABLES IN SCHEMA <schema> TO materialize;

--- a/doc/user/layouts/shortcodes/postgres-direct/create-an-ingestion-cluster.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/create-an-ingestion-cluster.html
@@ -1,11 +1,21 @@
-In Materialize, a [cluster](/get-started/key-concepts/#clusters) is an isolated environment, similar to a virtual warehouse in Snowflake. When you create a cluster, you choose the size of its compute resource allocation based on the work you need the cluster to do, whether ingesting data from a source, computing always-up-to-date query results, serving results to clients, or a combination.
+In Materialize, a [cluster](/get-started/key-concepts/#clusters) is an isolated
+environment, similar to a virtual warehouse in Snowflake. When you create a
+cluster, you choose the size of its compute resource allocation based on the
+work you need the cluster to do, whether ingesting data from a source,
+computing always-up-to-date query results, serving results to clients, or a
+combination.
 
-In this case, you'll create 1 new `small` cluster for ingesting source data from your PostgreSQL database.
+In this case, you'll create 1 new `small` cluster for ingesting source data from
+your PostgreSQL database.
 
-1. In the [Materialize SQL shell](https://console.materialize.com/), or your preferred SQL client connected to Materialize, use the [`CREATE CLUSTER`](/sql/create-cluster/) command to create the new cluster:
+1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, use the [`CREATE CLUSTER`](/sql/create-cluster/)
+   command to create the new cluster:
 
     ```sql
     CREATE CLUSTER ingest_postgres (SIZE = 'small');
+
+    SET CLUSTER = ingest_postgres;
     ```
 
     A cluster of [size](/sql/create-cluster/#size) `small` should be enough to

--- a/doc/user/layouts/shortcodes/postgres-direct/ingesting-data/allow-materialize-ips.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/ingesting-data/allow-materialize-ips.html
@@ -1,11 +1,15 @@
 
-1. In a SQL client connected to Materialize, use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
+1. In a SQL client connected to Materialize, use the [`CREATE SECRET`](/sql/create-secret/)
+   command to securely store the password for the `materialize` PostgreSQL user you
+   created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
-1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create a connection object with access and authentication details for Materialize to use:
+1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create a
+   connection object with access and authentication details for Materialize to
+   use:
 
     ```sql
     CREATE CONNECTION pg_connection TO POSTGRES (
@@ -20,9 +24,12 @@
 
     - Replace `<host>` with your Postgres endpoint.
 
-    - Replace `<database>` with the name of the database containing the tables you want to replicate to Materialize.
+    - Replace `<database>` with the name of the database containing the tables
+      you want to replicate to Materialize.
 
-1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your Postgres instance and start ingesting data from the publication you created [earlier](#step-2-create-a-publication):
+1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize
+to your Postgres instance and start ingesting data from the publication you
+created [earlier](#step-2-create-a-publication):
 
     ```sql
     CREATE SOURCE mz_source
@@ -31,6 +38,12 @@
       FOR ALL TABLES;
     ```
 
-    To ingest data from specific schemas or tables in your publication, use `FOR SCHEMAS (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR ALL TABLES`.
+    By default, the source will be created in the active cluster; to use a
+    different cluster, use the `IN CLUSTER` clause. To ingest data from
+    specific schemas or tables in your publication, use `FOR SCHEMAS
+    (<schema1>,<schema2>)` or `FOR TABLES (<table1>, <table2>)` instead of `FOR
+    ALL TABLES`.
 
-1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes) for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP} SUBSOURCE`](/sql/alter-source/#context) syntax.
+1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
+   for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP SUBSOURCE`](/sql/alter-source/#context)
+   syntax.

--- a/doc/user/layouts/shortcodes/postgres-direct/next-steps.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/next-steps.html
@@ -1,6 +1,16 @@
-With Materialize ingesting your PostgreSQL data into durable storage, you can start exploring the data, computing real-time results that stay up-to-date as new data arrives, and serving results efficiently.
+With Materialize ingesting your PostgreSQL data into durable storage, you can
+start exploring the data, computing real-time results that stay up-to-date as
+new data arrives, and serving results efficiently.
 
 - Explore your data with [`SHOW SOURCES`](/sql/show-sources) and [`SELECT`](/sql/select/).
-- Compute real-time results in memory with [`CREATE VIEW`](/sql/create-view/) and [`CREATE INDEX`](/sql/create-index/) or in durable storage with [`CREATE MATERIALIZED VIEW`](/sql/create-materialized-view/).
-- Serve results to a PostgreSQL-compatible SQL client or driver with [`SELECT`](/sql/select/) or [`SUBSCRIBE`](/sql/subscribe/) or to an external message broker with [`CREATE SINK`](/sql/create-sink/).
-- Check out the [tools and integrations](/integrations/) supported by Materialize.
+
+- Compute real-time results in memory with [`CREATE VIEW`](/sql/create-view/)
+  and [`CREATE INDEX`](/sql/create-index/) or in durable
+  storage with [`CREATE MATERIALIZED VIEW`](/sql/create-materialized-view/).
+
+- Serve results to a PostgreSQL-compatible SQL client or driver with [`SELECT`](/sql/select/)
+  or [`SUBSCRIBE`](/sql/subscribe/) or to an external message broker with
+  [`CREATE SINK`](/sql/create-sink/).
+
+- Check out the [tools and integrations](/integrations/) supported by
+  Materialize.

--- a/doc/user/layouts/shortcodes/postgres-direct/postgres-schema-changes.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/postgres-schema-changes.html
@@ -7,8 +7,10 @@ follows:
   you use [`ALTER SOURCE...{DROP | ADD} SUBSOURCE`](/sql/alter-source/) to
   first drop the affected subsource, and then add the table back to the
   source.
+
 - Dropping columns that were added after the source was created. These columns
   are never ingested, so you can drop them without issue.
+
 - Adding or removing `NOT NULL` constraints to tables that were nullable when
   the source was created.
 
@@ -18,8 +20,7 @@ All other schema changes to tables in the publication will set the corresponding
 subsource into an error state, which prevents you from reading from the
 subsource(s).
 
-To handle incompatible [schema changes](#schema-changes), use [`ALTER SOURCE...
-{DROP | ADD} SUBSOURCE`](/sql/alter-source/) to first drop the affected
-subsource, and then add the table back to the source. When you add the
-subsource, it will have the updated schema from the corresponding upstream
-table.
+To handle incompatible [schema changes](#schema-changes), use [`ALTER SOURCE...{DROP | ADD} SUBSOURCE`](/sql/alter-source/)
+to first drop the affected subsource, and then add the table back to the source.
+When you add the subsource, it will have the updated schema from the
+corresponding upstream table.

--- a/doc/user/layouts/shortcodes/postgres-direct/right-size-the-cluster.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/right-size-the-cluster.html
@@ -1,14 +1,20 @@
-After the snapshotting phase, Materialize starts ingesting change events from the PostgreSQL replication stream. For this work, Materialize generally performs well with an `xsmall` replica, so you can resize the cluster accordingly.
+After the snapshotting phase, Materialize starts ingesting change events from
+the PostgreSQL replication stream. For this work, Materialize generally
+performs well with an `xsmall` replica, so you can resize the cluster
+accordingly.
 
-1. Still in a SQL client connected to Materialize, use the [`ALTER CLUSTER`](/sql/alter-cluster/) command to downsize the cluster to `xsmall`:
+1. Still in a SQL client connected to Materialize, use the [`ALTER CLUSTER`](/sql/alter-cluster/)
+   command to downsize the cluster to `xsmall`:
 
     ```sql
     ALTER CLUSTER ingest_postgres SET (SIZE 'xsmall');
     ```
 
-    Behind the scenes, this command adds a new `xsmall` replica and removes the `small` replica.
+    Behind the scenes, this command adds a new `xsmall` replica and removes the
+    `small` replica.
 
-1. Use the [`SHOW CLUSTER REPLICAS`](/sql/show-cluster-replicas/) command to check the status of the new replica:
+1. Use the [`SHOW CLUSTER REPLICAS`](/sql/show-cluster-replicas/) command to
+   check the status of the new replica:
 
     ```sql
     SHOW CLUSTER REPLICAS WHERE cluster = 'ingest_postgres';
@@ -22,9 +28,12 @@ After the snapshotting phase, Materialize starts ingesting change events from th
     (1 row)
     ```
 
-1. Going forward, you can verify that your new replica size is sufficient as follows:
+1. Going forward, you can verify that your new cluster size is sufficient as
+follows:
 
-    1. In Materialize, get the replication slot name associated with your PostgreSQL source from the [`mz_internal.mz_postgres_sources`](/sql/system-catalog/mz_internal/#mz_postgres_sources) table:
+    1. In Materialize, get the replication slot name associated with your
+    PostgreSQL source from the [`mz_internal.mz_postgres_sources`](/sql/system-catalog/mz_internal/#mz_postgres_sources)
+    table:
 
         ```sql
         SELECT
@@ -39,7 +48,8 @@ After the snapshotting phase, Materialize starts ingesting change events from th
             JOIN mz_databases AS d ON d.id = n.database_id;
         ```
 
-    1. In PostgreSQL, check the replication slot lag, using the replication slot name from the previous step:
+    1. In PostgreSQL, check the replication slot lag, using the replication slot
+       name from the previous step:
 
         ```sql
         SELECT
@@ -49,4 +59,9 @@ After the snapshotting phase, Materialize starts ingesting change events from th
         WHERE slot_name = '<slot_name>';
         ```
 
-        The result of this query is the amount of data your PostgreSQL cluster must retain in its replication log because of this replication slot. Typically, this means Materialize has not yet communicated back to PostgreSQL that it has committed this data. A high value can indicate that the source has fallen behind and that you might need to scale up your ingestion cluster.
+        The result of this query is the amount of data your PostgreSQL cluster
+        must retain in its replication log because of this replication slot.
+        Typically, this means Materialize has not yet communicated back to
+        PostgreSQL that it has committed this data. A high value can indicate
+        that the source has fallen behind and that you might need to scale up
+        your ingestion cluster.


### PR DESCRIPTION
This PR updates our integrations guides to match the current state of Materialize:

* Remove `IN CLUSTER` from the `CREATE SOURCE` command for all webhook guides, as a follow-up to #25398.
* Add a note about the default behavior of `CREATE SOURCE` to all guides:
   > By default, the source will be created in the active cluster; to use a different cluster, use the `IN CLUSTER` clause.
* Make cluster creation an optional step in all guides. Refrained from completely removing the step because, in the end, we still recommend using multiple clusters for resource isolation. Added a note to that effect:
   > {{< note >}}
   > If you are prototyping and already have a cluster to host your PostgreSQL
   > source (e.g. `quickstart`), **you can skip this step**. For production
   > scenarios, we recommend separating your workloads into multiple clusters for
   > [resource isolation](https://materialize.com/docs/sql/create-cluster/#resource-isolation).
   > {{< /note >}}
* Replace mentions to `psql` with:
   > In the [SQL Shell](https://console.materialize.com/), or your preferred SQL client connected to Materialize,

Fixes #25687.