### PR TITLE
repr: remove an alloc in the Datum::Bytes decode path

### DIFF
--- a/misc/scratch/provision.bash
+++ b/misc/scratch/provision.bash
@@ -17,9 +17,11 @@ set -euo pipefail
 # Install APT dependencies.
 apt-get update
 apt-get install -y \
+    build-essential \
     cmake \
     g++ \
     libclang-dev \
+    lld \
     postgresql-client \
     python3-venv \
     unzip

--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -15,6 +15,7 @@ fn main() {
     prost_build::Config::new()
         .btree_map(["."])
         .extern_path(".mz_proto", "::mz_proto")
+        .bytes([".mz_repr.row.ProtoDatum.bytes"])
         .compile_protos(
             &[
                 "repr/src/antichain.proto",

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -11,7 +11,7 @@
 //!
 //! See row.proto for details.
 
-use bytes::BufMut;
+use bytes::{BufMut, Bytes};
 use chrono::Timelike;
 use dec::Decimal;
 use enum_dispatch::enum_dispatch;
@@ -802,7 +802,7 @@ impl<'a> From<Datum<'a>> for ProtoDatum {
             Datum::Timestamp(x) => DatumType::Timestamp(x.into_proto()),
             Datum::TimestampTz(x) => DatumType::TimestampTz(x.into_proto()),
             Datum::Interval(x) => DatumType::Interval(x.into_proto()),
-            Datum::Bytes(x) => DatumType::Bytes(x.to_vec()),
+            Datum::Bytes(x) => DatumType::Bytes(Bytes::copy_from_slice(x)),
             Datum::String(x) => DatumType::String(x.to_owned()),
             Datum::Array(x) => DatumType::Array(ProtoArray {
                 elements: Some(ProtoRow {


### PR DESCRIPTION
Small win and irrelevant once we change the blob format, but easy.

    roundtrip_bytes_decode_legacy
                        time:   [2.8988 ms 2.8990 ms 2.8993 ms]
                        change: [-3.9216% -3.9051% -3.8878%] (p = 0.00 < 0.05)

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
