### PR TITLE
compute: rename `NodeId` to `LirId`

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -307,7 +307,7 @@ A dataflow operator is hydrated on a given replica when it has fully processed t
 | Field                   | Type        | Meaning  |
 | ----------------------- | ----------- | -------- |
 | `object_id`             | [`text`]    | The ID of a compute object. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes) or [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views). |
-| `physical_plan_node_id` | [`uint8`]   | The ID of a node in the physical plan of the compute object. Corresponds to a `node_id` displayed in the output of `EXPLAIN PHYSICAL PLAN WITH (node_ids)`. |
+| `physical_plan_node_id` | [`uint8`]   | The ID of a node in the physical plan of the compute object. Corresponds to a `node_id` displayed in the output of `EXPLAIN PHYSICAL PLAN WITH (node identifiers)`. |
 | `replica_id`            | [`text`]    | The ID of a cluster replica. |
 | `hydrated`              | [`boolean`] | Whether the node is hydrated on the replica. |
 

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -11,7 +11,7 @@
 
 use std::num::NonZeroUsize;
 
-use mz_compute_types::plan::NodeId;
+use mz_compute_types::plan::LirId;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_proto::{any_uuid, IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Diff, GlobalId, Row};
@@ -587,7 +587,7 @@ pub struct OperatorHydrationStatus {
     /// The ID of the compute collection exported by the dataflow.
     pub collection_id: GlobalId,
     /// The ID of the LIR node for which the hydration status changed.
-    pub lir_id: NodeId,
+    pub lir_id: LirId,
     /// The ID of the worker for which the hydration status changed.
     pub worker_id: usize,
     /// Whether the node is hydrated on the worker.

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -105,13 +105,13 @@ impl<T> DataflowDescription<Plan<T>, (), mz_repr::Timestamp> {
     /// Check invariants expected to be true about `DataflowDescription`s.
     pub fn check_invariants(&self) -> Result<(), String> {
         let mut plans: Vec<_> = self.objects_to_build.iter().map(|o| &o.plan).collect();
-        let mut node_ids = BTreeSet::new();
+        let mut lir_ids = BTreeSet::new();
 
         while let Some(plan) = plans.pop() {
-            let node_id = plan.node_id();
-            if !node_ids.insert(node_id) {
+            let lir_id = plan.lir_id();
+            if !lir_ids.insert(lir_id) {
                 return Err(format!(
-                    "duplicate `NodeId` in `DataflowDescription`: {node_id}"
+                    "duplicate `LirId` in `DataflowDescription`: {lir_id}"
                 ));
             }
             plans.extend(plan.children());

--- a/src/compute-types/src/plan/interpret/api.rs
+++ b/src/compute-types/src/plan/interpret/api.rs
@@ -250,7 +250,7 @@ where
         use Plan::*;
         rg.checked_recur(|_| {
             match expr {
-                Constant { rows, node_id: _ } => {
+                Constant { rows, lir_id: _ } => {
                     // Interpret the current node.
                     Ok(self.interpret.constant(&self.ctx, rows))
                 }
@@ -258,7 +258,7 @@ where
                     id,
                     keys,
                     plan,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Interpret the current node.
                     Ok(self.interpret.get(&self.ctx, id, keys, plan))
@@ -267,7 +267,7 @@ where
                     id,
                     value,
                     body,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Extend context with the `value` result.
                     let res_value = self.apply_rec(value, rg)?;
@@ -291,7 +291,7 @@ where
                     values,
                     limits,
                     body,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Make context recursive and extend it with `bottom` for each recursive
                     // binding. This corresponds to starting with the most optimistic value.
@@ -369,7 +369,7 @@ where
                     input,
                     mfp,
                     input_key_val,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -382,7 +382,7 @@ where
                     exprs,
                     mfp_after: mfp,
                     input_key,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -394,7 +394,7 @@ where
                 Join {
                     inputs,
                     plan,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let inputs = inputs
@@ -410,7 +410,7 @@ where
                     plan,
                     input_key,
                     mfp_after,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -427,14 +427,14 @@ where
                 TopK {
                     input,
                     top_k_plan,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
                     // Interpret the current node.
                     Ok(self.interpret.top_k(&self.ctx, input, top_k_plan))
                 }
-                Negate { input, node_id: _ } => {
+                Negate { input, lir_id: _ } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
                     // Interpret the current node.
@@ -443,7 +443,7 @@ where
                 Threshold {
                     input,
                     threshold_plan,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -453,7 +453,7 @@ where
                 Union {
                     inputs,
                     consolidate_output,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let inputs = inputs
@@ -468,7 +468,7 @@ where
                     forms,
                     input_key,
                     input_mfp,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -530,7 +530,7 @@ where
         use Plan::*;
         rg.checked_recur(|_| {
             match expr {
-                Constant { rows, node_id: _ } => {
+                Constant { rows, lir_id: _ } => {
                     // Interpret the current node.
                     let result = self.interpret.constant(&self.ctx, rows);
                     // Mutate the current node using the given `action`.
@@ -542,7 +542,7 @@ where
                     id,
                     keys,
                     plan,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Interpret the current node.
                     let result = self.interpret.get(&self.ctx, id, keys, plan);
@@ -555,7 +555,7 @@ where
                     id,
                     value,
                     body,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Extend context with the `value` result.
                     let res_value = self.apply_rec(value, rg)?;
@@ -579,7 +579,7 @@ where
                     values,
                     limits,
                     body,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Make context recursive and extend it with `bottom` for each recursive
                     // binding. This corresponds to starting with the most optimistic value.
@@ -657,7 +657,7 @@ where
                     input,
                     mfp,
                     input_key_val,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -676,7 +676,7 @@ where
                     exprs,
                     mfp_after: mfp,
                     input_key,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -697,7 +697,7 @@ where
                 Join {
                     inputs,
                     plan,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let inputs: Vec<_> = inputs
@@ -717,7 +717,7 @@ where
                     plan,
                     input_key,
                     mfp_after,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -738,7 +738,7 @@ where
                 TopK {
                     input,
                     top_k_plan,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -749,7 +749,7 @@ where
                     // Pass the interpretation result up.
                     Ok(result)
                 }
-                Negate { input, node_id: _ } => {
+                Negate { input, lir_id: _ } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
                     // Interpret the current node.
@@ -762,7 +762,7 @@ where
                 Threshold {
                     input,
                     threshold_plan,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -778,7 +778,7 @@ where
                 Union {
                     inputs,
                     consolidate_output,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let inputs: Vec<_> = inputs
@@ -799,7 +799,7 @@ where
                     forms,
                     input_key,
                     input_mfp,
-                    node_id: _,
+                    lir_id: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -29,7 +29,7 @@ use mz_compute_client::protocol::response::{
 };
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::flat_plan::FlatPlan;
-use mz_compute_types::plan::NodeId;
+use mz_compute_types::plan::LirId;
 use mz_dyncfg::ConfigSet;
 use mz_expr::SafeMfpPlan;
 use mz_ore::cast::CastFrom;
@@ -1346,7 +1346,7 @@ pub struct HydrationEvent {
     /// The ID of the export this dataflow maintains.
     pub export_id: GlobalId,
     /// The ID of the LIR node.
-    pub lir_id: NodeId,
+    pub lir_id: LirId,
     /// Whether the node is hydrated.
     pub hydrated: bool,
 }

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -113,7 +113,7 @@ use differential_dataflow::{AsCollection, Collection, Data, ExchangeData, Hashab
 use mz_compute_types::dataflows::{BuildDesc, DataflowDescription, IndexDesc};
 use mz_compute_types::dyncfgs::ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING;
 use mz_compute_types::plan::flat_plan::{FlatPlan, FlatPlanNode};
-use mz_compute_types::plan::NodeId;
+use mz_compute_types::plan::LirId;
 use mz_expr::{EvalError, Id};
 use mz_persist_client::operators::shard_source::SnapshotMode;
 use mz_repr::{Datum, Diff, GlobalId, Row, SharedRow};
@@ -743,7 +743,7 @@ where
     pub fn render_plan(&mut self, plan: FlatPlan) -> CollectionBundle<G> {
         let (mut nodes, root_id, topological_order) = plan.destruct();
 
-        // Rendered collections by their `NodeId`.
+        // Rendered collections by their `LirId`.
         let mut collections = BTreeMap::new();
 
         for id in topological_order {
@@ -771,7 +771,7 @@ where
     fn render_plan_node(
         &mut self,
         node: FlatPlanNode,
-        collections: &BTreeMap<NodeId, CollectionBundle<G>>,
+        collections: &BTreeMap<LirId, CollectionBundle<G>>,
     ) -> CollectionBundle<G> {
         use FlatPlanNode::*;
 

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -113,7 +113,7 @@ SELECT 1 / 0
           "rows": {
             "Err": "DivisionByZero"
           },
-          "node_id": 0
+          "lir_id": 0
         }
       }
     }
@@ -161,7 +161,7 @@ EXPLAIN PHYSICAL PLAN WITH(no fast path) AS JSON FOR
               ]
             ]
           },
-          "node_id": 0
+          "lir_id": 0
         }
       }
     }
@@ -219,7 +219,7 @@ SELECT * FROM t
             ]
           },
           "plan": "PassArrangements",
-          "node_id": 0
+          "lir_id": 0
         }
       }
     }
@@ -250,7 +250,7 @@ SELECT * FROM u
             "types": null
           },
           "plan": "PassArrangements",
-          "node_id": 0
+          "lir_id": 0
         }
       }
     }
@@ -351,7 +351,7 @@ SELECT a + b, 1 FROM t
               }
             ]
           },
-          "node_id": 0
+          "lir_id": 0
         }
       }
     }
@@ -392,7 +392,7 @@ SELECT c + d, 1 FROM u
               "input_arity": 2
             }
           },
