### PR TITLE
misc: add ci-aarch64-large scratch box

### DIFF
--- a/misc/scratch/ci-aarch64-large.json
+++ b/misc/scratch/ci-aarch64-large.json
@@ -1,0 +1,8 @@
+{
+    "name": "c7g.12xlarge as used by CI, when a large box is needed (aarch64-large)",
+    "launch_script": "true",
+    "instance_type": "c7g.12xlarge",
+    "ami": "ami-0568072f574d822a4",
+    "size_gb": 128,
+    "tags": {}
+}


### PR DESCRIPTION
At least once I've used this to repro/investigate ci failures.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
