### PR TITLE
mzcompose: Hash sharded job in a stable way

### DIFF
--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -9,6 +9,7 @@
 
 """Buildkite utilities."""
 
+import hashlib
 import os
 from collections.abc import Callable
 from pathlib import Path
@@ -149,7 +150,7 @@ def accepted_by_shard(
     if parallelism_count is None:
         parallelism_count = get_parallelism_count()
 
-    hash_value = hash(identifier)
+    hash_value = int.from_bytes(hashlib.md5(identifier.encode("utf-8")).digest())
     return hash_value % parallelism_count == parallelism_index
 
 


### PR DESCRIPTION
hash() is not stable across runs

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
