### PR TITLE
fivetran-destination: Mirror tester image

### DIFF
--- a/misc/images/fivetran-destination-tester/Dockerfile
+++ b/misc/images/fivetran-destination-tester/Dockerfile
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM fivetrandocker/sdk-destination-tester:024.0222.002

--- a/misc/images/fivetran-destination-tester/Dockerfile
+++ b/misc/images/fivetran-destination-tester/Dockerfile
@@ -7,4 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Note: This mzimage is a simple wrapper around the Fivetran Destination Tester to act as a mirror
+#       and decouple ourselves from Fivetran's Dockerhub, incase Fivetran removes the image that we
+#       depend on.
+
 FROM fivetrandocker/sdk-destination-tester:024.0222.002

--- a/misc/images/fivetran-destination-tester/mzbuild.yml
+++ b/misc/images/fivetran-destination-tester/mzbuild.yml
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: fivetran-destination-tester
+description: Tester for the Fivetran Destination

--- a/misc/python/materialize/mzcompose/services/fivetran_destination_tester.py
+++ b/misc/python/materialize/mzcompose/services/fivetran_destination_tester.py
@@ -28,7 +28,7 @@ class FivetranDestinationTester(Service):
         super().__init__(
             name="fivetran-destination-tester",
             config={
-                "image": f"fivetrandocker/sdk-destination-tester:{FIVETRAN_TESTER_VERSION}",
+                "mzbuild": "fivetran-destination-tester",
                 "command": command,
                 "environment": environment,
                 "volumes": volumes_extra,

--- a/misc/python/materialize/mzcompose/services/fivetran_destination_tester.py
+++ b/misc/python/materialize/mzcompose/services/fivetran_destination_tester.py
@@ -9,8 +9,6 @@
 
 from materialize.mzcompose.service import Service
 
-FIVETRAN_TESTER_VERSION = "024.0222.002"
-
 
 class FivetranDestinationTester(Service):
     def __init__(


### PR DESCRIPTION
Wraps the fivetran-destination-tester Docker image with mzimage to mirror it.

### Motivation

Decouples our CI from the upstream Fivetran Dockerhub

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Testing only change