-          "node_id": 0
+          "lir_id": 0
         }
       }
     }
@@ -494,7 +494,7 @@ SELECT * FROM ov
                     ]
                   },
                   "plan": "PassArrangements",
-                  "node_id": 0
+                  "lir_id": 0
                 }
               },
               "forms": {
@@ -516,7 +516,7 @@ SELECT * FROM ov
                 ],
                 "input_arity": 2
               },
-              "node_id": 1
+              "lir_id": 1
             }
           },
           "top_k_plan": {
@@ -554,7 +554,7 @@ SELECT * FROM ov
               "must_consolidate": true
             }
           },
-          "node_id": 2
+          "lir_id": 2
         }
       }
     }
@@ -633,7 +633,7 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                             }
                           ]
                         },
-                        "node_id": 0
+                        "lir_id": 0
                       }
                     },
                     {
@@ -660,15 +660,15 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                                 "input_arity": 1
                               }
                             },
-                            "node_id": 1
+                            "lir_id": 1
                           }
                         },
-                        "node_id": 2
+                        "lir_id": 2
                       }
                     }
                   ],
                   "consolidate_output": true,
-                  "node_id": 3
+                  "lir_id": 3
                 }
               },
               "forms": {
@@ -702,7 +702,7 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                 ],
                 "input_arity": 1
               },
