### PR TITLE
environmentd: add balancer label to mz_connection_status

### DIFF
--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -612,6 +612,7 @@ impl Listeners {
         // Launch SQL server.
         task::spawn(|| "sql_server", {
             let sql_server = mz_pgwire::Server::new(mz_pgwire::Config {
+                label: "external_pgwire",
                 tls: pgwire_tls.clone(),
                 adapter_client: adapter_client.clone(),
                 frontegg: config.frontegg.clone(),
@@ -625,6 +626,7 @@ impl Listeners {
         // Launch internal SQL server.
         task::spawn(|| "internal_sql_server", {
             let internal_sql_server = mz_pgwire::Server::new(mz_pgwire::Config {
+                label: "internal_pgwire",
                 tls: pgwire_tls.map(|mut pgwire_tls| {
                     // Allow, but do not require, TLS connections on the internal
                     // port. Some users of the internal SQL server do not support
@@ -677,6 +679,7 @@ impl Listeners {
         // Launch SQL server exposed to balancers
         task::spawn(|| "balancer_sql_server", {
             let balancer_sql_server = mz_pgwire::Server::new(mz_pgwire::Config {
+                label: "balancer_pgwire",
                 tls: None,
                 adapter_client: adapter_client.clone(),
                 frontegg: config.frontegg.clone(),

--- a/src/pgwire/src/metrics.rs
+++ b/src/pgwire/src/metrics.rs
@@ -31,12 +31,12 @@ impl MetricsConfig {
 #[derive(Clone, Debug)]
 pub struct Metrics {
     inner: MetricsConfig,
-    internal: bool,
+    label: &'static str,
 }
 
 impl Metrics {
-    pub fn new(inner: MetricsConfig, internal: bool) -> Self {
-        let self_ = Self { inner, internal };
+    pub fn new(inner: MetricsConfig, label: &'static str) -> Self {
+        let self_ = Self { inner, label };
 
         // pre-initialize labels we are planning to use to ensure they are all
         // always emitted as time series
@@ -61,10 +61,6 @@ impl Metrics {
     }
 
     fn source_label(&self) -> &'static str {
-        if self.internal {
-            "internal_pgwire"
-        } else {
-            "external_pgwire"
-        }
+        self.label
     }
 }

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -33,6 +33,8 @@ use crate::protocol;
 /// Configures a [`Server`].
 #[derive(Debug)]
 pub struct Config {
+    /// The label for the mz_connection_status metric.
+    pub label: &'static str,
     /// A client for the adapter with which the server will communicate.
     pub adapter_client: mz_adapter::Client,
     /// The TLS configuration for the server.
@@ -84,7 +86,7 @@ impl Server {
             tls: config.tls,
             adapter_client: config.adapter_client,
             frontegg: config.frontegg,
-            metrics: Metrics::new(config.metrics, config.internal),
+            metrics: Metrics::new(config.metrics, config.label),
             internal: config.internal,
             active_connection_count: config.active_connection_count,
         }


### PR DESCRIPTION
Needed to disambiguate external and balancer connections, so we can tell when folks are using the balancer.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a