### PR TITLE
dyncfg: add support for `Option<usize>` configs

### DIFF
--- a/src/dyncfg/Cargo.toml
+++ b/src/dyncfg/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 workspace = true
 
 [dependencies]
-mz-ore = { path = "../ore", default-features = false, features = ["proptest"] }
+mz-ore = { path = "../ore", default-features = false, features = ["proptest", "test"] }
 mz-proto = { path = "../proto" }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}

--- a/src/dyncfg/src/dyncfg.proto
+++ b/src/dyncfg/src/dyncfg.proto
@@ -34,7 +34,12 @@ message ProtoConfigVal {
         bool bool = 2;
         uint32 u32 = 6;
         uint64 usize = 3;
+        ProtoOptionU64 opt_usize = 7;
         string string = 4;
         mz_proto.ProtoDuration duration = 5;
     }
+}
+
+message ProtoOptionU64 {
+    optional uint64 val = 1;
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1227,6 +1227,12 @@ impl SystemVars {
                     cfg.desc(),
                     true,
                 ),
+                ConfigVal::OptUsize(default) => VarDefinition::new_runtime(
+                    cfg.name(),
+                    <Option<usize> as ConfigType>::get(default),
+                    cfg.desc(),
+                    true,
+                ),
                 ConfigVal::String(default) => VarDefinition::new_runtime(
                     cfg.name(),
                     <String as ConfigType>::get(default),
@@ -1862,6 +1868,10 @@ impl SystemVars {
                 ConfigVal::Usize(x) => {
                     <usize as ConfigType>::set(x, *self.expect_config_value::<usize>(name))
                 }
+                ConfigVal::OptUsize(x) => <Option<usize> as ConfigType>::set(
+                    x,
+                    *self.expect_config_value::<Option<usize>>(name),
+                ),
                 ConfigVal::String(x) => {
                     <String as ConfigType>::set(x, self.expect_config_value::<String>(name).clone())
                 }


### PR DESCRIPTION
While I'm in here, fix the Shared type for `usize` to `AtomicUsize` instead of `AtomicU64`. Not sure how that happened.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
