### PR TITLE
storage: correctly initialize source statistics on ALTER SOURCE ADD SUBSOURCE

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -601,23 +601,17 @@ where
                         debug!(desc = ?description, meta = ?metadata, "registering {} with persist table worker", id);
                         table_registers.push((id, write, collection_state));
                     }
-                    DataSource::Ingestion(_)
-                    | DataSource::Progress
-                    | DataSource::Other(DataSourceOther::Compute)
-                    | DataSource::Other(DataSourceOther::Source) => {
+                    DataSource::Progress | DataSource::Other(DataSourceOther::Compute) => {
                         debug!(desc = ?description, meta = ?metadata, "not registering {} with a controller persist worker", id);
                         self.collections.insert(id, collection_state);
                     }
-                }
-                self.persist_read_handles.register(id, since_handle);
-
-                if let DataSource::Ingestion(i) = &description.data_source {
-                    source_statistics.insert(id, None);
-                    // Note that `source_exports` contains the subsources as well.
-                    for (id, _) in i.source_exports.iter() {
-                        source_statistics.insert(*id, None);
+                    DataSource::Ingestion(_) | DataSource::Other(DataSourceOther::Source) => {
+                        debug!(desc = ?description, meta = ?metadata, "not registering {} with a controller persist worker", id);
+                        self.collections.insert(id, collection_state);
+                        source_statistics.insert(id, None);
                     }
                 }
+                self.persist_read_handles.register(id, since_handle);
 
                 to_create.push((id, description));
             }

--- a/test/pg-cdc/statistics.td
+++ b/test/pg-cdc/statistics.td
@@ -135,3 +135,25 @@ true
   GROUP BY s.name
   ORDER BY s.name
 mz_source 1 1
+
+# Ensure subsource stats show up, and then are removed when we drop subsources.
+> SELECT
+    s.name,
+    SUM(u.updates_committed) > 0
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('alt')
+  GROUP BY s.name
+  ORDER BY s.name
+alt true
+
+> ALTER SOURCE mz_source DROP SUBSOURCE alt;
+
+> SELECT
+    count(*)
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name IN ('alt')
+0
+
+# TODO(guswynn): consider adding an envd restart test for pg statistics, not just kafka ones like in test/cluster.


### PR DESCRIPTION
Closes: https://github.com/MaterializeInc/materialize/issues/22235

### Motivation

  * This PR fixes a recognized bug.



### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
