### PR TITLE
storage: avoid connecting to upstream services from timely threads as a stopgap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6089,6 +6089,7 @@ name = "mz-storage-types"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-sts",

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2649,9 +2649,9 @@ impl Coordinator {
         self.controller.connection_context()
     }
 
-    /// Obtain a reference to the coordinator's secret reader.
-    fn secrets_reader(&self) -> &dyn SecretsReader {
-        &*self.connection_context().secrets_reader
+    /// Obtain a reference to the coordinator's secret reader, in an `Arc`.
+    fn secrets_reader(&self) -> &Arc<dyn SecretsReader> {
+        &self.connection_context().secrets_reader
     }
 
     /// Publishes a notice message to all sessions.

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -28,6 +28,7 @@ use mz_compute_client::protocol::response::PeekResponse;
 use mz_controller::clusters::ReplicaLocation;
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_ore::error::ErrorExt;
+use mz_ore::future::InTask;
 use mz_ore::instrument;
 use mz_ore::retry::Retry;
 use mz_ore::str::StrExt;
@@ -229,6 +230,7 @@ impl Coordinator {
                                             .config(
                                                 self.secrets_reader(),
                                                 self.controller.storage.config(),
+                                                InTask::No,
                                             )
                                             .await
                                             .map_err(|e| {

--- a/src/storage-client/src/sink.rs
+++ b/src/storage-client/src/sink.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context};
 use mz_kafka_util::client::MzClientContext;
 use mz_ore::collections::CollectionExt;
+use mz_ore::future::{InTask, OreFutureExt};
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::errors::ContextCreationErrorExt;
 use mz_storage_types::sinks::KafkaSinkConnection;
@@ -207,6 +208,8 @@ pub async fn ensure_kafka_topic(
             storage_configuration,
             MzClientContext::default(),
             &BTreeMap::new(),
+            // Only called from `mz_storage`.
+            InTask::Yes,
         )
         .await
         .add_context("creating admin client failed")?;
@@ -275,9 +278,9 @@ pub async fn ensure_kafka_topic(
 /// TODO(benesch): do we need to delete the Kafka topic if publishing the
 /// schema fails?
 pub async fn publish_kafka_schemas(
-    ccsr: &mz_ccsr::Client,
-    topic: &str,
-    key_schema: Option<&str>,
+    ccsr: mz_ccsr::Client,
+    topic: String,
+    key_schema: Option<String>,
     key_schema_type: Option<mz_ccsr::SchemaType>,
     value_schema: &str,
     value_schema_type: mz_ccsr::SchemaType,
@@ -296,9 +299,13 @@ pub async fn publish_kafka_schemas(
         let key_schema_type =
             key_schema_type.ok_or_else(|| anyhow!("expected schema type for key schema"))?;
         Some(
-            ccsr.publish_schema(&format!("{}-key", topic), key_schema, key_schema_type, &[])
-                .await
-                .context("unable to publish key schema to registry in kafka sink")?,
+            async move {
+                ccsr.publish_schema(&format!("{}-key", topic), &key_schema, key_schema_type, &[])
+                    .await
+            }
+            .run_in_task(|| "publish_kafka_schemas".to_string())
+            .await
+            .context("unable to publish key schema to registry in kafka sink")?,
         )
     } else {
         None

--- a/src/storage-operators/src/s3_oneshot_sink.rs
+++ b/src/storage-operators/src/s3_oneshot_sink.rs
@@ -20,6 +20,7 @@ use http::Uri;
 use mz_aws_util::s3_uploader::{
     CompletedUpload, S3MultiPartUploadError, S3MultiPartUploader, S3MultiPartUploaderConfig,
 };
+use mz_ore::future::InTask;
 use mz_ore::task::JoinHandleExt;
 use mz_pgcopy::{encode_copy_format, CopyFormatParams};
 use mz_repr::{Diff, GlobalId, RelationDesc, Row, Timestamp};
@@ -79,7 +80,7 @@ pub fn copy_to<G, F>(
         }
 
         let sdk_config = match aws_connection
-            .load_sdk_config(&connection_context, connection_id)
+            .load_sdk_config(&connection_context, connection_id, InTask::Yes)
             .await
         {
             Ok(sdk_config) => sdk_config,

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -15,6 +15,7 @@ harness = false
 
 [dependencies]
 anyhow = "1.0.66"
+async-trait = "0.1.68"
 aws-config = { version = "1.1.1", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.1.1", features = ["hardcoded-credentials"] }
 aws-sdk-sts = { version = "1.7.0", default-features = false, features = ["rt-tokio"] }

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -22,6 +22,7 @@ use mz_kafka_util::client::{
     BrokerRewrite, MzClientContext, MzKafkaError, TunnelConfig, TunnelingClientContext,
 };
 use mz_ore::error::ErrorExt;
+use mz_ore::future::{InTask, OreFutureExt};
 use mz_proto::tokio_postgres::any_ssl_mode;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::url::any_url;
@@ -55,6 +56,48 @@ pub mod inline;
 
 include!(concat!(env!("OUT_DIR"), "/mz_storage_types.connections.rs"));
 
+/// An extension trait for [`SecretsReader`]
+#[async_trait::async_trait]
+trait SecretsReaderExt {
+    /// `SecretsReader::read`, but optionally run in a task.
+    async fn read_in_task_if(
+        &self,
+        in_task: InTask,
+        id: GlobalId,
+    ) -> Result<Vec<u8>, anyhow::Error>;
+
+    /// `SecretsReader::read_string`, but optionally run in a task.
+    async fn read_string_in_task_if(
+        &self,
+        in_task: InTask,
+        id: GlobalId,
+    ) -> Result<String, anyhow::Error>;
+}
+
+#[async_trait::async_trait]
+impl SecretsReaderExt for Arc<dyn SecretsReader> {
+    async fn read_in_task_if(
+        &self,
+        in_task: InTask,
+        id: GlobalId,
+    ) -> Result<Vec<u8>, anyhow::Error> {
+        let sr = Arc::clone(self);
+        async move { sr.read(id).await }
+            .run_in_task_if(in_task, || "secrets_reader_read".to_string())
+            .await
+    }
+    async fn read_string_in_task_if(
+        &self,
+        in_task: InTask,
+        id: GlobalId,
+    ) -> Result<String, anyhow::Error> {
+        let sr = Arc::clone(self);
+        async move { sr.read_string(id).await }
+            .run_in_task_if(in_task, || "secrets_reader_read".to_string())
+            .await
+    }
+}
+
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum StringOrSecret {
     String(String),
@@ -63,10 +106,14 @@ pub enum StringOrSecret {
 
 impl StringOrSecret {
     /// Gets the value as a string, reading the secret if necessary.
-    pub async fn get_string(&self, secrets_reader: &dyn SecretsReader) -> anyhow::Result<String> {
+    pub async fn get_string(
+        &self,
+        in_task: InTask,
+        secrets_reader: &Arc<dyn SecretsReader>,
+    ) -> anyhow::Result<String> {
         match self {
             StringOrSecret::String(s) => Ok(s.clone()),
-            StringOrSecret::Secret(id) => secrets_reader.read_string(*id).await,
+            StringOrSecret::Secret(id) => secrets_reader.read_string_in_task_if(in_task, *id).await,
         }
     }
 
@@ -474,6 +521,7 @@ impl KafkaConnection {
         storage_configuration: &StorageConfiguration,
         context: C,
         extra_options: &BTreeMap<&str, String>,
+        in_task: InTask,
     ) -> Result<T, ContextCreationError>
     where
         C: ClientContext,
@@ -538,9 +586,12 @@ impl KafkaConnection {
         for (k, v) in options {
             config.set(
                 k,
-                v.get_string(&*storage_configuration.connection_context.secrets_reader)
-                    .await
-                    .context("reading kafka secret")?,
+                v.get_string(
+                    in_task,
+                    &storage_configuration.connection_context.secrets_reader,
+                )
+                .await
+                .context("reading kafka secret")?,
             );
         }
         for (k, v) in extra_options {
@@ -555,6 +606,7 @@ impl KafkaConnection {
                 .ssh_tunnel_manager
                 .clone(),
             storage_configuration.parameters.ssh_timeout_config,
+            in_task,
         );
 
         match &self.default_tunnel {
@@ -571,7 +623,7 @@ impl KafkaConnection {
                 let secret = storage_configuration
                     .connection_context
                     .secrets_reader
-                    .read(ssh_tunnel.connection_id)
+                    .read_in_task_if(in_task, ssh_tunnel.connection_id)
                     .await?;
                 let key_pair = SshKeyPair::from_bytes(&secret)?;
 
@@ -631,7 +683,7 @@ impl KafkaConnection {
                                     &storage_configuration
                                         .connection_context
                                         .secrets_reader
-                                        .read(ssh_tunnel.connection_id)
+                                        .read_in_task_if(in_task, ssh_tunnel.connection_id)
                                         .await?,
                                 )?,
                             },
@@ -652,7 +704,13 @@ impl KafkaConnection {
     ) -> Result<(), anyhow::Error> {
         let (context, error_rx) = MzClientContext::with_errors();
         let consumer: BaseConsumer<_> = self
-            .create_with_context(storage_configuration, context, &BTreeMap::new())
+            .create_with_context(
+                storage_configuration,
+                context,
+                &BTreeMap::new(),
+                // We are in a normal tokio context during validation, already.
+                InTask::No,
+            )
             .await?;
         let consumer = Arc::new(consumer);
 
@@ -855,11 +913,15 @@ impl CsrConnection {
     pub async fn connect(
         &self,
         storage_configuration: &StorageConfiguration,
+        in_task: InTask,
     ) -> Result<mz_ccsr::Client, CsrConnectError> {
         let mut client_config = mz_ccsr::ClientConfig::new(self.url.clone());
         if let Some(root_cert) = &self.tls_root_cert {
             let root_cert = root_cert
-                .get_string(&*storage_configuration.connection_context.secrets_reader)
+                .get_string(
+                    in_task,
+                    &storage_configuration.connection_context.secrets_reader,
+                )
                 .await?;
             let root_cert = Certificate::from_pem(root_cert.as_bytes())?;
             client_config = client_config.add_root_certificate(root_cert);
@@ -869,11 +931,14 @@ impl CsrConnection {
             let key = &storage_configuration
                 .connection_context
                 .secrets_reader
-                .read_string(tls_identity.key)
+                .read_string_in_task_if(in_task, tls_identity.key)
                 .await?;
             let cert = tls_identity
                 .cert
-                .get_string(&*storage_configuration.connection_context.secrets_reader)
+                .get_string(
+                    in_task,
+                    &storage_configuration.connection_context.secrets_reader,
+                )
                 .await?;
             let ident = Identity::from_pem(key.as_bytes(), cert.as_bytes())?;
             client_config = client_config.identity(ident);
@@ -882,7 +947,10 @@ impl CsrConnection {
         if let Some(http_auth) = &self.http_auth {
             let username = http_auth
                 .username
-                .get_string(&*storage_configuration.connection_context.secrets_reader)
+                .get_string(
+                    in_task,
+                    &storage_configuration.connection_context.secrets_reader,
+                )
                 .await?;
             let password = match http_auth.password {
                 None => None,
@@ -890,7 +958,7 @@ impl CsrConnection {
                     storage_configuration
                         .connection_context
                         .secrets_reader
-                        .read_string(password)
+                        .read_string_in_task_if(in_task, password)
                         .await?,
                 ),
             };
@@ -919,6 +987,7 @@ impl CsrConnection {
                         // Default to the default http port, but this
                         // could default to 8081...
                         self.url.port().unwrap_or(80),
+                        in_task,
                     )
                     .await
                     .map_err(CsrConnectError::Ssh)?;
@@ -986,7 +1055,13 @@ impl CsrConnection {
         _id: GlobalId,
         storage_configuration: &StorageConfiguration,
     ) -> Result<(), anyhow::Error> {
-        let client = self.connect(storage_configuration).await?;
+        let client = self
+            .connect(
+                storage_configuration,
+                // We are in a normal tokio context during validation, already.
+                InTask::No,
+            )
+            .await?;
         client.list_subjects().await?;
         Ok(())
     }
@@ -1161,27 +1236,35 @@ impl<C: ConnectionAccess> PostgresConnection<C> {
 impl PostgresConnection<InlinedConnection> {
     pub async fn config(
         &self,
-        secrets_reader: &dyn mz_secrets::SecretsReader,
+        secrets_reader: &Arc<dyn mz_secrets::SecretsReader>,
         storage_configuration: &StorageConfiguration,
+        in_task: InTask,
     ) -> Result<mz_postgres_util::Config, anyhow::Error> {
         let mut config = tokio_postgres::Config::new();
         config
             .host(&self.host)
             .port(self.port)
             .dbname(&self.database)
-            .user(&self.user.get_string(secrets_reader).await?)
+            .user(&self.user.get_string(in_task, secrets_reader).await?)
             .ssl_mode(self.tls_mode);
         if let Some(password) = self.password {
-            let password = secrets_reader.read_string(password).await?;
+            let password = secrets_reader
+                .read_string_in_task_if(in_task, password)
+                .await?;
             config.password(password);
         }
         if let Some(tls_root_cert) = &self.tls_root_cert {
-            let tls_root_cert = tls_root_cert.get_string(secrets_reader).await?;
+            let tls_root_cert = tls_root_cert.get_string(in_task, secrets_reader).await?;
             config.ssl_root_cert(tls_root_cert.as_bytes());
         }
         if let Some(tls_identity) = &self.tls_identity {
-            let cert = tls_identity.cert.get_string(secrets_reader).await?;
-            let key = secrets_reader.read_string(tls_identity.key).await?;
+            let cert = tls_identity
+                .cert
+                .get_string(in_task, secrets_reader)
+                .await?;
+            let key = secrets_reader
+                .read_string_in_task_if(in_task, tls_identity.key)
+                .await?;
             config.ssl_cert(cert.as_bytes()).ssl_key(key.as_bytes());
         }
 
@@ -1191,7 +1274,9 @@ impl PostgresConnection<InlinedConnection> {
                 connection_id,
                 connection,
             }) => {
-                let secret = secrets_reader.read(*connection_id).await?;
+                let secret = secrets_reader
+                    .read_in_task_if(in_task, *connection_id)
+                    .await?;
                 let key_pair = SshKeyPair::from_bytes(&secret)?;
                 mz_postgres_util::TunnelConfig::Ssh {
                     config: SshTunnelConfig {
@@ -1218,6 +1303,7 @@ impl PostgresConnection<InlinedConnection> {
                 .pg_source_tcp_timeouts
                 .clone(),
             storage_configuration.parameters.ssh_timeout_config,
+            in_task,
         )?)
     }
 
@@ -1228,8 +1314,10 @@ impl PostgresConnection<InlinedConnection> {
     ) -> Result<(), anyhow::Error> {
         let config = self
             .config(
-                &*storage_configuration.connection_context.secrets_reader,
+                &storage_configuration.connection_context.secrets_reader,
                 storage_configuration,
+                // We are in a normal tokio context during validation, already.
+                InTask::No,
             )
             .await?;
         config
@@ -1480,17 +1568,20 @@ impl<C: ConnectionAccess> MySqlConnection<C> {
 impl MySqlConnection<InlinedConnection> {
     pub async fn config(
         &self,
-        secrets_reader: &dyn mz_secrets::SecretsReader,
+        secrets_reader: &Arc<dyn mz_secrets::SecretsReader>,
         storage_configuration: &StorageConfiguration,
+        in_task: InTask,
     ) -> Result<mz_mysql_util::Config, anyhow::Error> {
         // TODO(roshan): Set appropriate connection timeouts
         let mut opts = mysql_async::OptsBuilder::default()
             .ip_or_hostname(&self.host)
             .tcp_port(self.port)
-            .user(Some(&self.user.get_string(secrets_reader).await?));
+            .user(Some(&self.user.get_string(in_task, secrets_reader).await?));
 
         if let Some(password) = self.password {
-            let password = secrets_reader.read_string(password).await?;
+            let password = secrets_reader
+                .read_string_in_task_if(in_task, password)
+                .await?;
             opts = opts.pass(Some(password));
         }
 
@@ -1516,7 +1607,7 @@ impl MySqlConnection<InlinedConnection> {
             MySqlSslMode::VerifyCa | MySqlSslMode::VerifyIdentity
         ) {
             if let Some(tls_root_cert) = &self.tls_root_cert {
-                let tls_root_cert = tls_root_cert.get_string(secrets_reader).await?;
+                let tls_root_cert = tls_root_cert.get_string(in_task, secrets_reader).await?;
                 ssl_opts = ssl_opts.map(|opts| {
                     opts.with_root_certs(vec![tls_root_cert.as_bytes().to_vec().into()])
                 });
@@ -1524,8 +1615,10 @@ impl MySqlConnection<InlinedConnection> {
         }
 
         if let Some(identity) = &self.tls_identity {
-            let key = secrets_reader.read_string(identity.key).await?;
-            let cert = identity.cert.get_string(secrets_reader).await?;
+            let key = secrets_reader
+                .read_string_in_task_if(in_task, identity.key)
+                .await?;
+            let cert = identity.cert.get_string(in_task, secrets_reader).await?;
             let Pkcs12Archive { der, pass } =
                 mz_tls_util::pkcs12der_from_pem(key.as_bytes(), cert.as_bytes())?;
 
@@ -1545,7 +1638,9 @@ impl MySqlConnection<InlinedConnection> {
                 connection_id,
                 connection,
             }) => {
-                let secret = secrets_reader.read(*connection_id).await?;
+                let secret = secrets_reader
+                    .read_in_task_if(in_task, *connection_id)
+                    .await?;
                 let key_pair = SshKeyPair::from_bytes(&secret)?;
                 mz_mysql_util::TunnelConfig::Ssh {
                     config: SshTunnelConfig {
@@ -1573,6 +1668,7 @@ impl MySqlConnection<InlinedConnection> {
             opts.into(),
             tunnel,
             storage_configuration.parameters.ssh_timeout_config,
+            in_task,
         ))
     }
 
@@ -1583,8 +1679,10 @@ impl MySqlConnection<InlinedConnection> {
     ) -> Result<(), anyhow::Error> {
         let config = self
             .config(
-                &*storage_configuration.connection_context.secrets_reader,
+                &storage_configuration.connection_context.secrets_reader,
                 storage_configuration,
+                // We are in a normal tokio context during validation, already.
+                InTask::No,
             )
             .await?;
         let conn = config
@@ -1824,6 +1922,7 @@ impl SshTunnel<InlinedConnection> {
         storage_configuration: &StorageConfiguration,
         remote_host: &str,
         remote_port: u16,
+        in_task: InTask,
     ) -> Result<ManagedSshTunnelHandle, anyhow::Error> {
         storage_configuration
             .connection_context
@@ -1837,13 +1936,14 @@ impl SshTunnel<InlinedConnection> {
                         &storage_configuration
                             .connection_context
                             .secrets_reader
-                            .read(self.connection_id)
+                            .read_in_task_if(in_task, self.connection_id)
                             .await?,
                     )?,
                 },
                 remote_host,
                 remote_port,
                 storage_configuration.parameters.ssh_timeout_config,
+                in_task,
             )
             .await
     }
@@ -1890,7 +1990,11 @@ impl SshConnection {
         let secret = storage_configuration
             .connection_context
             .secrets_reader
-            .read(id)
+            .read_in_task_if(
+                // We are in a normal tokio context during validation, already.
+                InTask::No,
+                id,
+            )
             .await?;
         let key_pair = SshKeyPair::from_bytes(&secret)?;
         let config = SshTunnelConfig {
@@ -1925,6 +2029,7 @@ impl AwsPrivatelinkConnection {
             return Err(anyhow!("AWS PrivateLink connections are unsupported"));
         };
 
+        // No need to optionally run this in a task, as we are just validating from envd.
         let status = cloud_resource_reader.read(id).await?;
 
         let availability = status

--- a/src/storage-types/src/connections/aws.rs
+++ b/src/storage-types/src/connections/aws.rs
@@ -18,6 +18,7 @@ use aws_sdk_sts::operation::get_caller_identity::GetCallerIdentityError;
 use aws_types::region::Region;
 use aws_types::SdkConfig;
 use mz_ore::error::ErrorExt;
+use mz_ore::future::{InTask, OreFutureExt};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::GlobalId;
 use proptest_derive::Arbitrary;
@@ -117,11 +118,14 @@ impl AwsCredentials {
     async fn load_credentials_provider(
         &self,
         connection_context: &ConnectionContext,
+        // Whether or not to do IO in a separate Tokio task.
+        in_task: InTask,
     ) -> Result<impl ProvideCredentials, anyhow::Error> {
-        let secrets_reader = connection_context.secrets_reader.as_ref();
+        let secrets_reader = &connection_context.secrets_reader;
         Ok(Credentials::from_keys(
             self.access_key_id
-                .get_string(secrets_reader)
+                // We will already be contained within a tokio task from `load_sdk_config`.
+                .get_string(in_task, secrets_reader)
                 .await
                 .map_err(|_| {
                     anyhow!("internal error: failed to read access key ID from secret store")
@@ -135,7 +139,7 @@ impl AwsCredentials {
                 })?,
             match &self.session_token {
                 Some(t) => {
-                    let t = t.get_string(secrets_reader).await.map_err(|_| {
+                    let t = t.get_string(in_task, secrets_reader).await.map_err(|_| {
                         anyhow!("internal error: failed to read session token from secret store")
                     })?;
                     Some(t)
@@ -318,20 +322,29 @@ impl AwsConnection {
         &self,
         connection_context: &ConnectionContext,
         connection_id: GlobalId,
+        in_task: InTask,
     ) -> Result<SdkConfig, anyhow::Error> {
-        let credentials = match &self.auth {
-            AwsAuth::Credentials(credentials) => SharedCredentialsProvider::new(
-                credentials
-                    .load_credentials_provider(connection_context)
-                    .await?,
-            ),
-            AwsAuth::AssumeRole(assume_role) => SharedCredentialsProvider::new(
-                assume_role
-                    .load_credentials_provider(connection_context, connection_id)
-                    .await?,
-            ),
-        };
-        self.load_sdk_config_from_credentials(credentials).await
+        let connection_context = connection_context.clone();
+        let this = self.clone();
+        // This entire block is wrapped in a `run_in_task_if`, so the inner futures are
+        // run in-line with `InTask::No`.
+        async move {
+            let credentials = match &this.auth {
+                AwsAuth::Credentials(credentials) => SharedCredentialsProvider::new(
+                    credentials
+                        .load_credentials_provider(&connection_context, InTask::No)
+                        .await?,
+                ),
+                AwsAuth::AssumeRole(assume_role) => SharedCredentialsProvider::new(
+                    assume_role
+                        .load_credentials_provider(&connection_context, connection_id)
+                        .await?,
+                ),
+            };
+            this.load_sdk_config_from_credentials(credentials).await
+        }
+        .run_in_task_if(in_task, || "load_sdk_config".to_string())
+        .await
     }
 
     async fn load_sdk_config_from_credentials(
@@ -354,7 +367,12 @@ impl AwsConnection {
         storage_configuration: &StorageConfiguration,
     ) -> Result<(), AwsConnectionValidationError> {
         let aws_config = self
-            .load_sdk_config(&storage_configuration.connection_context, id)
+            .load_sdk_config(
+                &storage_configuration.connection_context,
+                id,
+                // We are in a normal tokio context during validation, already.
+                InTask::No,
+            )
             .await?;
         let sts_client = aws_sdk_sts::Client::new(&aws_config);
         let _ = sts_client.get_caller_identity().send().await?;

--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use differential_dataflow::capture::{Message, Progress, YieldingIter};
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use mz_ore::error::ErrorExt;
-use mz_ore::future::OreFutureExt;
+use mz_ore::future::InTask;
 use mz_repr::{Datum, Diff, Row};
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::errors::{CsrConnectError, DecodeError, DecodeErrorKind};
@@ -317,13 +317,9 @@ async fn get_decoder(
             let csr_client = match csr_connection {
                 None => None,
                 Some(csr_connection) => {
-                    let debug_name = debug_name.to_string();
-                    let storage_configuration = storage_configuration.clone();
-                    let csr_client =
-                        async move { csr_connection.connect(&storage_configuration).await }
-                            .run_in_task(move || format!("connect_csr:{}", debug_name))
-                            .await?;
-
+                    let csr_client = csr_connection
+                        .connect(storage_configuration, InTask::Yes)
+                        .await?;
                     Some(csr_client)
                 }
             };

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -22,6 +22,7 @@ use futures::StreamExt;
 use maplit::btreemap;
 use mz_kafka_util::client::{get_partitions, MzClientContext, PartitionId, TunnelingClientContext};
 use mz_ore::error::ErrorExt;
+use mz_ore::future::InTask;
 use mz_ore::thread::{JoinHandleExt, UnparkOnDropHandle};
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::{adt::jsonb::Jsonb, Datum, Diff, GlobalId, Row};
@@ -283,6 +284,7 @@ impl SourceRender for KafkaSourceConnection {
                         // consumer.
                         "client.id" => client_id.clone(),
                     },
+                    InTask::Yes,
                 )
                 .await;
 

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -50,6 +50,7 @@ use futures::StreamExt;
 use itertools::Itertools;
 use mysql_async::prelude::Queryable;
 use mysql_async::{BinlogStream, BinlogStreamRequest, GnoInterval, Sid};
+use mz_ore::future::InTask;
 use mz_ssh_util::tunnel_manager::ManagedSshTunnelHandle;
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::{Concat, Map};
@@ -145,8 +146,9 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
             let connection_config = connection
                 .connection
                 .config(
-                    &*config.config.connection_context.secrets_reader,
+                    &config.config.connection_context.secrets_reader,
                     &config.config,
+                    InTask::Yes,
                 )
                 .await?;
 

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -98,6 +98,7 @@ use timely::progress::{Antichain, Timestamp};
 use tracing::{error, trace};
 
 use mz_mysql_util::{pack_mysql_row, query_sys_var, MySqlError, MySqlTableDesc, ER_NO_SUCH_TABLE};
+use mz_ore::future::InTask;
 use mz_ore::metrics::MetricsFutureExt;
 use mz_ore::result::ResultExt;
 use mz_repr::{Diff, GlobalId, Row};
@@ -212,8 +213,9 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                 let connection_config = connection
                     .connection
                     .config(
-                        &*config.config.connection_context.secrets_reader,
+                        &config.config.connection_context.secrets_reader,
                         &config.config,
+                        InTask::Yes,
                     )
                     .await?;
                 let task_name = format!("timely-{worker_id} MySQL snapshotter");

--- a/src/storage/src/source/mysql/statistics.rs
+++ b/src/storage/src/source/mysql/statistics.rs
@@ -15,6 +15,7 @@ use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 
 use mz_mysql_util::query_sys_var;
+use mz_ore::future::InTask;
 use mz_storage_types::sources::mysql::{gtid_set_frontier, GtidPartition, GtidState};
 use mz_storage_types::sources::MySqlSourceConnection;
 use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
@@ -67,8 +68,9 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
             let connection_config = connection
                 .connection
                 .config(
-                    &*config.config.connection_context.secrets_reader,
+                    &config.config.connection_context.secrets_reader,
                     &config.config,
+                    InTask::Yes,
                 )
                 .await?;
 

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -82,6 +82,7 @@ use futures::{future, future::select, FutureExt, Stream as AsyncStream, StreamEx
 use mz_expr::MirScalarExpr;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::HashSet;
+use mz_ore::future::InTask;
 use mz_ore::result::ResultExt;
 use mz_postgres_util::desc::PostgresTableDesc;
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
@@ -202,8 +203,9 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             let connection_config = connection
                 .connection
                 .config(
-                    &*config.config.connection_context.secrets_reader,
+                    &config.config.connection_context.secrets_reader,
                     &config.config,
+                    InTask::Yes,
                 )
                 .await?;
 

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -142,6 +142,7 @@ use anyhow::bail;
 use differential_dataflow::{AsCollection, Collection};
 use futures::TryStreamExt;
 use mz_expr::MirScalarExpr;
+use mz_ore::future::InTask;
 use mz_ore::result::ResultExt;
 use mz_postgres_util::desc::PostgresTableDesc;
 use mz_postgres_util::{simple_query_opt, PostgresError};
@@ -266,8 +267,9 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             let connection_config = connection
                 .connection
                 .config(
-                    &*config.config.connection_context.secrets_reader,
+                    &config.config.connection_context.secrets_reader,
                     &config.config,
+                    InTask::Yes,
                 )
                 .await?;
             let task_name = format!("timely-{worker_id} PG snapshotter");


### PR DESCRIPTION
Partially closes: https://github.com/MaterializeInc/materialize/issues/25707

We have seen erroneous timeouts and pathological behavior when IO futures that expects to be polled promptly is starved from busy timely threads. This pr addresses, and ensures that ALL IO performed from storage (with the exception of mysql queries, which is tracked here: https://github.com/MaterializeInc/materialize/issues/25390) is performed in a tokio task. This is already true for persist, but we have (many) leftover spots.


I went through a couple iterations here, and even tried to create a single trait that defined and `async connect` method for all storage connections. However, in practice, the various connections have very different interactions at their callsites, so I went with a single boolean.

The pr is designed to not change the code that the adapter runs, with the exceptions of a few more clones. Arguably, we could just ALWAYS run io in tokio tasks, regardless of if its happening as part of purification, validation, or within a timely operator. I don't have a strong opinion.


Also, I _believe_ this to cover all io (other than mysql queries), but please let me know if you know of any I'm missing!

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
