### PR TITLE
ci: Improve annotation for code coverage

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -304,7 +304,7 @@ def annotate_logged_errors(log_files: list[str]) -> int:
             msg = "\n".join(filter(None, [error.message, error.text]))
             if "in Code Coverage" in error.text or "covered" in error.message:
                 # Don't bother looking up known issues for code coverage report, just print it verbatim as an info message
-                known_errors.append(f"{error.testcase}:\n{msg}")
+                known_errors.append(f"{error.testcase}:\n```\n{msg}\n```")
             else:
                 handle_error(msg.encode("utf-8"), error.testcase)
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/coverage/builds/385

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
