### PR TITLE
persist: add context to the "expects earliest live diff to advance" log

### DIFF
--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -388,7 +388,12 @@ impl StateVersions {
                         .expect("initialized shard should have at least one diff")
                         .seqno;
                     if earliest_before_refetch >= earliest_after_refetch {
-                        warn!("logic error: fetch_current_state refetch expects earliest live diff to advance: {} vs {}", earliest_before_refetch, earliest_after_refetch)
+                        warn!(concat!(
+                            "fetch_current_state refetch expects earliest live diff to advance: {} vs {}. ",
+                            "In dev and testing, this happens when persist's Blob (files in mzdata) ",
+                            "is deleted out from under it or when two processes are talking to ",
+                            "different Blobs (e.g. docker containers without it shared)."),
+                            earliest_before_refetch, earliest_after_refetch)
                     }
                     continue;
                 }
@@ -452,7 +457,12 @@ impl StateVersions {
                         .expect("initialized shard should have at least one diff")
                         .seqno;
                     if earliest_before_refetch >= earliest_after_refetch {
-                        warn!("logic error: fetch_all_live_states refetch expects earliest live diff to advance: {} vs {}", earliest_before_refetch, earliest_after_refetch)
+                        warn!(concat!(
+                            "fetch_all_live_states refetch expects earliest live diff to advance: {} vs {}. ",
+                            "In dev and testing, this happens when persist's Blob (files in mzdata) ",
+                            "is deleted out from under it or when two processes are talking to ",
+                            "different Blobs (e.g. docker containers without it shared)."),
+                            earliest_before_refetch, earliest_after_refetch)
                     }
                     continue;
                 }


### PR DESCRIPTION
This comes up often enough during dev and testing that it's worth making it more self-service.

Closes #25460.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
