### PR TITLE
session variables: Allow max_copy_from_size > 4 GB

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -3680,7 +3680,7 @@ fn copy_from() {
         .connect(postgres::NoTls)
         .unwrap();
     system_client
-        .batch_execute("ALTER SYSTEM SET max_copy_from_size = 50")
+        .batch_execute("ALTER SYSTEM SET max_copy_from_size = '50B'")
         .unwrap();
     drop(system_client);
 

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -538,7 +538,7 @@ pub static MAX_QUERY_RESULT_SIZE: VarDefinition = VarDefinition::new(
 pub static MAX_COPY_FROM_SIZE: VarDefinition = VarDefinition::new(
     "max_copy_from_size",
     // 1 GiB, this limit is noted in the docs, if you change it make sure to update our docs.
-    value!(u32; 1_073_741_824),
+    value!(ByteSize; ByteSize::gb(1)),
     "The maximum size in bytes we buffer for COPY FROM statements (Materialize).",
     false,
 );

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -41,7 +41,7 @@ is_superuser                        off                     "Reports whether the
 max_aws_privatelink_connections     0                       "The maximum number of AWS PrivateLink connections in the region, across all schemas (Materialize)."
 max_clusters                        10                      "The maximum number of clusters in the region (Materialize)."
 max_connections                     5000                    "The maximum number of concurrent connections (PostgreSQL)."
-max_copy_from_size                  1073741824              "The maximum size in bytes we buffer for COPY FROM statements (Materialize)."
+max_copy_from_size                  1GB                     "The maximum size in bytes we buffer for COPY FROM statements (Materialize)."
 max_credit_consumption_rate         1024                    "The maximum rate of credit consumption in a region. Credits are consumed based on the size of cluster replicas in use (Materialize)."
 max_databases                       1000                    "The maximum number of databases in the region (Materialize)."
 max_identifier_length               255                     "The maximum length of object identifiers in bytes (PostgreSQL)."


### PR DESCRIPTION
Previously failed:
```
materialize=> alter system set max_copy_from_size=15000000000; ERROR:  parameter "max_copy_from_size" requires a "unsigned integer" value
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
