### PR TITLE
Parsing for REFRESH's automated cluster scheduling

### DIFF
--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -239,6 +239,7 @@ Logical
 Login
 Lowering
 Managed
+Manual
 Map
 Marketing
 Materialize
@@ -356,6 +357,7 @@ Row
 Rows
 Sasl
 Scale
+Schedule
 Schema
 Schemas
 Second

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1733,6 +1733,8 @@ pub enum ClusterOptionName {
     ReplicationFactor,
     /// The `SIZE` option.
     Size,
+    /// The `SCHEDULE` option.
+    Schedule,
 }
 
 impl AstDisplay for ClusterOptionName {
@@ -1749,6 +1751,7 @@ impl AstDisplay for ClusterOptionName {
             ClusterOptionName::Replicas => f.write_str("REPLICAS"),
             ClusterOptionName::ReplicationFactor => f.write_str("REPLICATION FACTOR"),
             ClusterOptionName::Size => f.write_str("SIZE"),
+            ClusterOptionName::Schedule => f.write_str("SCHEDULE"),
         }
     }
 }
@@ -1769,7 +1772,8 @@ impl WithOptionName for ClusterOptionName {
             | ClusterOptionName::Managed
             | ClusterOptionName::Replicas
             | ClusterOptionName::ReplicationFactor
-            | ClusterOptionName::Size => false,
+            | ClusterOptionName::Size
+            | ClusterOptionName::Schedule => false,
         }
     }
 }
@@ -3467,6 +3471,7 @@ pub enum WithOptionValue<T: AstInfo> {
     ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink<T>),
     RetainHistoryFor(Value),
     Refresh(RefreshOptionValue<T>),
+    ClusterScheduleOptionValue(ClusterScheduleOptionValue),
 }
 
 impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
@@ -3489,7 +3494,8 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
                 | WithOptionValue::Item(_)
                 | WithOptionValue::UnresolvedItemName(_)
                 | WithOptionValue::ConnectionAwsPrivatelink(_)
-                | WithOptionValue::ClusterReplicas(_) => {
+                | WithOptionValue::ClusterReplicas(_)
+                | WithOptionValue::ClusterScheduleOptionValue(_) => {
                     // These do not need redaction.
                 }
             }
@@ -3524,6 +3530,7 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
                 f.write_node(value);
             }
             WithOptionValue::Refresh(opt) => f.write_node(opt),
+            WithOptionValue::ClusterScheduleOptionValue(value) => f.write_node(value),
         }
     }
 }
@@ -3574,6 +3581,25 @@ impl<T: AstInfo> AstDisplay for RefreshOptionValue<T> {
                     f.write_str(" ALIGNED TO ");
                     f.write_node(aligned_to)
                 }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ClusterScheduleOptionValue {
+    Manual,
+    Refresh,
+}
+
+impl AstDisplay for ClusterScheduleOptionValue {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            ClusterScheduleOptionValue::Manual => {
+                f.write_str("MANUAL");
+            }
+            ClusterScheduleOptionValue::Refresh => {
+                f.write_str("ON REFRESH");
             }
         }
     }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1508,14 +1508,14 @@ CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Cluster
 parse-statement
 CREATE CLUSTER cluster WITH REPLICAS ()
 ----
-error: Expected one of AVAILABILITY or DISK or IDLE or INTROSPECTION or MANAGED or REPLICAS or REPLICATION or SIZE, found WITH
+error: Expected one of AVAILABILITY or DISK or IDLE or INTROSPECTION or MANAGED or REPLICAS or REPLICATION or SIZE or SCHEDULE, found WITH
 CREATE CLUSTER cluster WITH REPLICAS ()
                        ^
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (), BADOPT
 ----
-error: Expected one of AVAILABILITY or DISK or IDLE or INTROSPECTION or MANAGED or REPLICAS or REPLICATION or SIZE, found identifier "badopt"
+error: Expected one of AVAILABILITY or DISK or IDLE or INTROSPECTION or MANAGED or REPLICAS or REPLICATION or SIZE or SCHEDULE, found identifier "badopt"
 CREATE CLUSTER cluster REPLICAS (), BADOPT
                                     ^
 
@@ -1644,6 +1644,20 @@ CREATE CLUSTER cluster INTROSPECTION DEBUGGING true
 CREATE CLUSTER cluster (INTROSPECTION DEBUGGING = true)
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }], features: [] })
+
+parse-statement
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = MANUAL)
+----
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = MANUAL)
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Manual)) }], features: [] })
+
+parse-statement
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH)
+----
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH)
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh)) }], features: [] })
 
 parse-statement
 ALTER CLUSTER cluster SET (SIZE '1')

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1801,6 +1801,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
             }
             RetainHistoryFor(value) => RetainHistoryFor(self.fold_value(value)),
             Refresh(refresh) => Refresh(self.fold_refresh_option_value(refresh)),
