### PR TITLE
DNM: Try to reproduce incident-100

### DIFF
--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -46,6 +46,7 @@ def workflow_sink_networking(c: Composition) -> None:
     seed = random.getrandbits(16)
     for i, failure_mode in enumerate(
         [
+            "toxiproxy-close-csr-connection.td",
             "toxiproxy-close-connection.td",
             "toxiproxy-limit-connection.td",
             "toxiproxy-timeout.td",
@@ -61,6 +62,16 @@ def workflow_sink_networking(c: Composition) -> None:
             "sink-networking/setup.td",
             f"sink-networking/{failure_mode}",
             "sink-networking/during.td",
+        )
+
+        c.kill("materialized")
+        c.up("materialized")
+
+        c.run_testdrive_files(
+            "--no-reset",
+            "--max-errors=1",
+            f"--seed={seed}{i}",
+            f"--temp-dir=/share/tmp/kafka-resumption-{seed}{i}",
             "sink-networking/sleep.td",
             "sink-networking/toxiproxy-restore-connection.td",
             "sink-networking/verify-success.td",
@@ -80,7 +91,7 @@ def workflow_source_resumption(c: Composition) -> None:
         c.run_testdrive_files("source-resumption/setup.td")
         c.run_testdrive_files("source-resumption/verify.td")
 
-        # Disabled due to https://github.com/MaterializeInc/materialize/issues/20819
+        # TODO: Reenable when #20819 is fixed
         # assert (
         #    find_source_resume_upper(
         #        c,
@@ -100,7 +111,7 @@ def workflow_source_resumption(c: Composition) -> None:
         # the first clusterd instance ingested 3 messages, so our
         # upper is at the 4th offset (0-indexed)
 
-        # Disabled due to https://github.com/MaterializeInc/materialize/issues/20819
+        # TODO: Reenable when #20819 is fixed
         # assert (
         #    find_source_resume_upper(
         #        c,

--- a/test/kafka-resumption/sink-networking/setup.td
+++ b/test/kafka-resumption/sink-networking/setup.td
@@ -22,9 +22,14 @@ $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=applic
 }
 
 $ kafka-create-topic topic=input
-$ kafka-ingest topic=input format=bytes
+$ kafka-ingest topic=input format=bytes repeat=1000000000
 Rochester,NY,14618
 New York,NY,10004
+
+$ kafka-create-topic topic=input2
+$ kafka-ingest topic=input2 format=bytes repeat=1000000000
+Rochester,NY,14618,0
+New York,NY,10004,0
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn1 TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
@@ -36,26 +41,21 @@ New York,NY,10004
   FORMAT CSV WITH 3 COLUMNS
   INCLUDE OFFSET
 
+> CREATE SOURCE input2 (city, state, zip, x)
+  FROM KAFKA CONNECTION kafka_conn1 (TOPIC 'testdrive-input2-${testdrive.seed}')
+  FORMAT CSV WITH 3 COLUMNS
+  INCLUDE OFFSET
+
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL 'http://toxiproxy:8081/'
   );
 
