### PR TITLE
adapter: save `system_parameter_defaults` to disk

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -42,7 +42,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     # -----
     # Unsafe functions
     "enable_unsafe_functions": "true",
-    "enable_dangerous_functions": "true",  # former name of 'enable_unsafe_functions'
     # -----
     # To reduce CRDB load as we are struggling with it in CI (values based on load test environment):
     "persist_next_listen_batch_retryer_clamp": "16s",

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -101,6 +101,9 @@ class Materialized(Service):
         if additional_system_parameter_defaults is not None:
             system_parameter_defaults.update(additional_system_parameter_defaults)
 
+        # Make the computed system_parameter_defaults available for as a property.
+        self.system_parameter_defaults = system_parameter_defaults
+
         if len(system_parameter_defaults) > 0:
             environment += [
                 "MZ_SYSTEM_PARAMETER_DEFAULT="

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2108,7 +2108,7 @@ feature_flags!(
     {
         name: enable_equivalence_propagation,
         desc: "Enable the EquivalencePropagation transform in the optimizer",
-        default: true, // TODO(aalexandrov): revert this to false
+        default: false,
         internal: true,
         enable_for_item_parsing: false,
     },

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -14,6 +14,7 @@ operational after an upgrade.
 import random
 
 from materialize.mz_version import MzVersion
+from materialize.mzcompose import DEFAULT_SYSTEM_PARAMETERS
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.kafka import Kafka
@@ -144,8 +145,22 @@ def test_upgrade_from_version(
         )
         with c.override(mz_from):
             c.up("materialized")
+
+            for key, value in mz_from.system_parameter_defaults.items():
+                c.sql(
+                    f"ALTER SYSTEM SET {key} = '{value}'",
+                    port=6877,
+                    user="mz_system",
+                )
     else:
         c.up("materialized")
+
+        for key, value in DEFAULT_SYSTEM_PARAMETERS.items():
+            c.sql(
+                f"ALTER SYSTEM SET {key} = '{value}'",
+                port=6877,
+                user="mz_system",
+            )
 
     if from_version == "current_source" or MzVersion.parse_mz(
         from_version

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -95,6 +95,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     with c.override(testdrive, materialized):
         c.up(*dependencies)
 
+        for key, value in materialized.system_parameter_defaults.items():
+            c.sql(
+                f"ALTER SYSTEM SET {key} = '{value}'",
+                port=6877,
+                user="mz_system",
+            )
+
         c.sql(
             "ALTER SYSTEM SET max_clusters = 50;",
             port=6877,


### PR DESCRIPTION
Save `system_parameter_defaults` to disk and revert back the hard-coded default for `enable_equivalence_propagation` to `false`.

### Motivation

   * This PR refactors existing code.

This addresses an issue observed while trying to merge #24155.

More specifically, since `system_parameter_defaults` are not persisted to disk, Testdrive tests that [run consistency checks](https://github.com/MaterializeInc/materialize/blob/7c60dc4e2434e99dd9420f19cff707b93e78498c/src/testdrive/src/action/consistency.rs#L67-L92) re-hydrate the in-memory catalog without respecting the feature flags defined in `DEFAULT_SYSTEM_PARAMETERS` and consequently fail with the following error:

> error: catalog inconsistency: catalog state

For example, see [this Buildkite run](https://buildkite.com/materialize/tests/builds/77987).

We will always hit these issues when introducing a feature flag that affects the optimizer pipeline across the board, so it's better to come up with a more general solution than "add `ALTER SYSTEM SET <optimizer feature> = true` to all affected `*.td` files".

### Tips for reviewer

If this causes issues outside of our Testdrive tests (in other CI tests or in production, I suggest to parameterize the behavior of the `system_parameter_defaults` loop in `load_system_configuration` by another boolean parameter `persist_system_parameter_defaults: bool`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
