### PR TITLE
[WIP] persist: store sum of diffs on HollowBatch

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -386,6 +386,7 @@ where
     parts_written: usize,
 
     num_updates: usize,
+    diffs_sum: Option<D>,
     parts: BatchParts<T>,
 
     since: Antichain<T>,
@@ -445,6 +446,7 @@ where
             parts_written: 0,
             runs: Vec::new(),
             num_updates: 0,
+            diffs_sum: None,
             parts,
             shard_id,
             version,
@@ -508,6 +510,7 @@ where
                 desc,
                 parts,
                 len: self.num_updates,
+                diffs_sum: self.diffs_sum.map(|x| D::encode(&x)),
                 runs: self.runs,
             },
         );
@@ -951,6 +954,38 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
         });
     }
     Ok(())
+}
+
+#[derive(Debug)]
+pub(crate) struct MaybeDiff<D>(pub(crate) Option<D>);
+
+impl<D> Default for MaybeDiff<D> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+impl<D: Semigroup> std::ops::AddAssign<D> for MaybeDiff<D> {
+    fn add_assign(&mut self, rhs: D) {
+        match self.0.as_mut() {
+            Some(x) => x.plus_equals(&rhs),
+            None => self.0 = Some(rhs),
+        }
+    }
+}
+
+impl<D: Semigroup + Codec64> MaybeDiff<D> {
+    pub(crate) fn into_inner(self) -> Option<[u8; 8]> {
+        self.0.map(|x| D::encode(&x))
+    }
+
+    pub(crate) fn add_encoded(&mut self, rhs: Option<[u8; 8]>) {
+        let rhs = match rhs {
+            Some(x) => D::decode(x),
+            None => return,
+        };
+        *self += rhs;
+    }
 }
 
 #[cfg(test)]

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -31,7 +31,7 @@ use tokio::sync::{mpsc, oneshot, TryAcquireError};
 use tracing::{debug, debug_span, trace, warn, Instrument, Span};
 
 use crate::async_runtime::IsolatedRuntime;
-use crate::batch::{BatchBuilderConfig, BatchBuilderInternal};
+use crate::batch::{BatchBuilderConfig, BatchBuilderInternal, MaybeDiff};
 use crate::cfg::MiB;
 use crate::fetch::FetchBatchFilter;
 use crate::internal::encoding::Schemas;
@@ -467,6 +467,7 @@ where
         let mut all_parts = vec![];
         let mut all_runs = vec![];
         let mut len = 0;
+        let mut diffs_sum = MaybeDiff::<D>::default();
 
         for (runs, run_chunk_max_memory_usage) in
             Self::chunk_runs(&req, &cfg, metrics.as_ref(), run_reserved_memory_bytes)
@@ -530,6 +531,7 @@ where
             all_runs.extend(runs.iter().map(|run_start| run_start + run_offset));
             all_parts.extend(parts);
             len += updates;
