### PR TITLE
persist: add a sentry tag to the pushdown audit panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6044,6 +6044,7 @@ dependencies = [
  "mz-timely-util",
  "prometheus",
  "proptest",
+ "sentry",
  "serde",
  "timely",
  "tokio",

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -29,6 +29,7 @@ mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+sentry = { version = "0.29.1" }
 serde = { version = "1.0.152", features = ["derive"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util", "time"] }

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -546,9 +546,23 @@ impl PendingWork {
                             |time| !until.less_equal(time),
                             row_builder,
                         ) {
-                            if let Some(_stats) = is_filter_pushdown_audit {
-                                // TODO: include more (redacted) information here.
-                                panic!("persist filter pushdown correctness violation! {}", name);
+                            if let Some(_stats) = &is_filter_pushdown_audit {
+                                // NB: The tag added by this scope is used for alerting. The panic
+                                // message may be changed arbitrarily, but the tag key and val must
+                                // stay the same.
+                                sentry::with_scope(
+                                    |scope| {
+                                        scope
+                                            .set_tag("alert_id", "persist_pushdown_audit_violation")
+                                    },
+                                    || {
+                                        // TODO: include more (redacted) information here.
+                                        panic!(
+                                            "persist filter pushdown correctness violation! {}",
+                                            name
+                                        );
+                                    },
+                                );
                             }
                             match result {
                                 Ok((row, time, diff)) => {


### PR DESCRIPTION
This will make alerts for instances of audit failures less brittle (i.e. not based on the panic message).

Closes #25776

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

The tag(s) used is just a strawman. Gonna hash out the exact set in slack.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
