### PR TITLE
storage, compute: copy to s3 with multiple workers

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -435,6 +435,8 @@ pub struct CopyToContext {
     pub max_file_size: u64,
     /// Number of batches the output of the COPY TO will be partitioned into
     /// to distribute the load across workers deterministically.
+    /// This is only an option since it's not set when CopyToContext is instantiated
+    /// but immediately after in the PeekStageValidate stage.
     pub output_batch_count: Option<u64>,
 }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -433,9 +433,9 @@ pub struct CopyToContext {
     pub format_params: CopyFormatParams<'static>,
     /// Approximate max file size of each uploaded file.
     pub max_file_size: u64,
-    /// Number of buckets the output of the COPY TO will be partitioned into
+    /// Number of batches the output of the COPY TO will be partitioned into
     /// to distribute the load across workers deterministically.
-    pub output_bucket_count: Option<u64>,
+    pub output_batch_count: Option<u64>,
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -433,6 +433,9 @@ pub struct CopyToContext {
     pub format_params: CopyFormatParams<'static>,
     /// Approximate max file size of each uploaded file.
     pub max_file_size: u64,
+    /// Number of buckets the output of the COPY TO will be partitioned into
+    /// to distribute the load across workers deterministically.
+    pub output_bucket_count: Option<u64>,
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -17,6 +17,7 @@ use itertools::Either;
 use maplit::btreemap;
 use mz_controller_types::ClusterId;
 use mz_expr::{CollectionPlan, ResultSpec};
+use mz_ore::cast::CastFrom;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{instrument, task};
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
@@ -142,6 +143,8 @@ impl Coordinator {
                     connection_id,
                     format_params,
                     max_file_size,
+                    // This will be set in `peek_stage_validate` stage below.
+                    output_bucket_count: None,
                 }),
                 explain_ctx: ExplainContext::None,
             }),
@@ -297,6 +300,12 @@ impl Coordinator {
             .override_from(&self.catalog.get_cluster(cluster.id()).config.features())
             .override_from(&explain_ctx);
 
+        if cluster.replicas().next().is_none() {
+            return Err(AdapterError::NoClusterReplicasAvailable(
+                cluster.name.clone(),
+            ));
+        }
+
         let optimizer = match copy_to_ctx {
             None => {
                 // Collect optimizer parameters specific to the peek::Optimizer.
@@ -317,7 +326,17 @@ impl Coordinator {
                     self.optimizer_metrics(),
                 ))
             }
-            Some(copy_to_ctx) => {
+            Some(mut copy_to_ctx) => {
+                // Getting the max worker count across replicas
+                // and using that value for the number of buckets to
+                // divide the copy to output into.
+                let max_worker_count = cluster
+                    .replicas()
+                    .map(|r| r.config.location.workers())
+                    .max()
+                    .map(u64::cast_from);
+                assert!(max_worker_count.is_some());
+                copy_to_ctx.output_bucket_count = max_worker_count;
                 // Build an optimizer for this COPY TO.
                 Either::Right(optimize::copy_to::Optimizer::new(
                     Arc::clone(&catalog),
@@ -341,12 +360,6 @@ impl Coordinator {
                     })
             })
             .transpose()?;
-
-        if cluster.replicas().next().is_none() {
-            return Err(AdapterError::NoClusterReplicasAvailable(
-                cluster.name.clone(),
-            ));
-        }
 
         let source_ids = plan.source.depends_on();
         let mut timeline_context = self.validate_timeline_context(source_ids.clone())?;
@@ -942,7 +955,6 @@ impl Coordinator {
         stage: PeekStageExplainPushdown,
     ) -> Result<ExecuteResponse, AdapterError> {
         use futures::stream::TryStreamExt;
-        use mz_ore::cast::CastFrom;
 
         let as_of = stage.determination.timestamp_context.antichain();
         let mz_now = stage

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -242,10 +242,10 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
                     },
                     aws_connection: aws_connection.clone(),
                     connection_id: self.copy_to_context.connection_id,
-                    output_bucket_count: self
+                    output_batch_count: self
                         .copy_to_context
-                        .output_bucket_count
-                        .expect("output_bucket_count should be set in sequencer"),
+                        .output_batch_count
+                        .expect("output_batch_count should be set in sequencer"),
                 })
             }
             _ => {

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -242,6 +242,10 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
                     },
                     aws_connection: aws_connection.clone(),
                     connection_id: self.copy_to_context.connection_id,
