### PR TITLE
test/cluster: unflake test-github-15531

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -338,7 +338,8 @@ def workflow_test_github_15531(c: Composition) -> None:
     # Wait a bit to let the metrics refresh.
     time.sleep(2)
 
-    # obtain initial history size and dataflow count
+    # Obtain initial history size and dataflow count.
+    # Dataflow count can plausibly be more than 1, if compaction is delayed.
     (
         controller_command_count,
         controller_dataflow_count,
@@ -347,10 +348,16 @@ def workflow_test_github_15531(c: Composition) -> None:
     ) = find_command_history_metrics(c)
     assert controller_command_count > 0, "controller history cannot be empty"
     assert (
-        controller_dataflow_count == 1
-    ), "expected a single dataflow in controller history"
+        controller_dataflow_count > 0
+    ), "at least one dataflow expected in controller history"
+    assert (
+        controller_dataflow_count < 5
+    ), "more dataflows than expected in controller history"
     assert replica_command_count > 0, "replica history cannot be empty"
-    assert replica_dataflow_count == 1, "expected a single dataflow in replica history"
+    assert (
+        replica_dataflow_count > 0
+    ), "at least one dataflow expected in replica history"
+    assert replica_dataflow_count < 5, "more dataflows than expected in replica history"
 
     # execute 400 fast- and slow-path peeks
     for _ in range(20):


### PR DESCRIPTION
[The last unflake attempt](https://github.com/MaterializeInc/materialize/pull/25876) introduced a new slow-path SELECT, which caused the creation of a new dataflow, which had the potential to reflect in the dataflow count metrics and make the test fail. Fixed by making the initial dataflow count check more lenient.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/25917

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A