### PR TITLE
Make `compute_dataflow_max_inflight_bytes` a dyncfg

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -27,7 +27,6 @@ use mz_timestamp_oracle::postgres_oracle::PostgresTimestampOracleParameters;
 pub fn compute_config(config: &SystemVars) -> ComputeParameters {
     ComputeParameters {
         max_result_size: Some(config.max_result_size()),
-        dataflow_max_inflight_bytes: Some(config.compute_dataflow_max_inflight_bytes()),
         tracing: tracing_config(config),
         grpc_client: grpc_client_config(config),
         dyncfg_updates: config.dyncfg_updates(),

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -78,11 +78,6 @@ message ProtoPeek {
 message ProtoComputeParameters {
     optional uint64 max_result_size = 1;
     mz_dyncfg.ConfigUpdates dyncfg_updates = 2;
-    ProtoComputeMaxInflightBytesConfig dataflow_max_inflight_bytes = 3;
     mz_tracing.params.ProtoTracingParameters tracing = 5;
     mz_service.params.ProtoGrpcClientParameters grpc_client = 6;
-}
-
-message ProtoComputeMaxInflightBytesConfig {
-    optional uint64 dataflow_max_inflight_bytes = 1;
 }

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -364,12 +364,6 @@ pub struct ComputeParameters {
     /// [`PeekResponse::Error`]: super::response::PeekResponse::Error
     /// [`SubscribeBatch::updates`]: super::response::SubscribeBatch::updates
     pub max_result_size: Option<u64>,
-    /// The maximum number of in-flight bytes emitted by persist_sources feeding
-    /// dataflows.
-    ///
-    /// NB: This value is optional, so the outer option indicates if this update
-    /// includes an override and the inner option is part of the config value.
-    pub dataflow_max_inflight_bytes: Option<Option<usize>>,
     /// Tracing configuration.
     pub tracing: TracingParameters,
     /// gRPC client configuration.
@@ -384,7 +378,6 @@ impl ComputeParameters {
     pub fn update(&mut self, other: ComputeParameters) {
         let ComputeParameters {
             max_result_size,
-            dataflow_max_inflight_bytes,
             tracing,
             grpc_client,
             dyncfg_updates,
@@ -392,9 +385,6 @@ impl ComputeParameters {
 
         if max_result_size.is_some() {
             self.max_result_size = max_result_size;
-        }
-        if dataflow_max_inflight_bytes.is_some() {
-            self.dataflow_max_inflight_bytes = dataflow_max_inflight_bytes;
         }
 
         self.tracing.update(tracing);
@@ -415,11 +405,6 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
     fn into_proto(&self) -> ProtoComputeParameters {
         ProtoComputeParameters {
             max_result_size: self.max_result_size.into_proto(),
-            dataflow_max_inflight_bytes: self.dataflow_max_inflight_bytes.map(|x| {
-                ProtoComputeMaxInflightBytesConfig {
-                    dataflow_max_inflight_bytes: x.into_proto(),
-                }
-            }),
             tracing: Some(self.tracing.into_proto()),
             grpc_client: Some(self.grpc_client.into_proto()),
             dyncfg_updates: Some(self.dyncfg_updates.clone()),
@@ -429,10 +414,6 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
     fn from_proto(proto: ProtoComputeParameters) -> Result<Self, TryFromProtoError> {
         Ok(Self {
             max_result_size: proto.max_result_size.into_rust()?,
-            dataflow_max_inflight_bytes: proto
-                .dataflow_max_inflight_bytes
-                .map(|x| x.dataflow_max_inflight_bytes.into_rust())
-                .transpose()?,
             tracing: proto
                 .tracing
                 .into_rust_if_some("ProtoComputeParameters::tracing")?,

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -59,6 +59,14 @@ pub const ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING: Config<bool> = Config::new(
     "Enable logging of the hydration status of compute operators.",
 );
 
+/// Maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
+pub const DATAFLOW_MAX_INFLIGHT_BYTES: Config<Option<usize>> = Config::new(
+    "compute_dataflow_max_inflight_bytes",
+    None,
+    "The maximum number of in-flight bytes emitted by persist_sources feeding \
+     compute dataflows in non-cc clusters.",
+);
+
 /// The "physical backpressure" of `compute_dataflow_max_inflight_bytes_cc` has
 /// been replaced in cc replicas by persist lgalloc and we intend to remove it
 /// once everything has switched to cc. In the meantime, this is a CYA to turn
@@ -67,7 +75,7 @@ pub const DATAFLOW_MAX_INFLIGHT_BYTES_CC: Config<Option<usize>> = Config::new(
     "compute_dataflow_max_inflight_bytes_cc",
     None,
     "The maximum number of in-flight bytes emitted by persist_sources feeding \
-    compute dataflows in cc clusters (Materialize).",
+     compute dataflows in cc clusters.",
 );
 
 /// The interval at which the background thread wakes.
@@ -93,6 +101,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
         .add(&ENABLE_CHUNKED_STACK)
         .add(&ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING)
+        .add(&DATAFLOW_MAX_INFLIGHT_BYTES)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)
         .add(&LGALLOC_BACKGROUND_INTERVAL)
         .add(&LGALLOC_SLOW_CLEAR_BYTES)

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1116,7 +1116,6 @@ impl SystemVars {
             &upsert_rocksdb::UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_CLUSTER_MEMORY_FRACTION,
             &upsert_rocksdb::UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_MEMORY_BYTES,
             &upsert_rocksdb::UPSERT_ROCKSDB_WRITE_BUFFER_MANAGER_ALLOW_STALL,
-            &COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES,
             &STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES,
             &STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION,
             &STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY,
@@ -1802,11 +1801,6 @@ impl SystemVars {
         ))
     }
 
-    /// Returns the `compute_dataflow_max_inflight_bytes` configuration parameter.
-    pub fn compute_dataflow_max_inflight_bytes(&self) -> Option<usize> {
-        *self.expect_value(&COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES)
-    }
-
     /// Returns the `storage_dataflow_max_inflight_bytes` configuration parameter.
     pub fn storage_dataflow_max_inflight_bytes(&self) -> Option<usize> {
         *self.expect_value(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES)
@@ -2119,10 +2113,7 @@ impl SystemVars {
     /// (things that go in `ComputeParameters` and are sent to replicas via `UpdateConfiguration`
     /// commands).
     pub fn is_compute_config_var(&self, name: &str) -> bool {
-        name == MAX_RESULT_SIZE.name()
-            || name == COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
-            || self.is_dyncfg_var(name)
-            || is_tracing_var(name)
+        name == MAX_RESULT_SIZE.name() || self.is_dyncfg_var(name) || is_tracing_var(name)
     }
 
     /// Returns whether the named variable is a storage configuration parameter.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1124,15 +1124,6 @@ pub static KAFKA_DEFAULT_METADATA_FETCH_INTERVAL: VarDefinition = VarDefinition:
     true,
 );
 
-/// The maximum number of in-flight bytes emitted by persist_sources feeding compute dataflows.
-pub static COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES: VarDefinition = VarDefinition::new(
-    "compute_dataflow_max_inflight_bytes",
-    value!(Option<usize>; None),
-    "The maximum number of in-flight bytes emitted by persist_sources feeding \
-        compute dataflows (Materialize).",
-    true,
-);
-
 /// The maximum number of in-flight bytes emitted by persist_sources feeding _storage
 /// dataflows_.
 /// Currently defaults to 256MiB = 268435456 bytes


### PR DESCRIPTION
Now that `Option<usize>` is a supported type, we can make `compute_dataflow_max_inflight_bytes` a dyncfg too. This concludes the migration of the compute parameters. `max_result_size` will remain a legacy config var because it doesn't fit well into the dyncfg model (it's a session variable that's checked in multiple places across components).

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A