### PR TITLE
adapter: support mock LaunchDarkly connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "launchdarkly-server-sdk"
 version = "1.0.0"
-source = "git+https://github.com/MaterializeInc/rust-server-sdk#df1440c8b93a192d50470d1b258615febe52f1f8"
+source = "git+https://github.com/aalexandrov/rust-server-sdk?branch=ld_mock#abb93aca271dd6fff73e3d828081b2d59036d3fc"
 dependencies = [
  "built",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,7 @@ opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-ru
 # it into a release.
 # Also bumps lru to 0.12.0
 # Needs a more complex update to 2.0.0, with a custom TLS connector.
-launchdarkly-server-sdk = { git = "https://github.com/MaterializeInc/rust-server-sdk" }
+launchdarkly-server-sdk = { git = "https://github.com/aalexandrov/rust-server-sdk", branch = "ld_mock"}
 
 # Waiting on https://github.com/AltSysrq/proptest/pull/264.
 proptest = { git = "https://github.com/MaterializeInc/proptest.git" }

--- a/misc/python/materialize/ld_mock.py
+++ b/misc/python/materialize/ld_mock.py
@@ -1,0 +1,91 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import argparse
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from materialize.mzcompose import DEFAULT_SYSTEM_PARAMETERS
+
+
+def handler_factory(config: dict[str, str]) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/polling/sdk/latest-all":
+                self.handle_latest_all()
+            else:
+                self.handle_empty(404)
+
+        def do_POST(self):
+            self.handle_empty(200)  # accept all
+
+        def handle_latest_all(self) -> None:
+            response = json.dumps(
+                {
+                    "segments": {},
+                    "flags": {
+                        key: {
+                            "key": key,
+                            "on": False,
+                            "prerequisites": [],
+                            "targets": [],
+                            "rules": [],
+                            "fallthrough": {"variation": 0},
+                            "offVariation": 0,
+                            "variations": [val],
+                            "salt": "",
+                        }
+                        for key, val in config.items()
+                    },
+                },
+                indent=2,
+            )
+            print(str(len(response)))
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(response)))
+            self.send_header("accept-ranges", "none")
+            self.end_headers()
+            self.wfile.write(response.encode("utf-8"))
+            self.wfile.flush()
+
+        def handle_empty(self, code: int):
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+
+    return Handler
+
+
+def run(addr: str, port: int, config: dict[str, str]):
+    server_address = (addr, port)
+    httpd = HTTPServer(server_address, handler_factory(config))
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run a simple mock LaunchDarkly server",
+    )
+    parser.add_argument(
+        "-l",
+        "--listen",
+        default="0.0.0.0",
+        help="Specify the IP address on which the server listens",
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        type=int,
+        default=9000,
+        help="Specify the port on which the server listens",
+    )
+
+    args = parser.parse_args()
+    run(addr=args.listen, port=args.port, config=DEFAULT_SYSTEM_PARAMETERS)


### PR DESCRIPTION
Interpret values of `launchdarkly-sdk-key` / `MZ_LAUNCHDARKLY_SDK_KEY` that can be parsed as a socket address as an indication to configure LaunchDarkly to work against a polling address sitting behind `http://{url}/polling`.

This can be used to provide overrides in CI tests without depending directly on LaunchDarkly. Note that hopefully at some point  the Rust SDK will catch up with other languages and we will be able to use [this feature](https://docs.launchdarkly.com/sdk/features/flags-from-files) and won't need to run a mock LD server process. 

### Motivation

  * This PR adds a feature that has not yet been specified.

Exploring another solution of #25924

### Tips for reviewer

To test this, first start a mock LaunchDarkly server (1):

```bash
bin/pyactivate -m materialize.ld_mock -l 127.0.0.1 -p 9000
```

and then `environmentd` with a custom `MZ_LAUNCHDARKLY_SDK_KEY` (2)

```bash
MZ_LAUNCHDARKLY_SDK_KEY=127.0.0.1:9000 MZ_CONFIG_SYNC_LOOP_INTERVAL=30s bin/environmentd
```

If there is an easy way to make (1) available to (2) in `mzcompose` I think we could fix the issue described in #25924 with a more general, single `*.py` extension in a single place.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
