### PR TITLE
ci: Remove useless junit_*xml uploads in mysql tests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -386,7 +386,6 @@ steps:
         timeout_in_minutes: 120
         agents:
           queue: linux-aarch64
-        artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
               composition: zippy
@@ -441,7 +440,6 @@ steps:
         agents:
           # no matching manifest of MySQL 5.7.x for linux/arm64/v8 in the manifest list entries
           queue: linux-x86_64-small
-        artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
@@ -451,7 +449,6 @@ steps:
         timeout_in_minutes: 30
         agents:
           queue: linux-aarch64-small
-        artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -71,7 +71,6 @@ steps:
       timeout_in_minutes: 2880
       agents:
         queue: linux-aarch64-large
-      artifact_paths: junit_*.xml
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -345,7 +345,6 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/mysql-cdc-resumption]
-        artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc-resumption


### PR DESCRIPTION
Seen in
https://buildkite.com/materialize/tests/builds/77783#018e1537-d1e7-46bf-8c81-6abf76b6934e, just leads to duplicate uploads now, so not really harmful

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
