### PR TITLE
feature-benchmark: Allow specifying the relative threshold per scenario

### DIFF
--- a/misc/python/materialize/feature_benchmark/scenario.py
+++ b/misc/python/materialize/feature_benchmark/scenario.py
@@ -10,6 +10,7 @@
 from math import ceil
 
 from materialize.feature_benchmark.action import Action, DummyAction, TdAction
+from materialize.feature_benchmark.measurement import MeasurementType
 from materialize.feature_benchmark.measurement_source import MeasurementSource
 from materialize.mz_version import MzVersion
 
@@ -19,6 +20,11 @@ BenchmarkingSequence = MeasurementSource | list[Action | MeasurementSource]
 class RootScenario:
     SCALE: float = 6
     FIXED_SCALE: bool = False  # Will --scale=N have effect on the scenario
+    RELATIVE_THRESHOLD: dict[MeasurementType, float] = {
+        MeasurementType.WALLCLOCK: 0.10,
+        MeasurementType.MESSAGES: 0.10,
+        MeasurementType.MEMORY: 0.10,
+    }
 
     def __init__(self, scale: float, mz_version: MzVersion, default_size: int) -> None:
         self._name = self.__class__.__name__

--- a/misc/python/materialize/feature_benchmark/scenarios/optbench.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/optbench.py
@@ -18,6 +18,7 @@ import materialize.optbench
 import materialize.optbench.sql
 from materialize.feature_benchmark.action import Action
 from materialize.feature_benchmark.executor import Executor
+from materialize.feature_benchmark.measurement import MeasurementType
 from materialize.feature_benchmark.measurement_source import (
     MeasurementSource,
     Timestamp,
@@ -93,6 +94,11 @@ class OptbenchTPCH(Scenario):
     """Run optbench TPCH for optimizer benchmarks"""
 
     QUERY = 1
+    RELATIVE_THRESHOLD: dict[MeasurementType, float] = {
+        MeasurementType.WALLCLOCK: 0.20,  # increased because it's easy to regress
+        MeasurementType.MESSAGES: 0.10,
+        MeasurementType.MEMORY: 0.10,
+    }
 
     def init(self) -> list[Action]:
         return [OptbenchInit("tpch")]

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -94,8 +94,12 @@ def make_aggregation_class() -> type[Aggregation]:
     return MinAggregation
 
 
-def make_comparator(name: str, type: MeasurementType) -> Comparator:
-    return RelativeThresholdComparator(name=name, type=type, threshold=0.10)
+def make_comparator(
+    name: str, type: MeasurementType, relative_threshold: float
+) -> Comparator:
+    return RelativeThresholdComparator(
+        name=name, type=type, threshold=relative_threshold
+    )
 
 
 default_timeout = "1800s"
@@ -127,7 +131,12 @@ def run_one_scenario(
     if args.measure_memory:
         measurement_types.append(MeasurementType.MEMORY)
 
-    comparators = [make_comparator(name=name, type=t) for t in measurement_types]
+    comparators = [
+        make_comparator(
+            name=name, type=t, relative_threshold=scenario_class.RELATIVE_THRESHOLD[t]
+        )
+        for t in measurement_types
+    ]
 
     common_seed = round(time.time())
 


### PR DESCRIPTION
As discussed in https://materializeinc.slack.com/archives/C01LKF361MZ/p1710150069800399, might be useful in the future.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
