### PR TITLE
doc/user: fix CREATE CLUSTER [REPLICA] railroad diagrams

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/create-cluster-replica.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-cluster-replica.svg
@@ -1,68 +1,84 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="505" height="163">
-   <polygon points="9 17 1 13 1 21"/>
-   <polygon points="17 17 9 13 9 21"/>
-   <rect x="31" y="3" width="76" height="32" rx="10"/>
-   <rect x="29"
+<svg xmlns="http://www.w3.org/2000/svg" width="535" height="163">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="76" height="32" rx="10"/>
+   <rect x="31"
          y="1"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="21">CREATE</text>
-   <rect x="127" y="3" width="84" height="32" rx="10"/>
-   <rect x="125"
+   <text class="terminal" x="41" y="21">CREATE</text>
+   <rect x="129" y="3" width="84" height="32" rx="10"/>
+   <rect x="127"
          y="1"
          width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="135" y="21">CLUSTER</text>
-   <rect x="231" y="3" width="80" height="32" rx="10"/>
-   <rect x="229"
+   <text class="terminal" x="137" y="21">CLUSTER</text>
+   <rect x="233" y="3" width="80" height="32" rx="10"/>
+   <rect x="231"
          y="1"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="239" y="21">REPLICA</text>
-   <rect x="331" y="3" width="108" height="32"/>
-   <rect x="329" y="1" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="339" y="21">cluster_name</text>
-   <rect x="459" y="3" width="24" height="32" rx="10"/>
-   <rect x="457"
+   <text class="terminal" x="241" y="21">REPLICA</text>
+   <rect x="333" y="3" width="108" height="32"/>
+   <rect x="331" y="1" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="341" y="21">cluster_name</text>
+   <rect x="461" y="3" width="24" height="32" rx="10"/>
+   <rect x="459"
          y="1"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="467" y="21">.</text>
