### PR TITLE
storage/mysql: Add support for IGNORE COLUMNS to ignore columns of types we can't decode

### DIFF
--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -47,6 +47,8 @@ breaking:
     - compute-types/src/sinks.proto
     # reason: Ignore because plans are currently not persisted.
     - expr/src/relation.proto
+    # reason: not yet released
+    - mysql-util/src/desc.proto
     # reason: still under active development
     - persist-types/src/stats.proto
     # reason: does currently not require backward-compatibility

--- a/src/mysql-util/src/desc.proto
+++ b/src/mysql-util/src/desc.proto
@@ -13,6 +13,11 @@ package mz_mysql_util;
 
 import "repr/src/relation_and_scalar.proto";
 
+// TODO: Remove this ignore after MySQL Private Preview begins
+// This was to allow converting ProtoMySqlColumnDesc.column_type to an optional field
+// which should be wire compatible but is not generated-bindings-compatible.
+// buf breaking: ignore (not yet released)
+
 message ProtoMySqlTableDesc {
     string name = 1;
     string schema_name = 2;
@@ -28,7 +33,7 @@ message ProtoMySqlColumnMetaJson {}
 
 message ProtoMySqlColumnDesc {
     string name = 1;
-    mz_repr.relation_and_scalar.ProtoColumnType column_type = 2;
+    optional mz_repr.relation_and_scalar.ProtoColumnType column_type = 2;
 
     oneof meta {
         ProtoMySqlColumnMetaEnum enum = 3;

--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -72,6 +72,11 @@ pub enum MySqlError {
     },
     #[error("unsupported data types: {columns:?}")]
     UnsupportedDataTypes { columns: Vec<UnsupportedDataType> },
+    #[error("duplicated column names in table '{qualified_table_name}': {columns:?}")]
+    DuplicatedColumnNames {
+        qualified_table_name: String,
+        columns: Vec<String>,
+    },
     #[error("invalid mysql system setting '{setting}'. Expected '{expected}'. Got '{actual}'.")]
     InvalidSystemSetting {
         setting: String,

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -935,6 +935,8 @@ pub enum MySqlConfigOptionName {
     Details,
     /// Columns whose types you want to unconditionally format as text
     TextColumns,
+    /// Columns you want to ignore
+    IgnoreColumns,
 }
 
 impl AstDisplay for MySqlConfigOptionName {
@@ -942,6 +944,7 @@ impl AstDisplay for MySqlConfigOptionName {
         f.write_str(match self {
             MySqlConfigOptionName::Details => "DETAILS",
             MySqlConfigOptionName::TextColumns => "TEXT COLUMNS",
+            MySqlConfigOptionName::IgnoreColumns => "IGNORE COLUMNS",
         })
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -492,6 +492,41 @@ CREATE CONNECTION mysqlconn TO MYSQL (AWS PRIVATELINK = db.schema.item, PORT = 1
 CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("mysqlconn")]), connection_type: MySql, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])), port: None })) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("auth"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }], with_options: [] })
 
 parse-statement
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn FOR TABLES (foo, bar as qux, baz into zop);
+----
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn FOR TABLES (foo, bar AS qux, baz AS zop)
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(SubsetTables([CreateSourceSubsource { reference: UnresolvedItemName([Ident("foo")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("bar")]), subsource: Some(Deferred(UnresolvedItemName([Ident("qux")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(Deferred(UnresolvedItemName([Ident("zop")]))) }])), progress_subsource: None })
+
+parse-statement
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn FOR TABLES ([s1 AS foo.bar]);
+----
+error: Expected identifier, found left square bracket
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn FOR TABLES ([s1 AS foo.bar]);
+                                                                    ^
+
+parse-statement
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (TEXT COLUMNS (public.foo.bar)) FOR ALL TABLES;
+----
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (TEXT COLUMNS = (public.foo.bar)) FOR ALL TABLES
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
+
+parse-statement
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (IGNORE COLUMNS (public.foo.bar)) FOR ALL TABLES;
+----
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (IGNORE COLUMNS = (public.foo.bar)) FOR ALL TABLES
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: IgnoreColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
+
+parse-statement
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (IGNORE COLUMNS (public.foo.bar), TEXT COLUMNS (public.foo.baz)) FOR ALL TABLES;
+----
+CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (IGNORE COLUMNS = (public.foo.bar), TEXT COLUMNS = (public.foo.baz)) FOR ALL TABLES
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: IgnoreColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }, MySqlConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("baz")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
+
+parse-statement
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red');
 ----
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red')

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -240,6 +240,8 @@ pub enum MySqlSourcePurificationError {
     ReplicationSettingsError(Vec<(String, String, String)>),
     #[error("referenced tables use unsupported types")]
     UnrecognizedTypes { cols: Vec<(String, String, String)> },
+    #[error("duplicated column name references in table {0}: {1:?}")]
+    DuplicatedColumnNames(String, Vec<String>),
     #[error("Invalid MySQL table reference: {0}")]
     InvalidTableReference(String),
     #[error("No tables found")]
@@ -298,7 +300,7 @@ impl MySqlSourcePurificationError {
             ),
             Self::UnrecognizedTypes { cols: _ } => Some(
                 "Check the docs -- some types can be supported using the TEXT COLUMNS option to \
-                ingest their values as text."
+                ingest their values as text, or ignored using IGNORE COLUMNS."
                     .into(),
             ),
             _ => None,

--- a/src/storage-types/src/sources/mysql.proto
+++ b/src/storage-types/src/sources/mysql.proto
@@ -27,6 +27,7 @@ message ProtoMySqlSourceConnection {
     ProtoMySqlSourceDetails details = 3;
 
     repeated ProtoMySqlColumnRef text_columns = 4;
+    repeated ProtoMySqlColumnRef ignore_columns = 5;
 }
 
 message ProtoMySqlSourceDetails {

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -69,6 +69,7 @@ pub struct MySqlSourceConnection<C: ConnectionAccess = InlinedConnection> {
     pub connection: C::MySql,
     pub details: MySqlSourceDetails,
     pub text_columns: Vec<MySqlColumnRef>,
+    pub ignore_columns: Vec<MySqlColumnRef>,
 }
 
 impl<R: ConnectionResolver> IntoInlineConnection<MySqlSourceConnection, R>
@@ -80,6 +81,7 @@ impl<R: ConnectionResolver> IntoInlineConnection<MySqlSourceConnection, R>
             connection,
             details,
             text_columns,
+            ignore_columns,
         } = self;
 
         MySqlSourceConnection {
@@ -87,6 +89,7 @@ impl<R: ConnectionResolver> IntoInlineConnection<MySqlSourceConnection, R>
             connection: r.resolve_connection(connection).unwrap_mysql(),
             details,
             text_columns,
+            ignore_columns,
         }
     }
 }
