### PR TITLE
tests: Only print shard when it's not all

### DIFF
--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -154,7 +154,9 @@ async fn main() -> ExitCode {
     };
 
     if let (Some(shard), Some(shard_count)) = (args.shard, args.shard_count) {
-        eprintln!("Shard: {}/{}", shard + 1, shard_count);
+        if shard != 0 || shard_count != 1 {
+            eprintln!("Shard: {}/{}", shard + 1, shard_count);
+        }
     }
 
     if args.rewrite_results {

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -306,7 +306,9 @@ async fn main() {
         args.consistency_checks,
     );
     if let (Some(shard), Some(shard_count)) = (args.shard, args.shard_count) {
-        eprintln!("    Shard: {}/{}", shard + 1, shard_count);
+        if shard != 0 || shard_count != 1 {
+            eprintln!("    Shard: {}/{}", shard + 1, shard_count);
+        }
     }
 
     let mut arg_vars = BTreeMap::new();


### PR DESCRIPTION
Shard: 1/1 is not all that interesting

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
