### PR TITLE
storage: perform csr operations off the timely thread

### DIFF
--- a/src/ccsr/src/config.rs
+++ b/src/ccsr/src/config.rs
@@ -118,12 +118,15 @@ impl ClientConfig {
             builder = builder.resolve_to_addrs(&domain, &addrs);
         }
 
+        // TODO(guswynn): make this configurable.
+        let timeout = Duration::from_secs(60);
+
         let inner = builder
             .redirect(reqwest::redirect::Policy::none())
-            .timeout(Duration::from_secs(60))
+            .timeout(timeout)
             .build()
             .unwrap();
 
-        Client::new(inner, self.url, self.auth)
+        Client::new(inner, self.url, self.auth, timeout)
     }
 }


### PR DESCRIPTION
Part of: https://github.com/MaterializeInc/materialize/issues/25707

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
