### PR TITLE
compute: use a separate dyncfg for persist_source backpressure on cc

### DIFF
--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -57,6 +57,17 @@ pub const ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING: Config<bool> = Config::new(
     "Enable logging of the hydration status of compute operators.",
 );
 
+/// The "physical backpressure" of `compute_dataflow_max_inflight_bytes_cc` has
+/// been replaced in cc replicas by persist lgalloc and we intend to remove it
+/// once everything has switched to cc. In the meantime, this is a CYA to turn
+/// it back on if absolutely necessary.
+pub const DATAFLOW_MAX_INFLIGHT_BYTES_CC: Config<Option<usize>> = Config::new(
+    "compute_dataflow_max_inflight_bytes_cc",
+    None,
+    "The maximum number of in-flight bytes emitted by persist_sources feeding \
+    compute dataflows in cc clusters (Materialize).",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -66,4 +77,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
         .add(&ENABLE_CHUNKED_STACK)
         .add(&ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING)
+        .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -102,7 +102,7 @@ pub struct ComputeState {
     /// Max size in bytes of any result.
     max_result_size: u64,
     /// Maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
-    pub dataflow_max_inflight_bytes: Option<usize>,
+    dataflow_max_inflight_bytes: Option<usize>,
     /// Specification for rendering linear joins.
     pub linear_join_spec: LinearJoinSpec,
     /// Metrics for this replica.
@@ -221,6 +221,16 @@ impl ComputeState {
         let chunked_stack = ENABLE_CHUNKED_STACK.get(config);
         info!("using chunked stack: {chunked_stack}");
         crate::containers::stack::use_chunked_stack(chunked_stack);
+    }
+
+    /// Returns the cc or non-cc version of "dataflow_max_inflight_bytes", as
+    /// appropriate to this replica.
+    pub fn dataflow_max_inflight_bytes(&self) -> Option<usize> {
+        if self.persist_clients.cfg.is_cc_active {
+            mz_compute_types::dyncfgs::DATAFLOW_MAX_INFLIGHT_BYTES_CC.get(&self.worker_config)
+        } else {
+            self.dataflow_max_inflight_bytes
+        }
     }
 }
 

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -222,7 +222,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                         SnapshotMode::Include,
                         dataflow.until.clone(),
                         mfp.as_mut(),
-                        compute_state.dataflow_max_inflight_bytes,
+                        compute_state.dataflow_max_inflight_bytes(),
                     );
 
                     // If `mfp` is non-identity, we need to apply what remains.

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -107,7 +107,7 @@ where
         SnapshotMode::Include,
         Antichain::new(), // we want all updates
         None,             // no MFP
-        compute_state.dataflow_max_inflight_bytes,
+        compute_state.dataflow_max_inflight_bytes(),
     );
     let persist_collection = ok_stream
         .as_collection()


### PR DESCRIPTION
Replicas in cc sizes use lgalloc with persist, which is intended to replace this backpressure. Use a separate dyncfg, so existing users of the backpressure, don't rely on it when re-sizing to the cc sizes.

It's possible that this has already happened, but given that cc sizes are prpr, we're okay with that. This new config can be used to get them working again, but we'll have to get them to resize.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
