### PR TITLE
compute: sequential dataflow hydration

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -56,6 +56,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     # Others (ordered by name)
     "cluster_always_use_disk": "true",
     "compute_dataflow_max_inflight_bytes": "134217728",  # 128 MiB
+    "compute_hydration_concurrency": 4,
     "default_arrangement_exert_proportionality": "16",
     "default_idle_arrangement_merge_effort": "0",
     "disk_cluster_replicas_default": "true",

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -92,6 +92,13 @@ pub const LGALLOC_SLOW_CLEAR_BYTES: Config<usize> = Config::new(
     "Clear byte size per size class for every invocation",
 );
 
+/// The number of dataflows that may hydrate concurrently.
+pub const HYDRATION_CONCURRENCY: Config<usize> = Config::new(
+    "compute_hydration_concurrency",
+    usize::MAX,
+    "Controls how many compute dataflows may hydrate concurrently.",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -105,4 +112,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)
         .add(&LGALLOC_BACKGROUND_INTERVAL)
         .add(&LGALLOC_SLOW_CLEAR_BYTES)
+        .add(&HYDRATION_CONCURRENCY)
 }

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -220,6 +220,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                         dataflow.until.clone(),
                         mfp.as_mut(),
                         compute_state.dataflow_max_inflight_bytes(),
+                        async {},
                     );
 
                     // If `mfp` is non-identity, we need to apply what remains.

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -102,14 +102,20 @@
 
 use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet};
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
+use std::task::Poll;
 
 use differential_dataflow::dynamic::pointstamp::PointStamp;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::trace::{Batch, Batcher, Trace, TraceReader};
 use differential_dataflow::{AsCollection, Collection, Data, ExchangeData, Hashable};
+use futures::channel::oneshot;
+use futures::FutureExt;
 use mz_compute_types::dataflows::{BuildDesc, DataflowDescription, IndexDesc};
 use mz_compute_types::dyncfgs::ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING;
 use mz_compute_types::plan::flat_plan::{FlatPlan, FlatPlanNode};
@@ -165,6 +171,7 @@ pub fn build_compute_dataflow<A: Allocate>(
     timely_worker: &mut TimelyWorker<A>,
     compute_state: &mut ComputeState,
     dataflow: DataflowDescription<FlatPlan, CollectionMetadata>,
+    start_signal: StartSignal,
 ) {
     // Mutually recursive view definitions require special handling.
     let recursive = dataflow
@@ -220,7 +227,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                         dataflow.until.clone(),
                         mfp.as_mut(),
                         compute_state.dataflow_max_inflight_bytes(),
-                        async {},
+                        start_signal.clone(),
                     );
 
                     // If `mfp` is non-identity, we need to apply what remains.
@@ -308,7 +315,14 @@ pub fn build_compute_dataflow<A: Allocate>(
 
                 // Export declared sinks.
                 for (sink_id, dependencies, sink) in sinks {
-                    context.export_sink(compute_state, &tokens, dependencies, sink_id, &sink);
+                    context.export_sink(
+                        compute_state,
+                        &tokens,
+                        dependencies,
+                        sink_id,
+                        &sink,
+                        start_signal.clone(),
+                    );
                 }
             });
         } else {
@@ -353,7 +367,14 @@ pub fn build_compute_dataflow<A: Allocate>(
 
                 // Export declared sinks.
                 for (sink_id, dependencies, sink) in sinks {
-                    context.export_sink(compute_state, &tokens, dependencies, sink_id, &sink);
+                    context.export_sink(
+                        compute_state,
+                        &tokens,
+                        dependencies,
+                        sink_id,
+                        &sink,
+                        start_signal.clone(),
+                    );
                 }
             });
         }
@@ -1118,6 +1139,40 @@ impl RenderTimestamp for Product<mz_repr::Timestamp, PointStamp<u64>> {
             *item = item.saturating_sub(1);
         }
         Product::new(self.outer.saturating_sub(1), PointStamp::new(vec))
+    }
+}
+
+/// A signal that can be awaited by operators to suspend them prior to startup.
+///
+/// Used to enforce a given configured hydration concurrency by only allowing that number of
+/// dataflows to perform hydration at the same time.
+///
+/// Note that currently only `persist_source` operators support suspension. Data can still enter a
+/// suspended dataflow through arrangement imports and ideally we would be able to suspend those as
+/// well.
+#[derive(Clone)]
+pub(super) struct StartSignal(
+    // The inner type is `Infallible` because no data is ever expected on this channel. Instead the
+    // signal is activated by dropping the corresponding `Sender`.
+    futures::future::Shared<oneshot::Receiver<Infallible>>,
+);
+
+impl StartSignal {
+    /// Create a new `StartSignal` and a corresponding token that activates the signal when
+    /// dropped.
+    pub fn new() -> (Self, Box<dyn Any>) {
+        let (tx, rx) = oneshot::channel::<Infallible>();
+        let token = Box::new(tx);
+        let signal = Self(rx.shared());
+        (signal, token)
+    }
+}
+
+impl Future for StartSignal {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0).poll(cx).map(|_| ())
     }
 }
 

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -30,7 +30,7 @@ use timely::progress::Antichain;
 use crate::compute_state::SinkToken;
 use crate::logging::compute::LogDataflowErrors;
 use crate::render::context::Context;
-use crate::render::RenderTimestamp;
+use crate::render::{RenderTimestamp, StartSignal};
 
 impl<'g, G, T> Context<Child<'g, G, T>>
 where
@@ -45,6 +45,7 @@ where
         dependency_ids: BTreeSet<GlobalId>,
         sink_id: GlobalId,
         sink: &ComputeSinkDesc<CollectionMetadata>,
