### PR TITLE
adapter: bump all coord messages to INFO

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2543,8 +2543,9 @@ impl Coordinator {
                 // for them to make it easy to find slow messages.
                 let msg_kind = msg.kind();
                 let span = span!(
-                    Level::DEBUG,
-                    "coordinator processing (handle_message)",
+                    target: "mz_adapter::coord::handle_message_loop",
+                    Level::INFO,
+                    "coord::handle_message",
                     kind = msg_kind
                 );
                 let otel_context = span.context().span().span_context().clone();


### PR DESCRIPTION
This will help us track down slow coord messages, at the increased risk of overwhelming our tracing infra or envd resources to trace everything. If that happens, we can decrease the otel levels in LD until this commit is reverted.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a