### PR TITLE
Fix `CastArrayToJsonb` to return a `JsonNull` for a `Null` input

### DIFF
--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -187,7 +187,7 @@ impl LazyUnaryFunc for CastArrayToJsonb {
 
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
-            return Ok(Datum::Null);
+            return Ok(Datum::JsonNull);
         }
         let a = a.unwrap_array();
         let elements = a.elements();
@@ -203,12 +203,12 @@ impl LazyUnaryFunc for CastArrayToJsonb {
         Ok(temp_storage.push_unary_row(row))
     }
 
-    fn output_type(&self, input_type: ColumnType) -> ColumnType {
-        ScalarType::Jsonb.nullable(input_type.nullable)
+    fn output_type(&self, _input_type: ColumnType) -> ColumnType {
+        ScalarType::Jsonb.nullable(false)
     }
 
     fn propagates_nulls(&self) -> bool {
-        true
+        false
     }
 
     fn introduces_nulls(&self) -> bool {

--- a/src/expr/src/scalar/func/impls/list.rs
+++ b/src/expr/src/scalar/func/impls/list.rs
@@ -88,7 +88,7 @@ impl LazyUnaryFunc for CastListToJsonb {
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if a.is_null() {
-            return Ok(Datum::Null);
+            return Ok(Datum::JsonNull);
         }
         let mut row = Row::default();
         row.packer().push_list_with(|packer| {
@@ -101,12 +101,12 @@ impl LazyUnaryFunc for CastListToJsonb {
         Ok(temp_storage.push_unary_row(row))
     }
 
-    fn output_type(&self, input_type: ColumnType) -> ColumnType {
-        ScalarType::Jsonb.nullable(input_type.nullable)
+    fn output_type(&self, _input_type: ColumnType) -> ColumnType {
+        ScalarType::Jsonb.nullable(false)
     }
 
     fn propagates_nulls(&self) -> bool {
-        true
+        false
     }
 
     fn introduces_nulls(&self) -> bool {

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -1055,7 +1055,7 @@ SELECT to_jsonb(1.234::FLOAT)
 query T
 SELECT to_jsonb(null::int[])
 ----
-NULL
+null
 
 query T
 SELECT to_jsonb(array[1]::int[])
@@ -1090,7 +1090,7 @@ SELECT to_jsonb(array[row(1, 2), row(3, 4)])
 query T
 SELECT to_jsonb(null::int list)
 ----
-NULL
+null
 
 query T
 SELECT to_jsonb(list[1]::int list)
@@ -2070,3 +2070,35 @@ query T
 SELECT '{}'::JSONB #> '{-9223372036854775808}';
 ----
 NULL
+
+# Regression tests for #25899.
+
+statement ok
+SELECT NULL AS c2, pg_catalog.jsonb_object_agg(subq_2.c2, mz_internal.mz_normalize_schema_name(NULL)) AS c3 FROM (SELECT subq_1.c9 AS c2 FROM (SELECT subq_0.c0 AS c9 FROM LATERAL (SELECT 89 AS c0) AS subq_0) AS subq_1) AS subq_2;
+
+statement ok
+create table t3(x int[]);
+
+statement ok
+insert into t3 values (null::int[]);
+
+query T
+SELECT * FROM (SELECT to_jsonb(x) as y from t3) where y is not null;
+----
+null
+
+query T
+SELECT * FROM (SELECT to_jsonb(x) as y from t3);
+----
+null
+
+# Result type should be non-nullable (i.e., no `?` after `jsonb`)
+query T multiline
+explain with(types) SELECT * FROM (SELECT to_jsonb(x) as y from t3);
+----
+Explained Query:
+  Project (#1) // { types: "(jsonb)" }
+    Map (arraytojsonb(#0)) // { types: "(integer[]?, jsonb)" }
+      ReadStorage materialize.public.t3 // { types: "(integer[]?)" }
+
+EOF


### PR DESCRIPTION
Fixes casting null arrays and lists to jsonb.

I added some tests, but note that the only ones of these that actually fail on `main` are the really complicated one from the PR description and the last one, which is just explicitly checking the types. At first, I thought I'll be able to write a very simple test that fails on `main`, but all my attempts have failed: If the result type is nullable, then the error is not caught by the type sanity check, because then the check just considers a normal null acceptable. But if I put a WHERE IS NOT NULL on the result, then the null is filtered out. I have no idea how exactly the query from the original issue catches this.

Note that I didn't add a test for `CastListToJsonb`, because of the above difficulties.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/25899

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
