### PR TITLE
doc/user: patch search

### DIFF
--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -78,7 +78,7 @@ toCSS | fingerprint }}
 <script defer>
   addEventListener("DOMContentLoaded", () => {
     docsearch({
-      apiKey: "5fb0a95d60e603d3c83c2506e1de4a64",
+      apiKey: "c52bbb10b43c177106333976cfe07e11",
       appId: "9LF5B9GMOF",
       indexName: "materialize",
       container: "#docsearch",


### PR DESCRIPTION
Deleting a deactivated user caused the docs search to stop working, since the API key used was associated with the user. Replacing with a working key, in the meantime — though we should add a service account to Algolia and generate keys through that account instead of individual users. 