### PR TITLE
compute/persist_sink: efficient handling of future updates

### DIFF
--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -59,6 +59,13 @@ pub const ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING: Config<bool> = Config::new(
     "Enable logging of the hydration status of compute operators.",
 );
 
+/// Enable usage of a pre-correction stash in the `persist_sink`.
+pub const ENABLE_PERSIST_SINK_STASH: Config<bool> = Config::new(
+    "enable_compute_persist_sink_stash",
+    true,
+    "Enable usage of a pre-correction stash in the compute `persist_sink`.",
+);
+
 /// Maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
 pub const DATAFLOW_MAX_INFLIGHT_BYTES: Config<Option<usize>> = Config::new(
     "compute_dataflow_max_inflight_bytes",
@@ -101,6 +108,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
         .add(&ENABLE_CHUNKED_STACK)
         .add(&ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING)
+        .add(&ENABLE_PERSIST_SINK_STASH)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)
         .add(&LGALLOC_BACKGROUND_INTERVAL)


### PR DESCRIPTION
This PR makes the compute `persist_sink` more efficiently handle updates for future times by moving received updates into a stash first and then moving them into the `correction` buffer only when the input frontier has passed their times. The result is that we can ignore updates for future times in the process of determining which updates need to be sinked to persist. This has the potential for avoiding a large amount of unnecessary work, particularly in dataflows that contain temporal filters.

### Motivation

 * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/25844

### Tips for reviewer

I think long-term we want to move to some more sophisticated merge batcher implementation that also enables us to spill to lgalloc, but this seems like a good short-term fix for the temporal filter issue.

See performance test results in the comments.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
