### PR TITLE
txn-wal: write down data shard schemas in registration records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6803,6 +6803,7 @@ dependencies = [
  "prost-build",
  "rand",
  "serde",
+ "serde_json",
  "timely",
  "tokio",
  "tracing",

--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -74,8 +74,6 @@ impl Transactor {
             client.clone(),
             Arc::new(TxnMetrics::new(&MetricsRegistry::new())),
             txns_id,
-            Arc::new(StringSchema),
-            Arc::new(UnitSchema),
         )
         .await;
         oracle.apply_write(init_ts.into()).await;

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -198,6 +198,11 @@ where
         self.machine.shard_id()
     }
 
+    /// This handle's schemas.
+    pub fn schemas(&self) -> (&Arc<K::Schema>, &Arc<V::Schema>) {
+        (&self.schemas.key, &self.schemas.val)
+    }
+
     /// A cached version of the shard-global `upper` frontier.
     ///
     /// This is the most recent upper discovered by this handle. It is

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -37,10 +37,11 @@ use crate::dyn_struct::{
     ColumnsMut, ColumnsRef, DynStruct, DynStructCfg, DynStructCol, DynStructMut, DynStructRef,
 };
 use crate::stats::{BytesStats, NoneStats, OptionStats, PrimitiveStats, StatsFn, StructStats};
+use crate::txn::TxnsDataSchema;
 use crate::{Codec, Codec64, Opaque, ShardId};
 
 /// An implementation of [Schema] for [()].
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct UnitSchema;
 
 /// [`PartEncoder`] for [`UnitSchema`].
@@ -81,6 +82,8 @@ impl Schema<()> for UnitSchema {
         Ok(UnitSchemaEncoder { len })
     }
 }
