### PR TITLE
Revert "Revert "testdrive: Refactor consistency checks, add leaked shard check (#25306)""

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -229,6 +229,12 @@ Shuffle the list of tests before running them (using the value from --seed, if a
 
 ## Other options
 
+#### `--consistency-checks=<file, statement, disable>`
+
+There are internal invariants that we want to make sure are upheld within Materialize. By default
+we check these invariants after an entire test run. You can also optionally disable them, or when
+debugging, run them after every statement.
+
 #### `--validate-catalog-store=<store-kind>`
 
 After executing a DDL statement, validate that representation of the catalog is identical to the in-memory one. `<store-kind>` can be one of:

--- a/misc/python/materialize/feature_benchmark/executor.py
+++ b/misc/python/materialize/feature_benchmark/executor.py
@@ -68,7 +68,7 @@ class Docker(Executor):
             f"--seed={self._seed}",
             "--initial-backoff=10ms",  # Retry every 10ms until success
             "--backoff-factor=0",
-            "--no-consistency-checks",
+            "--consistency-checks=disable",
             f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
             stdin=input,
             capture=True,
@@ -174,7 +174,7 @@ class MzCloud(Executor):
             *self._testdrive_args,
             "--initial-backoff=10ms",
             "--backoff-factor=0",
-            "--no-consistency-checks",
+            "--consistency-checks=disable",
             stdin=input,
             capture=True,
         ).stdout

--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -123,7 +123,7 @@ class Testdrive(Service):
             entrypoint.append(f"--seed={seed}")
 
         if no_consistency_checks:
-            entrypoint.append("--no-consistency-checks")
+            entrypoint.append("--consistency-checks=disable")
 
         if external_minio:
             depends_graph["minio"] = {"condition": "service_healthy"}

--- a/src/testdrive/src/action/consistency.rs
+++ b/src/testdrive/src/action/consistency.rs
@@ -1,0 +1,261 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+use std::fmt::Write;
+use std::io::Write as _;
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context};
+use http::StatusCode;
+use mz_ore::retry::{Retry, RetryResult};
+use mz_persist_client::{PersistLocation, ShardId};
+use serde::{Deserialize, Serialize};
+
+use crate::action::{ControlFlow, State};
+use crate::parser::BuiltinCommand;
+
+/// Level of consistency checks we should enable on a testdrive run.
+#[derive(clap::ValueEnum, Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Level {
+    /// Run the consistency checks after the completion of a test file.
+    #[default]
+    File,
+    /// Run the consistency checks after each statement, good for debugging.
+    Statement,
+    /// Disable consistency checks entirely.
+    Disable,
+}
+
+impl FromStr for Level {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "file" => Ok(Level::File),
+            "statement" => Ok(Level::Statement),
+            "disable" => Ok(Level::Disable),
+            s => Err(format!("Unknown consistency check level: {s}")),
+        }
+    }
+}
+
+/// Skips consistency checks for the current file.
+pub fn skip_consistency_checks(
+    mut cmd: BuiltinCommand,
+    state: &mut State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let reason = cmd
+        .args
+        .string("reason")
+        .context("must provide reason for skipping")?;
+    tracing::info!(reason, "Skipping consistency checks as requested.");
+
+    state.consistency_checks_adhoc_skip = true;
+    Ok(ControlFlow::Continue)
+}
+
+/// Runs consistency checks against multiple parts of Materialize to make sure we haven't violated
+/// our invariants or leaked resources.
+pub async fn run_consistency_checks(state: &State) -> Result<ControlFlow, anyhow::Error> {
+    // Return early if the user adhoc disabled consistency checks for the current file.
+    if state.consistency_checks_adhoc_skip {
+        return Ok(ControlFlow::Continue);
+    }
+
+    let coordinator = check_coordinator(state).await.context("coordinator");
+    let catalog_state = check_catalog_state(state).await.context("catalog state");
+    // TODO(parkmycar): Fix subsources so they don't leak their shards and then add a leaked shards
+    // consistency check.
+
+    // Make sure to report all inconsistencies, not just the first.
+    let mut msg = String::new();
+    if let Err(e) = coordinator {
+        writeln!(&mut msg, "coordinator inconsistency: {e:?}")?;
+    }
+    if let Err(e) = catalog_state {
+        writeln!(&mut msg, "catalog inconsistency: {e:?}")?;
+    }
+
+    if msg.is_empty() {
+        Ok(ControlFlow::Continue)
+    } else {
+        Err(anyhow!("{msg}"))
+    }
+}
+
+/// Checks if a shard in Persist has been tombstoned.
+///
+/// TODO(parkmycar): Run this as part of the consistency checks, instead of as a specific command.
+pub async fn run_check_shard_tombstoned(
+    mut cmd: BuiltinCommand,
+    state: &State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let shard_id = cmd.args.string("shard-id")?;
+    check_shard_tombstoned(state, &shard_id).await?;
+    Ok(ControlFlow::Continue)
+}
+
+/// Asks the Coordinator to run it's own internal consistency checks.
+async fn check_coordinator(state: &State) -> Result<(), anyhow::Error> {
+    let response = Retry::default()
+        .max_duration(Duration::from_secs(2))
+        .retry_async(|_| async {
+            reqwest::get(&format!(
+                "http://{}/api/coordinator/check",
+                state.materialize_internal_http_addr,
+            ))
+            .await
+        })
+        .await
+        .context("querying coordinator")?;
+    if response.status() == StatusCode::NOT_FOUND {
+        bail!("Coordinator consistency check not available");
+    }
+
+    let inconsistencies: serde_json::Value =
+        response.json().await.context("deserialize response")?;
+
+    match inconsistencies {
+        serde_json::Value::String(x) if x.is_empty() => Ok(()),
+        other => Err(anyhow!("coordinator inconsistencies! {other:?}")),
+    }
+}
+
+/// Checks that the in-memory catalog matches what we have persisted on disk.
+async fn check_catalog_state(state: &State) -> Result<(), anyhow::Error> {
+    let maybe_disk_catalog = state
+        .with_catalog_copy(|catalog| catalog.state().clone())
+        .await
+        .map_err(|e| anyhow!("failed to read on-disk catalog state: {e}"))?
+        .map(|catalog| catalog.dump().expect("state must be dumpable"));
+    let Some(disk_catalog) = maybe_disk_catalog else {
+        // TODO(parkmycar): Ideally this could be an error, but a lot of test suites fail.
+        tracing::warn!("No Catalog state on disk, skipping consistency check");
+        return Ok(());
+    };
+
+    let memory_catalog = reqwest::get(&format!(
+        "http://{}/api/catalog/dump",
+        state.materialize_internal_http_addr,
+    ))
+    .await
+    .context("GET catalog")?
+    .text()
+    .await
+    .context("deserialize catalog")?;
+
+    if disk_catalog != memory_catalog {
+        // The state objects here are around 100k lines pretty printed, so find the
+        // first lines that differs and show context around it.
+        let diff = similar::TextDiff::from_lines(&memory_catalog, &disk_catalog)
+            .unified_diff()
+            .context_radius(50)
+            .to_string()
+            .lines()
+            .take(200)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        bail!("the in-memory state of the catalog does not match its on-disk state:\n{diff}");
+    }
+
+    Ok(())
+}
+
+/// Checks if the provided `shard_id` is a tombstone, returning an error if it's not.
+async fn check_shard_tombstoned(state: &State, shard_id: &str) -> Result<(), anyhow::Error> {
+    let (Some(consensus_uri), Some(blob_uri)) =
+        (&state.persist_consensus_url, &state.persist_blob_url)
+    else {
+        // TODO(parkmycar): Testdrive on Cloud Test doesn't currently supply the Persist URLs.
+        tracing::warn!("Persist consensus or blob URL not known");
+        return Ok(());
+    };
+
+    let location = PersistLocation {
+        blob_uri: blob_uri.clone(),
+        consensus_uri: consensus_uri.clone(),
+    };
+    let client = state
+        .persist_clients
+        .open(location)
+        .await
+        .context("openning persist client")?;
+    let shard_id = ShardId::from_str(shard_id).map_err(|s| anyhow!("invalid ShardId: {s}"))?;
+
+    // It might take the storage-controller a moment to drop it's handles, so do a couple retries.
+    let (_client, result) = Retry::default()
+        .max_duration(state.timeout)
+        .retry_async_with_state(client, |retry_state, client| async move {
+            let inspect_state = client
+                .inspect_shard::<mz_repr::Timestamp>(&shard_id)
+                .await
+                .context("inspecting shard")
+                .and_then(|state| serde_json::to_value(state).context("to json"))
+                .and_then(|state| {
+                    serde_json::from_value::<ShardState>(state).context("to shard state")
+                });
+
+            let result = match inspect_state {
+                Ok(state) if state.is_tombstone() => RetryResult::Ok(()),
+                Ok(state) if state.should_retry() => {
+                    if retry_state.i == 0 {
+                        print!("shard isn't tombstoned; sleeping to see if it gets cleaned up.");
+                    }
+                    if let Some(backoff) = retry_state.next_backoff {
+                        if !backoff.is_zero() {
+                            print!(" {:.0?}", backoff);
+                        }
+                    }
+                    std::io::stdout().flush().expect("flushing stdout");
+
+                    RetryResult::RetryableErr(anyhow!("non-tombstone state: {state:?}"))
+                }
+                Result::Ok(state) => {
+                    RetryResult::FatalErr(anyhow!("non-tombstone state: {state:?}"))
+                }
+                Result::Err(e) => RetryResult::FatalErr(e),
+            };
+
+            (client, result)
+        })
+        .await;
+
+    result
+}
+
+/// Parts of a shard's state that we read to determine if it's a tombstone.
+#[derive(Debug, Serialize, Deserialize)]
+struct ShardState {
+    leased_readers: BTreeMap<String, serde_json::Value>,
+    critical_readers: BTreeMap<String, serde_json::Value>,
+    writers: BTreeMap<String, serde_json::Value>,
+    since: Vec<mz_repr::Timestamp>,
+    upper: Vec<mz_repr::Timestamp>,
+}
+
+impl ShardState {
+    /// It can take the storage-controller a few moments to cleanup and drop it's state. Signal
+    /// that we might be cleaning up is if the controller still has a critical since shard.
+    fn should_retry(&self) -> bool {
+        let controller_id = mz_persist_client::PersistClient::CONTROLLER_CRITICAL_SINCE.to_string();
+        self.critical_readers.contains_key(&controller_id)
+    }
+
+    /// Returns if this shard is currently a tombstsone.
+    fn is_tombstone(&self) -> bool {
+        self.upper.is_empty()
+            && self.since.is_empty()
+            && self.writers.is_empty()
+            && self.leased_readers.is_empty()
+            && self.critical_readers.is_empty()
+    }
+}

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -11,10 +11,9 @@ use std::ascii;
 use std::error::Error;
 use std::fmt::{self, Display, Formatter, Write as _};
 use std::io::{self, Write};
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
-use anyhow::{anyhow, bail, Context};
-use http::StatusCode;
+use anyhow::{bail, Context};
 use md5::{Digest, Md5};
 use mz_ore::collections::CollectionExt;
 use mz_ore::retry::Retry;
