### PR TITLE
sql: add comment about JSON nulls to jsonb_object_agg implementation

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3071,6 +3071,12 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
 
                 let json_null = HirScalarExpr::literal(Datum::JsonNull, ScalarType::Jsonb);
                 let key = typeconv::to_string(ecx, key);
+                // `AggregateFunc::JsonbObjectAgg` uses the same underlying
+                // implementation as `AggregateFunc::MapAgg`, so it's our
+                // responsibility to apply the JSON-specific behavior of casting
+                // SQL nulls to JSON nulls; otherwise the produced `Datum::Map`
+                // can contain `Datum::Null` values that are not valid for the
+                // `ScalarType::Jsonb` type.
                 let val = HirScalarExpr::CallVariadic {
                     func: VariadicFunc::Coalesce,
                     exprs: vec![typeconv::to_jsonb(ecx, val), json_null],


### PR DESCRIPTION
Requested in the review of #25941.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