@@ -140,6 +143,7 @@ impl RustType<ProtoMySqlSourceConnection> for MySqlSourceConnection {
             connection_id: Some(self.connection_id.into_proto()),
             details: Some(self.details.into_proto()),
             text_columns: self.text_columns.into_proto(),
+            ignore_columns: self.ignore_columns.into_proto(),
         }
     }
 
@@ -155,6 +159,7 @@ impl RustType<ProtoMySqlSourceConnection> for MySqlSourceConnection {
                 .details
                 .into_rust_if_some("ProtoMySqlSourceConnection::details")?,
             text_columns: proto.text_columns.into_rust()?,
+            ignore_columns: proto.ignore_columns.into_rust()?,
         })
     }
 }

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -292,6 +292,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                 &table_info,
                 &metrics,
                 &connection.text_columns,
+                &connection.ignore_columns,
                 &mut data_output,
                 data_cap_set,
                 upper_cap_set,

--- a/src/storage/src/source/mysql/replication/context.rs
+++ b/src/storage/src/source/mysql/replication/context.rs
@@ -34,6 +34,7 @@ pub(super) struct ReplContext<'a> {
     pub(super) table_info: &'a BTreeMap<MySqlTableName, (usize, MySqlTableDesc)>,
     pub(super) metrics: &'a MySqlSourceMetrics,
     pub(super) text_columns: &'a Vec<MySqlColumnRef>,
