### PR TITLE
mysql tests: Reenable test cases working with 24952

### DIFF
--- a/test/mysql-cdc/alter-source.td
+++ b/test/mysql-cdc/alter-source.td
@@ -90,7 +90,7 @@ CREATE TABLE table_e (pk INTEGER PRIMARY KEY, f2 TEXT);
 INSERT INTO table_e VALUES (1, 'one');
 INSERT INTO table_e VALUES (2, 'two');
 
-# TODO: requires #24732 OR #24952
+# TODO: requires #24732
 # CREATE TABLE table_f (pk INTEGER PRIMARY KEY, f2 ENUM ('var0', 'var1'));
 CREATE TABLE table_f (pk INTEGER PRIMARY KEY, f2 TEXT);
 INSERT INTO table_f VALUES (1, 'var0');
@@ -118,9 +118,8 @@ table_g               subsource
 > SELECT regexp_match(create_sql, 'FOR TABLES \((.+?)\) EXPOSE')[1] FROM (SHOW CREATE SOURCE mz_source);
 "\"mysql\".\"public\".\"table_a\" AS \"materialize\".\"public\".\"table_a\", \"mysql\".\"public\".\"table_b\" AS \"materialize\".\"public\".\"table_b\", \"mysql\".\"public\".\"table_c\" AS \"materialize\".\"public\".\"table_c\", \"mysql\".\"public\".\"table_d\" AS \"materialize\".\"public\".\"table_d\", \"mysql\".\"public\".\"table_e\" AS \"materialize\".\"public\".\"table_e\", \"mysql\".\"public\".\"table_f\" AS \"materialize\".\"public\".\"table_f\", \"mysql\".\"public\".\"table_g\" AS \"materialize\".\"public\".\"table_g\""
 
-# TODO enable if used with #24952
-# > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
-# "\"mysql\".\"public\".\"table_f\".\"f2\""
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+"\"mysql\".\"public\".\"table_f\".\"f2\""
 
 #
 # Error checking
@@ -237,10 +236,9 @@ contains:cannot drop source "table_e": still depended upon by materialized view 
 # IF NOT EXISTS + CASCADE works
 > ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e, table_f CASCADE;
 
-# TODO enable if used with #24952
 # TEXT COLUMNS removed from table_f
-# > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
-# <null>
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+<null>
 
 > SHOW SUBSOURCES ON mz_source
 mz_source_progress    progress

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -606,104 +606,94 @@ DELETE FROM mixED_CAse;
 0
 
 # Reference exists in two schemas, so is not unambiguous
-# TODO: #24732 (enum unsupported) / #24952 (text column)
-# ! CREATE SOURCE enum_source
-#   IN CLUSTER cdc_cluster
-#   FROM MYSQL CONNECTION mysql_conn (
-#     TEXT COLUMNS [another_enum_table."колона"]
-#   )
-#   FOR TABLES(
-#     conflict_schema.another_enum_table AS conflict_enum,
-#     public.another_enum_table AS public_enum
-#   );
-# contains: invalid TEXT COLUMNS option value: table another_enum_table is ambiguous, consider specifying the schema
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM MYSQL CONNECTION mysql_conn (
+    TEXT COLUMNS [another_enum_table."колона"]
+  )
+  FOR TABLES(
+    conflict_schema.another_enum_table AS conflict_enum,
+    public.another_enum_table AS public_enum
+  );
+contains: invalid TEXT COLUMNS option value: table another_enum_table is ambiguous, consider specifying the schema
 
-# TODO: #24732 (enum unsupported) / #24952 (text column)
-# ! CREATE SOURCE enum_source
-#   IN CLUSTER cdc_cluster
-#   FROM MYSQL CONNECTION mysql_conn (
-#     TEXT COLUMNS [foo]
-#   )
-#   FOR TABLES (pk_table);
-# contains: invalid TEXT COLUMNS option value: column name 'foo' must have at least a table qualification
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM MYSQL CONNECTION mysql_conn (
+    TEXT COLUMNS [foo]
+  )
+  FOR TABLES (pk_table);
+contains: invalid TEXT COLUMNS option value: column name 'foo' must have at least a table qualification
 
-# TODO: #24732 (enum unsupported) / #24952 (text column)
-# ! CREATE SOURCE enum_source
-#   IN CLUSTER cdc_cluster
-#   FROM MYSQL CONNECTION mysql_conn (
-#     TEXT COLUMNS [foo.bar.qux.qax.foo]
-#   )
-#   FOR TABLES (pk_table);
-# contains: invalid TEXT COLUMNS option value: qualified name did not have between 1 and 3 components: foo.bar.qux.qax
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM MYSQL CONNECTION mysql_conn (
+    TEXT COLUMNS [foo.bar.qux.qax.foo]
+  )
+  FOR TABLES (pk_table);
+contains: invalid TEXT COLUMNS option value: qualified name did not have between 1 and 3 components: foo.bar.qux.qax
 
