### PR TITLE
Revert "catalog: Remove shadow catalog (#25636)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,7 +5696,6 @@ dependencies = [
  "junit-report",
  "md-5",
  "mz-build-info",
- "mz-catalog",
  "mz-cloud-resources",
  "mz-controller",
  "mz-dyncfgs",

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -51,7 +51,7 @@ class StartMz(MzcomposeAction):
         self.system_parameter_defaults = system_parameter_defaults
         self.additional_system_parameter_defaults = additional_system_parameter_defaults
         self.catalog_store = catalog_store or (
-            "persist"
+            "shadow"
             if scenario.base_version() >= MzVersion.parse_mz("v0.82.0-dev")
             else "stash"
         )

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -98,7 +98,6 @@ IGNORE_RE = re.compile(
     | persist-txn-fencing-mz_first-.* \| .*unexpected\ fence\ epoch
     | persist-txn-fencing-mz_first-.* \| .*fenced\ by\ new\ catalog\ upper
     | platform-checks-mz_txn_tables.* \| .*unexpected\ fence\ epoch
-    | platform-checks-mz_txn_tables.* \| .*fenced\ by\ new\ catalog\ upper
     # For platform-checks upgrade tests
     | platform-checks-clusterd.* \| .* received\ persist\ state\ from\ the\ future
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage(\ to\ set\ (default|configured)\ parameter)?

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -52,7 +52,7 @@ class Materialized(Service):
         additional_system_parameter_defaults: dict[str, str] | None = None,
         soft_assertions: bool = True,
         sanity_restart: bool = True,
-        catalog_store: str | None = "persist",
+        catalog_store: str | None = "shadow",
         platform: str | None = None,
         healthcheck: list[str] | None = None,
     ) -> None:

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -83,7 +83,7 @@ use mz_sql::session::vars::{
 };
 use mz_sql::{rbac, DEFAULT_SCHEMA};
 use mz_sql_parser::ast::QualifiedReplica;
-use mz_stash::StashFactory;
+use mz_stash::{DebugStashFactory, StashFactory};
 use mz_storage_types::connections::inline::{ConnectionResolver, InlinedConnection};
 use mz_storage_types::connections::ConnectionContext;
 use mz_transform::dataflow::DataflowMetainfo;