-> CREATE SINK output FROM input
+> CREATE SINK output2 FROM input2
   INTO KAFKA CONNECTION kafka_conn2 (TOPIC 'output-byo-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
 
-> CREATE SINK output2 FROM input
-  INTO KAFKA CONNECTION kafka_conn2 (TOPIC 'output2-byo-sink-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE DEBEZIUM
-
-> CREATE SINK output3 FROM input
-  INTO KAFKA CONNECTION kafka_conn2 (TOPIC 'output3-byo-sink-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE DEBEZIUM
-
-> CREATE SINK output4 FROM input
-  INTO KAFKA CONNECTION kafka_conn2 (TOPIC 'output4-byo-sink-${testdrive.seed}')
+> CREATE SINK output FROM input
+  INTO KAFKA CONNECTION kafka_conn2 (TOPIC 'output-byo-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM

--- a/test/kafka-resumption/sink-networking/setup.td
+++ b/test/kafka-resumption/sink-networking/setup.td
@@ -14,24 +14,48 @@ $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=applic
   "upstream": "kafka:9092"
 }
 
+$ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
+{
+  "name": "csr",
+  "listen": "0.0.0.0:8081",
+  "upstream": "schema-registry:8081"
+}
+
 $ kafka-create-topic topic=input
 $ kafka-ingest topic=input format=bytes
 Rochester,NY,14618
 New York,NY,10004
 
-> CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+> CREATE CONNECTION IF NOT EXISTS kafka_conn1 TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE CONNECTION IF NOT EXISTS kafka_conn2 TO KAFKA (BROKER 'toxiproxy:9093', SECURITY PROTOCOL PLAINTEXT);
 
 # The source intentionally does not go through toxiproxy.
 > CREATE SOURCE input (city, state, zip)
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn1 (TOPIC 'testdrive-input-${testdrive.seed}')
   FORMAT CSV WITH 3 COLUMNS
   INCLUDE OFFSET
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
-    URL '${testdrive.schema-registry-url}'
+    URL 'http://toxiproxy:8081/'
   );
 
 > CREATE SINK output FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-byo-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn2 (TOPIC 'output-byo-sink-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+> CREATE SINK output2 FROM input
+  INTO KAFKA CONNECTION kafka_conn2 (TOPIC 'output2-byo-sink-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+> CREATE SINK output3 FROM input
+  INTO KAFKA CONNECTION kafka_conn2 (TOPIC 'output3-byo-sink-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+> CREATE SINK output4 FROM input
+  INTO KAFKA CONNECTION kafka_conn2 (TOPIC 'output4-byo-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM

--- a/test/kafka-resumption/sink-networking/sleep.td
+++ b/test/kafka-resumption/sink-networking/sleep.td
@@ -7,7 +7,123 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
+$ kafka-ingest topic=input format=bytes
+Rochester,NY,14618
+New York,NY,10004
+
 # We need this length to be noticably longer than any internal
 # timeouts if we want this test to be informative.
-> SELECT mz_unsafe.mz_sleep(60);
+> SELECT mz_unsafe.mz_sleep(7200);
 <null>

--- a/test/kafka-resumption/sink-networking/toxiproxy-close-csr-connection.td
+++ b/test/kafka-resumption/sink-networking/toxiproxy-close-csr-connection.td
@@ -7,9 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ http-request method=POST url=http://toxiproxy:8474/proxies/csr/toxics content-type=application/json
-{
-  "name": "csr",
-  "type": "limit_data",
-  "attributes": { "bytes": 0 }
-}
+> select 1
+1
+#$ http-request method=POST url=http://toxiproxy:8474/proxies/csr/toxics content-type=application/json
+#{
+#  "name": "csr",
+#  "type": "limit_data",
+#  "attributes": { "bytes": 0 }
+#}

--- a/test/kafka-resumption/sink-networking/toxiproxy-close-csr-connection.td
+++ b/test/kafka-resumption/sink-networking/toxiproxy-close-csr-connection.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies/csr/toxics content-type=application/json
+{
+  "name": "csr",
+  "type": "limit_data",
+  "attributes": { "bytes": 0 }
+}

--- a/test/kafka-resumption/sink-queue-full/during.td
+++ b/test/kafka-resumption/sink-queue-full/during.td
@@ -18,6 +18,6 @@ A,B,0
 11000001
 
 > CREATE SINK output FROM largeinput
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-byo-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn2 (TOPIC 'output-byo-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM

--- a/test/kafka-resumption/sink-queue-full/setup.td
+++ b/test/kafka-resumption/sink-queue-full/setup.td
@@ -18,11 +18,13 @@ $ kafka-create-topic topic=largeinput
 $ kafka-ingest topic=largeinput format=bytes
 A,B,0
 
-> CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+> CREATE CONNECTION IF NOT EXISTS kafka_conn1 TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE CONNECTION IF NOT EXISTS kafka_conn2 TO KAFKA (BROKER 'toxiproxy:9093', SECURITY PROTOCOL PLAINTEXT);
 
 # The source intentionally does not go through toxiproxy.
 > CREATE SOURCE largeinput (city, state, zip)
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-largeinput-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn1 (TOPIC 'testdrive-largeinput-${testdrive.seed}')
   FORMAT CSV WITH 3 COLUMNS
   INCLUDE OFFSET
 

--- a/test/ssh-connection/kafka-sink-after-ssh-failure.td
+++ b/test/ssh-connection/kafka-sink-after-ssh-failure.td
@@ -29,3 +29,5 @@ one
   WHERE s.name IN ('sink_fixed')
   GROUP BY s.name
 sink_fixed 1 1 true true
+
+> select mz_unsafe.mz_sleep(7200);

--- a/test/ssh-connection/kafka-sink.td
+++ b/test/ssh-connection/kafka-sink.td
@@ -14,7 +14,7 @@ ALTER SYSTEM SET enable_create_source_denylist_with_options = true
 
 $ kafka-create-topic topic=thetopic
 
-$ kafka-ingest topic=thetopic format=bytes
+$ kafka-ingest topic=thetopic format=bytes repeat=1000000000
 one
 
 > DROP CLUSTER IF EXISTS sc;


### PR DESCRIPTION
`bin/mzcompose --find kafka-resumption down && bin/mzcompose --find kafka-resumption run sink-networking` (without SSH) and `bin/mzcompose --find ssh-connection down && bin/mzcompose --find ssh-connection run kafka-sink` (with SSH)

Unfortunately no success, seems to be stable at ~140 MB RAM in clusterd, but keeps continously using 20% CPU
![profile001](https://github.com/MaterializeInc/materialize/assets/2335377/9944c876-6b99-4d0f-9a54-20f588c42a2c)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
