### PR TITLE
mzbuild: add ensure subcommand to bin/mzimage

### DIFF
--- a/misc/python/materialize/cli/mzimage.py
+++ b/misc/python/materialize/cli/mzimage.py
@@ -35,6 +35,8 @@ def main() -> int:
             rimage.run(args.image_args)
         elif args.command == "acquire":
             deps.acquire()
+        elif args.command == "ensure":
+            deps.ensure()
         elif args.command == "fingerprint":
             print(rimage.fingerprint())
         elif args.command == "spec":
@@ -91,6 +93,11 @@ def _parse_args() -> argparse.Namespace:
 
     add_image_subcommand(
         "acquire", description="Download or build an image.", help="acquire an image"
+    )
+    add_image_subcommand(
+        "ensure",
+        description="Ensure an image exists in the remote registry.",
+        help="ensure an image",
     )
 
     run_parser = add_image_subcommand(


### PR DESCRIPTION
Expose the mzbuild "ensure" operation, which builds and pushes an image if it does not already exist in the remote registry, to the mzimage CLI.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
