### PR TITLE
dbt-materialize: skip deploy_init checks if under CI and pushing to the same PR

### DIFF
--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
@@ -60,7 +60,9 @@
         {% set schema_object_count = run_query(schema_empty) %}
         {% if execute %}
             {% if schema_object_count and schema_object_count.columns[0] and schema_object_count.rows[0][0] > 0 %}
-                {% if ignore_existing_objects %}
+                {% if check_schema_ci_tag(deploy_schema) %}
+                    {{ log("Schema " ~ deploy_schema ~ " was already created for this pull request", info=True) }}
+                {% elif ignore_existing_objects %}
                     {{ log("[Warning] Deployment schema " ~ deploy_schema ~ " is not empty", info=True) }}
                     {{ log("[Warning] Confirm the objects it contains are expected before deployment", info=True) }}
                 {% else %}
@@ -84,6 +86,7 @@
         CREATE SCHEMA {{ deploy_schema }};
         {% endset %}
         {{ run_query(create_schema) }}
+        {{ set_schema_ci_tag() }}
     {% endif %}
 {% endfor %}
 
@@ -129,7 +132,9 @@
         {% set cluster_object_count = run_query(cluster_empty) %}
         {% if execute %}
             {% if cluster_object_count and cluster_object_count.columns[0] and cluster_object_count.rows[0][0] > 0 %}
-                {% if ignore_existing_objects %}
+                {% if check_cluster_ci_tag(deploy_cluster) %}
+                    {{ log("Cluster " ~ deploy_cluster ~ " was already created for this pull request", info=True) }}
+                {% elif ignore_existing_objects %}
                     {{ log("[Warning] Deployment cluster " ~ deploy_cluster ~ " is not empty", info=True) }}
                     {{ log("[Warning] Confirm the objects it contains are expected before deployment", info=True) }}
                 {% else %}
@@ -175,6 +180,7 @@
                 );
             {% endset %}
             {{ run_query(create_cluster) }}
