### PR TITLE
test/cluster: unflake test_github_15531

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -325,8 +325,15 @@ def workflow_test_github_15531(c: Composition) -> None:
         -- table for slow-path peeks
         CREATE TABLE t2 (a int);
         INSERT INTO t2 VALUES (84);
+
+        -- Wait for the cluster to be ready.
+        SELECT * FROM t;
+        SELECT * FROM t2;
         """
     )
+
+    # Wait a bit to let the metrics refresh.
+    time.sleep(2)
 
     # obtain initial history size and dataflow count
     (
@@ -368,6 +375,9 @@ def workflow_test_github_15531(c: Composition) -> None:
             SELECT * FROM t2;
             """
         )
+
+    # Wait a bit to let the metrics refresh.
+    time.sleep(2)
 
     # Check that history size and dataflow count are well-behaved.
     # Dataflow count can plausibly be more than 1, if compaction is delayed.


### PR DESCRIPTION
This test fetches metrics which are refreshed asynchronously, so we need to wait a bit to ensure we always see the current state reflected.

Additionally, we run a query against the inspected replica in the beginning, to ensure it has successfully started up.

### Motivation

  * This PR fixes a recognized bug.

Fixes #25861.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A