### PR TITLE
storage: compact committed upper stream if source is slow to report it

### DIFF
--- a/src/storage/src/metrics/source.rs
+++ b/src/storage/src/metrics/source.rs
@@ -36,6 +36,8 @@ pub(crate) struct GeneralSourceMetricDefs {
     pub(crate) capability: UIntGaugeVec,
     pub(crate) resume_upper: IntGaugeVec,
     pub(crate) inmemory_remap_bindings: UIntGaugeVec,
+    pub(crate) commit_upper_ready_times: UIntGaugeVec,
+    pub(crate) commit_upper_accepted_times: UIntGaugeVec,
 
     // OffsetCommitMetrics
     pub(crate) offset_commit_failures: IntCounterVec,
@@ -70,6 +72,16 @@ impl GeneralSourceMetricDefs {
             inmemory_remap_bindings: registry.register(metric!(
                 name: "mz_source_inmemory_remap_bindings",
                 help: "The number of in-memory remap bindings that reclocking a time needs to iterate over.",
+                var_labels: ["source_id", "worker_id"],
+            )),
+            commit_upper_ready_times: registry.register(metric!(
+                name: "mz_source_commit_upper_ready_times",
+                help: "The number of ready remap bindings that are held in the reclock commit upper operator.",
+                var_labels: ["source_id", "worker_id"],
+            )),
+            commit_upper_accepted_times: registry.register(metric!(
+                name: "mz_source_commit_upper_accepted_times",
+                help: "The number of accepted remap bindings that are held in the reclock commit upper operator.",
                 var_labels: ["source_id", "worker_id"],
             )),
             offset_commit_failures: registry.register(metric!(
@@ -120,6 +132,10 @@ pub(crate) struct SourceMetrics {
     pub(crate) resume_upper: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
     /// The number of in-memory remap bindings that reclocking a time needs to iterate over.
     pub(crate) inmemory_remap_bindings: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    /// The number of ready remap bindings that are held in the reclock commit upper operator.
+    pub(crate) commit_upper_ready_times: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    /// The number of accepted remap bindings that are held in the reclock commit upper operator.
+    pub(crate) commit_upper_accepted_times: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
 }
 
 impl SourceMetrics {
@@ -142,6 +158,12 @@ impl SourceMetrics {
                 .get_delete_on_drop_gauge(vec![source_id.to_string()]),
             inmemory_remap_bindings: defs
                 .inmemory_remap_bindings
+                .get_delete_on_drop_gauge(vec![source_id.to_string(), worker_id.to_string()]),
+            commit_upper_ready_times: defs
+                .commit_upper_ready_times
+                .get_delete_on_drop_gauge(vec![source_id.to_string(), worker_id.to_string()]),
+            commit_upper_accepted_times: defs
+                .commit_upper_accepted_times
                 .get_delete_on_drop_gauge(vec![source_id.to_string(), worker_id.to_string()]),
         }
     }

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -372,10 +372,12 @@ where
         consolidation::consolidate_updates(&mut inner.remap_trace);
     }
 
+    #[allow(dead_code)]
     pub fn since(&self) -> AntichainRef<'_, IntoTime> {
         self.since.borrow()
     }
 
+    #[allow(dead_code)]
     pub fn share(&self) -> Self {
         self.inner
             .borrow_mut()


### PR DESCRIPTION
This PR replaces the raw async stream of committed uppers that was previously being supplied to source implementations with a stream that monitors a tokio `Watch`, which is itself updated by a timely operator.

With this approach every committed upper notification is replacing the previous one in the `Watch` instead of piling up and causing issues with accumulating reclock bindings.

This is a stop gap fix for the reclock CPU bug until the full re-implementation is merged.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
