### PR TITLE
Fix frontegg-mock merge skew in the tests

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1990,6 +1990,7 @@ async fn test_max_connections_limits() {
         encoding_key,
         decoding_key,
         users,
+        None,
         SYSTEM_TIME.clone(),
         500,
         None,


### PR DESCRIPTION
Fix some merge skew introduced by https://github.com/MaterializeInc/materialize/pull/25664

### Motivation

  * This PR fixes a previously unreported bug.
```
error[E0061]: this function takes 9 arguments but 8 arguments were supplied
    --> src/environmentd/tests/server.rs:1987:27
     |
1987 |     let frontegg_server = FronteggMockServer::start(
     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^
...
1993 |         SYSTEM_TIME.clone(),
     |         ------------------- an argument of type `std::option::Option<BTreeMap<std::string::String, Vec<std::string::String>>>` is missing
     |
```

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No user-facing behavior changes.
