### PR TITLE
storage: add timeline_id to mz_postgres_sources

### DIFF
--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -93,7 +93,7 @@ When you define a source, Materialize will automatically:
     `mz_internal.mz_postgres_sources`.
 
     ```sql
-    SELECT * FROM mz_internal.mz_postgres_sources;
+    SELECT id, replication_slot FROM mz_internal.mz_postgres_sources;
     ```
 
     ```

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -477,6 +477,7 @@ system.
 | ------------------- | ---------------- | --------                                                                                                       |
 | `id`                | [`text`]         | The ID of the source. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources).                   |
 | `replication_slot`  | [`text`]         | The name of the replication slot in the PostgreSQL database that Materialize will create and stream data from. |
+| `timeline_id`       | [`uint8`]        | The PostgreSQL timeline ID determined when creating the source.                                                |
 
 <!--
 ### `mz_prepared_statement_history`

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -563,6 +563,7 @@ impl CatalogState {
             row: Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::String(&postgres.publication_details.slot),
+                Datum::from(postgres.publication_details.timeline_id),
             ]),
             diff,
         }]

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -1954,7 +1954,8 @@ pub static MZ_POSTGRES_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     oid: oid::TABLE_MZ_POSTGRES_SOURCES_OID,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
-        .with_column("replication_slot", ScalarType::String.nullable(false)),
+        .with_column("replication_slot", ScalarType::String.nullable(false))
+        .with_column("timeline_id", ScalarType::UInt64.nullable(true)),
     is_retained_metrics_object: false,
     access: vec![PUBLIC_SELECT],
 });

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -338,9 +338,9 @@ $ set-regex match=(\s{12}0|\d{13,20}|u\d{1,5}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\
 $ set-regex match=[0-9]+|_[a-f0-9]+ replacement=<SUPPRESSED>
 
 > SELECT * FROM mz_internal.mz_postgres_sources
-id             replication_slot
----------------------------------------
-u<SUPPRESSED>  materialize<SUPPRESSED>
+id             replication_slot         timeline_id
+---------------------------------------------------
+u<SUPPRESSED>  materialize<SUPPRESSED>  <SUPPRESSED>
 
 $ unset-regex
 

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -279,6 +279,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 ----
 1  id  text
 2  replication_slot  text
+3  timeline_id  uint8
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_sessions' ORDER BY position


### PR DESCRIPTION
Used to help debug things like: https://github.com/MaterializeInc/materialize/issues/25802

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - adds `timeline_id` to `mz_internal.mz_postgres_sources`
