### PR TITLE
[dnm] columnar: UUID support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5079,6 +5079,8 @@ dependencies = [
  "protobuf-src",
  "serde",
  "serde_json",
+ "static_assertions",
+ "uuid",
  "workspace-hack",
 ]
 

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -21,10 +21,12 @@ mz-ore = { path = "../ore", features = ["test"] }
 mz-proto = { path = "../proto" }
 parquet2 = { version = "0.17.1", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
+static_assertions = "1.1"
+uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]


### PR DESCRIPTION
**_Work in progress_**

The persist bits are implemented and type check, it's not hooked up to any `mz_repr` stuff yet, e.g. `DatumEncoder`.

### Motivation

Exercise to learn about stats collection, `arrow2`, and our columnar `trait Data`

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
