### PR TITLE
adapter: start using dyncfg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,6 +3665,7 @@ dependencies = [
 name = "mz-adapter-types"
 version = "0.0.0"
 dependencies = [
+ "mz-dyncfg",
  "mz-ore",
  "mz-repr",
  "mz-storage-types",
@@ -4255,6 +4256,7 @@ dependencies = [
 name = "mz-dyncfgs"
 version = "0.0.0"
 dependencies = [
+ "mz-adapter-types",
  "mz-compute-types",
  "mz-dyncfg",
  "mz-persist-client",

--- a/src/adapter-types/Cargo.toml
+++ b/src/adapter-types/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
+mz-dyncfg = { path = "../dyncfg" }
 mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
 mz-storage-types = { path = "../storage-types" }

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -1,0 +1,24 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Dyncfgs used by the adapter layer.
+
+use mz_dyncfg::{Config, ConfigSet};
+
+/// Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.
+pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: Config<bool> = Config::new(
+    "enable_statement_lifecycle_logging",
+    false,
+    "Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.",
+);
+
+/// Adds the full set of all compute `Config`s.
+pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
+    configs.add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
+}

--- a/src/adapter-types/src/lib.rs
+++ b/src/adapter-types/src/lib.rs
@@ -11,4 +11,5 @@
 
 pub mod compaction;
 pub mod connection;
+pub mod dyncfgs;
 pub mod timestamp_oracle;

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -739,10 +739,8 @@ impl Coordinator {
         event: &StatementLifecycleEvent,
         when: EpochMillis,
     ) {
-        if self
-            .catalog()
-            .system_config()
-            .enable_statement_lifecycle_logging()
+        if mz_adapter_types::dyncfgs::ENABLE_STATEMENT_LIFECYCLE_LOGGING
+            .get(self.catalog().system_config().dyncfgs())
         {
             let row = Self::pack_statement_lifecycle_event(id, event, when);
             self.statement_logging

--- a/src/dyncfgs/Cargo.toml
+++ b/src/dyncfgs/Cargo.toml
@@ -11,10 +11,11 @@ publish = false
 workspace = true
 
 [dependencies]
-mz-compute-types = { path = "../compute-types"}
-mz-dyncfg = { path = "../dyncfg"}
-mz-persist-client = { path = "../persist-client"}
-mz-persist-txn = { path = "../persist-txn"}
+mz-adapter-types = { path = "../adapter-types" }
+mz-compute-types = { path = "../compute-types" }
+mz-dyncfg = { path = "../dyncfg" }
+mz-persist-client = { path = "../persist-client" }
+mz-persist-txn = { path = "../persist-txn" }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]

--- a/src/dyncfgs/src/lib.rs
+++ b/src/dyncfgs/src/lib.rs
@@ -29,5 +29,6 @@ pub fn all_dyncfgs() -> ConfigSet {
     configs = mz_persist_client::cfg::all_dyncfgs(configs);
     configs = mz_persist_txn::all_dyncfgs(configs);
     configs = mz_compute_types::dyncfgs::all_dyncfgs(configs);
+    configs = mz_adapter_types::dyncfgs::all_dyncfgs(configs);
     configs
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1035,10 +1035,9 @@ pub struct SystemVars {
     vars: BTreeMap<&'static UncasedStr, SystemVar>,
 
     active_connection_count: Arc<Mutex<ConnectionCounter>>,
-    /// NB: This is intentionally disconnected from the one that is plumbed
-    /// around to various components. This is so we can explictly control and
-    /// reason about when changes to config values are propagated to the rest
-    /// of the system.
+    /// NB: This is intentionally disconnected from the one that is plumbed around to persist and
+    /// the controllers. This is so we can explictly control and reason about when changes to config
+    /// values are propagated to the rest of the system.
     dyncfgs: ConfigSet,
 }
 
@@ -1193,7 +1192,6 @@ impl SystemVars {
             &OPTIMIZER_ONESHOT_STATS_TIMEOUT,
             &PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE,
             &WEBHOOK_CONCURRENT_REQUEST_LIMIT,
-            &ENABLE_STATEMENT_LIFECYCLE_LOGGING,
             &ENABLE_DEPENDENCY_READ_HOLD_ASSERTS,
             &TIMESTAMP_ORACLE_IMPL,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE,
@@ -1267,6 +1265,10 @@ impl SystemVars {
         vars.refresh_internal_state();
 
         vars
+    }
+
+    pub fn dyncfgs(&self) -> &ConfigSet {
+        &self.dyncfgs
     }
 
     pub fn set_unsafe(mut self, allow_unsafe: bool) -> Self {
@@ -2064,10 +2066,6 @@ impl SystemVars {
     /// Returns the `webhook_concurrent_request_limit` configuration parameter.
     pub fn webhook_concurrent_request_limit(&self) -> usize {
         *self.expect_value(&WEBHOOK_CONCURRENT_REQUEST_LIMIT)
-    }
-
-    pub fn enable_statement_lifecycle_logging(&self) -> bool {
-        *self.expect_value(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
     }
 
     /// Returns the `timestamp_oracle` configuration parameter.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1450,13 +1450,6 @@ pub static USER_STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION: VarDefinition = VarD
     true,
 );
 
-pub static ENABLE_STATEMENT_LIFECYCLE_LOGGING: VarDefinition = VarDefinition::new(
-    "enable_statement_lifecycle_logging",
-    value!(bool; false),
-    "Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history",
-    true,
-);
-
 pub static ENABLE_DEPENDENCY_READ_HOLD_ASSERTS: VarDefinition = VarDefinition::new(
     "enable_dependency_read_hold_asserts",
     value!(bool; true),


### PR DESCRIPTION
Switch over just a single var for now to ensure plumbing is correct, then can do more.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a