+            ClusterScheduleOptionValue(value) => ClusterScheduleOptionValue(value),
         }
     }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -45,8 +45,9 @@ use mz_repr::optimize::OptimizerFeatureOverrides;
 use mz_repr::role_id::RoleId;
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType, Timestamp};
 use mz_sql_parser::ast::{
-    AlterSourceAddSubsourceOption, ConnectionOptionName, CreateSourceSubsource, QualifiedReplica,
-    TransactionIsolationLevel, TransactionMode, WithOptionValue,
+    AlterSourceAddSubsourceOption, ClusterScheduleOptionValue, ConnectionOptionName,
+    CreateSourceSubsource, QualifiedReplica, TransactionIsolationLevel, TransactionMode,
+    WithOptionValue,
 };
 use mz_storage_types::connections::inline::ReferencedConnection;
 use mz_storage_types::sinks::{SinkEnvelope, StorageSinkConnection};
@@ -1558,6 +1559,7 @@ pub struct PlanClusterOption {
     pub replication_factor: AlterOptionParameter<u32>,
     pub size: AlterOptionParameter,
     pub disk: AlterOptionParameter<bool>,
+    pub schedule: AlterOptionParameter<ClusterScheduleOptionValue>,
 }
 
 impl Default for PlanClusterOption {
@@ -1572,6 +1574,7 @@ impl Default for PlanClusterOption {
             replication_factor: AlterOptionParameter::Unchanged,
             size: AlterOptionParameter::Unchanged,
             disk: AlterOptionParameter::Unchanged,
+            schedule: AlterOptionParameter::Unchanged,
         }
     }
 }

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -19,7 +19,7 @@ ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = on;
 ----
 COMPLETE 0
 
-statement error db error: ERROR: Expected one of AVAILABILITY or DISK or IDLE or INTROSPECTION or MANAGED or REPLICAS or REPLICATION or SIZE, found EOF
+statement error db error: ERROR: Expected one of AVAILABILITY or DISK or IDLE or INTROSPECTION or MANAGED or REPLICAS or REPLICATION or SIZE or SCHEDULE, found EOF
 CREATE CLUSTER foo
 
 statement ok

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1097,3 +1097,46 @@ SELECT mz_unsafe.mz_sleep(2);
 # This would fail to get read holds if it attempted to do so.
 statement ok
 EXPLAIN REPLAN MATERIALIZED VIEW mv8;
+
+# ----------------------------------------
+# Automated cluster scheduling for REFRESH
+# ----------------------------------------
+
+statement error db error: ERROR: Expected one of MANUAL or ON, found identifier "aaaaaaaa"
+CREATE CLUSTER c_schedule_0 (SIZE = '1', SCHEDULE = AAAAAAAA);
+
+statement error db error: ERROR: Expected one of MANUAL or ON, found number "42"
+CREATE CLUSTER c_schedule_0 (SIZE = '1', SCHEDULE = 42);
+
+statement error db error: ERROR: Expected one of MANUAL or ON, found REFRESH
+CREATE CLUSTER c_schedule_0 (SIZE = '1', SCHEDULE = REFRESH);
+
+statement ok
+CREATE CLUSTER c_schedule_1 (SIZE = '1', SCHEDULE = MANUAL);
+
+statement ok
+CREATE CLUSTER c_schedule_2 (SIZE = '1', SCHEDULE MANUAL);
+
+statement error cluster schedules other than MANUAL not yet supported
+CREATE CLUSTER c_schedule_3 (SIZE = '1', SCHEDULE = ON REFRESH);
+
+statement ok
+ALTER cluster c_schedule_1 RESET (SCHEDULE);
+
+statement ok
+ALTER cluster c_schedule_1 SET (SCHEDULE = MANUAL);
+
+statement error cluster schedules other than MANUAL not yet supported
+ALTER cluster c_schedule_1 SET (SCHEDULE = ON REFRESH);
+
+statement ok
+CREATE CLUSTER unmanaged1 (SCHEDULE = MANUAL, REPLICAS (r1 (SIZE '1')))
+
+statement ok
+ALTER cluster unmanaged1 SET (SCHEDULE = MANUAL);
+
+statement error db error: ERROR: cluster schedules other than MANUAL are not supported for unmanaged clusters
+ALTER cluster unmanaged1 SET (SCHEDULE = ON REFRESH);
+
+statement error db error: ERROR: cluster schedules other than MANUAL are not supported for unmanaged clusters
+CREATE CLUSTER unmanaged2 (SCHEDULE = ON REFRESH, REPLICAS (r1 (SIZE '1')))


### PR DESCRIPTION
This PR just adds the 
`SCHEDULE = {MANUAL | ON REFRESH}`
option to `CREATE CLUSTER` and `ALTER CLUSTER`.
`REFRESH` is not yet implemented, so we just error if the user tries to specify it.

Discussion on whether to have `REFRESH` or `ON REFRESH` [here](https://materializeinc.slack.com/archives/C063H5S7NKE/p1710355545343079).

### Motivation

  * This PR is the first step towards adding a known-desirable feature: https://github.com/MaterializeInc/materialize/issues/25712

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