-              "node_id": 4
+              "lir_id": 4
             }
           },
           "threshold_plan": {
@@ -720,7 +720,7 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
               ]
             }
           },
-          "node_id": 5
+          "lir_id": 5
         }
       }
     }
@@ -792,7 +792,7 @@ SELECT * FROM ov
                     ]
                   },
                   "plan": "PassArrangements",
-                  "node_id": 0
+                  "lir_id": 0
                 }
               },
               "forms": {
@@ -814,7 +814,7 @@ SELECT * FROM ov
                 ],
                 "input_arity": 2
               },
-              "node_id": 1
+              "lir_id": 1
             }
           },
           "top_k_plan": {
@@ -852,7 +852,7 @@ SELECT * FROM ov
               "must_consolidate": true
             }
           },
-          "node_id": 2
+          "lir_id": 2
         }
       }
     }
@@ -935,7 +935,7 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                 }
                               ]
                             },
-                            "node_id": 0
+                            "lir_id": 0
                           }
                         },
                         {
@@ -962,15 +962,15 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                     "input_arity": 1
                                   }
                                 },
-                                "node_id": 1
+                                "lir_id": 1
                               }
                             },
-                            "node_id": 2
+                            "lir_id": 2
                           }
                         }
                       ],
                       "consolidate_output": true,
-                      "node_id": 3
+                      "lir_id": 3
                     }
                   },
                   "forms": {
@@ -1004,7 +1004,7 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                     ],
                     "input_arity": 1
                   },
-                  "node_id": 4
+                  "lir_id": 4
                 }
               },
               "threshold_plan": {
@@ -1022,7 +1022,7 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                   ]
                 }
               },