+                    output_bucket_count: self
+                        .copy_to_context
+                        .output_bucket_count
+                        .expect("output_bucket_count should be set in sequencer"),
                 })
             }
             _ => {

--- a/src/compute-types/src/sinks.proto
+++ b/src/compute-types/src/sinks.proto
@@ -50,5 +50,5 @@ message ProtoCopyToS3OneshotSinkConnection {
     mz_storage_types.sinks.ProtoS3UploadInfo upload_info = 1;
     mz_storage_types.connections.aws.ProtoAwsConnection aws_connection = 2;
     mz_repr.global_id.ProtoGlobalId connection_id = 3;
-    uint64 output_bucket_count = 4;
+    uint64 output_batch_count = 4;
 }

--- a/src/compute-types/src/sinks.proto
+++ b/src/compute-types/src/sinks.proto
@@ -50,4 +50,5 @@ message ProtoCopyToS3OneshotSinkConnection {
     mz_storage_types.sinks.ProtoS3UploadInfo upload_info = 1;
     mz_storage_types.connections.aws.ProtoAwsConnection aws_connection = 2;
     mz_repr.global_id.ProtoGlobalId connection_id = 3;
+    uint64 output_bucket_count = 4;
 }

--- a/src/compute-types/src/sinks.rs
+++ b/src/compute-types/src/sinks.rs
@@ -184,9 +184,9 @@ pub struct CopyToS3OneshotSinkConnection {
     /// The ID of the Connection object, used to generate the External ID when
     /// using AssumeRole with AWS connection.
     pub connection_id: GlobalId,
-    /// The number of buckets the COPY TO output will be divided into
-    /// where each worker will process 0 or more buckets of data.
-    pub output_bucket_count: u64,
+    /// The number of batches the COPY TO output will be divided into
+    /// where each worker will process 0 or more batches of data.
+    pub output_batch_count: u64,
 }
 
 impl RustType<ProtoCopyToS3OneshotSinkConnection> for CopyToS3OneshotSinkConnection {
@@ -195,7 +195,7 @@ impl RustType<ProtoCopyToS3OneshotSinkConnection> for CopyToS3OneshotSinkConnect
             upload_info: Some(self.upload_info.into_proto()),
             aws_connection: Some(self.aws_connection.into_proto()),
             connection_id: Some(self.connection_id.into_proto()),
-            output_bucket_count: self.output_bucket_count,
+            output_batch_count: self.output_batch_count,
         }
     }
 
@@ -210,7 +210,7 @@ impl RustType<ProtoCopyToS3OneshotSinkConnection> for CopyToS3OneshotSinkConnect
             connection_id: proto
                 .connection_id
                 .into_rust_if_some("ProtoCopyToS3OneshotSinkConnection::connection_id")?,
-            output_bucket_count: proto.output_bucket_count,
+            output_batch_count: proto.output_batch_count,
         })
     }
 }

--- a/src/compute-types/src/sinks.rs
+++ b/src/compute-types/src/sinks.rs
@@ -184,6 +184,9 @@ pub struct CopyToS3OneshotSinkConnection {
     /// The ID of the Connection object, used to generate the External ID when
     /// using AssumeRole with AWS connection.
     pub connection_id: GlobalId,
+    /// The number of buckets the COPY TO output will be divided into
+    /// where each worker will process 0 or more buckets of data.
+    pub output_bucket_count: u64,
 }
 
 impl RustType<ProtoCopyToS3OneshotSinkConnection> for CopyToS3OneshotSinkConnection {
@@ -192,6 +195,7 @@ impl RustType<ProtoCopyToS3OneshotSinkConnection> for CopyToS3OneshotSinkConnect
             upload_info: Some(self.upload_info.into_proto()),
             aws_connection: Some(self.aws_connection.into_proto()),
             connection_id: Some(self.connection_id.into_proto()),
+            output_bucket_count: self.output_bucket_count,
         }
     }
 
