### PR TITLE
Minor adjustments in REFRESH tests to not use so much memory

### DIFF
--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -187,11 +187,19 @@ ALTER SYSTEM SET enable_refresh_every_mvs = true
 > SELECT * FROM mv_gs;
 10000000
 
+# `mv_gs` consumes a non-trivial amount of memory because of the big `generate_series`, so let's drop it.
+> DROP MATERIALIZED VIEW mv_gs;
+> SELECT mz_unsafe.mz_sleep(1);
+<null>
+
 ## Test turning replicas off and on, part 4:
 ## - Turn the replica off while it's in a non-caught-up state after an input change.
 ## - Turn the replica off while it's still rehydrating after turning a replica on.
 ## - More than 1 replicas.
 ## - MV that reads from an index.
+> DELETE FROM tg;
+> INSERT INTO tg VALUES (100);
+
 > CREATE MATERIALIZED VIEW mv_gs2
   IN CLUSTER refresh_cluster
   WITH (REFRESH EVERY '4 sec') AS
@@ -207,9 +215,9 @@ ALTER SYSTEM SET enable_refresh_every_mvs = true
 
 # Wait for the first refresh.
 > SELECT * FROM mv_gs2;
-10000000
+100
 > SELECT * FROM mv_gs2_index;
-10000000
+100
 
 > INSERT INTO tg VALUES (10000000);
 
@@ -220,13 +228,13 @@ ALTER SYSTEM SET enable_refresh_every_mvs = true
 <null>
 
 > ALTER CLUSTER refresh_cluster SET (REPLICATION FACTOR 0);
-> ALTER CLUSTER refresh_cluster SET (REPLICATION FACTOR 3);
+> ALTER CLUSTER refresh_cluster SET (REPLICATION FACTOR 2);
 
 # Check that we recover.
 > SELECT * FROM mv_gs2;
-20000000
+10000100
 > SELECT * FROM mv_gs2_index;
-20000000
+10000100
 
 ## REFRESH AT + REFRESH EVERY
 


### PR DESCRIPTION
Use less memory:
- drop old MV with `generate_series` that's not needed for later tests
- smaller `generate_series`
- 2 replicas instead of 3

I'm sorry for the flake!

### Motivation

  * This PR fixes a recognized test issue: #25983

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