-# TODO: #24732 (enum unsupported) / #24952 (text column)
-# ! CREATE SOURCE enum_source
-#   IN CLUSTER cdc_cluster
-#   FROM MYSQL CONNECTION mysql_conn (
-#     TEXT COLUMNS [enum_table.a, enum_table.a]
-#   )
-#   FOR TABLES (enum_table);
-# contains: invalid TEXT COLUMNS option value: unexpected multiple references to postgres.public.enum_table.a
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM MYSQL CONNECTION mysql_conn (
+    TEXT COLUMNS [enum_table.a, enum_table.a]
+  )
+  FOR TABLES (enum_table);
+contains: invalid TEXT COLUMNS option value: unexpected multiple references to postgres.public.enum_table.a
 
-# TODO: #24732 (enum unsupported) / #24952 (text column)
-# utf8_table is not part of mz_source_narrow publication
-# ! CREATE SOURCE enum_source
-#   IN CLUSTER cdc_cluster
-#   FROM MYSQL CONNECTION mysql_conn (
-#     TEXT COLUMNS [enum_table.a, utf8_table.f1]
-#   )
-#   FOR TABLES (enum_table);
-# contains: invalid TEXT COLUMNS option value: table utf8_table not found in source
+utf8_table is not part of mz_source_narrow publication
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM MYSQL CONNECTION mysql_conn (
+    TEXT COLUMNS [enum_table.a, utf8_table.f1]
+  )
+  FOR TABLES (enum_table);
+contains: invalid TEXT COLUMNS option value: table utf8_table not found in source
 
 # n.b includes a reference to pk_table, which is not a table that's part of the
 # source, but is part of the publication.
 
-# TODO: #24732 (enum unsupported) / #24952 (text column)
-# ! CREATE SOURCE enum_source
-#   IN CLUSTER cdc_cluster
-#   FROM MYSQL CONNECTION mysql_conn (
-#     TEXT COLUMNS [
-#       enum_table.a,
-#       public.another_enum_table."колона",
-#       pk_table.pk
-#     ]
-#   )
-#   FOR TABLES (
-#     "enum_table",
-#     public.another_enum_table
-#   );
-# contains:TEXT COLUMNS refers to table not currently being added
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM MYSQL CONNECTION mysql_conn (
+    TEXT COLUMNS [
+      enum_table.a,
+      public.another_enum_table."колона",
+      pk_table.pk
+    ]
+  )
+  FOR TABLES (
+    "enum_table",
+    public.another_enum_table
+  );
+contains:TEXT COLUMNS refers to table not currently being added
 
-# TODO: #24732 (enum unsupported) / #24952 (text column)
-# > CREATE SOURCE enum_source
-#   IN CLUSTER cdc_cluster
-#   FROM MYSQL CONNECTION mysql_conn (
-#     TEXT COLUMNS [
-#       enum_table.a,
-#       public.another_enum_table."колона"
-#     ]
-#   )
-#   FOR TABLES (
-#     "enum_table",
-#     public.another_enum_table
-#   );
+> CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM MYSQL CONNECTION mysql_conn (
+    TEXT COLUMNS [
+      enum_table.a,
+      public.another_enum_table."колона"
+    ]
+  )
+  FOR TABLES (
+    "enum_table",
+    public.another_enum_table
+  );
 
-# TODO: #24732 (enum unsupported) / #24952 (text column)
-# > SELECT * FROM (SHOW SOURCES) WHERE name LIKE '%enum%';
-# another_enum_table      subsource <null> <null>
-# enum_source             mysql     ${arg.default-replica-size} cdc_cluster
-# enum_source_progress    progress  <null> <null>
-# enum_table              subsource <null> <null>
+> SELECT * FROM (SHOW SOURCES) WHERE name LIKE '%enum%';
+another_enum_table      subsource <null> <null>
+enum_source             mysql     ${arg.default-replica-size} cdc_cluster
+enum_source_progress    progress  <null> <null>
+enum_table              subsource <null> <null>
 
-# TODO: #24732 (enum unsupported) / #24952 (text column)
-# > SELECT * FROM enum_table
-# var0
-# var1
+> SELECT * FROM enum_table
+var0
+var1
 
-# TODO: #24732 (enum unsupported) / #24952 (text column)
-# > SELECT "колона" FROM another_enum_table
-# var2
-# var3
+> SELECT "колона" FROM another_enum_table
+var2
+var3
 
 #
 # Cleanup
@@ -713,8 +703,7 @@ DELETE FROM mixED_CAse;
 $ mysql-execute name=mysql
 INSERT INTO pk_table VALUES (99999, 'abc');
 
-# TODO: #24732 (enum unsupported) / #24952 (text column)
-# > DROP SOURCE enum_source CASCADE;
+> DROP SOURCE enum_source CASCADE;
 > DROP SOURCE "mz_source" CASCADE;
 
 #


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