+    pub(super) ignore_columns: &'a Vec<MySqlColumnRef>,
     pub(super) data_output: &'a mut AsyncOutputHandle<
         GtidPartition,
         Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>,
@@ -54,6 +55,7 @@ impl<'a> ReplContext<'a> {
         table_info: &'a BTreeMap<MySqlTableName, (usize, MySqlTableDesc)>,
         metrics: &'a MySqlSourceMetrics,
         text_columns: &'a Vec<MySqlColumnRef>,
+        ignore_columns: &'a Vec<MySqlColumnRef>,
         data_output: &'a mut AsyncOutputHandle<
             GtidPartition,
             Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>,
@@ -70,6 +72,7 @@ impl<'a> ReplContext<'a> {
             table_info,
             metrics,
             text_columns,
+            ignore_columns,
             data_output,
             data_cap_set,
             upper_cap_set,

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -367,6 +367,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                         .map(|(table, (_, desc))| (table, desc))
                         .collect::<Vec<_>>(),
                     &connection.text_columns,
+                    &connection.ignore_columns,
                 )
                 .await?;
                 let mut removed_tables = vec![];

--- a/test/mysql-cdc/35-ignore-columns.td
+++ b/test/mysql-cdc/35-ignore-columns.td
@@ -1,0 +1,74 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test mysql TEXT COLUMNS support
+#
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_mysql_source = true
+
+> CREATE CONNECTION mysqc TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+CREATE TABLE t1 (f1 INTEGER, f2 GEOMETRY, f3 POINT, f4 VARCHAR(64));
+
+INSERT INTO t1 VALUES (1, ST_GeomFromText('LINESTRING(0 0,1 1,2 2)'), ST_GeomFromText('POINT(1 1)'), 'test');
+
+! CREATE SOURCE da_other
+  FROM MYSQL CONNECTION mysqc
+  FOR TABLES (public.t1);
+contains: unsupported type
+
+! CREATE SOURCE da
+  FROM MYSQL CONNECTION mysqc (
+    IGNORE COLUMNS (t1.f2, t1.f3)
+  )
+  FOR TABLES (public.t1);
+contains:invalid IGNORE COLUMNS option value: column name 't1.f2' must have at least a table qualification
+
+> CREATE SOURCE da
+  FROM MYSQL CONNECTION mysqc (
+    IGNORE COLUMNS (public.t1.f2, public.t1.f3)
+  )
+  FOR TABLES (public.t1);
+
+# Insert the same data post-snapshot
+$ mysql-execute name=mysql
+USE public;
+INSERT INTO t1 SELECT * FROM t1;
+
+> SELECT * FROM t1;
+1 "test"
+1 "test"
+
+> SELECT f4 FROM t1;
+"test"
+"test"
+
+! SELECT f2 FROM t1;
+contains:column "f2" does not exist
+
+# Remove one of the ignored columns, and we should still error
+$ mysql-execute name=mysql
+ALTER TABLE t1 DROP COLUMN f2;
+
+! select * from t1;
+contains:incompatible schema change


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes: https://github.com/MaterializeInc/materialize/issues/24952

cc @morsapaes - I wasn't sure whether to go with `IGNORE COLUMNS` or `IGNORED COLUMNS`, but went with `IGNORE` since there is already a keyword defined for it :) Happy to change as desired.

<!--
Which of the following best describes the motivation behind this PR?



    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
