### PR TITLE
lint: decrease risk of unused mzcompose workflows

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -288,6 +288,7 @@ steps:
       plugins:
         - ./ci/plugins/mzcompose:
             composition: limits
+            run: main
       timeout_in_minutes: 120
 
     - id: limits-instance-size

--- a/ci/slt/pipeline.template.yml
+++ b/ci/slt/pipeline.template.yml
@@ -27,7 +27,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
-          run: sqllogictest
+          run: slow-tests
 
   - id: sqllogictest-1-replica
     label: ":bulb: SQL logic tests 1 replica %N"
@@ -39,7 +39,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
-          run: sqllogictest
+          run: slow-tests
           args: [--replicas=1]
     skip: "Too expensive, didn't find anything interesting yet"
 

--- a/ci/test/lint-main/checks/check-mzcompose-files.sh
+++ b/ci/test/lint-main/checks/check-mzcompose-files.sh
@@ -36,7 +36,11 @@ check_all_files_referenced_in_ci() {
 
 check_default_workflow_references_others() {
     RETURN=0
-    mapfile -t MZCOMPOSE_TEST_FILES < <(find ./test -name "mzcompose.py")
+    mapfile -t MZCOMPOSE_TEST_FILES < <(find ./test -name "mzcompose.py" \
+        -not -wholename "./test/canary-environment/mzcompose.py" `# Only run manually` \
+        -not -wholename "./test/ssh-connection/mzcompose.py" `# Handled differently` \
+        -not -wholename "./test/scalability/mzcompose.py" `# Other workflows are for manual usage` \
+    )
 
     for file in "${MZCOMPOSE_TEST_FILES[@]}"; do
       MATCHES_COUNT=$(grep "def workflow_" "$file" -c)

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -584,6 +584,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: chbench
+          run: no-load
           args: [--run-seconds=10, --wait]
     timeout_in_minutes: 30
     agents:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -266,6 +266,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
+          run: fast-tests
     agents:
       queue: linux-aarch64-small
 

--- a/test/chbench/mzcompose.py
+++ b/test/chbench/mzcompose.py
@@ -41,7 +41,16 @@ SERVICES = [
 ]
 
 
-def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+def workflow_default(c: Composition) -> None:
+    for name in c.workflows:
+        if name == "default":
+            continue
+
+        with c.test_case(name):
+            c.workflow(name)
+
+
+def workflow_no_load(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Run CH-benCHmark without any load on Materialize"""
 
     # Parse arguments.
@@ -105,6 +114,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
 
+# invoked by ci/load
 def workflow_load_test(c: Composition) -> None:
     """Run CH-benCHmark with a selected amount of load against Materialize."""
     c.workflow(

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -92,7 +92,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = parser.parse_args()
 
     if args.cleanup:
-        workflow_disable_region(c)
+        disable_region(c)
 
     test_failed = True
     try:
@@ -117,12 +117,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     finally:
         # Clean up
         if args.cleanup:
-            workflow_disable_region(c)
+            disable_region(c)
 
     assert not test_failed
 
 
-def workflow_disable_region(c: Composition) -> None:
+def disable_region(c: Composition) -> None:
     print(f"Shutting down region {REGION} ...")
 
     c.run("mz", "region", "disable")

--- a/test/debezium/mzcompose.py
+++ b/test/debezium/mzcompose.py
@@ -33,6 +33,15 @@ SERVICES = [
 ]
 
 
+def workflow_default(c: Composition) -> None:
+    for name in c.workflows:
+        if name == "default":
+            continue
+
+        with c.test_case(name):
+            c.workflow(name)
+
+
 def workflow_postgres(c: Composition) -> None:
     c.up(*prerequisites, "postgres")
 

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1429,7 +1429,16 @@ SERVICES = [
 ]
 
 
-def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+def workflow_default(c: Composition) -> None:
+    for name in c.workflows:
+        if name == "default":
+            continue
+
+        with c.test_case(name):
+            c.workflow(name)
+
+
+def workflow_main(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Run all the limits tests against a multi-node, multi-replica cluster"""
 
     parser.add_argument(

--- a/test/mz-e2e/mzcompose.py
+++ b/test/mz-e2e/mzcompose.py
@@ -62,7 +62,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     psql_config_path = os.path.join(home_dir, ".psqlrc-mz")
 
     if args.cleanup:
-        workflow_disable_region(c)
+        disable_region(c)
         if os.path.exists(psql_config_path):
             os.remove(psql_config_path)
 
@@ -233,12 +233,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     finally:
         # Clean up
         if args.cleanup:
-            workflow_disable_region(c)
+            disable_region(c)
 
     assert not test_failed
 
 
-def workflow_disable_region(c: Composition) -> None:
+def disable_region(c: Composition) -> None:
     print(f"Shutting down region {REGION} ...")
 
     c.run("mz", "region", "disable")

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -212,13 +212,14 @@ def workflow_inspect_shard(c: Composition) -> None:
 
 
 def workflow_default(c: Composition) -> None:
-    for workflow in [
-        "inspect-shard",
-        "kafka-sources",
-        "user-tables",
-        # Legacy tests, not currently operational
-        # "failpoints",
-        # "compaction"
-    ]:
-        c.down(destroy_volumes=True)
-        c.workflow(workflow)
+    for name in c.workflows:
+        if name == "default":
+            continue
+
+        if name in ["failpoints", "compaction"]:
+            # Legacy tests, not currently operational
+            continue
+
+        with c.test_case(name):
+            c.down(destroy_volumes=True)
+            c.workflow(name)

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -22,12 +22,21 @@ SERVICES = [Cockroach(in_memory=True), SqlLogicTest()]
 COCKROACH_DEFAULT_PORT = 26257
 
 
-def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+def workflow_default(c: Composition) -> None:
+    for name in c.workflows:
+        if name == "default":
+            continue
+
+        with c.test_case(name):
+            c.workflow(name)
+
+
+def workflow_fast_tests(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Run fast SQL logic tests"""
     run_sqllogictest(c, parser, compileFastSltConfig())
 
 
-def workflow_sqllogictest(c: Composition, parser: WorkflowArgumentParser) -> None:
+def workflow_slow_tests(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Run slow SQL logic tests"""
     run_sqllogictest(
         c,


### PR DESCRIPTION
### Commits
98bfd51467 lint: check mzcompose files: add logic
8ccc3c164e lint: check mzcompose files: add ignores
0f0c76696d tests: cloud-canary: rename function
60d352bc77 tests: mz-e2e: rename function
21a42a7bdd tests: persistence: align default workload
b1e672c166 tests: limits: new default entry point
e89deaf387 tests: chbench: new default entry point
9164e2d71c tests: debezium: new default entry point
a8c1d8ae04 tests: slt: new default entry point

### Presentation of an error
```
--- check_default_workflow_references_others
./test/sqllogictest/mzcompose.py contains more than one workflow but does not seem to loop over the workflows
Use this pattern in the default workflow:
for name in c.workflows:
  if name == "default":
    continue

  with c.test_case(name):
    c.workflow(name)
^^^ 🚨 Failed: check_default_workflow_references_others
```