### PR TITLE
storage/purification: Correctly error on ALTER SOURCE .. DROP SUBSOURCE statements for unsupported source types

### DIFF
--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1322,29 +1322,25 @@ async fn purify_alter_source(
             }
         };
 
-        // If there's no further work to do here, early return.
-        if !matches!(action, AlterSourceAction::AddSubsources { .. }) {
-            return Ok((vec![], Statement::AlterSource(stmt)));
-        }
-
+        // Ensure it's a source that supports ALTER SOURCE...
         match desc.connection {
             GenericSourceConnection::Postgres(pg_connection) => pg_connection,
             _ => sql_bail!(
-                "{} is a {} source, which does not support ALTER SOURCE...ADD SUBSOURCES",
+                "{} is a {} source, which does not support ALTER SOURCE.",
                 scx.catalog.minimal_qualification(item.name()),
                 desc.connection.name()
             ),
         }
     };
 
-    // If there's no further work to do here, early return.
+    // If we don't need to handle added subsources, early return.
     let (targeted_subsources, details, options) = match action {
         AlterSourceAction::AddSubsources {
             subsources,
             details,
             options,
         } => (subsources, details, options),
-        _ => unreachable!(),
+        _ => return Ok((vec![], Statement::AlterSource(stmt))),
     };
 
     assert!(

--- a/test/mysql-cdc-resumption/alter-mz.td
+++ b/test/mysql-cdc-resumption/alter-mz.td
@@ -7,4 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# TODO #24975 (support ALTER SOURCE)
+# Uncomment all calls to alter-mz.td in test/mysql-cdc-resumption/mzcompose.py
 > ALTER SOURCE mz_source DROP SUBSOURCE t0;

--- a/test/mysql-cdc-resumption/cleanup.td
+++ b/test/mysql-cdc-resumption/cleanup.td
@@ -8,4 +8,6 @@
 # by the Apache License, Version 2.0.
 
 # Tests expect healthy sources at end of test.
-> ALTER SOURCE mz_source DROP SUBSOURCE alter_fail_drop_constraint, alter_fail_drop_col;
+# TODO: Once we support ALTER SOURCE .. DROP SUBSOURCE for mysql, just
+# drop the unhealthy subsource rather than the whole source.
+> DROP SOURCE mz_source;

--- a/test/mysql-cdc-resumption/mzcompose.py
+++ b/test/mysql-cdc-resumption/mzcompose.py
@@ -137,7 +137,7 @@ def disconnect_mysql_during_snapshot(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
-        "alter-mz.td",
+        # "alter-mz.td",
     )
 
 
@@ -149,12 +149,12 @@ def restart_mysql_during_snapshot(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
-        "alter-mz.td",
+        # "alter-mz.td",
     )
 
 
 def restart_mz_during_snapshot(c: Composition) -> None:
-    run_testdrive_files(c, "alter-mz.td")
+    # run_testdrive_files(c, "alter-mz.td")
     restart_mz(c)
 
     run_testdrive_files(c, "delete-rows-t1.td", "delete-rows-t2.td", "alter-table.td")
@@ -167,7 +167,7 @@ def disconnect_mysql_during_replication(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
-        "alter-mz.td",
+        # "alter-mz.td",
         "toxiproxy-close-connection.td",
         "toxiproxy-restore-connection.td",
     )
@@ -179,7 +179,7 @@ def restart_mysql_during_replication(c: Composition) -> None:
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
         "alter-table.td",
-        "alter-mz.td",
+        # "alter-mz.td",
     )
 
     restart_mysql(c)
@@ -193,7 +193,7 @@ def restart_mz_during_replication(c: Composition) -> None:
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
         "alter-table.td",
-        "alter-mz.td",
+        # "alter-mz.td",
     )
 
     restart_mz(c)
@@ -207,7 +207,7 @@ def fix_mysql_schema_while_mz_restarts(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
-        "alter-mz.td",
+        # "alter-mz.td",
         "verify-data.td",
         "alter-table-fix.td",
     )
@@ -227,7 +227,7 @@ def verify_no_snapshot_reingestion(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
-        "alter-mz.td",
+        # "alter-mz.td",
     )
 
 
@@ -260,7 +260,12 @@ def mysql_out_of_disk_space(c: Composition) -> None:
     time.sleep(30)
     c.exec("mysql", "bash", "-c", f"rm {fill_file}")
 
