### PR TITLE
storage: add source statistics for webhooks

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1053,12 +1053,17 @@ impl Coordinator {
                 .controller
                 .storage
                 .monotonic_appender(entry.id())
+                .map_err(|_| name.clone())?;
+            let stats = coord
+                .controller
+                .storage
+                .webhook_statistics(entry.id())
                 .map_err(|_| name)?;
             let invalidator = coord
                 .active_webhooks
                 .entry(entry.id())
                 .or_insert_with(WebhookAppenderInvalidator::new);
-            let tx = WebhookAppender::new(row_tx, invalidator.guard());
+            let tx = WebhookAppender::new(row_tx, invalidator.guard(), stats);
 
             Ok(AppendWebhookResponse {
                 tx,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -380,6 +380,11 @@ pub trait StorageController: Debug {
 
     /// Returns a shared [`WebhookStatistics`] which can be used to report user-facing
     /// statistics for this given webhhook, specified by the [`GlobalId`].
+    ///
+    // This is used to support a fairly special case, where a source needs to report statistics
+    // from outside the ordinary controller-clusterd path. Its possible to merge this with
+    // `monotonic_appender`, whose only current user is webhooks, but given that they will
+    // likely be moved to clusterd, we just leave this a special case.
     fn webhook_statistics(&self, id: GlobalId) -> Result<Arc<WebhookStatistics>, StorageError>;
 
     /// Returns the snapshot of the contents of the local input named `id` at `as_of`.

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -20,6 +20,7 @@
 
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use differential_dataflow::lattice::Lattice;
@@ -43,6 +44,7 @@ use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::client::TimestamplessUpdate;
+use crate::statistics::WebhookStatistics;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum IntrospectionType {
@@ -375,6 +377,10 @@ pub trait StorageController: Debug {
     /// Returns a [`MonotonicAppender`] which is a channel that can be used to monotonically
     /// append to the specified [`GlobalId`].
     fn monotonic_appender(&self, id: GlobalId) -> Result<MonotonicAppender, StorageError>;
+
+    /// Returns a shared [`WebhookStatistics`] which can be used to report user-facing
+    /// statistics for this given webhhook, specified by the [`GlobalId`].
+    fn webhook_statistics(&self, id: GlobalId) -> Result<Arc<WebhookStatistics>, StorageError>;
 
     /// Returns the snapshot of the contents of the local input named `id` at `as_of`.
     async fn snapshot(

--- a/test/cluster/storage/01-create-sources.td
+++ b/test/cluster/storage/01-create-sources.td
@@ -12,6 +12,9 @@ $ set-sql-timeout duration=180s
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
+ALTER SYSTEM SET kafka_default_metadata_fetch_interval = 1000
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
 
 # Create sources and verify they can ingest data while `environmentd` is online.
 
@@ -45,6 +48,12 @@ one
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-remote2-${testdrive.seed}')
   FORMAT TEXT
 
+> CREATE SOURCE webhook_text IN CLUSTER storage_cluster FROM WEBHOOK
+  BODY FORMAT TEXT;
+
+$ webhook-append database=materialize schema=public name=webhook_text
+a
+
 > SELECT * from remote1
 one
 > SELECT * from remote2
@@ -61,3 +70,11 @@ one
   GROUP BY s.id, s.name
 remote1 true 1 1 1
 remote2 true 1 1 1
+
+> SELECT s.name,
+  SUM(u.updates_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('webhook_text')
+  GROUP BY s.id, s.name
+webhook_text 1

--- a/test/cluster/storage/02-after-environmentd-restart.td
+++ b/test/cluster/storage/02-after-environmentd-restart.td
@@ -31,10 +31,20 @@ one
 remote1 true 1 1 1
 remote2 true 1 1 1
 
+> SELECT s.name,
+  SUM(u.updates_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('webhook_text')
+  GROUP BY s.id, s.name
+webhook_text 1
+
 $ kafka-ingest format=bytes topic=remote1
 two
 $ kafka-ingest format=bytes topic=remote2
 two
+$ webhook-append database=materialize schema=public name=webhook_text
+b
 
 > SELECT * from remote1
 one
@@ -55,3 +65,11 @@ two
   GROUP BY s.id, s.name
 remote1 true 2 2 2
 remote2 true 2 2 2
+
+> SELECT s.name,
+  SUM(u.updates_committed)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('webhook_text')
+  GROUP BY s.id, s.name
+webhook_text 2

--- a/test/testdrive/webhook-statistics.td
+++ b/test/testdrive/webhook-statistics.td
@@ -1,0 +1,61 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
+
+> CREATE CLUSTER webhook_cluster REPLICAS (r1 (SIZE '1'));
+
+> CREATE SOURCE webhook_text IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT TEXT;
+
+$ webhook-append database=materialize schema=public name=webhook_text
+a
+
+> SELECT
+    s.name,
+    u.messages_received,
+    u.bytes_received > 0,
+    u.updates_staged,
+    u.updates_committed
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('webhook_text')
+webhook_text 1 true 1 1
+
+$ set-from-sql var=bytes-received
+SELECT
+    (u.bytes_received)::text
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('webhook_text')
+
+$ webhook-append database=materialize schema=public name=webhook_text
+b
+
+> SELECT
+    s.name,
+    u.messages_received,
+    u.bytes_received > ${bytes-received},
+    u.updates_staged,
+    u.updates_committed
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('webhook_text')
+webhook_text 2 true 2 2
+
+> DROP SOURCE webhook_text;
+
+> SELECT
+    count(*)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('webhook_text')
+0


### PR DESCRIPTION
Closes: https://github.com/MaterializeInc/materialize/issues/24868

### Motivation

  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