-              "node_id": 5
+              "lir_id": 5
             }
           },
           "body": {
@@ -1098,7 +1098,7 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                         }
                       ]
                     },
-                    "node_id": 6
+                    "lir_id": 6
                   }
                 },
                 {
@@ -1171,15 +1171,15 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                         }
                       ]
                     },
-                    "node_id": 7
+                    "lir_id": 7
                   }
                 }
               ],
               "consolidate_output": false,
-              "node_id": 8
+              "lir_id": 8
             }
           },
-          "node_id": 9
+          "lir_id": 9
         }
       }
     }
@@ -1261,7 +1261,7 @@ SELECT x * 5 FROM cte WHERE x = 5
                                     ]
                                   },
                                   "plan": "PassArrangements",
-                                  "node_id": 0
+                                  "lir_id": 0
                                 }
                               },
                               {
@@ -1282,7 +1282,7 @@ SELECT x * 5 FROM cte WHERE x = 5
                                           ]
                                         ]
                                       },
-                                      "node_id": 1
+                                      "lir_id": 1
                                     }
                                   },
                                   "forms": {
@@ -1316,7 +1316,7 @@ SELECT x * 5 FROM cte WHERE x = 5
                                     ],
                                     "input_arity": 1
                                   },
-                                  "node_id": 2
+                                  "lir_id": 2
                                 }
                               }
                             ],
@@ -1361,7 +1361,7 @@ SELECT x * 5 FROM cte WHERE x = 5
                                 "final_closure": null
                               }
                             },
-                            "node_id": 3
+                            "lir_id": 3
                           }
                         },
                         {
@@ -1388,15 +1388,15 @@ SELECT x * 5 FROM cte WHERE x = 5
                                     "input_arity": 1
                                   }
                                 },
-                                "node_id": 4
+                                "lir_id": 4
                               }
                             },
-                            "node_id": 5
+                            "lir_id": 5
                           }
                         }
                       ],
                       "consolidate_output": true,
-                      "node_id": 6
+                      "lir_id": 6
                     }
                   },
                   "forms": {
@@ -1430,7 +1430,7 @@ SELECT x * 5 FROM cte WHERE x = 5
                     ],
                     "input_arity": 1
                   },
-                  "node_id": 7
+                  "lir_id": 7
                 }
               },
               "threshold_plan": {
@@ -1448,7 +1448,7 @@ SELECT x * 5 FROM cte WHERE x = 5
                   ]
                 }
               },
-              "node_id": 8
+              "lir_id": 8
             }
           },
           "mfp": {
@@ -1484,7 +1484,7 @@ SELECT x * 5 FROM cte WHERE x = 5
             ],
             null
           ],
-          "node_id": 9
+          "lir_id": 9
         }
       }
     }
@@ -1583,7 +1583,7 @@ SELECT generate_series(a, b) from t
                 ]
               },
               "plan": "PassArrangements",
-              "node_id": 0
+              "lir_id": 0
             }
           },
           "func": "GenerateSeriesInt32",
@@ -1624,7 +1624,7 @@ SELECT generate_series(a, b) from t
               "Column": 0
             }
           ],
-          "node_id": 1
+          "lir_id": 1
         }
       }
     }
@@ -1681,7 +1681,7 @@ SELECT DISTINCT a, b FROM t
                 ]
               },
               "plan": "PassArrangements",
-              "node_id": 0
+              "lir_id": 0
             }
           },
           "key_val_plan": {
@@ -1720,7 +1720,7 @@ SELECT DISTINCT a, b FROM t
             ],
             "input_arity": 2
           },
-          "node_id": 1
+          "lir_id": 1
         }
       }
     }
@@ -1782,7 +1782,7 @@ GROUP BY a
                 ]
               },
               "plan": "PassArrangements",
-              "node_id": 0
+              "lir_id": 0
             }
           },
           "key_val_plan": {
@@ -1869,7 +1869,7 @@ GROUP BY a
             ],
             "input_arity": 3
           },
-          "node_id": 1
+          "lir_id": 1
         }
       }
     }
@@ -1949,7 +1949,7 @@ FROM t
                       }
                     ]
                   },
-                  "node_id": 0
+                  "lir_id": 0
                 }
               },
               "key_val_plan": {
@@ -2029,7 +2029,7 @@ FROM t
                 ],
                 "input_arity": 2
               },
