### PR TITLE
auth: Refactor Frontegg Auth to not use refresh tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efa59af2ddfad1854ae27d75009d538d0998b4b2fd47083e743ac1a10e46c60"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
  "hashbrown 0.14.0",
 ]
@@ -4494,6 +4494,7 @@ dependencies = [
  "derivative",
  "futures",
  "jsonwebtoken",
+ "lru",
  "mz-ore",
  "mz-repr",
  "prometheus",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -635,6 +635,12 @@ user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2021-06-12"
 end = "2024-11-16"
 
+[[trusted.lru]]
+criteria = "safe-to-deploy"
+user-id = 4747 # Jerome Froelich (jeromefroe)
+start = "2019-03-04"
+end = "2025-03-04"
+
 [[trusted.memchr]]
 criteria = "safe-to-deploy"
 user-id = 189 # Andrew Gallant (BurntSushi)

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -798,10 +798,6 @@ criteria = "safe-to-deploy"
 version = "0.5.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.lru]]
-version = "0.12.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.lsp-types]]
 version = "0.94.1"
 criteria = "safe-to-deploy"

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -441,6 +441,13 @@ user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
+[[publisher.lru]]
+version = "0.12.3"
+when = "2024-02-24"
+user-id = 4747
+user-login = "jeromefroe"
+user-name = "Jerome Froelich"
+
 [[publisher.memchr]]
 version = "2.5.0"
 when = "2022-04-30"

--- a/src/balancerd/src/service.rs
+++ b/src/balancerd/src/service.rs
@@ -17,7 +17,10 @@ use anyhow::Context;
 use futures::StreamExt;
 use jsonwebtoken::DecodingKey;
 use mz_balancerd::{BalancerConfig, BalancerService, FronteggResolver, Resolver, BUILD_INFO};
-use mz_frontegg_auth::{Authentication, AuthenticationConfig};
+use mz_frontegg_auth::{
+    Authenticator, AuthenticatorConfig, DEFAULT_REFRESH_DROP_FACTOR,
+    DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+};
 use mz_ore::metrics::MetricsRegistry;
 use mz_server_core::TlsCliArgs;
 use tokio_stream::wrappers::IntervalStream;
@@ -91,8 +94,8 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
     let metrics_registry = MetricsRegistry::new();
     let resolver = match (args.static_resolver_addr, args.frontegg_resolver_template) {
         (None, Some(addr_template)) => {
-            let auth = Authentication::new(
-                AuthenticationConfig {
+            let auth = Authenticator::new(
+                AuthenticatorConfig {
                     admin_api_token_url: args.frontegg_api_token_url.expect("clap enforced"),
                     decoding_key: match (args.frontegg_jwk, args.frontegg_jwk_file) {
                         (None, Some(path)) => {
@@ -109,6 +112,8 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
                     tenant_id: None,
                     now: mz_ore::now::SYSTEM_TIME.clone(),
                     admin_role: args.frontegg_admin_role.expect("clap enforced"),
+                    refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+                    refresh_drop_factor: DEFAULT_REFRESH_DROP_FACTOR,
                 },
                 mz_frontegg_auth::Client::environmentd_default(),
                 &metrics_registry,

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -20,7 +20,8 @@ use jsonwebtoken::{DecodingKey, EncodingKey};
 use mz_balancerd::{BalancerConfig, BalancerService, FronteggResolver, Resolver, BUILD_INFO};
 use mz_environmentd::test_util::{self, make_pg_tls, Ca};
 use mz_frontegg_auth::{
-    Authentication as FronteggAuthentication, AuthenticationConfig as FronteggConfig,
+    Authenticator as FronteggAuthentication, AuthenticatorConfig as FronteggConfig,
+    DEFAULT_REFRESH_DROP_FACTOR, DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
 };
 use mz_frontegg_mock::{FronteggMockServer, UserApiToken, UserConfig};
 use mz_ore::cast::CastFrom;
@@ -91,6 +92,8 @@ async fn test_balancer() {
             tenant_id: Some(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
+            refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+            refresh_drop_factor: DEFAULT_REFRESH_DROP_FACTOR,
         },
         mz_frontegg_auth::Client::default(),
         &metrics_registry,

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -31,7 +31,7 @@ use mz_catalog::config::ClusterReplicaSizeMap;
 use mz_cloud_resources::{AwsExternalIdPrefix, CloudResourceController};
 use mz_controller::ControllerConfig;
 use mz_environmentd::{CatalogConfig, Listeners, ListenersConfig, BUILD_INFO};
-use mz_frontegg_auth::{Authentication, FronteggCliArgs};
+use mz_frontegg_auth::{Authenticator, FronteggCliArgs};
 use mz_orchestrator::Orchestrator;
 use mz_orchestrator_kubernetes::{
     KubernetesImagePullPolicy, KubernetesOrchestrator, KubernetesOrchestratorConfig,
@@ -633,7 +633,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
 
     // Configure connections.
     let tls = args.tls.into_config()?;
-    let frontegg = Authentication::from_args(args.frontegg, &metrics_registry)?;
+    let frontegg = Authenticator::from_args(args.frontegg, &metrics_registry)?;
 
     // Configure CORS.
     let allowed_origins = if !args.cors_allowed_origin.is_empty() {

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -33,7 +33,7 @@ use mz_catalog::config::ClusterReplicaSizeMap;
 use mz_catalog::durable::{BootstrapArgs, CatalogError, OpenableDurableCatalogState, StashConfig};
 use mz_cloud_resources::CloudResourceController;
 use mz_controller::ControllerConfig;
-use mz_frontegg_auth::Authentication as FronteggAuthentication;
+use mz_frontegg_auth::Authenticator as FronteggAuthentication;
 use mz_ore::future::OreFutureExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -2253,7 +2253,7 @@ async fn test_refresh_dropped_session() {
     let labels = metric.get_label();
     assert_eq!(
         (labels[0].get_name(), labels[0].get_value()),
-        ("receiver_count", "0")
+        ("outstanding_receivers", "false")
     );
     assert_eq!(
         (labels[1].get_name(), labels[1].get_value()),

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -31,7 +31,8 @@ use mz_environmentd::http::{
 use mz_environmentd::test_util::{self, make_pg_tls, Ca, PostgresErrorExt, KAFKA_ADDRS};
 use mz_environmentd::{WebSocketAuth, WebSocketResponse};
 use mz_frontegg_auth::{
-    Authentication as FronteggAuthentication, AuthenticationConfig as FronteggConfig,
+    Authenticator as FronteggAuthentication, AuthenticatorConfig as FronteggConfig,
+    DEFAULT_REFRESH_DROP_FACTOR, DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
 };
 use mz_frontegg_mock::{FronteggMockServer, UserConfig};
 use mz_ore::cast::CastFrom;
@@ -2003,6 +2004,8 @@ async fn test_max_connections_limits() {
             tenant_id: Some(tenant_id),
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
+            refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+            refresh_drop_factor: DEFAULT_REFRESH_DROP_FACTOR,
         },
         mz_frontegg_auth::Client::default(),
         &metrics_registry,

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "3.2.24", features = ["wrap_help", "env", "derive"] }
 derivative = "2.2.0"
 futures = "0.3.25"
 jsonwebtoken = "9.2.0"
+lru = "0.12.3"
 mz-ore = { path = "../ore", features = ["network", "metrics"] }
 mz-repr = { path = "../repr" }
 prometheus = { version = "0.13.3", default-features = false }

--- a/src/frontegg-auth/src/app_password.rs
+++ b/src/frontegg-auth/src/app_password.rs
@@ -34,7 +34,7 @@ pub const PREFIX: &str = "mzp_";
 ///     This format allows for the UUIDs to be formatted with hyphens, or
 ///     not.
 ///
-#[derive(Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AppPassword {
     /// The client ID embedded in the app password.
     pub client_id: Uuid,

--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -486,6 +486,10 @@ impl AuthenticatorInner {
                     let mut sessions = inner.active_sessions.lock().expect("lock poisoned");
                     sessions.remove(&password);
                 }
+                {
+                    let mut dropped_session = inner.dropped_sessions.lock().expect("lock poisoned");
+                    dropped_session.pop(&password);
+                }
 
                 tracing::debug!(?password.client_id, "shutting down refresh task");
                 gauge.dec();

--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -37,7 +37,7 @@ use crate::{ApiTokenArgs, AppPassword, Client, Error, FronteggCliArgs};
 pub const DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE: NonZeroUsize =
     unsafe { NonZeroUsize::new_unchecked(1024) };
 
-/// If a session is dropped within `DEFAULT_REFRESH_DROP_WINDOW * valid_for` seconds of an
+/// If a session is dropped within [`DEFAULT_REFRESH_DROP_FACTOR`] `* valid_for` seconds of an
 /// authentication token expiring, then we'll continue to refresh the auth token, with the
 /// assumption that a new instance of this session will be started soon.
 pub const DEFAULT_REFRESH_DROP_FACTOR: f64 = 0.05;

--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -7,31 +7,46 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use anyhow::Context;
+use anyhow::Context as _;
 use derivative::Derivative;
-use futures::future::BoxFuture;
+use futures::future::Shared;
+use futures::FutureExt;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation};
-use mz_ore::cast::{CastLossy, ReinterpretCast};
-use mz_ore::collections::HashMap;
+use lru::LruCache;
+use mz_ore::cast::CastLossy;
+use mz_ore::instrument;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 use mz_repr::user::ExternalUserMetadata;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{oneshot, watch};
+use tokio::sync::watch;
+use tokio::time;
+use tracing::{debug_span, warn, Instrument};
 use uuid::Uuid;
 
 use crate::metrics::Metrics;
-use crate::{ApiTokenArgs, ApiTokenResponse, AppPassword, Client, Error, FronteggCliArgs};
+use crate::{ApiTokenArgs, AppPassword, Client, Error, FronteggCliArgs};
 
-pub const REFRESH_SUFFIX: &str = "/token/refresh";
+/// SAFETY: Value is known to be non-zero.
+pub const DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE: NonZeroUsize =
+    unsafe { NonZeroUsize::new_unchecked(1024) };
 
+/// If a session is dropped within `DEFAULT_REFRESH_DROP_WINDOW * valid_for` seconds of an
+/// authentication token expiring, then we'll continue to refresh the auth token, with the
+/// assumption that a new instance of this session will be started soon.
+pub const DEFAULT_REFRESH_DROP_FACTOR: f64 = 0.05;
+
+/// Configures an [`Authenticator`].
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
-pub struct AuthenticationConfig {
+pub struct AuthenticatorConfig {
     /// URL for the token endpoint, including full path.
     pub admin_api_token_url: String,
     /// JWK used to validate JWTs.
@@ -43,60 +58,26 @@ pub struct AuthenticationConfig {
     pub now: NowFn,
     /// Name of admin role.
     pub admin_role: String,
+    /// How many [`AppPassword`]s we'll track the last dropped time for.
+    ///
+    /// TODO(parkmycar): Wire this up to LaunchDarkly.
+    pub refresh_drop_lru_size: NonZeroUsize,
+    /// How large of a window we'll use for determining if a session was dropped "recently", and if
+    /// we should refresh the session, even if there are not any active handles to it.
+    ///
+    /// TODO(parkmycar): Wire this up to LaunchDarkly.
+    pub refresh_drop_factor: f64,
 }
 
 /// Facilitates authenticating users via Frontegg, and verifying returned JWTs.
 #[derive(Clone, Debug)]
-pub struct Authentication {
-    /// Configuration for validating JWTs.
-    validation_config: ValidationConfig,
-
-    /// Metrics to track the performance of Frontegg.
-    metrics: Metrics,
-
-    /// URL for the token endpoint, including full path.
-    admin_api_token_url: String,
-    /// HTTP client for making requests.
-    client: Client,
-    /// Map of inflight authentication requests, used for de-duplicating requests.
-    inflight_auth_requests: Arc<Mutex<HashMap<ApiTokenArgs, ResponseHandles>>>,
+pub struct Authenticator {
+    inner: Arc<AuthenticatorInner>,
 }
 
-type ResponseHandles =
-    Vec<oneshot::Sender<Result<(ExchangePasswordForTokenResponse, RefreshTaskId), Error>>>;
-
-/// An ID emitted in logs to help debug.
-#[derive(Copy, Clone, Debug)]
-pub struct RefreshTaskId(Uuid);
-
-impl RefreshTaskId {
-    /// Generates a new [`RefreshTaskId`].
-    pub fn new() -> Self {
-        RefreshTaskId(uuid::Uuid::new_v4())
-    }
-}
-
-impl fmt::Display for RefreshTaskId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-#[derive(Derivative)]
-#[derivative(Debug)]
-pub struct ExchangePasswordForTokenResponse {
-    /// Validated JWT.
-    pub claims: ValidatedClaims,
-    /// Recieves periodic updates of [`ExternalUserMetadata`] when the initial JWT is refreshed.
-    pub refresh_updates: watch::Receiver<ExternalUserMetadata>,
-    /// Our current authentication is valid, until this Future resolves.
-    #[derivative(Debug = "ignore")]
-    pub valid_until_fut: BoxFuture<'static, ()>,
-}
-
-impl Authentication {
-    /// Creates a new frontegg auth.
-    pub fn new(config: AuthenticationConfig, client: Client, registry: &MetricsRegistry) -> Self {
+impl Authenticator {
+    /// Creates a new authenticator.
+    pub fn new(config: AuthenticatorConfig, client: Client, registry: &MetricsRegistry) -> Self {
         let mut validation = Validation::new(Algorithm::RS256);
 
         // We validate the token expiration with our own now function.
@@ -117,27 +98,28 @@ impl Authentication {
         // [0]: https://materializeinc.slack.com/archives/C02940WNMRQ/p1704131331041669
         validation.validate_aud = false;
 
-        let validation_config = ValidationConfig {
-            decoding_key: config.decoding_key,
-            tenant_id: config.tenant_id,
-            now: config.now,
-            admin_role: config.admin_role,
-            validation,
-        };
-
-        let inflight_auth_requests = Arc::new(Mutex::new(HashMap::new()));
         let metrics = Metrics::register_into(registry);
+        let active_sessions = Mutex::new(BTreeMap::new());
+        let dropped_sessions = Mutex::new(LruCache::new(config.refresh_drop_lru_size));
 
-        Self {
-            validation_config,
-            metrics,
-            admin_api_token_url: config.admin_api_token_url,
-            client,
-            inflight_auth_requests,
+        Authenticator {
+            inner: Arc::new(AuthenticatorInner {
+                admin_api_token_url: config.admin_api_token_url,
+                client,
+                validation,
+                decoding_key: config.decoding_key,
+                tenant_id: config.tenant_id,
+                admin_role: config.admin_role,
+                now: config.now,
+                active_sessions,
+                dropped_sessions,
+                refresh_drop_factor: config.refresh_drop_factor,
+                metrics,
+            }),
         }
     }
 
-    /// Create an [`Authentication`] from [`FronteggCliArgs`].
+    /// Create an [`Authenticator`] from [`FronteggCliArgs`].
     pub fn from_args(
         args: FronteggCliArgs,
         registry: &MetricsRegistry,
@@ -165,12 +147,14 @@ impl Authentication {
                         .into())
                     }
                 };
-                AuthenticationConfig {
+                AuthenticatorConfig {
                     admin_api_token_url,
                     decoding_key,
                     tenant_id: Some(tenant_id),
                     now: mz_ore::now::SYSTEM_TIME.clone(),
                     admin_role,
+                    refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+                    refresh_drop_factor: DEFAULT_REFRESH_DROP_FACTOR,
                 }
             }
             _ => unreachable!("clap enforced"),
@@ -180,123 +164,99 @@ impl Authentication {
         Ok(Some(Self::new(config, client, registry)))
     }
 
-    /// Exchanges a password for an access token and a refresh token.
-    pub async fn exchange_password_for_token(
+    /// Establishes a new authentication session.
+    ///
+    /// If successful, returns a handle to the authentication session.
+    /// Otherwise, returns the authentication error.
+    pub async fn authenticate(
         &self,
+        expected_email: &str,
         password: &str,
-        expected_email: String,
-    ) -> Result<ExchangePasswordForTokenResponse, Error> {
+    ) -> Result<AuthSessionHandle, Error> {
         let password: AppPassword = password.parse()?;
-        let req = ApiTokenArgs {
-            client_id: password.client_id,
-            secret: password.secret_key,
-        };
+        match self.authenticate_inner(expected_email, password).await {
+            Ok(handle) => {
+                tracing::debug!("authentication successful");
+                Ok(handle)
+            }
+            Err(e) => {
+                tracing::debug!(error = ?e, "authentication failed");
+                Err(e)
+            }
+        }
+    }
 
-        // Note: we get the reciever in a block to scope the access to the mutex.
-        let rx = {
-            let mut inflight = self
-                .inflight_auth_requests
-                .lock()
-                .expect("Frontegg Auth Client panicked");
-            let (tx, rx) = tokio::sync::oneshot::channel();
+    #[instrument(level = "debug", fields(client_id = %password.client_id))]
+    async fn authenticate_inner(
+        &self,
+        expected_email: &str,
+        password: AppPassword,
+    ) -> Result<AuthSessionHandle, Error> {
+        let request = {
+            let mut sessions = self.inner.active_sessions.lock().expect("lock poisoned");
+            match sessions.get_mut(&password) {
+                // We have an existing session for this app password.
+                Some(AuthSession::Active {
+                    ident,
+                    external_metadata_tx,
+                    ..
+                }) => {
+                    tracing::debug!(?password.client_id, "joining active session");
 
-            match inflight.get_mut(&req) {
-                // Already have an inflight request, add to our list of waiters.
-                Some(senders) => {
-                    tracing::debug!(?req, "reusing request");
-                    senders.push(tx);
-                    rx
+                    validate_email(&ident.user, expected_email)?;
+                    self.inner
+                        .metrics
+                        .session_request_count
+                        .with_label_values(&["active"])
+                        .inc();
+
+                    // Return a handle to the existing session.
+                    return Ok(AuthSessionHandle {
+                        ident: Arc::clone(ident),
+                        external_metadata_rx: external_metadata_tx.subscribe(),
+                        authenticator: Arc::clone(&self.inner),
+                        app_password: password,
+                    });
                 }
-                // New request! Need to queue one up.
+
+                // We have an in flight request to establish a session.
+                Some(AuthSession::Pending(request)) => {
+                    // Latch on to the existing session.
+                    tracing::debug!(?password.client_id, "joining pending session");
+                    self.inner
+                        .metrics
+                        .session_request_count
+                        .with_label_values(&["pending"])
+                        .inc();
+                    request.clone()
+                }
+
+                // We do not have an existing session for this API key.
                 None => {
-                    tracing::debug!(?req, "spawning new request");
+                    tracing::debug!(?password.client_id, "starting new session");
 
-                    inflight.insert(req.clone(), vec![tx]);
-                    // Explicitly drop the lock guard.
-                    drop(inflight);
-
-                    let client = self.client.clone();
-                    let inflight = Arc::clone(&self.inflight_auth_requests);
-                    let req_ = req.clone();
-                    let url = self.admin_api_token_url.clone();
-                    let validate_config = self.validation_config.clone();
-                    let metrics = self.metrics.clone();
-
-                    let name = format!("frontegg-auth-request-{}", req.client_id);
-                    mz_ore::task::spawn(move || name, async move {
-                        // Make the actual request.
-                        let result = client
-                            .exchange_client_secret_for_token(req_, &url, &metrics)
-                            .await;
-
-                        // Validate the returned JWT.
-                        let validated_result = result.and_then(|api_resp| {
-                            validate_access_token(
-                                &validate_config,
-                                &api_resp.access_token,
-                                Some(&expected_email),
-                            )
-                            .map(|claims| (api_resp, claims))
-                        });
-
-                        // Get all of our waiters.
-                        let mut inflight = inflight.lock().expect("Frontegg Auth Client panicked");
-                        let Some(waiters) = inflight.remove(&req) else {
-                            tracing::error!(?req, "Inflight entry already removed?");
-                            return;
-                        };
-
-                        // If the request failed then notify and bail.
-                        let (api_resp, claims) = match validated_result {
-                            Err(err) => {
-                                tracing::warn!(?err, "failed to exchange secret for token");
-                                for tx in waiters {
-                                    let _ = tx.send(Err(err.clone()));
-                                }
-                                return;
-                            }
-                            Ok(result) => result,
-                        };
-
-                        // Spawn a task to continuously refresh our token.
-                        let external_metadata = ExternalUserMetadata {
-                            user_id: claims.user_id,
-                            admin: claims.is_admin,
-                        };
-                        let (refresh_tx, refresh_rx) = watch::channel(external_metadata);
-                        let id = continuously_refresh(
-                            &url,
-                            client,
-                            metrics,
-                            api_resp,
-                            expected_email,
-                            validate_config,
-                            refresh_tx,
-                        );
-
-                        // Respond to all of our waiters.
-                        for tx in waiters {
-                            let valid_until_fut = make_valid_until_future(&refresh_rx);
-                            let resp = ExchangePasswordForTokenResponse {
-                                claims: claims.clone(),
-                                refresh_updates: refresh_rx.clone(),
-                                valid_until_fut,
-                            };
-                            let _ = tx.send(Ok((resp, id)));
-                        }
+                    // Prepare the request to create a new session.
+                    let request: Pin<Box<AuthFuture>> = Box::pin({
+                        let inner = Arc::clone(&self.inner);
+                        let expected_email = String::from(expected_email);
+                        async move { inner.authenticate(expected_email, password).await }
                     });
 
-                    rx
+                    // Store the future so that future requests can latch on.
+                    let request = request.shared();
+                    sessions.insert(password, AuthSession::Pending(request.clone()));
+                    self.inner
+                        .metrics
+                        .session_request_count
+                        .with_label_values(&["new"])
+                        .inc();
+
+                    // Wait for the request to complete.
+                    request
                 }
             }
         };
-
-        let resp = rx.await.context("waiting for inflight response")?;
-
-        let (result, id) = resp?;
-        tracing::debug!(?id, "token being refreshed");
-
-        Ok(result)
+        request.await
     }
 
     /// Validates an access token, returning the validated claims.
@@ -314,206 +274,314 @@ impl Authentication {
         token: &str,
         expected_email: Option<&str>,
     ) -> Result<ValidatedClaims, Error> {
-        validate_access_token(&self.validation_config, token, expected_email)
+        self.inner.validate_access_token(token, expected_email)
     }
 }
 
-#[derive(Clone, Derivative)]
+/// A handle to an authentication session.
+///
+/// An authentication session represents a duration of time during which a
+/// user's authentication is known to be valid.
+///
+/// An authentication session begins with a successful API key exchange with
+/// Frontegg. While there is at least one outstanding handle to the session, the
+/// session's metadata and validity are refreshed with Frontegg at a regular
+/// interval. The session ends when all outstanding handles are dropped and the
+/// refresh interval is reached.
+///
+/// [`AuthSessionHandle::external_metadata_rx`] can be used to receive events if
+/// the session's metadata is updated.
+///
+/// [`AuthSessionHandle::expired`] can be used to learn if the session has
+/// failed to refresh the validity of the API key.
+#[derive(Debug, Clone)]
+pub struct AuthSessionHandle {
+    ident: Arc<AuthSessionIdent>,
+    external_metadata_rx: watch::Receiver<ExternalUserMetadata>,
+    /// Hold a handle to the [`AuthenticatorInner`] so we can record when this session was dropped.
+    authenticator: Arc<AuthenticatorInner>,
+    /// Used to record when the session linked with this [`AppPassword`] was dropped.
+    app_password: AppPassword,
+}
+
+impl AuthSessionHandle {
+    /// Returns the name of the user that created the session.
+    pub fn user(&self) -> &str {
+        &self.ident.user
+    }
+
+    /// Returns the ID of the tenant that created the session.
+    pub fn tenant_id(&self) -> Uuid {
+        self.ident.tenant_id
+    }
+
+    /// Mints a receiver for updates to the session user's external metadata.
+    pub fn external_metadata_rx(&self) -> watch::Receiver<ExternalUserMetadata> {
+        self.external_metadata_rx.clone()
+    }
+
+    /// Completes when the authentication session has expired.
+    pub async fn expired(&mut self) {
+        // We piggyback on the external metadata channel to determine session
+        // expiration. The external metadata channel is closed when the session
+        // expires.
+        let _ = self.external_metadata_rx.wait_for(|_| false).await;
+    }
+}
+
+impl Drop for AuthSessionHandle {
+    fn drop(&mut self) {
+        self.authenticator.record_dropped_session(self.app_password);
+    }
+}
+
+#[derive(Derivative)]
 #[derivative(Debug)]
-pub struct ValidationConfig {
-    /// Fields of a JWT that we validate.
-    pub validation: Validation,
-    /// JWK used to validate JWTs.
-    #[derivative(Debug = "ignore")]
-    pub decoding_key: DecodingKey,
-    /// Tenant id used to validate JWTs.
-    pub tenant_id: Option<Uuid>,
-    /// Function to provide system time to validate exp (expires at) field of JWTs.
-    pub now: NowFn,
-    /// Name of admin role.
-    pub admin_role: String,
-}
-
-/// Validates the provided JSON web token, returning [`ValidatedClaims`].
-fn validate_access_token(
-    config: &ValidationConfig,
-    jwt: &str,
-    expected_email: Option<&str>,
-) -> Result<ValidatedClaims, Error> {
-    let msg = jsonwebtoken::decode::<Claims>(jwt, &config.decoding_key, &config.validation)?;
-    if msg.claims.exp < config.now.as_secs() {
-        return Err(Error::TokenExpired);
-    }
-    if let Some(expected_tenant_id) = config.tenant_id {
-        if msg.claims.tenant_id != expected_tenant_id {
-            return Err(Error::UnauthorizedTenant);
-        }
-    }
-    if let Some(expected_email) = expected_email {
-        // To match Frontegg, email addresses are compared case
-        // insensitively.
-        //
-        // NOTE(benesch): we could save some allocations by using
-        // `unicase::eq` here, but the `unicase` crate has had some critical
-        // correctness bugs that make it scary to use in such
-        // security-sensitive code.
-        //
-        // See: https://github.com/seanmonstar/unicase/pull/39
-        if msg.claims.email.to_lowercase() != expected_email.to_lowercase() {
-            return Err(Error::WrongEmail);
-        }
-    }
-    Ok(ValidatedClaims {
-        exp: msg.claims.exp,
-        email: msg.claims.email,
-        tenant_id: msg.claims.tenant_id,
-        // If the claims come from the exchange of an API token, the `sub`
-        // will be the ID of the API token and the user ID will be in the
-        // `user_id` field. If the claims come from the exchange of a
-        // username and password, the `sub` is the user ID and the `user_id`
-        // field will not be present. This makes sense once you think about
-        // it, but is confusing enough that we massage into a single
-        // `user_id` field that always contains the user ID.
-        user_id: msg.claims.user_id.unwrap_or(msg.claims.sub),
-        // The user is an administrator if they have the admin role that the
-        // `Authenticator` has been configured with.
-        is_admin: msg.claims.roles.iter().any(|r| *r == config.admin_role),
-        _private: (),
-    })
-}
-
-/// Returns a [`Duration`] for how long the provided claims are valid for.
-fn valid_for(now: &NowFn, claims: &ValidatedClaims) -> Duration {
-    let valid_for = claims.exp - now.as_secs();
-    let valid_for = u64::try_from(valid_for).unwrap_or(0);
-
-    Duration::from_secs(valid_for)
-}
-
-/// Returns a `Future` that resolves when the sending side of the provided channel closes.
-fn make_valid_until_future(
-    refresh_rx: &watch::Receiver<ExternalUserMetadata>,
-) -> BoxFuture<'static, ()> {
-    // Our auth is valid for as long as the sender is alive.
-    let mut refresh_rx = refresh_rx.clone();
-    let future = async move { while let Ok(_) = refresh_rx.changed().await {} };
-    Box::pin(future)
-}
-
-/// Spawns a task that will continuously refresh the `RefreshToken` provided in `first_response`.
-fn continuously_refresh(
-    admin_api_token_url: &str,
+struct AuthenticatorInner {
+    /// Frontegg API fields.
+    admin_api_token_url: String,
     client: Client,
+    /// JWT decoding and validation fields.
+    validation: Validation,
+    #[derivative(Debug = "ignore")]
+    decoding_key: DecodingKey,
+    tenant_id: Option<Uuid>,
+    admin_role: String,
+    now: NowFn,
+    /// Session tracking.
+    active_sessions: Mutex<BTreeMap<AppPassword, AuthSession>>,
+    /// Most recent time at which a session created with an [`AppPassword`] was dropped.
+    ///
+    /// We track when a session was dropped to handle the case of many one-shot queries being
+    /// issued in rapid succession. If it comes time to refresh an auth token, and there are no
+    /// currently alive sessions, but one was recently dropped, we'll pre-emptively refresh to get
+    /// ahead of another session being created with the same [`AppPassword`].
+    dropped_sessions: Mutex<LruCache<AppPassword, Instant>>,
+    /// How large of a window we'll use for determining if a session was dropped "recently", and if
+    /// we should refresh the session, even if there are not any active handles to it.
+    refresh_drop_factor: f64,
+    /// Metrics.
     metrics: Metrics,
-    first_response: ApiTokenResponse,
-    expected_email: String,
-    validation_config: ValidationConfig,
-    refresh_tx: watch::Sender<ExternalUserMetadata>,
-) -> RefreshTaskId {
-    let refresh_url = format!("{}{}", admin_api_token_url, REFRESH_SUFFIX);
-    let id = RefreshTaskId::new();
+}
 
-    // Continuously refresh.
-    let name = format!("frontegg-auth-refresh-{}", id);
-    mz_ore::task::spawn(|| name, async move {
-        tracing::debug!(?id, "starting refresh task");
-        let mut latest_response = first_response;
+impl AuthenticatorInner {
+    async fn authenticate(
+        self: &Arc<Self>,
+        expected_email: String,
+        password: AppPassword,
+    ) -> Result<AuthSessionHandle, Error> {
+        // Attempt initial app password exchange.
+        let mut claims = self
+            .exchange_app_password(&expected_email, password)
+            .await?;
 
-        let gauge = metrics.refresh_tasks_active.with_label_values(&[]);
-        gauge.inc();
+        // Prep session information.
+        let ident = Arc::new(AuthSessionIdent {
+            user: claims.email.clone(),
+            tenant_id: claims.tenant_id,
+        });
+        let external_metadata = claims.to_external_user_metadata();
+        let (external_metadata_tx, external_metadata_rx) = watch::channel(external_metadata);
+        let external_metadata_tx = Arc::new(external_metadata_tx);
 
-        loop {
-            // If the token is not valid, close the channel.
-            let validated = validate_access_token(
-                &validation_config,
-                &latest_response.access_token,
-                Some(&expected_email),
-            );
-            let claims = match validated {
-                Err(err) => {
-                    tracing::warn!(?id, ?err, "Token expired!");
-                    drop(refresh_tx);
-                    break;
-                }
-                Ok(claims) => claims,
-            };
-            let valid_for = valid_for(&validation_config.now, &claims);
-
-            // Notify listeners that we've refreshed.
-            let metadata = ExternalUserMetadata {
-                user_id: claims.user_id,
-                admin: claims.is_admin,
-            };
-            if let Err(_) = refresh_tx.send(metadata) {
-                tracing::info!(?id, "All listeners disappeared");
-                break;
-            }
-
-            // Odd, but guards against a negative "expires_in" value.
-            let expires_in = latest_response.expires_in.max(60);
-            // Safe because we know expires_in will always be positive.
-            let expires_in = u64::reinterpret_cast(expires_in);
-            // Need to to be a float so we can scale the value.
-            let expires_in = f64::cast_lossy(expires_in);
-
-            // The Frontegg Python SDK scales the expires_in this way.
-            //
-            // <https://github.com/frontegg/python-sdk/blob/840f8318aced35cea6a41d83270597edfceb4019/frontegg/common/frontegg_authenticator.py#L45>
-            let scaled_expires_in = expires_in * 0.8;
-            let scaled_expires_in = Duration::from_secs_f64(scaled_expires_in);
-            tracing::debug!(?id, ?expires_in, ?scaled_expires_in, "waiting to refresh");
-
-            // Weird. The token would expire before the refresh token window.
-            let refresh_in = if valid_for < scaled_expires_in {
-                tracing::warn!(
-                    ?id,
-                    ?valid_for,
-                    ?scaled_expires_in,
-                    "refresh after token expires"
-                );
-                valid_for.saturating_sub(Duration::from_secs(10))
-            } else {
-                scaled_expires_in
-            };
-
-            // While we wait for the refresh, continuously check if our listeners went away.
-            tokio::select! {
-                // Waiting on a tokio::Sleep is cancel safe.
-                _ = tokio::time::sleep(refresh_in) => (),
-                // Checking if the channel closed is cancel safe.
-                _ = refresh_tx.closed() => {
-                    tracing::debug!(?id, "channel closed, exiting");
-                    break;
+        // Store session to make it available for future requests to latch on
+        // to.
+        {
+            let mut sessions = self.active_sessions.lock().expect("lock poisoned");
+            sessions.insert(
+                password,
+                AuthSession::Active {
+                    ident: Arc::clone(&ident),
+                    external_metadata_tx: Arc::clone(&external_metadata_tx),
                 },
-            }
-
-            let current_response = client
-                .refresh_token(&refresh_url, &latest_response.refresh_token, &metrics)
-                .await;
-
-            // If we failed to refresh, then close the channel.
-            let current_response = match current_response {
-                Ok(resp) => {
-                    tracing::debug!(?id, "refresh successful");
-                    resp
-                }
-                Err(err) => {
-                    tracing::warn!(?id, ?err, "failed to refresh");
-
-                    // Dropping the channel will close it.
-                    drop(refresh_tx);
-                    break;
-                }
-            };
-
-            latest_response = current_response;
+            );
         }
 
-        gauge.dec();
-        tracing::debug!(?id, "shutting down refresh task");
-    });
+        // Start background refresh task.
+        let name = format!("frontegg-auth-refresh-{}", password.client_id);
+        mz_ore::task::spawn(|| name, {
+            let inner = Arc::clone(self);
+            async move {
+                tracing::debug!(?password.client_id, "starting refresh task");
+                let gauge = inner.metrics.refresh_tasks_active.with_label_values(&[]);
+                gauge.inc();
 
-    id
+                loop {
+                    let valid_for = f64::cast_lossy(claims.exp - inner.now.as_secs());
+                    // If we have no outstanding handling to this session, but a handle was dropped
+                    // within this window, then we'll still refresh.
+                    let drop_window = u64::cast_lossy(valid_for * inner.refresh_drop_factor).max(1);
+                    // Scale the validity duration by 0.8. The Frontegg Python
+                    // SDK scales the expires_in this way.
+                    //
+                    // <https://github.com/frontegg/python-sdk/blob/840f8318aced35cea6a41d83270597edfceb4019/frontegg/common/frontegg_authenticator.py#L45>
+                    let valid_for = u64::cast_lossy(valid_for * 0.8);
+
+                    if valid_for < 60 {
+                        warn!(%valid_for, "unexpectedly low token validity");
+                    }
+
+                    tracing::debug!(%valid_for, %drop_window, "waiting for token validity period");
+
+                    // Wait out validity duration.
+                    time::sleep(Duration::from_secs(valid_for)).await;
+
+                    // Check to see if all external metadata receivers have gone away, or if a
+                    // session created with this password was recently dropped. If no one is
+                    // listening nor any recent handles were dropped we can clean up the session.
+                    let receiver_count = external_metadata_tx.receiver_count();
+                    let last_drop = inner.last_dropped_session(&password);
+                    let recent_drop = last_drop
+                        .map(|dropped_at| dropped_at.elapsed() <= Duration::from_secs(drop_window))
+                        .unwrap_or(false);
+                    if receiver_count == 0 && !recent_drop {
+                        tracing::debug!(
+                            ?last_drop,
+                            ?password.client_id,
+                            "all listeners have dropped and none of them were recent!"
+                        );
+                        break;
+                    }
+
+                    // TODO(parkmycar): Allocating the labels here feels bad.
+                    inner
+                        .metrics
+                        .session_refresh_count
+                        .with_label_values(&[&receiver_count.to_string(), &recent_drop.to_string()])
+                        .inc();
+                    tracing::debug!(
+                        receiver_count,
+                        ?last_drop,
+                        ?password.client_id,
+                        "refreshing due to interest in the session"
+                    );
+
+                    // We still have interest, attempt to refresh the session.
+                    let res = inner.exchange_app_password(&expected_email, password).await;
+                    claims = match res {
+                        Ok(claims) => {
+                            tracing::debug!("refresh successful");
+                            claims
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = ?e, "refresh failed");
+                            break;
+                        }
+                    };
+                    external_metadata_tx.send_replace(ExternalUserMetadata {
+                        admin: claims.is_admin,
+                        user_id: claims.user_id,
+                    });
+                }
+
+                // The session has expired. Clean up the state.
+                {
+                    let mut sessions = inner.active_sessions.lock().expect("lock poisoned");
+                    sessions.remove(&password);
+                }
+
+                tracing::debug!(?password.client_id, "shutting down refresh task");
+                gauge.dec();
+            }
+            .instrument(debug_span!("frontegg_auth_refresh_task", client_id = %password.client_id))
+        });
+
+        // Return handle to session.
+        Ok(AuthSessionHandle {
+            ident,
+            external_metadata_rx,
+            authenticator: Arc::clone(self),
+            app_password: password,
+        })
+    }
+
+    async fn exchange_app_password(
+        &self,
+        expected_email: &str,
+        password: AppPassword,
+    ) -> Result<ValidatedClaims, Error> {
+        let req = ApiTokenArgs {
+            client_id: password.client_id,
+            secret: password.secret_key,
+        };
+        let res = self
+            .client
+            .exchange_client_secret_for_token(req, &self.admin_api_token_url, &self.metrics)
+            .await?;
+        self.validate_access_token(&res.access_token, Some(expected_email))
+    }
+
+    fn validate_access_token(
+        &self,
+        token: &str,
+        expected_email: Option<&str>,
+    ) -> Result<ValidatedClaims, Error> {
+        let msg = jsonwebtoken::decode::<Claims>(token, &self.decoding_key, &self.validation)?;
+        if msg.claims.exp < self.now.as_secs() {
+            return Err(Error::TokenExpired);
+        }
+        if let Some(expected_tenant_id) = self.tenant_id {
+            if msg.claims.tenant_id != expected_tenant_id {
+                return Err(Error::UnauthorizedTenant);
+            }
+        }
+        if let Some(expected_email) = expected_email {
+            validate_email(&msg.claims.email, expected_email)?;
+        }
+        Ok(ValidatedClaims {
+            exp: msg.claims.exp,
+            email: msg.claims.email,
+            tenant_id: msg.claims.tenant_id,
+            // If the claims come from the exchange of an API token, the `sub`
+            // will be the ID of the API token and the user ID will be in the
+            // `user_id` field. If the claims come from the exchange of a
+            // username and password, the `sub` is the user ID and the `user_id`
+            // field will not be present. This makes sense once you think about
+            // it, but is confusing enough that we massage into a single
+            // `user_id` field that always contains the user ID.
+            user_id: msg.claims.user_id.unwrap_or(msg.claims.sub),
+            // The user is an administrator if they have the admin role that the
+            // `Authenticator` has been configured with.
+            is_admin: msg.claims.roles.iter().any(|r| *r == self.admin_role),
+            _private: (),
+        })
+    }
+
+    /// Records an [`AuthSessionHandle`] that was recently dropped.
+    fn record_dropped_session(&self, app_password: AppPassword) {
+        let now = Instant::now();
+        let Ok(mut dropped_sessions) = self.dropped_sessions.lock() else {
+            return;
+        };
+        dropped_sessions.push(app_password, now);
+    }
+
+    /// Returns the instant that an [`AuthSessionHandle`] created with the provided [`AppPassword`]
+    /// was last dropped.
+    fn last_dropped_session(&self, app_password: &AppPassword) -> Option<Instant> {
+        let Ok(dropped_sessions) = self.dropped_sessions.lock() else {
+            return None;
+        };
+        dropped_sessions.peek(app_password).copied()
+    }
+}
+
+type AuthFuture = dyn Future<Output = Result<AuthSessionHandle, Error>> + Send;
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+enum AuthSession {
+    Pending(Shared<Pin<Box<AuthFuture>>>),
+    Active {
+        ident: Arc<AuthSessionIdent>,
+        external_metadata_tx: Arc<watch::Sender<ExternalUserMetadata>>,
+    },
+}
+
+#[derive(Debug)]
+struct AuthSessionIdent {
+    user: String,
+    tenant_id: Uuid,
 }
 
 // TODO: Do we care about the sub? Do we need to validate the sub or other
@@ -552,4 +620,28 @@ pub struct ValidatedClaims {
     pub is_admin: bool,
     // Prevent construction outside of `Authentication::validate_access_token`.
     _private: (),
+}
+
+impl ValidatedClaims {
+    /// Constructs an [`ExternalUserMetadata`] from the claims data.
+    fn to_external_user_metadata(&self) -> ExternalUserMetadata {
+        ExternalUserMetadata {
+            admin: self.is_admin,
+            user_id: self.user_id,
+        }
+    }
+}
+
+fn validate_email(email: &str, expected_email: &str) -> Result<(), Error> {
+    // To match Frontegg, email addresses are compared case insensitively.
+    //
+    // NOTE(benesch): we could save some allocations by using `unicase::eq`
+    // here, but the `unicase` crate has had some critical correctness bugs that
+    // make it scary to use in such security-sensitive code.
+    //
+    // See: https://github.com/seanmonstar/unicase/pull/39
+    if email.to_lowercase() != expected_email.to_lowercase() {
+        return Err(Error::WrongEmail);
+    }
+    Ok(())
 }

--- a/src/frontegg-auth/src/error.rs
+++ b/src/frontegg-auth/src/error.rs
@@ -26,6 +26,8 @@ pub enum Error {
     TokenExpired,
     #[error("unauthorized organization")]
     UnauthorizedTenant,
+    #[error("the app password was not valid")]
+    InvalidAppPassword,
     #[error("email in access token did not match the expected email")]
     WrongEmail,
     #[error("request timeout")]

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -16,9 +16,10 @@ mod metrics;
 use std::path::PathBuf;
 
 pub use auth::{
-    Authentication, AuthenticationConfig, Claims, ExchangePasswordForTokenResponse, REFRESH_SUFFIX,
+    Authenticator, AuthenticatorConfig, Claims, DEFAULT_REFRESH_DROP_FACTOR,
+    DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
 };
-pub use client::tokens::{ApiTokenArgs, ApiTokenResponse, RefreshToken};
+pub use client::tokens::{ApiTokenArgs, ApiTokenResponse};
 pub use client::Client;
 pub use error::Error;
 use uuid::Uuid;

--- a/src/frontegg-auth/src/metrics.rs
+++ b/src/frontegg-auth/src/metrics.rs
@@ -54,7 +54,7 @@ impl Metrics {
             session_refresh_count: registry.register(metric!(
                 name: "mz_auth_session_refresh_count",
                 help: "Total number of authentication sessions that get refreshed.",
-                var_labels: ["receiver_count", "recent_drop"],
+                var_labels: ["outstanding_receivers", "recent_drop"],
             )),
         }
     }

--- a/src/frontegg-auth/src/metrics.rs
+++ b/src/frontegg-auth/src/metrics.rs
@@ -17,17 +17,21 @@ use prometheus::{HistogramVec, IntCounterVec, IntGaugeVec};
 #[derive(Debug, Clone)]
 pub struct Metrics {
     /// Total number of requests since process start.
-    pub request_count: IntCounterVec,
+    pub http_request_count: IntCounterVec,
     /// How long it takes for a request to Frontegg to complete.
     pub request_duration_seconds: HistogramVec,
     /// The number of active refresh tasks we have running.
     pub refresh_tasks_active: IntGaugeVec,
+    /// Number of sessions that have requested to start.
+    pub session_request_count: IntCounterVec,
+    /// Number of sessions that get refreshed.
+    pub session_refresh_count: IntCounterVec,
 }
 
 impl Metrics {
     pub(crate) fn register_into(registry: &MetricsRegistry) -> Self {
         Self {
-            request_count: registry.register(metric!(
+            http_request_count: registry.register(metric!(
                 name: "mz_auth_request_count",
                 help: "Total number of HTTP requests made to Frontegg for authentication",
                 var_labels: ["path", "status"],
@@ -41,6 +45,16 @@ impl Metrics {
             refresh_tasks_active: registry.register(metric!(
                 name: "mz_auth_refresh_tasks_active",
                 help: "The number of active refresh tasks we have running.",
+            )),
+            session_request_count: registry.register(metric!(
+                name: "mz_auth_session_request_count",
+                help: "Total number of session start requests the Authenticator has received.",
+                var_labels: ["existing_session"],
+            )),
+            session_refresh_count: registry.register(metric!(
+                name: "mz_auth_session_refresh_count",
+                help: "Total number of authentication sessions that get refreshed.",
+                var_labels: ["receiver_count", "recent_drop"],
             )),
         }
     }

--- a/src/frontegg-mock/src/lib.rs
+++ b/src/frontegg-mock/src/lib.rs
@@ -41,7 +41,7 @@ const USERS_API_TOKENS_PATH: &str = "/identity/resources/users/api-tokens/v1";
 pub struct FronteggMockServer {
     pub base_url: String,
     pub refreshes: Arc<Mutex<u64>>,
-    pub enable_refresh: Arc<AtomicBool>,
+    pub enable_auth: Arc<AtomicBool>,
     pub auth_requests: Arc<Mutex<u64>>,
     pub role_updates_tx: UnboundedSender<(String, Vec<String>)>,
     pub handle: JoinHandle<Result<(), hyper::Error>>,
@@ -61,8 +61,8 @@ impl FronteggMockServer {
     ) -> Result<FronteggMockServer, anyhow::Error> {
         let (role_updates_tx, role_updates_rx) = unbounded_channel();
 
+        let enable_auth = Arc::new(AtomicBool::new(true));
         let refreshes = Arc::new(Mutex::new(0u64));
-        let enable_refresh = Arc::new(AtomicBool::new(true));
         let auth_requests = Arc::new(Mutex::new(0u64));
 
         let user_api_tokens: BTreeMap<UserApiToken, String> = users
@@ -87,7 +87,7 @@ impl FronteggMockServer {
             latency,
             refresh_tokens: Mutex::new(BTreeMap::new()),
             refreshes: Arc::clone(&refreshes),
-            enable_refresh: Arc::clone(&enable_refresh),
+            enable_auth: Arc::clone(&enable_auth),
             auth_requests: Arc::clone(&auth_requests),
         });
 
@@ -119,20 +119,20 @@ impl FronteggMockServer {
         Ok(FronteggMockServer {
             base_url,
             refreshes,
-            enable_refresh,
+            enable_auth,
             auth_requests,
             role_updates_tx,
             handle,
         })
     }
 
-    pub fn wait_for_refresh(&self, expires_in_secs: u64) {
-        let expected = *self.refreshes.lock().unwrap() + 1;
+    pub fn wait_for_auth(&self, expires_in_secs: u64) {
+        let expected = *self.auth_requests.lock().unwrap() + 1;
         Retry::default()
             .factor(1.0)
             .max_duration(Duration::from_secs(expires_in_secs + 20))
             .retry(|_| {
-                let refreshes = *self.refreshes.lock().unwrap();
+                let refreshes = *self.auth_requests.lock().unwrap();
                 if refreshes >= expected {
                     Ok(())
                 } else {
@@ -237,6 +237,11 @@ async fn handle_post_auth_api_token(
     Json(request): Json<UserApiToken>,
 ) -> Result<Json<ApiTokenResponse>, StatusCode> {
     *context.auth_requests.lock().unwrap() += 1;
+
+    if !context.enable_auth.load(Ordering::Relaxed) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
     let user_api_tokens = context.user_api_tokens.lock().unwrap();
     let (email, user) = match user_api_tokens.get(&request) {
         Some(email) => {
@@ -268,6 +273,11 @@ async fn handle_post_auth_user(
     Json(request): Json<AuthUserRequest>,
 ) -> Result<Json<ApiTokenResponse>, StatusCode> {
     *context.auth_requests.lock().unwrap() += 1;
+
+    if !context.enable_auth.load(Ordering::Relaxed) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
     let users = context.users.lock().unwrap();
     let user = match users.get(&request.email) {
         Some(user) if request.password == user.password => user.to_owned(),
@@ -290,17 +300,20 @@ async fn handle_post_token_refresh(
 ) -> Result<Json<ApiTokenResponse>, StatusCode> {
     // Always count refresh attempts, even if enable_refresh is false.
     *context.refreshes.lock().unwrap() += 1;
-    let email = match (
-        context
-            .refresh_tokens
-            .lock()
-            .unwrap()
-            .remove(&previous_refresh_token.refresh_token),
-        context.enable_refresh.load(Ordering::Relaxed),
-    ) {
-        (Some(email), true) => email.to_string(),
-        _ => return Err(StatusCode::UNAUTHORIZED),
+
+    if !context.enable_auth.load(Ordering::Relaxed) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let maybe_email = context
+        .refresh_tokens
+        .lock()
+        .unwrap()
+        .remove(&previous_refresh_token.refresh_token);
+    let Some(email) = maybe_email else {
+        return Err(StatusCode::UNAUTHORIZED);
     };
+
     let users = context.users.lock().unwrap();
     let user = match users.get(&email) {
         Some(user) => user.to_owned(),
@@ -308,6 +321,7 @@ async fn handle_post_token_refresh(
     };
     let refresh_token = generate_refresh_token(&context, email.clone());
     let access_token = generate_access_token(&context, email, user.tenant_id, user.roles.clone());
+
     Ok(Json(ApiTokenResponse {
         expires: "".to_string(),
         expires_in: context.expires_in_secs,
@@ -425,6 +439,12 @@ struct Context {
     // Uuid -> email
     refresh_tokens: Mutex<BTreeMap<String, String>>,
     refreshes: Arc<Mutex<u64>>,
-    enable_refresh: Arc<AtomicBool>,
+    enable_auth: Arc<AtomicBool>,
     auth_requests: Arc<Mutex<u64>>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RefreshToken<'a> {
+    refresh_token: &'a str,
 }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -93,6 +93,7 @@ yansi = { version = "0.5.1", optional = true }
 anyhow = { version = "1.0.66" }
 criterion = { version = "0.4.0", features = ["async_tokio"] }
 mz-ore = { path = "../ore", features = ["id_gen"] }
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 scopeguard = "1.1.0"
 serde_json = "1.0.89"
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -90,6 +90,7 @@ pub mod task;
 #[cfg(any(test, feature = "test"))]
 pub mod test;
 pub mod thread;
+pub mod time;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "tracing_")))]
 #[cfg(feature = "tracing_")]
 pub mod tracing;

--- a/src/ore/src/time.rs
+++ b/src/ore/src/time.rs
@@ -1,0 +1,98 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Timing related extensions.
+
+use std::time::Duration;
+
+use num::Zero;
+
+/// Generic Error type returned from methods on [`DurationExt`].
+#[derive(Copy, Clone, Debug)]
+pub struct DurationError(&'static str);
+
+/// Extensions for [`std::time::Duration`].
+pub trait DurationExt {
+    /// Creates a [`Duration`] from the specified number of seconds represented as an `i64`.
+    ///
+    /// Returns an error if the provided number of seconds is negative.
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use mz_ore::time::DurationExt;
+    ///
+    /// // Negative numbers will fail.
+    /// assert!(Duration::try_from_secs_i64(-100).is_err());
+    ///
+    /// // i64 max works.
+    /// assert!(Duration::try_from_secs_i64(i64::MAX).is_ok());
+    /// ```
+    fn try_from_secs_i64(secs: i64) -> Result<Duration, DurationError>;
+
+    /// Saturating `Duration` multiplication. Computes `self * rhs`, saturating at the numeric
+    /// bounds instead of overflowing.
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use mz_ore::time::DurationExt;
+    ///
+    /// let one = Duration::from_secs(1);
+    /// assert_eq!(one.saturating_mul_f64(f64::INFINITY), Duration::from_secs(u64::MAX));
+    ///
+    /// assert_eq!(one.saturating_mul_f64(f64::NEG_INFINITY), Duration::from_secs(0));
+    /// assert_eq!(one.saturating_mul_f64(f64::NAN), Duration::from_secs(0));
+    /// assert_eq!(one.saturating_mul_f64(-0.0), Duration::from_secs(0));
+    /// assert_eq!(one.saturating_mul_f64(0.0), Duration::from_secs(0));
+    ///
+    /// assert_eq!(Duration::from_secs(20).saturating_mul_f64(0.1), Duration::from_secs(2));
+    /// ```
+    fn saturating_mul_f64(&self, rhs: f64) -> Duration;
+}
+
+impl DurationExt for Duration {
+    fn try_from_secs_i64(secs: i64) -> Result<Duration, DurationError> {
+        let secs: u64 = secs
+            .try_into()
+            .map_err(|_| DurationError("negative number of seconds"))?;
+        Ok(Duration::from_secs(secs))
+    }
+
+    fn saturating_mul_f64(&self, rhs: f64) -> Duration {
+        let x = self.as_secs_f64() * rhs;
+        let bound = if x.is_sign_negative() || x.is_nan() || x.is_zero() {
+            u64::MIN
+        } else {
+            u64::MAX
+        };
+        Duration::try_from_secs_f64(x).unwrap_or(Duration::from_secs(bound))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DurationExt;
+    use proptest::prelude::*;
+    use std::time::Duration;
+
+    const ONE: Duration = Duration::from_secs(1);
+
+    proptest! {
+        #[crate::test]
+        fn proptest_saturating_mul_f64(rhs: f64) {
+            // Saturating multiplication should never panic.
+            let _ = ONE.saturating_mul_f64(rhs);
+        }
+    }
+}

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -13,7 +13,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use mz_frontegg_auth::Authentication as FronteggAuthentication;
+use mz_frontegg_auth::Authenticator as FronteggAuthentication;
 use mz_ore::netio::AsyncReady;
 use mz_pgwire_common::{
     decode_startup, Conn, FrontendStartupMessage, ACCEPT_SSL_ENCRYPTION, REJECT_ENCRYPTION,


### PR DESCRIPTION
This PR refactors our Frontegg authentication code, it's based on https://github.com/MaterializeInc/materialize/pull/25409.

We make a few notable changes here:

1. We stop using Refresh Tokens, instead use the initially provided App Password to continuously check if the auth session is still valid.
    * Previously our authentication flow would get a JWT which would provide a refresh token that we would periodically send to Frontegg to keep the session alive and make sure the user wasn't deleted. These refresh tokens were fragile though and caused incident-98.
2. Further de-duplicate authentication requests by allowing new sessions to attach to an existing auth session.
    * Whenever we exchange an App Password for a token, we create an "authentication session" and if another SQL session is created with that same App Password, we'll attach to the existing "authentication session" instead of issuing another request to Frontegg.
3. Continue to refresh an "authentication session" if there are no active handles but a handle was recently dropped.
    * Some users will make a lot of "one-shot" requests to Materialize, e.g. with AWS lambda. Because of change [2] these one-shot requests should not need to re-authenticate every time, but there is an edge case where one SQL session ends, auth expires, then another SQL session gets created. The latter SQL session would then encounter a latency spike as it is forced to re-authenticate with Frontegg. We track the most recent time a session associated with an App Password was dropped, and when it comes time to refresh our auth, even if there aren't any active handles to the "authentication session" we'll proactively refresh anyways assuming another session may try to connect soon.

### Motivation

#incident_98 and other desired improvements to auth.

Fixes https://github.com/MaterializeInc/materialize/issues/25705

### Tips for reviewer

This is a relatively large PR so I broke it down to separate commits:

1. **Refactor to `frontegg_auth` crate**. This is the most important commit and deserves the most attention.
2. Update callers (e.g. `environmentd` and `balancerd`) because the auth function names changed.
3. Update and add new tests to exercise new behavior
4. Clippy and cargo vet changes.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Reduces connection latency when SQL sessions are started with the same app password in quick succession.
