### PR TITLE
Update lgalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,9 +3135,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lgalloc"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7da66e048ec66e9bcd886b4f704a3702787a517ebed8fb5a0e7c4ed25ee742"
+checksum = "78fb7dff306cb817d4acf3e0d45f0992721cd509e85e6950eea8b9100f5bbcb9"
 dependencies = [
  "crossbeam-deque",
  "libc",

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -759,7 +759,7 @@ version = "1.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.lgalloc]]
-version = "0.2.2"
+version = "0.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -9,6 +9,8 @@
 
 //! Dyncfgs used by the compute layer.
 
+use std::time::Duration;
+
 use mz_dyncfg::{Config, ConfigSet};
 
 /// Whether rendering should use `mz_join_core` rather than DD's `JoinCore::join_core`.
@@ -68,6 +70,20 @@ pub const DATAFLOW_MAX_INFLIGHT_BYTES_CC: Config<Option<usize>> = Config::new(
     compute dataflows in cc clusters (Materialize).",
 );
 
+/// The interval at which the background thread wakes.
+pub const LGALLOC_BACKGROUND_INTERVAL: Config<Duration> = Config::new(
+    "lgalloc_background_interval",
+    Duration::from_secs(1),
+    "Scheduling interval for lgalloc's background worker.",
+);
+
+/// The bytes to reclaim (slow path) per size class, for each background thread activation.
+pub const LGALLOC_SLOW_CLEAR_BYTES: Config<usize> = Config::new(
+    "lgalloc_slow_clear_bytes",
+    32 << 20,
+    "Clear byte size per size class for every invocation",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -78,4 +94,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_CHUNKED_STACK)
         .add(&ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)
+        .add(&LGALLOC_BACKGROUND_INTERVAL)
+        .add(&LGALLOC_SLOW_CLEAR_BYTES)
 }

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -21,7 +21,7 @@ differential-dataflow = "0.12.0"
 dogsdogsdogs = "0.1.0"
 futures = "0.3.25"
 itertools = "0.10.5"
-lgalloc = "0.2"
+lgalloc = "0.3"
 mz-build-info = { path = "../build-info" }
 mz-cluster = { path = "../cluster" }
 mz-cluster-client = { path = "../cluster-client" }

--- a/src/metrics/Cargo.toml
+++ b/src/metrics/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-lgalloc = "0.2"
+lgalloc = "0.3"
 libc = "0.2.138"
 mz-ore = { path = "../ore", features = ["metrics"] }
 paste = "1.0"

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -29,7 +29,7 @@ ctor = { version = "0.1.26", optional = true }
 either = "1.8.0"
 futures = { version = "0.3.25", optional = true }
 hibitset = { version = "0.6.4", optional = true }
-lgalloc = { version = "0.2", optional = true }
+lgalloc = { version = "0.3", optional = true }
 mz-ore-proc = { path = "../ore-proc", default-features = false }
 num = "0.4.0"
 once_cell = "1.16.0"


### PR DESCRIPTION
Update our dependency on lgalloc and use the new clear_bytes API to specify
clearing of 32MiB (configurable) for every wake up.

### Motivation

This updates our dependency on lgalloc to the latest version, which is 0.3.0.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