-              "node_id": 1
+              "lir_id": 1
             }
           },
           "body": {
@@ -2060,7 +2060,7 @@ FROM t
                           "types": null
                         },
                         "plan": "PassArrangements",
-                        "node_id": 2
+                        "lir_id": 2
                       }
                     },
                     "forms": {
@@ -2078,7 +2078,7 @@ FROM t
                       ],
                       "input_arity": 2
                     },
-                    "node_id": 8
+                    "lir_id": 8
                   }
                 },
                 {
@@ -2122,10 +2122,10 @@ FROM t
                                       }
                                     ]
                                   },
-                                  "node_id": 3
+                                  "lir_id": 3
                                 }
                               },
-                              "node_id": 4
+                              "lir_id": 4
                             }
                           },
                           {
@@ -2141,12 +2141,12 @@ FROM t
                                   ]
                                 ]
                               },
-                              "node_id": 5
+                              "lir_id": 5
                             }
                           }
                         ],
                         "consolidate_output": true,
-                        "node_id": 6
+                        "lir_id": 6
                       }
                     },
                     "mfp": {
@@ -2190,15 +2190,15 @@ FROM t
                       "input_arity": 0
                     },
                     "input_key_val": null,
-                    "node_id": 7
+                    "lir_id": 7
                   }
                 }
               ],
               "consolidate_output": false,
-              "node_id": 9
+              "lir_id": 9
             }
           },
-          "node_id": 10
+          "lir_id": 10
         }
       }
     }
@@ -2255,7 +2255,7 @@ SELECT * FROM hierarchical_group_by
                 ]
               },
               "plan": "PassArrangements",
-              "node_id": 0
+              "lir_id": 0
             }
           },
           "key_val_plan": {
@@ -2311,7 +2311,7 @@ SELECT * FROM hierarchical_group_by
             ],
             "input_arity": 3
           },
-          "node_id": 1
+          "lir_id": 1
         }
       }
     }
@@ -2388,7 +2388,7 @@ MATERIALIZED VIEW hierarchical_global_mv
                       }
                     ]
                   },
-                  "node_id": 0
+                  "lir_id": 0
                 }
               },
               "key_val_plan": {
@@ -2445,7 +2445,7 @@ MATERIALIZED VIEW hierarchical_global_mv
                 ],
                 "input_arity": 2
               },
-              "node_id": 1
+              "lir_id": 1
             }
           },
           "body": {
@@ -2476,7 +2476,7 @@ MATERIALIZED VIEW hierarchical_global_mv
                           "types": null
                         },
                         "plan": "PassArrangements",
-                        "node_id": 2
+                        "lir_id": 2
                       }
                     },
                     "forms": {
@@ -2494,7 +2494,7 @@ MATERIALIZED VIEW hierarchical_global_mv
                       ],
                       "input_arity": 2
                     },
-                    "node_id": 8
+                    "lir_id": 8
                   }
                 },
                 {
@@ -2538,10 +2538,10 @@ MATERIALIZED VIEW hierarchical_global_mv
                                       }
                                     ]
                                   },
-                                  "node_id": 3
+                                  "lir_id": 3
                                 }
                               },
-                              "node_id": 4
+                              "lir_id": 4
                             }
                           },
                           {
@@ -2557,12 +2557,12 @@ MATERIALIZED VIEW hierarchical_global_mv
                                   ]
                                 ]
                               },
-                              "node_id": 5
+                              "lir_id": 5
                             }
                           }
                         ],
                         "consolidate_output": true,
-                        "node_id": 6
+                        "lir_id": 6
                       }
                     },
                     "mfp": {
@@ -2606,15 +2606,15 @@ MATERIALIZED VIEW hierarchical_global_mv
                       "input_arity": 0
                     },
                     "input_key_val": null,
-                    "node_id": 7
+                    "lir_id": 7
                   }
                 }
               ],
               "consolidate_output": false,
-              "node_id": 9
+              "lir_id": 9
             }
           },
-          "node_id": 10
+          "lir_id": 10
         }
       }
     }
@@ -2691,7 +2691,7 @@ SELECT * FROM hierarchical_global
                       }
                     ]
                   },
-                  "node_id": 0
+                  "lir_id": 0
                 }
               },
               "key_val_plan": {
@@ -2740,7 +2740,7 @@ SELECT * FROM hierarchical_global
                 ],
                 "input_arity": 2
               },