-    run_testdrive_files(c, "delete-rows-t2.td", "alter-table.td", "alter-mz.td")
+    run_testdrive_files(
+        c,
+        "delete-rows-t2.td",
+        "alter-table.td",
+        # "alter-mz.td"
+    )
 
 
 def backup_restore_mysql(c: Composition) -> None:

--- a/test/mysql-cdc-resumption/verify-data.td
+++ b/test/mysql-cdc-resumption/verify-data.td
@@ -26,5 +26,6 @@ contains:incompatible schema change
 > SELECT COUNT(*) = 0 FROM mz_internal.mz_source_statuses WHERE error LIKE '%Connection refused%';
 true
 
-! SELECT * FROM t0
-contains:unknown catalog item 't0'
+# TODO #24975 (support ALTER SOURCE)
+# ! SELECT * FROM t0
+# contains:unknown catalog item 't0'

--- a/test/mysql-cdc/alter-source.td
+++ b/test/mysql-cdc/alter-source.td
@@ -30,7 +30,6 @@ USE public;
 CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
 INSERT INTO table_a VALUES (1, 'one');
 INSERT INTO table_a VALUES (2, 'two');
-
 # Check empty publication on ALTER
 
 > CREATE SOURCE mz_source
@@ -45,7 +44,7 @@ $ mysql-execute name=mysql
 DROP TABLE table_a CASCADE;
 
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_b;
-contains:mz_source is a mysql source, which does not support ALTER SOURCE...ADD SUBSOURCES
+contains:mz_source is a mysql source, which does not support ALTER SOURCE.
 
 # Adding a table with the same name as a running table does not allow you to add
 # the new table, even though its OID is the different.
@@ -62,7 +61,10 @@ INSERT INTO table_a VALUES (9, 'nine');
 
 # We are not aware that the new table_a is different
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_a;
-contains:mz_source is a mysql source, which does not support ALTER SOURCE...ADD SUBSOURCES
+contains:mz_source is a mysql source, which does not support ALTER SOURCE.
+
+! ALTER SOURCE mz_source DROP SUBSOURCE table_a;
+contains:mz_source is a mysql source, which does not support ALTER SOURCE.
 
 > DROP SOURCE mz_source;
 
@@ -125,136 +127,138 @@ table_g               subsource
 # Error checking
 #
 
