### PR TITLE
storage/mysql: Fix non-positive accumulation bug caused by incorrect caching behavior

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -916,8 +916,9 @@ impl PersistPeek {
                 let row = data.map_err(|e| e.to_string())?;
                 let count: usize = d.try_into().map_err(|_| {
                     format!(
-                        "Invalid data in source, saw retractions ({}) for row that does not exist",
+                        "Invalid data in source, saw retractions ({}) for row that does not exist: {:?}",
                         d * -1,
+                        row,
                     )
                 })?;
                 let Some(count) = NonZeroUsize::new(count) else {

--- a/src/storage/src/source/mysql/replication/context.rs
+++ b/src/storage/src/source/mysql/replication/context.rs
@@ -40,9 +40,6 @@ pub(super) struct ReplContext<'a> {
     pub(super) upper_cap_set: &'a mut CapabilitySet<GtidPartition>,
     // Owned values:
     pub(super) rewinds: BTreeMap<MySqlTableName, ([Capability<GtidPartition>; 2], RewindRequest)>,
-    // Binlog Table Id -> Table Name (its key in the `table_info` map)
-    pub(super) table_id_map: BTreeMap<u64, MySqlTableName>,
-    pub(super) skipped_table_ids: BTreeSet<u64>,
     pub(super) errored_tables: BTreeSet<MySqlTableName>,
 }
 
@@ -70,18 +67,16 @@ impl<'a> ReplContext<'a> {
             data_cap_set,
             upper_cap_set,
             rewinds,
-            table_id_map: BTreeMap::new(),
-            skipped_table_ids: BTreeSet::new(),
             errored_tables: BTreeSet::new(),
         }
     }
 
     /// Advances the frontier of the data and upper capability sets to `new_upper`,
     /// and drops any existing rewind requests that are no longer applicable.
-    pub(super) fn advance(&mut self, new_upper: Antichain<GtidPartition>) {
+    pub(super) fn advance(&mut self, reason: &str, new_upper: Antichain<GtidPartition>) {
         let (id, worker_id) = (self.config.id, self.config.worker_id);
 
-        trace!(%id, "timely-{worker_id} advancing frontier to {new_upper:?}");
+        trace!(%id, "timely-{worker_id} [{reason}] advancing frontier to {new_upper:?}");
 
         self.data_cap_set.downgrade(&*new_upper);
         self.upper_cap_set.downgrade(&*new_upper);


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/materialize/issues/25582

The bug was caused by a `table_id_map` I had created to store a cache of binlog-table-ids (u64 value) --> table-schema/name (vec of strings) to avoid a couple of extra string clones on each event we receive on the replication stream. 

It turns out that the table-id mappings will change after mysql rotates its binary logs, even during the course of long-running replication connection.

This removes that unnecessary optimization and adds some additional tracing that was used during debugging.

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I was replicating the issue using `bin/mzcompose --find zippy down -v && bin/mzcompose --find zippy --dev run default --scenario=MySqlCdc` and confirmed that this fix allows that test scenario to continue successfully.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
