### PR TITLE
tests: RQG: use Postgres 16.2, re-enable test

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1075,7 +1075,6 @@ steps:
     steps:
       - id: rqg-simple-aggregates
         label: "RQG simple-aggregates workload"
-        skip: "#25926"
         timeout_in_minutes: 45
         agents:
           queue: linux-aarch64-small

--- a/test/rqg/mzcompose.py
+++ b/test/rqg/mzcompose.py
@@ -233,7 +233,8 @@ def run_workload(c: Composition, args: argparse.Namespace, workload: Workload) -
             )
             psql_urls.append("postgresql://materialize@mz_other:6875/materialize")
         case ReferenceImplementation.POSTGRES:
-            participants.append(Postgres(ports=["15432:5432"]))
+            # PG with at least version 16.2 is required due to #25926
+            participants.append(Postgres(image="postgres:16.2", ports=["15432:5432"]))
             psql_urls.append("postgresql://postgres:postgres@postgres/postgres")
         case None:
             pass


### PR DESCRIPTION
Nightly: https://buildkite.com/materialize/nightlies/builds/6861 ✅ 