### PR TITLE
ci: fix shellcheck version check to support 0.10.0

### DIFF
--- a/ci/test/lint-main/before/can-lint.sh
+++ b/ci/test/lint-main/before/can-lint.sh
@@ -24,7 +24,7 @@ if [[ ! "${MZDEV_NO_SHELLCHECK:-}" ]]; then
         echo -e "hint: you can disable shellcheck locally by setting \$MZDEV_NO_SHELLCHECK=1" >&2
         exit 1
     fi
-    version=$(shellcheck --version | grep version: | grep -oE "[0-9]\.[0-9]\.[0-9]" || echo "0.0.0+unknown")
+    version=$(shellcheck --version | grep version: | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" || echo "0.0.0+unknown")
     if ! version_compat "0.7.0" "$version"; then
         echo -e "lint: $(red fatal:) shellcheck v0.7.0+ is required" >&2
         echo -e "hint: detected version \"$version\"" >&2


### PR DESCRIPTION
The shellcheck version check expected a version of the form `d.d.d` where `d` is a digit; the stable version of shellcheck has a two-digit minor version number (0.10.0).

### Motivation

  * This PR fixes a previously unreported bug.

  `can-lint.sh` spuriously fails for shellcheck versions that involve multi-digit numbers.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
