### PR TITLE
[dnm] columnar: Array support

### DIFF
--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -28,10 +28,11 @@ use crate::columnar::{
     ColumnCfg, ColumnFormat, ColumnGet, ColumnPush, Data, DataType, PartDecoder, PartEncoder,
     Schema,
 };
+use crate::dyn_array::{DynArray, DynArrayCfg, DynArrayCol, DynArrayRef};
 use crate::dyn_struct::{
     ColumnsMut, ColumnsRef, DynStruct, DynStructCfg, DynStructCol, DynStructMut, DynStructRef,
 };
-use crate::stats::{BytesStats, OptionStats, PrimitiveStats, StatsFn, StructStats};
+use crate::stats::{BytesStats, NoneStats, OptionStats, PrimitiveStats, StatsFn, StructStats};
 use crate::{Codec, Codec64, Opaque};
 
 /// An implementation of [Schema] for [()].
@@ -445,6 +446,14 @@ impl ColumnCfg<Option<String>> for () {
             format: ColumnFormat::String,
         }
     }
+}
+
+impl Data for DynArray {
+    type Cfg = DynArrayCfg;
+    type Ref<'a> = DynArrayRef<'a>;
+    type Col = DynArrayCol;
+    type Mut = DynArrayCol;
+    type Stats = NoneStats;
 }
 
 impl Data for DynStruct {

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -52,6 +52,7 @@ use std::fmt::Debug;
 
 use crate::codec_impls::UnitSchema;
 use crate::columnar::sealed::{ColumnMut, ColumnRef};
+use crate::dyn_array::DynArrayCfg;
 use crate::dyn_struct::{ColumnsMut, ColumnsRef, DynStructCfg};
 use crate::part::PartBuilder;
 use crate::stats::{ColumnStats, StatsFrom};
@@ -122,6 +123,11 @@ pub trait ColumnGet<T: Data>: ColumnRef<T::Cfg> {
 pub trait ColumnPush<T: Data>: ColumnMut<T::Cfg> {
     /// Pushes a new value into this column.
     fn push<'a>(&mut self, val: T::Ref<'a>);
+
+    /// TODO(parkmycar): Expose this more cleanly.
+    fn cfg(&self) -> &T::Cfg {
+        ColumnMut::cfg(self)
+    }
 }
 
 pub(crate) mod sealed {
@@ -221,6 +227,8 @@ pub enum ColumnFormat {
     String,
     /// A column of type [crate::dyn_struct::DynStruct].
     Struct(DynStructCfg),
+    /// A column of type [crate::dyn_array::DynArray].
+    List(DynArrayCfg),
     // TODO: FixedSizedBytes for UUIDs?
 }
 

--- a/src/persist-types/src/dyn_array.rs
+++ b/src/persist-types/src/dyn_array.rs
@@ -1,0 +1,169 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Dynamic columnar array.
+
+use std::sync::Arc;
+
+use arrow2::array::growable::{Growable, GrowableList};
+use arrow2::array::{Array, ListArray};
+use arrow2::io::parquet::write::Encoding;
+use arrow2::offset::OffsetsBuffer;
+
+use crate::columnar::sealed::{ColumnMut, ColumnRef};
+use crate::columnar::{ColumnCfg, ColumnFormat, ColumnGet, ColumnPush, Data, DataType};
+use crate::dyn_col::{DynColumnMut, DynColumnRef};
+use crate::stats::StatsFn;
+
+/// A columnar array.
+#[derive(Debug)]
+pub struct DynArray;
+
+/// Describes the inner type of a [`DynArray`] and the stats we collect for it.
+#[derive(Debug, Clone)]
+#[cfg_attr(debug_assertions, derive(PartialEq))]
+pub struct DynArrayCfg {
+    /// The inner type of this array.
+    pub col: Arc<(DataType, StatsFn)>,
+}
+
+impl DynArrayCfg {
+    /// Create a new [`DynArrayCfg`] where `ty` is the inner type of the array.
+    ///
+    /// For example, an array if `i32`s would pass a `ty` with [`ColumnFormat::I32`].
+    pub fn new(ty: DataType, stats: StatsFn) -> Self {
+        DynArrayCfg {
+            col: Arc::new((ty, stats)),
+        }
+    }
+}
+
+impl ColumnCfg<DynArray> for DynArrayCfg {
+    fn as_type(&self) -> DataType {
+        DataType {
+            optional: false,
+            format: ColumnFormat::List(self.clone()),
+        }
+    }
+}
+
+/// The [Data::Ref] type for [`DynArray`].
+#[derive(Debug, Default)]
+pub enum DynArrayRef<'a> {
+    /// An empty inner array.
+    ///
+    /// Note: This variant exists because we need to have some default value for [`DynArrayRef`]
+    /// and [`DynColumnRef`] itself does not implement default.
+    #[default]
+    Empty,
+    /// One instance of the inner array.
+    Value(&'a DynColumnRef),
+}
+
+/// A [`ColumnGet`] impl for [`DynArray`].
+///
+/// [`ColumnGet`]: crate::columnar::ColumnGet
+#[derive(Debug)]
+pub struct DynArrayCol {
+    len: usize,
+    cfg: DynArrayCfg,
+    pub(crate) validity: Option<<bool as Data>::Col>,
+    pub(crate) arrays: Vec<DynColumnRef>,
+}
+
+impl ColumnRef<DynArrayCfg> for DynArrayCol {
+    fn cfg(&self) -> &DynArrayCfg {
+        &self.cfg
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
+        let cols: Vec<ListArray<i64>> = self
+            .arrays
+            .iter()
+            .map(|array| {
+                let (_encoding, col, is_nullable) = array.to_arrow();
+                let field =
+                    arrow2::datatypes::Field::new("item", col.data_type().clone(), is_nullable);
+                let data_type = arrow2::datatypes::DataType::LargeList(Box::new(field));
+                ListArray::<i64>::new(data_type, OffsetsBuffer::new(), col, None)
+            })
+            .collect();
+        let refs = cols.iter().collect();
+
+        // Create the final ListArray, I think?
+        let mut growable = GrowableList::new(refs, false, cols.len());
+        for (idx, col) in cols.iter().enumerate() {
+            growable.extend(idx, 0, col.len());
+        }
+        let array = ListArray::<i64>::from(growable);
+
+        (Encoding::Plain, Box::new(array))
+    }
+
+    fn from_arrow(cfg: &DynArrayCfg, array: &Box<dyn Array>) -> Result<Self, String> {
+        let col = array
+            .as_any()
+            .downcast_ref::<ListArray<i64>>()
+            .ok_or_else(|| format!("expected ListArray<i64> but was {:?}", array.data_type()))?;
+        let len = array.len();
+        let validity = array.validity().cloned();
+        let arrays = col
+            .values_iter()
+            .map(|array| DynColumnRef::from_arrow(&cfg.col.0, &array))
+            .collect::<Result<Vec<_>, String>>()?;
+
+        Ok(DynArrayCol {
+            len,
+            cfg: cfg.clone(),
+            validity,
+            arrays,
+        })
+    }
+}
+
+impl ColumnGet<DynArray> for DynArrayCol {
+    fn get<'a>(&'a self, idx: usize) -> <DynArray as Data>::Ref<'a> {
+        assert!(self.validity.is_none());
+        let array = self.arrays.get(idx).expect("index to be valid");
+        DynArrayRef::Value(array)
+    }
+}
+
+impl ColumnMut<DynArrayCfg> for DynArrayCol {
+    fn new(cfg: &DynArrayCfg) -> Self {
+        DynArrayCol {
+            len: 0,
+            cfg: cfg.clone(),
+            validity: None,
+            arrays: Vec::new(),
+        }
+    }
+
+    fn cfg(&self) -> &DynArrayCfg {
+        &self.cfg
+    }
+}
+
+impl ColumnPush<DynArray> for DynArrayCol {
+    fn push<'a>(&mut self, val: DynArrayRef<'a>) {
+        let array = match val {
+            DynArrayRef::Empty => {
+                let new = DynColumnMut::new_untyped(&self.cfg.col.0);
+                DynColumnRef::from(new)
+            }
+            DynArrayRef::Value(array) => array.clone(),
+        };
+        self.arrays.push(array);
+        self.len = self.len + 1;
+    }
+}

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -22,6 +22,7 @@ use crate::columnar::Schema;
 
 pub mod codec_impls;
 pub mod columnar;
