### PR TITLE
clusterd: ensure system vars apply to persist PubSub connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4257,6 +4257,7 @@ dependencies = [
 name = "mz-dyncfg"
 version = "0.0.0"
 dependencies = [
+ "futures",
  "mz-ore",
  "mz-proto",
  "proptest",
@@ -4265,6 +4266,7 @@ dependencies = [
  "prost-build",
  "protobuf-src",
  "serde",
+ "tokio",
  "tracing",
  "workspace-hack",
 ]

--- a/src/dyncfg/Cargo.toml
+++ b/src/dyncfg/Cargo.toml
@@ -11,14 +11,18 @@ publish = false
 workspace = true
 
 [dependencies]
-mz-ore = { path = "../ore", default-features = false, features = ["proptest", "test"] }
+mz-ore = { path = "../ore", default-features = false, features = ["async", "proptest", "test"] }
 mz-proto = { path = "../proto" }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
+tokio = "1.32.0"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+
+[dev-dependencies]
+futures = "0.3.25"
 
 [build-dependencies]
 prost-build = "0.11.2"

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -35,6 +35,7 @@ use crate::operators::{
     STORAGE_SOURCE_DECODE_FUEL,
 };
 use crate::read::READER_LEASE_DURATION;
+use crate::rpc::PUBSUB_CLIENT_ENABLED;
 
 /// The tunable knobs for persist.
 ///
@@ -231,6 +232,11 @@ impl PersistConfig {
     /// operator before yielding.
     pub fn storage_source_decode_fuel(&self) -> usize {
         STORAGE_SOURCE_DECODE_FUEL.get(self)
+    }
+
+    /// Overrides the value for "persist_pubsub_client_enabled".
+    pub fn set_pubsub_client_enabled(&self, val: bool) {
+        self.set_config(&PUBSUB_CLIENT_ENABLED, val);
     }
 
     /// Overrides the value for "persist_reader_lease_duration".

--- a/src/persist-client/src/rpc.rs
+++ b/src/persist-client/src/rpc.rs
@@ -17,7 +17,7 @@ use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock, Weak};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Instant, SystemTime};
 
 use anyhow::{anyhow, Error};
 use async_trait::async_trait;
@@ -214,10 +214,12 @@ impl GrpcPubSubClient {
         loop {
             metrics.pubsub_client.grpc_connection.connected.set(0);
 
-            if !PUBSUB_CLIENT_ENABLED.get(&config.persist_cfg) {
-                tokio::time::sleep(Duration::from_secs(5)).await;
-                continue;
-            }
+            config.persist_cfg.wait_for(|| PUBSUB_CLIENT_ENABLED.get(&config.persist_cfg)).await;
+
+            // N.B.: the guarantees of `ConfigSet::wait_for` mean that we'll now
+            // observe updates to any other PubSub configuration settings, like
+            // the connection timeout, that were in the same `ConfigUpdates`
+            // batch that enabled PubSub.
 
             // add a bit of backoff when reconnecting after some network/server failure
             if is_first_connection_attempt {


### PR DESCRIPTION
Keeps `clusterd` from establishing its persist PubSub
connection until `environmentd` sends over its initial batch of
configuration values. This ensures that any parameters that should apply
to the connection (e.g., timeouts) actually take effect.

This relies on dyncfg's newly-added support for waiting for a
configuration update to be applied.

Fix https://github.com/MaterializeInc/materialize/issues/23869.

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

@danhhz: there are some potentially 🌶️ changes to dyncfg in the earlier commits. Might be helpful to discuss on Slack or live before you get too deep.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
