### PR TITLE
dbt-materialize: copy grants and default privileges in deploy_init

### DIFF
--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_cleanup.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_cleanup.sql
@@ -33,7 +33,7 @@
     {% set deploy_schema = schema ~ "_dbt_deploy" %}
     {{ log("Dropping schema " ~ deploy_schema ~ " for target " ~ current_target_name, info=True) }}
     {% set drop_schema %}
-    DROP SCHEMA IF EXISTS {{ deploy_schema }} CASCADE;
+    DROP SCHEMA IF EXISTS "{{ deploy_schema }}" CASCADE;
     {% endset %}
     {{ run_query(drop_schema) }}
 {% endfor %}
@@ -42,7 +42,7 @@
     {% set deploy_cluster = cluster ~ "_dbt_deploy" %}
     {{ log("Dropping cluster " ~ deploy_cluster ~ " for target " ~ current_target_name, info=True) }}
     {% set drop_cluster %}
-    DROP CLUSTER IF EXISTS {{ deploy_cluster }} CASCADE;
+    DROP CLUSTER IF EXISTS "{{ deploy_cluster }}" CASCADE;
     {% endset %}
     {{ run_query(drop_cluster) }}
 {% endfor %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_cleanup.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_cleanup.sql
@@ -33,7 +33,7 @@
     {% set deploy_schema = schema ~ "_dbt_deploy" %}
     {{ log("Dropping schema " ~ deploy_schema ~ " for target " ~ current_target_name, info=True) }}
     {% set drop_schema %}
-    DROP SCHEMA IF EXISTS "{{ deploy_schema }}" CASCADE;
+    DROP SCHEMA IF EXISTS {{ adapter.quote(deploy_schema) }} CASCADE;
     {% endset %}
     {{ run_query(drop_schema) }}
 {% endfor %}
@@ -42,7 +42,7 @@
     {% set deploy_cluster = cluster ~ "_dbt_deploy" %}
     {{ log("Dropping cluster " ~ deploy_cluster ~ " for target " ~ current_target_name, info=True) }}
     {% set drop_cluster %}
-    DROP CLUSTER IF EXISTS "{{ deploy_cluster }}" CASCADE;
+    DROP CLUSTER IF EXISTS {{ adapter.quote(deploy_cluster) }} CASCADE;
     {% endset %}
     {{ run_query(drop_cluster) }}
 {% endfor %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
@@ -317,4 +317,3 @@ WHERE grantee.name NOT IN ('none', 'mz_system', 'mz_support')
 {% endif %}
 
 {% endmacro %}
-

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_permission_validation.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_permission_validation.sql
@@ -89,7 +89,7 @@ WITH clusters_under_deployment AS (
     WHERE name IN (
     {% if clusters|length > 0 %}
         {% for cluster in clusters %}
-            lower(trim('{{ cluster }}')){% if not loop.last %},{% endif %}
+            {{ dbt.string_literal(cluster) }}{% if not loop.last %},{% endif %}
         {% endfor %}
     {% else %}
         NULL
@@ -139,7 +139,7 @@ WITH schemas_under_deployment AS (
     WHERE mz_databases.name = current_database() AND mz_schemas.name IN (
     {% if schemas|length > 0 %}
         {% for schema in schemas %}
-            lower(trim('{{ schema }}')){% if not loop.last %},{% endif %}
+            {{ dbt.string_literal(schema) }}{% if not loop.last %},{% endif %}
         {% endfor %}
     {% else %}
         NULL

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
@@ -94,13 +94,13 @@ BEGIN;
 {% for schema in schemas %}
     {% set deploy_schema = schema ~ "_dbt_deploy" %}
     {{ log("Swapping schemas " ~ schema ~ " and " ~ deploy_schema, info=True) }}
-    ALTER SCHEMA {{ schema }} SWAP WITH {{ deploy_schema }};
+    ALTER SCHEMA "{{ schema }}" SWAP WITH "{{ deploy_schema }}";
 {% endfor %}
 
 {% for cluster in clusters %}
     {% set deploy_cluster = cluster ~ "_dbt_deploy" %}
     {{ log("Swapping clusters " ~ cluster ~ " and " ~ deploy_cluster, info=True) }}
-    ALTER CLUSTER {{ cluster }} SWAP WITH {{ deploy_cluster }};
+    ALTER CLUSTER "{{ cluster }}" SWAP WITH "{{ deploy_cluster }}";
 {% endfor %}
 
 COMMIT;
@@ -122,7 +122,7 @@ COMMIT;
         SELECT count(*) > 0
         FROM sources_and_sinks
         JOIN mz_clusters ON sources_and_sinks.cluster_id = mz_clusters.id
-        WHERE mz_clusters.name = lower(trim('{{ cluster }}'))
+        WHERE mz_clusters.name = {{ dbt.string_literal(cluster) }}
     {% endset %}
 
     {% set count = run_query(query) %}
@@ -147,7 +147,7 @@ COMMIT;
         FROM sources_and_sinks
         JOIN mz_schemas ON sources_and_sinks.schema_id = mz_schemas.id
         JOIN mz_databases ON mz_schemas.database_id = mz_databases.id
-        WHERE mz_schemas.name = lower(trim('{{ schema }}'))
+        WHERE mz_schemas.name = {{ dbt.string_literal(schema) }}
             AND mz_databases.name = current_database()
     {% endset %}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
@@ -94,13 +94,13 @@ BEGIN;
 {% for schema in schemas %}
     {% set deploy_schema = schema ~ "_dbt_deploy" %}
     {{ log("Swapping schemas " ~ schema ~ " and " ~ deploy_schema, info=True) }}
-    ALTER SCHEMA "{{ schema }}" SWAP WITH "{{ deploy_schema }}";
+    ALTER SCHEMA {{ adapter.quote(schema) }} SWAP WITH {{ adapter.quote(deploy_schema) }};
 {% endfor %}
 
 {% for cluster in clusters %}
     {% set deploy_cluster = cluster ~ "_dbt_deploy" %}
     {{ log("Swapping clusters " ~ cluster ~ " and " ~ deploy_cluster, info=True) }}
-    ALTER CLUSTER "{{ cluster }}" SWAP WITH "{{ deploy_cluster }}";
+    ALTER CLUSTER {{ adapter.quote(cluster) }} SWAP WITH {{ adapter.quote(deploy_cluster) }};
 {% endfor %}
 
 COMMIT;

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/ci_utils.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/ci_utils.sql
@@ -16,7 +16,7 @@
 {% macro set_cluster_ci_tag(cluster, ci_tag=env_var('CI_TAG', '')) %}
     {% if ci_tag != '' %}
         {% set ci_comment %}
-            COMMENT ON CLUSTER "{{ cluster }}" IS {{ dbt.string_literal(ci_tag) }};
+            COMMENT ON CLUSTER {{ adapter.quote(cluster) }} IS {{ dbt.string_literal(ci_tag) }};
         {% endset %}
         {{ run_query(ci_comment) }}
     {% endif %}
@@ -25,7 +25,7 @@
 {% macro set_schema_ci_tag(schema, ci_tag=env_var('CI_TAG', '')) %}
     {% if ci_tag != '' %}
         {% set ci_comment %}
-            COMMENT ON SCHEMA "{{ schema }}" IS {{ dbt.string_literal(ci_tag) }};
+            COMMENT ON SCHEMA {{ adapter.quote(schema) }} IS {{ dbt.string_literal(ci_tag) }};
         {% endset %}
         {{ run_query(ci_comment) }}
     {% endif %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/ci_utils.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/ci_utils.sql
@@ -16,7 +16,7 @@
 {% macro set_cluster_ci_tag(cluster, ci_tag=env_var('CI_TAG', '')) %}
     {% if ci_tag != '' %}
         {% set ci_comment %}
-            COMMENT ON CLUSTER {{ cluster }} IS '{{ ci_tag }}';
+            COMMENT ON CLUSTER "{{ cluster }}" IS {{ dbt.string_literal(ci_tag) }};
         {% endset %}
         {{ run_query(ci_comment) }}
     {% endif %}
@@ -25,7 +25,7 @@
 {% macro set_schema_ci_tag(schema, ci_tag=env_var('CI_TAG', '')) %}
     {% if ci_tag != '' %}
         {% set ci_comment %}
-            COMMENT ON SCHEMA {{ schema }} IS '{{ ci_tag }}';
+            COMMENT ON SCHEMA "{{ schema }}" IS {{ dbt.string_literal(ci_tag) }};
         {% endset %}
         {{ run_query(ci_comment) }}
     {% endif %}
@@ -37,10 +37,10 @@
     {% endif %}
 
     {% set query %}
-        SELECT comment = '{{ ci_tag }}', comment
+        SELECT comment = {{ dbt.string_literal(ci_tag) }}, comment
         FROM mz_internal.mz_comments
         JOIN mz_clusters USING (id)
-        WHERE mz_clusters.name = lower(trim('{{ cluster }}'))
+        WHERE mz_clusters.name = {{ dbt.string_literal(cluster) }}
     {% endset %}
     {% set results = run_query(query) %}
     {% if execute %}
@@ -65,11 +65,11 @@
     {% endif %}
 
     {% set query %}
-        SELECT comment = '{{ ci_tag }}', comment
+        SELECT comment = {{ dbt.string_literal(ci_tag) }}, comment
         FROM mz_internal.mz_comments c
         JOIN mz_schemas s ON c.id = s.id
         JOIN mz_databases d ON s.database_id = d.id
-        WHERE s.name = lower(trim('{{ schema }}'))
+        WHERE s.name = {{ dbt.string_literal(schema) }}
             AND d.name = current_database()
     {% endset %}
     {% set results = run_query(query) %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/exists.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/exists.sql
@@ -29,7 +29,7 @@
     FROM mz_schemas
     JOIN mz_databases ON mz_schemas.database_id = mz_databases.id
     WHERE mz_databases.name = current_database()
-    AND mz_schemas.name = lower(trim('{{ schema }}'))
+    AND mz_schemas.name = {{ dbt.string_literal(schema) }}
 {%- endset -%}
 
 {% set results = run_query(query) %}
@@ -56,7 +56,7 @@
 
 {% set query %}
     SELECT * FROM mz_clusters
-    WHERE name = lower(trim('{{ cluster }}'))
+    WHERE name = {{ dbt.string_literal(cluster) }}
 {%- endset -%}
 
 {% set results = run_query(query) %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/is_cluster_ready.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/is_cluster_ready.sql
@@ -31,7 +31,7 @@ WITH total_replicas AS (
 SELECT COALESCE(replicas, 0) AS replicas
 FROM mz_clusters
 LEFT JOIN total_replicas ON mz_clusters.id = cluster_id
-WHERE mz_clusters.name = lower(trim('{{ cluster }}'))
+WHERE mz_clusters.name = {{ dbt.string_literal(cluster) }}
 {%- endset -%}
 
 {%- set result = run_query(cluster_exists) %}
@@ -58,7 +58,7 @@ WITH dataflows AS (
     FROM mz_indexes
     JOIN mz_clusters ON mz_indexes.cluster_id = mz_clusters.id
     JOIN mz_cluster_replicas ON mz_clusters.id = mz_cluster_replicas.cluster_id
-    WHERE mz_clusters.name = lower(trim('{{ cluster }}'))
+    WHERE mz_clusters.name = {{ dbt.string_literal(cluster) }}
 
     UNION ALL
 
@@ -70,7 +70,7 @@ WITH dataflows AS (
     FROM mz_materialized_views
     JOIN mz_clusters ON mz_materialized_views.cluster_id = mz_clusters.id
     JOIN mz_cluster_replicas ON mz_clusters.id = mz_cluster_replicas.cluster_id
-    WHERE mz_clusters.name = lower(trim('{{ cluster }}'))
+    WHERE mz_clusters.name = {{ dbt.string_literal(cluster) }}
 
     UNION ALL
 
@@ -82,7 +82,7 @@ WITH dataflows AS (
     FROM mz_sources
     JOIN mz_clusters ON mz_clusters.id = mz_sources.cluster_id
     JOIN mz_cluster_replicas ON mz_clusters.id = mz_cluster_replicas.cluster_id
-    WHERE mz_clusters.name = lower(trim('{{ cluster }}'))
+    WHERE mz_clusters.name = {{ dbt.string_literal(cluster) }}
 
     UNION ALL
 
@@ -94,7 +94,7 @@ WITH dataflows AS (
     FROM mz_sinks
     JOIN mz_clusters ON mz_clusters.id = mz_sinks.cluster_id
     JOIN mz_cluster_replicas ON mz_clusters.id = mz_cluster_replicas.cluster_id
-    WHERE mz_clusters.name = lower(trim('{{ cluster }}'))
+    WHERE mz_clusters.name = {{ dbt.string_literal(cluster) }}
 
 ),
 
@@ -120,7 +120,7 @@ ready_replicas AS (
     SELECT mz_cluster_replicas.id AS replica_id
     FROM mz_cluster_replicas
     JOIN mz_clusters ON mz_clusters.id = mz_cluster_replicas.cluster_id
-    WHERE mz_clusters.name = '{{ cluster }}'
+    WHERE mz_clusters.name = {{ dbt.string_literal(cluster) }}
 
     EXCEPT
 


### PR DESCRIPTION
### Motivation

Assign permissions to newly created schemas and clusters that match those of the schemas and clusters we are copying.  

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
