### PR TITLE
doc/user: document supported PostgreSQL types

### DIFF
--- a/doc/user/content/ingest-data/postgres-alloydb.md
+++ b/doc/user/content/ingest-data/postgres-alloydb.md
@@ -5,10 +5,10 @@ menu:
   main:
     parent: "postgresql"
     name: "AlloyDB"
-    weight: 25
+    weight: 1
 ---
 
-This page shows you how to stream data from [AlloyDB](https://cloud.google.com/alloydb)
+This page shows you how to stream data from [AlloyDB for PostgreSQL](https://cloud.google.com/alloydb)
 to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
 
 ## Before you begin

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -152,7 +152,46 @@ ingestion progress and debugging related issues, see [Troubleshooting](/ops/trou
 
 ##### Supported types
 
-Replicating tables that contain [data types](/sql/types/) unsupported in Materialize is possible via the `TEXT COLUMNS` option. The specified columns will be treated as `text`, and will thus not offer the expected PostgreSQL type features. For example:
+Materialize natively supports the following PostgreSQL types:
+
+<ul style="column-count: 3">
+<li><code>bool</code></li>
+<li><code>bpchar</code></li>
+<li><code>bytea</code></li>
+<li><code>char</code></li>
+<li><code>date</code></li>
+<li><code>daterange</code></li>
+<li><code>float4</code></li>
+<li><code>float8</code></li>
+<li><code>int2</code></li>
+<li><code>int2vector</code></li>
+<li><code>int4</code></li>
+<li><code>int4range</code></li>
+<li><code>int8</code></li>
+<li><code>int8range</code></li>
+<li><code>interval</code></li>
+<li><code>json</code></li>
+<li><code>jsonb</code></li>
+<li><code>numeric</code></li>
+<li><code>numrange</code></li>
+<li><code>oid</code></li>
+<li><code>regclass</code></li>
+<li><code>regproc</code></li>
+<li><code>regtype</code></li>
+<li><code>text</code></li>
+<li><code>time</code></li>
+<li><code>timestamp</code></li>
+<li><code>timestamptz</code></li>
+<li><code>timetz</code></li>
+<li><code>tsrange</code></li>
+<li><code>tstzrange</code></li>
+<li><code>uuid</code></li>
+<li><code>varchar</code></li>
+</ul>
+
+Materialize also supports the array type for each of the above types.
+
+Replicating tables that contain unsupported [data types](/sql/types/) is possible via the `TEXT COLUMNS` option. The specified columns will be treated as `text`, and will thus not offer the expected PostgreSQL type features. For example:
 
 * [`enum`]: the implicit ordering of the original PostgreSQL `enum` type is not preserved, as Materialize will sort values as `text`.
 * [`money`]: the resulting `text` value cannot be cast back to e.g. `numeric`, since PostgreSQL adds typical currency formatting to the output.

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -13,11 +13,22 @@ aliases:
 ---
 
 {{% create-source/intro %}}
-Materialize supports PostgreSQL (11+) as a data source. To connect to a PostgreSQL instance, you first need to [create a connection](#creating-a-connection) that specifies access and authentication parameters. Once created, a connection is **reusable** across multiple `CREATE SOURCE` statements.
+Materialize supports PostgreSQL (11+) as a data source. To connect to a
+PostgreSQL instance, you first need to [create a connection]
+(#creating-a-connection) that specifies access and authentication parameters.
+Once created, a connection is **reusable** across multiple `CREATE SOURCE`
+statements.
 {{% /create-source/intro %}}
 
 {{< warning >}}
-Before creating a PostgreSQL source, you must set up logical replication in the upstream database. For step-by-step instructions, see the integration guide for your PostgreSQL service: [Amazon RDS](/ingest-data/postgres-amazon-rds/), [Amazon Aurora](/ingest-data/postgres-amazon-aurora/), [Azure DB](/ingest-data/postgres-azure-db/), [Google Cloud SQL](/ingest-data/postgres-google-cloud-sql/), [Self-hosted](/ingest-data/postgres-self-hosted/).
+Before creating a PostgreSQL source, you must set up logical replication in the
+upstream database. For step-by-step instructions, see the integration guide for
+your PostgreSQL service: [AlloyDB](/ingest-data/postgres-alloydb/),
+[Amazon RDS](/ingest-data/postgres-amazon-rds/),
+[Amazon Aurora](/ingest-data/postgres-amazon-aurora/),
+[Azure DB](/ingest-data/postgres-azure-db/),
+[Google Cloud SQL](/ingest-data/postgres-google-cloud-sql/),
+[Self-hosted](/ingest-data/postgres-self-hosted/).
 {{< /warning >}}
 
 ## Syntax
@@ -46,9 +57,19 @@ Field                                | Value     | Description
 
 ### Change data capture
 
-This source uses PostgreSQL's native replication protocol to continually ingest changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the upstream database — a process also known as _change data capture_.
+This source uses PostgreSQL's native replication protocol to continually ingest
+changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the
+upstream database — a process also known as _change data capture_.
 
-For this reason, you must configure the upstream PostgreSQL database to support logical replication before creating a source in Materialize. Follow the step-by-step instructions in relevant integration guide to get logical replication set up: [Amazon RDS](/ingest-data/postgres-amazon-rds/), [Amazon Aurora](/ingest-data/postgres-amazon-aurora/), [Azure DB](/ingest-data/postgres-azure-db/), [Google Cloud SQL](/ingest-data/postgres-google-cloud-sql/), [Self-hosted](/ingest-data/postgres-self-hosted/).
+For this reason, you must configure the upstream PostgreSQL database to support
+logical replication before creating a source in Materialize. For step-by-step
+instructions, see the integration guide for your PostgreSQL service:
+[AlloyDB](/ingest-data/postgres-alloydb/),
+[Amazon RDS](/ingest-data/postgres-amazon-rds/),
+[Amazon Aurora](/ingest-data/postgres-amazon-aurora/),
+[Azure DB](/ingest-data/postgres-azure-db/),
+[Google Cloud SQL](/ingest-data/postgres-google-cloud-sql/),
+[Self-hosted](/ingest-data/postgres-self-hosted/).
 
 #### Creating a source
 
@@ -64,9 +85,12 @@ CREATE SOURCE mz_source
 
 When you define a source, Materialize will automatically:
 
-1. Create a **replication slot** in the upstream PostgreSQL database (see [PostgreSQL replication slots](#postgresql-replication-slots)).
+1. Create a **replication slot** in the upstream PostgreSQL database (see
+   [PostgreSQL replication slots](#postgresql-replication-slots)).
 
-    The name of the replication slot created by Materialize is prefixed with `materialize_` for easy identification, and can be looked up in `mz_internal.mz_postgres_sources`.
+    The name of the replication slot created by Materialize is prefixed with
+    `materialize_` for easy identification, and can be looked up in
+    `mz_internal.mz_postgres_sources`.
 
     ```sql
     SELECT * FROM mz_internal.mz_postgres_sources;
@@ -92,27 +116,48 @@ When you define a source, Materialize will automatically:
      table_2              | subsource |
     ```
 
-    And perform an initial, snapshot-based sync of the tables in the publication before it starts ingesting change events.
+    And perform an initial, snapshot-based sync of the tables in the publication
+    before it starts ingesting change events.
 
-1. Incrementally update any materialized or indexed views that depend on the source as change events stream in, as a result of `INSERT`, `UPDATE` and `DELETE` operations in the upstream PostgreSQL database.
+1. Incrementally update any materialized or indexed views that depend on the
+source as change events stream in, as a result of `INSERT`, `UPDATE` and
+`DELETE` operations in the upstream PostgreSQL database.
 
-It's important to note that the schema metadata is captured when the source is initially created, and is validated against the upstream schema upon restart. If you wish to add additional tables to the original publication and use them in Materialize, the source must be dropped and recreated.
+It's important to note that the schema metadata is captured when the source is
+initially created, and is validated against the upstream schema upon restart.
+If you wish to add additional tables to the original publication and use them
+in Materialize, the source must be dropped and recreated.
 
 ##### PostgreSQL replication slots
 
-Each source ingests the raw replication stream data for all tables in the specified publication using **a single** replication slot. This allows you to minimize the performance impact on the upstream database, as well as reuse the same source across multiple materializations.
+Each source ingests the raw replication stream data for all tables in the
+specified publication using **a single** replication slot. This allows you to
+minimize the performance impact on the upstream database, as well as reuse the
+same source across multiple materializations.
 
 {{< warning >}}
-Make sure to delete any replication slots if you stop using Materialize, or if either the Materialize or PostgreSQL instances crash. To look up the name of the replication slot created for each source, use `mz_internal.mz_postgres_sources`.
+Make sure to delete any replication slots if you stop using Materialize, or if
+either the Materialize or PostgreSQL instances crash. To look up the name of
+the replication slot created for each source, use `mz_internal.mz_postgres_sources`.
 {{< /warning >}}
 
-If you delete all objects that depend on a source without also dropping the source, the upstream replication slot will linger and continue to accumulate data so that the source can resume in the future. To avoid unbounded disk space usage, make sure to use [`DROP SOURCE`](/sql/drop-source/) or manually delete the replication slot.
+If you delete all objects that depend on a source without also dropping the
+source, the upstream replication slot will linger and continue to accumulate
+data so that the source can resume in the future. To avoid unbounded disk space
+usage, make sure to use [`DROP SOURCE`](/sql/drop-source/) or manually delete
+the replication slot.
 
-For PostgreSQL 13+, it is recommended that you set a reasonable value for [`max_slot_wal_keep_size`](https://www.postgresql.org/docs/13/runtime-config-replication.html#GUC-MAX-SLOT-WAL-KEEP-SIZE) to limit the amount of storage used by replication slots.
+For PostgreSQL 13+, it is recommended that you set a reasonable value for
+[`max_slot_wal_keep_size`](https://www.postgresql.org/docs/13/runtime-config-replication.html#GUC-MAX-SLOT-WAL-KEEP-SIZE)
+to limit the amount of storage used by replication slots.
 
 ##### PostgreSQL schemas
 
-`CREATE SOURCE` will attempt to create each upstream table in the same schema as the source. This may lead to naming collisions if, for example, you are replicating `schema1.table_1` and `schema2.table_1`. Use the `FOR TABLES` clause to provide aliases for each upstream table, in such cases, or to specify an alternative destination schema in Materialize.
+`CREATE SOURCE` will attempt to create each upstream table in the same schema as
+the source. This may lead to naming collisions if, for example, you are
+replicating `schema1.table_1` and `schema2.table_1`. Use the `FOR TABLES`
+clause to provide aliases for each upstream table, in such cases, or to specify
+an alternative destination schema in Materialize.
 
 ```sql
 CREATE SOURCE mz_source
@@ -152,7 +197,8 @@ ingestion progress and debugging related issues, see [Troubleshooting](/ops/trou
 
 ##### Supported types
 
-Materialize natively supports the following PostgreSQL types:
+Materialize natively supports the following PostgreSQL types (including the
+array type for each of the types):
 
 <ul style="column-count: 3">
 <li><code>bool</code></li>
@@ -189,17 +235,23 @@ Materialize natively supports the following PostgreSQL types:
 <li><code>varchar</code></li>
 </ul>
 
-Materialize also supports the array type for each of the above types.
+Replicating tables that contain **unsupported [data types](/sql/types/)** is
+possible via the `TEXT COLUMNS` option. The specified columns will be treated
+as `text`, and will thus not offer the expected PostgreSQL type features. For
+example:
 
-Replicating tables that contain unsupported [data types](/sql/types/) is possible via the `TEXT COLUMNS` option. The specified columns will be treated as `text`, and will thus not offer the expected PostgreSQL type features. For example:
+* [`enum`]: the implicit ordering of the original PostgreSQL `enum` type is not
+  preserved, as Materialize will sort values as `text`.
 
-* [`enum`]: the implicit ordering of the original PostgreSQL `enum` type is not preserved, as Materialize will sort values as `text`.
-* [`money`]: the resulting `text` value cannot be cast back to e.g. `numeric`, since PostgreSQL adds typical currency formatting to the output.
+* [`money`]: the resulting `text` value cannot be cast back to e.g. `numeric`,
+  since PostgreSQL adds typical currency formatting to the output.
 
 ##### Truncation
 
-Tables replicated into Materialize should not be truncated. If a table is truncated while replicated, the whole source becomes inaccessible and will not produce any data until it is recreated.
-Instead, remove all rows from a table using an unqualified `DELETE`.
+Tables replicated into Materialize should not be truncated. If a table is
+truncated while replicated, the whole source becomes inaccessible and will not
+produce any data until it is recreated. Instead, remove all rows from a table
+using an unqualified `DELETE`.
 
 ```sql
 DELETE FROM t;
@@ -207,8 +259,7 @@ DELETE FROM t;
 
 ##### Inherited tables
 
-When using [PostgreSQL table
-inheritance](https://www.postgresql.org/docs/current/tutorial-inheritance.html),
+When using [PostgreSQL table inheritance](https://www.postgresql.org/docs/current/tutorial-inheritance.html),
 PostgreSQL serves data from `SELECT`s as if the inheriting tables' data is also
 present in the inherited table. However, both PostgreSQL's logical replication
 and `COPY` only present data written to the tables themselves, i.e. the
@@ -229,14 +280,24 @@ non-) that unions the new table.
 ## Examples
 
 {{< warning >}}
-Before creating a PostgreSQL source, you must set up logical replication in the upstream database. For step-by-step instructions, see the integration guide for your PostgreSQL service: [Amazon RDS](/ingest-data/postgres-amazon-rds/), [Amazon Aurora](/ingest-data/postgres-amazon-aurora/), [Azure DB](/ingest-data/postgres-azure-db/), [Google Cloud SQL](/ingest-data/postgres-google-cloud-sql/), [Self-hosted](/ingest-data/postgres-self-hosted/).
+Before creating a PostgreSQL source, you must set up logical replication in the
+upstream database. For step-by-step instructions, see the integration guide for
+your PostgreSQL service: [AlloyDB](/ingest-data/postgres-alloydb/),
+[Amazon RDS](/ingest-data/postgres-amazon-rds/),
+[Amazon Aurora](/ingest-data/postgres-amazon-aurora/),
+[Azure DB](/ingest-data/postgres-azure-db/),
+[Google Cloud SQL](/ingest-data/postgres-google-cloud-sql/),
+[Self-hosted](/ingest-data/postgres-self-hosted/).
 {{< /warning >}}
 
 ### Creating a connection
 
-A connection describes how to connect and authenticate to an external system you want Materialize to read data from.
+A connection describes how to connect and authenticate to an external system you
+want Materialize to read data from.
 
-Once created, a connection is **reusable** across multiple `CREATE SOURCE` statements. For more details on creating connections, check the [`CREATE CONNECTION`](/sql/create-connection/#postgresql) documentation page.
+Once created, a connection is **reusable** across multiple `CREATE SOURCE`
+statements. For more details on creating connections, check the
+[`CREATE CONNECTION`](/sql/create-connection/#postgresql) documentation page.
 
 ```sql
 CREATE SECRET pgpass AS '<POSTGRES_PASSWORD>';
@@ -251,7 +312,9 @@ CREATE CONNECTION pg_connection TO POSTGRES (
 );
 ```
 
-If your PostgreSQL server is not exposed to the public internet, you can [tunnel the connection](/sql/create-connection/#network-security-connections) through an AWS PrivateLink service or an SSH bastion host.
+If your PostgreSQL server is not exposed to the public internet, you can
+[tunnel the connection](/sql/create-connection/#network-security-connections)
+through an AWS PrivateLink service or an SSH bastion host.
 
 {{< tabs tabID="1" >}}
 {{< tab "AWS PrivateLink">}}
@@ -278,7 +341,10 @@ CREATE CONNECTION pg_connection TO POSTGRES (
 );
 ```
 
-For step-by-step instructions on creating AWS PrivateLink connections and configuring an AWS PrivateLink service to accept connections from Materialize, check [this guide](/ops/network-security/privatelink/).
+For step-by-step instructions on creating AWS PrivateLink connections and
+configuring an AWS PrivateLink service to accept connections from Materialize,
+check [this guide](/ops/network-security/privatelink/).
+
 {{< /tab >}}
 {{< tab "SSH tunnel">}}
 ```sql
@@ -298,7 +364,10 @@ CREATE CONNECTION pg_connection TO POSTGRES (
 );
 ```
 
-For step-by-step instructions on creating SSH tunnel connections and configuring an SSH bastion server to accept connections from Materialize, check [this guide](/ops/network-security/ssh-tunnel/).
+For step-by-step instructions on creating SSH tunnel connections and configuring
+an SSH bastion server to accept connections from Materialize, check
+[this guide](/ops/network-security/ssh-tunnel/).
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -312,7 +381,8 @@ CREATE SOURCE mz_source
     FOR ALL TABLES;
 ```
 
-_Create subsources for all tables from specific schemas included in the PostgreSQL publication_
+_Create subsources for all tables from specific schemas included in the
+ PostgreSQL publication_
 
 ```sql
 CREATE SOURCE mz_source
@@ -345,7 +415,10 @@ CREATE SOURCE mz_source
 
 ### Adding/dropping tables to/from a source
 
-To handle upstream [schema changes](#schema-changes), use the [`ALTER SOURCE...DROP SUBSOURCE`](/sql/alter-source/#context) syntax to drop the affected subsource, and then `ALTER SOURCE...ADD SUBSOURCE` to add the subsource back to the source.
+To handle upstream [schema changes](#schema-changes), use the
+[`ALTER SOURCE...DROP SUBSOURCE`](/sql/alter-source/#context) syntax to drop
+the affected subsource, and then `ALTER SOURCE...ADD SUBSOURCE` to add the
+subsource back to the source.
 
 ```sql
 -- List all subsources in mz_source
@@ -364,6 +437,7 @@ ALTER SOURCE mz_source ADD SUBSOURCE table_1;
 - [`CREATE CONNECTION`](/sql/create-connection)
 - [`CREATE SOURCE`](../)
 - PostgreSQL integration guides:
+  - [AlloyDB](/ingest-data/postgres-alloydb/)
   - [Amazon RDS](/ingest-data/postgres-amazon-rds/)
   - [Amazon Aurora](/ingest-data/postgres-amazon-aurora/)
   - [Azure DB](/ingest-data/postgres-azure-db/)


### PR DESCRIPTION
And use some fancy CSS to wrap the list to three columns, to avoid taking up too much vertical space in the docs.

![image](https://github.com/MaterializeInc/materialize/assets/882976/90fd39ab-04ff-4510-95f9-6f6f8412afb8)

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature requested twice on Slack recently.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
