### PR TITLE
environmentd: disambiguate external vs balancer in http metrics

### DIFF
--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -650,6 +650,7 @@ impl Listeners {
         let http_metrics = http::Metrics::register_into(&config.metrics_registry, "mz_http");
         task::spawn(|| "http_server", {
             let http_server = HttpServer::new(HttpConfig {
+                source: "external",
                 tls: http_tls,
                 frontegg: config.frontegg.clone(),
                 adapter_client: adapter_client.clone(),
@@ -664,6 +665,7 @@ impl Listeners {
         // Launch HTTP server exposed to balancers
         task::spawn(|| "balancer_http_server", {
             let balancer_http_server = HttpServer::new(HttpConfig {
+                source: "balancer",
                 // TODO(Alex): implement self-signed TLS for all internal connections
                 tls: None,
                 frontegg: config.frontegg.clone(),

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2790,7 +2790,7 @@ async fn smoketest_webhook_source() {
     let path_label = &total_requests_metric.get_label()[0];
     assert_eq!(path_label.get_value(), "/api/webhook/:database/:schema/:id");
 
-    let status_label = &total_requests_metric.get_label()[1];
+    let status_label = &total_requests_metric.get_label()[2];
     assert_eq!(status_label.get_value(), "200");
 
     // Wait for the events to be persisted.
@@ -3136,12 +3136,12 @@ async fn test_http_metrics() {
     let success_metric = &request_metric.get_metric()[0];
     assert_eq!(success_metric.get_counter().get_value(), 1.0);
     assert_eq!(success_metric.get_label()[0].get_value(), "/api/sql");
-    assert_eq!(success_metric.get_label()[1].get_value(), "200");
+    assert_eq!(success_metric.get_label()[2].get_value(), "200");
 
     let failure_metric = &request_metric.get_metric()[1];
     assert_eq!(failure_metric.get_counter().get_value(), 1.0);
     assert_eq!(failure_metric.get_label()[0].get_value(), "/api/sql");
-    assert_eq!(failure_metric.get_label()[1].get_value(), "400");
+    assert_eq!(failure_metric.get_label()[2].get_value(), "400");
 }
 
 #[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 2))]


### PR DESCRIPTION
Add a metric label for the http server source so we can tell apart balancer from external traffic.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a