### PR TITLE
DNM: Migrate filters in redundant join elimination

### DIFF
--- a/test/sqllogictest/github-9147.slt
+++ b/test/sqllogictest/github-9147.slt
@@ -17,17 +17,11 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE 1 in (SELECT 1 FROM (VALUES (0)) CONSTANT WHERE f1 > 1);
 ----
 Explained Query:
-  Project (#0, #1) // { arity: 2 }
-    Join on=(#0 = #2) type=differential // { arity: 3 }
-      implementation
-        %1[#0]UKA » %0:t1[#0]K
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Distinct project=[#0] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Filter (#0 > 1) // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
+  Filter (#0 > 1) // { arity: 2 }
+    ReadStorage materialize.public.t1 // { arity: 2 }
+
+Source materialize.public.t1
+  filter=((#0 > 1))
 
 EOF
 

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -165,43 +165,30 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
         implementation
-          %1[#0]UKA » %0:l[#0]K
+          %1[#0]UKA » %0:l0[#0]K
         ArrangeBy keys=[[#0]] // { arity: 2 }
-          ReadStorage materialize.public.l // { arity: 2 }
+          Get l0 // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
-          Distinct project=[#0] // { arity: 1 }
+          Distinct project=[(#0 + 1)] // { arity: 1 }
             Project (#0) // { arity: 1 }
-              Join on=(#1 = #2 = #3) type=delta // { arity: 4 }
+              Join on=(#0 = #1) type=differential // { arity: 2 }
                 implementation
-                  %0:l1 » %1[#0]UKA » %2[#0]UKA
-                  %1 » %2[#0]UKA » %0:l1[#1]Kf
-                  %2 » %1[#0]UKA » %0:l1[#1]Kf
-                ArrangeBy keys=[[#1]] // { arity: 2 }
-                  Filter (#0 = (#1 + 1)) // { arity: 2 }
-                    Get l1 // { arity: 2 }
+                  %1[#0]UKA » %0:l1[#0]K
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct project=[#0] // { arity: 1 }
-                    Project (#1) // { arity: 1 }
-                      Filter (#1) IS NOT NULL // { arity: 2 }
-                        Get l1 // { arity: 2 }
+                  Get l1 // { arity: 1 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[(#0 + 1)] // { arity: 1 }
-                    Project (#0) // { arity: 1 }
-                      Filter (#0) IS NOT NULL // { arity: 2 }
-                        ReadStorage materialize.public.l // { arity: 2 }
+                    Get l1 // { arity: 1 }
   With
     cte l1 =
-      CrossJoin type=differential // { arity: 2 }
-        implementation
-          %0[×] » %1:l0[×]
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Distinct project=[#0] // { arity: 1 }
-            Get l0 // { arity: 1 }
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Get l0 // { arity: 1 }
-    cte l0 =
       Project (#0) // { arity: 1 }
+        Get l0 // { arity: 2 }
+    cte l0 =
+      Filter (#0) IS NOT NULL // { arity: 2 }
         ReadStorage materialize.public.l // { arity: 2 }
+
+Source materialize.public.l
+  filter=((#0) IS NOT NULL)
 
 EOF
 

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -757,50 +757,39 @@ Explained Query:
     With
       cte l3 =
         Project (#0..=#3, #5) // { arity: 5 }
-          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{containerforumid} = #18{id}) type=delta // { arity: 19 }
-            implementation
-              %0:l2 » %1:message[#9]KA » %2[#0]UKA » %3[#0]UKA
-              %1:message » %2[#0]UKA » %3[#0]UKA » %0:l2[#1]K
-              %2 » %3[#0]UKA » %1:message[#10]KA » %0:l2[#1]K
-              %3 » %2[#0]UKA » %1:message[#10]KA » %0:l2[#1]K
-            Get l2 // { arity: 4 }
-            ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
-              ReadIndex on=message message_containerforumid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-              Distinct project=[#0{containerforumid}] // { arity: 1 }
-                Project (#10) // { arity: 1 }
-                  Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
-                    ReadIndex on=message message_creatorpersonid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Get l0 // { arity: 1 }
+          Filter (#14{containerforumid}) IS NOT NULL // { arity: 18 }
+            Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{id}) type=delta // { arity: 18 }
+              implementation
+                %0:l2 » %1:message[#9]KA » %2[#0]UKA
+                %1:message » %2[#0]UKA » %0:l2[#1]K
+                %2 » %1:message[#10]KA » %0:l2[#1]K
+              Get l2 // { arity: 4 }
+              ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
+                ReadIndex on=message message_containerforumid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                Distinct project=[#0{id}] // { arity: 1 }
+                  Get l0 // { arity: 1 }
       cte l2 =
         ArrangeBy keys=[[#1{id}]] // { arity: 4 }
           Get l1 // { arity: 4 }
       cte l1 =
         Project (#0..=#3) // { arity: 4 }
-          Join on=(#1{id} = #11{id} = #12{personid}) type=delta // { arity: 13 }
-            implementation
-              %0:person » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:person[#1]KA
-              %2 » %1[#0]UKA » %0:person[#1]KA
-            ArrangeBy keys=[[#1{id}]] // { arity: 11 }
-              ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#1{id}) IS NOT NULL // { arity: 11 }
-                    ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
-            ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
-              Distinct project=[#0{personid}] // { arity: 1 }
-                Project (#3) // { arity: 1 }
-                  Join on=(#0{id} = #2{forumid}) type=differential // { arity: 4 }
-                    implementation
-                      %1:forum_hasmember_person[#1]KA » %0:l0[#0]K
-                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                      Get l0 // { arity: 1 }
-                    ArrangeBy keys=[[#1{forumid}]] // { arity: 3 }
-                      ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[differential join] // { arity: 3 }
+          Filter (#1{id}) IS NOT NULL // { arity: 12 }
+            Join on=(#1{id} = #11{personid}) type=differential // { arity: 12 }
+              implementation
+                %1[#0]UKA » %0:person[#1]KA
+              ArrangeBy keys=[[#1{id}]] // { arity: 11 }
+                ReadIndex on=person person_id=[differential join] // { arity: 11 }
+              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                Distinct project=[#0{personid}] // { arity: 1 }
+                  Project (#3) // { arity: 1 }
+                    Join on=(#0{id} = #2{forumid}) type=differential // { arity: 4 }
+                      implementation
+                        %1:forum_hasmember_person[#1]KA » %0:l0[#0]K
+                      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                        Get l0 // { arity: 1 }
+                      ArrangeBy keys=[[#1{forumid}]] // { arity: 3 }
+                        ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[differential join] // { arity: 3 }
       cte l0 =
         Project (#0) // { arity: 1 }
           TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
@@ -809,10 +798,10 @@ Explained Query:
                 ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.person_id (*** full scan ***, delta join 1st input (full scan))
+  - materialize.public.person_id (differential join)
   - materialize.public.forum_hasmember_person_forumid (differential join)
   - materialize.public.message_containerforumid (delta join lookup)
-  - materialize.public.message_creatorpersonid (*** full scan ***, delta join lookup)
+  - materialize.public.message_creatorpersonid (delta join lookup)
   - materialize.public.top100popularforumsq04_id (*** full scan ***)
 
 EOF
@@ -2520,9 +2509,9 @@ Explained Query:
     Return // { arity: 3 }
       Project (#1, #2, #2) // { arity: 3 }
         Filter (#1{person2id} = 15393162796819) AND (#2 = #2) // { arity: 3 }
-          Get l4 // { arity: 3 }
+          Get l3 // { arity: 3 }
     With Mutually Recursive
-      cte l4 =
+      cte l3 =
         Project (#2, #0, #1) // { arity: 3 }
           Map (1450) // { arity: 3 }
             Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
@@ -2532,10 +2521,10 @@ Explained Query:
                     Map ((#1 + #4)) // { arity: 6 }
                       Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
                         implementation
-                          %0:l4[#0]K » %1[#0]K
+                          %0:l3[#0]K » %1[#0]K
                         ArrangeBy keys=[[#0]] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
-                            Get l4 // { arity: 3 }
+                            Get l3 // { arity: 3 }
                         ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
                           Project (#0, #1, #3) // { arity: 3 }
                             Map ((10 / bigint_to_double((coalesce(#2, 0) + 10)))) // { arity: 4 }
@@ -2546,21 +2535,21 @@ Explained Query:
                                       Project (#0, #1) // { arity: 2 }
                                         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                                           implementation
-                                            %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
+                                            %1[#1, #0]UKK » %0:l2[greatest(#0, #1), least(#0, #1)]KK
                                           ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                                            Get l3 // { arity: 2 }
+                                            Get l2 // { arity: 2 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                                             Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                                               Project (#0, #1) // { arity: 2 }
-                                                Get l2 // { arity: 3 }
-                                    Get l3 // { arity: 2 }
-                                Get l2 // { arity: 3 }
+                                                Get l1 // { arity: 3 }
+                                    Get l2 // { arity: 2 }
+                                Get l1 // { arity: 3 }
                   Constant // { arity: 2 }
                     - (1450, 0)
-      cte l3 =
+      cte l2 =
         Project (#1, #2) // { arity: 2 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-      cte l2 =
+      cte l1 =
         Project (#0, #1, #4) // { arity: 3 }
           Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
             implementation
@@ -2570,59 +2559,32 @@ Explained Query:
                 ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
             ArrangeBy keys=[[#1, #0]] // { arity: 3 }
               Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
-                  Join on=(#3{containerforumid} = #4{containerforumid} = #5{id}) type=delta // { arity: 6 }
+                Project (#1, #2, #6) // { arity: 3 }
+                  Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                     implementation
-                      %0:l1 » %1[#0]UKA » %2[#0]UKA
-                      %1 » %2[#0]UKA » %0:l1[#3]K
-                      %2 » %1[#0]UKA » %0:l1[#3]K
-                    ArrangeBy keys=[[#3{containerforumid}]] // { arity: 4 }
-                      Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-                      Distinct project=[#0{containerforumid}] // { arity: 1 }
-                        Project (#3) // { arity: 1 }
-                          Filter (#3{containerforumid}) IS NOT NULL // { arity: 4 }
-                            Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                      Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#1) // { arity: 1 }
-                          Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                            ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
-      cte l1 =
-        Project (#0, #1, #3, #4) // { arity: 4 }
-          Join on=(#2{containerforumid} = #5{containerforumid} = #6{id}) type=delta // { arity: 7 }
-            implementation
-              %0:l0 » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:l0[#2]K
-              %2 » %1[#0]UKA » %0:l0[#2]K
-            ArrangeBy keys=[[#2{containerforumid}]] // { arity: 5 }
-              Get l0 // { arity: 5 }
-            ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-              Distinct project=[#0{containerforumid}] // { arity: 1 }
-                Project (#2) // { arity: 1 }
-                  Filter (#2{containerforumid}) IS NOT NULL // { arity: 5 }
-                    Get l0 // { arity: 5 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                    ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+                      %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
+                      %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                      %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                      %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                      %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                    ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                      ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
+                    ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                      Project (#1, #9, #10, #12) // { arity: 4 }
+                        Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                      Project (#9, #10, #12) // { arity: 3 }
+                        Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    Get l0 // { arity: 1 }
+                    Get l0 // { arity: 1 }
       cte l0 =
-        Project (#1, #2, #5, #6, #8) // { arity: 5 }
-          Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid}) type=delta // { arity: 10 }
-            implementation
-              %0:person_knows_person » %1:message[#1]KA » %2:message[#0, #2]KK
-              %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK
-              %2:message » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK
-            ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-              ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
-            ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
-              Project (#1, #9, #10, #12) // { arity: 4 }
-                ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
-              Project (#9, #10, #12) // { arity: 3 }
-                Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                  ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+          Distinct project=[#0{id}] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
+                ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -2744,175 +2706,175 @@ Explained Query:
       Project (#1) // { arity: 1 }
         Map (coalesce(#0, -1)) // { arity: 2 }
           Union // { arity: 1 }
-            Get l19 // { arity: 1 }
+            Get l18 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Project () // { arity: 0 }
-                    Get l19 // { arity: 1 }
+                    Get l18 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
     With
-      cte l19 =
+      cte l18 =
         Reduce aggregates=[min(#0)] // { arity: 1 }
           Project (#2) // { arity: 1 }
             Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
                 Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
                   implementation
-                    %0:l18[#1]Kef » %1:l18[#1]Kef
+                    %0:l17[#1]Kef » %1:l17[#1]Kef
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
-                        Get l18 // { arity: 4 }
+                        Get l17 // { arity: 4 }
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
-                        Get l18 // { arity: 4 }
-      cte l18 =
+                        Get l17 // { arity: 4 }
+      cte l17 =
         Project (#0..=#3) // { arity: 4 }
           Join on=(#4 = #5) type=differential // { arity: 6 }
             implementation
-              %1[#0]UK » %0:l17[#4]K
+              %1[#0]UK » %0:l16[#4]K
             ArrangeBy keys=[[#4]] // { arity: 5 }
               Project (#0..=#3, #5) // { arity: 5 }
                 Filter (#5) IS NOT NULL // { arity: 6 }
-                  Get l17 // { arity: 6 }
+                  Get l16 // { arity: 6 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 1 }
                 Reduce aggregates=[max(#0)] // { arity: 1 }
                   Project (#5) // { arity: 1 }
-                    Get l17 // { arity: 6 }
+                    Get l16 // { arity: 6 }
   With Mutually Recursive
-    cte l17 =
+    cte l16 =
       Distinct project=[#0..=#5] // { arity: 6 }
         Union // { arity: 6 }
           Map (0) // { arity: 6 }
             Union // { arity: 5 }
               Project (#1, #0, #0, #2, #1) // { arity: 5 }
                 Map (1450, false, 0) // { arity: 3 }
-                  Get l16 // { arity: 0 }
+                  Get l15 // { arity: 0 }
               Project (#1, #0, #0, #2, #3) // { arity: 5 }
                 Map (15393162796819, true, 0, false) // { arity: 4 }
-                  Get l16 // { arity: 0 }
+                  Get l15 // { arity: 0 }
           Project (#0..=#3, #7, #8) // { arity: 6 }
             Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
               CrossJoin type=delta // { arity: 7 }
                 implementation
-                  %0:l13 » %1[×]U » %2[×]U
-                  %1 » %2[×]U » %0:l13[×]
-                  %2 » %1[×]U » %0:l13[×]
+                  %0:l12 » %1[×]U » %2[×]U
+                  %1 » %2[×]U » %0:l12[×]
+                  %2 » %1[×]U » %0:l12[×]
                 ArrangeBy keys=[[]] // { arity: 5 }
-                  Get l13 // { arity: 5 }
+                  Get l12 // { arity: 5 }
                 ArrangeBy keys=[[]] // { arity: 1 }
                   TopK limit=1 // { arity: 1 }
                     Project (#4) // { arity: 1 }
-                      Get l9 // { arity: 5 }
+                      Get l8 // { arity: 5 }
                 ArrangeBy keys=[[]] // { arity: 1 }
                   Union // { arity: 1 }
-                    Get l15 // { arity: 1 }
+                    Get l14 // { arity: 1 }
                     Map (null) // { arity: 1 }
                       Union // { arity: 0 }
                         Negate // { arity: 0 }
                           Project () // { arity: 0 }
-                            Get l15 // { arity: 1 }
+                            Get l14 // { arity: 1 }
                         Constant // { arity: 0 }
                           - ()
-    cte l16 =
+    cte l15 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
-            Get l8 // { arity: 2 }
-    cte l15 =
+            Get l7 // { arity: 2 }
+    cte l14 =
       Project (#1) // { arity: 1 }
         Map ((#0 / 2)) // { arity: 2 }
           Union // { arity: 1 }
-            Get l14 // { arity: 1 }
+            Get l13 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Project () // { arity: 0 }
-                    Get l14 // { arity: 1 }
+                    Get l13 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
-    cte l14 =
+    cte l13 =
       Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
         Project (#1, #3) // { arity: 2 }
           Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %0:l13[#0]Kef » %1:l13[#0]Kef
+              %0:l12[#0]Kef » %1:l12[#0]Kef
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = false) // { arity: 5 }
-                  Get l13 // { arity: 5 }
+                  Get l12 // { arity: 5 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = true) // { arity: 5 }
-                  Get l13 // { arity: 5 }
-    cte l13 =
+                  Get l12 // { arity: 5 }
+    cte l12 =
       TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
         Union // { arity: 5 }
           Project (#3, #4, #1, #7, #8) // { arity: 5 }
             Map ((#6 + #2), false) // { arity: 9 }
               Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
                 implementation
-                  %0:l4[#0]K » %1:l9[#2]K
+                  %0:l3[#0]K » %1:l8[#2]K
                 ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
-                  Get l4 // { arity: 3 }
+                  Get l3 // { arity: 3 }
                 ArrangeBy keys=[[#2]] // { arity: 4 }
                   Project (#0..=#3) // { arity: 4 }
-                    Get l9 // { arity: 5 }
+                    Get l8 // { arity: 5 }
           Project (#0..=#3, #16) // { arity: 5 }
             Map ((#4 OR #15)) // { arity: 17 }
               Join on=(#0 = #6 = #12 AND #1 = #7 = #13 AND #2 = #8 = #14 AND #3 = #9 AND #4 = #10 AND #5 = #11) type=delta // { arity: 16 }
                 implementation
-                  %0:l17 » %1:l10[#0..=#5]UKKKKKK » %2[#0..=#2]KKK
-                  %1:l10 » %0:l17[#0..=#5]KKKKKK » %2[#0..=#2]KKK
-                  %2 » %0:l17[#0..=#2]KKK » %1:l10[#0..=#5]UKKKKKK
+                  %0:l16 » %1:l9[#0..=#5]UKKKKKK » %2[#0..=#2]KKK
+                  %1:l9 » %0:l16[#0..=#5]KKKKKK » %2[#0..=#2]KKK
+                  %2 » %0:l16[#0..=#2]KKK » %1:l9[#0..=#5]UKKKKKK
                 ArrangeBy keys=[[#0..=#2], [#0..=#5]] // { arity: 6 }
-                  Get l17 // { arity: 6 }
+                  Get l16 // { arity: 6 }
                 ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
-                  Get l10 // { arity: 6 }
+                  Get l9 // { arity: 6 }
                 ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                   Union // { arity: 4 }
                     Map (true) // { arity: 4 }
-                      Get l12 // { arity: 3 }
+                      Get l11 // { arity: 3 }
                     Project (#0..=#2, #6) // { arity: 4 }
                       Map (false) // { arity: 7 }
                         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                           implementation
-                            %1:l11[#0..=#2]UKKK » %0[#0..=#2]KKK
+                            %1:l10[#0..=#2]UKKK » %0[#0..=#2]KKK
                           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                             Union // { arity: 3 }
                               Negate // { arity: 3 }
-                                Get l12 // { arity: 3 }
-                              Get l11 // { arity: 3 }
+                                Get l11 // { arity: 3 }
+                              Get l10 // { arity: 3 }
                           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                            Get l11 // { arity: 3 }
-    cte l12 =
+                            Get l10 // { arity: 3 }
+    cte l11 =
       Project (#0..=#2) // { arity: 3 }
         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
           implementation
-            %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
+            %1[#0..=#2]UKKKA » %0:l10[#0..=#2]UKKK
           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Get l11 // { arity: 3 }
+            Get l10 // { arity: 3 }
           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
             Distinct project=[#0..=#2] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
-                Get l9 // { arity: 5 }
-    cte l11 =
+                Get l8 // { arity: 5 }
+    cte l10 =
       Distinct project=[#0..=#2] // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
-          Get l10 // { arity: 6 }
-    cte l10 =
-      Distinct project=[#0..=#5] // { arity: 6 }
-        Get l17 // { arity: 6 }
+          Get l9 // { arity: 6 }
     cte l9 =
+      Distinct project=[#0..=#5] // { arity: 6 }
+        Get l16 // { arity: 6 }
+    cte l8 =
       TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
         Project (#0..=#3, #5) // { arity: 5 }
           Filter (#4 = false) // { arity: 6 }
-            Get l17 // { arity: 6 }
-    cte l8 =
+            Get l16 // { arity: 6 }
+    cte l7 =
       Distinct project=[#0{person2id}, #1] // { arity: 2 }
         Union // { arity: 2 }
           Distinct project=[#0{person2id}, #1] // { arity: 2 }
@@ -2920,51 +2882,51 @@ Explained Query:
               Project (#1, #0) // { arity: 2 }
                 CrossJoin type=differential // { arity: 2 }
                   implementation
-                    %0:l5[×] » %1[×]
+                    %0:l4[×] » %1[×]
                   ArrangeBy keys=[[]] // { arity: 2 }
-                    Get l5 // { arity: 2 }
+                    Get l4 // { arity: 2 }
                   ArrangeBy keys=[[]] // { arity: 0 }
                     Union // { arity: 0 }
                       Negate // { arity: 0 }
-                        Get l7 // { arity: 0 }
+                        Get l6 // { arity: 0 }
                       Constant // { arity: 0 }
                         - ()
               Project (#1, #0) // { arity: 2 }
                 Map (true, -1) // { arity: 2 }
-                  Get l7 // { arity: 0 }
+                  Get l6 // { arity: 0 }
           Constant // { arity: 2 }
             - (1450, true)
             - (15393162796819, false)
-    cte l7 =
+    cte l6 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
             implementation
-              %0:l6[#0]Kf » %1:l6[#0]Kf
+              %0:l5[#0]Kf » %1:l5[#0]Kf
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter #1 // { arity: 2 }
-                  Get l6 // { arity: 2 }
+                  Get l5 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter NOT(#1) // { arity: 2 }
-                  Get l6 // { arity: 2 }
-    cte l6 =
+                  Get l5 // { arity: 2 }
+    cte l5 =
       Union // { arity: 2 }
         Project (#1, #0) // { arity: 2 }
-          Get l5 // { arity: 2 }
-        Get l8 // { arity: 2 }
-    cte l5 =
+          Get l4 // { arity: 2 }
+        Get l7 // { arity: 2 }
+    cte l4 =
       Project (#1, #3) // { arity: 2 }
         Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
           implementation
-            %0:l8[#0]K » %1:l4[#0]K
+            %0:l7[#0]K » %1:l3[#0]K
           ArrangeBy keys=[[#0]] // { arity: 2 }
-            Get l8 // { arity: 2 }
+            Get l7 // { arity: 2 }
           ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
-              Get l4 // { arity: 3 }
-    cte l4 =
+              Get l3 // { arity: 3 }
+    cte l3 =
       Project (#0, #1, #3) // { arity: 3 }
         Map ((10 / bigint_to_double((coalesce(#2, 0) + 10)))) // { arity: 4 }
           Union // { arity: 3 }
@@ -2974,19 +2936,19 @@ Explained Query:
                   Project (#0, #1) // { arity: 2 }
                     Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                       implementation
-                        %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
+                        %1[#1, #0]UKK » %0:l2[greatest(#0, #1), least(#0, #1)]KK
                       ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                        Get l3 // { arity: 2 }
+                        Get l2 // { arity: 2 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                         Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                           Project (#0, #1) // { arity: 2 }
-                            Get l2 // { arity: 3 }
-                Get l3 // { arity: 2 }
-            Get l2 // { arity: 3 }
-    cte l3 =
+                            Get l1 // { arity: 3 }
+                Get l2 // { arity: 2 }
+            Get l1 // { arity: 3 }
+    cte l2 =
       Project (#1, #2) // { arity: 2 }
         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-    cte l2 =
+    cte l1 =
       Project (#0, #1, #4) // { arity: 3 }
         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
           implementation
@@ -2996,59 +2958,32 @@ Explained Query:
               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
             Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#0..=#2) // { arity: 3 }
-                Join on=(#3{containerforumid} = #4{containerforumid} = #5{id}) type=delta // { arity: 6 }
+              Project (#1, #2, #6) // { arity: 3 }
+                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                   implementation
-                    %0:l1 » %1[#0]UKA » %2[#0]UKA
-                    %1 » %2[#0]UKA » %0:l1[#3]K
-                    %2 » %1[#0]UKA » %0:l1[#3]K
-                  ArrangeBy keys=[[#3{containerforumid}]] // { arity: 4 }
-                    Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-                    Distinct project=[#0{containerforumid}] // { arity: 1 }
-                      Project (#3) // { arity: 1 }
-                        Filter (#3{containerforumid}) IS NOT NULL // { arity: 4 }
-                          Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                    Distinct project=[#0{id}] // { arity: 1 }
-                      Project (#1) // { arity: 1 }
-                        Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                          ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
-    cte l1 =
-      Project (#0, #1, #3, #4) // { arity: 4 }
-        Join on=(#2{containerforumid} = #5{containerforumid} = #6{id}) type=delta // { arity: 7 }
-          implementation
-            %0:l0 » %1[#0]UKA » %2[#0]UKA
-            %1 » %2[#0]UKA » %0:l0[#2]K
-            %2 » %1[#0]UKA » %0:l0[#2]K
-          ArrangeBy keys=[[#2{containerforumid}]] // { arity: 5 }
-            Get l0 // { arity: 5 }
-          ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-            Distinct project=[#0{containerforumid}] // { arity: 1 }
-              Project (#2) // { arity: 1 }
-                Filter (#2{containerforumid}) IS NOT NULL // { arity: 5 }
-                  Get l0 // { arity: 5 }
-          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-            Distinct project=[#0{id}] // { arity: 1 }
-              Project (#1) // { arity: 1 }
-                Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                  ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+                    %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                    %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
+                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                    Project (#1, #9, #10, #12) // { arity: 4 }
+                      Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                    Project (#9, #10, #12) // { arity: 3 }
+                      Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  Get l0 // { arity: 1 }
+                  Get l0 // { arity: 1 }
     cte l0 =
-      Project (#1, #2, #5, #6, #8) // { arity: 5 }
-        Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid}) type=delta // { arity: 10 }
-          implementation
-            %0:person_knows_person » %1:message[#1]KA » %2:message[#0, #2]KK
-            %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK
-            %2:message » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK
-          ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-            ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
-          ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
-            Project (#1, #9, #10, #12) // { arity: 4 }
-              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-          ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
-            Project (#9, #10, #12) // { arity: 3 }
-              Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+        Distinct project=[#0{id}] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
+              ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -3636,18 +3571,12 @@ Explained Query:
     With
       cte l1 =
         Project (#0..=#2) // { arity: 3 }
-          Join on=(#1{id} = #3{id} = #4{id}) type=delta // { arity: 5 }
+          Join on=(#1{id} = #3{id}) type=differential // { arity: 4 }
             implementation
-              %0:l0 » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:l0[#1]K
-              %2 » %1[#0]UKA » %0:l0[#1]K
+              %1[#0]UKA » %0:l0[#1]K
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                    Get l0 // { arity: 3 }
+              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                Get l0 // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
                 Project (#1) // { arity: 1 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -764,50 +764,39 @@ Explained Query:
     With
       cte l3 =
         Project (#0..=#3, #5) // { arity: 5 }
-          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{containerforumid} = #18{id}) type=delta // { arity: 19 }
-            implementation
-              %0:l2 » %1:message[#9]KA » %2[#0]UKA » %3[#0]UKA
-              %1:message » %2[#0]UKA » %3[#0]UKA » %0:l2[#1]K
-              %2 » %3[#0]UKA » %1:message[#10]KA » %0:l2[#1]K
-              %3 » %2[#0]UKA » %1:message[#10]KA » %0:l2[#1]K
-            Get l2 // { arity: 4 }
-            ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
-              ReadIndex on=message message_containerforumid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-              Distinct project=[#0{containerforumid}] // { arity: 1 }
-                Project (#10) // { arity: 1 }
-                  Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
-                    ReadIndex on=message message_creatorpersonid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Get l0 // { arity: 1 }
+          Filter (#14{containerforumid}) IS NOT NULL // { arity: 18 }
+            Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{id}) type=delta // { arity: 18 }
+              implementation
+                %0:l2 » %1:message[#9]KA » %2[#0]UKA
+                %1:message » %2[#0]UKA » %0:l2[#1]K
+                %2 » %1:message[#10]KA » %0:l2[#1]K
+              Get l2 // { arity: 4 }
+              ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
+                ReadIndex on=message message_containerforumid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                Distinct project=[#0{id}] // { arity: 1 }
+                  Get l0 // { arity: 1 }
       cte l2 =
         ArrangeBy keys=[[#1{id}]] // { arity: 4 }
           Get l1 // { arity: 4 }
       cte l1 =
         Project (#0..=#3) // { arity: 4 }
-          Join on=(#1{id} = #11{id} = #12{personid}) type=delta // { arity: 13 }
-            implementation
-              %0:person » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:person[#1]KA
-              %2 » %1[#0]UKA » %0:person[#1]KA
-            ArrangeBy keys=[[#1{id}]] // { arity: 11 }
-              ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#1{id}) IS NOT NULL // { arity: 11 }
-                    ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
-            ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
-              Distinct project=[#0{personid}] // { arity: 1 }
-                Project (#3) // { arity: 1 }
-                  Join on=(#0{id} = #2{forumid}) type=differential // { arity: 4 }
-                    implementation
-                      %1:forum_hasmember_person[#1]KA » %0:l0[#0]K
-                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                      Get l0 // { arity: 1 }
-                    ArrangeBy keys=[[#1{forumid}]] // { arity: 3 }
-                      ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[differential join] // { arity: 3 }
+          Filter (#1{id}) IS NOT NULL // { arity: 12 }
+            Join on=(#1{id} = #11{personid}) type=differential // { arity: 12 }
+              implementation
+                %1[#0]UKA » %0:person[#1]KA
+              ArrangeBy keys=[[#1{id}]] // { arity: 11 }
+                ReadIndex on=person person_id=[differential join] // { arity: 11 }
+              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                Distinct project=[#0{personid}] // { arity: 1 }
+                  Project (#3) // { arity: 1 }
+                    Join on=(#0{id} = #2{forumid}) type=differential // { arity: 4 }
+                      implementation
+                        %1:forum_hasmember_person[#1]KA » %0:l0[#0]K
+                      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                        Get l0 // { arity: 1 }
+                      ArrangeBy keys=[[#1{forumid}]] // { arity: 3 }
+                        ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[differential join] // { arity: 3 }
       cte l0 =
         Project (#0) // { arity: 1 }
           TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
@@ -816,10 +805,10 @@ Explained Query:
                 ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.person_id (*** full scan ***, delta join 1st input (full scan))
+  - materialize.public.person_id (differential join)
   - materialize.public.forum_hasmember_person_forumid (differential join)
   - materialize.public.message_containerforumid (delta join lookup)
-  - materialize.public.message_creatorpersonid (*** full scan ***, delta join lookup)
+  - materialize.public.message_creatorpersonid (delta join lookup)
   - materialize.public.top100popularforumsq04_id (*** full scan ***)
 
 EOF
@@ -2527,9 +2516,9 @@ Explained Query:
     Return // { arity: 3 }
       Project (#1, #2, #2) // { arity: 3 }
         Filter (#1{person2id} = 15393162796819) AND (#2 = #2) // { arity: 3 }
-          Get l4 // { arity: 3 }
+          Get l3 // { arity: 3 }
     With Mutually Recursive
-      cte l4 =
+      cte l3 =
         Project (#2, #0, #1) // { arity: 3 }
           Map (1450) // { arity: 3 }
             Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
@@ -2539,10 +2528,10 @@ Explained Query:
                     Map ((#1 + #4)) // { arity: 6 }
                       Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
                         implementation
-                          %0:l4[#0]K » %1[#0]K
+                          %0:l3[#0]K » %1[#0]K
                         ArrangeBy keys=[[#0]] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
-                            Get l4 // { arity: 3 }
+                            Get l3 // { arity: 3 }
                         ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
                           Project (#0, #1, #3) // { arity: 3 }
                             Map ((10 / bigint_to_double((coalesce(#2, 0) + 10)))) // { arity: 4 }
@@ -2553,21 +2542,21 @@ Explained Query:
                                       Project (#0, #1) // { arity: 2 }
                                         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                                           implementation
-                                            %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
+                                            %1[#1, #0]UKK » %0:l2[greatest(#0, #1), least(#0, #1)]KK
                                           ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                                            Get l3 // { arity: 2 }
+                                            Get l2 // { arity: 2 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                                             Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                                               Project (#0, #1) // { arity: 2 }
-                                                Get l2 // { arity: 3 }
-                                    Get l3 // { arity: 2 }
-                                Get l2 // { arity: 3 }
+                                                Get l1 // { arity: 3 }
+                                    Get l2 // { arity: 2 }
+                                Get l1 // { arity: 3 }
                   Constant // { arity: 2 }
                     - (1450, 0)
-      cte l3 =
+      cte l2 =
         Project (#1, #2) // { arity: 2 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-      cte l2 =
+      cte l1 =
         Project (#0, #1, #4) // { arity: 3 }
           Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
             implementation
@@ -2577,59 +2566,32 @@ Explained Query:
                 ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
             ArrangeBy keys=[[#1, #0]] // { arity: 3 }
               Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
-                  Join on=(#3{containerforumid} = #4{containerforumid} = #5{id}) type=delta // { arity: 6 }
+                Project (#1, #2, #6) // { arity: 3 }
+                  Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                     implementation
-                      %0:l1 » %1[#0]UKA » %2[#0]UKA
-                      %1 » %2[#0]UKA » %0:l1[#3]K
-                      %2 » %1[#0]UKA » %0:l1[#3]K
-                    ArrangeBy keys=[[#3{containerforumid}]] // { arity: 4 }
-                      Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-                      Distinct project=[#0{containerforumid}] // { arity: 1 }
-                        Project (#3) // { arity: 1 }
-                          Filter (#3{containerforumid}) IS NOT NULL // { arity: 4 }
-                            Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                      Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#1) // { arity: 1 }
-                          Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                            ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
-      cte l1 =
-        Project (#0, #1, #3, #4) // { arity: 4 }
-          Join on=(#2{containerforumid} = #5{containerforumid} = #6{id}) type=delta // { arity: 7 }
-            implementation
-              %0:l0 » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:l0[#2]K
-              %2 » %1[#0]UKA » %0:l0[#2]K
-            ArrangeBy keys=[[#2{containerforumid}]] // { arity: 5 }
-              Get l0 // { arity: 5 }
-            ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-              Distinct project=[#0{containerforumid}] // { arity: 1 }
-                Project (#2) // { arity: 1 }
-                  Filter (#2{containerforumid}) IS NOT NULL // { arity: 5 }
-                    Get l0 // { arity: 5 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                    ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+                      %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
+                      %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                      %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                      %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                      %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                    ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                      ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
+                    ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                      Project (#1, #9, #10, #12) // { arity: 4 }
+                        Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                      Project (#9, #10, #12) // { arity: 3 }
+                        Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    Get l0 // { arity: 1 }
+                    Get l0 // { arity: 1 }
       cte l0 =
-        Project (#1, #2, #5, #6, #8) // { arity: 5 }
-          Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid}) type=delta // { arity: 10 }
-            implementation
-              %0:person_knows_person » %1:message[#1]KA » %2:message[#0, #2]KK
-              %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK
-              %2:message » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK
-            ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-              ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
-            ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
-              Project (#1, #9, #10, #12) // { arity: 4 }
-                ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
-              Project (#9, #10, #12) // { arity: 3 }
-                Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                  ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+          Distinct project=[#0{id}] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
+                ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -2751,175 +2713,175 @@ Explained Query:
       Project (#1) // { arity: 1 }
         Map (coalesce(#0, -1)) // { arity: 2 }
           Union // { arity: 1 }
-            Get l19 // { arity: 1 }
+            Get l18 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Project () // { arity: 0 }
-                    Get l19 // { arity: 1 }
+                    Get l18 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
     With
-      cte l19 =
+      cte l18 =
         Reduce aggregates=[min(#0)] // { arity: 1 }
           Project (#2) // { arity: 1 }
             Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
                 Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
                   implementation
-                    %0:l18[#1]Kef » %1:l18[#1]Kef
+                    %0:l17[#1]Kef » %1:l17[#1]Kef
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
-                        Get l18 // { arity: 4 }
+                        Get l17 // { arity: 4 }
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
-                        Get l18 // { arity: 4 }
-      cte l18 =
+                        Get l17 // { arity: 4 }
+      cte l17 =
         Project (#0..=#3) // { arity: 4 }
           Join on=(#4 = #5) type=differential // { arity: 6 }
             implementation
-              %1[#0]UK » %0:l17[#4]K
+              %1[#0]UK » %0:l16[#4]K
             ArrangeBy keys=[[#4]] // { arity: 5 }
               Project (#0..=#3, #5) // { arity: 5 }
                 Filter (#5) IS NOT NULL // { arity: 6 }
-                  Get l17 // { arity: 6 }
+                  Get l16 // { arity: 6 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 1 }
                 Reduce aggregates=[max(#0)] // { arity: 1 }
                   Project (#5) // { arity: 1 }
-                    Get l17 // { arity: 6 }
+                    Get l16 // { arity: 6 }
   With Mutually Recursive
-    cte l17 =
+    cte l16 =
       Distinct project=[#0..=#5] // { arity: 6 }
         Union // { arity: 6 }
           Map (0) // { arity: 6 }
             Union // { arity: 5 }
               Project (#1, #0, #0, #2, #1) // { arity: 5 }
                 Map (1450, false, 0) // { arity: 3 }
-                  Get l16 // { arity: 0 }
+                  Get l15 // { arity: 0 }
               Project (#1, #0, #0, #2, #3) // { arity: 5 }
                 Map (15393162796819, true, 0, false) // { arity: 4 }
-                  Get l16 // { arity: 0 }
+                  Get l15 // { arity: 0 }
           Project (#0..=#3, #7, #8) // { arity: 6 }
             Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
               CrossJoin type=delta // { arity: 7 }
                 implementation
-                  %0:l13 » %1[×]U » %2[×]U
-                  %1 » %2[×]U » %0:l13[×]
-                  %2 » %1[×]U » %0:l13[×]
+                  %0:l12 » %1[×]U » %2[×]U
+                  %1 » %2[×]U » %0:l12[×]
+                  %2 » %1[×]U » %0:l12[×]
                 ArrangeBy keys=[[]] // { arity: 5 }
-                  Get l13 // { arity: 5 }
+                  Get l12 // { arity: 5 }
                 ArrangeBy keys=[[]] // { arity: 1 }
                   TopK limit=1 // { arity: 1 }
                     Project (#4) // { arity: 1 }
-                      Get l9 // { arity: 5 }
+                      Get l8 // { arity: 5 }
                 ArrangeBy keys=[[]] // { arity: 1 }
                   Union // { arity: 1 }
-                    Get l15 // { arity: 1 }
+                    Get l14 // { arity: 1 }
                     Map (null) // { arity: 1 }
                       Union // { arity: 0 }
                         Negate // { arity: 0 }
                           Project () // { arity: 0 }
-                            Get l15 // { arity: 1 }
+                            Get l14 // { arity: 1 }
                         Constant // { arity: 0 }
                           - ()
-    cte l16 =
+    cte l15 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
-            Get l8 // { arity: 2 }
-    cte l15 =
+            Get l7 // { arity: 2 }
+    cte l14 =
       Project (#1) // { arity: 1 }
         Map ((#0 / 2)) // { arity: 2 }
           Union // { arity: 1 }
-            Get l14 // { arity: 1 }
+            Get l13 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Project () // { arity: 0 }
-                    Get l14 // { arity: 1 }
+                    Get l13 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
-    cte l14 =
+    cte l13 =
       Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
         Project (#1, #3) // { arity: 2 }
           Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %0:l13[#0]Kef » %1:l13[#0]Kef
+              %0:l12[#0]Kef » %1:l12[#0]Kef
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = false) // { arity: 5 }
-                  Get l13 // { arity: 5 }
+                  Get l12 // { arity: 5 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = true) // { arity: 5 }
-                  Get l13 // { arity: 5 }
-    cte l13 =
+                  Get l12 // { arity: 5 }
+    cte l12 =
       TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
         Union // { arity: 5 }
           Project (#3, #4, #1, #7, #8) // { arity: 5 }
             Map ((#6 + #2), false) // { arity: 9 }
               Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
                 implementation
-                  %0:l4[#0]K » %1:l9[#2]K
+                  %0:l3[#0]K » %1:l8[#2]K
                 ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
-                  Get l4 // { arity: 3 }
+                  Get l3 // { arity: 3 }
                 ArrangeBy keys=[[#2]] // { arity: 4 }
                   Project (#0..=#3) // { arity: 4 }
-                    Get l9 // { arity: 5 }
+                    Get l8 // { arity: 5 }
           Project (#0..=#3, #16) // { arity: 5 }
             Map ((#4 OR #15)) // { arity: 17 }
               Join on=(#0 = #6 = #12 AND #1 = #7 = #13 AND #2 = #8 = #14 AND #3 = #9 AND #4 = #10 AND #5 = #11) type=delta // { arity: 16 }
                 implementation
-                  %0:l17 » %1:l10[#0..=#5]UKKKKKK » %2[#0..=#2]KKK
-                  %1:l10 » %0:l17[#0..=#5]KKKKKK » %2[#0..=#2]KKK
-                  %2 » %0:l17[#0..=#2]KKK » %1:l10[#0..=#5]UKKKKKK
+                  %0:l16 » %1:l9[#0..=#5]UKKKKKK » %2[#0..=#2]KKK
+                  %1:l9 » %0:l16[#0..=#5]KKKKKK » %2[#0..=#2]KKK
+                  %2 » %0:l16[#0..=#2]KKK » %1:l9[#0..=#5]UKKKKKK
                 ArrangeBy keys=[[#0..=#2], [#0..=#5]] // { arity: 6 }
-                  Get l17 // { arity: 6 }
+                  Get l16 // { arity: 6 }
                 ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
-                  Get l10 // { arity: 6 }
+                  Get l9 // { arity: 6 }
                 ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                   Union // { arity: 4 }
                     Map (true) // { arity: 4 }
-                      Get l12 // { arity: 3 }
+                      Get l11 // { arity: 3 }
                     Project (#0..=#2, #6) // { arity: 4 }
                       Map (false) // { arity: 7 }
                         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                           implementation
-                            %1:l11[#0..=#2]UKKK » %0[#0..=#2]KKK
+                            %1:l10[#0..=#2]UKKK » %0[#0..=#2]KKK
                           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                             Union // { arity: 3 }
                               Negate // { arity: 3 }
-                                Get l12 // { arity: 3 }
-                              Get l11 // { arity: 3 }
+                                Get l11 // { arity: 3 }
+                              Get l10 // { arity: 3 }
                           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                            Get l11 // { arity: 3 }
-    cte l12 =
+                            Get l10 // { arity: 3 }
+    cte l11 =
       Project (#0..=#2) // { arity: 3 }
         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
           implementation
-            %1[#0..=#2]UKKKA » %0:l11[#0..=#2]UKKK
+            %1[#0..=#2]UKKKA » %0:l10[#0..=#2]UKKK
           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Get l11 // { arity: 3 }
+            Get l10 // { arity: 3 }
           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
             Distinct project=[#0..=#2] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
-                Get l9 // { arity: 5 }
-    cte l11 =
+                Get l8 // { arity: 5 }
+    cte l10 =
       Distinct project=[#0..=#2] // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
-          Get l10 // { arity: 6 }
-    cte l10 =
-      Distinct project=[#0..=#5] // { arity: 6 }
-        Get l17 // { arity: 6 }
+          Get l9 // { arity: 6 }
     cte l9 =
+      Distinct project=[#0..=#5] // { arity: 6 }
+        Get l16 // { arity: 6 }
+    cte l8 =
       TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
         Project (#0..=#3, #5) // { arity: 5 }
           Filter (#4 = false) // { arity: 6 }
-            Get l17 // { arity: 6 }
-    cte l8 =
+            Get l16 // { arity: 6 }
+    cte l7 =
       Distinct project=[#0{person2id}, #1] // { arity: 2 }
         Union // { arity: 2 }
           Distinct project=[#0{person2id}, #1] // { arity: 2 }
@@ -2927,51 +2889,51 @@ Explained Query:
               Project (#1, #0) // { arity: 2 }
                 CrossJoin type=differential // { arity: 2 }
                   implementation
-                    %0:l5[×] » %1[×]
+                    %0:l4[×] » %1[×]
                   ArrangeBy keys=[[]] // { arity: 2 }
-                    Get l5 // { arity: 2 }
+                    Get l4 // { arity: 2 }
                   ArrangeBy keys=[[]] // { arity: 0 }
                     Union // { arity: 0 }
                       Negate // { arity: 0 }
-                        Get l7 // { arity: 0 }
+                        Get l6 // { arity: 0 }
                       Constant // { arity: 0 }
                         - ()
               Project (#1, #0) // { arity: 2 }
                 Map (true, -1) // { arity: 2 }
-                  Get l7 // { arity: 0 }
+                  Get l6 // { arity: 0 }
           Constant // { arity: 2 }
             - (1450, true)
             - (15393162796819, false)
-    cte l7 =
+    cte l6 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
             implementation
-              %0:l6[#0]Kf » %1:l6[#0]Kf
+              %0:l5[#0]Kf » %1:l5[#0]Kf
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter #1 // { arity: 2 }
-                  Get l6 // { arity: 2 }
+                  Get l5 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter NOT(#1) // { arity: 2 }
-                  Get l6 // { arity: 2 }
-    cte l6 =
+                  Get l5 // { arity: 2 }
+    cte l5 =
       Union // { arity: 2 }
         Project (#1, #0) // { arity: 2 }
-          Get l5 // { arity: 2 }
-        Get l8 // { arity: 2 }
-    cte l5 =
+          Get l4 // { arity: 2 }
+        Get l7 // { arity: 2 }
+    cte l4 =
       Project (#1, #3) // { arity: 2 }
         Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
           implementation
-            %0:l8[#0]K » %1:l4[#0]K
+            %0:l7[#0]K » %1:l3[#0]K
           ArrangeBy keys=[[#0]] // { arity: 2 }
-            Get l8 // { arity: 2 }
+            Get l7 // { arity: 2 }
           ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
-              Get l4 // { arity: 3 }
-    cte l4 =
+              Get l3 // { arity: 3 }
+    cte l3 =
       Project (#0, #1, #3) // { arity: 3 }
         Map ((10 / bigint_to_double((coalesce(#2, 0) + 10)))) // { arity: 4 }
           Union // { arity: 3 }
@@ -2981,19 +2943,19 @@ Explained Query:
                   Project (#0, #1) // { arity: 2 }
                     Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                       implementation
-                        %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
+                        %1[#1, #0]UKK » %0:l2[greatest(#0, #1), least(#0, #1)]KK
                       ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                        Get l3 // { arity: 2 }
+                        Get l2 // { arity: 2 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                         Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                           Project (#0, #1) // { arity: 2 }
-                            Get l2 // { arity: 3 }
-                Get l3 // { arity: 2 }
-            Get l2 // { arity: 3 }
-    cte l3 =
+                            Get l1 // { arity: 3 }
+                Get l2 // { arity: 2 }
+            Get l1 // { arity: 3 }
+    cte l2 =
       Project (#1, #2) // { arity: 2 }
         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-    cte l2 =
+    cte l1 =
       Project (#0, #1, #4) // { arity: 3 }
         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
           implementation
@@ -3003,59 +2965,32 @@ Explained Query:
               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
             Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#0..=#2) // { arity: 3 }
-                Join on=(#3{containerforumid} = #4{containerforumid} = #5{id}) type=delta // { arity: 6 }
+              Project (#1, #2, #6) // { arity: 3 }
+                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                   implementation
-                    %0:l1 » %1[#0]UKA » %2[#0]UKA
-                    %1 » %2[#0]UKA » %0:l1[#3]K
-                    %2 » %1[#0]UKA » %0:l1[#3]K
-                  ArrangeBy keys=[[#3{containerforumid}]] // { arity: 4 }
-                    Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-                    Distinct project=[#0{containerforumid}] // { arity: 1 }
-                      Project (#3) // { arity: 1 }
-                        Filter (#3{containerforumid}) IS NOT NULL // { arity: 4 }
-                          Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                    Distinct project=[#0{id}] // { arity: 1 }
-                      Project (#1) // { arity: 1 }
-                        Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                          ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
-    cte l1 =
-      Project (#0, #1, #3, #4) // { arity: 4 }
-        Join on=(#2{containerforumid} = #5{containerforumid} = #6{id}) type=delta // { arity: 7 }
-          implementation
-            %0:l0 » %1[#0]UKA » %2[#0]UKA
-            %1 » %2[#0]UKA » %0:l0[#2]K
-            %2 » %1[#0]UKA » %0:l0[#2]K
-          ArrangeBy keys=[[#2{containerforumid}]] // { arity: 5 }
-            Get l0 // { arity: 5 }
-          ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-            Distinct project=[#0{containerforumid}] // { arity: 1 }
-              Project (#2) // { arity: 1 }
-                Filter (#2{containerforumid}) IS NOT NULL // { arity: 5 }
-                  Get l0 // { arity: 5 }
-          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-            Distinct project=[#0{id}] // { arity: 1 }
-              Project (#1) // { arity: 1 }
-                Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                  ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+                    %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                    %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
+                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                    Project (#1, #9, #10, #12) // { arity: 4 }
+                      Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                    Project (#9, #10, #12) // { arity: 3 }
+                      Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  Get l0 // { arity: 1 }
+                  Get l0 // { arity: 1 }
     cte l0 =
-      Project (#1, #2, #5, #6, #8) // { arity: 5 }
-        Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid}) type=delta // { arity: 10 }
-          implementation
-            %0:person_knows_person » %1:message[#1]KA » %2:message[#0, #2]KK
-            %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK
-            %2:message » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK
-          ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-            ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
-          ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
-            Project (#1, #9, #10, #12) // { arity: 4 }
-              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-          ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
-            Project (#9, #10, #12) // { arity: 3 }
-              Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+        Distinct project=[#0{id}] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
+              ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -3643,18 +3578,12 @@ Explained Query:
     With
       cte l1 =
         Project (#0..=#2) // { arity: 3 }
-          Join on=(#1{id} = #3{id} = #4{id}) type=delta // { arity: 5 }
+          Join on=(#1{id} = #3{id}) type=differential // { arity: 4 }
             implementation
-              %0:l0 » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:l0[#1]K
-              %2 » %1[#0]UKA » %0:l0[#1]K
+              %1[#0]UKA » %0:l0[#1]K
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                    Get l0 // { arity: 3 }
+              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                Get l0 // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
                 Project (#1) // { arity: 1 }

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -434,19 +434,12 @@ materialize.public.q04_primary_idx:
 materialize.public.q04:
   Reduce group_by=[#0{o_orderpriority}] aggregates=[count(*)] // { arity: 2 }
     Project (#5) // { arity: 1 }
-      Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 11 }
-        Join on=(#0{o_orderkey} = #9{o_orderkey} = #10{l_orderkey}) type=delta // { arity: 11 }
+      Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 10 }
+        Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 10 }
           implementation
-            %0:orders » %1[#0]UKA » %2[#0]UKA
-            %1 » %2[#0]UKA » %0:orders[#0]KAiif
-            %2 » %1[#0]UKA » %0:orders[#0]KAiif
+            %1[#0]UKA » %0:orders[#0]KAiif
           ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
-            ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
-          ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
-            Distinct project=[#0{o_orderkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
-                  ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+            ReadIndex on=orders pk_orders_orderkey=[differential join] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
             Distinct project=[#0{l_orderkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
@@ -454,7 +447,7 @@ materialize.public.q04:
                   ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
-  - materialize.public.pk_orders_orderkey (*** full scan ***, delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (differential join)
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
 
 EOF

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -395,19 +395,12 @@ ORDER BY
 materialize.public.q04:
   Reduce group_by=[#0{o_orderpriority}] aggregates=[count(*)] // { arity: 2 }
     Project (#5) // { arity: 1 }
-      Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 11 }
-        Join on=(#0{o_orderkey} = #9{o_orderkey} = #10{l_orderkey}) type=delta // { arity: 11 }
+      Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 10 }
+        Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 10 }
           implementation
-            %0:orders » %1[#0]UKA » %2[#0]UKA
-            %1 » %2[#0]UKA » %0:orders[#0]KAiif
-            %2 » %1[#0]UKA » %0:orders[#0]KAiif
+            %1[#0]UKA » %0:orders[#0]KAiif
           ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
-            ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
-          ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
-            Distinct project=[#0{o_orderkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
-                  ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+            ReadIndex on=orders pk_orders_orderkey=[differential join] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
             Distinct project=[#0{l_orderkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
@@ -415,7 +408,7 @@ materialize.public.q04:
                   ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
-  - materialize.public.pk_orders_orderkey (*** full scan ***, delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (differential join)
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
 
 EOF

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -394,19 +394,12 @@ Explained Query:
   Finish order_by=[#0{o_orderpriority} asc nulls_last] output=[#0, #1]
     Reduce group_by=[#0{o_orderpriority}] aggregates=[count(*)] // { arity: 2 }
       Project (#5) // { arity: 1 }
-        Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 11 }
-          Join on=(#0{o_orderkey} = #9{o_orderkey} = #10{l_orderkey}) type=delta // { arity: 11 }
+        Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 10 }
+          Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 10 }
             implementation
-              %0:orders » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:orders[#0]KAiif
-              %2 » %1[#0]UKA » %0:orders[#0]KAiif
+              %1[#0]UKA » %0:orders[#0]KAiif
             ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
-              ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
-            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
-              Distinct project=[#0{o_orderkey}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
-                    ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+              ReadIndex on=orders pk_orders_orderkey=[differential join] // { arity: 9 }
             ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
               Distinct project=[#0{l_orderkey}] // { arity: 1 }
                 Project (#0) // { arity: 1 }
@@ -414,7 +407,7 @@ Explained Query:
                     ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
-  - materialize.public.pk_orders_orderkey (*** full scan ***, delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (differential join)
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
 
 EOF

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -46,7 +46,6 @@ DistinctByErrorCheck
   );
 
 > SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
-"ArrangeBy[[Column(0), Column(1)]] [val: empty]"
 "ArrangeBy[[Column(0)]] [val: empty]"
 "ArrangeBy[[Column(0)]]"
 "Arranged DistinctBy [val: empty]"

--- a/test/testdrive/top-1-monotonic.td
+++ b/test/testdrive/top-1-monotonic.td
@@ -273,8 +273,6 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=5
 > SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
 ArrangeBy[[Column(0)]]
 ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
 "ArrangeBy[[Column(0)]] [val: empty]"
 "ArrangeBy[[Column(0)]] [val: empty]"
 "Arranged DistinctBy [val: empty]"


### PR DESCRIPTION
WIP that aims to make `RedundantJoin` robust to filters, allowing it to optimize queries like
```
select * from foo where foo.x in (select y from bar)
```
which currently plans as a 3-way join, but should be a 2-way join between `foo` and `distinct bar`.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