-              "node_id": 1
+              "lir_id": 1
             }
           },
           "body": {
@@ -2771,7 +2771,7 @@ SELECT * FROM hierarchical_global
                           "types": null
                         },
                         "plan": "PassArrangements",
-                        "node_id": 2
+                        "lir_id": 2
                       }
                     },
                     "forms": {
@@ -2789,7 +2789,7 @@ SELECT * FROM hierarchical_global
                       ],
                       "input_arity": 2
                     },
-                    "node_id": 8
+                    "lir_id": 8
                   }
                 },
                 {
@@ -2833,10 +2833,10 @@ SELECT * FROM hierarchical_global
                                       }
                                     ]
                                   },
-                                  "node_id": 3
+                                  "lir_id": 3
                                 }
                               },
-                              "node_id": 4
+                              "lir_id": 4
                             }
                           },
                           {
@@ -2852,12 +2852,12 @@ SELECT * FROM hierarchical_global
                                   ]
                                 ]
                               },
-                              "node_id": 5
+                              "lir_id": 5
                             }
                           }
                         ],
                         "consolidate_output": true,
-                        "node_id": 6
+                        "lir_id": 6
                       }
                     },
                     "mfp": {
@@ -2901,15 +2901,15 @@ SELECT * FROM hierarchical_global
                       "input_arity": 0
                     },
                     "input_key_val": null,
-                    "node_id": 7
+                    "lir_id": 7
                   }
                 }
               ],
               "consolidate_output": false,
-              "node_id": 9
+              "lir_id": 9
             }
           },
-          "node_id": 10
+          "lir_id": 10
         }
       }
     }
@@ -2971,7 +2971,7 @@ GROUP BY a
                 ]
               },
               "plan": "PassArrangements",
-              "node_id": 0
+              "lir_id": 0
             }
           },
           "key_val_plan": {
@@ -3341,7 +3341,7 @@ GROUP BY a
             ],
             "input_arity": 3
           },
-          "node_id": 1
+          "lir_id": 1
         }
       }
     }
@@ -3421,7 +3421,7 @@ FROM t
                       }
                     ]
                   },
-                  "node_id": 0
+                  "lir_id": 0
                 }
               },
               "key_val_plan": {
@@ -3784,7 +3784,7 @@ FROM t
                 ],
                 "input_arity": 2
               },
-              "node_id": 1
+              "lir_id": 1
             }
           },
           "body": {
@@ -3815,7 +3815,7 @@ FROM t
                           "types": null
                         },
                         "plan": "PassArrangements",
-                        "node_id": 2
+                        "lir_id": 2
                       }
                     },
                     "forms": {
@@ -3833,7 +3833,7 @@ FROM t
                       ],
                       "input_arity": 2
                     },
-                    "node_id": 8
+                    "lir_id": 8
                   }
                 },
                 {
@@ -3877,10 +3877,10 @@ FROM t
                                       }
                                     ]
                                   },
-                                  "node_id": 3
+                                  "lir_id": 3
                                 }
                               },
-                              "node_id": 4
+                              "lir_id": 4
                             }
                           },
                           {
@@ -3896,12 +3896,12 @@ FROM t
                                   ]
                                 ]
                               },
-                              "node_id": 5
+                              "lir_id": 5
                             }
                           }
                         ],
                         "consolidate_output": true,
-                        "node_id": 6
+                        "lir_id": 6
                       }
                     },
                     "mfp": {
@@ -3945,15 +3945,15 @@ FROM t
                       "input_arity": 0
                     },
                     "input_key_val": null,
-                    "node_id": 7
+                    "lir_id": 7
                   }
                 }
               ],
               "consolidate_output": false,
-              "node_id": 9
+              "lir_id": 9
             }
           },
-          "node_id": 10
+          "lir_id": 10
         }
       }
     }
@@ -4010,7 +4010,7 @@ MATERIALIZED VIEW collated_group_by_mv
                 ]
               },
               "plan": "PassArrangements",
-              "node_id": 0
+              "lir_id": 0
             }
           },
           "key_val_plan": {
@@ -4463,7 +4463,7 @@ MATERIALIZED VIEW collated_group_by_mv
             ],
             "input_arity": 7
           },
-          "node_id": 1
+          "lir_id": 1
         }
       }
     }
@@ -4520,7 +4520,7 @@ SELECT * FROM collated_group_by
                 ]
               },
               "plan": "PassArrangements",
