### PR TITLE
ci: Detect all clusterds instead of only the first

### DIFF
--- a/bin/ci-upload-heap-profiles
+++ b/bin/ci-upload-heap-profiles
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# ci-upload-heap-profiles - Upload memory heap profiles during an mzcompose run
+
+exec "$(dirname "$0")"/pyactivate -m materialize.cli.ci_upload_heap_profiles "$@"

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -9,13 +9,16 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Disable pipefail for the upload_artifact function, which can have failures in pipes and should still keep working
-set -eu +o pipefail
+set -euo pipefail
 
 . misc/shlib/shlib.bash
 
 mzcompose() {
     stdbuf --output=L --error=L bin/ci-builder run stable bin/mzcompose --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
+}
+
+faketty() {
+    script -qfc "$(printf "%q " "$@")" /dev/null
 }
 
 service=${BUILDKITE_PLUGIN_MZCOMPOSE_RUN:-default}
@@ -79,45 +82,12 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
     mzcompose --mz-quiet cp balancerd:/usr/local/bin/balancerd coverage/ || true
 fi
 
-upload_artifact() {
-    cservice="$1"
-    artifact="$2"
-    # For materialized
-    if mzcompose --mz-quiet exec "$cservice" curl --silent http://127.0.0.1:6878/prof/heap > "$artifact" 2> /dev/null; then
-        if [ -s "$artifact" ]; then
-            buildkite-agent artifact upload --log-level error "$artifact"
-            i=0
-            all_sockets="$(mzcompose --mz-quiet exec "$cservice" ps aux 2> /dev/null | grep "/usr/local/bin/clusterd" | grep -v grep | sed -e "s/.* --internal-http-listen-addr=\(\/tmp\/[^ ]*\) .*/\1/")"
-            while IFS= read -r socket; do
-                artifact_socket=$(echo "$artifact" | sed -e "s#prof/#prof/clusterd$i-#")
-                if mzcompose --mz-quiet exec "$cservice" curl --silent --unix-socket "$socket" http:/prof/heap > "$artifact_socket" 2> /dev/null || true; then
-                    if [ -s "$artifact_socket" ]; then
-                        buildkite-agent artifact upload --log-level error "$artifact_socket" || true
-                    fi
-                fi
-                ((i++))
-            done <<< "$all_sockets"
-        else
-            # For clusterd
-            if mzcompose --mz-quiet exec "$cservice" curl --silent http://127.0.0.1:6878/heap > "$artifact" 2> /dev/null; then
-                if [ -s "$artifact" ]; then
-                    # shellcheck disable=SC2034
-                    artifact_uuid=$(buildkite-agent artifact upload --log-level info "$artifact" | grep "Uploading artifact" | sed -e "s/Uploading artifact \([^ ]*\) .*/\1/")
-                fi
-            fi
-        fi
-    fi
-}
-
 if is_truthy "${CI_HEAP_PROFILES:-}"; then
-    rm -rf prof
-    mkdir prof
     (while true; do
-        sleep 10
-        for cservice in $(mzcompose --mz-quiet ps --services 2> /dev/null); do
-            artifact=$(date "+prof/$cservice-%Y-%m-%d_%H:%M:%S.pb.gz")
-            upload_artifact "$cservice" "$artifact" &
-        done
+        sleep 5
+        # faketty because otherwise docker will complain about not being inside
+        # of a TTY when run in a background job
+        faketty bin/ci-builder run stable bin/ci-upload-heap-profiles "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION"
     done
     ) &
 fi

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -9,7 +9,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-set -euo pipefail
+# Disable pipefail for the upload_artifact function, which can have failures in pipes and should still keep working
+set -eu +o pipefail
 
 . misc/shlib/shlib.bash
 