+            diffs_sum.add_encoded(batch.diffs_sum);
         }
 
         Ok(CompactRes {
@@ -538,6 +540,7 @@ where
                 parts: all_parts,
                 runs: all_runs,
                 len,
+                diffs_sum: diffs_sum.into_inner(),
             },
         })
     }

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -101,6 +101,7 @@ impl<'a> DirectiveArgs<'a> {
         HollowBatch {
             desc,
             len,
+            diffs_sum: None,
             parts: keys
                 .iter()
                 .map(|x| HollowBatchPart {

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1091,6 +1091,7 @@ impl<T: Timestamp + Codec64> RustType<ProtoHollowBatch> for HollowBatch<T> {
             desc: Some(self.desc.into_proto()),
             parts: self.parts.into_proto(),
             len: self.len.into_proto(),
+            diffs_sum: self.diffs_sum.as_ref().map(|x| i64::from_le_bytes(*x)),
             runs: self.runs.into_proto(),
             deprecated_keys: vec![],
         }
@@ -1115,6 +1116,7 @@ impl<T: Timestamp + Codec64> RustType<ProtoHollowBatch> for HollowBatch<T> {
             desc: proto.desc.into_rust_if_some("desc")?,
             parts,
             len: proto.len.into_rust()?,
+            diffs_sum: proto.diffs_sum.map(i64::to_le_bytes),
             runs: proto.runs.into_rust()?,
         })
     }
@@ -1346,6 +1348,7 @@ mod tests {
                 Antichain::from_elem(3u64),
             ),
             len: 4,
+            diffs_sum: None,
             parts: vec![HollowBatchPart {
                 key: PartialBatchKey("a".into()),
                 encoded_size_bytes: 5,

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -35,6 +35,7 @@ message ProtoHollowBatch {
     ProtoU64Description desc = 1;
     repeated ProtoHollowBatchPart parts = 4;
     uint64 len = 3;
+    optional int64 diffs_sum = 6;
     repeated uint64 runs = 5;
 
     repeated string deprecated_keys = 2;

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -205,6 +205,8 @@ pub struct HollowBatch<T> {
     ///     parts=[p1, p2, p3], runs=[1, 2] --> runs are [p1], [p2], [p3]
     /// ```
     pub runs: Vec<usize>,
+    /// WIP
+    pub diffs_sum: Option<[u8; 8]>,
 }
 
 impl<T: Debug> Debug for HollowBatch<T> {
@@ -214,6 +216,7 @@ impl<T: Debug> Debug for HollowBatch<T> {
             parts,
             len,
             runs,
+            diffs_sum,
         } = self;
         f.debug_struct("HollowBatch")
             .field(
@@ -224,6 +227,7 @@ impl<T: Debug> Debug for HollowBatch<T> {
                     desc.since().elements(),
                 ),
             )
+            .field("diffs_sum", &diffs_sum)
             .field("parts", &parts)
             .field("len", &len)
             .field("runs", &runs)
@@ -239,12 +243,15 @@ impl<T: Serialize> serde::Serialize for HollowBatch<T> {
             // Both parts and runs are covered by the self.runs call.
             parts: _,
             runs: _,
+            diffs_sum,
         } = self;
         let mut s = s.serialize_struct("HollowBatch", 5)?;
         let () = s.serialize_field("lower", &desc.lower().elements())?;
         let () = s.serialize_field("upper", &desc.upper().elements())?;
         let () = s.serialize_field("since", &desc.since().elements())?;
         let () = s.serialize_field("len", len)?;
+        // This is only used for debugging, so hack that to assume D is i64.
+        let () = s.serialize_field("diffs_sum", &diffs_sum.as_ref().map(|x| i64::decode(*x)))?;
         let () = s.serialize_field("part_runs", &self.runs().collect::<Vec<_>>())?;
         s.end()
     }
@@ -264,12 +271,14 @@ impl<T: Ord> Ord for HollowBatch<T> {
             desc: self_desc,
             parts: self_parts,
             len: self_len,
+            diffs_sum: self_diffs_sum,
             runs: self_runs,
         } = self;
         let HollowBatch {
             desc: other_desc,
             parts: other_parts,
             len: other_len,
+            diffs_sum: other_diffs_sum,
             runs: other_runs,
         } = other;
         (
@@ -278,6 +287,7 @@ impl<T: Ord> Ord for HollowBatch<T> {
             self_desc.since().elements(),
             self_parts,
             self_len,
+            self_diffs_sum,
             self_runs,
         )
             .cmp(&(
@@ -286,6 +296,7 @@ impl<T: Ord> Ord for HollowBatch<T> {
                 other_desc.since().elements(),
                 other_parts,
                 other_len,
+                other_diffs_sum,
                 other_runs,
             ))
     }
@@ -921,6 +932,7 @@ where
             parts: Vec::new(),
             runs: Vec::new(),
             len: 0,
+            diffs_sum: None,
         }
     }
 
@@ -979,6 +991,7 @@ where
                     parts: vec![],
                     len: 0,
                     runs: vec![],
+                    diffs_sum: None,
                 },
             };
             let result = self.trace.apply_merge_res(&fake_merge);
@@ -1528,9 +1541,10 @@ pub(crate) mod tests {
                 any::<T>(),
                 proptest::collection::vec(any::<HollowBatchPart>(), 0..3),
                 any::<usize>(),
+                any::<i64>(),
                 any::<bool>(),
             ),
-            |(t0, t1, since, parts, len, runs)| {
+            |(t0, t1, since, parts, len, diffs_sum, runs)| {
                 let (lower, upper) = if t0 <= t1 {
                     (Antichain::from_elem(t0), Antichain::from_elem(t1))
                 } else {
@@ -1538,11 +1552,13 @@ pub(crate) mod tests {
                 };
                 let since = Antichain::from_elem(since);
                 let runs = if runs { vec![parts.len()] } else { vec![] };
+                let len = len % 10;
                 HollowBatch {
                     desc: Description::new(lower, upper, since),
                     parts,
-                    len: len % 10,
+                    len,
                     runs,
+                    diffs_sum: (len > 0).then(|| i64::encode(&diffs_sum)),
                 }
             },
         )
@@ -1689,6 +1705,7 @@ pub(crate) mod tests {
                 })
                 .collect(),
             len,
+            diffs_sum: None,
             runs: vec![],
         }
     }

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -690,6 +690,7 @@ fn apply_diffs_spine<T: Timestamp + Lattice>(
                     ),
                     parts: vec![],
                     len: 0,
