### PR TITLE
Fixed doc typo temporal filter

### DIFF
--- a/doc/user/content/transform-data/patterns/temporal-filters.md
+++ b/doc/user/content/transform-data/patterns/temporal-filters.md
@@ -70,7 +70,7 @@ In this case, we will filter a table to only include only records from the last 
 
 1. Next, subscribe to the results of the view.
     ```sql
-    COPY (SUBSCRIBE (SELECT ts, content FROM last_30_sec)) TO STDOUT;
+    COPY (SUBSCRIBE (SELECT event_ts, content FROM last_30_sec)) TO STDOUT;
     ```
 
 1. In a separate session, insert a record.

--- a/doc/user/content/transform-data/patterns/temporal-filters.md
+++ b/doc/user/content/transform-data/patterns/temporal-filters.md
@@ -70,7 +70,7 @@ In this case, we will filter a table to only include only records from the last 
 
 1. Next, subscribe to the results of the view.
     ```sql
-    COPY (SUBSCRIBE (SELECT event_ts, content FROM last_30_sec)) TO STDOUT;
+    SUBSCRIBE(SELECT event_ts, content FROM last_30_sec);
     ```
 
 1. In a separate session, insert a record.


### PR DESCRIPTION

Ran through the temporal filter guide in our docs and found a typo with the subscribe. Removed the COPY and STDOUT for easier console use.


