### PR TITLE
storage/mysql: Configurable TCP keepalive, snapshot lock timeout, and snapshot statement timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3601,6 +3601,7 @@ dependencies = [
  "mz-controller-types",
  "mz-expr",
  "mz-kafka-util",
+ "mz-mysql-util",
  "mz-orchestrator",
  "mz-ore",
  "mz-persist-client",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -44,6 +44,7 @@ mz-controller = { path = "../controller" }
 mz-controller-types = { path = "../controller-types" }
 mz-expr = { path = "../expr" }
 mz-kafka-util = { path = "../kafka-util" }
+mz-mysql-util = { path = "../mysql-util" }
 mz-orchestrator = { path = "../orchestrator" }
 mz-ore = { path = "../ore", features = ["chrono", "async", "tracing_"] }
 mz-persist-types = { path = "../persist-types" }

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -91,6 +91,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
         mysql_source_timeouts: mz_mysql_util::TimeoutConfig {
             tcp_keepalive: Some(config.mysql_source_tcp_keepalive()),
         },
+        mysql_source_snapshot_max_execution_time: config.mysql_source_snapshot_max_execution_time(),
         keep_n_source_status_history_entries: config.keep_n_source_status_history_entries(),
         keep_n_sink_status_history_entries: config.keep_n_sink_status_history_entries(),
         keep_n_privatelink_status_history_entries: config

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -92,6 +92,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             tcp_keepalive: Some(config.mysql_source_tcp_keepalive()),
         },
         mysql_source_snapshot_max_execution_time: config.mysql_source_snapshot_max_execution_time(),
+        mysql_source_snapshot_lock_wait_timeout: config.mysql_source_snapshot_lock_wait_timeout(),
         keep_n_source_status_history_entries: config.keep_n_source_status_history_entries(),
         keep_n_sink_status_history_entries: config.keep_n_sink_status_history_entries(),
         keep_n_privatelink_status_history_entries: config

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -88,6 +88,9 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             tcp_user_timeout: Some(config.pg_source_tcp_user_timeout()),
         },
         pg_source_snapshot_statement_timeout: config.pg_source_snapshot_statement_timeout(),
+        mysql_source_timeouts: mz_mysql_util::TimeoutConfig {
+            tcp_keepalive: Some(config.mysql_source_tcp_keepalive()),
+        },
         keep_n_source_status_history_entries: config.keep_n_source_status_history_entries(),
         keep_n_sink_status_history_entries: config.keep_n_sink_status_history_entries(),
         keep_n_privatelink_status_history_entries: config

--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -11,8 +11,8 @@
 
 mod tunnel;
 pub use tunnel::{
-    Config, MySqlConn, TimeoutConfig, TunnelConfig, DEFAULT_SNAPSHOT_MAX_EXECUTION_TIME,
-    DEFAULT_TCP_KEEPALIVE,
+    Config, MySqlConn, TimeoutConfig, TunnelConfig, DEFAULT_SNAPSHOT_LOCK_WAIT_TIMEOUT,
+    DEFAULT_SNAPSHOT_MAX_EXECUTION_TIME, DEFAULT_TCP_KEEPALIVE,
 };
 
 mod desc;

--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -10,7 +10,10 @@
 //! MySQL utility library.
 
 mod tunnel;