@@ -121,101 +120,11 @@ pub async fn run_sql(mut cmd: SqlCommand, state: &State) -> Result<ControlFlow, 
         println!();
         return Err(e);
     }
-
-    if !state.no_consistency_checks {
-        run_extra_checks(state, &stmt).await?;
+    if state.consistency_checks == super::consistency::Level::Statement {
+        super::consistency::run_consistency_checks(state).await?;
     }
 
     Ok(ControlFlow::Continue)
-}
-
-async fn run_extra_checks(state: &State, stmt: &Statement<Raw>) -> Result<(), anyhow::Error> {
-    match stmt {
-        Statement::AlterDefaultPrivileges { .. }
-        | Statement::AlterOwner { .. }
-        | Statement::CreateDatabase { .. }
-        | Statement::CreateIndex { .. }
-        | Statement::CreateSchema { .. }
-        | Statement::CreateSource { .. }
-        | Statement::CreateTable { .. }
-        | Statement::CreateView { .. }
-        | Statement::CreateMaterializedView { .. }
-        | Statement::DropObjects { .. }
-        | Statement::GrantPrivileges { .. }
-        | Statement::GrantRole { .. }
-        | Statement::RevokePrivileges { .. }
-        | Statement::RevokeRole { .. } => {
-            let response = Retry::default()
-                .max_duration(Duration::from_secs(3))
-                .clamp_backoff(Duration::from_millis(500))
-                .retry_async(|_| async {
-                    reqwest::get(&format!(
-                        "http://{}/api/coordinator/check",
-                        state.materialize_internal_http_addr,
-                    ))
-                    .await
-                    .context("while getting response from coordinator check")
-                })
-                .await?;
-            if response.status() == StatusCode::NOT_FOUND {
-                tracing::info!(
-                    "not performing coordinator check because the endpoint doesn't exist"
-                );
-            } else {
-                // 404 can happen if we're testing an older version of environmentd
-                let inconsistencies = response
-                    .error_for_status()
-                    .context("response from coordinator check returned an error")?
-                    .text()
-                    .await
-                    .context("while getting text from coordinator check")?;
-                let inconsistencies: serde_json::Value = serde_json::from_str(&inconsistencies)
-                    .with_context(|| {
-                        format!(
-                            "while parsing result from consistency check: {:?}",
-                            inconsistencies
-                        )
-                    })?;
-                if inconsistencies != serde_json::json!("") {
-                    bail!("Internal catalog inconsistencies {inconsistencies:#?}");
-                }
-            }
-
-            let catalog_state = state
-                .with_catalog_copy(|catalog| catalog.state().clone())
-                .await
-                .map_err(|e| anyhow!("failed to read on-disk catalog state: {e}"))?;
-
-            // Check that our on-disk state matches the in-memory state.
-            let disk_state =
-                catalog_state.map(|state| state.dump().expect("state must be dumpable"));
-            if let Some(disk_state) = disk_state {
-                let mem_state = reqwest::get(&format!(
-                    "http://{}/api/catalog/dump",
-                    state.materialize_internal_http_addr,
-                ))
-                .await?
-                .text()
-                .await?;
-                if disk_state != mem_state {
-                    // The state objects here are around 100k lines pretty printed, so find the
-                    // first lines that differs and show context around it.
-                    let diff = similar::TextDiff::from_lines(&mem_state, &disk_state)
-                        .unified_diff()
-                        .context_radius(50)
-                        .to_string()
-                        .lines()
-                        .take(200)
-                        .collect::<Vec<_>>()
-                        .join("\n");
-
-                    bail!("the in-memory state of the catalog does not match its on-disk state:\n{diff}");
-                }
-            }
-        }
-        _ => {}
-    }
-    Ok(())
 }
 
 async fn try_run_sql(

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -22,7 +22,7 @@ use mz_build_info::{build_info, BuildInfo};
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::path::PathExt;
 use mz_sql::session::vars::CatalogKind;
-use mz_testdrive::{CatalogConfig, Config};
+use mz_testdrive::{CatalogConfig, Config, ConsistencyCheckLevel};
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
@@ -105,8 +105,8 @@ struct Args {
     #[clap(long, value_name = "FILE")]
     junit_report: Option<PathBuf>,
     /// Whether we skip coordinator and catalog consistency checks.
-    #[clap(long)]
-    no_consistency_checks: bool,
+    #[clap(long, default_value_t = ConsistencyCheckLevel::default(), value_enum)]
+    consistency_checks: ConsistencyCheckLevel,
     /// Which log messages to emit.
     ///
     /// See environmentd's `--startup-log-filter` option for details.
@@ -306,12 +306,12 @@ async fn main() {
     Schema registry URL: {}
     Materialize host: {:?}
     Error limit: {}
-    Skipping consistency checks: {}",
+    Consistency check level: {:?}",
         args.kafka_addr,
         args.schema_registry_url,
         args.materialize_url.get_hosts()[0],
         args.max_errors,
-        args.no_consistency_checks
+        args.consistency_checks,
     );
     if let (Some(shard), Some(shard_count)) = (args.shard, args.shard_count) {
         eprintln!("    Shard: {}/{}", shard + 1, shard_count);
@@ -362,7 +362,7 @@ async fn main() {
         default_max_tries: args.default_max_tries,
         initial_backoff: args.initial_backoff,
         backoff_factor: args.backoff_factor,
-        no_consistency_checks: args.no_consistency_checks,
+        consistency_checks: args.consistency_checks,
 
         // === Materialize options. ===
         materialize_pgconfig: args.materialize_url,

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -30,6 +30,7 @@ mod format;
 mod parser;
 mod util;
 
+pub use crate::action::consistency::Level as ConsistencyCheckLevel;
 pub use crate::action::{CatalogConfig, Config};
 pub use crate::error::Error;
 
@@ -154,6 +155,12 @@ pub(crate) async fn run_line_reader(
             }
         }
     }
+    if config.consistency_checks == action::consistency::Level::File {
+        if let Err(e) = action::consistency::run_consistency_checks(&state).await {
+            errors.push(e.into());
+        }
+    }
+    state.clear_skip_consistency_checks();
 
     if config.reset {
         drop(state);

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -202,6 +202,9 @@ A
 > SELECT * FROM source1
 A
 
+# TODO: This should be made reliable without sleeping, #25479
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
+
 # Sinks
 > CREATE SINK sink1 FROM v1mat
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink1')

--- a/test/pg-cdc/status/04-drop-publication.td
+++ b/test/pg-cdc/status/04-drop-publication.td
@@ -23,6 +23,9 @@ true
 > SELECT error ILIKE '%publication "mz_source" does not exist' FROM mz_internal.mz_source_statuses WHERE name = 't';
 true
 
+# TODO: This should be made reliable without sleeping, #25479
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
+
 ! SELECT * FROM t;
 contains:publication "mz_source" does not exist
 

--- a/test/testdrive/connection-alter.td
+++ b/test/testdrive/connection-alter.td
@@ -9,6 +9,8 @@
 #
 # Test basic connection functionality
 
+$ skip-consistency-checks reason="workflow uses SSH keys which we currently can't check"
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_connection_validation_syntax = true
 

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -9,6 +9,8 @@
 #
 # Test basic connection functionality
 
+$ skip-consistency-checks reason="workflow uses SSH keys which we currently can't check"
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_connection_validation_syntax = true
 

--- a/test/testdrive/connection-validation.td
+++ b/test/testdrive/connection-validation.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ skip-consistency-checks reason="workflow uses SSH keys which we currently can't check"
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_connection_validation_syntax = true
 

--- a/test/testdrive/mz-depends.td
+++ b/test/testdrive/mz-depends.td
@@ -9,6 +9,8 @@
 
 # Test `mz_internal.mz_object_dependencies`.
 
+$ skip-consistency-checks reason="workflow uses SSH keys which we currently can't check"
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_connection_validation_syntax = true
 

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -68,7 +68,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         default=["*.td"],
         help="run against the specified files",
     )
-    args = parser.parse_args()
+    (args, passthrough_args) = parser.parse_known_args()
 
     dependencies = ["materialized"]
     if args.redpanda:
@@ -140,7 +140,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         try:
             junit_report = ci_util.junit_report_filename(c.name)
-            print("")
+            print(f"Passing through arguments to testdrive {passthrough_args}\n")
             for file in args.files:
                 c.run_testdrive_files(
                     f"--junit-report={junit_report}",
@@ -148,6 +148,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     f"--var=default-replica-size={materialized.default_replica_size}",
                     f"--var=default-storage-size={materialized.default_storage_size}",
                     f"--var=single-replica-cluster={single_replica_cluster}",
+                    *passthrough_args,
                     file,
                 )
                 c.sanity_restart_mz()

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -382,20 +382,33 @@ a    true     integer
 
 # Test that the underlying Persist shard gets cleaned up on DROP.
 > CREATE TABLE shard_drop_test (a int, b text);
-
 > INSERT INTO shard_drop_test VALUES (1, 'hello');
+
+> CREATE TABLE shard_drop_test_empty (a int, b text);
 
 $ set-from-sql var=shard-drop-test-id
 SELECT id FROM mz_tables WHERE name = 'shard_drop_test';
 
-> CREATE TABLE shard_drop_test_empty (a int, b text);
-
 $ set-from-sql var=shard-drop-test-empty-id
 SELECT id FROM mz_tables WHERE name = 'shard_drop_test_empty';
 
-> DROP TABLE shard_drop_test;
+# Wait for the mz_storage_shards table to get updated.
+> SELECT COUNT(shard_id) FROM mz_internal.mz_storage_shards WHERE object_id IN ('${shard-drop-test-id}', '${shard-drop-test-empty-id}');
+2
 
+$ set-from-sql var=shard-drop-test-shard-id
+SELECT shard_id FROM mz_internal.mz_storage_shards WHERE object_id = '${shard-drop-test-id}';
+
+$ set-from-sql var=shard-drop-test-empty-shard-id
+SELECT shard_id FROM mz_internal.mz_storage_shards WHERE object_id = '${shard-drop-test-empty-id}';
+
+> DROP TABLE shard_drop_test;
 > DROP TABLE shard_drop_test_empty;
 
-> SELECT COUNT(*) FROM mz_internal.mz_storage_shards WHERE object_id IN ('$shard-drop-test-id', '$shard-drop-test-empty-id');
+> SELECT COUNT(*) FROM mz_internal.mz_storage_shards WHERE object_id IN ('${shard-drop-test-id}', '${shard-drop-test-empty-id}');
 0
+
+$ check-shard-tombstone shard-id=${shard-drop-test-shard-id}
+
+# TODO(parkmycar): The since and upper of the shard are empty, but the controller still has it's handle registered.
+# $ check-shard-tombstone shard-id=${shard-drop-test-empty-shard-id}

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -511,6 +511,9 @@ baz-after
 $ set-from-sql var=webhook-source-id
 SELECT id FROM mz_sources WHERE name = 'webhook_bytes';
 
+$ set-from-sql var=webhook-source-shard-id
+SELECT shard_id FROM mz_internal.mz_storage_shards WHERE object_id = '${webhook-source-id}';
+
 > SELECT COUNT(*) FROM mz_internal.mz_storage_shards WHERE object_id = '${webhook-source-id}';
 1
 
@@ -518,6 +521,11 @@ SELECT id FROM mz_sources WHERE name = 'webhook_bytes';
 
 > SELECT COUNT(*) FROM mz_internal.mz_storage_shards WHERE object_id = '${webhook-source-id}';
 0
+
+$ check-shard-tombstone shard-id=${webhook-source-shard-id}
+
+# Cleanup.
+> DROP CLUSTER webhook_cluster CASCADE;
 
 # Creating a webhook source without specifying the cluster.
 $ skip-if


### PR DESCRIPTION
I think we should get this in again, even if we don't understand the test flakiness. So I added two sleeps for now, but will keep the issue open for a proper fix.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
