### PR TITLE
storage/mysql: Add support for 'year' type as a text column

### DIFF
--- a/src/mysql-util/src/decoding.rs
+++ b/src/mysql-util/src/decoding.rs
@@ -161,6 +161,11 @@ fn val_to_datum<'a>(
                             ))?
                         }
                     }
+                    Some(MySqlColumnMeta::Year) => {
+                        let val = from_value_opt::<u16>(value)?;
+                        temp_strs.push(val.to_string());
+                        Datum::from(temp_strs.last().unwrap().as_str())
+                    }
                     None => {
                         temp_strs.push(from_value_opt::<String>(value)?);
                         Datum::from(temp_strs.last().unwrap().as_str())

--- a/src/mysql-util/src/desc.proto
+++ b/src/mysql-util/src/desc.proto
@@ -26,6 +26,8 @@ message ProtoMySqlColumnMetaEnum {
 
 message ProtoMySqlColumnMetaJson {}
 
+message ProtoMySqlColumnMetaYear {}
+
 message ProtoMySqlColumnDesc {
     string name = 1;
     mz_repr.relation_and_scalar.ProtoColumnType column_type = 2;
@@ -33,6 +35,7 @@ message ProtoMySqlColumnDesc {
     oneof meta {
         ProtoMySqlColumnMetaEnum enum = 3;
         ProtoMySqlColumnMetaJson json = 4;
+        ProtoMySqlColumnMetaYear year = 5;
     }
 }
 

--- a/src/mysql-util/src/desc.rs
+++ b/src/mysql-util/src/desc.rs
@@ -159,6 +159,8 @@ pub enum MySqlColumnMeta {
     Enum(MySqlColumnMetaEnum),
     /// The described column is a json value.
     Json,
+    /// The described column is a year value.
+    Year,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
@@ -179,6 +181,7 @@ impl RustType<ProtoMySqlColumnDesc> for MySqlColumnDesc {
             meta: self.meta.as_ref().and_then(|meta| match meta {
                 MySqlColumnMeta::Enum(e) => Some(Meta::Enum(e.into_proto())),
                 MySqlColumnMeta::Json => Some(Meta::Json(ProtoMySqlColumnMetaJson {})),
+                MySqlColumnMeta::Year => Some(Meta::Year(ProtoMySqlColumnMetaYear {})),
             }),
         }
     }
@@ -197,6 +200,7 @@ impl RustType<ProtoMySqlColumnDesc> for MySqlColumnDesc {
                             .and_then(|e| Ok(MySqlColumnMeta::Enum(e))),
                     ),
                     Meta::Json(_) => Some(Ok(MySqlColumnMeta::Json)),
+                    Meta::Year(_) => Some(Ok(MySqlColumnMeta::Year)),
                 })
                 .transpose()?,
         })

--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -359,7 +359,7 @@ fn parse_data_type(
                     intended_type: None,
                 })?,
         }),
-        "text" | "mediumtext" | "longtext" => Ok(ScalarType::String),
+        "text" | "tinytext" | "mediumtext" | "longtext" => Ok(ScalarType::String),
         "binary" | "varbinary" | "tinyblob" | "blob" | "mediumblob" | "longblob" => {
             Ok(ScalarType::Bytes)
         }
@@ -382,6 +382,7 @@ fn parse_as_text_column(
     table_name: &str,
 ) -> Result<(ScalarType, Option<MySqlColumnMeta>), UnsupportedDataType> {
     match info.data_type.as_str() {
+        "year" => Ok((ScalarType::String, Some(MySqlColumnMeta::Year))),
         "json" => Ok((ScalarType::String, Some(MySqlColumnMeta::Json))),
         "enum" => Ok((
             ScalarType::String,

--- a/test/mysql-cdc/30-text-columns.td
+++ b/test/mysql-cdc/30-text-columns.td
@@ -28,13 +28,13 @@ $ mysql-execute name=mysql
 DROP DATABASE IF EXISTS public;
 CREATE DATABASE public;
 USE public;
-CREATE TABLE t1 (f1 JSON, f2 ENUM('small', 'medium', 'large'));
+CREATE TABLE t1 (f1 JSON, f2 ENUM('small', 'medium', 'large'), f3 YEAR);
 
-INSERT INTO t1 VALUES (CAST('{"bar": "baz", "balance": 7.77, "active": false, "nest": {"birds": ["seagull", "robin"]}}' AS JSON), 'large');
+INSERT INTO t1 VALUES (CAST('{"bar": "baz", "balance": 7.77, "active": false, "nest": {"birds": ["seagull", "robin"]}}' AS JSON), 'large', 2024);
 
 > CREATE SOURCE da
   FROM MYSQL CONNECTION mysqc (
-    TEXT COLUMNS (public.t1.f1, public.t1.f2)
+    TEXT COLUMNS (public.t1.f1, public.t1.f2, public.t1.f3)
   )
   FOR TABLES (public.t1);
 
@@ -50,6 +50,10 @@ INSERT INTO t1 SELECT * FROM t1;
 > SELECT f2 FROM t1;
 "large"
 "large"
+
+> SELECT f3 FROM t1;
+"2024"
+"2024"
 
 # verify JSON representation is consistent between snapshot and replication
 > SELECT f1 FROM t1;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/materialize/issues/25846

There is no equivalent `year` type in postgres/materialize, so we are allowing support for this type represented as TEXT.

More comprehensive tests are being added in https://github.com/MaterializeInc/materialize/pull/25852

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
