### PR TITLE
Rewrite recursion as iteration

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1822,18 +1822,16 @@ impl MirRelationExpr {
     }
 
     /// Computes the size (total number of nodes) and maximum depth of a MirRelationExpr for
-    /// debug printing purposes. Might grow the stack to a size proportional to the maximum depth.
+    /// debug printing purposes.
     pub fn debug_size_and_depth(&self) -> (usize, usize) {
         let mut size = 0;
         let mut max_depth = 0;
-        fn dfs(expr: &MirRelationExpr, size: &mut usize, max_depth: &mut usize, cur_depth: usize) {
-            mz_ore::stack::maybe_grow(|| {
-                *size += 1;
-                *max_depth = max(*max_depth, cur_depth);
-                expr.visit_children(|child| dfs(child, size, max_depth, cur_depth + 1));
-            });
+        let mut todo = vec![(self, 1)];
+        while let Some((expr, depth)) = todo.pop() {
+            size += 1;
+            max_depth = max(max_depth, depth);
+            todo.extend(expr.children().map(|c| (c, depth + 1)));
         }
-        dfs(self, &mut size, &mut max_depth, 1);
         (size, max_depth)
     }
 


### PR DESCRIPTION
Rewrites a recursive traversal as an iterative traversal, removing stack pressure and simplifying.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
