### PR TITLE
storage/mysql: Add metrics to mysql source

### DIFF
--- a/src/storage/src/metrics/source/mysql.rs
+++ b/src/storage/src/metrics/source/mysql.rs
@@ -7,21 +7,132 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Metrics for Postgres.
+//! Metrics for MySQL.
 
-use mz_ore::metric;
-use mz_ore::metrics::{DeleteOnDropGauge, GaugeVec, GaugeVecExt, MetricsRegistry};
-use mz_repr::GlobalId;
-use prometheus::core::AtomicF64;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use mz_ore::metric;
+use mz_ore::metrics::{
+    CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVec, GaugeVecExt, IntCounterVec,
+    MetricsRegistry, UIntGaugeVec,
+};
+use mz_repr::GlobalId;
+use prometheus::core::{AtomicF64, AtomicU64};
+
 #[derive(Clone, Debug)]
 pub(crate) struct MySqlSourceMetricDefs {
-    pub(crate) table_count_latency: GaugeVec,
+    pub(crate) total_messages: IntCounterVec,
+    pub(crate) ignored_messages: IntCounterVec,
+    pub(crate) insert_rows: IntCounterVec,
+    pub(crate) update_rows: IntCounterVec,
+    pub(crate) delete_rows: IntCounterVec,
+    pub(crate) tables: UIntGaugeVec,
+    pub(crate) gtid: UIntGaugeVec,
+
+    pub(crate) snapshot_defs: MySqlSnapshotMetricDefs,
 }
 
 impl MySqlSourceMetricDefs {
+    pub(crate) fn register_with(registry: &MetricsRegistry) -> Self {
+        Self {
+            total_messages: registry.register(metric!(
+                name: "mz_mysql_per_source_messages_total",
+                help: "The total number of replication messages for this source, not expected to be the sum of the other values.",
+                var_labels: ["source_id"],
+            )),
+            ignored_messages: registry.register(metric!(
+                name: "mz_mysql_per_source_ignored_messages",
+                help: "The number of messages ignored because of an irrelevant type or relation_id",
+                var_labels: ["source_id"],
+            )),
+            insert_rows: registry.register(metric!(
+                name: "mz_mysql_per_source_inserts",
+                help: "The number of inserts for all tables in this source",
+                var_labels: ["source_id"],
+            )),
+            update_rows: registry.register(metric!(
+                name: "mz_mysql_per_source_updates",
+                help: "The number of updates for all tables in this source",
+                var_labels: ["source_id"],
+            )),
+            delete_rows: registry.register(metric!(
+                name: "mz_mysql_per_source_deletes",
+                help: "The number of deletes for all tables in this source",
+                var_labels: ["source_id"],
+            )),
+            tables: registry.register(metric!(
+                name: "mz_mysql_per_source_tables_count",
+                help: "The number of upstream tables for this source",
+                var_labels: ["source_id"],
+            )),
+            gtid: registry.register(metric!(
+                name: "mz_mysql_per_source_gtid",
+                help: "Transaction-id of the latest committed GTID for the specific GTID Source-ID UUID for this source",
+                var_labels: ["source_id", "gtid_source_uuid"],
+            )),
+            snapshot_defs: MySqlSnapshotMetricDefs::register_with(registry),
+        }
+    }
+}
+
+/// Metrics for MySql sources.
+pub(crate) struct MySqlSourceMetrics {
+    source_id: GlobalId,
+
+    pub(crate) inserts: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) updates: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) deletes: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) ignored: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) total: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) tables: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+
+    gtid_def: UIntGaugeVec,
+
+    pub(crate) snapshot_metrics: MySqlSnapshotMetrics,
+}
+
+pub(crate) type GtidMetricGauge = DeleteOnDropGauge<'static, AtomicU64, Vec<String>>;
+
+impl MySqlSourceMetrics {
+    /// Create a `MySqlSourceMetrics` from the `MySqlSourceMetricDefs`.
+    pub(crate) fn new(defs: &MySqlSourceMetricDefs, source_id: GlobalId) -> Self {
+        let labels = &[source_id.to_string()];
+        Self {
+            source_id,
+            inserts: defs.insert_rows.get_delete_on_drop_counter(labels.to_vec()),
+            updates: defs.update_rows.get_delete_on_drop_counter(labels.to_vec()),
+            deletes: defs.delete_rows.get_delete_on_drop_counter(labels.to_vec()),
+            ignored: defs
+                .ignored_messages
+                .get_delete_on_drop_counter(labels.to_vec()),
+            total: defs
+                .total_messages
+                .get_delete_on_drop_counter(labels.to_vec()),
+            tables: defs.tables.get_delete_on_drop_gauge(labels.to_vec()),
+            gtid_def: defs.gtid.clone(),
+            snapshot_metrics: MySqlSnapshotMetrics {
+                source_id,
+                gauges: Default::default(),
+                defs: defs.snapshot_defs.clone(),
+            },
+        }
+    }
+
+    pub(crate) fn get_gtid_gauge(&self, gtid_source_uuid: String) -> GtidMetricGauge {
+        self.gtid_def.get_delete_on_drop_gauge(vec![
+            self.source_id.to_string(),
+            gtid_source_uuid.to_string(),
+        ])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MySqlSnapshotMetricDefs {
+    pub(crate) table_count_latency: GaugeVec,
+}
+
+impl MySqlSnapshotMetricDefs {
     pub(crate) fn register_with(registry: &MetricsRegistry) -> Self {
         Self {
             table_count_latency: registry.register(metric!(
@@ -40,7 +151,7 @@ pub(crate) struct MySqlSnapshotMetrics {
     // of these metrics happens once in those tasks, which do not live long enough to keep them
     // alive.
     gauges: Arc<Mutex<Vec<DeleteOnDropGauge<'static, AtomicF64, Vec<String>>>>>,
-    defs: MySqlSourceMetricDefs,
+    defs: MySqlSnapshotMetricDefs,
 }
 
 impl MySqlSnapshotMetrics {
@@ -57,23 +168,5 @@ impl MySqlSnapshotMetrics {
         ]);
         latency_gauge.set(latency);
         self.gauges.lock().expect("poisoned").push(latency_gauge)
-    }
-}
-
-/// Metrics for MySql sources.
-pub(crate) struct MySqlSourceMetrics {
-    pub(crate) snapshot_metrics: MySqlSnapshotMetrics,
-}
-
-impl MySqlSourceMetrics {
-    /// Create a `MySqlSourceMetrics` from the `MySqlSourceMetricDefs`.
-    pub(crate) fn new(defs: &MySqlSourceMetricDefs, source_id: GlobalId) -> Self {
-        Self {
-            snapshot_metrics: MySqlSnapshotMetrics {
-                source_id,
-                gauges: Default::default(),
-                defs: defs.clone(),
-            },
-        }
     }
 }

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -283,8 +283,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
             // Store all partitions from the resume_upper so we can create a frontier that comprises
             // timestamps for partitions representing the full range of UUIDs to advance our main
             // capabilities.
-            let mut repl_partitions =
-                partitions::GtidReplicationPartitions::from_frontier(resume_upper, &metrics);
+            let mut repl_partitions: partitions::GtidReplicationPartitions = resume_upper.into();
 
             let mut repl_context = context::ReplContext::new(
                 &config,
@@ -321,7 +320,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                                 _ => unreachable!(),
                             }
 
-                            if let Err(err) = repl_partitions.update(new_gtid, &metrics) {
+                            if let Err(err) = repl_partitions.update(new_gtid) {
                                 return Ok(return_definite_error(
                                     err,
                                     &output_indexes,
@@ -361,7 +360,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                         // This is still useful to allow data committed at previous timestamps to become available
                         // without waiting for the next break in data at which point we should receive a Heartbeat
                         // Event.
-                        if let Err(err) = repl_partitions.update(new_gtid.clone(), &metrics) {
+                        if let Err(err) = repl_partitions.update(new_gtid.clone()) {
                             return Ok(return_definite_error(
                                 err,
                                 &output_indexes,

--- a/src/storage/src/source/mysql/replication/context.rs
+++ b/src/storage/src/source/mysql/replication/context.rs
@@ -21,7 +21,8 @@ use mz_repr::Row;
 use mz_storage_types::sources::mysql::GtidPartition;
 use mz_timely_util::builder_async::AsyncOutputHandle;
 
-use super::super::{DefiniteError, MySqlTableName, RewindRequest};
+use crate::metrics::source::mysql::MySqlSourceMetrics;
+use crate::source::mysql::{DefiniteError, MySqlTableName, RewindRequest};
 use crate::source::RawSourceCreationConfig;
 
 /// A container to hold various context information for the replication process, used when
@@ -31,6 +32,7 @@ pub(super) struct ReplContext<'a> {
     pub(super) connection_config: &'a Config,
     pub(super) stream: Pin<&'a mut futures::stream::Peekable<BinlogStream>>,
     pub(super) table_info: &'a BTreeMap<MySqlTableName, (usize, MySqlTableDesc)>,
+    pub(super) metrics: &'a MySqlSourceMetrics,
     pub(super) data_output: &'a mut AsyncOutputHandle<
         GtidPartition,
         Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>,
@@ -52,6 +54,7 @@ impl<'a> ReplContext<'a> {
         connection_config: &'a Config,
         stream: Pin<&'a mut futures::stream::Peekable<BinlogStream>>,
         table_info: &'a BTreeMap<MySqlTableName, (usize, MySqlTableDesc)>,
+        metrics: &'a MySqlSourceMetrics,
         data_output: &'a mut AsyncOutputHandle<
             GtidPartition,
             Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>,
@@ -66,6 +69,7 @@ impl<'a> ReplContext<'a> {
             connection_config,
             stream,
             table_info,
+            metrics,
             data_output,
             data_cap_set,
             upper_cap_set,

--- a/src/storage/src/source/mysql/replication/partitions.rs
+++ b/src/storage/src/source/mysql/replication/partitions.rs
@@ -17,7 +17,6 @@ use uuid::Uuid;
 use mz_storage_types::sources::mysql::{GtidPartition, GtidState};
 
 use super::super::DefiniteError;
-use crate::metrics::source::mysql::{GtidMetricGauge, MySqlSourceMetrics};
 
 /// Holds the active and future GTID partitions that represent the complete
 /// UUID range of all possible GTID source-ids from a MySQL server.
@@ -39,26 +38,20 @@ use crate::metrics::source::mysql::{GtidMetricGauge, MySqlSourceMetrics};
 /// capabilities externally will be preserved even in the case of an error in
 /// the operator, which is why we just manage a single frontier and capability set.
 pub(super) struct GtidReplicationPartitions {
-    active: BTreeMap<Uuid, (GtidPartition, GtidMetricGauge)>,
+    active: BTreeMap<Uuid, GtidPartition>,
     future: Vec<GtidPartition>,
 }
 
-impl GtidReplicationPartitions {
-    pub(super) fn from_frontier(
-        frontier: Antichain<GtidPartition>,
-        metrics: &MySqlSourceMetrics,
-    ) -> Self {
+impl From<Antichain<GtidPartition>> for GtidReplicationPartitions {
+    fn from(frontier: Antichain<GtidPartition>) -> Self {
         let mut active = BTreeMap::new();
         let mut future = Vec::new();
         for part in frontier.iter() {
-            match part.timestamp() {
-                GtidState::Absent => future.push(part.clone()),
-                GtidState::Active(tx_id) => {
-                    let source_id = part.interval().singleton().unwrap().clone();
-                    let gauge = metrics.get_gtid_gauge(source_id.to_string());
-                    gauge.set(tx_id.get());
-                    active.insert(source_id, (part.clone(), gauge));
-                }
+            if part.timestamp() == &GtidState::Absent {
+                future.push(part.clone());
+            } else {
+                let source_id = part.interval().singleton().unwrap().clone();
+                active.insert(source_id, part.clone());
             }
         }
         Self { active, future }
@@ -72,7 +65,7 @@ impl GtidReplicationPartitions {
         Antichain::from_iter(
             self.active
                 .values()
-                .map(|(part, _)| part.clone())
+                .cloned()
                 .chain(self.future.iter().cloned()),
         )
     }
@@ -87,15 +80,11 @@ impl GtidReplicationPartitions {
     /// of all the active and future GTID partition timestamps.
     /// This call should usually be followed up by downgrading capabilities
     /// using the frontier returned by `self.frontier()`
-    pub(super) fn update(
-        &mut self,
-        new_part: GtidPartition,
-        metrics: &MySqlSourceMetrics,
-    ) -> Result<(), DefiniteError> {
+    pub(super) fn update(&mut self, new_part: GtidPartition) -> Result<(), DefiniteError> {
         let source_id = new_part.interval().singleton().unwrap();
         // Check if we have an active partition for the GTID UUID
         match self.active.get_mut(source_id) {
-            Some((active_part, gauge)) => {
+            Some(active_part) => {
                 // Since we start replication at a specific upper, we
                 // should only see GTID transaction-ids
                 // in a monotonic order for each source, starting at that upper.
@@ -109,10 +98,6 @@ impl GtidReplicationPartitions {
 
                 // replace this active partition with the new one
                 *active_part = new_part;
-                // update the gauge for this GTID UUID
-                if let GtidState::Active(tx_id) = active_part.timestamp() {
-                    gauge.set(tx_id.get());
-                }
             }
             // We've received a GTID for a UUID we don't yet know about
             None => {
@@ -137,13 +122,8 @@ impl GtidReplicationPartitions {
                 self.future
                     .extend(before_range.into_iter().chain(after_range.into_iter()));
 
-                // Get a metrics object for this new GTID UUID
-                let gauge = metrics.get_gtid_gauge(source_id.to_string());
-                if let GtidState::Active(tx_id) = new_part.timestamp() {
-                    gauge.set(tx_id.get());
-                }
                 // Store the new part in our active partitions
-                self.active.insert(source_id.clone(), (new_part, gauge));
+                self.active.insert(source_id.clone(), new_part);
             }
         };
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/25725


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I'm not sure how to test this -- when I run the mysql-cdc tests and look at the metrics at `localhost:6878/metrics` I don't see any of the storage metrics included. Any ideas?


<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
