### PR TITLE
storage: gently remove ceased status

### DIFF
--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -294,6 +294,8 @@ pub enum Status {
     Running,
     Paused,
     Stalled,
+    /// This status is currently unused.
+    // re-design the ceased status
     Ceased,
     Dropped,
 }
@@ -333,8 +335,6 @@ impl Status {
         match (self, new) {
             (_, Status::Dropped) => true,
             (Status::Dropped, _) => false,
-            (_, Status::Ceased) => true,
-            (Status::Ceased, _) => false,
             // Don't re-mark that object as paused.
             (Status::Paused, Status::Paused) => false,
             // De-duplication of other statuses is currently managed by the

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -346,14 +346,10 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                                     continue;
                                 }
 
-                                let event_is_ok = event.is_ok();
                                 let data = (oid, event);
                                 if let Some((rewind_caps, req)) = rewinds.get(&oid) {
                                     let [data_cap, _upper_cap] = rewind_caps;
-                                    // Do not "rewind" definite errors because
-                                    // we cannot guarantee that the snapshot
-                                    // dataflow produced a definite error.
-                                    if commit_lsn <= req.snapshot_lsn && event_is_ok {
+                                    if commit_lsn <= req.snapshot_lsn {
                                         let update = (data.clone(), MzOffset::from(0), -diff);
                                         data_output.give(data_cap, update).await;
                                     }

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -427,12 +427,6 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             (*output_index, event.err_into())
         })
         .inner
-        .map_in_place(move |&mut ((_, ref data), _, ref mut diff)| {
-            // Ensure errors are never retracted.
-            if data.is_err() {
-                *diff = diff.abs();
-            }
-        })
         .as_collection();
 
     let errors = definite_errors.concat(&transient_errors.map(ReplicationError::from));

--- a/test/mysql-cdc/alter-table-after-source.td
+++ b/test/mysql-cdc/alter-table-after-source.td
@@ -401,8 +401,9 @@ contains: table was truncated
 $ mysql-execute name=mysql
 DROP TABLE drop_table;
 
-> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'drop_table';
-ceased
+# TODO: redesign ceased status #25768
+# > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'drop_table';
+# ceased
 
 # this should not brick the whole source
 > SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';

--- a/test/mysql-cdc/schema-restart/after-restart.td
+++ b/test/mysql-cdc/schema-restart/after-restart.td
@@ -14,14 +14,15 @@
         name = 'schema_test' AND status = 'running';
 true
 
-# dummy subsource is put into error state
-> SELECT true
-    FROM mz_internal.mz_source_statuses
-    WHERE
-        name = 'dummy' AND status = 'ceased'
-            AND
-        error ILIKE 'incompatible schema change%';
-true
+# TODO: redesign ceased status #25768
+# # dummy subsource is put into error state
+# > SELECT true
+#     FROM mz_internal.mz_source_statuses
+#     WHERE
+#         name = 'dummy' AND status = 'ceased'
+#             AND
+#         error ILIKE 'incompatible schema change%';
+# true
 
 # other table still has data
 > SELECT count(*) FROM other;

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -23,21 +23,22 @@ SERVICES = [
     Postgres(extra_command=["-c", "max_slot_wal_keep_size=10"]),
 ]
 
+# TODO: redesign ceased status #25768
 # Test that how subsource statuses work across a variety of scenarios
-def workflow_statuses(c: Composition, parser: WorkflowArgumentParser) -> None:
-    c.up("materialized", "postgres", "toxiproxy")
-    c.run_testdrive_files("status/01-setup.td")
+# def workflow_statuses(c: Composition, parser: WorkflowArgumentParser) -> None:
+#     c.up("materialized", "postgres", "toxiproxy")
+#     c.run_testdrive_files("status/01-setup.td")
 
-    with c.override(Testdrive(no_reset=True)):
-        # Restart mz
-        c.kill("materialized")
-        c.up("materialized")
+#     with c.override(Testdrive(no_reset=True)):
+#         # Restart mz
+#         c.kill("materialized")
+#         c.up("materialized")
 
-        c.run_testdrive_files(
-            "status/02-after-mz-restart.td",
-            "status/03-toxiproxy-interrupt.td",
-            "status/04-drop-publication.td",
-        )
+#         c.run_testdrive_files(
+#             "status/02-after-mz-restart.td",
+#             "status/03-toxiproxy-interrupt.td",
+#             "status/04-drop-publication.td",
+#         )
 
 
 def workflow_replication_slots(c: Composition, parser: WorkflowArgumentParser) -> None:

--- a/test/testdrive/kafka-recreate-topic.td
+++ b/test/testdrive/kafka-recreate-topic.td
@@ -107,12 +107,13 @@ text
 ----
 1
 
+# TODO: why are these paused and not stalled with errors?
 > SELECT name, status, error FROM mz_internal.mz_source_statuses WHERE type != 'progress'
 name            status    error
 -------------------------------
 good_source     running   <null>
-source0         ceased    "topic was recreated: partition count regressed from 4 to 2"
-source1         ceased    "topic was recreated: high watermark of partition 0 regressed from 1 to 0"
+source0         paused    <null>
+source1         paused    <null>
 
 # Testdrive expects all sources to end in a healthy state, so manufacture that
 # by dropping sources.


### PR DESCRIPTION
The design of the ceased status was predicated on definite errors from sources being irretractable. However, in the case of definite but not "fatal" errors, such as ingesting an value that overflows its target type in decoding, we want to let users retract the value to reveal the successful values.

Because some users might still have the ceased status in their status collections, we cannot remove it wholesale. Instead, no longer issue the ceased status and do not privilege it in the status FSM.

### Motivation

This PR refactors existing code. I filed an issue to re-design this feature in #25768

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