-! ALTER SOURCE mz_source DROP SUBSOURCE mz_source_progress
-contains:SOURCE "mz_source_progress" is a progress collection and cannot be dropped independently of its primary source
-
-! ALTER SOURCE mz_source DROP SUBSOURCE table_a, mz_source_progress
-contains:SOURCE "mz_source_progress" is a progress collection and cannot be dropped independently of its primary source
-
-! ALTER SOURCE mz_source DROP SUBSOURCE mz_source_progress, table_a
-contains:SOURCE "mz_source_progress" is a progress collection and cannot be dropped independently of its primary source
-
-! ALTER SOURCE mz_source DROP SUBSOURCE mz_source;
-contains:SOURCE "mz_source" is not a subsource of "mz_source"
-
-> CREATE TABLE mz_table (a int);
-
-! ALTER SOURCE mz_source DROP SUBSOURCE mz_table;
-contains:mz_table is a table not a source
-
-> DROP TABLE mz_table;
-
-> CREATE SOURCE "mz_source_too"
-  FROM MYSQL CONNECTION mysql_conn
-  FOR TABLES (public.table_a AS t_a);
-
-! ALTER SOURCE mz_source DROP SUBSOURCE t_a;
-contains:SOURCE "t_a" is not a subsource of "mz_source"
-
-! ALTER SOURCE mz_source DROP SUBSOURCE mz_source_too;
-contains:SOURCE "mz_source_too" is not a subsource of "mz_source"
-
-> DROP SOURCE mz_source_too;
-
-! ALTER SOURCE mz_source DROP SUBSOURCE dne;
-contains:unknown catalog item 'dne'
-
-> ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS dne;
-
-> ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS dne, dne, dne;
-
-> ALTER SOURCE IF EXISTS dne DROP SUBSOURCE IF EXISTS dne;
-
-> ALTER SOURCE IF EXISTS mz_source DROP SUBSOURCE IF EXISTS dne, dne, dne;
+# TODO #24975 (support ALTER SOURCE)
+#
+# ! ALTER SOURCE mz_source DROP SUBSOURCE mz_source_progress
+# contains:SOURCE "mz_source_progress" is a progress collection and cannot be dropped independently of its primary source
+#
+# ! ALTER SOURCE mz_source DROP SUBSOURCE table_a, mz_source_progress
+# contains:SOURCE "mz_source_progress" is a progress collection and cannot be dropped independently of its primary source
+#
+# ! ALTER SOURCE mz_source DROP SUBSOURCE mz_source_progress, table_a
+# contains:SOURCE "mz_source_progress" is a progress collection and cannot be dropped independently of its primary source
+#
+# ! ALTER SOURCE mz_source DROP SUBSOURCE mz_source;
+# contains:SOURCE "mz_source" is not a subsource of "mz_source"
+#
+# > CREATE TABLE mz_table (a int);
+#
+# ! ALTER SOURCE mz_source DROP SUBSOURCE mz_table;
+# contains:"materialize.public.mz_table" is a table not a source
+#
+# > DROP TABLE mz_table;
+#
+# > CREATE SOURCE "mz_source_too"
+#   FROM MYSQL CONNECTION mysql_conn
+#   FOR TABLES (public.table_a AS t_a);
+#
+# ! ALTER SOURCE mz_source DROP SUBSOURCE t_a;
+# contains:SOURCE "t_a" is not a subsource of "mz_source"
+#
+# ! ALTER SOURCE mz_source DROP SUBSOURCE mz_source_too;
+# contains:SOURCE "mz_source_too" is not a subsource of "mz_source"
+#
+# > DROP SOURCE mz_source_too;
+#
+# ! ALTER SOURCE mz_source DROP SUBSOURCE dne;
+# contains:unknown catalog item 'dne'
+#
+# > ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS dne;
+#
+# > ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS dne, dne, dne;
+#
+# > ALTER SOURCE IF EXISTS dne DROP SUBSOURCE IF EXISTS dne;
+#
+# > ALTER SOURCE IF EXISTS mz_source DROP SUBSOURCE IF EXISTS dne, dne, dne;
 
 #
 # State checking
 #
 
-> ALTER SOURCE mz_source DROP SUBSOURCE table_a
-
-> SELECT * FROM table_b;
-1 one
-2 two
-
-> SHOW SUBSOURCES ON mz_source
-mz_source_progress    progress
-table_b               subsource
-table_c               subsource
-table_d               subsource
-table_e               subsource
-table_f               subsource
-table_g               subsource
-
-! SELECT * FROM table_a;
-contains: unknown catalog item 'table_a'
-
-# Makes progress after dropping subsources
-$ mysql-execute name=mysql
-INSERT INTO table_b VALUES (3, 'three');
-
-> SELECT * FROM table_b;
-1 one
-2 two
-3 three
-
-# IF EXISTS works
-> ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_a;
-
-# Multiple, repetitive tables work
-> ALTER SOURCE mz_source DROP SUBSOURCE table_b, table_c, table_b, table_c, table_b, table_c;
-
-# IF EXISTS works with multiple tables
-> ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_c, table_d;
-
-> CREATE MATERIALIZED VIEW mv_e AS SELECT pk + 1 FROM table_e;
-> CREATE MATERIALIZED VIEW mv_f AS SELECT pk + 1 FROM table_f;
-
-# Makes progress after dropping subsources
-$ mysql-execute name=mysql
-INSERT INTO table_e VALUES (3, 'three');
-
-> SELECT * FROM mv_e;
-2
-3
-4
-
-> SHOW MATERIALIZED VIEWS
-mv_e quickstart
-mv_f quickstart
-
-# RESTRICT works
-! ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e;
-contains:cannot drop source "table_e": still depended upon by materialized view "mv_e"
-
-! ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e RESTRICT;
-contains:cannot drop source "table_e": still depended upon by materialized view "mv_e"
-
-# CASCADE works
-> ALTER SOURCE mz_source DROP SUBSOURCE table_e CASCADE;
-
-# IF NOT EXISTS + CASCADE works
-> ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e, table_f CASCADE;
-
+# > ALTER SOURCE mz_source DROP SUBSOURCE table_a
+#
+# > SELECT * FROM table_b;
+# 1 one
+# 2 two
+#
+# > SHOW SUBSOURCES ON mz_source
+# mz_source_progress    progress
+# table_b               subsource
+# table_c               subsource
+# table_d               subsource
+# table_e               subsource
+# table_f               subsource
+# table_g               subsource
+#
+# ! SELECT * FROM table_a;
+# contains: unknown catalog item 'table_a'
+#
+# # Makes progress after dropping subsources
+# $ mysql-execute name=mysql
+# INSERT INTO table_b VALUES (3, 'three');
+#
+# > SELECT * FROM table_b;
+# 1 one
+# 2 two
+# 3 three
+#
+# # IF EXISTS works
+# > ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_a;
+#
+# # Multiple, repetitive tables work
+# > ALTER SOURCE mz_source DROP SUBSOURCE table_b, table_c, table_b, table_c, table_b, table_c;
+#
+# # IF EXISTS works with multiple tables
+# > ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_c, table_d;
+#
+# > CREATE MATERIALIZED VIEW mv_e AS SELECT pk + 1 FROM table_e;
+# > CREATE MATERIALIZED VIEW mv_f AS SELECT pk + 1 FROM table_f;
+#
+# # Makes progress after dropping subsources
+# $ mysql-execute name=mysql
+# INSERT INTO table_e VALUES (3, 'three');
+#
+# > SELECT * FROM mv_e;
+# 2
+# 3
+# 4
+#
+# > SHOW MATERIALIZED VIEWS
+# mv_e quickstart
+# mv_f quickstart
+#
+# # RESTRICT works
+# ! ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e;
+# contains:cannot drop source "table_e": still depended upon by materialized view "mv_e"
+#
+# ! ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e RESTRICT;
+# contains:cannot drop source "table_e": still depended upon by materialized view "mv_e"
+#
+# # CASCADE works
+# > ALTER SOURCE mz_source DROP SUBSOURCE table_e CASCADE;
+#
+# # IF NOT EXISTS + CASCADE works
+# > ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e, table_f CASCADE;
+#
 # TODO: #25882 (text column entry not cascaded)
 # TEXT COLUMNS removed from table_f
 # > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
 # <null>
 
