### PR TITLE
storage/mysql: Fix 2 mysql TEXT COLUMNS bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6092,6 +6092,7 @@ dependencies = [
  "mz-rocksdb-types",
  "mz-secrets",
  "mz-service",
+ "mz-sql-parser",
  "mz-ssh-util",
  "mz-stash-types",
  "mz-timely-util",

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1021,7 +1021,7 @@ async fn purify_create_source(
                 .find(|option| option.name == MySqlConfigOptionName::TextColumns)
             {
                 text_cols_option.value = Some(WithOptionValue::Sequence(
-                    mysql::normalize_column_refs(text_columns, &mysql_catalog),
+                    mysql::normalize_column_refs(text_columns, &mysql_catalog)?,
                 ));
             }
             if let Some(ignore_cols_option) = options
@@ -1029,7 +1029,7 @@ async fn purify_create_source(
                 .find(|option| option.name == MySqlConfigOptionName::IgnoreColumns)
             {
                 ignore_cols_option.value = Some(WithOptionValue::Sequence(
-                    mysql::normalize_column_refs(ignore_columns, &mysql_catalog),
+                    mysql::normalize_column_refs(ignore_columns, &mysql_catalog)?,
                 ));
             }
 

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -46,6 +46,7 @@ mz-rocksdb-types = { path = "../rocksdb-types" }
 mz-secrets = { path = "../secrets" }
 mz-service = { path = "../service" }
 mz-ssh-util = { path = "../ssh-util" }
+mz-sql-parser = { path = "../sql-parser" }
 mz-stash-types = { path = "../stash-types" }
 mz-timely-util = { path = "../timely-util" }
 mz-tls-util = { path = "../tls-util" }

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -675,32 +675,32 @@ DELETE FROM mixED_CAse;
 # contains:TEXT COLUMNS refers to table not currently being added
 
 # TODO: #25884 (enum in text columns does not work)
-# > CREATE SOURCE enum_source
-#   IN CLUSTER cdc_cluster
-#   FROM MYSQL CONNECTION mysql_conn (
-#     TEXT COLUMNS [
-#       public.enum_table.a,
-#       public.another_enum_table."колона"
-#     ]
-#   )
-#   FOR TABLES (
-#     public."enum_table",
-#     public.another_enum_table
-#   );
-#
-# > SELECT * FROM (SHOW SOURCES) WHERE name LIKE '%enum%';
-# another_enum_table      subsource <null> <null>
-# enum_source             mysql     ${arg.default-replica-size} cdc_cluster
-# enum_source_progress    progress  <null> <null>
-# enum_table              subsource <null> <null>
-#
-# > SELECT * FROM enum_table
-# var0
-# var1
-#
-# > SELECT "колона" FROM another_enum_table
-# var2
-# var3
+> CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM MYSQL CONNECTION mysql_conn (
+    TEXT COLUMNS [
+      public.enum_table.a,
+      public.another_enum_table."колона"
+    ]
+  )
+  FOR TABLES (
+    public."enum_table",
+    public.another_enum_table
+  );
+
+> SELECT * FROM (SHOW SOURCES) WHERE name LIKE '%enum%';
+another_enum_table      subsource <null> <null>
+enum_source             mysql     ${arg.default-replica-size} cdc_cluster
+enum_source_progress    progress  <null> <null>
+enum_table              subsource <null> <null>
+
+> SELECT * FROM enum_table
+var0
+var1
+
+> SELECT "колона" FROM another_enum_table
+var2
+var3
 
 #
 # Cleanup
@@ -711,7 +711,7 @@ $ mysql-execute name=mysql
 INSERT INTO pk_table VALUES (99999, 'abc');
 
 # TODO: #25884 (enum in text columns does not work)
-# > DROP SOURCE enum_source CASCADE;
+> DROP SOURCE enum_source CASCADE;
 > DROP SOURCE "mz_source" CASCADE;
 
 #

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -658,23 +658,21 @@ DELETE FROM mixED_CAse;
 # n.b includes a reference to pk_table, which is not a table that's part of the
 # source, but is part of the publication.
 
-# TODO: #25883 (reference to unrelated table should fail)
-# ! CREATE SOURCE enum_source
-#   IN CLUSTER cdc_cluster
-#   FROM MYSQL CONNECTION mysql_conn (
-#     TEXT COLUMNS [
-#       public.enum_table.a,
-#       public.another_enum_table."колона",
-#       public.pk_table.pk
-#     ]
-#   )
-#   FOR TABLES (
-#     "enum_table",
-#     public.another_enum_table
-#   );
-# contains:TEXT COLUMNS refers to table not currently being added
+! CREATE SOURCE enum_source
+  IN CLUSTER cdc_cluster
+  FROM MYSQL CONNECTION mysql_conn (
+    TEXT COLUMNS [
+      public.enum_table.a,
+      public.another_enum_table."колона",
+      public.pk_table.pk
+    ]
+  )
+  FOR TABLES (
+    public."enum_table",
+    public.another_enum_table
+  );
+contains:TEXT COLUMNS refers to columns not currently being added
 
-# TODO: #25884 (enum in text columns does not work)
 > CREATE SOURCE enum_source
   IN CLUSTER cdc_cluster
   FROM MYSQL CONNECTION mysql_conn (
@@ -710,7 +708,6 @@ var3
 $ mysql-execute name=mysql
 INSERT INTO pk_table VALUES (99999, 'abc');
 
-# TODO: #25884 (enum in text columns does not work)
 > DROP SOURCE enum_source CASCADE;
 > DROP SOURCE "mz_source" CASCADE;
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/materialize/issues/25884 and Fixes https://github.com/MaterializeInc/materialize/issues/25883

Fix 2 issues related to MySQL `TEXT COLUMNS` and `IGNORE COLUMNS` purification/planning.

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer


The first issue was when encountering column names with special characters -- we were inadvertently storing a postgres-style-escaped string for the column name in our source connection options which later led to errors when verifying the schema in the source operator.

The second issue was ignoring any column references that didn't match -- this change just propagates those up as an error to the user during sql purification.

The 2 commits correspond to each of the issues fixed.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
