### PR TITLE
canary-load: subscribe can return multiple results

### DIFF
--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -146,13 +146,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                         if i == 0:
                             assert len(r) == 1, f"Unexpected results: {r}"
                         else:
-                            assert len(r) == 2, f"Unexpected results: {r}"
+                            assert len(r) % 2 == 0, f"Unexpected results: {r}"
                             assert (
-                                int(r[0][0]) >= current_time
+                                int(r[-2][0]) >= current_time
                             ), f"Unexpected results: {r}"
-                            assert int(r[0][1]) == -1, f"Unexpected results: {r}"
+                            assert int(r[-2][1]) == -1, f"Unexpected results: {r}"
                             assert (
-                                int(r[0][2]) == i * 100 - 1
+                                int(r[-2][2]) == i * 100 - 1
                             ), f"Unexpected results: {r}"
                         assert int(r[-1][0]) >= current_time, f"Unexpected results: {r}"
                         assert int(r[-1][1]) == 1, f"Unexpected results: {r}"


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/qa-canary-environment-base-load/builds/27#018e1ebf-afb6-41ce-9d0c-f7ebae08056b

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
