### PR TITLE
Refresh MV warmup before first refresh

### DIFF
--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -692,6 +692,8 @@ pub struct MaterializedView {
     pub non_null_assertions: Vec<usize>,
     pub custom_logical_compaction_window: Option<CompactionWindow>,
     pub refresh_schedule: Option<RefreshSchedule>,
+    // The initial `as_of` of the storage collection associated with the materialized view.
+    // (The dataflow's initial `as_of` can be different.)
     pub initial_as_of: Option<Antichain<mz_repr::Timestamp>>,
 }
 

--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -266,3 +266,26 @@ true
   WHERE m.name = 'mv8'
 r1 true
 r2 true
+
+## Warmup before the first refresh
+
+# MV with a first refresh in the far future
+> CREATE MATERIALIZED VIEW mv9 WITH (REFRESH AT mz_now()::text::int8 + 1000000) AS
+  SELECT x*x FROM t3;
+
+# Check that all operators have hydrated. Ideally, we'd want to check `mz_hydration_statuses`, but that is
+# currently wrong for REFRESH MVs, see https://github.com/MaterializeInc/materialize/issues/25518
+> SELECT DISTINCT hydrated
+  FROM mz_internal.mz_compute_operator_hydration_statuses h JOIN mz_objects o ON (h.object_id = o.id)
+  WHERE name = 'mv9';
+true
+
+# Try the same with a less trivial MV. (In particular, hydration behaves differently when we have a pipeline breaker,
+# such as an arrangement.)
+> CREATE MATERIALIZED VIEW mv10 WITH (REFRESH AT mz_now()::text::int8 + 1000000) AS
+  SELECT DISTINCT x, y FROM t2, t3;
+
+> SELECT DISTINCT hydrated
+  FROM mz_internal.mz_compute_operator_hydration_statuses h JOIN mz_objects o ON (h.object_id = o.id)
+  WHERE name = 'mv10';
+true


### PR DESCRIPTION
To allow REFRESH MVs to warm up before their first refresh (when the first refresh is in the future), we tweak the `as_of` selection of REFRESH MVs: for the Storage collection, we use the same `as_of` as before (the first refresh, so that the MV is not readable before the first refresh), but for the dataflow we just select `least_valid_read`, so that hydration can start immediately.

The added test currently relies on `mz_compute_operator_hydration_statuses`, but we can change it to `mz_hydration_statuses` after we do the tweak described [here](https://github.com/MaterializeInc/materialize/issues/25518#issuecomment-1980891837) in a later PR. Btw. here we have a different problem in `mz_hydration_statuses` from what is described in that issue. Here, the problem is that `mz_hydration_statuses` shows `false` up until the first refresh, because the Persist sink's frontier is not advanced before that, because it wants to read the Persist collection at the Persist collection's `since` (which is the first refresh) to do the self-correcting behavior.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/25278

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
  - [ ] Nightly run: https://buildkite.com/materialize/nightlies/builds/6785#018e1403-a91d-4a76-bcfc-415b1d9b83f4
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
