### PR TITLE
ci: Track misc/python dependencies

### DIFF
--- a/bin/ci-python-imports
+++ b/bin/ci-python-imports
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# ci-python-imports - List all files transitively imported by a mzcompose
+# composition. This is a separate script instead of a module to prevent
+# polluting namespaces and inherting a polluted namespace.
+
+import os
+import sys
+import argparse
+from materialize import MZ_ROOT
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="ci-python-imports",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+ci-python-imports - List all files transitively imported by a mzcompose
+composition. This is a separate script instead of a module to prevent polluting
+namespaces and inherting a polluted namespace.""",
+    )
+    parser.add_argument("path", type=str, help="path to composition")
+    args = parser.parse_args()
+
+    sys.path.insert(1, args.path)
+    import mzcompose
+
+    for key, module in sys.modules.items():
+        if not key.startswith("materialize."):
+            continue
+        if module.__file__ is not None:
+            print(os.path.relpath(module.__file__, MZ_ROOT))
+        # Ignore all not explicitly imported files of the module
+        # else:
+        #     for path in module.__path__:
+        #         for file in os.listdir(path):
+        #             if file.endswith(".py"):
+        #                 print(os.path.relpath(os.path.join(path, file), MZ_ROOT))
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
 instead of not trimming pipelines whenever any file in there way touched

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
