### PR TITLE
parallel-workload test: Ignore recursion limit error in SQLsmith

### DIFF
--- a/misc/python/materialize/sqlsmith.py
+++ b/misc/python/materialize/sqlsmith.py
@@ -131,4 +131,5 @@ known_errors = [
     "nested aggregate functions are not allowed",
     "function map_build(text list) does not exist",
     "timestamp cannot be NaN",
+    "exceeded recursion limit of 2048",
 ]


### PR DESCRIPTION
seen in https://buildkite.com/materialize/nightlies/builds/6733#018dfc94-0f69-4087-b0e6-1c60a54d1fe1

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
