### PR TITLE
[persist] Make the streaming consolidate impls the default

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -52,8 +52,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     # Persist internals changes: advance coverage
     "persist_enable_arrow_lgalloc_noncc_sizes": "true",
     "persist_enable_s3_lgalloc_noncc_sizes": "true",
-    "persist_streaming_compaction_enabled": "true",
-    "persist_streaming_snapshot_and_fetch_enabled": "true",
     # -----
     # Others (ordered by name)
     "cluster_always_use_disk": "true",

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -36,7 +36,7 @@ use crate::operators::{
     PERSIST_SINK_MINIMUM_BATCH_UPDATES, STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES,
     STORAGE_SOURCE_DECODE_FUEL,
 };
-use crate::read::{READER_LEASE_DURATION, STREAMING_SNAPSHOT_AND_FETCH_ENABLED};
+use crate::read::READER_LEASE_DURATION;
 
 /// The tunable knobs for persist.
 ///
@@ -263,7 +263,6 @@ impl PersistConfig {
         let mut cfg = Self::new_default_configs(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
         cfg.hostname = "tests".into();
         cfg.set_config(&STREAMING_COMPACTION_ENABLED, true);
-        cfg.set_config(&STREAMING_SNAPSHOT_AND_FETCH_ENABLED, true);
         cfg
     }
 }
@@ -296,7 +295,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::operators::STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
         .add(&crate::operators::STORAGE_SOURCE_DECODE_FUEL)
         .add(&crate::read::READER_LEASE_DURATION)
-        .add(&crate::read::STREAMING_SNAPSHOT_AND_FETCH_ENABLED)
         .add(&crate::rpc::PUBSUB_CLIENT_ENABLED)
         .add(&crate::rpc::PUBSUB_PUSH_DIFF_ENABLED)
         .add(&crate::stats::STATS_AUDIT_PERCENT)

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -26,7 +26,6 @@ use proptest_derive::Arbitrary;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use crate::internal::compact::STREAMING_COMPACTION_ENABLED;
 use crate::internal::machine::{
     NEXT_LISTEN_BATCH_RETRYER_CLAMP, NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF,
     NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER,
@@ -262,7 +261,6 @@ impl PersistConfig {
 
         let mut cfg = Self::new_default_configs(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
         cfg.hostname = "tests".into();
-        cfg.set_config(&STREAMING_COMPACTION_ENABLED, true);
         cfg
     }
 }
@@ -285,7 +283,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::cfg::CRDB_TCP_USER_TIMEOUT)
         .add(&crate::internal::cache::BLOB_CACHE_MEM_LIMIT_BYTES)
         .add(&crate::internal::compact::COMPACTION_MINIMUM_TIMEOUT)
-        .add(&crate::internal::compact::STREAMING_COMPACTION_ENABLED)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_CLAMP)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_FIXED_SLEEP)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1239,9 +1239,7 @@ pub mod datadriven {
         BLOB_TARGET_SIZE,
     };
     use crate::fetch::{fetch_batch_part, Cursor};
-    use crate::internal::compact::{
-        CompactConfig, CompactReq, Compactor, STREAMING_COMPACTION_ENABLED,
-    };
+    use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
     use crate::internal::datadriven::DirectiveArgs;
     use crate::internal::encoding::Schemas;
     use crate::internal::gc::GcReq;
