### PR TITLE
Remove equivalent columns from Project

### DIFF
--- a/test/sqllogictest/explain/view.slt
+++ b/test/sqllogictest/explain/view.slt
@@ -124,7 +124,7 @@ Return
             Negate
               Join on=(#2 = integer_to_bigint(#0))
                 Get l1
-                Distinct project=[#2]
+                Distinct project=[integer_to_bigint(#0)]
                   Get l0
           Get l1
       Filter (#1 = 100)
@@ -173,7 +173,7 @@ Return
             Negate
               Join on=(#2 = integer_to_bigint(#0))
                 Get l1
-                Distinct project=[#2]
+                Distinct project=[integer_to_bigint(#0)]
                   Get l0
           Get l1
       Filter (#1 = 100)

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -193,18 +193,17 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT t1.f1 FROM t1, t2 WHERE t1.f1 = t2.f1 GROUP BY t1.f1 HAVING t1.f1 = 123;
 ----
 Explained Query:
-  Map (123) // { arity: 1 }
-    CrossJoin type=differential // { arity: 0 }
-      implementation
-        %0:t1[×]Uef » %1:t2[×]Uef
-      ArrangeBy keys=[[]] // { arity: 0 }
-        Project () // { arity: 0 }
-          Filter (#0 = 123) // { arity: 2 }
-            ReadStorage materialize.public.t1 // { arity: 2 }
-      ArrangeBy keys=[[]] // { arity: 0 }
-        Project () // { arity: 0 }
-          Filter (#0 = 123) // { arity: 2 }
-            ReadStorage materialize.public.t2 // { arity: 2 }
+  CrossJoin type=differential // { arity: 1 }
+    implementation
+      %0:t1[×]Uef » %1:t2[×]Uef
+    ArrangeBy keys=[[]] // { arity: 1 }
+      Project (#0) // { arity: 1 }
+        Filter (#0 = 123) // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
+    ArrangeBy keys=[[]] // { arity: 0 }
+      Project () // { arity: 0 }
+        Filter (#0 = 123) // { arity: 2 }
+          ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -359,16 +358,17 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1, (SELECT t2.f1 FROM t2) AS dt1 WHERE dt1.f1 = t1.f1 AND t1.f1 = 123;
 ----
 Explained Query:
-  CrossJoin type=differential // { arity: 3 }
-    implementation
-      %0:t1[×]Uef » %1:t2[×]Uef
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 1 }
-      Project (#0) // { arity: 1 }
+  Project (#0, #1, #0) // { arity: 3 }
+    CrossJoin type=differential // { arity: 2 }
+      implementation
+        %0:t1[×]Uef » %1:t2[×]Uef
+      ArrangeBy keys=[[]] // { arity: 2 }
         Filter (#0 = 123) // { arity: 2 }
-          ReadStorage materialize.public.t2 // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
+      ArrangeBy keys=[[]] // { arity: 0 }
+        Project () // { arity: 0 }
+          Filter (#0 = 123) // { arity: 2 }
+            ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -241,8 +241,8 @@ EXPLAIN WITH(arity, join implementations) SELECT *
 ----
 Explained Query:
   Return // { arity: 15 }
-    Project (#0..=#9, #4, #5, #12..=#14) // { arity: 15 }
-      Join on=(#4 = #10 AND #5 = #11) type=delta // { arity: 15 }
+    Project (#0..=#9, #4, #5, #9, #12, #13) // { arity: 15 }
+      Join on=(#4 = #10 AND #5 = #11) type=delta // { arity: 14 }
         implementation
           %0:lineitem » %1:orders[#2, #3]KKe » %2:customer[×]e
           %1:orders » %0:lineitem[#4, #5]KKf » %2:customer[×]e
@@ -253,8 +253,8 @@ Explained Query:
         ArrangeBy keys=[[], [#2, #3]] // { arity: 4 }
           Project (#0..=#3) // { arity: 4 }
             ReadIndex on=materialize.public.orders fk_orders_custkey=[lookup values=<Get l0>] // { arity: 5 }
-        ArrangeBy keys=[[]] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#1, #2) // { arity: 2 }
             ReadIndex on=materialize.public.customer pk_customer_custkey=[lookup values=<Get l0>] // { arity: 4 }
   With
     cte l0 =

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -716,20 +716,20 @@ Explained Query:
       CrossJoin type=differential // { arity: 1 }
         implementation
           %0:l1[×]e » %1:l1[×]e
-        ArrangeBy keys=[[]] // { arity: 0 }
-          Project () // { arity: 0 }
-            Get l1 // { arity: 3 }
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#0) // { arity: 1 }
+            Get l1 // { arity: 3 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
             Get l1 // { arity: 3 }
       CrossJoin type=differential // { arity: 1 }
         implementation
           %0:l2[×]e » %1:l2[×]e
-        ArrangeBy keys=[[]] // { arity: 0 }
-          Project () // { arity: 0 }
-            Get l2 // { arity: 3 }
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#0) // { arity: 1 }
+            Get l2 // { arity: 3 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
             Get l2 // { arity: 3 }
   With
     cte l2 =
@@ -754,21 +754,20 @@ WHERE s1.f1 = 1 AND s2.f1 = 1
 ----
 Explained Query:
   Return // { arity: 2 }
-    CrossJoin type=delta // { arity: 2 }
-      implementation
-        %0:l1 » %1:l2[×]e » %2:l1[×]e » %3:l2[×]e
-        %1:l2 » %0:l1[×]e » %2:l1[×]e » %3:l2[×]e
-        %2:l1 » %0:l1[×]e » %1:l2[×]e » %3:l2[×]e
-        %3:l2 » %0:l1[×]e » %1:l2[×]e » %2:l1[×]e
-      Get l1 // { arity: 0 }
-      Get l2 // { arity: 1 }
-      Get l1 // { arity: 0 }
-      Get l2 // { arity: 1 }
+    Project (#0, #0) // { arity: 2 }
+      CrossJoin type=delta // { arity: 1 }
+        implementation
+          %0:l0 » %1:l1[×]e » %2:l1[×]e » %3:l1[×]e
+          %1:l1 » %0:l0[×]e » %2:l1[×]e » %3:l1[×]e
+          %2:l1 » %0:l0[×]e » %1:l1[×]e » %3:l1[×]e
+          %3:l1 » %0:l0[×]e » %1:l1[×]e » %2:l1[×]e
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Get l0 // { arity: 3 }
+        Get l1 // { arity: 0 }
+        Get l1 // { arity: 0 }
+        Get l1 // { arity: 0 }
   With
-    cte l2 =
-      ArrangeBy keys=[[]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l0 // { arity: 3 }
     cte l1 =
       ArrangeBy keys=[[]] // { arity: 0 }
         Project () // { arity: 0 }
@@ -796,17 +795,17 @@ Explained Query:
         %1:l1 » %0:l1[×]e » %2:l2[×]e » %3:l2[×]e
         %2:l2 » %0:l1[×]e » %1:l1[×]e » %3:l2[×]e
         %3:l2 » %0:l1[×]e » %1:l1[×]e » %2:l2[×]e
-      ArrangeBy keys=[[]] // { arity: 0 }
-        Project () // { arity: 0 }
-          Get l1 // { arity: 3 }
       ArrangeBy keys=[[]] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l1 // { arity: 3 }
       ArrangeBy keys=[[]] // { arity: 0 }
         Project () // { arity: 0 }
+          Get l1 // { arity: 3 }
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
           Get l2 // { arity: 3 }
-      ArrangeBy keys=[[]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
+      ArrangeBy keys=[[]] // { arity: 0 }
+        Project () // { arity: 0 }
           Get l2 // { arity: 3 }
   With
     cte l2 =
@@ -1314,20 +1313,20 @@ Explained Query:
       CrossJoin type=differential // { arity: 1 }
         implementation
           %0:l1[×]e » %1:l1[×]e
-        ArrangeBy keys=[[]] // { arity: 0 }
-          Project () // { arity: 0 }
-            Get l1 // { arity: 3 }
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#0) // { arity: 1 }
+            Get l1 // { arity: 3 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
             Get l1 // { arity: 3 }
       CrossJoin type=differential // { arity: 1 }
         implementation
           %0:l2[×]e » %1:l2[×]e
-        ArrangeBy keys=[[]] // { arity: 0 }
-          Project () // { arity: 0 }
-            Get l2 // { arity: 3 }
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#0) // { arity: 1 }
+            Get l2 // { arity: 3 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
             Get l2 // { arity: 3 }
   With
     cte l2 =


### PR DESCRIPTION
`MIR::Project` may produce multiple columns that are equivalent but have different indexes, but we can rewrite them once we know the columns are equivalent (to the least column identifier).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