+pub mod dyn_array;
 pub mod dyn_col;
 pub mod dyn_struct;
 pub mod parquet;

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -206,7 +206,7 @@ mod tests {
         let actual: StructStats = RustType::from_proto(actual).unwrap();
         for (name, typ) in schema.iter() {
             struct ColMinMaxNulls<'a>(&'a dyn DynStats);
-            impl<'a> DatumToPersistFn<()> for ColMinMaxNulls<'a> {
+            impl<'a> DatumToPersistFn<'a, ()> for ColMinMaxNulls<'a> {
                 fn call<T: DatumToPersist>(self) {
                     let ColMinMaxNulls(stats) = self;
                     let stats = stats

--- a/src/storage-types/src/stats.rs
+++ b/src/storage-types/src/stats.rs
@@ -299,7 +299,7 @@ impl RelationPartStats<'_> {
             &'a RowArena,
             Option<usize>,
         );
-        impl<'a> DatumToPersistFn<Option<ResultSpec<'a>>> for ColValues<'a> {
+        impl<'a> DatumToPersistFn<'a, Option<ResultSpec<'a>>> for ColValues<'a> {
             fn call<T: DatumToPersist>(self) -> Option<ResultSpec<'a>> {
                 let ColValues(metrics, name, col_name, stats, arena, total_count) = self;
                 let stats = downcast_stats::<T::Data>(metrics, name, col_name, stats)?;
@@ -365,7 +365,7 @@ mod tests {
         }
 
         struct ValidateStats<'a>(RelationPartStats<'a>, &'a RowArena, Datum<'a>);
-        impl<'a> DatumToPersistFn<()> for ValidateStats<'a> {
+        impl<'a> DatumToPersistFn<'a, ()> for ValidateStats<'a> {
             fn call<T: DatumToPersist>(self) -> () {
                 let ValidateStats(stats, arena, datum) = self;
                 if let Some(spec) = stats.col_values(0, arena) {


### PR DESCRIPTION
This PR prototypes support for Array types in our columnar framework. It skips collecting stats on Arrays, but my thought is we would collect the same kind of stats as the inner type. e.g. for an `Array<i32>` we would collect a lower and upper bound for the array itself.

### Motivation

Really get my feet with with our columnar implementation.

### Tips for reviewer

This implementation is quite inefficient, but I couldn't figure out any other way to do it, would love feedback if possible.

Currently `DynArrayMut` contains a `Vec<DynColumnMut>`, which is pretty inefficient when encoding a `Row` because for each `Datum::Array` we need to create a new column which requires an allocation. Ideally a `DynArrayMut` would instead have an `arrow2::array::MutableListArray` which would allow us to more efficiently encode the `Datum::Array`s from multiple `Row`s because the `arrow2::array::MutableListArray` would most likely grow in a way to ammortize the cost of allocations.

The problem though is `MutableListArray` is generic over some type `M: arrow2::array::MutableArray`, in other words, it needs to know the inner type of the array. So I _think_ the only way to solve this is adding a new associated type to `trait Data`, e.g.

```
trait Data {
  // ... existing associated types
  type Arrow2MutableArray: arrow2::array::MutableArray,
```

This would allow `DynArrayMut` to contain a `MutableListArray<Box<dyn MutableArray>>` and then when pushing values we could use our inner `DataType` to downcast to the actual type of the inner array.

Other options I explored were:

1. Require the existing associated `type Mut` implement `MutableArray`, which they mostly already do except for `DynStructMut`. We could implement `MutableArray` for `DynStructMut` but at that point it felt like we should just use `arrow2::array::MutableStructArray`?
2. Add a `fn to_arrow(...)` for `ColumnMut` that returns `Box<dyn MutableArray>`. This doesn't help us though because we still wouldn't know what type to downcast the returned array to. There is the `arrow2::arrow::TryPush<A>` trait, but that doesn't seem to help us either, especially because something like `TryPush<Self>` isn't object safe.

This experiment sort of points me towards having `trait Data` expose the relevant `arrow2` types directly, e.g.

```
trait Data {
  // ...
  type Col: arrow2::array::Array,
  type Mut: arrow2::Array::MutableArray,
```

Curious what other folks think though, I could totally be missing something

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