+            {{ set_cluster_ci_tag() }}
         {% endif %}
     {% endif %}
 {% endfor %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
@@ -56,15 +56,6 @@
     {% if not schema_exists(deploy_schema) %}
         {{ exceptions.raise_compiler_error("Deployment schema " ~ deploy_schema ~ " does not exist") }}
     {% endif %}
-
-    {% if schema_contains_sources_or_sinks(schema) %}
-        {{ exceptions.raise_compiler_error("""
-        Production schema " ~ schema ~ " contains sources or sinks. This is not currently
-        supported by dbt run-operation deploy_promote.
-
-        If this feature is important to you, please reach out!
-        """) }}
-    {% endif %}
     {% if schema_contains_sources_or_sinks(deploy_schema) %}
         {{ exceptions.raise_compiler_error("""
         Deployment schema " ~ deploy_schema ~ " contains sources or sinks. This is not currently
@@ -82,15 +73,6 @@
     {% endif %}
     {% if not cluster_exists(deploy_cluster) %}
         {{ exceptions.raise_compiler_error("Deployment cluster " ~ deploy_cluster ~ " does not exist") }}
-    {% endif %}
-
-    {% if cluster_contains_sources_or_sinks(cluster) %}
-        {{ exceptions.raise_compiler_error("""
-        Production cluster " ~ cluster ~ " contains sources or sinks. This is not currently
-        supported by dbt run-operation deploy_promote.
-
-        If this feature is important to you, please reach out!
-        """) }}
     {% endif %}
     {% if cluster_contains_sources_or_sinks(deploy_cluster) %}
         {{ exceptions.raise_compiler_error("""

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/ci_utils.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/ci_utils.sql
@@ -1,0 +1,90 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{% macro set_cluster_ci_tag(cluster, ci_tag=env_var('CI_TAG', '')) %}
+    {% if ci_tag != '' %}
+        {% set ci_comment %}
+            COMMENT ON CLUSTER {{ cluster }} IS '{{ ci_tag }}';
+        {% endset %}
+        {{ run_query(ci_comment) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro set_schema_ci_tag(schema, ci_tag=env_var('CI_TAG', '')) %}
+    {% if ci_tag != '' %}
+        {% set ci_comment %}
+            COMMENT ON SCHEMA {{ schema }} IS '{{ ci_tag }}';
+        {% endset %}
+        {{ run_query(ci_comment) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro check_cluster_ci_tag(cluster, ci_tag=env_var('CI_TAG', '')) %}
+    {% if ci_tag == '' %}
+        {{ return(false) }}
+    {% endif %}
+
+    {% set query %}
+        SELECT comment = '{{ ci_tag }}', comment
+        FROM mz_internal.mz_comments
+        JOIN mz_clusters USING (id)
+        WHERE mz_clusters.name = lower(trim('{{ cluster }}'))
+    {% endset %}
+    {% set results = run_query(query) %}
+    {% if execute %}
+        {% if results|length > 0 %}
+            {% if results.rows[0][0] is false %}
+                {{ exceptions.raise_compiler_error("""
+                    Deployment cluster """ ~ cluster ~ """ already exists and is tagged
+                    for CI deployment """ ~ results.rows[0][1]
+                )}}
+            {% else %}
+                {{ return(true) }}
+            {% endif %}
+        {% endif %}
+
+        {{ return(false) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro check_schema_ci_tag(schema, ci_tag=env_var('CI_TAG', '')) %}
+    {% if ci_tag == '' %}
+        {{ return(false) }}
+    {% endif %}
+
+    {% set query %}
+        SELECT comment = '{{ ci_tag }}', comment
+        FROM mz_internal.mz_comments c
+        JOIN mz_schemas s ON c.id = s.id
+        JOIN mz_databases d ON s.database_id = d.id
+        WHERE s.name = lower(trim('{{ schema }}'))
+            AND d.name = current_database()
+    {% endset %}
+    {% set results = run_query(query) %}
+    {% if execute %}
+        {% if results|length > 0 %}
+            {% if results.rows[0][0] is false %}
+                {{ exceptions.raise_compiler_error("""
+                    Deployment schema """ ~ schema ~ """ already exists and is tagged
+                    for CI deployment """ ~ results.rows[0][1]
+                )}}
+            {% else %}
+                {{ return(true) }}
+            {% endif %}
+        {% endif %}
+
+        {{ return(false) }}
+    {% endif %}
+{% endmacro %}

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -24,6 +24,85 @@ from fixtures import (
 )
 
 
+class TestCIFixture:
+    @pytest.fixture(autouse=True)
+    def cleanup(self, project):
+        project.run_sql("COMMENT ON CLUSTER quickstart IS NULL")
+        project.run_sql("COMMENT ON SCHEMA public IS NULL")
+
+    def test_ci_tags_match(self, project):
+        run_dbt(
+            [
+                "run-operation",
+                "set_cluster_ci_tag",
+                "--args",
+                "{cluster: quickstart, ci_tag: test}",
+            ]
+        )
+        run_dbt(
+            [
+                "run-operation",
+                "set_schema_ci_tag",
+                "--args",
+                "{schema: public, ci_tag: test}",
+            ]
+        )
+
+        run_dbt(
+            [
+                "run-operation",
+                "check_cluster_ci_tag",
+                "--args",
+                "{cluster: quickstart, ci_tag: test}",
+            ]
+        )
+        run_dbt(
+            [
+                "run-operation",
+                "check_schema_ci_tag",
+                "--args",
+                "{schema: public, ci_tag: test}",
+            ]
+        )
+
+    def test_ci_tags_mismatch(self, project):
+        run_dbt(
+            [
+                "run-operation",
+                "set_cluster_ci_tag",
+                "--args",
+                "{cluster: quickstart, ci_tag: test}",
+            ]
+        )
+        run_dbt(
+            [
+                "run-operation",
+                "set_schema_ci_tag",
+                "--args",
+                "{schema: public, ci_tag: test}",
+            ]
+        )
+
+        run_dbt(
+            [
+                "run-operation",
+                "check_cluster_ci_tag",
+                "--args",
+                "{cluster: quickstart, ci_tag: different}",
+            ],
+            expect_pass=False,
+        )
+        run_dbt(
+            [
+                "run-operation",
+                "check_schema_ci_tag",
+                "--args",
+                "{schema: public, ci_tag: different}",
+            ],
+            expect_pass=False,
+        )
+
+
 class TestRunWithDeploy:
     @pytest.fixture(scope="class")
     def project_config_update(self):


### PR DESCRIPTION
### Motivation

By default, `deploy_init` will fail if the schema or cluster already exists and contains user defined objects. However, we don't want this check to run if someone is working on a PR and pushing to the same branch multiple times. Unforunately, github actions are not expressive enough to only run a command once. So instead, we tag each schema and cluster with a comment based on a CI environment variable on creation. If set, the checks will be skipped on subsequent invocations. 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
