### PR TITLE
Normalize type information better

### DIFF
--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -115,11 +115,12 @@ impl NormalizeLets {
         let_motion::assert_no_lets(relation);
         let_motion::assert_letrec_major(relation);
 
-        // Refresh types while we are in letrec-major form.
-        support::refresh_types(relation)?;
-
         // Inlining may violate letrec-major form.
         inlining::inline_lets(relation, self.inline_mfp)?;
+
+        // Return to letrec-major form to refresh types.
+        let_motion::promote_let_rec(relation);
+        support::refresh_types(relation)?;
 
         // Renumber bindings for good measure.
         // Ideally we could skip when `action` is a no-op, but hard to thread that through at the moment.


### PR DESCRIPTION
The `normalize_lets` logic would refresh type information before inlining let bindings that are used only once. Our unique key determination logic .. is not invariant under inlining, and in particular can learn more once it has inlined terms. This PR moves the type refreshing after inlining, which I think is where it used to be until we learned that inlining may violate letrec-major form.

PR up to see if this dramatically alters anything, but probably we want to land this or something like it (perhaps with an explainer about why inlining violates letrec-major, to be totally certain we must re-establish it, or a fix that maintains it while inlining, instead).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