-              "node_id": 0
+              "lir_id": 0
             }
           },
           "key_val_plan": {
@@ -4965,7 +4965,7 @@ SELECT * FROM collated_group_by
             ],
             "input_arity": 7
           },
-          "node_id": 1
+          "lir_id": 1
         }
       }
     }
@@ -5042,7 +5042,7 @@ MATERIALIZED VIEW collated_global_mv
                       }
                     ]
                   },
-                  "node_id": 0
+                  "lir_id": 0
                 }
               },
               "key_val_plan": {
@@ -5488,7 +5488,7 @@ MATERIALIZED VIEW collated_global_mv
                 ],
                 "input_arity": 6
               },
-              "node_id": 1
+              "lir_id": 1
             }
           },
           "body": {
@@ -5527,7 +5527,7 @@ MATERIALIZED VIEW collated_global_mv
                           "types": null
                         },
                         "plan": "PassArrangements",
-                        "node_id": 2
+                        "lir_id": 2
                       }
                     },
                     "forms": {
@@ -5549,7 +5549,7 @@ MATERIALIZED VIEW collated_global_mv
                       ],
                       "input_arity": 6
                     },
-                    "node_id": 8
+                    "lir_id": 8
                   }
                 },
                 {
@@ -5601,10 +5601,10 @@ MATERIALIZED VIEW collated_global_mv
                                       }
                                     ]
                                   },
-                                  "node_id": 3
+                                  "lir_id": 3
                                 }
                               },
-                              "node_id": 4
+                              "lir_id": 4
                             }
                           },
                           {
@@ -5620,12 +5620,12 @@ MATERIALIZED VIEW collated_global_mv
                                   ]
                                 ]
                               },
-                              "node_id": 5
+                              "lir_id": 5
                             }
                           }
                         ],
                         "consolidate_output": true,
-                        "node_id": 6
+                        "lir_id": 6
                       }
                     },
                     "mfp": {
@@ -5733,15 +5733,15 @@ MATERIALIZED VIEW collated_global_mv
                       "input_arity": 0
                     },
                     "input_key_val": null,
-                    "node_id": 7
+                    "lir_id": 7
                   }
                 }
               ],
               "consolidate_output": false,
-              "node_id": 9
+              "lir_id": 9
             }
           },
-          "node_id": 10
+          "lir_id": 10
         }
       }
     }
@@ -5818,7 +5818,7 @@ SELECT * FROM collated_global
                       }
                     ]
                   },
-                  "node_id": 0
+                  "lir_id": 0
                 }
               },
               "key_val_plan": {
@@ -6256,7 +6256,7 @@ SELECT * FROM collated_global
                 ],
                 "input_arity": 6
               },
-              "node_id": 1
+              "lir_id": 1
             }
           },
           "body": {
@@ -6295,7 +6295,7 @@ SELECT * FROM collated_global
                           "types": null
                         },
                         "plan": "PassArrangements",
-                        "node_id": 2
+                        "lir_id": 2
                       }
                     },
                     "forms": {
@@ -6317,7 +6317,7 @@ SELECT * FROM collated_global
                       ],
                       "input_arity": 6
                     },
-                    "node_id": 8
+                    "lir_id": 8
                   }
                 },
                 {
@@ -6369,10 +6369,10 @@ SELECT * FROM collated_global
                                       }
                                     ]
                                   },
-                                  "node_id": 3
+                                  "lir_id": 3
                                 }
                               },
-                              "node_id": 4
+                              "lir_id": 4
                             }
                           },
                           {
@@ -6388,12 +6388,12 @@ SELECT * FROM collated_global
                                   ]
                                 ]
                               },
-                              "node_id": 5
+                              "lir_id": 5
                             }
                           }
                         ],
                         "consolidate_output": true,
-                        "node_id": 6
+                        "lir_id": 6
                       }
                     },
                     "mfp": {
@@ -6501,15 +6501,15 @@ SELECT * FROM collated_global
                       "input_arity": 0
                     },
                     "input_key_val": null,
-                    "node_id": 7
+                    "lir_id": 7
                   }
                 }
               ],
               "consolidate_output": false,
-              "node_id": 9
+              "lir_id": 9
             }
           },
-          "node_id": 10
+          "lir_id": 10
         }
       }
     }
