### PR TITLE
sql: Emit notice if default cluster for role does not exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,6 +2827,7 @@ dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "serde",
  "similar",
  "yaml-rust",
 ]
@@ -4286,6 +4287,7 @@ dependencies = [
  "hyper-openssl",
  "hyper-tls",
  "include_dir",
+ "insta",
  "itertools",
  "jsonwebtoken",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10086,6 +10086,7 @@ dependencies = [
  "hashbrown 0.14.0",
  "hyper",
  "indexmap 1.9.1",
+ "insta",
  "itertools",
  "k8s-openapi",
  "kube",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -613,6 +613,12 @@ user-id = 539 # Josh Stone (cuviper)
 start = "2020-01-15"
 end = "2024-11-16"
 
+[[trusted.insta]]
+criteria = "safe-to-deploy"
+user-id = 39 # Armin Ronacher (mitsuhiko)
+start = "2019-03-05"
+end = "2025-03-04"
+
 [[trusted.itoa]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -698,10 +698,6 @@ criteria = "safe-to-deploy"
 version = "0.17.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.insta]]
-version = "1.33.0"
-criteria = "safe-to-run"
-
 [[exemptions.instant]]
 version = "0.1.12"
 criteria = "safe-to-deploy"

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -393,6 +393,13 @@ user-id = 539
 user-login = "cuviper"
 user-name = "Josh Stone"
 
+[[publisher.insta]]
+version = "1.33.0"
+when = "2023-09-28"
+user-id = 39
+user-login = "mitsuhiko"
+user-name = "Armin Ronacher"
+
 [[publisher.itoa]]
 version = "1.0.6"
 when = "2023-03-03"

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -272,7 +272,9 @@ Issue a SQL query to get started. Need help?
         if catalog.resolve_cluster(Some(&cluster_active)).is_err() {
             let cluster_notice = 'notice: {
                 // If the user provided a cluster via a connection configuration parameter, do not
-                // notify them if that cluster does not exist.
+                // notify them if that cluster does not exist. We omit the notice here because even
+                // if they were to update the role or system default, it would not make a
+                // difference since the connection parameter takes precedence over the defaults.
                 if cluster_var.inspect_session_value().is_some() {
                     break 'notice None;
                 }
@@ -288,7 +290,7 @@ Issue a SQL query to get started. Need help?
                     }
                 };
 
-                let alter_role = "with ALTER ROLE <role> SET cluster TO <cluster>";
+                let alter_role = "with `ALTER ROLE <role> SET cluster TO <cluster>;`";
                 match role_cluster {
                     // If there is no default, suggest a Role default.
                     None => Some(AdapterNotice::DefaultClusterDoesNotExist {
@@ -303,7 +305,7 @@ Issue a SQL query to get started. Need help?
                         name: cluster_active,
                         kind: Some("role"),
                         suggested_action: format!(
-                            "Change the default cluster for the current role with {alter_role}."
+                            "Change the default cluster for the current role {alter_role}."
                         ),
                     }),
                 }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -125,6 +125,7 @@ assert_cmd = "2.0.5"
 bytes = "1.3.0"
 datadriven = "0.6.0"
 fallible-iterator = "0.2.0"
+insta = { version = "1.32", features = ["json"] }
 itertools = "0.10.5"
 jsonwebtoken = "9.2.0"
 mz-environmentd = { path = "../environmentd", features = ["test"] }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -4002,7 +4002,7 @@ async fn test_startup_cluster_notice_with_http_options() {
 
 #[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // too slow
-async fn test_startup_cluster_notice1() {
+async fn test_startup_cluster_notice() {
     let server = test_util::TestHarness::default().start().await;
 
     let notices = Arc::new(Mutex::new(Vec::new()));
@@ -4050,7 +4050,7 @@ async fn test_startup_cluster_notice1() {
             message: "default cluster \"quickstart\" does not exist",
             detail: None,
             hint: Some(
-                "Set a default cluster for the current role with ALTER ROLE <role> SET cluster TO <cluster>.",
+                "Set a default cluster for the current role with `ALTER ROLE <role> SET cluster TO <cluster>;`.",
             ),
             position: None,
             where_: None,
@@ -4095,7 +4095,7 @@ async fn test_startup_cluster_notice1() {
             message: "role default cluster \"non_existant\" does not exist",
             detail: None,
             hint: Some(
-                "Change the default cluster for the current role with with ALTER ROLE <role> SET cluster TO <cluster>.",
+                "Change the default cluster for the current role with `ALTER ROLE <role> SET cluster TO <cluster>;`.",
             ),
             position: None,
             where_: None,

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -4012,7 +4012,7 @@ async fn test_startup_cluster_notice1() {
         .notice_callback(move |notice| notices_.lock().expect("not poisoned").push(notice))
         .await
         .expect("success");
-    let notices = notices.lock().expect("not poisoned");
+    let notices = { notices.lock().expect("not poisoned").clone() };
     assert!(notices.is_empty());
     drop(client);
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -302,6 +302,14 @@ impl SessionVar {
             .unwrap_or(self.definition.value.value())
     }
 
+    /// Returns the [`Value`] that is currently stored as the `session_value`.
+    ///
+    /// Note: This should __only__ be used for inspection, if you want to determine the current
+    /// value of this [`SessionVar`] you should use [`SessionVar::value`].
+    pub fn inspect_session_value(&self) -> Option<&dyn Value> {
+        self.session_value.as_deref()
+    }
+
     fn validate_constraints(&self, val: &dyn Value) -> Result<(), VarError> {
         if let Some(constraint) = &self.definition.constraint {
             constraint.check_constraint(self, self.value_dyn(), val)
@@ -476,6 +484,14 @@ impl SessionVars {
                 .transpose()?
                 .ok_or_else(|| VarError::UnknownParameter(name.to_string()))
         }
+    }
+
+    /// Returns a [`SessionVar`] for inspection.
+    ///
+    /// Note: If you're trying to determine the value of the variable with `name` you should
+    /// instead use the named accessor, or [`SessionVars::get`].
+    pub fn inspect(&self, name: &str) -> Option<&SessionVar> {
+        self.vars.get(UncasedStr::new(name))
     }
 
     /// Sets the configuration parameter named `name` to the value represented

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -56,6 +56,7 @@ globset = { version = "0.4.9", features = ["serde1"] }
 hashbrown = { version = "0.14.0", features = ["raw"] }
 hyper = { version = "0.14.27", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
+insta = { version = "1.33.0", features = ["json"] }
 itertools = { version = "0.10.5" }
 k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_26"] }
 kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
@@ -173,6 +174,7 @@ globset = { version = "0.4.9", features = ["serde1"] }
 hashbrown = { version = "0.14.0", features = ["raw"] }
 hyper = { version = "0.14.27", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
+insta = { version = "1.33.0", features = ["json"] }
 itertools = { version = "0.10.5" }
 k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_26"] }
 kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }


### PR DESCRIPTION
This PR adds a notice that gets emitted at the time of connection/session startup if the default cluster does not exist, the logic is as follows:

1. If the user already has a session variable set for cluster (e.g. via connection params) do not emit a notice
2. If the active cluster does not exist, and the user does not have a role default, suggest they set one. If they already have a role default, suggest they modify it.

It also updates the welcome message to include `(does not exist)` next to the cluster name. For example, after dropping the "quickstart" cluster and connecting with a regular user:

```
$ psql "postgres://materialize@localhost:6875/materialize"
NOTICE:  connected to Materialize v0.91.0-dev
  Org ID: 42df3f87-3067-4f2f-9052-274b340c5379
  Region: local/az1
  User: materialize
  Cluster: quickstart (does not exist)
  Database: materialize
  Schema: public

Issue a SQL query to get started. Need help?
  View documentation: https://materialize.com/s/docs
  Join our Slack community: https://materialize.com/s/chat

NOTICE:  default cluster "quickstart" does not exist
HINT:  Set a default cluster for the current role with ALTER ROLE <role> SET cluster TO <cluster>.
psql (15.5 (Homebrew), server 9.5.0)
Type "help" for help.

materialize=>
```



### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/25541

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Emits a SQL notice if the default cluster does not exist