@@ -523,30 +523,51 @@ impl Catalog {
         F: FnOnce(Catalog) -> Fut,
         Fut: Future<Output = T>,
     {
+        let debug_stash_factory = DebugStashFactory::new().await;
         let persist_client = PersistClient::new_for_tests().await;
         let environmentd_id = Uuid::new_v4();
-        let catalog =
-            match Self::open_debug_catalog(persist_client, environmentd_id, now, None).await {
-                Ok(catalog) => catalog,
-                Err(err) => {
-                    panic!("unable to open debug stash: {err}");
-                }
-            };
-        f(catalog).await
+        let catalog = match Self::open_debug_catalog(
+            &debug_stash_factory,
+            persist_client,
+            environmentd_id,
+            now,
+            None,
+        )
+        .await
+        {
+            Ok(catalog) => catalog,
+            Err(err) => {
+                debug_stash_factory.drop().await;
+                panic!("unable to open debug stash: {err}");
+            }
+        };
+        let res = f(catalog).await;
+        debug_stash_factory.drop().await;
+        res
     }
 
     /// Opens a debug catalog.
     ///
     /// See [`Catalog::with_debug`].
     pub async fn open_debug_catalog(
+        debug_stash_factory: &DebugStashFactory,
         persist_client: PersistClient,
         organization_id: Uuid,
         now: NowFn,
         environment_id: Option<EnvironmentId>,
     ) -> Result<Catalog, anyhow::Error> {
         let openable_storage = Box::new(
-            mz_catalog::durable::test_persist_backed_catalog_state(persist_client, organization_id)
-                .await,
+            mz_catalog::durable::shadow_catalog_state(
+                StashConfig {
+                    stash_factory: debug_stash_factory.stash_factory().clone(),
+                    stash_url: debug_stash_factory.url().to_string(),
+                    schema: Some(debug_stash_factory.schema().to_string()),
+                    tls: debug_stash_factory.tls().clone(),
+                },
+                persist_client,
+                organization_id,
+            )
+            .await,
         );
         let storage = openable_storage
             .open(now(), &test_bootstrap_args(), None, None)
@@ -609,6 +630,30 @@ impl Catalog {
     ) -> Result<Catalog, anyhow::Error> {
         let openable_storage = Box::new(
             mz_catalog::durable::test_persist_backed_catalog_state(
+                persist_client,
+                environment_id.organization_id(),
+            )
+            .await,
+        );
+        let storage = openable_storage
+            .open_read_only(&test_bootstrap_args())
+            .await?;
+        Self::open_debug_catalog_inner(storage, now, Some(environment_id)).await
+    }
+
+    /// Opens a read only debug persist backed catalog defined by `stash_config`, `persist_client`
+    /// and `organization_id`.
+    ///
+    /// See [`Catalog::with_debug`].
+    pub async fn open_debug_read_only_shadow_catalog_config(
+        stash_config: StashConfig,
+        persist_client: PersistClient,
+        now: NowFn,
+        environment_id: EnvironmentId,
+    ) -> Result<Catalog, anyhow::Error> {
+        let openable_storage = Box::new(
+            mz_catalog::durable::shadow_catalog_state(
+                stash_config,
                 persist_client,
                 environment_id.organization_id(),
             )
@@ -4329,10 +4374,12 @@ mod tests {
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn test_catalog_revision() {
+        let debug_stash_factory = DebugStashFactory::new().await;
         let persist_client = PersistClient::new_for_tests().await;
         let organization_id = Uuid::new_v4();
         {
             let mut catalog = Catalog::open_debug_catalog(
+                &debug_stash_factory,
                 persist_client.clone(),
                 organization_id.clone(),
                 NOW_ZERO.clone(),
@@ -4359,6 +4406,7 @@ mod tests {
         }
         {
             let catalog = Catalog::open_debug_catalog(
+                &debug_stash_factory,
                 persist_client,
                 organization_id,
                 NOW_ZERO.clone(),
@@ -4370,6 +4418,7 @@ mod tests {
             assert_eq!(catalog.transient_revision(), 1);
             catalog.expire().await;
         }
+        debug_stash_factory.drop().await;
     }
 
     #[mz_ore::test(tokio::test)]
@@ -4562,11 +4611,13 @@ mod tests {
         assert!(mz_sql_parser::parser::parse_statements(&create_sql).is_ok());
         assert!(mz_sql_parser::parser::parse_statements_with_limit(&create_sql).is_err());
 
+        let debug_stash_factory = DebugStashFactory::new().await;
         let persist_client = PersistClient::new_for_tests().await;
         let organization_id = Uuid::new_v4();
         let id = GlobalId::User(1);
         {
             let mut catalog = Catalog::open_debug_catalog(
+                &debug_stash_factory,
                 persist_client.clone(),
                 organization_id.clone(),
                 SYSTEM_TIME.clone(),
@@ -4602,6 +4653,7 @@ mod tests {
         }
         {
             let catalog = Catalog::open_debug_catalog(
+                &debug_stash_factory,
                 persist_client,
                 organization_id,
                 SYSTEM_TIME.clone(),
@@ -4617,6 +4669,7 @@ mod tests {
             }
             catalog.expire().await;
         }
+        debug_stash_factory.drop().await;
     }
 
     #[mz_ore::test]
@@ -5505,10 +5558,12 @@ mod tests {
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn test_builtin_migrations() {
+        let debug_stash_factory = DebugStashFactory::new().await;
         let persist_client = PersistClient::new_for_tests().await;
         let organization_id = Uuid::new_v4();
         let id = {
             let catalog = Catalog::open_debug_catalog(
+                &debug_stash_factory,
                 persist_client.clone(),
                 organization_id.clone(),
                 NOW_ZERO.clone(),
@@ -5534,6 +5589,7 @@ mod tests {
         }
         {
             let catalog = Catalog::open_debug_catalog(
+                &debug_stash_factory,
                 persist_client,
                 organization_id,
                 NOW_ZERO.clone(),
@@ -5552,6 +5608,7 @@ mod tests {
 
             catalog.expire().await;
         }
+        debug_stash_factory.drop().await;
     }
 
     #[mz_ore::test(tokio::test)]

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -218,6 +218,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                 .await?,
             )
         }
+        CatalogKind::Shadow => panic!("cannot use shadow catalog with catalog-debug tool"),
         CatalogKind::EmergencyStash => {
             panic!("cannot use emergency stash variant with catalog-debug tool, use stash instead")
         }

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -32,6 +32,7 @@ pub use crate::durable::error::{CatalogError, DurableCatalogError};
 use crate::durable::impls::migrate::{CatalogMigrator, Direction};
 pub use crate::durable::impls::persist::metrics::Metrics;
 use crate::durable::impls::persist::UnopenedPersistCatalogState;
+use crate::durable::impls::shadow::OpenableShadowCatalogState;
 use crate::durable::impls::stash::{OpenableConnection, TestOpenableConnection};
 pub use crate::durable::impls::stash::{
     StashConfig, ALL_COLLECTIONS, AUDIT_LOG_COLLECTION, CLUSTER_COLLECTION,
@@ -360,6 +361,21 @@ pub async fn test_persist_backed_catalog_state_with_version(
 ) -> Result<UnopenedPersistCatalogState, DurableCatalogError> {
     let metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
     persist_backed_catalog_state(persist_client, organization_id, version, metrics).await
+}
+
+/// Creates an openable durable catalog state implemented using both the stash and persist, that
+/// compares the results. The stash results is used as the source of truth when there's a
+/// discrepancy.
+pub async fn shadow_catalog_state(
+    stash_config: StashConfig,
+    persist_client: PersistClient,
+    organization_id: Uuid,
+) -> impl OpenableDurableCatalogState {
+    let stash = Box::new(stash_backed_catalog_state(stash_config));
+    // Shadow catalog is only used for tests, so it's OK to get a test persist catalog state.
+    let persist =
+        Box::new(test_persist_backed_catalog_state(persist_client, organization_id).await);
+    OpenableShadowCatalogState { stash, persist }
 }
 
 /// Creates an openable durable catalog state that migrates the current state from the stash to

--- a/src/catalog/src/durable/impls.rs
+++ b/src/catalog/src/durable/impls.rs
@@ -9,4 +9,5 @@
 
 pub(crate) mod migrate;
 pub(crate) mod persist;
+pub(crate) mod shadow;
 pub(crate) mod stash;

--- a/src/catalog/src/durable/impls/migrate.rs
+++ b/src/catalog/src/durable/impls/migrate.rs
@@ -53,6 +53,7 @@ impl TryFrom<CatalogKind> for TargetImplementation {
                 Direction::MigrateToPersist,
             )),
             CatalogKind::EmergencyStash => Ok(TargetImplementation::EmergencyStash),
+            CatalogKind::Shadow => Err(catalog_kind),
         }
     }
 }
@@ -420,7 +421,19 @@ mod tests {
                 TargetImplementation::MigrationDirection(Direction::MigrateToPersist)
             );
 
+            catalog.set_catalog_kind(CatalogKind::Shadow);
+            assert_eq!(
+                catalog.target,
+                TargetImplementation::MigrationDirection(Direction::MigrateToPersist)
+            );
+
             catalog.set_catalog_kind(CatalogKind::Stash);
+            assert_eq!(
+                catalog.target,
+                TargetImplementation::MigrationDirection(Direction::RollbackToStash)
+            );
+
+            catalog.set_catalog_kind(CatalogKind::Shadow);
             assert_eq!(
                 catalog.target,
                 TargetImplementation::MigrationDirection(Direction::RollbackToStash)
@@ -448,7 +461,19 @@ mod tests {
                 TargetImplementation::MigrationDirection(Direction::RollbackToStash)
             );
 
+            catalog.set_catalog_kind(CatalogKind::Shadow);
+            assert_eq!(
+                catalog.target,
+                TargetImplementation::MigrationDirection(Direction::RollbackToStash)
+            );
+
             catalog.set_catalog_kind(CatalogKind::Persist);
+            assert_eq!(
+                catalog.target,
+                TargetImplementation::MigrationDirection(Direction::MigrateToPersist)
+            );
+
+            catalog.set_catalog_kind(CatalogKind::Shadow);
             assert_eq!(
                 catalog.target,
                 TargetImplementation::MigrationDirection(Direction::MigrateToPersist)

--- a/src/catalog/src/durable/impls/shadow.rs
+++ b/src/catalog/src/durable/impls/shadow.rs
@@ -1,0 +1,592 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::cmp::max;
+use std::fmt::Debug;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use mz_storage_types::controller::PersistTxnTablesImpl;
+use timely::progress::Timestamp as TimelyTimestamp;
+
+use mz_audit_log::{VersionedEvent, VersionedStorageUsage};
+use mz_ore::cast::u64_to_usize;
+use mz_ore::now::EpochMillis;
+use mz_ore::soft_assert_eq_or_log;
+use mz_repr::Timestamp;
+use mz_sql::session::vars::CatalogKind;
+
+use crate::durable::debug::{DebugCatalogState, Trace};
+use crate::durable::objects::serialization::proto;
+use crate::durable::objects::Snapshot;
+use crate::durable::transaction::TransactionBatch;
+use crate::durable::{
+    BootstrapArgs, CatalogError, DurableCatalogState, Epoch, OpenableDurableCatalogState,
+    ReadOnlyDurableCatalogState, Transaction, STORAGE_USAGE_ID_ALLOC_KEY,
+};
+
+macro_rules! compare_and_return {
+    ($shadow:expr, $method:ident $(, $arg:expr)*) => {{
+        let stash = $shadow.stash.$method($($arg.clone()),*);
+        let persist = $shadow.persist.$method($($arg),*);
+        soft_assert_eq_or_log!(stash, persist);
+        stash
+    }};
+}
+
+macro_rules! compare_and_return_async {
+    ($shadow:expr, $method:ident $(, $arg:expr)*) => {{
+        let stash = $shadow.stash.$method($($arg),*);
+        let persist = $shadow.persist.$method($($arg),*);
+        let (stash, persist) = futures::future::join(stash, persist).await;
+        soft_assert_eq_or_log!(
+            stash.is_ok(),
+            persist.is_ok(),
+            "stash and persist result variant do not match. stash: {stash:?}. persist: {persist:?}"
+        );
+        let stash = stash?;
+        let persist = persist?;
+        soft_assert_eq_or_log!(stash, persist);
+        Ok(stash)
+    }};
+}
+
+#[derive(Debug)]
+pub(crate) struct OpenableShadowCatalogState<S, P>
+where
+    S: OpenableDurableCatalogState,
+    P: OpenableDurableCatalogState,
+{
+    pub stash: Box<S>,
+    pub persist: Box<P>,
+}
+
+#[async_trait]
+impl<S, P> OpenableDurableCatalogState for OpenableShadowCatalogState<S, P>
+where
+    S: OpenableDurableCatalogState,
+    P: OpenableDurableCatalogState,
+{
+    async fn open_savepoint(
+        self: Box<Self>,
+        initial_ts: EpochMillis,
+        bootstrap_args: &BootstrapArgs,
+        deploy_generation: Option<u64>,
+        epoch_lower_bound: Option<Epoch>,
+    ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
+        let stash = self.stash.open_savepoint(
+            initial_ts.clone(),
+            bootstrap_args,
+            deploy_generation.clone(),
+            epoch_lower_bound,
+        );
+        let persist = self.persist.open_savepoint(
+            initial_ts,
+            bootstrap_args,
+            deploy_generation,
+            epoch_lower_bound,
+        );
+        let (stash, persist) = futures::future::join(stash, persist).await;
+        soft_assert_eq_or_log!(
+            stash.is_ok(),
+            persist.is_ok(),
+            "stash and persist result variant do not match. stash: {stash:?}. persist: {persist:?}"
+        );
+        let stash = stash?;
+        let persist = persist?;
+        Ok(Box::new(ShadowCatalogState::new(stash, persist).await?))
+    }
+
+    async fn open_read_only(
+        self: Box<Self>,
+        bootstrap_args: &BootstrapArgs,
+    ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
+        let stash = self.stash.open_read_only(bootstrap_args);
+        let persist = self.persist.open_read_only(bootstrap_args);
+        let (stash, persist) = futures::future::join(stash, persist).await;
+        soft_assert_eq_or_log!(
+            stash.is_ok(),
+            persist.is_ok(),
+            "stash and persist result variant do not match. stash: {stash:?}. persist: {persist:?}"
+        );
+        let stash = stash?;
+        let persist = persist?;
+        Ok(Box::new(ShadowCatalogState::new_read_only(stash, persist)))
+    }
+
+    async fn open(
+        self: Box<Self>,
+        initial_ts: EpochMillis,
+        bootstrap_args: &BootstrapArgs,
+        deploy_generation: Option<u64>,
+        epoch_lower_bound: Option<Epoch>,
+    ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
+        let stash = self.stash.open(
+            initial_ts.clone(),
+            bootstrap_args,
+            deploy_generation.clone(),
+            epoch_lower_bound,
+        );
+        let persist = self.persist.open(
+            initial_ts,
+            bootstrap_args,
+            deploy_generation,
+            epoch_lower_bound,
+        );
+        let (stash, persist) = futures::future::join(stash, persist).await;
+        soft_assert_eq_or_log!(
+            stash.is_ok(),
+            persist.is_ok(),
+            "stash and persist result variant do not match. stash: {stash:?}. persist: {persist:?}"
+        );
+        let stash = stash?;
+        let persist = persist?;
+        Ok(Box::new(ShadowCatalogState::new(stash, persist).await?))
+    }
+
+    async fn open_debug(mut self: Box<Self>) -> Result<DebugCatalogState, CatalogError> {
+        panic!("ShadowCatalog is not used for catalog-debug tool");
+    }
+
+    async fn is_initialized(&mut self) -> Result<bool, CatalogError> {
+        compare_and_return_async!(self, is_initialized)
+    }
+
+    async fn epoch(&mut self) -> Result<Epoch, CatalogError> {
+        compare_and_return_async!(self, epoch)
+    }
+
+    async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError> {
+        compare_and_return_async!(self, get_deployment_generation)
+    }
+
+    async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError> {
+        compare_and_return_async!(self, has_system_config_synced_once)
+    }
+
+    async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {
+        compare_and_return_async!(self, get_tombstone)
+    }
+
+    async fn get_catalog_kind_config(&mut self) -> Result<Option<CatalogKind>, CatalogError> {
+        compare_and_return_async!(self, get_catalog_kind_config)
+    }
+
+    async fn trace(&mut self) -> Result<Trace, CatalogError> {
+        panic!("ShadowCatalog is not used for catalog-debug tool");
+    }
+
+    fn set_catalog_kind(&mut self, catalog_kind: CatalogKind) {
+        compare_and_return!(self, set_catalog_kind, catalog_kind)
+    }
+
+    async fn expire(self: Box<Self>) {
+        futures::future::join(self.stash.expire(), self.persist.expire()).await;
+    }
+}
+
+#[derive(Debug)]
+pub struct ShadowCatalogState {
+    pub stash: Box<dyn DurableCatalogState>,
+    pub persist: Box<dyn DurableCatalogState>,
+}
+
+impl ShadowCatalogState {
+    async fn new(
+        stash: Box<dyn DurableCatalogState>,
+        persist: Box<dyn DurableCatalogState>,
+    ) -> Result<ShadowCatalogState, CatalogError> {
+        let mut state = ShadowCatalogState { stash, persist };
+        state.fix_storage_usage().await?;
+        Ok(state)
+    }
+
+    fn new_read_only(
+        stash: Box<dyn DurableCatalogState>,
+        persist: Box<dyn DurableCatalogState>,
+    ) -> ShadowCatalogState {
+        // We cannot fix timestamp discrepancies in a read-only catalog, so we'll just have to
+        // ignore them.
+        ShadowCatalogState { stash, persist }
+    }
+
+    /// The Coordinator will update storage usage continuously on an interval.
+    /// If we shut down the Coordinator while it's updating storage usage, then it's possible that
+    /// only one catalog implementation is updated, while the other is not. This will leave the two
+    /// catalogs in an inconsistent state. Since this implementation is just used for tests, and
+    /// that specific inconsistency is expected, we fix it during open.
+    async fn fix_storage_usage(&mut self) -> Result<(), CatalogError> {
+        let stash_storage_usage_id = self.stash.get_next_id(STORAGE_USAGE_ID_ALLOC_KEY).await?;
+        let persist_storage_usage_id = self.persist.get_next_id(STORAGE_USAGE_ID_ALLOC_KEY).await?;
+        if stash_storage_usage_id > persist_storage_usage_id {
+            let diff = stash_storage_usage_id - persist_storage_usage_id;
+            let _ = self
+                .persist
+                .allocate_id(STORAGE_USAGE_ID_ALLOC_KEY, diff)
+                .await?;
+            let stash_storage_usage = self
+                .stash
+                .get_and_prune_storage_usage(None, Timestamp::minimum(), false)
+                .await?;
+            let mut txn = self.persist.transaction().await?;
+            let start_idx = stash_storage_usage.len() - u64_to_usize(diff);
+            for event in &stash_storage_usage[start_idx..] {
+                txn.insert_storage_usage_event(event.clone());
+            }
+            txn.commit().await?;
+        } else if persist_storage_usage_id > stash_storage_usage_id {
+            let diff = persist_storage_usage_id - stash_storage_usage_id;
+            let _ = self
+                .stash
+                .allocate_id(STORAGE_USAGE_ID_ALLOC_KEY, diff)
+                .await?;
+            let persist_storage_usage = self
+                .persist
+                .get_and_prune_storage_usage(None, Timestamp::minimum(), false)
+                .await?;
+            let mut txn = self.stash.transaction().await?;
+            let start_idx = persist_storage_usage.len() - u64_to_usize(diff);
+            for event in &persist_storage_usage[start_idx..] {
+                txn.insert_storage_usage_event(event.clone());
+            }
+            txn.commit().await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ReadOnlyDurableCatalogState for ShadowCatalogState {
+    fn epoch(&mut self) -> Epoch {
+        compare_and_return!(self, epoch)
+    }
+
+    async fn expire(self: Box<Self>) {
+        futures::future::join(self.stash.expire(), self.persist.expire()).await;
+    }
+
+    async fn get_audit_logs(&mut self) -> Result<Vec<VersionedEvent>, CatalogError> {
+        compare_and_return_async!(self, get_audit_logs)
+    }
+
+    async fn get_next_id(&mut self, id_type: &str) -> Result<u64, CatalogError> {
+        if self.is_read_only() && id_type == STORAGE_USAGE_ID_ALLOC_KEY {
+            // Read-only catalogs cannot fix storage usage so we must ignore them. See
+            // `Self::fix_storage_usage`.
+            let stash_storage_usage_id = self.stash.get_next_id(STORAGE_USAGE_ID_ALLOC_KEY).await?;
+            let persist_storage_usage_id =
+                self.persist.get_next_id(STORAGE_USAGE_ID_ALLOC_KEY).await?;
+            Ok(max(stash_storage_usage_id, persist_storage_usage_id))
+        } else {
+            compare_and_return_async!(self, get_next_id, id_type)
+        }
+    }
+
+    async fn get_persist_txn_tables(
+        &mut self,
+    ) -> Result<Option<PersistTxnTablesImpl>, CatalogError> {
+        compare_and_return_async!(self, get_persist_txn_tables)
+    }
+
+    async fn get_tombstone(&mut self) -> Result<Option<bool>, CatalogError> {
+        compare_and_return_async!(self, get_tombstone)
+    }
+
+    async fn snapshot(&mut self) -> Result<Snapshot, CatalogError> {
+        if self.is_read_only() {
+            // Read-only catalogs cannot fix timestamps or storage usage ID so we must ignore them.
+            // See `Self::fix_timestamps` and `Self::fix_storage_usage`.
+            let stash = self.stash.snapshot();
+            let persist = self.persist.snapshot();
+            let (stash, persist) = futures::future::join(stash, persist).await;
+            soft_assert_eq_or_log!(
+                stash.is_ok(),
+                persist.is_ok(),
+                "stash and persist result variant do not match. stash: {stash:?}. persist: {persist:?}"
+            );
+            let mut stash = stash?;
+            let mut persist = persist?;
+            let stash_storage_usage_id = stash
+                .id_allocator
+                .get(&proto::IdAllocKey {
+                    name: STORAGE_USAGE_ID_ALLOC_KEY.to_string(),
+                })
+                .expect("storage usage id alloc key must exist")
+                .next_id;
+            let persist_storage_usage_id = persist
+                .id_allocator
+                .get(&proto::IdAllocKey {
+                    name: STORAGE_USAGE_ID_ALLOC_KEY.to_string(),
+                })
+                .expect("storage usage id alloc key must exist")
+                .next_id;
+            let reconciled_storage_usage_id = max(stash_storage_usage_id, persist_storage_usage_id);
+            stash.id_allocator.insert(
+                proto::IdAllocKey {
+                    name: STORAGE_USAGE_ID_ALLOC_KEY.to_string(),
+                },
+                proto::IdAllocValue {
+                    next_id: reconciled_storage_usage_id,
+                },
+            );
+            persist.id_allocator.insert(
+                proto::IdAllocKey {
+                    name: STORAGE_USAGE_ID_ALLOC_KEY.to_string(),
+                },
+                proto::IdAllocValue {
+                    next_id: reconciled_storage_usage_id,
+                },
+            );
+            soft_assert_eq_or_log!(stash, persist);
+            Ok(stash)
+        } else {
+            compare_and_return_async!(self, snapshot)
+        }
+    }
+
+    async fn whole_migration_snapshot(
+        &mut self,
+    ) -> Result<(Snapshot, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
+        panic!("Shadow catalog should never get a full snapshot")
+    }
+}
+
+#[async_trait]
+impl DurableCatalogState for ShadowCatalogState {
+    fn is_read_only(&self) -> bool {
+        compare_and_return!(self, is_read_only)
+    }
+
+    async fn transaction(&mut self) -> Result<Transaction, CatalogError> {
+        // We don't actually want to return this transaction since it's specific to the stash. We
+        // just want to compare results.
+        if self.is_read_only() {
+            let stash = self.stash.transaction();
+            let persist = self.persist.transaction();
+            let (stash, persist) = futures::future::join(stash, persist).await;
+            soft_assert_eq_or_log!(
+            stash.is_ok(),
+            persist.is_ok(),
+            "stash and persist result variant do not match. stash: {stash:?}. persist: {persist:?}"
+        );
+            let _ = stash?;
+            let _ = persist?;
+            // We can't actually compare the contents because the timestamps and storage usage IDs
+            // may have diverged. When the transaction commits we'll check that they both had the
+            // same effect so it's probably fine. Read-only catalogs should not really being
+            // transacting a lot either. See `Self::fix_timestamps` and `Self::fix_storage_usage`.
+        } else {
+            let res: Result<_, CatalogError> = compare_and_return_async!(self, transaction);
+            res?;
+        }
+
+        // Return a transaction with a reference to the shadow catalog so the commit is applied to
+        // both implementations.
+        let snapshot = self.snapshot().await?;
+        Transaction::new(self, snapshot)
+    }
+
+    async fn whole_migration_transaction(
+        &mut self,
+    ) -> Result<(Transaction, Vec<VersionedEvent>, Vec<VersionedStorageUsage>), CatalogError> {
+        panic!("Shadow catalog should never get a full transaction")
+    }
+
+    async fn commit_transaction(
+        &mut self,
+        txn_batch: TransactionBatch,
+    ) -> Result<(), CatalogError> {
+        let res = compare_and_return_async!(self, commit_transaction, txn_batch.clone());
+        // After committing a transaction, check that both implementations return the same snapshot
+        // to ensure that the commit had the same effect on the underlying state. Call
+        // `self.snapshot()` directly to avoid timestamp and storage usage ID discrepancies.
+        let _: Result<_, CatalogError> = self.snapshot().await;
+        res
+    }
+
+    async fn confirm_leadership(&mut self) -> Result<(), CatalogError> {
+        compare_and_return_async!(self, confirm_leadership)
+    }
+
+    async fn get_and_prune_storage_usage(
+        &mut self,
+        retention_period: Option<Duration>,
+        boot_ts: Timestamp,
+        wait_for_consolidation: bool,
+    ) -> Result<Vec<VersionedStorageUsage>, CatalogError> {
+        if self.is_read_only() {
+            // Read-only catalogs cannot fix storage usage so we must ignore them. See
+            // `Self::fix_storage_usage`.
+            let stash_storage_usage = self
+                .stash
+                .get_and_prune_storage_usage(retention_period, boot_ts, wait_for_consolidation)
+                .await?;
+            let persist_storage_usage = self
+                .stash
+                .get_and_prune_storage_usage(retention_period, boot_ts, wait_for_consolidation)
+                .await?;
+            if stash_storage_usage.len() >= persist_storage_usage.len() {
+                Ok(stash_storage_usage)
+            } else {
+                Ok(persist_storage_usage)
+            }
+        } else {
+            compare_and_return_async!(
+                self,
+                get_and_prune_storage_usage,
+                retention_period,
+                boot_ts,
+                wait_for_consolidation
+            )
+        }
+    }
+
+    async fn allocate_id(&mut self, id_type: &str, amount: u64) -> Result<Vec<u64>, CatalogError> {
+        compare_and_return_async!(self, allocate_id, id_type, amount)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_audit_log::{StorageUsageV1, VersionedStorageUsage};
+    use mz_ore::cast::u64_to_usize;
+    use mz_ore::now::SYSTEM_TIME;
+    use mz_persist_client::PersistClient;
+    use mz_repr::Timestamp;
+    use timely::progress::Timestamp as TimelyTimestamp;
+    use uuid::Uuid;
+
+    use crate::durable::{
+        shadow_catalog_state, test_bootstrap_args, test_persist_backed_catalog_state,
+        test_stash_backed_catalog_state, test_stash_config, OpenableDurableCatalogState,
+        STORAGE_USAGE_ID_ALLOC_KEY,
+    };
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn test_fix_storage_usage_persist() {
+        let persist_client = PersistClient::new_for_tests().await;
+        let organization_id = Uuid::new_v4();
+        let (debug_factory, stash_config) = test_stash_config().await;
+
+        let openable_persist_state =
+            test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+        let openable_stash_state = test_stash_backed_catalog_state(&debug_factory);
+        let openable_shadow_state = shadow_catalog_state(
+            stash_config.clone(),
+            persist_client.clone(),
+            organization_id,
+        )
+        .await;
+
+        test_fix_storage_usage(
+            openable_persist_state,
+            openable_stash_state,
+            openable_shadow_state,
+        )
+        .await;
+
+        debug_factory.drop().await;
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn test_fix_storage_usage_stash() {
+        let persist_client = PersistClient::new_for_tests().await;
+        let organization_id = Uuid::new_v4();
+        let (debug_factory, stash_config) = test_stash_config().await;
+
+        let openable_persist_state =
+            test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+        let openable_stash_state = test_stash_backed_catalog_state(&debug_factory);
+        let openable_shadow_state = shadow_catalog_state(
+            stash_config.clone(),
+            persist_client.clone(),
+            organization_id,
+        )
+        .await;
+
+        test_fix_storage_usage(
+            openable_stash_state,
+            openable_persist_state,
+            openable_shadow_state,
+        )
+        .await;
+
+        debug_factory.drop().await;
+    }
+
+    async fn test_fix_storage_usage(
+        ahead: impl OpenableDurableCatalogState,
+        behind: impl OpenableDurableCatalogState,
+        shadow: impl OpenableDurableCatalogState,
+    ) {
+        let ahead_id = 200;
+        let behind_id = 100;
+        assert!(ahead_id > behind_id);
+
+        let storage_usages: Vec<_> = (0..ahead_id)
+            .map(|i| {
+                VersionedStorageUsage::V1(StorageUsageV1 {
+                    id: i,
+                    shard_id: Some(format!("{i}")),
+                    size_bytes: i,
+                    collection_timestamp: Timestamp::minimum().into(),
+                })
+            })
+            .collect();
+
+        {
+            let mut ahead_state = Box::new(ahead)
+                .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
+                .await
+                .expect("failed to open");
+            let _ = ahead_state
+                .allocate_id(STORAGE_USAGE_ID_ALLOC_KEY, ahead_id)
+                .await
+                .expect("failed to allocate");
+            let mut tx = ahead_state
+                .transaction()
+                .await
+                .expect("failed to open transaction");
+            tx.insert_storage_usage_events(storage_usages.clone());
+            tx.commit().await.expect("failed to commit transaction");
+        }
+
+        {
+            let mut behind_state = Box::new(behind)
+                .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
+                .await
+                .expect("failed to open");
+            let _ = behind_state
+                .allocate_id(STORAGE_USAGE_ID_ALLOC_KEY, behind_id)
+                .await
+                .expect("failed to allocate");
+            let mut tx = behind_state
+                .transaction()
+                .await
+                .expect("failed to open transaction");
+            tx.insert_storage_usage_events(storage_usages[0..u64_to_usize(behind_id)].to_vec());
+            tx.commit().await.expect("failed to commit transaction");
+        }
+
+        {
+            let mut shadow_state = Box::new(shadow)
+                .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
+                .await
+                .expect("failed to open");
+            let shadow_storage_usage = shadow_state
+                .get_and_prune_storage_usage(None, Timestamp::minimum(), false)
+                .await
+                .expect("failed to get storage usage");
+            assert_eq!(shadow_storage_usage, storage_usages)
+        }
+    }
+}

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -376,6 +376,7 @@ pub struct Args {
         env = "ADAPTER_STASH_URL",
         value_name = "POSTGRES_URL",
         required_if_eq("catalog-store", "stash"),
+        required_if_eq("catalog-store", "shadow"),
         required_if_eq("catalog-store", "persist"),
         required_if_eq("catalog-store", "emergency-stash")
     )]
@@ -908,6 +909,10 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                     .expect("required for persist catalog"),
                 persist_clients,
                 metrics: Arc::new(mz_catalog::durable::Metrics::new(&metrics_registry)),
+            },
+            CatalogKind::Shadow => CatalogConfig::Shadow {
+                url: args.adapter_stash_url.expect("required for shadow catalog"),
+                persist_clients,
             },
             CatalogKind::EmergencyStash => CatalogConfig::EmergencyStash {
                 url: args

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -207,6 +207,14 @@ pub enum CatalogConfig {
         /// Persist catalog metrics.
         metrics: Arc<mz_catalog::durable::Metrics>,
     },
+    /// The catalog contents are stored in both persist and the stash and their contents are
+    /// compared. This is mostly used for testing purposes.
+    Shadow {
+        /// The PostgreSQL URL for the adapter stash.
+        url: String,
+        /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
+        persist_clients: Arc<PersistClientCache>,
+    },
 }
 
 impl CatalogConfig {
@@ -214,6 +222,7 @@ impl CatalogConfig {
         match self {
             CatalogConfig::Stash { .. } => CatalogKind::Stash,
             CatalogConfig::Persist { .. } => CatalogKind::Persist,
+            CatalogConfig::Shadow { .. } => CatalogKind::Shadow,
             CatalogConfig::EmergencyStash { .. } => CatalogKind::EmergencyStash,
         }
     }
@@ -813,6 +822,30 @@ async fn catalog_opener(
                     Arc::clone(metrics),
                 )
                 .await?,
+            )
+        }
+        CatalogConfig::Shadow {
+            url,
+            persist_clients,
+        } => {
+            let stash_factory =
+                mz_stash::StashFactory::from_metrics(Arc::clone(&controller_config.stash_metrics));
+            let tls = mz_tls_util::make_tls(&tokio_postgres::config::Config::from_str(url)?)?;
+            let persist_client = persist_clients
+                .open(controller_config.persist_location.clone())
+                .await?;
+            Box::new(
+                mz_catalog::durable::shadow_catalog_state(
+                    StashConfig {
+                        stash_factory,
+                        stash_url: url.clone(),
+                        schema: None,
+                        tls,
+                    },
+                    persist_client,
+                    environment_id.organization_id(),
+                )
+                .await,
             )
         }
     })

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -411,10 +411,9 @@ impl Listeners {
             (TracingHandle::disabled(), None)
         };
         let host_name = format!("localhost:{}", self.inner.http_local_addr().port());
-        let catalog_config = CatalogConfig::Persist {
+        let catalog_config = CatalogConfig::Shadow {
             url: adapter_stash_url,
             persist_clients: Arc::clone(&persist_clients),
-            metrics: Arc::new(mz_catalog::durable::Metrics::new(&MetricsRegistry::new())),
         };
 
         let inner = self

--- a/src/sql/src/session/vars/value.rs
+++ b/src/sql/src/session/vars/value.rs
@@ -1157,6 +1157,7 @@ impl Value for PersistTxnTablesImpl {
 pub enum CatalogKind {
     Stash = 0,
     Persist = 1,
+    Shadow = 2,
     /// Escape hatch to use the stash directly without trying to rollover from persist.
     EmergencyStash = 3,
 }
@@ -1166,6 +1167,7 @@ impl CatalogKind {
         match self {
             CatalogKind::Stash => "stash",
             CatalogKind::Persist => "persist",
+            CatalogKind::Shadow => "shadow",
             CatalogKind::EmergencyStash => "emergency-stash",
         }
     }
@@ -1174,6 +1176,7 @@ impl CatalogKind {
         vec![
             CatalogKind::Stash.as_str(),
             CatalogKind::Persist.as_str(),
+            CatalogKind::Shadow.as_str(),
             CatalogKind::EmergencyStash.as_str(),
         ]
     }

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -22,7 +22,6 @@ junit-report = "0.8.3"
 once_cell = "1.16.0"
 md-5 = "0.10.5"
 mz-build-info = { path = "../build-info" }
-mz-catalog = { path = "../catalog" }
 mz-controller = { path = "../controller" }
 mz-dyncfgs = { path = "../dyncfgs" }
 mz-environmentd = { path = "../environmentd", default-features = false }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1012,10 +1012,9 @@ impl<'a> RunnerInner<'a> {
         ));
         let listeners = mz_environmentd::Listeners::bind_any_local().await?;
         let host_name = format!("localhost:{}", listeners.http_local_addr().port());
-        let catalog_config = CatalogConfig::Persist {
+        let catalog_config = CatalogConfig::Shadow {
             url: adapter_stash_url,
             persist_clients: Arc::clone(&persist_clients),
-            metrics: Arc::new(mz_catalog::durable::Metrics::new(&MetricsRegistry::new())),
         };
         let server_config = mz_environmentd::Config {
             catalog_config,

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -358,6 +358,26 @@ impl State {
                     )
                     .await?
                 }
+                CatalogConfig::Shadow {
+                    url,
+                    persist_consensus_url,
+                    persist_blob_url,
+                } => {
+                    let stash_config = stash_config(url.clone(), self.postgres_factory.clone());
+                    let persist_client = persist_client(
+                        persist_consensus_url.clone(),
+                        persist_blob_url.clone(),
+                        &self.persist_clients,
+                    )
+                    .await?;
+                    Catalog::open_debug_read_only_shadow_catalog_config(
+                        stash_config,
+                        persist_client,
+                        SYSTEM_TIME.clone(),
+                        self.environment_id.clone(),
+                    )
+                    .await?
+                }
             };
             let res = f(catalog.for_session(&Session::dummy()));
             catalog.expire().await;
@@ -637,6 +657,16 @@ pub enum CatalogConfig {
     },
     /// The catalog contents are stored in persist.
     Persist {
+        /// Handle to the persist consensus system.
+        persist_consensus_url: String,
+        /// Handle to the persist blob storage.
+        persist_blob_url: String,
+    },
+    /// The catalog contents are stored in both persist and the stash and their contents are
+    /// compared. This is mostly used for testing purposes.
+    Shadow {
+        /// The PostgreSQL URL for the adapter stash.
+        url: String,
         /// Handle to the persist consensus system.
         persist_consensus_url: String,
         /// Handle to the persist blob storage.

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -149,7 +149,8 @@ struct Args {
     #[clap(
         long,
         value_name = "POSTGRES_URL",
-        required_if_eq("validate-catalog-store", "stash")
+        required_if_eq("validate-catalog-store", "stash"),
+        required_if_eq("validate-catalog-store", "shadow")
     )]
     postgres_stash: Option<String>,
     /// Validate the catalog state of the specified catalog kind.
@@ -161,14 +162,16 @@ struct Args {
     #[clap(
         long,
         value_name = "PERSIST_CONSENSUS_URL",
-        required_if_eq("validate-catalog-store", "persist")
+        required_if_eq("validate-catalog-store", "persist"),
+        required_if_eq("validate-catalog-store", "shadow")
     )]
     persist_consensus_url: Option<String>,
     /// Handle to the persist blob storage.
     #[clap(
         long,
         value_name = "PERSIST_BLOB_URL",
-        required_if_eq("validate-catalog-store", "persist")
+        required_if_eq("validate-catalog-store", "persist"),
+        required_if_eq("validate-catalog-store", "shadow")
     )]
     persist_blob_url: Option<String>,
 
@@ -346,6 +349,17 @@ async fn main() {
                     .persist_blob_url
                     .clone()
                     .expect("required for persist catalog"),
+            },
+            CatalogKind::Shadow => CatalogConfig::Shadow {
+                url: args.postgres_stash.expect("required for shadow catalog"),
+                persist_consensus_url: args
+                    .persist_consensus_url
+                    .clone()
+                    .expect("required for shadow catalog"),
+                persist_blob_url: args
+                    .persist_blob_url
+                    .clone()
+                    .expect("required for shadow catalog"),
             },
             CatalogKind::EmergencyStash => panic!("emergency stash cannot be used with testdrive"),
         }),

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -51,6 +51,7 @@ SERVICES = [
         # We use mz_panic() in some test scenarios, so environmentd must stay up.
         propagate_crashes=False,
         external_cockroach=True,
+        # Kills make the shadow catalog not work properly
         catalog_store="persist",
     ),
     Redpanda(),

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -72,8 +72,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     random.seed(args.seed)
     scenario = Scenario(args.scenario)
     complexity = Complexity(args.complexity)
-    catalog_store = "persist"
-    sanity_restart = False
+
+    if scenario in (Scenario.Kill, Scenario.BackupRestore, Scenario.TogglePersistTxn):
+        catalog_store = "persist"
+        sanity_restart = False
+    else:
+        catalog_store = "shadow"
+        sanity_restart = True
 
     with c.override(
         Materialized(

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -84,7 +84,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         kafka_default_partitions=args.kafka_default_partitions,
         aws_region=args.aws_region,
         postgres_stash="materialized",
-        validate_catalog_store="persist",
+        validate_catalog_store="shadow",
         default_timeout=args.default_timeout,
         volumes_extra=["mzdata:/mzdata"],
     )

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -97,7 +97,7 @@ def workflow_testdrive(c: Composition, parser: WorkflowArgumentParser) -> None:
         forward_buildkite_shard=True,
         kafka_default_partitions=args.kafka_default_partitions,
         postgres_stash="materialized",
-        validate_catalog_store="persist",
+        validate_catalog_store="shadow",
         volumes_extra=["mzdata:/mzdata"],
     )
 


### PR DESCRIPTION
This reverts commit f0ef1ffa4d394723150a6b9a1ad261cc9407a4c8.

This was merged by accident, it's causing some strange test failures: https://github.com/MaterializeInc/materialize/pull/25636#issuecomment-1976638562

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