@@ -1277,7 +1275,6 @@ pub mod datadriven {
             client
                 .cfg
                 .set_config(&BLOB_TARGET_SIZE, *BLOB_TARGET_SIZE.default());
-            client.cfg.set_config(&STREAMING_COMPACTION_ENABLED, true);
             let state_versions = Arc::new(StateVersions::new(
                 client.cfg.clone(),
                 Arc::clone(&client.consensus),

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1247,9 +1247,7 @@ pub mod datadriven {
     use crate::internal::gc::GcReq;
     use crate::internal::paths::{BlobKey, BlobKeyPrefix, PartialBlobKey};
     use crate::internal::state_versions::EncodedRollup;
-    use crate::read::{
-        Listen, ListenEvent, READER_LEASE_DURATION, STREAMING_SNAPSHOT_AND_FETCH_ENABLED,
-    };
+    use crate::read::{Listen, ListenEvent, READER_LEASE_DURATION};
     use crate::rpc::NoopPubSubSender;
     use crate::tests::new_test_client;
     use crate::{GarbageCollector, PersistClient};
@@ -1280,9 +1278,6 @@ pub mod datadriven {
                 .cfg
                 .set_config(&BLOB_TARGET_SIZE, *BLOB_TARGET_SIZE.default());
             client.cfg.set_config(&STREAMING_COMPACTION_ENABLED, true);
-            client
-                .cfg
-                .set_config(&STREAMING_SNAPSHOT_AND_FETCH_ENABLED, true);
             let state_versions = Arc::new(StateVersions::new(
                 client.cfg.clone(),
                 Arc::clone(&client.consensus),

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -983,12 +983,6 @@ where
     }
 }
 
-pub(crate) const STREAMING_SNAPSHOT_AND_FETCH_ENABLED: Config<bool> = Config::new(
-    "persist_streaming_snapshot_and_fetch_enabled",
-    false,
-    "use the new streaming consolidate during snapshot_and_fetch",
-);
-
 impl<K, V, T, D> ReadHandle<K, V, T, D>
 where
     K: Debug + Codec + Ord,
@@ -1010,58 +1004,6 @@ where
     /// - Reuse any code we write to streaming-merge consolidate in
     ///   persist_source here.
     pub async fn snapshot_and_fetch(
-        &mut self,
-        as_of: Antichain<T>,
-    ) -> Result<Vec<((Result<K, String>, Result<V, String>), T, D)>, Since<T>> {
-        if STREAMING_SNAPSHOT_AND_FETCH_ENABLED.get(&self.machine.applier.cfg) {
-            return self.snapshot_and_fetch_streaming(as_of).await;
-        }
-
-        let snap = self.snapshot(as_of).await?;
-
-        let mut contents = Vec::new();
-        let mut last_consolidate_len = 0;
-        let mut is_consolidated = true;
-        for part in snap {
-            let fetched_part = fetch_leased_part(
-                &part,
-                self.blob.as_ref(),
-                Arc::clone(&self.metrics),
-                &self.metrics.read.snapshot,
-                &self.machine.applier.shard_metrics,
-                &self.reader_id,
-                self.schemas.clone(),
-            )
-            .await;
-            self.process_returned_leased_part(part);
-            contents.extend(fetched_part);
-            // NB: FetchedPart streaming consolidates its output, but it's possible
-            // that decoding introduces duplicates again.
-            is_consolidated = false;
-
-            // If the size of contents has doubled since the last consolidated
-            // size, try consolidating it again.
-            if contents.len() >= last_consolidate_len * 2 {
-                consolidate_updates(&mut contents);
-                last_consolidate_len = contents.len();
-                is_consolidated = true
-            }
-        }
-
-        // Note that if there is only one part, it's consolidated in the loop
-        // above, and we don't consolidate it again here.
-        if !is_consolidated {
-            consolidate_updates(&mut contents);
-        }
-        Ok(contents)
-    }
-
-    /// Generates a [Self::snapshot], and fetches all of the batches it
-    /// contains.
-    ///
-    /// The output is consolidated. Furthermore, to keep memory usage down when
-    /// reading a snapshot that consolidates well, this consolidates as it goes.
-    async fn snapshot_and_fetch_streaming(
         &mut self,
         as_of: Antichain<T>,
     ) -> Result<Vec<((Result<K, String>, Result<V, String>), T, D)>, Since<T>> {


### PR DESCRIPTION
These streaming impls have been enabled in our staging and sandbox envs for a long time with no issues.

### Motivation

We don't expect (or observe) huge improvements from making these streaming, since they both read all the data into memory. (They are _probably_ a bit more memory-efficient, but it's hard to measure.) However, this does let us avoid duplicating a bunch of code for the streaming and non-streaming cases.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
