### PR TITLE
storage/mysql: Add json null type checks

### DIFF
--- a/test/mysql-cdc/types-json.td
+++ b/test/mysql-cdc/types-json.td
@@ -35,6 +35,8 @@ USE public;
 CREATE TABLE t1 (f1 JSON);
 
 INSERT INTO t1 VALUES (CAST('{"bar": "baz", "balance": 7.77, "active": false}' AS JSON));
+INSERT INTO t1 VALUES (CAST('null' AS JSON));
+INSERT INTO t1 VALUES (NULL);
 
 > CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_conn
@@ -51,9 +53,23 @@ INSERT INTO t1 SELECT * FROM t1;
 jsonb
 
 > SELECT * FROM t1;
+<null>
+<null>
+null
+null
 "{\"active\":false,\"balance\":7.77,\"bar\":\"baz\"}"
 "{\"active\":false,\"balance\":7.77,\"bar\":\"baz\"}"
 
 > SELECT f1->>'balance' FROM t1;
+<null>
+<null>
+<null>
+<null>
 7.77
 7.77
+
+> SELECT count(*) FROM t1 WHERE f1 IS NULL;
+2
+
+> SELECT count(*) FROM t1 WHERE f1 = 'null'::jsonb;
+2


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.
Discussed on slack, verifies the distinction between a top-level json `null` value and a SQL NULL value in the MySQL source.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]


    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