@@ -206,6 +210,7 @@ impl RustType<ProtoCopyToS3OneshotSinkConnection> for CopyToS3OneshotSinkConnect
             connection_id: proto
                 .connection_id
                 .into_rust_if_some("ProtoCopyToS3OneshotSinkConnection::connection_id")?,
+            output_bucket_count: proto.output_bucket_count,
         })
     }
 }

--- a/src/compute/src/sink/copy_to_s3_oneshot.rs
+++ b/src/compute/src/sink/copy_to_s3_oneshot.rs
@@ -64,8 +64,7 @@ where
         // we can write files to s3 deterministically across different replicas of different sizes
         // using the bucket ID. Each worker will split a bucket's data into 1 or more
         // files based on the user provided `MAX_FILE_SIZE`.
-        // TODO(#7256): make the number of buckets configurable.
-        let bucket_count = 20;
+        let bucket_count = self.output_bucket_count;
 
         let input = consolidate_pact::<KeyBatcher<_, _, _>, _, _, _, _, _>(
             &sinked_collection.map(move |row| {

--- a/src/compute/src/sink/copy_to_s3_oneshot.rs
+++ b/src/compute/src/sink/copy_to_s3_oneshot.rs
@@ -66,6 +66,8 @@ where
         // files based on the user provided `MAX_FILE_SIZE`.
         let bucket_count = self.output_bucket_count;
 
+        // TODO(#25835): Note, even though we do get deterministic output currently
+        // after the exchange below, it's not explicitly supported and we should change it.
         let input = consolidate_pact::<KeyBatcher<_, _, _>, _, _, _, _, _>(
             &sinked_collection.map(move |row| {
                 let bucket = row.hashed() % bucket_count;

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -197,6 +197,16 @@ impl ReplicaLocation {
             ReplicaLocation::Unmanaged(_) => false,
         }
     }
+
+    pub fn workers(&self) -> usize {
+        let workers_per_process = match self {
+            ReplicaLocation::Managed(ManagedReplicaLocation { allocation, .. }) => {
+                allocation.workers
+            }
+            ReplicaLocation::Unmanaged(UnmanagedReplicaLocation { workers, .. }) => *workers,
+        };
+        workers_per_process * self.num_processes()
+    }
 }
 
 /// The "role" of a cluster, which is currently used to determine the

--- a/src/storage-operators/src/s3_oneshot_sink.rs
+++ b/src/storage-operators/src/s3_oneshot_sink.rs
@@ -32,8 +32,11 @@ use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::Scope;
 use timely::progress::Antichain;
 use timely::PartialOrder;
-use tracing::info;
+use tracing::{debug, info};
 
+/// Copy the rows from the input collection to s3.
+/// `onetime_callback` is used to send the final count of rows uploaded to s3,
+/// or an error message if the operator failed.
 pub fn copy_to<G, F>(
     input_collection: Collection<G, ((Row, u64), ()), Diff>,
     err_collection: Collection<G, ((DataflowError, u64), ()), Diff>,
@@ -104,7 +107,7 @@ pub fn copy_to<G, F>(
                             let uploader = s3_uploaders
                                 .entry(batch)
                                 .or_insert_with(|| {
-                                    info!("worker_id: {} will be handling batch: {}", worker_id, batch);
+                                    debug!("worker_id: {} will be handling batch: {}", worker_id, batch);
                                     let file_name_prefix = format!("batch-{:04}", batch);
                                     CopyToS3Uploader::new(sdk_config.clone(), connection_details.clone(), file_name_prefix)
                                 });

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -16,27 +16,46 @@ pub async fn run_verify_data(
     mut cmd: BuiltinCommand,
     state: &State,
 ) -> Result<ControlFlow, anyhow::Error> {
-    let expected_body = cmd.input.join("\n") + "\n";
+    let mut expected_body = cmd.input;
     let bucket: String = cmd.args.parse("bucket")?;
     let key: String = cmd.args.parse("key")?;
+    let sort_rows = cmd.args.opt_bool("sort-rows")?.unwrap_or(false);
     cmd.args.done()?;
 
     println!("Verifying contents of S3 bucket {bucket} key {key}...");
 
     let client = mz_aws_util::s3::new_client(&state.aws_config);
-    let file = client
-        .get_object()
-        .bucket(bucket)
-        .key(format!("{}/part-0001.csv", key))
+    let files = client
+        .list_objects_v2()
+        .bucket(&bucket)
+        .prefix(&format!("{}/", key))
         .send()
         .await?;
-    let bytes = file.body.collect().await?.into_bytes();
-    let actual_body = str::from_utf8(bytes.as_ref())?;
-    if *actual_body != *expected_body {
+    if files.contents.is_none() {
+        bail!("no files found in bucket {bucket} key {key}");
+    }
+
+    let mut rows = vec![];
+    for obj in files.contents.unwrap().iter() {
+        let file = client
+            .get_object()
+            .bucket(&bucket)
+            .key(obj.key().unwrap())
+            .send()
+            .await?;
+        let bytes = file.body.collect().await?.into_bytes();
+        let actual_body = str::from_utf8(bytes.as_ref())?;
+        rows.extend(actual_body.lines().map(|l| l.to_string()));
+    }
+    if sort_rows {
+        expected_body.sort();
+        rows.sort();
+    }
+    if rows != expected_body {
         bail!(
             "content did not match\nexpected:\n{:?}\n\nactual:\n{:?}",
             expected_body,
-            actual_body
+            rows
         );
     }
 

--- a/test/aws-localstack/copy-to-s3/copy-to-s3.td
+++ b/test/aws-localstack/copy-to-s3/copy-to-s3.td
@@ -15,8 +15,7 @@ ALTER SYSTEM SET enable_copy_to_expr = true;
 
 # Prepare table data
 > CREATE TABLE t (a int);
-> INSERT INTO t VALUES (1);
-> INSERT INTO t VALUES (2);
+> INSERT INTO t VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (0);
 
 > CREATE SECRET aws_secret_access_key as '${arg.secret-key}';
 > CREATE CONNECTION aws_conn
@@ -80,7 +79,7 @@ contains:ORDER BY is not supported in SELECT query for COPY statements
 contains:MAX FILE SIZE cannot be less than 16MB
 
 # Creating cluster with multiple replicas, each with multiple workers
-> CREATE CLUSTER c1 REPLICAS (r1 (size '2'), r2 (size '2'));
+> CREATE CLUSTER c1 REPLICAS (r1 (size '2'), r2 (size '1'));
 > SET cluster = c1;
 
 # functions like now() should work in the s3 path

--- a/test/aws-localstack/mzcompose.py
+++ b/test/aws-localstack/mzcompose.py
@@ -258,7 +258,7 @@ def workflow_copy_to_s3(c: Composition) -> None:
             assert output_lines == expected_output_set
 
         # asserting the uploaded files
-        date = datetime.now().strftime("%Y-%m-%d")
+        date = c.sql_query("SELECT TO_CHAR(now(), 'YYYY-MM-DD')")[0][0]
         expected_output = set(map(lambda x: str(x), range(10)))
         first_upload = s3_client.list_objects_v2(
             Bucket=bucket_name, Prefix=f"{path_prefix}/1/{date}/"

--- a/test/aws-localstack/mzcompose.py
+++ b/test/aws-localstack/mzcompose.py
@@ -246,54 +246,31 @@ def workflow_copy_to_s3(c: Composition) -> None:
             "copy-to-s3/copy-to-s3.td",
         )
 
+        def validate_upload(upload, expected_output_set):
+            assert len(upload["Contents"]) > 0
+            output_lines = set()
+            for obj in upload["Contents"]:
+                assert obj["Key"].endswith(".csv")
+                key = obj["Key"]
+                object_response = s3_client.get_object(Bucket=bucket_name, Key=key)
+                body = object_response["Body"].read().decode("utf-8")
+                output_lines.update(body.splitlines())
+            assert output_lines == expected_output_set
+
         # asserting the uploaded files
         date = datetime.now().strftime("%Y-%m-%d")
-        assert (
-            s3_client.list_objects_v2(
-                Bucket=bucket_name, Prefix=f"{path_prefix}/1/{date}/"
-            )["Contents"][0]["Key"]
-            == f"{path_prefix}/1/{date}/part-0001.csv"
+        expected_output = set(map(lambda x: str(x), range(10)))
+        first_upload = s3_client.list_objects_v2(
+            Bucket=bucket_name, Prefix=f"{path_prefix}/1/{date}/"
         )
+        validate_upload(first_upload, expected_output)
 
-        content = s3_client.get_object(
-            Bucket=bucket_name,
-            Key=f"{path_prefix}/1/{date}/part-0001.csv",
-        )["Body"].read()
-        assert content == b"1\n2\n", content
-
-        assert (
-            s3_client.list_objects_v2(Bucket=bucket_name, Prefix=f"{path_prefix}/2/")[
-                "Contents"
-            ][0]["Key"]
-            == f"{path_prefix}/2/part-0001.csv"
+        second_upload = s3_client.list_objects_v2(
+            Bucket=bucket_name, Prefix=f"{path_prefix}/2/"
         )
+        validate_upload(second_upload, expected_output)
 
-        content = s3_client.get_object(
-            Bucket=bucket_name, Key=f"{path_prefix}/2/part-0001.csv"
-        )["Body"].read()
-        assert content == b"1\n2\n", content
-
-        assert (
-            s3_client.list_objects_v2(Bucket=bucket_name, Prefix=f"{path_prefix}/3/")[
-                "Contents"
-            ][0]["Key"]
-            == f"{path_prefix}/3/part-0001.csv"
+        third_upload = s3_client.list_objects_v2(
+            Bucket=bucket_name, Prefix=f"{path_prefix}/3/"
         )
-
-        content = s3_client.get_object(
-            Bucket=bucket_name, Key=f"{path_prefix}/3/part-0001.csv"
-        )["Body"].read()
-        assert content == b"1000\n", content
-
-        assert (
-            s3_client.list_objects_v2(Bucket=bucket_name, Prefix=f"{path_prefix}/4/")[
-                "Contents"
-            ][0]["Key"]
-            == f"{path_prefix}/4/part-0001.csv"
-        )
-
-        content = s3_client.get_object(
-            Bucket=bucket_name, Key=f"{path_prefix}/4/part-0001.csv"
-        )["Body"].read()
-        expected = b"".join([f"{i}\n".encode() for i in range(1, 1000001)])
-        assert sorted(content.split(b"\n")) == sorted(expected.split(b"\n")), content
+        validate_upload(third_upload, set(["1000"]))

--- a/test/aws-localstack/mzcompose.py
+++ b/test/aws-localstack/mzcompose.py
@@ -10,7 +10,6 @@
 """Tests of AWS functionality that run against localstack."""
 
 import uuid
-from datetime import datetime
 from typing import Any, cast
 
 import boto3

--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -110,12 +110,14 @@ contains:MAX FILE SIZE cannot be less than 16MB
     FORMAT = 'csv'
   );
 
-> COPY (SELECT a FROM t) TO 's3://copytos3'
-  WITH (
-    AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "100MB",
-    FORMAT = 'csv'
-  );
+# TODO: #25857 (detect non-empty s3 path)
+# ! COPY (SELECT a FROM t) TO 's3://copytos3'
+#   WITH (
+#     AWS CONNECTION = aws_conn,
+#     MAX FILE SIZE = "100MB",
+#     FORMAT = 'csv'
+#   );
+
 
 > COPY (SELECT * FROM generate_series(1, 1000000)) TO 's3://copytos3/test/4'
   WITH (
@@ -137,7 +139,3 @@ $ s3-verify-data bucket=copytos3 key=test/2
 
 $ s3-verify-data bucket=copytos3 key=test/3
 "{1,2}",f,Infinity,"{""s"":""abc""}",1,32767,2147483647,9223372036854775807,12345678901234567890123.4567890123456789,2010-10-10,10:10:10,2010-10-10 10:10:10,00:00:00,aaaa,\x5c7841414141,това е,\xd182d0b5d0bad181d182
-
-$ s3-verify-data bucket=copytos3 key=
-1
-2


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->


### Motivation
Changes to write to s3 from multiple workers, part of https://github.com/MaterializeInc/materialize/issues/7256

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer
Opening this PR to get some early feedback. I will try to get the changes to make the bucket size configurable by tomorrow.

@benesch If I am not able to get this merged by this week, somebody else will have to pick this up.

cc @petrosagg @guswynn 
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
