### PR TITLE
dbt-materialize: check dbt has the proper permissions to execute a deployment

### DIFF
--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
@@ -43,6 +43,8 @@
     {% endif %}
 {% endfor %}
 
+{{ deploy_permission_validation(clusters) }}
+
 {% for schema in schemas %}
     {% set deploy_schema = schema ~ "_dbt_deploy" %}
     {% if schema_exists(deploy_schema) %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
@@ -43,7 +43,7 @@
     {% endif %}
 {% endfor %}
 
-{{ deploy_permission_validation(clusters) }}
+{{ deploy_validate_permissions(clusters, schemas) }}
 
 {% for schema in schemas %}
     {% set deploy_schema = schema ~ "_dbt_deploy" %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_permission_validation.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_permission_validation.sql
@@ -1,0 +1,111 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{% macro deploy_permission_validation(clusters=[]) %}
+
+{% set is_not_super_user %}
+    SELECT mz_is_superuser() IS FALSE;
+{% endset %}
+
+{% set not_super_user = run_query(is_not_super_user) %}
+{% if execute %}
+    {% if not_super_user.rows[0][0] %}
+        {{ internal_ensure_database_create_permission() }}
+        {{ internal_ensure_createcluster_permission() }}
+        {{ internal_ensure_cluster_ownership(clusters) }}
+    {% endif %}
+{% endif %}
+
+{% endmacro %}
+
+{% macro internal_ensure_database_create_permission() %}
+{% set database_can_create %}
+WITH permission AS (
+    SELECT count(*) = 0 AS missing_permission
+    FROM mz_internal.mz_show_my_database_privileges
+    WHERE privilege_type = 'CREATE' AND name = current_database()
+)
+
+SELECT missing_permission, current_user(), current_database()
+FROM permission;
+{% endset %}
+
+{% set database_check = run_query(database_can_create) %}
+{% if execute %}
+    {% if database_check.rows[0][0] %}
+        {{ exceptions.raise_compiler_error("""
+            Missing necessary permissions to execute a deployment.
+
+            The current user """ ~ database_check.rows[0][1] ~ """ needs
+            CREATE privlidges on database """ ~ database_check.rows[0][2]
+        ) }}
+    {% endif %}
+{% endif %}
+{% endmacro %}
+
+{% macro internal_ensure_createcluster_permission() %}
+{% set has_create_cluster = run_query("SELECT has_system_privilege('CREATECLUSTER') IS FALSE, current_user()") %}
+{% if execute %}
+    {% if has_create_cluster.rows[0][0] %}
+        {{ exceptions.raise_compiler_error("""
+            Missing necessary permissions to execute a deployment.
+
+            The current user """ ~ has_create_cluster.rows[0][1] ~ """ needs CREATECLUSTER privlidges
+        """) }}
+    {% endif %}
+{% endif %}
+{% endmacro %}
+
+{% macro internal_ensure_cluster_ownership(clusters=[]) %}
+{% set has_cluster_ownership %}
+WITH clusters_under_deployment AS (
+    SELECT * FROM mz_internal.mz_show_my_cluster_privileges
+    WHERE name IN (
+    {% if clusters|length > 0 %}
+        {% for cluster in clusters %}
+            lower(trim('{{ cluster }}')){% if not loop.last %},{% endif %}
+        {% endfor %}
+    {% else %}
+        NULL
+    {% endif %}
+    )
+),
+
+cluster_with_ownership AS (
+    SELECT * FROM clusters_under_deployment
+    WHERE privilege_type = 'OWNER'
+)
+
+SELECT name, current_user()
+FROM cluster_with_ownership
+
+EXCEPT
+
+SELECT name, current_user()
+FROM clusters_under_deployment
+{% endset %}
+
+{% set cluster_ownership = run_query(has_cluster_ownership) %}
+{% if execute %}
+    {% if cluster_ownership|length > 0 %}
+        {{ exceptions.raise_compiler_error("""
+            Missing necessary permissions to execute a deployment.
+
+            The current user """ ~ cluster_ownership.rows[0][1] ~ """ needs OWNER privlidges
+            on cluster """ ~ cluster_ownership.rows[0][0]
+        )}}
+    {% endif %}
+{% endif %}
+{% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_permission_validation.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_permission_validation.sql
@@ -13,7 +13,12 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro deploy_permission_validation(clusters=[]) %}
+-- The deployment user must be a superuser OR
+--
+-- Have CREATE and USAGE rights on the database
+-- Have CREATECLUSTER rights
+-- Have OWNERSHIP rights on the production clusters and schemas
+{% macro deploy_validate_permissions(clusters=[], schemas=[]) %}
 
 {% set is_not_super_user %}
     SELECT mz_is_superuser() IS FALSE;
@@ -22,35 +27,43 @@
 {% set not_super_user = run_query(is_not_super_user) %}
 {% if execute %}
     {% if not_super_user.rows[0][0] %}
-        {{ internal_ensure_database_create_permission() }}
+        {{ internal_ensure_database_permission() }}
         {{ internal_ensure_createcluster_permission() }}
+        {{ internal_ensure_schema_ownership(schemas) }}
         {{ internal_ensure_cluster_ownership(clusters) }}
     {% endif %}
 {% endif %}
 
 {% endmacro %}
 
-{% macro internal_ensure_database_create_permission() %}
-{% set database_can_create %}
-WITH permission AS (
-    SELECT count(*) = 0 AS missing_permission
+{% macro internal_ensure_database_permission() %}
+{% set database_permissions %}
+WITH create_permission AS (
+    SELECT count(*) = 0 AS missing_create
     FROM mz_internal.mz_show_my_database_privileges
     WHERE privilege_type = 'CREATE' AND name = current_database()
+),
+
+usage_permission AS (
+    SELECT count(*) = 0 AS missing_usage
+    FROM mz_internal.mz_show_my_database_privileges
+    WHERE privilege_type = 'USAGE' AND name = current_database()
 )
 
-SELECT missing_permission, current_user(), current_database()
-FROM permission;
+SELECT missing_create, missing_usage, quote_ident(current_role), current_database()
+FROM create_permission, usage_permission;
 {% endset %}
 
-{% set database_check = run_query(database_can_create) %}
+{% set database_check = run_query(database_permissions) %}
 {% if execute %}
-    {% if database_check.rows[0][0] %}
+    {% if database_check.rows[0][0] or database_check[0][1] %}
         {{ exceptions.raise_compiler_error("""
-            Missing necessary permissions to execute a deployment.
+            Missing necessary permissions to execute a deployment. The current role """ ~
+            database_check.rows[0][2] ~ """ needs CREATE and USAGE privileges on database """ ~
+            database_check.rows[0][3] ~ """.
 
-            The current user """ ~ database_check.rows[0][1] ~ """ needs
-            CREATE privlidges on database """ ~ database_check.rows[0][2]
-        ) }}
+            Hint: `GRANT USAGE, CREATE ON DATABASE """ ~ database_check.rows[0][2] ~ """ TO """ ~ database_check.rows[0][3] ~ """;`
+        """) }}
     {% endif %}
 {% endif %}
 {% endmacro %}
@@ -60,9 +73,10 @@ FROM permission;
 {% if execute %}
     {% if has_create_cluster.rows[0][0] %}
         {{ exceptions.raise_compiler_error("""
-            Missing necessary permissions to execute a deployment.
+            Missing necessary permissions to execute a deployment. The current role
+            """ ~ has_create_cluster.rows[0][1] ~ """ needs CREATECLUSTER privlidges.
 
-            The current user """ ~ has_create_cluster.rows[0][1] ~ """ needs CREATECLUSTER privlidges
+            Hint: `GRANT CREATECLUSTER ON SYSTEM TO """ ~ has_create_cluster.rows[0][1] ~ """;`
         """) }}
     {% endif %}
 {% endif %}
@@ -71,7 +85,7 @@ FROM permission;
 {% macro internal_ensure_cluster_ownership(clusters=[]) %}
 {% set has_cluster_ownership %}
 WITH clusters_under_deployment AS (
-    SELECT * FROM mz_internal.mz_show_my_cluster_privileges
+    SELECT name, owner_id FROM mz_clusters
     WHERE name IN (
     {% if clusters|length > 0 %}
         {% for cluster in clusters %}
@@ -84,28 +98,85 @@ WITH clusters_under_deployment AS (
 ),
 
 cluster_with_ownership AS (
-    SELECT * FROM clusters_under_deployment
-    WHERE privilege_type = 'OWNER'
+    SELECT c.name FROM clusters_under_deployment c
+    INNER JOIN mz_roles ON c.owner_id = mz_roles.id
+    WHERE mz_roles.name = current_role
+),
+
+missing_ownership AS (
+    SELECT name
+    FROM cluster_with_ownership
+
+    EXCEPT
+
+    SELECT name
+    FROM clusters_under_deployment
 )
 
-SELECT name, current_user()
-FROM cluster_with_ownership
-
-EXCEPT
-
-SELECT name, current_user()
-FROM clusters_under_deployment
+SELECT name, quote_ident(current_role)
+FROM missing_ownership
 {% endset %}
 
 {% set cluster_ownership = run_query(has_cluster_ownership) %}
 {% if execute %}
     {% if cluster_ownership|length > 0 %}
         {{ exceptions.raise_compiler_error("""
-            Missing necessary permissions to execute a deployment.
+            Missing necessary permissions to execute a deployment. The current role """
+            ~ cluster_ownership.rows[0][1] ~ """ needs to be an owner of cluster """ ~ cluster_ownership.rows[0][0] ~ """.
 
-            The current user """ ~ cluster_ownership.rows[0][1] ~ """ needs OWNER privlidges
-            on cluster """ ~ cluster_ownership.rows[0][0]
-        )}}
+            Hint: `ALTER CLUSTER """ ~ cluster_ownership.rows[0][0] ~ """ OWNER TO """ ~ cluster_ownership.rows[0][1] ~ """;`
+        """)}}
+    {% endif %}
+{% endif %}
+{% endmacro %}
+
+{% macro internal_ensure_schema_ownership(schemas=[]) %}
+{% set has_schema_ownership %}
+WITH schemas_under_deployment AS (
+    SELECT mz_schemas.*
+    FROM mz_schemas
+    JOIN mz_databases ON mz_schemas.database_id = mz_databases.id
+    WHERE mz_databases.name = current_database() AND mz_schemas.name IN (
+    {% if schemas|length > 0 %}
+        {% for schema in schemas %}
+            lower(trim('{{ schema }}')){% if not loop.last %},{% endif %}
+        {% endfor %}
+    {% else %}
+        NULL
+    {% endif %}
+    )
+),
+
+schemas_with_ownership AS (
+    SELECT s.name FROM schemas_under_deployment s
+    INNER JOIN mz_roles ON s.owner_id = mz_roles.id
+    WHERE mz_roles.name = current_role
+),
+
+missing_ownership AS (
+    SELECT name
+    FROM schemas_with_ownership
+
+    EXCEPT
+
+    SELECT name
+    FROM schemas_under_deployment
+)
+
+SELECT name, quote_ident(current_role)
+FROM missing_ownership
+{% endset %}
+
+{% set schema_ownership = run_query(has_schema_ownership) %}
+{% if execute %}
+    {% if schema_ownership|length > 0 %}
+        {{ exceptions.raise_compiler_error("""
+            Missing necessary permissions to execute a deployment. The current role """
+            ~ schema_ownership.rows[0][1] ~ """ needs to be an owner of cluster """ ~
+            schema_ownership.rows[0][0] ~ """.
+
+            Hint: `ALTER SCHEMA """ ~ schema_ownership.rows[0][0] ~ """ OWNER TO """ ~ schema_ownership.rows[0][1] ~ """;`
+        """)}}
     {% endif %}
 {% endif %}
 {% endmacro %}

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -106,13 +106,24 @@ class TestCIFixture:
 class TestPermissionValidation:
     """Tests for database permissions. We run against the internal
     macros because the materialize user is a superuser and we'd short
-    circuit these checks if executing deploy_permission_validation"""
+    circuit these checks if executing deploy_validate_permissions"""
 
     def test_createcluster_permissions(self, project):
         run_dbt(["run-operation", "internal_ensure_createcluster_permission"])
 
     def test_database_create_permissions(self, project):
-        run_dbt(["run-operation", "internal_ensure_database_create_permission"])
+        run_dbt(["run-operation", "internal_ensure_database_permission"])
+
+    def test_schema_owner_permissions(self, project):
+        project.run_sql("CREATE SCHEMA my_schema")
+        run_dbt(
+            [
+                "run-operation",
+                "internal_ensure_schema_ownership",
+                "--args",
+                "{schemas: ['my_schema']}",
+            ]
+        )
 
     def test_cluster_owner_permissions(self, project):
         run_dbt(

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -103,6 +103,28 @@ class TestCIFixture:
         )
 
 
+class TestPermissionValidation:
+    """Tests for database permissions. We run against the internal
+    macros because the materialize user is a superuser and we'd short
+    circuit these checks if executing deploy_permission_validation"""
+
+    def test_createcluster_permissions(self, project):
+        run_dbt(["run-operation", "internal_ensure_createcluster_permission"])
+
+    def test_database_create_permissions(self, project):
+        run_dbt(["run-operation", "internal_ensure_database_create_permission"])
+
+    def test_cluster_owner_permissions(self, project):
+        run_dbt(
+            [
+                "run-operation",
+                "internal_ensure_cluster_ownership",
+                "--args",
+                "{clusters: ['quickstart']}",
+            ]
+        )
+
+
 class TestRunWithDeploy:
     @pytest.fixture(scope="class")
     def project_config_update(self):


### PR DESCRIPTION
### Motivation

Validate the dbt user has the right permissions to execute a deployment. 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
