### PR TITLE
adapter: Bound ts selection in serializable

### DIFF
--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -367,8 +367,8 @@ pub trait TimestampProvider {
         {
             let mut timestamp = largest_not_in_advance_of_upper;
             // In practice advancing the timestamp into the future is confusing for users. So if
-            // there is an `oracle_read_ts` then we treat is as "the current time" bound the upper
-            // advancement to "the current time".
+            // there is an `oracle_read_ts` then we treat is as "the current time" and bound the
+            // upper advancement to "the current time".
             if isolation_level == &IsolationLevel::Serializable {
                 if let Some(oracle_read_ts) = oracle_read_ts {
                     timestamp.meet_assign(&oracle_read_ts);

--- a/src/adapter/tests/testdata/timestamp_selection
+++ b/src/adapter/tests/testdata/timestamp_selection
@@ -22,6 +22,7 @@ set-oracle
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -41,6 +42,7 @@ serializable
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -64,6 +66,7 @@ set-oracle
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -83,6 +86,7 @@ set-oracle
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -98,6 +102,7 @@ determine
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -118,6 +123,7 @@ set-oracle
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -143,6 +149,7 @@ set-oracle
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -160,6 +167,7 @@ determine
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -181,6 +189,7 @@ set-oracle
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -198,6 +207,7 @@ determine
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -219,6 +229,7 @@ set-oracle
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -241,6 +252,7 @@ set-oracle
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -258,6 +270,7 @@ determine
 
 determine
 {
+  "timeline_ctx": "timeline dependent",
   "id_bundle": {
     "compute_ids": {
       "s1": [
@@ -270,3 +283,65 @@ determine
 }
 ----
 13
+
+# Timestamp dependent serializable queries don't advance past the timestamp oracle.
+
+set-isolation
+serializable
+----
+
+set-oracle
+15
+----
+
+determine
+{
+  "timeline_ctx": "timestamp dependent",
+  "id_bundle": {
+    "compute_ids": {
+      "s1": [
+        "s10"
+      ]
+    }
+  },
+  "when": "Immediately",
+  "instance": "s1"
+}
+----
+15
+
+# Timeline dependent serializable queries can advance past the timestamp oracle.
+
+determine
+{
+  "timeline_ctx": "timeline dependent",
+  "id_bundle": {
+    "compute_ids": {
+      "s1": [
+        "s10"
+      ]
+    }
+  },
+  "when": "Immediately",
+  "instance": "s1"
+}
+----
+19
+
+# Timestamp independent serializable queries advance to the end of time.
+
+determine
+{
+  "timeline_ctx": "timestamp independent",
+  "id_bundle": {
+    "compute_ids": {
+      "s1": [
+        "s10"
+      ]
+    }
+  },
+  "when": "Immediately",
+  "instance": "s1"
+}
+----
+18446744073709551615


### PR DESCRIPTION
Previously, under the SERIALIZABLE isolation level, if `AS OF` was not specified, then the query timestamp would always be advanced to the upper. This is usually desirable and allows the user to read the most fresh data. Static queries, such as SELECTs on a constant view, have an empty upper and therefore have their timestamp advanced to the maximum timestamp. For static queries with temporal filters, this results in a predictable but sometimes confusing result. For example, consider the following query:
```
   WITH dt_series AS (
       SELECT generate_series(
           date_trunc('day', date '2024-01-01'),
           date_trunc('day', date '2024-01-03'),
           '1 day'::interval
       ) AS dt
       UNION ALL
       SELECT generate_series(
           date_trunc('day', date '30000-01-01'),
           date_trunc('day', date '30000-01-03'),
           '1 day'::interval
       ) AS dt
   )
   SELECT dt FROM dt_series WHERE dt <= mz_now()
```
A user may think that the results under SERIALIZABLE isolation level would not include dates in the year 30,000, given that the query was executed before the year 30,000. However, this was not the case because the query is static, the timestamp was advanced to the maximum timestamp and included the results from the year 30,000.

This commit fixes this confusion by bounding the timestamp advancement of SERIALIZABLE timestamp dependent queries to the EpochMillis timestamp oracle read timestamp. That means that those queries will never choose a timestamp larger than the EpochMillis timestamp oracle read timestamp. Timestamp dependent queries are queries whose results are affected by the chosen timestamp but do not belong to a specific timeline. Such queries include but are not limited to static queries with a temporal filter. Another example of timestamp dependent queries are constant materialize views (even ones without temporal filters).

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Bound ts selection in serializable for timestamp dependent queries to the current time.
