### PR TITLE
Update chunked stack setting on flag change

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -293,9 +293,9 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             }
             None => {}
         }
-        match enable_chunked_stack {
-            Some(setting) => crate::containers::stack::use_chunked_stack(setting),
-            None => {}
+        if let Some(enabled) = enable_chunked_stack {
+            info!(enabled, "Chunked stack");
+            crate::containers::stack::use_chunked_stack(enabled);
         }
         if let Some(v) = enable_operator_hydration_status_logging {
             self.compute_state.enable_operator_hydration_status_logging = v;

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2113,6 +2113,7 @@ impl SystemVars {
             || name == LINEAR_JOIN_YIELDING.name()
             || name == ENABLE_MZ_JOIN_CORE.name()
             || name == ENABLE_COLUMNATION_LGALLOC.name()
+            || name == ENABLE_COMPUTE_CHUNKED_STACK.name()
             || name == ENABLE_COMPUTE_OPERATOR_HYDRATION_STATUS_LOGGING.name()
             || name == ENABLE_LGALLOC_EAGER_RECLAMATION.name()
             || self.is_persist_config_var(name)


### PR DESCRIPTION
Update the `enable_compute_chunked_stack` flag when it changes.

### Motivation

Previously, we didn't notify the replica of changes to the chunked stack flag,
meaning it would not be picked up consistently. This fixes an unreported issue

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
