### PR TITLE
storage/mysql: Address nits from IGNORE COLUMNS PR

### DIFF
--- a/src/mysql-util/src/decoding.rs
+++ b/src/mysql-util/src/decoding.rs
@@ -55,7 +55,7 @@ pub fn pack_mysql_row(
             }
         };
         if col_desc.column_type.is_none() {
-            // This column is ignored, so don't decode it it
+            // This column is ignored, so don't decode it.
             continue;
         }
         let datum = match val_to_datum(

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -986,8 +986,8 @@ async fn purify_create_source(
             let tables = mz_mysql_util::schema_info(
                 &mut *conn,
                 &table_schema_request,
-                Some(&text_cols_map),
-                Some(&ignore_cols_map),
+                &text_cols_map,
+                &ignore_cols_map,
             )
             .await
             .map_err(|err| match err {

--- a/src/storage/src/source/mysql/schemas.rs
+++ b/src/storage/src/source/mysql/schemas.rs
@@ -40,8 +40,8 @@ where
                 .map(|(f, _)| (f.0.as_str(), f.1.as_str()))
                 .collect(),
         ),
-        Some(&text_column_map),
-        Some(&ignore_column_map),
+        &text_column_map,
+        &ignore_column_map,
     )
     .await?
     .into_iter()
@@ -83,7 +83,7 @@ fn verify_schema(
 }
 
 fn map_columns<'a>(
-    columns: &'a Vec<MySqlColumnRef>,
+    columns: &'a [MySqlColumnRef],
 ) -> BTreeMap<QualifiedTableRef<'a>, BTreeSet<&'a str>> {
     let mut column_map = BTreeMap::new();
     for column in columns {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Addresses nit comments from https://github.com/MaterializeInc/materialize/pull/25830 (it was merged before addressing to ensure it got in before today's release cut).


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
