### PR TITLE
catalog: Refactor persist catalog to use traces

### DIFF
--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -61,17 +61,24 @@ pub struct StateUpdate<T: IntoStateUpdateKindRaw = StateUpdateKind> {
 
 impl StateUpdate {
     /// Convert a [`TransactionBatch`] to a list of [`StateUpdate`]s at timestamp `ts`.
-    pub(crate) fn from_txn_batch(txn_batch: TransactionBatch, ts: Timestamp) -> Vec<StateUpdate> {
+    pub(crate) fn from_txn_batch_ts(
+        txn_batch: TransactionBatch,
+        ts: Timestamp,
+    ) -> impl Iterator<Item = StateUpdate> {
+        Self::from_txn_batch(txn_batch).map(move |(kind, diff)| StateUpdate { kind, ts, diff })
+    }
+
+    /// Convert a [`TransactionBatch`] to a list of [`StateUpdate`]s and [`Diff`]s.
+    pub(crate) fn from_txn_batch(
+        txn_batch: TransactionBatch,
+    ) -> impl Iterator<Item = (StateUpdateKind, Diff)> {
         fn from_batch<K, V>(
             batch: Vec<(K, V, Diff)>,
-            ts: Timestamp,
             kind: fn(K, V) -> StateUpdateKind,
-        ) -> impl Iterator<Item = StateUpdate> {
-            batch.into_iter().map(move |(k, v, diff)| StateUpdate {
-                kind: kind(k, v),
-                ts,
-                diff,
-            })
+        ) -> impl Iterator<Item = (StateUpdateKind, Diff)> {
+            batch
+                .into_iter()
+                .map(move |(k, v, diff)| (kind(k, v), diff))
         }
         let TransactionBatch {
             databases,
@@ -93,35 +100,30 @@ impl StateUpdate {
             audit_log_updates,
             storage_usage_updates,
         } = txn_batch;
-        let databases = from_batch(databases, ts, StateUpdateKind::Database);
-        let schemas = from_batch(schemas, ts, StateUpdateKind::Schema);
-        let items = from_batch(items, ts, StateUpdateKind::Item);
-        let comments = from_batch(comments, ts, StateUpdateKind::Comment);
-        let roles = from_batch(roles, ts, StateUpdateKind::Role);
-        let clusters = from_batch(clusters, ts, StateUpdateKind::Cluster);
-        let cluster_replicas = from_batch(cluster_replicas, ts, StateUpdateKind::ClusterReplica);
+        let databases = from_batch(databases, StateUpdateKind::Database);
+        let schemas = from_batch(schemas, StateUpdateKind::Schema);
+        let items = from_batch(items, StateUpdateKind::Item);
+        let comments = from_batch(comments, StateUpdateKind::Comment);
+        let roles = from_batch(roles, StateUpdateKind::Role);
+        let clusters = from_batch(clusters, StateUpdateKind::Cluster);
+        let cluster_replicas = from_batch(cluster_replicas, StateUpdateKind::ClusterReplica);
         let introspection_sources = from_batch(
             introspection_sources,
-            ts,
             StateUpdateKind::IntrospectionSourceIndex,
         );
-        let id_allocators = from_batch(id_allocator, ts, StateUpdateKind::IdAllocator);
-        let configs = from_batch(configs, ts, StateUpdateKind::Config);
-        let settings = from_batch(settings, ts, StateUpdateKind::Setting);
-        let timestamps = from_batch(timestamps, ts, StateUpdateKind::Timestamp);
+        let id_allocators = from_batch(id_allocator, StateUpdateKind::IdAllocator);
+        let configs = from_batch(configs, StateUpdateKind::Config);
+        let settings = from_batch(settings, StateUpdateKind::Setting);
+        let timestamps = from_batch(timestamps, StateUpdateKind::Timestamp);
         let system_object_mappings =
-            from_batch(system_gid_mapping, ts, StateUpdateKind::SystemObjectMapping);
-        let system_configurations = from_batch(
-            system_configurations,
-            ts,
-            StateUpdateKind::SystemConfiguration,
-        );
-        let default_privileges =
-            from_batch(default_privileges, ts, StateUpdateKind::DefaultPrivilege);
-        let system_privileges = from_batch(system_privileges, ts, StateUpdateKind::SystemPrivilege);
-        let audit_logs = from_batch(audit_log_updates, ts, StateUpdateKind::AuditLog);
+            from_batch(system_gid_mapping, StateUpdateKind::SystemObjectMapping);
+        let system_configurations =
+            from_batch(system_configurations, StateUpdateKind::SystemConfiguration);
+        let default_privileges = from_batch(default_privileges, StateUpdateKind::DefaultPrivilege);
+        let system_privileges = from_batch(system_privileges, StateUpdateKind::SystemPrivilege);
+        let audit_logs = from_batch(audit_log_updates, StateUpdateKind::AuditLog);
         let storage_usage_updates =
-            from_batch(storage_usage_updates, ts, StateUpdateKind::StorageUsage);
+            from_batch(storage_usage_updates, StateUpdateKind::StorageUsage);
 
         databases
             .chain(schemas)
@@ -141,7 +143,6 @@ impl StateUpdate {
             .chain(system_privileges)
             .chain(audit_logs)
             .chain(storage_usage_updates)
-            .collect()
     }
 }
 

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -52,7 +52,7 @@ use crate::durable::initialize::{
 use crate::durable::metrics::Metrics;
 use crate::durable::objects::serialization::proto;
 use crate::durable::objects::state_update::{
-    IntoStateUpdateKindRaw, StateUpdate, StateUpdateKind, StateUpdateKindRaw,
+    IntoStateUpdateKindRaw, StateUpdate, StateUpdateKind, StateUpdateKindRaw, TryIntoStateUpdateKind
 };
 use crate::durable::objects::{AuditLogKey, Snapshot, StorageUsageKey};
 use crate::durable::transaction::TransactionBatch;
@@ -145,6 +145,394 @@ impl FenceableEpoch {
                 "current catalog epoch {current_epoch} fenced by new catalog epoch {fence_epoch}",
             ))),
         }
+    }
+}
+
+/// TODO(jkosh44)
+#[derive(Debug)]
+pub struct PersistHandle<T: TryIntoStateUpdateKind> {
+    /// Since handle to control compaction.
+    since_handle: SinceHandle<SourceData, (), Timestamp, Diff, i64>,
+    /// Write handle to persist.
+    write_handle: WriteHandle<SourceData, (), Timestamp, Diff>,
+    /// Listener to catalog changes.
+    listen: Listen<SourceData, (), Timestamp, Diff>,
+    /// Handle for connecting to persist.
+    persist_client: PersistClient,
+    /// Catalog shard ID.
+    shard_id: ShardId,
+    /// Cache of the most recent catalog snapshot.
+    pub(crate) trace: Vec<StateUpdate<T>>,
+    /// The current upper of the persist shard.
+    pub(crate) upper: Timestamp,
+    /// The epoch of the catalog, if one exists. This information is also included in `snapshot`,
+    /// but it's useful to have quick access to this field without parsing through all updates.
+    epoch: FenceableEpoch,
+    /// Metrics for the persist catalog.
+    metrics: Arc<Metrics>,
+}
+
+impl<T: TryIntoStateUpdateKind> PersistHandle<T> {
+    /// Returns the schema of the `Row`s/`SourceData`s stored in the persist
+    /// shard backing the catalog.
+    pub fn desc() -> RelationDesc {
+        RelationDesc::empty().with_column("data", ScalarType::Jsonb.nullable(false))
+    }
+
+    /// Fetch the persist version of the catalog upgrade shard, if one exists. A version will not
+    /// exist if the catalog upgrade shard itself doesn't exist which could happen in the following
+    /// scenarios:
+    ///
+    ///   - We are creating a brand new environment.
+    ///   - We are upgrading from a version of the code where the catalog upgrade shard didn't
+    ///   exist.
+    async fn fetch_catalog_upgrade_shard_version(
+        persist_client: &PersistClient,
+        upgrade_shard_id: ShardId,
+    ) -> Option<semver::Version> {
+        let shard_state = persist_client
+            .inspect_shard::<Timestamp>(&upgrade_shard_id)
+            .await
+            .ok()?;
+        let json_state = serde_json::to_value(shard_state).expect("state serialization error");
+        let upgrade_version = json_state
+            .get("applier_version")
+            .cloned()
+            .expect("missing applier_version");
+        let upgrade_version =
+            serde_json::from_value(upgrade_version).expect("version deserialization error");
+        Some(upgrade_version)
+    }
+
+    /// Increment the version in the catalog upgrade shard to the code's current version.
+    async fn increment_catalog_upgrade_shard_version(&mut self, organization_id: Uuid) {
+        let upgrade_shard_id = shard_id(organization_id, UPGRADE_SEED);
+        let mut write_handle: WriteHandle<(), (), Timestamp, Diff> = self
+            .persist_client
+            .open_writer(
+                upgrade_shard_id,
+                Arc::new(UnitSchema::default()),
+                Arc::new(UnitSchema::default()),
+                Diagnostics {
+                    shard_name: UPGRADE_SHARD_NAME.to_string(),
+                    handle_purpose: "increment durable catalog upgrade shard version".to_string(),
+                },
+            )
+            .await
+            .expect("invalid usage");
+        const EMPTY_UPDATES: &[(((), ()), Timestamp, Diff)] = &[];
+        let mut upper = write_handle.fetch_recent_upper().await.clone();
+        loop {
+            let next_upper = upper
+                .iter()
+                .map(|timestamp| timestamp.step_forward())
+                .collect();
+            match write_handle
+                .compare_and_append(EMPTY_UPDATES, upper, next_upper)
+                .await
+                .expect("invalid usage")
+            {
+                Ok(()) => break,
+                Err(upper_mismatch) => {
+                    upper = upper_mismatch.current;
+                }
+            }
+        }
+    }
+
+    #[mz_ore::instrument]
+    async fn current_upper(&mut self) -> Timestamp {
+        current_upper(&mut self.write_handle).await
+    }
+
+    /// Appends `updates` to the catalog state and downgrades the catalog's upper to `next_upper`
+    /// iff the current global upper of the catalog is `current_upper`.
+    #[mz_ore::instrument]
+    pub(crate) async fn compare_and_append(
+        &mut self,
+        updates: Vec<(T, Diff)>,
+    ) -> Result<(), CatalogError> {
+        let updates = updates
+            .into_iter()
+            .map(|(kind, diff)| StateUpdate {
+                kind,
+                ts: self.upper,
+                diff,
+            })
+            .collect();
+        let next_upper = self.upper.step_forward();
+        compare_and_append(
+            &mut self.since_handle,
+            &mut self.write_handle,
+            updates,
+            self.upper,
+            next_upper,
+        )
+        .await?;
+        self.sync(next_upper).await?;
+        Ok(())
+    }
+
+    /// Generates an iterator of [`StateUpdate`] that contain all unconsolidated updates to the
+    /// catalog state up to, and including, `as_of`.
+    #[mz_ore::instrument]
+    async fn snapshot_unconsolidated(&mut self) -> Vec<StateUpdate<StateUpdateKind>> {
+        let current_upper = self.current_upper().await;
+
+        let mut snapshot = Vec::new();
+        let mut read_handle = self.read_handle().await;
+        let as_of = as_of(&read_handle, current_upper);
+        let mut stream = Box::pin(
+            // We use `snapshot_and_stream` because it guarantees unconsolidated output.
+            read_handle
+                .snapshot_and_stream(Antichain::from_elem(as_of))
+                .await
+                .expect("we have advanced the restart_as_of by the since"),
+        );
+        while let Some(update) = stream.next().await {
+            snapshot.push(update)
+        }
+        read_handle.expire().await;
+        snapshot
+            .into_iter()
+            .map(Into::<StateUpdate<StateUpdateKindRaw>>::into)
+            .map(|state_update| state_update.try_into().expect("kind decoding error"))
+            .collect()
+    }
+
+    /// Listen and apply all updates that are currently in persist.
+    #[mz_ore::instrument]
+    pub(crate) async fn sync_to_current_upper(&mut self) -> Result<(), DurableCatalogError> {
+        let upper = self.current_upper().await;
+        self.sync(upper).await
+    }
+
+    /// Listen and apply all updates up to `target_upper`.
+    #[mz_ore::instrument(level = "debug")]
+    pub(crate) async fn sync(
+        &mut self,
+        target_upper: Timestamp,
+    ) -> Result<(), DurableCatalogError> {
+        self.metrics.syncs.inc();
+        let counter = self.metrics.sync_latency_seconds.clone();
+        self.sync_inner(target_upper)
+            .wall_time()
+            .inc_by(counter)
+            .await
+    }
+
+    #[mz_ore::instrument(level = "debug")]
+    async fn sync_inner(&mut self, target_upper: Timestamp) -> Result<(), DurableCatalogError> {
+        self.epoch.validate()?;
+        let updates = sync(&mut self.listen, &mut self.upper, target_upper).await;
+        self.apply_updates(updates)?;
+        Ok(())
+    }
+
+    #[mz_ore::instrument(level = "debug")]
+    pub(crate) fn apply_updates(
+        &mut self,
+        updates: Vec<StateUpdate<T>>,
+    ) -> Result<(), DurableCatalogError> {
+        for update in updates {
+            let StateUpdate { kind, ts, diff } = &update;
+            if *diff != 1 && *diff != -1 {
+                panic!("invalid update in consolidated trace: ({kind:?}, {ts:?}, {diff:?})");
+            }
+
+            if let Ok(kind) = kind.clone().try_into() {
+                match (kind, diff) {
+                    (StateUpdateKind::Epoch(epoch), 1) => match self.epoch {
+                        FenceableEpoch::Unfenced(Some(current_epoch)) => {
+                            if epoch > current_epoch {
+                                self.epoch = FenceableEpoch::Fenced {
+                                    current_epoch,
+                                    fence_epoch: epoch,
+                                };
+                                self.epoch.validate()?;
+                            } else if epoch < current_epoch {
+                                panic!("Epoch went backwards from {current_epoch:?} to {epoch:?}");
+                            }
+                        }
+                        FenceableEpoch::Unfenced(None) => {
+                            self.epoch = FenceableEpoch::Unfenced(Some(epoch));
+                        }
+                        FenceableEpoch::Fenced { .. } => {}
+                    },
+                    (StateUpdateKind::Epoch(_), -1) => {
+                        // Nothing to do, we're about to get fenced.
+                    }
+                    _ => {}
+                }
+            }
+
+            self.trace.push(update);
+        }
+        self.consolidate();
+        Ok(())
+    }
+
+    #[mz_ore::instrument]
+    pub(crate) fn consolidate(&mut self) {
+        let snapshot = std::mem::take(&mut self.trace);
+        let ts = snapshot
+            .last()
+            .map(|update| update.ts)
+            .unwrap_or_else(Timestamp::minimum);
+        let mut updates = snapshot
+            .into_iter()
+            .map(|update| (update.kind, update.diff))
+            .collect();
+        differential_dataflow::consolidation::consolidate(&mut updates);
+        self.trace = updates
+            .into_iter()
+            .map(|(kind, diff)| StateUpdate { kind, ts, diff })
+            .collect();
+    }
+
+    /// Open a read handle to the catalog.
+    async fn read_handle(&mut self) -> ReadHandle<SourceData, (), Timestamp, Diff> {
+        self.persist_client
+            .open_leased_reader(
+                self.shard_id,
+                Arc::new(PersistCatalogState::desc()),
+                Arc::new(UnitSchema::default()),
+                Diagnostics {
+                    shard_name: CATALOG_SHARD_NAME.to_string(),
+                    handle_purpose: "openable durable catalog state temporary reader".to_string(),
+                },
+            )
+            .await
+            .expect("invalid usage")
+    }
+}
+
+impl PersistHandle<StateUpdateKindRaw> {
+    /// Create a new [`PersistHandle`] to the catalog state associated with
+    /// `organization_id`.
+    ///
+    /// All usages of the persist catalog must go through this function. That includes the
+    /// catalog-debug tool, the adapter's catalog, etc.
+    #[mz_ore::instrument]
+    pub(crate) async fn new(
+        persist_client: PersistClient,
+        organization_id: Uuid,
+        version: semver::Version,
+        metrics: Arc<Metrics>,
+    ) -> Result<PersistHandle<StateUpdateKindRaw>, DurableCatalogError> {
+        let catalog_shard_id = shard_id(organization_id, CATALOG_SEED);
+        let upgrade_shard_id = shard_id(organization_id, UPGRADE_SEED);
+        debug!(
+            ?catalog_shard_id,
+            ?upgrade_shard_id,
+            "new persist backed catalog state"
+        );
+
+        // Check the catalog upgrade shard to see ensure that we don't fence anyone out of persist.
+        let upgrade_version =
+            Self::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await;
+        // If this is `None`, no version was found in the upgrade shard. Either this is a brand new
+        // environment and we don't need to worry about fencing existing users or we're upgrading
+        // from a version that doesn't contain the catalog upgrade shard and we need to proceed
+        // with caution for that one week until the catalog upgrade shard exists in all
+        // environments.
+        if let Some(upgrade_version) = upgrade_version {
+            if mz_persist_client::cfg::check_data_version(&upgrade_version, &version).is_err() {
+                return Err(DurableCatalogError::IncompatiblePersistVersion {
+                    found_version: upgrade_version,
+                    catalog_version: version,
+                });
+            }
+        }
+
+        let since_handle = persist_client
+            .open_critical_since(
+                catalog_shard_id,
+                // TODO: We may need to use a different critical reader
+                // id for this if we want to be able to introspect it via SQL.
+                PersistClient::CONTROLLER_CRITICAL_SINCE,
+                Diagnostics {
+                    shard_name: CATALOG_SHARD_NAME.to_string(),
+                    handle_purpose: "durable catalog state critical since".to_string(),
+                },
+            )
+            .await
+            .expect("invalid usage");
+        let (mut write_handle, mut read_handle) = persist_client
+            .open(
+                catalog_shard_id,
+                Arc::new(PersistCatalogState::desc()),
+                Arc::new(UnitSchema::default()),
+                Diagnostics {
+                    shard_name: CATALOG_SHARD_NAME.to_string(),
+                    handle_purpose: "durable catalog state handles".to_string(),
+                },
+            )
+            .await
+            .expect("invalid usage");
+
+        // Commit an empty write at the minimum timestamp so the catalog is always readable.
+        const EMPTY_UPDATES: &[((SourceData, ()), Timestamp, Diff)] = &[];
+        let _ = write_handle
+            .compare_and_append(
+                EMPTY_UPDATES,
+                Antichain::from_elem(Timestamp::minimum()),
+                Antichain::from_elem(Timestamp::minimum().step_forward()),
+            )
+            .await
+            .expect("invalid usage");
+
+        let upper = current_upper(&mut write_handle).await;
+        let as_of = as_of(&mut read_handle, upper);
+        let snapshot: Vec<_> = snapshot_binary(&mut read_handle, as_of, &metrics)
+            .await
+            .collect();
+        let listen = read_handle
+            .listen(Antichain::from_elem(as_of))
+            .await
+            .expect("invalid usage");
+        let mut epoch = FenceableEpoch::Unfenced(None);
+        for StateUpdate { kind, ts: _, diff } in &snapshot {
+            soft_assert_eq_or_log!(*diff, 1, "snapshot should be consolidated");
+            if let Ok(kind) = <StateUpdateKindRaw as TryIntoStateUpdateKind>::try_into(kind.clone())
+            {
+                match kind {
+                    StateUpdateKind::Epoch(current_epoch) => {
+                        epoch = FenceableEpoch::Unfenced(Some(current_epoch));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Ok(PersistHandle {
+            since_handle,
+            write_handle,
+            listen,
+            persist_client,
+            shard_id: catalog_shard_id,
+            trace: snapshot,
+            upper,
+            epoch,
+            metrics,
+        })
+    }
+}
+
+impl PersistHandle<StateUpdateKind> {
+    /// Generates an iterator of [`StateUpdate`] that contain all updates to the catalog
+    /// state.
+    ///
+    /// The output is consolidated and sorted by timestamp in ascending order.
+    #[mz_ore::instrument(level = "debug")]
+    async fn persist_snapshot(
+        &mut self,
+    ) -> impl Iterator<Item = StateUpdate> + DoubleEndedIterator {
+        let mut read_handle = self.read_handle().await;
+        let as_of = as_of(&read_handle, self.upper);
+        let snapshot = snapshot(&mut read_handle, as_of, &self.metrics).await;
+        read_handle.expire().await;
+        snapshot
     }
 }
 
@@ -271,7 +659,8 @@ impl UnopenedPersistCatalogState {
         let mut configs = BTreeMap::new();
         for StateUpdate { kind, ts: _, diff } in &snapshot {
             soft_assert_eq_or_log!(*diff, 1, "snapshot should be consolidated");
-            if let Ok(kind) = kind.clone().try_into() {
+            if let Ok(kind) = <StateUpdateKindRaw as TryIntoStateUpdateKind>::try_into(kind.clone())
+            {
                 match kind {
                     StateUpdateKind::Epoch(current_epoch) => {
                         epoch = FenceableEpoch::Unfenced(Some(current_epoch));
@@ -542,7 +931,8 @@ impl UnopenedPersistCatalogState {
                 panic!("invalid update in consolidated trace: ({kind:?}, {ts:?}, {diff:?})");
             }
 
-            if let Ok(kind) = kind.clone().try_into() {
+            if let Ok(kind) = <StateUpdateKindRaw as TryIntoStateUpdateKind>::try_into(kind.clone())
+            {
                 match (kind, diff) {
                     (StateUpdateKind::Epoch(epoch), 1) => match self.epoch {
                         FenceableEpoch::Unfenced(Some(current_epoch)) => {
@@ -828,8 +1218,8 @@ pub struct PersistCatalogState {
 }
 
 impl PersistCatalogState {
-    // Returns the schema of the `Row`s/`SourceData`s stored in the persist
-    // shard backing the catalog.
+    /// Returns the schema of the `Row`s/`SourceData`s stored in the persist
+    /// shard backing the catalog.
     pub fn desc() -> RelationDesc {
         RelationDesc::empty().with_column("data", ScalarType::Jsonb.nullable(false))
     }

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -267,23 +267,46 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<StateUpdate<T>>> PersistHandle<T,
         &mut self,
         updates: Vec<(S, Diff)>,
     ) -> Result<(), CatalogError> {
-        let updates = updates
-            .into_iter()
-            .map(|(kind, diff)| StateUpdate {
-                kind,
-                ts: self.upper,
-                diff,
-            })
-            .collect();
+        let updates = updates.into_iter().map(|(kind, diff)| {
+            let kind: StateUpdateKindRaw = kind.into();
+            ((Into::<SourceData>::into(kind), ()), self.upper, diff)
+        });
         let next_upper = self.upper.step_forward();
-        compare_and_append(
-            &mut self.since_handle,
-            &mut self.write_handle,
-            updates,
-            self.upper,
-            next_upper,
-        )
-        .await?;
+        self.write_handle
+            .compare_and_append(
+                updates,
+                Antichain::from_elem(self.upper),
+                Antichain::from_elem(next_upper),
+            )
+            .await
+            .expect("invalid usage")
+            .map_err(|upper_mismatch| {
+                DurableCatalogError::Fence(format!(
+                    "current catalog upper {:?} fenced by new catalog upper {:?}",
+                    upper_mismatch.expected, upper_mismatch.current
+                ))
+            })?;
+
+        // Lag the shard's upper by 1 to keep it readable.
+        let downgrade_to = Antichain::from_elem(next_upper.saturating_sub(1));
+
+        // The since handle gives us the ability to fence out other writes using an opaque token.
+        // (See the method documentation for details.)
+        // That's not needed here, so we use a constant opaque token to avoid any comparison failures.
+        let opaque = i64::initial();
+        let downgrade = self
+            .since_handle
+            .maybe_compare_and_downgrade_since(&opaque, (&opaque, &downgrade_to))
+            .await;
+
+        match downgrade {
+            None => {}
+            Some(Err(e)) => soft_panic_or_log!("found opaque value {e}, but expected {opaque}"),
+            Some(Ok(updated)) => soft_assert_or_log!(
+                updated == downgrade_to,
+                "updated bound should match expected"
+            ),
+        }
         self.sync(next_upper).await?;
         Ok(())
     }
@@ -339,7 +362,36 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<StateUpdate<T>>> PersistHandle<T,
     #[mz_ore::instrument(level = "debug")]
     async fn sync_inner(&mut self, target_upper: Timestamp) -> Result<(), DurableCatalogError> {
         self.epoch.validate()?;
-        let updates = sync(&mut self.listen, &mut self.upper, target_upper).await;
+        let mut updates = Vec::new();
+
+        while self.upper < target_upper {
+            let listen_events = self.listen.fetch_next().await;
+            for listen_event in listen_events {
+                match listen_event {
+                    ListenEvent::Progress(upper) => {
+                        debug!("synced up to {upper:?}");
+                        self.upper = upper
+                            .as_option()
+                            .cloned()
+                            .expect("we use a totally ordered time and never finalize the shard");
+                    }
+                    ListenEvent::Updates(batch_updates) => {
+                        debug!("syncing updates {batch_updates:?}");
+                        let batch_updates = batch_updates
+                            .into_iter()
+                            .map(Into::<StateUpdate<StateUpdateKindRaw>>::into)
+                            .map(|update| {
+                                let kind = T::try_from(update.kind).expect("kind decoding error");
+                                (kind, update.ts, update.diff)
+                            });
+                        updates.extend(batch_updates);
+                    }
+                }
+            }
+        }
+        let updates = updates
+            .into_iter()
+            .map(|(kind, ts, diff)| StateUpdate { kind, ts, diff });
         self.apply_updates(updates)?;
         Ok(())
     }
@@ -663,9 +715,21 @@ impl<U: ApplyUpdate<StateUpdate<StateUpdateKind>>> PersistHandle<StateUpdateKind
     ) -> impl Iterator<Item = StateUpdate> + DoubleEndedIterator {
         let mut read_handle = self.read_handle().await;
         let as_of = as_of(&read_handle, self.upper);
-        let snapshot = snapshot(&mut read_handle, as_of, &self.metrics).await;
+        let snapshot = self.snapshot(&mut read_handle, as_of).await;
         read_handle.expire().await;
         snapshot
+    }
+
+    /// TODO(jkosh44)
+    #[mz_ore::instrument(level = "debug")]
+    async fn snapshot(
+        &mut self,
+        read_handle: &mut ReadHandle<SourceData, (), Timestamp, Diff>,
+        as_of: Timestamp,
+    ) -> impl Iterator<Item = StateUpdate<StateUpdateKind>> + DoubleEndedIterator {
+        snapshot_binary(read_handle, as_of, &self.metrics)
+            .await
+            .map(|update| update.try_into().expect("kind decoding error"))
     }
 }
 
@@ -1407,68 +1471,6 @@ fn as_of(read_handle: &ReadHandle<SourceData, (), Timestamp, Diff>, upper: Times
     as_of
 }
 
-/// Appends `updates` to the catalog state and downgrades the catalog's upper to `next_upper`
-/// iff the current global upper of the catalog is `current_upper`.
-async fn compare_and_append<T: IntoStateUpdateKindRaw>(
-    since_handle: &mut SinceHandle<SourceData, (), Timestamp, Diff, i64>,
-    write_handle: &mut WriteHandle<SourceData, (), Timestamp, Diff>,
-    updates: Vec<StateUpdate<T>>,
-    current_upper: Timestamp,
-    next_upper: Timestamp,
-) -> Result<(), CatalogError> {
-    let updates = updates.into_iter().map(|update| {
-        let kind: StateUpdateKindRaw = update.kind.into();
-        ((Into::<SourceData>::into(kind), ()), update.ts, update.diff)
-    });
-    write_handle
-        .compare_and_append(
-            updates,
-            Antichain::from_elem(current_upper),
-            Antichain::from_elem(next_upper),
-        )
-        .await
-        .expect("invalid usage")
-        .map_err(|upper_mismatch| {
-            DurableCatalogError::Fence(format!(
-                "current catalog upper {:?} fenced by new catalog upper {:?}",
-                upper_mismatch.expected, upper_mismatch.current
-            ))
-        })?;
-
-    // Lag the shard's upper by 1 to keep it readable.
-    let downgrade_to = Antichain::from_elem(next_upper.saturating_sub(1));
-
-    // The since handle gives us the ability to fence out other writes using an opaque token.
-    // (See the method documentation for details.)
-    // That's not needed here, so we use a constant opaque token to avoid any comparison failures.
-    let opaque = i64::initial();
-    let downgrade = since_handle
-        .maybe_compare_and_downgrade_since(&opaque, (&opaque, &downgrade_to))
-        .await;
-
-    match downgrade {
-        None => {}
-        Some(Err(e)) => soft_panic_or_log!("found opaque value {e}, but expected {opaque}"),
-        Some(Ok(updated)) => soft_assert_or_log!(
-            updated == downgrade_to,
-            "updated bound should match expected"
-        ),
-    }
-
-    Ok(())
-}
-
-#[mz_ore::instrument(level = "debug")]
-async fn snapshot(
-    read_handle: &mut ReadHandle<SourceData, (), Timestamp, Diff>,
-    as_of: Timestamp,
-    metrics: &Arc<Metrics>,
-) -> impl Iterator<Item = StateUpdate<StateUpdateKind>> + DoubleEndedIterator {
-    snapshot_binary(read_handle, as_of, metrics)
-        .await
-        .map(|update| update.try_into().expect("kind decoding error"))
-}
-
 /// Generates an iterator of [`StateUpdate`] that contain all updates to the catalog
 /// state up to, and including, `as_of`.
 ///
@@ -1508,48 +1510,6 @@ async fn snapshot_binary_inner(
         .into_iter()
         .map(Into::<StateUpdate<StateUpdateKindRaw>>::into)
         .sorted_by(|a, b| Ord::cmp(&b.ts, &a.ts))
-}
-
-/// Listen for all updates up to `target_upper`.
-///
-/// Results are guaranteed to be consolidated and sorted by timestamp then diff.
-#[mz_ore::instrument(level = "debug")]
-async fn sync<T: IntoStateUpdateKindRaw>(
-    listen: &mut Listen<SourceData, (), Timestamp, Diff>,
-    current_upper: &mut Timestamp,
-    target_upper: Timestamp,
-) -> Vec<StateUpdate<T>> {
-    let mut updates = Vec::new();
-
-    while *current_upper < target_upper {
-        let listen_events = listen.fetch_next().await;
-        for listen_event in listen_events {
-            match listen_event {
-                ListenEvent::Progress(upper) => {
-                    debug!("synced up to {upper:?}");
-                    *current_upper = upper
-                        .as_option()
-                        .cloned()
-                        .expect("we use a totally ordered time and never finalize the shard");
-                }
-                ListenEvent::Updates(batch_updates) => {
-                    debug!("syncing updates {batch_updates:?}");
-                    let batch_updates = batch_updates
-                        .into_iter()
-                        .map(Into::<StateUpdate<StateUpdateKindRaw>>::into)
-                        .map(|update| {
-                            let kind = T::try_from(update.kind).expect("kind decoding error");
-                            (kind, update.ts, update.diff)
-                        });
-                    updates.extend(batch_updates);
-                }
-            }
-        }
-    }
-    updates
-        .into_iter()
-        .map(|(kind, ts, diff)| StateUpdate { kind, ts, diff })
-        .collect()
 }
 
 // Debug methods.

--- a/src/catalog/src/durable/persist/tests.rs
+++ b/src/catalog/src/durable/persist/tests.rs
@@ -12,7 +12,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::PersistLocation;
 use uuid::Uuid;
 
-use crate::durable::persist::{shard_id, UnopenedPersistCatalogState, UPGRADE_SEED};
+use crate::durable::persist::{shard_id, PersistHandle, UnopenedPersistCatalogState, UPGRADE_SEED};
 use crate::durable::{
     test_bootstrap_args, test_persist_backed_catalog_state_with_version,
     OpenableDurableCatalogState,
@@ -35,11 +35,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         None,
-        UnopenedPersistCatalogState::fetch_catalog_upgrade_shard_version(
-            &persist_client,
-            upgrade_shard_id
-        )
-        .await
+        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await
     );
 
     let persist_openable_state = test_persist_backed_catalog_state_with_version(
@@ -56,11 +52,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         Some(first_version.clone()),
-        UnopenedPersistCatalogState::fetch_catalog_upgrade_shard_version(
-            &persist_client,
-            upgrade_shard_id
-        )
-        .await,
+        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
         "opening the catalog should increment the upgrade version"
     );
 
@@ -83,11 +75,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         Some(first_version.clone()),
-        UnopenedPersistCatalogState::fetch_catalog_upgrade_shard_version(
-            &persist_client,
-            upgrade_shard_id
-        )
-        .await,
+        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
         "opening a savepoint catalog should not increment the upgrade version"
     );
 
@@ -105,11 +93,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         Some(first_version),
-        UnopenedPersistCatalogState::fetch_catalog_upgrade_shard_version(
-            &persist_client,
-            upgrade_shard_id
-        )
-        .await,
+        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
         "opening a readonly catalog should not increment the upgrade version"
     );
 }

--- a/src/catalog/src/durable/persist/tests.rs
+++ b/src/catalog/src/durable/persist/tests.rs
@@ -12,7 +12,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::PersistLocation;
 use uuid::Uuid;
 
-use crate::durable::persist::{shard_id, PersistHandle, UnopenedPersistCatalogState, UPGRADE_SEED};
+use crate::durable::persist::{fetch_catalog_upgrade_shard_version, shard_id, UPGRADE_SEED};
 use crate::durable::{
     test_bootstrap_args, test_persist_backed_catalog_state_with_version,
     OpenableDurableCatalogState,
@@ -35,7 +35,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         None,
-        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await
+        fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await
     );
 
     let persist_openable_state = test_persist_backed_catalog_state_with_version(
@@ -52,7 +52,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         Some(first_version.clone()),
-        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
+        fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
         "opening the catalog should increment the upgrade version"
     );
 
@@ -75,7 +75,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         Some(first_version.clone()),
-        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
+        fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
         "opening a savepoint catalog should not increment the upgrade version"
     );
 
@@ -93,7 +93,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         Some(first_version),
-        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
+        fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
         "opening a readonly catalog should not increment the upgrade version"
     );
 }

--- a/src/catalog/src/durable/upgrade.rs
+++ b/src/catalog/src/durable/upgrade.rs
@@ -341,17 +341,18 @@ async fn run_versioned_upgrade<V1: IntoStateUpdateKindRaw, V2: IntoStateUpdateKi
 
     // 4. Apply migration to catalog.
     if matches!(mode, Mode::Writable) {
-        unopened_catalog_state.persist_handle.compare_and_append(updates).await?;
+        unopened_catalog_state
+            .persist_handle
+            .compare_and_append(updates)
+            .await?;
     } else {
+        let ts = unopened_catalog_state.persist_handle.upper;
         let updates = updates
             .into_iter()
-            .map(|(kind, diff)| StateUpdate {
-                kind,
-                ts: unopened_catalog_state.persist_handle.upper,
-                diff,
-            })
-            .collect();
-        unopened_catalog_state.persist_handle.apply_updates(updates)?;
+            .map(|(kind, diff)| StateUpdate { kind, ts, diff });
+        unopened_catalog_state
+            .persist_handle
+            .apply_updates(updates)?;
     }
 
     // 5. Consolidate snapshot to remove old versions.

--- a/src/catalog/src/durable/upgrade.rs
+++ b/src/catalog/src/durable/upgrade.rs
@@ -316,7 +316,7 @@ async fn run_versioned_upgrade<V1: IntoStateUpdateKindRaw, V2: IntoStateUpdateKi
 ) -> Result<u64, CatalogError> {
     // 1. Use the V1 to deserialize the contents of the current snapshot.
     let snapshot: Vec<_> = unopened_catalog_state
-        .snapshot
+        .trace
         .iter()
         .map(|update| {
             soft_assert_eq_or_log!(1, update.diff, "snapshot is consolidated, {update:?}");


### PR DESCRIPTION
This commit refactors the persist catalog implementation to store a trace of all catalog updates in memory instead of a map of all catalog contents. This simplifies the persist implementation slightly and will allow further refactors to combine the pre and post open catalog implementations.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
