### PR TITLE
[poc] compute: sequential dataflow hydration using a Timely suspend API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#9208396d1d86becbcc91c76e780ffe61fd51e65e"
+source = "git+https://github.com/teskje/timely-dataflow.git?branch=suspend-dataflow#b83763742a05025bde95a9999dced98b465d458e"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -8937,12 +8937,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#9208396d1d86becbcc91c76e780ffe61fd51e65e"
+source = "git+https://github.com/teskje/timely-dataflow.git?branch=suspend-dataflow#b83763742a05025bde95a9999dced98b465d458e"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#9208396d1d86becbcc91c76e780ffe61fd51e65e"
+source = "git+https://github.com/teskje/timely-dataflow.git?branch=suspend-dataflow#b83763742a05025bde95a9999dced98b465d458e"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -8958,7 +8958,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#9208396d1d86becbcc91c76e780ffe61fd51e65e"
+source = "git+https://github.com/teskje/timely-dataflow.git?branch=suspend-dataflow#b83763742a05025bde95a9999dced98b465d458e"
 dependencies = [
  "columnation",
  "serde",
@@ -8967,7 +8967,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#9208396d1d86becbcc91c76e780ffe61fd51e65e"
+source = "git+https://github.com/teskje/timely-dataflow.git?branch=suspend-dataflow#b83763742a05025bde95a9999dced98b465d458e"
 
 [[package]]
 name = "tiny-keccak"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,11 +177,11 @@ debug = 2
 # version of Materialize.
 [patch.crates-io]
 # Projects that do not reliably release to crates.io.
-timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
-timely_bytes = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
-timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
-timely_container = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
-timely_logging = { git = "https://github.com/MaterializeInc/timely-dataflow.git" }
+timely = { git = "https://github.com/teskje/timely-dataflow.git", branch = "suspend-dataflow" }
+timely_bytes = { git = "https://github.com/teskje/timely-dataflow.git", branch = "suspend-dataflow" }
+timely_communication = { git = "https://github.com/teskje/timely-dataflow.git", branch = "suspend-dataflow" }
+timely_container = { git = "https://github.com/teskje/timely-dataflow.git", branch = "suspend-dataflow" }
+timely_logging = { git = "https://github.com/teskje/timely-dataflow.git", branch = "suspend-dataflow" }
 differential-dataflow = { git = "https://github.com/MaterializeInc/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/MaterializeInc/differential-dataflow.git" }
 

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -42,6 +42,7 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
         enable_operator_hydration_status_logging: Some(
             config.enable_compute_operator_hydration_status_logging(),
         ),
+        hydration_concurrency: Some(u64::cast_from(config.compute_hydration_concurrency())),
         enable_lgalloc_eager_reclamation: Some(config.enable_lgalloc_eager_reclamation()),
         persist: persist_config(config),
         tracing: tracing_config(config),

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -87,6 +87,7 @@ message ProtoComputeParameters {
     optional bool enable_operator_hydration_status_logging = 11;
     optional bool enable_chunked_stack = 12;
     optional bool enable_lgalloc_eager_reclamation = 13;
+    optional uint64 hydration_concurrency = 14;
 }
 
 message ProtoComputeMaxInflightBytesConfig {

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -387,6 +387,8 @@ pub struct ComputeParameters {
     pub enable_operator_hydration_status_logging: Option<bool>,
     /// Enable lgalloc's eager memory return/reclamation feature.
     pub enable_lgalloc_eager_reclamation: Option<bool>,
+    /// The number of dataflows that can hydrate concurrently.
+    pub hydration_concurrency: Option<u64>,
     /// Persist client configuration.
     pub persist: PersistParameters,
     /// Tracing configuration.
@@ -407,6 +409,7 @@ impl ComputeParameters {
             enable_chunked_stack,
             enable_operator_hydration_status_logging,
             enable_lgalloc_eager_reclamation,
+            hydration_concurrency,
             persist,
             tracing,
             grpc_client,
@@ -437,6 +440,9 @@ impl ComputeParameters {
         if enable_lgalloc_eager_reclamation.is_some() {
             self.enable_lgalloc_eager_reclamation = enable_lgalloc_eager_reclamation;
         }
+        if hydration_concurrency.is_some() {
+            self.hydration_concurrency = hydration_concurrency;
+        }
 
         self.persist.update(persist);
         self.tracing.update(tracing);
@@ -466,6 +472,7 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
                 .enable_operator_hydration_status_logging
                 .into_proto(),
             enable_lgalloc_eager_reclamation: self.enable_lgalloc_eager_reclamation.into_proto(),
+            hydration_concurrency: self.hydration_concurrency.into_proto(),
             persist: Some(self.persist.into_proto()),
             tracing: Some(self.tracing.into_proto()),
             grpc_client: Some(self.grpc_client.into_proto()),
@@ -487,6 +494,7 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
                 .enable_operator_hydration_status_logging
                 .into_rust()?,
             enable_lgalloc_eager_reclamation: proto.enable_lgalloc_eager_reclamation.into_rust()?,
+            hydration_concurrency: proto.hydration_concurrency.into_rust()?,
             persist: proto
                 .persist
                 .into_rust_if_some("ProtoComputeParameters::persist")?,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -119,6 +119,9 @@ pub struct ComputeState {
     ///
     /// Copies of this sender are passed to the hydration logging operators.
     pub hydration_tx: mpsc::Sender<HydrationEvent>,
+
+    /// The number of dataflows that can hydrate concurrently.
+    hydration_concurrency: u64,
 }
 
 impl ComputeState {
@@ -153,6 +156,7 @@ impl ComputeState {
             context,
             hydration_rx,
             hydration_tx,
+            hydration_concurrency: u64::MAX,
         }
     }
 
@@ -237,6 +241,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             enable_chunked_stack,
             enable_operator_hydration_status_logging,
             enable_lgalloc_eager_reclamation,
+            hydration_concurrency,
             persist,
             tracing,
             grpc_client: _grpc_client,
@@ -299,6 +304,9 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         }
         if let Some(v) = enable_operator_hydration_status_logging {
             self.compute_state.enable_operator_hydration_status_logging = v;
+        }
+        if let Some(v) = hydration_concurrency {
+            self.compute_state.hydration_concurrency = v;
         }
 
         persist.apply(self.compute_state.persist_clients.cfg());

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -485,6 +485,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                 compute_state.process_peeks();
                 compute_state.process_subscribes();
                 compute_state.process_copy_tos();
+                compute_state.process_sequential_hydration();
             }
 
             self.metrics

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1166,6 +1166,7 @@ impl SystemVars {
             &ENABLE_LGALLOC_EAGER_RECLAMATION,
             &ENABLE_STATEMENT_LIFECYCLE_LOGGING,
             &ENABLE_DEPENDENCY_READ_HOLD_ASSERTS,
+            &COMPUTE_HYDRATION_CONCURRENCY,
             &TIMESTAMP_ORACLE_IMPL,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT,
@@ -2079,6 +2080,10 @@ impl SystemVars {
         *self.expect_value(&ENABLE_DEPENDENCY_READ_HOLD_ASSERTS)
     }
 
+    pub fn compute_hydration_concurrency(&self) -> usize {
+        *self.expect_value(&COMPUTE_HYDRATION_CONCURRENCY)
+    }
+
     /// Returns the `user_storage_managed_collections_batch_duration` configuration parameter.
     pub fn user_storage_managed_collections_batch_duration(&self) -> Duration {
         *self.expect_value(&USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION)
@@ -2095,6 +2100,7 @@ impl SystemVars {
             || name == ENABLE_COLUMNATION_LGALLOC.name()
             || name == ENABLE_COMPUTE_OPERATOR_HYDRATION_STATUS_LOGGING.name()
             || name == ENABLE_LGALLOC_EAGER_RECLAMATION.name()
+            || name == COMPUTE_HYDRATION_CONCURRENCY.name()
             || self.is_persist_config_var(name)
             || is_tracing_var(name)
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1499,7 +1499,7 @@ pub static ENABLE_DEPENDENCY_READ_HOLD_ASSERTS: VarDefinition = VarDefinition::n
 
 pub static COMPUTE_HYDRATION_CONCURRENCY: VarDefinition = VarDefinition::new(
     "compute_hydration_concurrency",
-    value!(usize; usize::MAX),
+    value!(usize; 4),
     "Controls how many compute dataflows can hydrate concurrently.",
     true,
 );

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1497,6 +1497,13 @@ pub static ENABLE_DEPENDENCY_READ_HOLD_ASSERTS: VarDefinition = VarDefinition::n
     true,
 );
 
+pub static COMPUTE_HYDRATION_CONCURRENCY: VarDefinition = VarDefinition::new(
+    "compute_hydration_concurrency",
+    value!(usize; usize::MAX),
+    "Controls how many compute dataflows can hydrate concurrently.",
+    true,
+);
+
 /// Configuration for gRPC client connections.
 pub mod grpc_client {
     use super::*;

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -108,8 +108,8 @@ syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extr
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.39", features = ["extra-traits", "full", "visit-mut"] }
 textwrap = { version = "0.16.0", default-features = false, features = ["terminal_size"] }
 time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
-timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = ["bincode", "getopts"] }
-timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = ["bincode", "getopts"] }
+timely = { git = "https://github.com/teskje/timely-dataflow.git", branch = "suspend-dataflow", default-features = false, features = ["bincode", "getopts"] }
+timely_communication = { git = "https://github.com/teskje/timely-dataflow.git", branch = "suspend-dataflow", default-features = false, features = ["bincode", "getopts"] }
 tokio = { version = "1.32.0", features = ["full", "stats", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.14", features = ["net", "sync"] }
@@ -226,8 +226,8 @@ syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.39", features = ["extra
 textwrap = { version = "0.16.0", default-features = false, features = ["terminal_size"] }
 time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
 time-macros = { version = "0.2.6", default-features = false, features = ["formatting", "parsing", "serde"] }
-timely = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = ["bincode", "getopts"] }
-timely_communication = { git = "https://github.com/MaterializeInc/timely-dataflow.git", default-features = false, features = ["bincode", "getopts"] }
+timely = { git = "https://github.com/teskje/timely-dataflow.git", branch = "suspend-dataflow", default-features = false, features = ["bincode", "getopts"] }
+timely_communication = { git = "https://github.com/teskje/timely-dataflow.git", branch = "suspend-dataflow", default-features = false, features = ["bincode", "getopts"] }
 tokio = { version = "1.32.0", features = ["full", "stats", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.14", features = ["net", "sync"] }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