+        start_signal: StartSignal,
     ) {
         soft_assert_or_log!(
             sink.non_null_assertions.is_strictly_sorted(),
@@ -133,6 +134,7 @@ where
                     sink,
                     sink_id,
                     self.as_of_frontier.clone(),
+                    start_signal,
                     ok_collection.enter_region(inner),
                     err_collection.enter_region(inner),
                 );
@@ -158,6 +160,7 @@ where
         sink: &ComputeSinkDesc<CollectionMetadata>,
         sink_id: GlobalId,
         as_of: Antichain<mz_repr::Timestamp>,
+        start_signal: StartSignal,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
     ) -> Option<Rc<dyn Any>>

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -487,6 +487,10 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                 compute_state.process_copy_tos();
             }
 
+            if let Some(compute_state) = &mut self.compute_state {
+                compute_state.process_sequential_hydration();
+            }
+
             self.metrics
                 .record_shared_row_metrics(self.timely_worker.index());
         }

--- a/src/compute/src/sink/copy_to_s3_oneshot.rs
+++ b/src/compute/src/sink/copy_to_s3_oneshot.rs
@@ -25,6 +25,7 @@ use timely::dataflow::Scope;
 use timely::progress::Antichain;
 
 use crate::render::sinks::SinkRender;
+use crate::render::StartSignal;
 use crate::typedefs::KeyBatcher;
 
 impl<G> SinkRender<G> for CopyToS3OneshotSinkConnection
@@ -37,6 +38,7 @@ where
         sink: &ComputeSinkDesc<CollectionMetadata>,
         sink_id: GlobalId,
         _as_of: Antichain<Timestamp>,
+        _start_signal: StartSignal,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
     ) -> Option<Rc<dyn Any>>

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -108,6 +108,7 @@ where
         Antichain::new(), // we want all updates
         None,             // no MFP
         compute_state.dataflow_max_inflight_bytes(),
+        async {},
     );
     let persist_collection = ok_stream
         .as_collection()

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -27,6 +27,7 @@ use timely::progress::Antichain;
 use timely::PartialOrder;
 
 use crate::render::sinks::SinkRender;
+use crate::render::StartSignal;
 
 impl<G> SinkRender<G> for SubscribeSinkConnection
 where
@@ -38,6 +39,7 @@ where
         sink: &ComputeSinkDesc<CollectionMetadata>,
         sink_id: GlobalId,
         as_of: Antichain<Timestamp>,
+        _start_signal: StartSignal,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
     ) -> Option<Rc<dyn Any>>

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -554,6 +554,7 @@ impl DataSubscribe {
                     Arc::new(UnitSchema),
                     |_, _| true,
                     false.then_some(|| unreachable!()),
+                    async {},
                 );
                 (data_stream.leave(), token)
             });

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -11,6 +11,7 @@
 
 use std::convert::Infallible;
 use std::fmt::Debug;
+use std::future::Future;
 use std::hash::Hash;
 use std::sync::Arc;
 use std::time::Instant;
@@ -137,6 +138,7 @@ pub fn persist_source<G>(
     until: Antichain<Timestamp>,
     map_filter_project: Option<&mut MfpPlan>,
     max_inflight_bytes: Option<usize>,
+    start_signal: impl Future<Output = ()> + 'static,
 ) -> (
     Stream<G, (Row, Timestamp, Diff)>,
     Stream<G, (DataflowError, Timestamp, Diff)>,
@@ -199,6 +201,7 @@ where
             map_filter_project,
             flow_control,
             subscribe_sleep,
+            start_signal,
         );
         tokens.extend(source_tokens);
 
@@ -266,6 +269,7 @@ pub fn persist_source_core<'g, G>(
     flow_control: Option<FlowControl<RefinedScope<'g, G>>>,
     // If Some, an override for the default listen sleep retry parameters.
     listen_sleep: Option<impl Fn() -> RetryParameters + 'static>,
+    start_signal: impl Future<Output = ()> + 'static,
 ) -> (
     Stream<
         RefinedScope<'g, G>,
@@ -346,6 +350,7 @@ where
             }
         },
         listen_sleep,
+        start_signal,
     );
     let rows = decode_and_mfp(cfg, &fetched, &name, until, map_filter_project);
     (rows, token)

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -61,6 +61,7 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
         timely::progress::Antichain::new(),
         None,
         None,
+        async {},
     );
     tokens.extend(persist_tokens);
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -309,6 +309,7 @@ where
                                 None,
                                 flow_control,
                                 false.then_some(|| unreachable!()),
+                                async {},
                             );
                             (
                                 stream.as_collection(),


### PR DESCRIPTION
Implement sequential dataflow hydration in compute by arranging for dataflow sources to be suspended after rendering and allowing them to resume only if there is hydration capacity. 

The available capacity is controlled by a new dyncfg option, `compute_hydration_concurrency`.

### Motivation

  * This PR adds a known-desirable feature.

Part of #25271.

### Tips for reviewer

* The first commit is relevant for @MaterializeInc/storage. It wires a new `start_signal` argument through `persist_source` and `shard_source` that the latter awaits before it starts ingesting any data. The plan is to not keep this around forever, but to replace it after the `persist_source`-internal backpressure has been removed, as discussed [in Slack](https://materializeinc.slack.com/archives/C01CFKM1QRF/p1709827468354719).
* The second commit is relevant for @MaterializeInc/compute. It introduces sequential dataflow hydration by suspending long-running dataflows using the `start_signal` introduced in the previous commit.

I opted to put both in the same PR because the context might be helpful for reviewers, but lmk if you'd rather have two instead. 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
