### PR TITLE
storage/mysql: Add support for real json type

### DIFF
--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -363,6 +363,7 @@ fn parse_data_type(
         "binary" | "varbinary" | "tinyblob" | "blob" | "mediumblob" | "longblob" => {
             Ok(ScalarType::Bytes)
         }
+        "json" => Ok(ScalarType::Jsonb),
         _ => Err(UnsupportedDataType {
             column_type: info.column_type.clone(),
             qualified_table_name: format!("{:?}.{:?}", schema_name, table_name),

--- a/test/mysql-cdc/types-json.td
+++ b/test/mysql-cdc/types-json.td
@@ -36,21 +36,24 @@ CREATE TABLE t1 (f1 JSON);
 
 INSERT INTO t1 VALUES (CAST('{"bar": "baz", "balance": 7.77, "active": false}' AS JSON));
 
-# TODO: #24796 (JSON support)
-# > CREATE SOURCE mz_source
-#   FROM MYSQL CONNECTION mysql_conn
-#   FOR ALL TABLES;
-#
-# > SELECT COUNT(*) > 0 FROM t1;
-# true
-#
-# # Insert the same data post-snapshot
-# $ mysql-execute name=mysql
-# INSERT INTO t1 SELECT * FROM t1;
-#
-# > SELECT pg_typeof(f1) FROM t1 LIMIT 1;
-# jsonb
-#
-# > SELECT * FROM t1;
-# "{\"active\":false,\"balance\":7.77,\"bar\":\"baz\"}"
-# "{\"active\":false,\"balance\":7.77,\"bar\":\"baz\"}"
+> CREATE SOURCE mz_source
+  FROM MYSQL CONNECTION mysql_conn
+  FOR ALL TABLES;
+
+> SELECT COUNT(*) > 0 FROM t1;
+true
+
+# Insert the same data post-snapshot
+$ mysql-execute name=mysql
+INSERT INTO t1 SELECT * FROM t1;
+
+> SELECT pg_typeof(f1) FROM t1 LIMIT 1;
+jsonb
+
+> SELECT * FROM t1;
+"{\"active\":false,\"balance\":7.77,\"bar\":\"baz\"}"
+"{\"active\":false,\"balance\":7.77,\"bar\":\"baz\"}"
+
+> SELECT f1->>'balance' FROM t1;
+7.77
+7.77


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/24796


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