+
+impl TxnsDataSchema for UnitSchema {}
 
 impl Codec for () {
     type Storage = ();
@@ -381,7 +384,7 @@ impl<X, T: Data> SimpleSchema<X, T> {
 }
 
 /// An implementation of [Schema] for [String].
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct StringSchema;
 
 impl Schema<String> for StringSchema {
@@ -418,6 +421,8 @@ impl Schema2<String> for StringSchema {
     }
 }
 
+impl TxnsDataSchema for StringSchema {}
+
 impl Codec for String {
     type Storage = ();
     type Schema = StringSchema;
@@ -439,7 +444,7 @@ impl Codec for String {
 }
 
 /// An implementation of [Schema] for [`Vec<u8>`].
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct VecU8Schema;
 
 impl Schema<Vec<u8>> for VecU8Schema {

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -23,7 +23,7 @@ use arrow::datatypes::{
     Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type,
     UInt64Type, UInt8Type,
 };
-use bytes::BufMut;
+use bytes::{BufMut, Bytes};
 use mz_ore::assert_none;
 use timely::order::Product;
 
@@ -83,7 +83,16 @@ impl Schema<()> for UnitSchema {
     }
 }
 
-impl TxnsDataSchema for UnitSchema {}
+impl TxnsDataSchema for UnitSchema {
+    fn encode(&self) -> Bytes {
+        Bytes::from("()")
+    }
+
+    fn decode(buf: Bytes) -> Self {
+        assert!(buf.is_empty() || buf == "()");
+        UnitSchema
+    }
+}
 
 impl Codec for () {
     type Storage = ();
@@ -421,7 +430,16 @@ impl Schema2<String> for StringSchema {
     }
 }
 
-impl TxnsDataSchema for StringSchema {}
+impl TxnsDataSchema for StringSchema {
+    fn encode(&self) -> Bytes {
+        Bytes::from("String")
+    }
+
+    fn decode(buf: Bytes) -> Self {
+        assert!(buf.is_empty() || buf == "String");
+        StringSchema
+    }
+}
 
 impl Codec for String {
     type Storage = ();

--- a/src/persist-types/src/txn.rs
+++ b/src/persist-types/src/txn.rs
@@ -104,7 +104,7 @@ pub trait TxnsDataSchema: Debug + PartialEq {
     /// Decode a schema previous encoded with this schema's
     /// [TxnsDataSchema::encode].
     ///
-    /// This must perfectly round-trip Self through [TxnsDataSchema::decode]. If
+    /// This must perfectly round-trip Self through [TxnsDataSchema::encode]. If
     /// the encode function for this schema ever changes, decode must be able to
     /// handle bytes output by all previous versions of encode.
     ///

--- a/src/persist-types/src/txn.rs
+++ b/src/persist-types/src/txn.rs
@@ -74,3 +74,6 @@ pub trait TxnsCodec: Debug {
     /// treated the same as `Some(true)`.
     fn should_fetch_part(data_id: &ShardId, stats: &PartStats) -> Option<bool>;
 }
+
+/// [crate::columnar::Schema] of a data shard used with txn-wal.
+pub trait TxnsDataSchema: Debug + PartialEq {}

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -405,8 +405,6 @@ where
                 txns_client.clone(),
                 Arc::clone(&txns_metrics),
                 txns_id,
-                Arc::new(RelationDesc::empty()),
-                Arc::new(UnitSchema),
             )
             .await;
 
@@ -425,7 +423,8 @@ where
             .await
             .expect("txns schema shouldn't change");
 
-        let txns_read = TxnsRead::start::<TxnsCodecRow>(txns_client.clone(), txns_id).await;
+        let txns_read =
+            TxnsRead::start::<SourceData, (), TxnsCodecRow>(txns_client.clone(), txns_id).await;
 
         let collections = Arc::new(std::sync::Mutex::new(BTreeMap::default()));
         let finalizable_shards = Arc::new(std::sync::Mutex::new(BTreeSet::default()));

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2326,12 +2326,11 @@ where
             txns_client.clone(),
             Arc::clone(&txns_metrics),
             txns_id,
-            Arc::new(RelationDesc::empty()),
-            Arc::new(UnitSchema),
         )
         .await;
         let persist_table_worker = persist_handles::PersistTableWriteWorker::new_txns(txns);
-        let txns_read = TxnsRead::start::<TxnsCodecRow>(txns_client.clone(), txns_id).await;
+        let txns_read =
+            TxnsRead::start::<SourceData, (), TxnsCodecRow>(txns_client.clone(), txns_id).await;
         let persist_monotonic_worker = persist_handles::PersistMonotonicWriteWorker::new();
         let collection_manager_write_handle = persist_monotonic_worker.clone();
 

--- a/src/storage-operators/src/stats.rs
+++ b/src/storage-operators/src/stats.rs
@@ -37,7 +37,7 @@ impl StatsCursor {
         // If and only if we are using txn-wal to manage this shard, then
         // this must be Some. This is because the upper might be advanced lazily
         // and we have to go through txn-wal for reads.
-        txns_read: Option<&mut TxnsCache<Timestamp, TxnsCodecRow>>,
+        txns_read: Option<&mut TxnsCache<SourceData, (), Timestamp, TxnsCodecRow>>,
         metrics: &Metrics,
         desc: &RelationDesc,
         as_of: Antichain<Timestamp>,

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -382,6 +382,8 @@ impl TxnsCodecRow {
             .with_column("shard_id", ScalarType::String.nullable(false))
             .with_column("ts", ScalarType::UInt64.nullable(false))
             .with_column("batch", ScalarType::Bytes.nullable(true))
+            .with_column("key_schema", ScalarType::Bytes.nullable(true))
+            .with_column("val_schema", ScalarType::Bytes.nullable(true))
     }
 }
 

--- a/src/txn-wal/Cargo.toml
+++ b/src/txn-wal/Cargo.toml
@@ -23,6 +23,7 @@ mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
+serde_json = "1.0.89"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.38.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"

--- a/src/txn-wal/src/metrics.rs
+++ b/src/txn-wal/src/metrics.rs
@@ -28,6 +28,8 @@ pub struct Metrics {
     pub(crate) compact_to: InfallibleOpMetrics,
 
     pub(crate) batches: BatchMetrics,
+
+    pub(crate) placeholder_schema_apply: IntCounter,
 }
 
 impl std::fmt::Debug for Metrics {
@@ -52,6 +54,10 @@ impl Metrics {
             apply_le: ops.infallible("apply_le"),
             compact_to: ops.infallible("compact_to"),
             batches: BatchMetrics::new(registry),
+            placeholder_schema_apply: registry.register(metric!(
+                name: "mz_txn_placeholder_schema_apply",
+                help: "count of batches applied using a placeholder schema",
+            )),
         }
     }
 }

--- a/src/txn-wal/src/txn_cache.rs
+++ b/src/txn-wal/src/txn_cache.rs
@@ -1145,7 +1145,7 @@ pub(crate) enum Unapplied<'a> {
 mod tests {
     use mz_ore::assert_err;
     use mz_persist_client::PersistClient;
-    use mz_persist_types::codec_impls::{ShardIdSchema, StringSchema, UnitSchema, VecU8Schema};
+    use mz_persist_types::codec_impls::{ShardIdSchema, StringSchema, UnitSchema};
     use DataListenNext::*;
 
     use crate::operator::DataSubscribe;
@@ -1468,7 +1468,7 @@ mod tests {
             .open_leased_reader(
                 txns.txns_id(),
                 Arc::new(ShardIdSchema),
-                Arc::new(VecU8Schema),
+                Arc::new(StringSchema),
                 Diagnostics::for_tests(),
                 true,
             )

--- a/src/txn-wal/src/txn_cache.rs
+++ b/src/txn-wal/src/txn_cache.rs
@@ -1125,6 +1125,10 @@ pub(crate) struct DataRegistered<KS, VS, T> {
 }
 
 impl<KS, VS, T: Timestamp + TotalOrder> DataRegistered<KS, VS, T> {
+    /// Returns whether the given time is included in this registration record.
+    ///
+    /// If it is, indicates this by returning a `Some` of the schemas at that
+    /// time. If it's not, returns a `None`.
     pub(crate) fn contains(&self, ts: &T) -> Option<(&KS, &VS)> {
         let contains = &self.register_ts <= ts && self.forget_ts.as_ref().map_or(true, |x| ts <= x);
         contains.then_some((&self.key_schema, &self.val_schema))

--- a/src/txn-wal/src/txn_write.rs
+++ b/src/txn-wal/src/txn_write.rs
@@ -22,7 +22,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::instrument;
 use mz_persist_client::batch::Batch;
 use mz_persist_client::ShardId;
-use mz_persist_types::txn::{TxnsCodec, TxnsEntry};
+use mz_persist_types::txn::{TxnsCodec, TxnsDataSchema, TxnsEntry};
 use mz_persist_types::{Codec, Codec64, Opaque, StepForward};
 use prost::Message;
 use timely::order::TotalOrder;
@@ -78,7 +78,9 @@ where
 impl<K, V, T, D> Txn<K, V, T, D>
 where
     K: Debug + Codec,
+    K::Schema: TxnsDataSchema,
     V: Debug + Codec,
+    V::Schema: TxnsDataSchema,
     T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
     D: Debug + Semigroup + Ord + Codec64 + Send + Sync,
 {
@@ -355,7 +357,9 @@ impl<T> TxnApply<T> {
     pub async fn apply<K, V, D, O, C>(self, handle: &mut TxnsHandle<K, V, T, D, O, C>) -> Tidy
     where
         K: Debug + Codec,
+        K::Schema: TxnsDataSchema,
         V: Debug + Codec,
+        V::Schema: TxnsDataSchema,
         T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
         D: Debug + Semigroup + Ord + Codec64 + Send + Sync,
         O: Opaque + Debug + Codec64,

--- a/src/txn-wal/src/txns.rs
+++ b/src/txn-wal/src/txns.rs
@@ -608,9 +608,11 @@ where
                 if x.val_schema != self.placeholder_val_schema {
                     assert_eq!(*v, x.val_schema);
                 }
-                if x.key_schema == self.placeholder_key_schema
-                    || x.val_schema == self.placeholder_val_schema
-                {
+                if x.key_schema == self.placeholder_key_schema {
+                    // HACK: In prod, we use UnitSchema for val, which always
+                    // compares as equal to itself, including the default.
+                    // Fixing this would be pretty invasive, so just sniff using
+                    // the key schema.
                     self.metrics.placeholder_schema_apply.inc();
                 }
                 u.push((unapplied, unapplied_ts));


### PR DESCRIPTION
This allows persist-txn to be self-sufficient with schemas, resolving
the cursed TODO to remove the (meaningless) default schemas passed in to
TxnsHandle on construction.

The key and value schema for each data shard is written down in the
record that registers it. Since we forget all data shards and
re-register them as part of boot, this means we (hopefully) only need
the backward compatibility shim for one release.

The production impl of TxnsCodec can sniff out the old format records by
the length of the Row (3 vs 5).

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

I tried to put as many mechanical things as I could in the first two commits.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
