### PR TITLE
compute-client: add debugging for SinceViolation

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -915,6 +915,9 @@ where
                 .read_capabilities
                 .frontier();
             if !(timely::order::PartialOrder::less_equal(since, &as_of.borrow())) {
+                tracing::error!(
+                    "SinceViolation for source {source_id}: as_of {as_of:?}, since {since:?}"
+                );
                 Err(DataflowCreationError::SinceViolation(*source_id))?;
             }
 
@@ -928,6 +931,9 @@ where
             let collection = self.compute.collection(*index_id)?;
             let since = collection.read_capabilities.frontier();
             if !(timely::order::PartialOrder::less_equal(&since, &as_of.borrow())) {
+                tracing::error!(
+                    "SinceViolation for index {index_id}: as_of {as_of:?}, since {since:?}"
+                );
                 Err(DataflowCreationError::SinceViolation(*index_id))?;
             }
 


### PR DESCRIPTION
The linked issue is still happening. Because it is unknown how to reproduce it locally, add some debugging to discover if this is due to source or index read holds.

See #25375

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