-pub use tunnel::{Config, MySqlConn, TimeoutConfig, TunnelConfig, DEFAULT_TCP_KEEPALIVE};
+pub use tunnel::{
+    Config, MySqlConn, TimeoutConfig, TunnelConfig, DEFAULT_SNAPSHOT_MAX_EXECUTION_TIME,
+    DEFAULT_TCP_KEEPALIVE,
+};
 
 mod desc;
 pub use desc::{

--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -10,7 +10,7 @@
 //! MySQL utility library.
 
 mod tunnel;
-pub use tunnel::{Config, MySqlConn, TunnelConfig};
+pub use tunnel::{Config, MySqlConn, TimeoutConfig, TunnelConfig, DEFAULT_TCP_KEEPALIVE};
 
 mod desc;
 pub use desc::{
@@ -32,6 +32,8 @@ pub use decoding::pack_mysql_row;
 
 #[derive(Debug, thiserror::Error)]
 pub enum MySqlError {
+    #[error("error creating mysql connection with config: {0}")]
+    InvalidClientConfig(String),
     #[error("error setting up ssh: {0}")]
     Ssh(#[source] anyhow::Error),
     #[error("decode error: {0}")]

--- a/src/mysql-util/src/tunnel.rs
+++ b/src/mysql-util/src/tunnel.rs
@@ -42,6 +42,7 @@ pub enum TunnelConfig {
 
 pub const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(60);
 pub const DEFAULT_SNAPSHOT_MAX_EXECUTION_TIME: Duration = Duration::ZERO;
+pub const DEFAULT_SNAPSHOT_LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(3600);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TimeoutConfig {

--- a/src/mysql-util/src/tunnel.rs
+++ b/src/mysql-util/src/tunnel.rs
@@ -41,6 +41,7 @@ pub enum TunnelConfig {
 }
 
 pub const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(60);
+pub const DEFAULT_SNAPSHOT_MAX_EXECUTION_TIME: Duration = Duration::ZERO;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TimeoutConfig {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1127,6 +1127,7 @@ impl SystemVars {
             &PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT,
             &PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT,
             &PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT,
+            &MYSQL_SOURCE_TCP_KEEPALIVE,
             &SSH_CHECK_INTERVAL,
             &SSH_CONNECT_TIMEOUT,
             &SSH_KEEPALIVES_IDLE,
@@ -1706,6 +1707,11 @@ impl SystemVars {
         *self.expect_value(&PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT)
     }
 
+    /// Returns the `mysql_source_tcp_keepalive` configuration parameter.
+    pub fn mysql_source_tcp_keepalive(&self) -> Duration {
+        *self.expect_value(&MYSQL_SOURCE_TCP_KEEPALIVE)
+    }
+
     /// Returns the `ssh_check_interval` configuration parameter.
     pub fn ssh_check_interval(&self) -> Duration {
         *self.expect_value(&SSH_CHECK_INTERVAL)
@@ -2131,6 +2137,7 @@ impl SystemVars {
             || name == PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT.name()
             || name == PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT.name()
             || name == PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT.name()
+            || name == MYSQL_SOURCE_TCP_KEEPALIVE.name()
             || name == ENABLE_STORAGE_SHARD_FINALIZATION.name()
             || name == SSH_CHECK_INTERVAL.name()
             || name == SSH_CONNECT_TIMEOUT.name()

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1129,6 +1129,7 @@ impl SystemVars {
             &PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT,
             &MYSQL_SOURCE_TCP_KEEPALIVE,
             &MYSQL_SOURCE_SNAPSHOT_MAX_EXECUTION_TIME,
+            &MYSQL_SOURCE_SNAPSHOT_LOCK_WAIT_TIMEOUT,
             &SSH_CHECK_INTERVAL,
             &SSH_CONNECT_TIMEOUT,
             &SSH_KEEPALIVES_IDLE,
@@ -1718,6 +1719,11 @@ impl SystemVars {
         *self.expect_value(&MYSQL_SOURCE_SNAPSHOT_MAX_EXECUTION_TIME)
     }
 
+    /// Returns the `mysql_source_snapshot_lock_wait_timeout` configuration parameter.
+    pub fn mysql_source_snapshot_lock_wait_timeout(&self) -> Duration {
+        *self.expect_value(&MYSQL_SOURCE_SNAPSHOT_LOCK_WAIT_TIMEOUT)
+    }
+
     /// Returns the `ssh_check_interval` configuration parameter.
     pub fn ssh_check_interval(&self) -> Duration {
         *self.expect_value(&SSH_CHECK_INTERVAL)
@@ -2145,6 +2151,7 @@ impl SystemVars {
             || name == PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT.name()
             || name == MYSQL_SOURCE_TCP_KEEPALIVE.name()
             || name == MYSQL_SOURCE_SNAPSHOT_MAX_EXECUTION_TIME.name()
+            || name == MYSQL_SOURCE_SNAPSHOT_LOCK_WAIT_TIMEOUT.name()
             || name == ENABLE_STORAGE_SHARD_FINALIZATION.name()
             || name == SSH_CHECK_INTERVAL.name()
             || name == SSH_CONNECT_TIMEOUT.name()

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1128,6 +1128,7 @@ impl SystemVars {
             &PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT,
             &PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT,
             &MYSQL_SOURCE_TCP_KEEPALIVE,
+            &MYSQL_SOURCE_SNAPSHOT_MAX_EXECUTION_TIME,
             &SSH_CHECK_INTERVAL,
             &SSH_CONNECT_TIMEOUT,
             &SSH_KEEPALIVES_IDLE,
@@ -1712,6 +1713,11 @@ impl SystemVars {
         *self.expect_value(&MYSQL_SOURCE_TCP_KEEPALIVE)
     }
 
+    /// Returns the `mysql_source_snapshot_max_execution_time` configuration parameter.
+    pub fn mysql_source_snapshot_max_execution_time(&self) -> Duration {
+        *self.expect_value(&MYSQL_SOURCE_SNAPSHOT_MAX_EXECUTION_TIME)
+    }
+
     /// Returns the `ssh_check_interval` configuration parameter.
     pub fn ssh_check_interval(&self) -> Duration {
         *self.expect_value(&SSH_CHECK_INTERVAL)
@@ -2138,6 +2144,7 @@ impl SystemVars {
             || name == PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT.name()
             || name == PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT.name()
             || name == MYSQL_SOURCE_TCP_KEEPALIVE.name()
+            || name == MYSQL_SOURCE_SNAPSHOT_MAX_EXECUTION_TIME.name()
             || name == ENABLE_STORAGE_SHARD_FINALIZATION.name()
             || name == SSH_CHECK_INTERVAL.name()
             || name == SSH_CONNECT_TIMEOUT.name()

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1003,6 +1003,14 @@ pub static PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT: VarDefinition = VarDefinition::new
     true,
 );
 
+/// Sets the time between TCP keepalive probes when connecting to MySQL via `mz_mysql_util`.
+pub static MYSQL_SOURCE_TCP_KEEPALIVE: VarDefinition = VarDefinition::new(
+    "mysql_source_tcp_keepalive",
+    value!(Duration; mz_mysql_util::DEFAULT_TCP_KEEPALIVE),
+    "Sets the time between TCP keepalive probes when connecting to MySQL",
+    true,
+);
+
 /// Controls the check interval for connections to SSH bastions via `mz_ssh_util`.
 pub static SSH_CHECK_INTERVAL: VarDefinition = VarDefinition::new(
     "ssh_check_interval",

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1020,6 +1020,15 @@ pub static MYSQL_SOURCE_SNAPSHOT_MAX_EXECUTION_TIME: VarDefinition = VarDefiniti
     true,
 );
 
+/// Sets the `lock_wait_timeout` value to use during the snapshotting phase of
+/// MySQL sources.
+pub static MYSQL_SOURCE_SNAPSHOT_LOCK_WAIT_TIMEOUT: VarDefinition = VarDefinition::new(
+    "mysql_source_snapshot_lock_wait_timeout",
+    value!(Duration; mz_mysql_util::DEFAULT_SNAPSHOT_LOCK_WAIT_TIMEOUT),
+    "Sets the `lock_wait_timeout` value to use during the snapshotting phase of MySQL sources (Materialize)",
+    true,
+);
+
 /// Controls the check interval for connections to SSH bastions via `mz_ssh_util`.
 pub static SSH_CHECK_INTERVAL: VarDefinition = VarDefinition::new(
     "ssh_check_interval",

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1011,6 +1011,15 @@ pub static MYSQL_SOURCE_TCP_KEEPALIVE: VarDefinition = VarDefinition::new(
     true,
 );
 
+/// Sets the `max_execution_time` value to use during the snapshotting phase of
+/// MySQL sources.
+pub static MYSQL_SOURCE_SNAPSHOT_MAX_EXECUTION_TIME: VarDefinition = VarDefinition::new(
+    "mysql_source_snapshot_max_execution_time",
+    value!(Duration; mz_mysql_util::DEFAULT_SNAPSHOT_MAX_EXECUTION_TIME),
+    "Sets the `max_execution_time` value to use during the snapshotting phase of MySQL sources (Materialize)",
+    true,
+);
+
 /// Controls the check interval for connections to SSH bastions via `mz_ssh_util`.
 pub static SSH_CHECK_INTERVAL: VarDefinition = VarDefinition::new(
     "ssh_check_interval",

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -1422,6 +1422,11 @@ impl MySqlConnection<InlinedConnection> {
             }
         };
 
+        opts = storage_configuration
+            .parameters
+            .mysql_source_timeouts
+            .apply(opts)?;
+
         Ok(mz_mysql_util::Config::new(
             opts.into(),
             tunnel,

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -42,8 +42,8 @@ message ProtoStorageParameters {
     ProtoPgSourceSnapshotConfig pg_snapshot_config = 24;
     bool enable_dependency_read_hold_asserts = 27;
     mz_proto.ProtoDuration user_storage_managed_collections_batch_duration = 28;
+    ProtoMySqlSourceTimeouts mysql_source_timeouts = 29;
 }
-
 
 message ProtoPgSourceTcpTimeouts {
     optional mz_proto.ProtoDuration connect_timeout = 1;
@@ -57,6 +57,10 @@ message ProtoPgSourceSnapshotConfig {
     bool collect_strict_count = 1;
     bool fallback_to_strict_count = 2;
     bool wait_for_count = 3;
+}
+
+message ProtoMySqlSourceTimeouts {
+    optional mz_proto.ProtoDuration tcp_keepalive = 1;
 }
 
 message ProtoKafkaTimeouts {

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -44,6 +44,7 @@ message ProtoStorageParameters {
     mz_proto.ProtoDuration user_storage_managed_collections_batch_duration = 28;
     ProtoMySqlSourceTimeouts mysql_source_timeouts = 29;
     mz_proto.ProtoDuration mysql_source_snapshot_max_execution_time = 30;
+    mz_proto.ProtoDuration mysql_source_snapshot_lock_wait_timeout = 31;
 }
 
 message ProtoPgSourceTcpTimeouts {

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -43,6 +43,7 @@ message ProtoStorageParameters {
     bool enable_dependency_read_hold_asserts = 27;
     mz_proto.ProtoDuration user_storage_managed_collections_batch_duration = 28;
     ProtoMySqlSourceTimeouts mysql_source_timeouts = 29;
+    mz_proto.ProtoDuration mysql_source_snapshot_max_execution_time = 30;
 }
 
 message ProtoPgSourceTcpTimeouts {

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -33,6 +33,7 @@ pub struct StorageParameters {
     pub pg_source_snapshot_statement_timeout: Duration,
     pub mysql_source_timeouts: mz_mysql_util::TimeoutConfig,
     pub mysql_source_snapshot_max_execution_time: Duration,
+    pub mysql_source_snapshot_lock_wait_timeout: Duration,
     pub keep_n_source_status_history_entries: usize,
     pub keep_n_sink_status_history_entries: usize,
     pub keep_n_privatelink_status_history_entries: usize,
@@ -93,6 +94,7 @@ impl Default for StorageParameters {
             pg_source_snapshot_statement_timeout: Default::default(),
             mysql_source_timeouts: Default::default(),
             mysql_source_snapshot_max_execution_time: Default::default(),
+            mysql_source_snapshot_lock_wait_timeout: Default::default(),
             keep_n_source_status_history_entries: Default::default(),
             keep_n_sink_status_history_entries: Default::default(),
             keep_n_privatelink_status_history_entries: Default::default(),
@@ -194,6 +196,7 @@ impl StorageParameters {
             pg_source_snapshot_statement_timeout,
             mysql_source_timeouts,
             mysql_source_snapshot_max_execution_time,
+            mysql_source_snapshot_lock_wait_timeout,
             keep_n_source_status_history_entries,
             keep_n_sink_status_history_entries,
             keep_n_privatelink_status_history_entries,
@@ -220,6 +223,7 @@ impl StorageParameters {
         self.pg_source_snapshot_statement_timeout = pg_source_snapshot_statement_timeout;
         self.mysql_source_timeouts = mysql_source_timeouts;
         self.mysql_source_snapshot_max_execution_time = mysql_source_snapshot_max_execution_time;
+        self.mysql_source_snapshot_lock_wait_timeout = mysql_source_snapshot_lock_wait_timeout;
         self.keep_n_source_status_history_entries = keep_n_source_status_history_entries;
         self.keep_n_sink_status_history_entries = keep_n_sink_status_history_entries;
         self.keep_n_privatelink_status_history_entries = keep_n_privatelink_status_history_entries;
@@ -257,6 +261,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             mysql_source_timeouts: Some(self.mysql_source_timeouts.into_proto()),
             mysql_source_snapshot_max_execution_time: Some(
                 self.mysql_source_snapshot_max_execution_time.into_proto(),
+            ),
+            mysql_source_snapshot_lock_wait_timeout: Some(
+                self.mysql_source_snapshot_lock_wait_timeout.into_proto(),
             ),
             keep_n_source_status_history_entries: u64::cast_from(
                 self.keep_n_source_status_history_entries,
@@ -313,6 +320,11 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
                 .mysql_source_snapshot_max_execution_time
                 .into_rust_if_some(
                     "ProtoStorageParameters::mysql_source_snapshot_max_execution_time",
+                )?,
+            mysql_source_snapshot_lock_wait_timeout: proto
+                .mysql_source_snapshot_lock_wait_timeout
+                .into_rust_if_some(
+                    "ProtoStorageParameters::mysql_source_snapshot_lock_wait_timeout",
                 )?,
             keep_n_source_status_history_entries: usize::cast_from(
                 proto.keep_n_source_status_history_entries,

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -32,6 +32,7 @@ pub struct StorageParameters {
     pub pg_source_tcp_timeouts: mz_postgres_util::TcpTimeoutConfig,
     pub pg_source_snapshot_statement_timeout: Duration,
     pub mysql_source_timeouts: mz_mysql_util::TimeoutConfig,
+    pub mysql_source_snapshot_max_execution_time: Duration,
     pub keep_n_source_status_history_entries: usize,
     pub keep_n_sink_status_history_entries: usize,
     pub keep_n_privatelink_status_history_entries: usize,
@@ -91,6 +92,7 @@ impl Default for StorageParameters {
             pg_source_tcp_timeouts: Default::default(),
             pg_source_snapshot_statement_timeout: Default::default(),
             mysql_source_timeouts: Default::default(),
+            mysql_source_snapshot_max_execution_time: Default::default(),
             keep_n_source_status_history_entries: Default::default(),
             keep_n_sink_status_history_entries: Default::default(),
             keep_n_privatelink_status_history_entries: Default::default(),
@@ -191,6 +193,7 @@ impl StorageParameters {
             pg_source_tcp_timeouts,
             pg_source_snapshot_statement_timeout,
             mysql_source_timeouts,
+            mysql_source_snapshot_max_execution_time,
             keep_n_source_status_history_entries,
             keep_n_sink_status_history_entries,
             keep_n_privatelink_status_history_entries,
@@ -216,6 +219,7 @@ impl StorageParameters {
         self.pg_source_tcp_timeouts = pg_source_tcp_timeouts;
         self.pg_source_snapshot_statement_timeout = pg_source_snapshot_statement_timeout;
         self.mysql_source_timeouts = mysql_source_timeouts;
+        self.mysql_source_snapshot_max_execution_time = mysql_source_snapshot_max_execution_time;
         self.keep_n_source_status_history_entries = keep_n_source_status_history_entries;
         self.keep_n_sink_status_history_entries = keep_n_sink_status_history_entries;
         self.keep_n_privatelink_status_history_entries = keep_n_privatelink_status_history_entries;
@@ -251,6 +255,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
                 self.pg_source_snapshot_statement_timeout.into_proto(),
             ),
             mysql_source_timeouts: Some(self.mysql_source_timeouts.into_proto()),
+            mysql_source_snapshot_max_execution_time: Some(
+                self.mysql_source_snapshot_max_execution_time.into_proto(),
+            ),
             keep_n_source_status_history_entries: u64::cast_from(
                 self.keep_n_source_status_history_entries,
             ),
@@ -302,6 +309,11 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             mysql_source_timeouts: proto
                 .mysql_source_timeouts
                 .into_rust_if_some("ProtoStorageParameters::mysql_source_timeouts")?,
+            mysql_source_snapshot_max_execution_time: proto
+                .mysql_source_snapshot_max_execution_time
+                .into_rust_if_some(
+                    "ProtoStorageParameters::mysql_source_snapshot_max_execution_time",
+                )?,
             keep_n_source_status_history_entries: usize::cast_from(
                 proto.keep_n_source_status_history_entries,
             ),

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -31,6 +31,7 @@ pub struct StorageParameters {
     pub persist: PersistParameters,
     pub pg_source_tcp_timeouts: mz_postgres_util::TcpTimeoutConfig,
     pub pg_source_snapshot_statement_timeout: Duration,
+    pub mysql_source_timeouts: mz_mysql_util::TimeoutConfig,
     pub keep_n_source_status_history_entries: usize,
     pub keep_n_sink_status_history_entries: usize,
     pub keep_n_privatelink_status_history_entries: usize,
@@ -89,6 +90,7 @@ impl Default for StorageParameters {
             persist: Default::default(),
             pg_source_tcp_timeouts: Default::default(),
             pg_source_snapshot_statement_timeout: Default::default(),
+            mysql_source_timeouts: Default::default(),
             keep_n_source_status_history_entries: Default::default(),
             keep_n_sink_status_history_entries: Default::default(),
             keep_n_privatelink_status_history_entries: Default::default(),
@@ -188,6 +190,7 @@ impl StorageParameters {
             persist,
             pg_source_tcp_timeouts,
             pg_source_snapshot_statement_timeout,
+            mysql_source_timeouts,
             keep_n_source_status_history_entries,
             keep_n_sink_status_history_entries,
             keep_n_privatelink_status_history_entries,
@@ -212,6 +215,7 @@ impl StorageParameters {
         self.persist.update(persist);
         self.pg_source_tcp_timeouts = pg_source_tcp_timeouts;
         self.pg_source_snapshot_statement_timeout = pg_source_snapshot_statement_timeout;
+        self.mysql_source_timeouts = mysql_source_timeouts;
         self.keep_n_source_status_history_entries = keep_n_source_status_history_entries;
         self.keep_n_sink_status_history_entries = keep_n_sink_status_history_entries;
         self.keep_n_privatelink_status_history_entries = keep_n_privatelink_status_history_entries;
@@ -246,6 +250,7 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             pg_source_snapshot_statement_timeout: Some(
                 self.pg_source_snapshot_statement_timeout.into_proto(),
             ),
+            mysql_source_timeouts: Some(self.mysql_source_timeouts.into_proto()),
             keep_n_source_status_history_entries: u64::cast_from(
                 self.keep_n_source_status_history_entries,
             ),
@@ -294,6 +299,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
                 .into_rust_if_some(
                     "ProtoStorageParameters::pg_source_snapshot_statement_timeout",
                 )?,
+            mysql_source_timeouts: proto
+                .mysql_source_timeouts
+                .into_rust_if_some("ProtoStorageParameters::mysql_source_timeouts")?,
             keep_n_source_status_history_entries: usize::cast_from(
                 proto.keep_n_source_status_history_entries,
             ),
@@ -467,6 +475,20 @@ impl RustType<ProtoKafkaTimeouts> for mz_kafka_util::client::TimeoutConfig {
                 .into_rust_if_some(
                     "ProtoKafkaSourceTcpTimeouts::default_metadata_fetch_interval",
                 )?,
+        })
+    }
+}
+
+impl RustType<ProtoMySqlSourceTimeouts> for mz_mysql_util::TimeoutConfig {
+    fn into_proto(&self) -> ProtoMySqlSourceTimeouts {
+        ProtoMySqlSourceTimeouts {
+            tcp_keepalive: self.tcp_keepalive.into_proto(),
+        }
+    }
+
+    fn from_proto(proto: ProtoMySqlSourceTimeouts) -> Result<Self, TryFromProtoError> {
+        Ok(mz_mysql_util::TimeoutConfig {
+            tcp_keepalive: proto.tcp_keepalive.into_rust()?,
         })
     }
 }

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -229,6 +229,15 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                         &config.config.connection_context.ssh_tunnel_manager,
                     )
                     .await?;
+                lock_conn.query_drop(format!(
+                    "SET @@session.lock_wait_timeout = {}",
+                    config
+                        .config
+                        .parameters
+                        .mysql_source_snapshot_lock_wait_timeout
+                        .as_secs()
+                ))
+                .await?;
 
                 trace!(%id, "timely-{worker_id} acquiring table locks: {lock_clauses}");
                 match lock_conn

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -133,12 +133,10 @@ CREATE SCHEMA another_schema;
 CREATE TABLE another_schema.another_table (f1 TEXT);
 INSERT INTO another_schema.another_table VALUES ('123');
 
-
-# TODO: #25120 (statement timeout)
-# Sneak in a test for pg_source_snapshot_statement_timeout
+# Sneak in a test for mysql_source_snapshot_max_execution_time
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
-# ALTER SYSTEM SET mysql_source_snapshot_statement_timeout = 1000
+ALTER SYSTEM SET mysql_source_snapshot_max_execution_time = 1000
 
 > CREATE SOURCE "test_slot_source"
   IN CLUSTER cdc_cluster
@@ -152,7 +150,7 @@ test_slot_source_progress progress
 > DROP SOURCE test_slot_source
 
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET pg_source_snapshot_statement_timeout = 0
+ALTER SYSTEM SET mysql_source_snapshot_max_execution_time = 0
 
 #
 # Error checking

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -152,6 +152,36 @@ test_slot_source_progress progress
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET mysql_source_snapshot_max_execution_time = 0
 
+# Validate mysql_source_snapshot_lock_wait_timeout
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET mysql_source_snapshot_lock_wait_timeout = 1
+
+$ mysql-execute name=mysql
+USE public;
+BEGIN;
+INSERT INTO pk_table VALUES (4, 'four');
+
+> CREATE SOURCE "test_slot_source"
+  IN CLUSTER cdc_cluster
+  FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (public.pk_table);
+
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'test_slot_source';
+stalled
+
+$ mysql-execute name=mysql
+ROLLBACK;
+
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'test_slot_source';
+running
+
+> DROP SOURCE test_slot_source
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET mysql_source_snapshot_lock_wait_timeout = 3600
+
+
 #
 # Error checking
 #


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/25120

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Each commit introduces one new flag. This matches the structure used for postgres source timeouts, but doesn't include as many options since the `mysql_async` crate only provides us with one setting to configure for the underlying TCP socket when not using a connection-pool.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