-> SHOW SUBSOURCES ON mz_source
-mz_source_progress    progress
-table_g               subsource
+# > SHOW SUBSOURCES ON mz_source
+# mz_source_progress    progress
+# table_g               subsource
 
-> SHOW MATERIALIZED VIEWS
+# > SHOW MATERIALIZED VIEWS
 
 # MySQL sources must retain at least one subsource, if nothing else than for parsing reasons, i.e.
 # empty input for subsources is invalid.
-! ALTER SOURCE mz_source DROP SUBSOURCE table_g;
-contains:SOURCE "mz_source" must retain at least one non-progress subsource
+# ! ALTER SOURCE mz_source DROP SUBSOURCE table_g;
+# contains:SOURCE "mz_source" must retain at least one non-progress subsource
 
 # Show that all table definitions have been updated
-> SELECT regexp_match(create_sql, 'FOR TABLES \((.+?)\) EXPOSE') FROM (SHOW CREATE SOURCE mz_source);
-"{\"mysql\".\"public\".\"table_g\" AS \"materialize\".\"public\".\"table_g\"}"
+# > SELECT regexp_match(create_sql, 'FOR TABLES \((.+?)\) EXPOSE') FROM (SHOW CREATE SOURCE mz_source);
+# "{\"mysql\".\"public\".\"table_g\" AS \"materialize\".\"public\".\"table_g\"}"
 
 #
 # Add subsources

--- a/test/testdrive/kafka-alter-source.td
+++ b/test/testdrive/kafka-alter-source.td
@@ -25,7 +25,7 @@ one
 one
 
 !ALTER SOURCE data ADD SUBSOURCE t;
-contains:data is a kafka source, which does not support ALTER SOURCE...ADD SUBSOURCES
+contains:data is a kafka source, which does not support ALTER SOURCE.
 
 !ALTER SOURCE data DROP SUBSOURCE t;
-contains:unknown catalog item 't'
+contains:data is a kafka source, which does not support ALTER SOURCE.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/materialize/issues/25826 and Fixes https://github.com/MaterializeInc/materialize/issues/25882

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Context for this PR is here https://github.com/MaterializeInc/materialize/issues/25826#issuecomment-1988816031

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
