### PR TITLE
docs: Fivetran Destination User Docs (for Fivetran)

### DIFF
--- a/doc/third-party/fivetran/overview.md
+++ b/doc/third-party/fivetran/overview.md
@@ -1,23 +1,24 @@
 ---
 name: Materialize
 title: Fivetran for Materialize | Configuration and documentation
-description: Connect data sources to Materialize in minutes using Fivetran. Explore documentation and start syncing your applications, databases, and events.
+description: Connect data sources to Materialize in minutes using Fivetran. Explore documentation and start syncing your applications and events.
 ---
 
 # Materialize {% badge text="Partner-Built" /%} {% badge text="Private Preview" /%}
 
-[Materialize](https://materialize.com) is an operational data warehouse that incrementally maintain your `VIEW`s, responding to queries in
-tens of milliseconds.
+[Materialize](https://materialize.com) is a data warehouse purpose-built for operational workloads where an analytical data warehouse would be too slow, and a stream processor would be too complicated.
+
+Using SQL and common tools in the wider data ecosystem, Materialize allows you to build real-time automation, engaging customer experiences, and interactive data products that drive value for your business while reducing the cost of data freshness.
 
 You can use Fivetran to sync data to Materialize for the following use cases:
 
 - To sync data from SaaS applications or platforms, such as HubSpot, Shopify, or Stripe.
 - To sync data from event streaming sources, such as Kinesis or Google Pub/Sub.
-- To sync data from other data warehouse, such as Snowflake, Databricks, or Oracle.
+- To sync data from other data warehouses, such as Snowflake, Databricks, or Oracle.
 
-For databases like Postgres or MySQL, and event streaming sources like Kafka, you should prefer to use [Materialize native sources](https://materialize.com/docs/sql/create-source/).
+For relational databases like PostgreSQL or MySQL, and event streaming sources like Apache Kafka, you should prefer to use [Materialize native sources](https://materialize.com/docs/sql/create-source/).
 
-> NOTE: This destination is [partner-built](/docs/partner-built-program). For any questions related to Materialize destination and its documentation, contact [Materialize Support](mailto:support@materialize.com).
+> NOTE: This destination is [partner-built](/docs/partner-built-program). For any questions related to the Materialize destination and its documentation, contact the [Materialize team](mailto:support@materialize.com).
 
 ----
 
@@ -29,7 +30,7 @@ Follow our [step-by-step Materialize setup guide](/docs/destinations/materialize
 
 ## Type transformation mapping
 
-As we extract your data, we match Fivetran data types to types that Materialize supports. If we don't support a specific data type, we automatically change that type to the closest supported data type or, in some cases, don't load that data.
+As we extract your data, we match Fivetran data types to types that Materialize supports. If we don't support a specific data type, we automatically change that type to the closest supported data type.
 
 The data types in Materialize follow Fivetran's [standard data type storage](/docs/destinations#datatypes).
 
@@ -48,13 +49,15 @@ The following table illustrates how we transform your Fivetran data types into M
 | LOCALDATETIME      | TIMESTAMP             |
 | INSTANT            | TIMESTAMP             |
 | STRING             | STRING                |
-| XML                | STRING                |
-| JSON               | JSON                  |
+| JSON               | JSONB                 |
 | BINARY             | STRING                |
+| XML                | Unsupported           |
 
 ----
 
 ## Schema changes
+
+Schema changes to existing tables is not currently supported, when creating a Connector you should select the option to "Block all" schema changes.
 
 | SCHEMA CHANGE      | SUPPORTED | NOTES                                                                                                     |
 |--------------------|-----------|-----------------------------------------------------------------------------------------------------------|
@@ -65,6 +68,6 @@ The following table illustrates how we transform your Fivetran data types into M
 
 ## Limitations
 
-Materialize has the following limitations:
+The Fivetran Materialize destination has the following known limitations:
 
 - Schema changes to an existing source are not supported.

--- a/doc/third-party/fivetran/overview.md
+++ b/doc/third-party/fivetran/overview.md
@@ -57,7 +57,7 @@ The following table illustrates how we transform your Fivetran data types into M
 
 ## Schema changes
 
-Schema changes to existing tables is not currently supported, when creating a Connector you should select the option to "Block all" schema changes.
+Schema changes to existing tables is not currently supported. When creating a Connector you should select the option to "Block all" schema changes.
 
 | SCHEMA CHANGE      | SUPPORTED | NOTES                                                                                                     |
 |--------------------|-----------|-----------------------------------------------------------------------------------------------------------|

--- a/doc/third-party/fivetran/overview.md
+++ b/doc/third-party/fivetran/overview.md
@@ -1,0 +1,70 @@
+---
+name: Materialize
+title: Fivetran for Materialize | Configuration and documentation
+description: Connect data sources to Materialize in minutes using Fivetran. Explore documentation and start syncing your applications, databases, and events.
+---
+
+# Materialize {% badge text="Partner-Built" /%} {% badge text="Private Preview" /%}
+
+[Materialize](https://materialize.com) is an operational data warehouse that incrementally maintain your `VIEW`s, responding to queries in
+tens of milliseconds.
+
+You can use Fivetran to sync data to Materialize for the following use cases:
+
+- To sync data from SaaS applications or platforms, such as HubSpot, Shopify, or Stripe.
+- To sync data from event streaming sources, such as Kinesis or Google Pub/Sub.
+- To sync data from other data warehouse, such as Snowflake, Databricks, or Oracle.
+
+For databases like Postgres or MySQL, and event streaming sources like Kafka, you should prefer to use [Materialize native sources](https://materialize.com/docs/sql/create-source/).
+
+> NOTE: This destination is [partner-built](/docs/partner-built-program). For any questions related to Materialize destination and its documentation, contact [Materialize Support](mailto:support@materialize.com).
+
+----
+
+## Setup guide
+
+Follow our [step-by-step Materialize setup guide](/docs/destinations/materialize/setup-guide) to connect Materialize to Fivetran.
+
+----
+
+## Type transformation mapping
+
+As we extract your data, we match Fivetran data types to types that Materialize supports. If we don't support a specific data type, we automatically change that type to the closest supported data type or, in some cases, don't load that data.
+
+The data types in Materialize follow Fivetran's [standard data type storage](/docs/destinations#datatypes).
+
+The following table illustrates how we transform your Fivetran data types into Materialize-supported types:
+
+| FIVETRAN DATA TYPE | MATERIALIZE DATA TYPE |
+|--------------------|-----------------------|
+| BOOLEAN            | BOOLEAN               |
+| SHORT              | INT16                 |
+| INT                | INT32                 |
+| LONG               | INT64                 |
+| BIGDECIMAL         | DOUBLE                |
+| FLOAT              | FLOAT                 |
+| DOUBLE             | DOUBLE                |
+| LOCALDATE          | DATE                  |
+| LOCALDATETIME      | TIMESTAMP             |
+| INSTANT            | TIMESTAMP             |
+| STRING             | STRING                |
+| XML                | STRING                |
+| JSON               | JSON                  |
+| BINARY             | STRING                |
+
+----
+
+## Schema changes
+
+| SCHEMA CHANGE      | SUPPORTED | NOTES                                                                                                     |
+|--------------------|-----------|-----------------------------------------------------------------------------------------------------------|
+| Add column         | No        | Adding a column to your source is not currently supported.                                                |
+| Change column type | No        | Changing column types is not supported as it is a breaking schema change.                                 |
+
+---
+
+## Limitations
+
+Materialize has the following limitations:
+
+- Schema changes to an existing source are not supported.

--- a/doc/third-party/fivetran/setup-guide.md
+++ b/doc/third-party/fivetran/setup-guide.md
@@ -8,7 +8,7 @@ description: Follow the guide to set up Materialize as a destination.
 
 Follow the setup guide to connect Materialize to Fivetran.
 
-> NOTE: This destination is [partner-built](/docs/partner-built-program). For any questions related to Materialize destination and its documentation, contact [Materialize Support](mailto:support@materialize.com).
+> NOTE: This destination is [partner-built](/docs/partner-built-program). For any questions related to the Materialize destination and its documentation, contact the [Materialize team](mailto:support@materialize.com).
 
 ---
 
@@ -16,39 +16,39 @@ Follow the setup guide to connect Materialize to Fivetran.
 
 To connect Materialize to Fivetran, you need the following:
 
-- A Materialize account with `CREATE` privileges on the database you're connecting to.
+- A Materialize account. If you already have one - great! If not, [sign up for a playground account](https://materialize.com/register/) first.
 - A Fivetran account with [permission to add destinations](/docs/using-fivetran/fivetran-dashboard/account-management/role-based-access-control#legacyandnewrbacmodel).
 
 ---
 
 ## Setup instructions
 
-### <span class="step-item"> Get Materialize credentials </span> 
+### <span class="step-item"> Get Materialize credentials </span>
 
-You must have a Materialize account with `CREATE` privileges on the database you're connecting to.
+The user you're using to connect to Fivetran must have [`CREATE`](https://materialize.com/docs/manage/access-control/rbac/#privileges) privileges on the target database in Materialize.
 
-1. Login to the [Materialize Console](https://console.materialize.com) with your account.
-2. Click "Connect externally" at the bottom of the sidebar.
-3. On the "External tools" tab, click "Create app password". 
-4. Copy the generated **password**, **Host**, and **User** somewhere safe, we'll use these soon!
+1. Log in to your [Materialize account](https://console.materialize.com).
+2. In the bottom left corner click on your user, then select "App passwords".
+3. From the "App passwords" page click "New app password" in the top right corner
+4. Create a new app password with a name related to Fivetran, for example "John's Fivetran App Password".
+5. Copy the newly created app password somewhere safe, you won't be able to see it again once you navigate away from this page!
+6. Click "Connect externally" at the bottom of the sidebar.
+7. Copy the **Host** and **User** fields somewhere safe, we'll use these soon!
 
 ### <span class="step-item">Finish Fivetran configuration </span>
 
 1. Log in to your Fivetran account.
-2. Go to the [**Destinations** page](https://fivetran.com/dashboard/destinations), and then click **+ Add Destination**.
+2. Go to the [**Destinations** page](https://fivetran.com/dashboard/destinations), and then click **Add Destination**.
 3. Enter a **Destination name** of your choice.
 4. Click **Add**.
 5. Select **Materialize** as the destination type.
-6. Enter the **Host**, **User**, and **App password** you copied in Step 1.
-7. Enter the **Database** you would like to connect to and have `CREATE` permissions for.
+6. Enter the **Host**, **User**, and **App password** you previously copied.
+7. Enter the **Database** you would like to connect to. As a reminder, the user specified in the previous step must have `CREATE` privileges on this database.
 7. Choose the **Data processing location**.
 8. Choose your **Time zone**.
 9. Click **Save & Test**.
 
-Fivetran [tests and validates](/docs/destinations/materialize/setup-guide#setuptest) the Materialize connection. On successful completion of the setup test, you can sync your data using Fivetran connectors to the Materialize destination.
-
-### Setup test
-
-Fivetran performs the following Materialize connection test:
-
-- The Connection test checks if we can connect to your Materialize account through the API using the Host, User, and App password you provided in the setup form.
+Fivetran will [test and validate](/docs/destinations/materialize/setup-guide#setuptest) that we can
+connect to your Materialize account with the Host, User, and App password you provided in the setup
+form. On successful completion of the setup test, you can sync your data using Fivetran connectors
+to the Materialize destination.

--- a/doc/third-party/fivetran/setup-guide.md
+++ b/doc/third-party/fivetran/setup-guide.md
@@ -1,0 +1,54 @@
+---
+name: Setup Guide
+title: Materialize Setup Guide
+description: Follow the guide to set up Materialize as a destination.
+---
+
+# Materialize Setup Guide {% badge text="Partner-Built" /%} {% badge text="Private Preview" /%}
+
+Follow the setup guide to connect Materialize to Fivetran.
+
+> NOTE: This destination is [partner-built](/docs/partner-built-program). For any questions related to Materialize destination and its documentation, contact [Materialize Support](mailto:support@materialize.com).
+
+---
+
+## Prerequisites
+
+To connect Materialize to Fivetran, you need the following:
+
+- A Materialize account with `CREATE` privileges on the database you're connecting to.
+- A Fivetran account with [permission to add destinations](/docs/using-fivetran/fivetran-dashboard/account-management/role-based-access-control#legacyandnewrbacmodel).
+
+---
+
+## Setup instructions
+
+### <span class="step-item"> Get Materialize credentials </span> 
+
+You must have a Materialize account with `CREATE` privileges on the database you're connecting to.
+
+1. Login to the [Materialize Console](https://console.materialize.com) with your account.
+2. Click "Connect externally" at the bottom of the sidebar.
+3. On the "External tools" tab, click "Create app password". 
+4. Copy the generated **password**, **Host**, and **User** somewhere safe, we'll use these soon!
+
+### <span class="step-item">Finish Fivetran configuration </span>
+
+1. Log in to your Fivetran account.
+2. Go to the [**Destinations** page](https://fivetran.com/dashboard/destinations), and then click **+ Add Destination**.
+3. Enter a **Destination name** of your choice.
+4. Click **Add**.
+5. Select **Materialize** as the destination type.
+6. Enter the **Host**, **User**, and **App password** you copied in Step 1.
+7. Enter the **Database** you would like to connect to and have `CREATE` permissions for.
+7. Choose the **Data processing location**.
+8. Choose your **Time zone**.
+9. Click **Save & Test**.
+
+Fivetran [tests and validates](/docs/destinations/materialize/setup-guide#setuptest) the Materialize connection. On successful completion of the setup test, you can sync your data using Fivetran connectors to the Materialize destination.
+
+### Setup test
+
+Fivetran performs the following Materialize connection test:
+
+- The Connection test checks if we can connect to your Materialize account through the API using the Host, User, and App password you provided in the setup form.


### PR DESCRIPTION
I do not intend to merge this PR, just receive edits.

Fivetran requested we write some brief docs on how to setup a Materialize destination. They [provided templates](https://materializeinc.slack.com/archives/C060KAR4802/p1709130386216599) that I more or less did a find-replace with the name "Materialize".

### Motivation

Currently the only blocker from moving the Fivetran Destination from "Closed Private Preview" to "Open Private Preview" on their end.

Makes progress towards: https://github.com/MaterializeInc/materialize/issues/25143

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a, these docs would be given to Fivetran