@@ -86,15 +87,16 @@ upload_artifact() {
         if [ -s "$artifact" ]; then
             buildkite-agent artifact upload --log-level error "$artifact"
             i=0
-            while read -r socket; do
+            all_sockets="$(mzcompose --mz-quiet exec "$cservice" ps aux 2> /dev/null | grep "/usr/local/bin/clusterd" | grep -v grep | sed -e "s/.* --internal-http-listen-addr=\(\/tmp\/[^ ]*\) .*/\1/")"
+            while IFS= read -r socket; do
                 artifact_socket=$(echo "$artifact" | sed -e "s#prof/#prof/clusterd$i-#")
-                if mzcompose --mz-quiet exec "$cservice" curl --silent --unix-socket "$socket" http:/prof/heap > "$artifact_socket" 2> /dev/null; then
+                if mzcompose --mz-quiet exec "$cservice" curl --silent --unix-socket "$socket" http:/prof/heap > "$artifact_socket" 2> /dev/null || true; then
                     if [ -s "$artifact_socket" ]; then
-                        buildkite-agent artifact upload --log-level error "$artifact_socket"
+                        buildkite-agent artifact upload --log-level error "$artifact_socket" || true
                     fi
                 fi
                 ((i++))
-            done <<< "$(mzcompose --mz-quiet exec "$cservice" ps aux | grep "/usr/local/bin/clusterd" | grep -v grep | sed -e "s/.* --internal-http-listen-addr=\(\/tmp\/[^ ]*\) .*/\1/" 2> /dev/null)"
+            done <<< "$all_sockets"
         else
             # For clusterd
             if mzcompose --mz-quiet exec "$cservice" curl --silent http://127.0.0.1:6878/heap > "$artifact" 2> /dev/null; then

--- a/misc/python/materialize/cli/ci_upload_heap_profiles.py
+++ b/misc/python/materialize/cli/ci_upload_heap_profiles.py
@@ -1,0 +1,111 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# ci_upload_heap_profiles.py - Upload memory heap profiles during an mzcompose run
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from threading import Thread
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="ci-upload-heap-profiles",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="ci-upload-heap-profiles uploads memory heap profiles during an mzcompose run",
+    )
+
+    parser.add_argument("composition", type=str)
+    parser.add_argument("--upload", action="store_true", default=True)
+
+    args = parser.parse_args()
+    mzcompose = ["bin/mzcompose", "--find", args.composition, "--mz-quiet"]
+    time_str = time.strftime("%Y-%m-%d_%H:%M:%S")
+    threads = []
+
+    def run(service: str, backend: list[str], suffix: str = ""):
+        heap_profile = subprocess.run(
+            mzcompose + ["exec", service, "curl", "--silent"] + backend,
+            text=False,
+            capture_output=True,
+        ).stdout
+
+        if not heap_profile:
+            return
+
+        filename = f"prof-{service}{suffix}-{time_str}.pb.gz"
+        with open(filename, "wb") as f:
+            f.write(heap_profile)
+        if args.upload:
+            subprocess.run(
+                [
+                    "buildkite-agent",
+                    "artifact",
+                    "upload",
+                    "--log-level",
+                    "error",
+                    filename,
+                ]
+            )
+
+    services = json.loads(
+        subprocess.run(
+            mzcompose + ["ps", "--format", "json"], text=True, capture_output=True
+        ).stdout
+    )
+    for service in services:
+        if service["Image"].startswith("materialize/clusterd:"):
+            threads.append(
+                Thread(
+                    target=run,
+                    args=(service["Service"], ["http://127.0.0.1:6878/heap"]),
+                )
+            )
+        elif service["Image"].startswith("materialize/materialized:"):
+            threads.append(
+                Thread(
+                    target=run,
+                    args=(service["Service"], ["http://127.0.0.1:6878/prof/heap"]),
+                )
+            )
+
+            clusterd_sockets = [
+                line.split("--internal-http-listen-addr=")[1].split(" ")[0]
+                for line in subprocess.run(
+                    mzcompose + ["exec", service["Service"], "ps", "aux"],
+                    text=True,
+                    capture_output=True,
+                ).stdout.splitlines()
+                if "--internal-http-listen-addr=" in line
+            ]
+            for i, socket in enumerate(clusterd_sockets):
+                threads.append(
+                    Thread(
+                        target=run,
+                        args=(
+                            service["Service"],
+                            ["--unix-socket", socket, "http:/prof/heap"],
+                            f"-clusterd{i}",
+                        ),
+                    )
+                )
+
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