@@ -6569,7 +6569,7 @@ WHERE a = c AND d = e AND b + d > 42
                   ]
                 },
                 "plan": "PassArrangements",
-                "node_id": 0
+                "lir_id": 0
               }
             },
             {
@@ -6597,7 +6597,7 @@ WHERE a = c AND d = e AND b + d > 42
                         "input_arity": 2
                       }
                     },
-                    "node_id": 1
+                    "lir_id": 1
                   }
                 },
                 "forms": {
@@ -6653,7 +6653,7 @@ WHERE a = c AND d = e AND b + d > 42
                   ],
                   "input_arity": 2
                 },
-                "node_id": 2
+                "lir_id": 2
               }
             },
             {
@@ -6680,7 +6680,7 @@ WHERE a = c AND d = e AND b + d > 42
                         "input_arity": 1
                       }
                     },
-                    "node_id": 3
+                    "lir_id": 3
                   }
                 },
                 "forms": {
@@ -6714,7 +6714,7 @@ WHERE a = c AND d = e AND b + d > 42
                   ],
                   "input_arity": 1
                 },
-                "node_id": 4
+                "lir_id": 4
               }
             }
           ],
@@ -7236,7 +7236,7 @@ WHERE a = c AND d = e AND b + d > 42
               ]
             }
           },
-          "node_id": 5
+          "lir_id": 5
         }
       }
     }
@@ -7397,7 +7397,7 @@ WHERE a = c AND d = e AND f = a
                   ]
                 },
                 "plan": "PassArrangements",
-                "node_id": 0
+                "lir_id": 0
               }
             },
             {
@@ -7498,7 +7498,7 @@ WHERE a = c AND d = e AND f = a
                         }
                       ]
                     },
-                    "node_id": 1
+                    "lir_id": 1
                   }
                 },
                 "forms": {
@@ -7555,7 +7555,7 @@ WHERE a = c AND d = e AND f = a
                   ],
                   "input_arity": 2
                 },
-                "node_id": 2
+                "lir_id": 2
               }
             },
             {
@@ -7656,7 +7656,7 @@ WHERE a = c AND d = e AND f = a
                         }
                       ]
                     },
-                    "node_id": 3
+                    "lir_id": 3
                   }
                 },
                 "forms": {
@@ -7699,7 +7699,7 @@ WHERE a = c AND d = e AND f = a
                   ],
                   "input_arity": 2
                 },
-                "node_id": 4
+                "lir_id": 4
               }
             }
           ],
@@ -8099,7 +8099,7 @@ WHERE a = c AND d = e AND f = a
               ]
             }
           },
-          "node_id": 5
+          "lir_id": 5
         }
       }
     }
@@ -8159,7 +8159,7 @@ WHERE a = c and a = e
                   ]
                 },
                 "plan": "PassArrangements",
-                "node_id": 0
+                "lir_id": 0
               }
             },
             {
@@ -8199,7 +8199,7 @@ WHERE a = c and a = e
                   ]
                 },
                 "plan": "PassArrangements",
-                "node_id": 1
+                "lir_id": 1
               }
             },
             {
@@ -8239,7 +8239,7 @@ WHERE a = c and a = e
                   ]
                 },
                 "plan": "PassArrangements",
-                "node_id": 2
+                "lir_id": 2
               }
             }
           ],
@@ -8634,7 +8634,7 @@ WHERE a = c and a = e
               ]
             }
           },
-          "node_id": 3
+          "lir_id": 3
         }
       }
     }


### PR DESCRIPTION
This PR renames the `NodeId` type to `LirId` and any `node_id` variables to `lir_id`. This is meant to remove some ambiguity when these IDs are used outside the `Plan` context, in which case the term "node" is probably too general to be obvious.

### Motivation

   * This PR refactors existing code.

This is a follow-up to #24906 where @antiguru pointed out that the term "node ID" can be ambiguous as a lot of things are called "nodes". There is not much ambiguity in the context of `Plan` and its methods, but we also use this ID outside of this context (e.g. when reporting hydration information), so a more specific name seems like a good idea.

### Tips for reviewer

This takes the approach of renaming all `node_id` fields to `lir_id`. We could alternatively leave the ones in `Plan` and `FlatPlan` called `node_id` because the meaning of "node" is clear from the context there, but I think calling them `lir_id` everywhere reduces the potential for confusion.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A