### PR TITLE
testing: Use newer toxiproxy dockerhub image

### DIFF
--- a/misc/python/materialize/mzcompose/services/toxiproxy.py
+++ b/misc/python/materialize/mzcompose/services/toxiproxy.py
@@ -19,7 +19,7 @@ class Toxiproxy(Service):
     def __init__(
         self,
         name: str = "toxiproxy",
-        image: str = "shopify/toxiproxy:2.1.4",
+        image: str = "jauderho/toxiproxy:v2.8.0",
         port: int = 8474,
         seed: int = random.randrange(2**63),
     ) -> None:


### PR DESCRIPTION
With linux/arm images. Should make CI faster

The shopify images have had no updates in the last 5 years(!)

This might explain https://github.com/MaterializeInc/materialize/issues/22486

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