+                    diffs_sum: None,
                     runs: vec![],
                 });
                 metrics.state.apply_spine_fast_path.inc();
@@ -920,6 +921,7 @@ fn apply_compaction_lenient<'a, T: Timestamp + Lattice>(
                 desc,
                 parts: Vec::new(),
                 len: 0,
+                diffs_sum: None,
                 runs: Vec::new(),
             });
             metrics.state.apply_spine_slow_path_lenient_adjustment.inc();
@@ -950,6 +952,7 @@ fn apply_compaction_lenient<'a, T: Timestamp + Lattice>(
                 desc,
                 parts: Vec::new(),
                 len: 0,
+                diffs_sum: None,
                 runs: Vec::new(),
             });
             metrics.state.apply_spine_slow_path_lenient_adjustment.inc();
@@ -1203,6 +1206,7 @@ mod tests {
                 ),
                 parts: Vec::new(),
                 len,
+                diffs_sum: None,
                 runs: Vec::new(),
             }
         }
@@ -1308,6 +1312,7 @@ mod tests {
                     desc,
                     parts: Vec::new(),
                     len: *len,
+                    diffs_sum: None,
                     runs: Vec::new(),
                 }
             }

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -405,6 +405,7 @@ impl<T: Timestamp + Lattice> SpineBatch<T> {
                 desc: Description::new(lower, upper, since),
                 parts: vec![],
                 len: 0,
+                diffs_sum: None,
                 runs: vec![],
             },
         }))

--- a/src/persist-client/src/internals_bench.rs
+++ b/src/persist-client/src/internals_bench.rs
@@ -45,6 +45,7 @@ pub fn trace_push_batch_one_iter(num_batches: usize) {
             ),
             parts: vec![],
             len,
+            diffs_sum: None,
             runs: vec![],
         });
     }

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -32,7 +32,7 @@ use uuid::Uuid;
 
 use crate::batch::{
     validate_truncate_batch, Added, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
-    ProtoBatch, BATCH_DELETE_ENABLED,
+    MaybeDiff, ProtoBatch, BATCH_DELETE_ENABLED,
 };
 use crate::error::{InvalidUsage, UpperMismatch};
 use crate::internal::compact::Compactor;
@@ -479,6 +479,7 @@ where
         let desc = Description::new(lower, upper, since);
 
         let (mut parts, mut num_updates, mut runs) = (vec![], 0, vec![]);
+        let mut diffs_sum = MaybeDiff::<D>::default();
         for batch in batches.iter() {
             let () = validate_truncate_batch(&batch.batch.desc, &desc)?;
             for run in batch.batch.runs() {
@@ -490,6 +491,7 @@ where
                 parts.extend_from_slice(run);
             }
             num_updates += batch.batch.len;
+            diffs_sum.add_encoded(batch.batch.diffs_sum);
         }
 
         let heartbeat_timestamp = (self.cfg.now)();
@@ -500,6 +502,7 @@ where
                     desc: desc.clone(),
                     parts,
                     len: num_updates,
+                    diffs_sum: diffs_sum.into_inner(),
                     runs,
                 },
                 &self.writer_id,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
