### PR TITLE
adapter,testdrive: respect overridden defaults when validating catalog

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -2007,10 +2007,12 @@ impl CatalogState {
         })?;
 
         // Stitch in system parameter defaults.
-        dump.as_object_mut().unwrap().insert(
-            "system_parameter_defaults".into(),
-            serde_json::json!(self.system_config().defaults()),
-        );
+        dump.as_object_mut()
+            .expect("state must have been dumped")
+            .insert(
+                "system_parameter_defaults".into(),
+                serde_json::json!(self.system_config().defaults()),
+            );
 
         // Emit as pretty-printed JSON.
         Ok(serde_json::to_string_pretty(&dump).expect("cannot fail on serde_json::Value"))

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1464,6 +1464,20 @@ impl SystemVars {
         Ok(result)
     }
 
+    /// Returns a map from each system parameter's name to its default value.
+    pub fn defaults(&self) -> BTreeMap<String, String> {
+        self.vars
+            .iter()
+            .map(|(name, var)| {
+                let default = var
+                    .dynamic_default
+                    .as_deref()
+                    .unwrap_or(var.definition.default_value());
+                (name.as_str().to_owned(), default.format())
+            })
+            .collect()
+    }
+
     /// Propagate a change to the parameter named `name` to our state.
     fn propagate_var_change(&mut self, name: &str) {
         if name == MAX_CONNECTIONS.name || name == SUPERUSER_RESERVED_CONNECTIONS.name {

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2101,7 +2101,7 @@ feature_flags!(
     {
         name: enable_equivalence_propagation,
         desc: "Enable the EquivalencePropagation transform in the optimizer",
-        default: true, // TODO(aalexandrov): revert this to false
+        default: false,
         internal: true,
         enable_for_item_parsing: false,
     },

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -304,7 +304,11 @@ impl State {
     }
     /// Makes of copy of the durable catalog and runs a function on its
     /// state. Returns `None` if there's no catalog information in the State.
-    pub async fn with_catalog_copy<F, T>(&self, f: F) -> Result<Option<T>, anyhow::Error>
+    pub async fn with_catalog_copy<F, T>(
+        &self,
+        system_parameter_defaults: BTreeMap<String, String>,
+        f: F,
+    ) -> Result<Option<T>, anyhow::Error>
     where
         F: FnOnce(ConnCatalog) -> T,
     {
@@ -335,6 +339,7 @@ impl State {
                 persist_client,
                 SYSTEM_TIME.clone(),
                 self.environment_id.clone(),
+                system_parameter_defaults,
             )
             .await?;
             let res = f(catalog.for_session(&Session::dummy()));


### PR DESCRIPTION
When Testdrive validates the in-memory state of the catalog against its on disk state, in needs to take any system parameter defaults that were overridden by the `--system-parameter-default` environmentd argument into consideration.

The approach taken here is to have the internal /catalog/dump return system parameter defaults as part of the catalog state. They're then readily available to Testdrive when it loads the on-disk catalog.

Alternative to https://github.com/MaterializeInc/materialize/pull/25946.
Alternative to https://github.com/MaterializeInc/materialize/pull/25924.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