-   <rect x="87" y="113" width="106" height="32"/>
-   <rect x="85" y="111" width="106" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="95" y="131">replica_name</text>
-   <rect x="253" y="113" width="62" height="32"/>
-   <rect x="251" y="111" width="62" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="261" y="131">option</text>
-   <rect x="335" y="113" width="28" height="32" rx="10"/>
-   <rect x="333"
+   <text class="terminal" x="469" y="21">.</text>
+   <rect x="25" y="113" width="106" height="32"/>
+   <rect x="23" y="111" width="106" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="33" y="131">replica_name</text>
+   <rect x="151" y="113" width="26" height="32" rx="10"/>
+   <rect x="149"
+         y="111"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="159" y="131">(</text>
+   <rect x="237" y="113" width="62" height="32"/>
+   <rect x="235" y="111" width="62" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="245" y="131">option</text>
+   <rect x="319" y="113" width="28" height="32" rx="10"/>
+   <rect x="317"
          y="111"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="343" y="131">=</text>
-   <rect x="383" y="113" width="54" height="32"/>
-   <rect x="381" y="111" width="54" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="391" y="131">value</text>
-   <rect x="253" y="69" width="24" height="32" rx="10"/>
-   <rect x="251"
+   <text class="terminal" x="327" y="131">=</text>
+   <rect x="367" y="113" width="54" height="32"/>
+   <rect x="365" y="111" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="375" y="131">value</text>
+   <rect x="237" y="69" width="24" height="32" rx="10"/>
+   <rect x="235"
          y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="261" y="87">,</text>
+   <text class="terminal" x="245" y="87">,</text>
+   <rect x="481" y="113" width="26" height="32" rx="10"/>
+   <rect x="479"
+         y="111"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="489" y="131">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-440 110 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m106 0 h10 m40 0 h10 m62 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m-224 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m204 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-204 0 h10 m24 0 h10 m0 0 h160 m-244 44 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v14 m264 0 v-14 m-264 14 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m0 0 h234 m23 -34 h-3"/>
-   <polygon points="495 127 503 123 503 131"/>
-   <polygon points="495 127 487 123 487 131"/>
+         d="m19 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-504 110 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m106 0 h10 m0 0 h10 m26 0 h10 m40 0 h10 m62 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m-224 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m204 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-204 0 h10 m24 0 h10 m0 0 h160 m-244 44 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v14 m264 0 v-14 m-264 14 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m0 0 h234 m20 -34 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="525 127 533 123 533 131"/>
+   <polygon points="525 127 517 123 517 131"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-managed-cluster.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-managed-cluster.svg
@@ -1,57 +1,65 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="379" height="147">
-   <polygon points="9 17 1 13 1 21"/>
-   <polygon points="17 17 9 13 9 21"/>
-   <rect x="31" y="3" width="76" height="32" rx="10"/>
-   <rect x="29"
+<svg xmlns="http://www.w3.org/2000/svg" width="457" height="135">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="76" height="32" rx="10"/>
+   <rect x="31"
          y="1"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="21">CREATE</text>
-   <rect x="127" y="3" width="84" height="32" rx="10"/>
-   <rect x="125"
+   <text class="terminal" x="41" y="21">CREATE</text>
+   <rect x="129" y="3" width="84" height="32" rx="10"/>
+   <rect x="127"
          y="1"
          width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="135" y="21">CLUSTER</text>
-   <rect x="231" y="3" width="56" height="32"/>
-   <rect x="229" y="1" width="56" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="239" y="21">name</text>
-   <rect x="307" y="3" width="50" height="32" rx="10"/>
-   <rect x="305"
+   <text class="terminal" x="137" y="21">CLUSTER</text>
+   <rect x="233" y="3" width="56" height="32"/>
+   <rect x="231" y="1" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="241" y="21">name</text>
+   <rect x="309" y="3" width="26" height="32" rx="10"/>
+   <rect x="307"
          y="1"
-         width="50"
+         width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="315" y="21">SIZE</text>
-   <rect x="175" y="113" width="28" height="32" rx="10"/>
-   <rect x="173"
-         y="111"
-         width="28"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="183" y="131">=</text>
-   <rect x="223" y="113" width="54" height="32"/>
-   <rect x="221" y="111" width="54" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="231" y="131">value</text>
-   <rect x="175" y="69" width="112" height="32"/>
-   <rect x="173" y="67" width="112" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="183" y="87">cluster_option</text>
-   <rect x="307" y="69" width="24" height="32" rx="10"/>
-   <rect x="305"
-         y="67"
+   <text class="terminal" x="317" y="21">(</text>
+   <rect x="65" y="85" width="24" height="32" rx="10"/>
+   <rect x="63"
+         y="83"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="315" y="87">,</text>
+   <text class="terminal" x="73" y="103">,</text>
+   <rect x="109" y="85" width="112" height="32"/>
+   <rect x="107" y="83" width="112" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="117" y="103">cluster_option</text>
+   <rect x="241" y="85" width="28" height="32" rx="10"/>
+   <rect x="239"
+         y="83"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="249" y="103">=</text>
+   <rect x="289" y="85" width="54" height="32"/>
+   <rect x="287" y="83" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="297" y="103">value</text>
+   <rect x="403" y="85" width="26" height="32" rx="10"/>
+   <rect x="401"
+         y="83"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="411" y="103">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m50 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-246 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m0 0 h54 m-196 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m176 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-176 0 h10 m112 0 h10 m0 0 h10 m24 0 h10 m23 44 h-3"/>
-   <polygon points="369 127 377 123 377 131"/>
-   <polygon points="369 127 361 123 361 131"/>
+         d="m19 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-354 82 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m24 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m-318 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m298 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-298 0 h10 m0 0 h288 m-338 32 h20 m338 0 h20 m-378 0 q10 0 10 10 m358 0 q0 -10 10 -10 m-368 10 v14 m358 0 v-14 m-358 14 q0 10 10 10 m338 0 q10 0 10 -10 m-348 10 h10 m0 0 h328 m20 -34 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="447 99 455 95 455 103"/>
+   <polygon points="447 99 439 95 439 103"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -84,11 +84,11 @@ create_cluster ::=
     'REPLICAS' '(' (replica_definition (',' replica_definition)*)? ')'
   )?
 create_managed_cluster ::=
-  'CREATE' 'CLUSTER' name 'SIZE' '=' value (',' cluster_option '=' value)*
+  'CREATE' 'CLUSTER' name '(' (',' cluster_option '=' value)* ')'
 cluster_replica_def ::=
   replica_name '(' replica_option '=' value ( ',' replica_option '=' value )* ')'
 create_cluster_replica ::=
-  'CREATE' 'CLUSTER' 'REPLICA' cluster_name '.' replica_name (option '=' value ( ',' option '=' value )*)?
+  'CREATE' 'CLUSTER' 'REPLICA' cluster_name '.' replica_name '(' (option '=' value ( ',' option '=' value )*)? ')'
 create_connection_aws ::=
   'CREATE' 'CONNECTION' 'IF NOT EXISTS'? connection_name 'TO' 'AWS'
   '(' field '='? val ( ',' field '='? val )* ')'


### PR DESCRIPTION
I failed to update this in #23434.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR fixes documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
