### PR TITLE
fivetran-destination: Mark primary_key columns as `NOT NULL`

### DIFF
--- a/src/fivetran-destination/src/destination.rs
+++ b/src/fivetran-destination/src/destination.rs
@@ -7,8 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
+
 use futures::Future;
 use mz_ore::retry::{Retry, RetryResult};
+use postgres_protocol::escape;
 use tonic::{Request, Response, Status};
 
 use crate::error::{Context, OpError};
@@ -19,6 +22,7 @@ use crate::fivetran_sdk::{
     DescribeTableResponse, TestRequest, TestResponse, TruncateRequest, TruncateResponse,
     WriteBatchRequest, WriteBatchResponse,
 };
+use crate::utils;
 
 mod config;
 mod ddl;
@@ -205,5 +209,50 @@ fn to_grpc<T>(response: Result<T, OpError>) -> Result<Response<T>, Status> {
     match response {
         Ok(t) => Ok(Response::new(t)),
         Err(e) => Err(Status::unknown(e.to_string())),
+    }
+}
+
+/// Metadata about a column that is relevant to operations peformed by the destination.
+#[derive(Debug)]
+struct ColumnMetadata {
+    /// Name of the column in the destination table.
+    name: String,
+    /// Type of the column in the destination table.
+    ty: Cow<'static, str>,
+    /// Is this column a primary key.
+    is_primary: bool,
+}
+
+impl ColumnMetadata {
+    /// Returns a [`String`] that is suitable for use when creating a table.
+    fn to_column_def(&self) -> String {
+        let mut def = format!("{} {}", self.name, self.ty);
+
+        if self.is_primary {
+            def.push_str(" NOT NULL");
+        }
+
+        def
+    }
+}
+
+impl TryFrom<&crate::fivetran_sdk::Column> for ColumnMetadata {
+    type Error = OpError;
+
+    fn try_from(value: &crate::fivetran_sdk::Column) -> Result<Self, Self::Error> {
+        let name = escape::escape_identifier(&value.name);
+        let mut ty: Cow<'static, str> = utils::to_materialize_type(value.r#type())?.into();
+        if let Some(d) = &value.decimal {
+            ty.to_mut()
+                .push_str(&format!("({}, {})", d.precision, d.scale));
+        }
+        let is_primary =
+            value.primary_key || value.name.to_lowercase() == FIVETRAN_SYSTEM_COLUMN_ID;
+
+        Ok(ColumnMetadata {
+            name,
+            ty,
+            is_primary,
+        })
     }
 }

--- a/src/fivetran-destination/src/destination/ddl.rs
+++ b/src/fivetran-destination/src/destination/ddl.rs
@@ -155,7 +155,7 @@ pub async fn handle_create_table(request: CreateTableRequest) -> Result<(), OpEr
     for column in columns.iter().filter(|col| col.is_primary) {
         let stmt = format!(
             "COMMENT ON COLUMN {qualified_table_name}.{column_name} IS {magic_comment}",
-            column_name = column.name,
+            column_name = column.escaped_name,
             magic_comment = escape::escape_literal(PRIMARY_KEY_MAGIC_STRING),
         );
         client

--- a/src/fivetran-destination/src/destination/dml.rs
+++ b/src/fivetran-destination/src/destination/dml.rs
@@ -266,7 +266,7 @@ async fn replace_files(
             SELECT {cols}
             FROM {qualified_temp_table_name}
         )"#,
-        cols = matching_cols.map(|col| &col.name).join(","),
+        cols = matching_cols.map(|col| &col.escaped_name).join(","),
     );
     let rows_changed = client.execute(&delete_stmt, &[]).await?;
     tracing::info!(rows_changed, "deleted rows from {qualified_table_name}");
@@ -277,7 +277,7 @@ async fn replace_files(
         INSERT INTO {qualified_table_name} ({cols})
         SELECT {cols} FROM {qualified_temp_table_name}
         "#,
-        cols = columns.iter().map(|col| &col.name).join(","),
+        cols = columns.iter().map(|col| &col.escaped_name).join(","),
     );
     let rows_changed = client.execute(&insert_stmt, &[]).await?;
     tracing::info!(rows_changed, "inserted rows to {qualified_table_name}");
@@ -426,7 +426,7 @@ async fn delete_files(
         )"#,
         deleted_col = escape::escape_identifier(FIVETRAN_SYSTEM_COLUMN_DELETE),
         synced_col = escape::escape_identifier(FIVETRAN_SYSTEM_COLUMN_SYNCED),
-        cols = matching_cols.map(|col| &col.name).join(","),
+        cols = matching_cols.map(|col| &col.escaped_name).join(","),
     );
     let total_count = client
         .execute(&merge_stmt, &[&synced_time])

--- a/src/fivetran-destination/src/destination/dml.rs
+++ b/src/fivetran-destination/src/destination/dml.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::pin::Pin;
@@ -27,7 +26,7 @@ use tokio_util::io::ReaderStream;
 
 use crate::crypto::AsyncAesDecrypter;
 use crate::destination::{
-    config, FIVETRAN_SYSTEM_COLUMN_DELETE, FIVETRAN_SYSTEM_COLUMN_ID, FIVETRAN_SYSTEM_COLUMN_SYNCED,
+    config, ColumnMetadata, FIVETRAN_SYSTEM_COLUMN_DELETE, FIVETRAN_SYSTEM_COLUMN_SYNCED,
 };
 use crate::error::{Context, OpError, OpErrorKind};
 use crate::fivetran_sdk::write_batch_request::FileParams;
@@ -501,26 +500,11 @@ async fn get_scratch_table<'a>(
     let columns = table
         .columns
         .iter()
-        .map(|col| {
-            let mut ty: Cow<'static, str> = utils::to_materialize_type(col.r#type())?.into();
-            if let Some(d) = &col.decimal {
-                ty.to_mut()
-                    .push_str(&format!("({}, {})", d.precision, d.scale));
-            }
-
-            Ok(ColumnMetadata {
-                name: col.name.to_string(),
-                ty,
-                is_primary: col.primary_key || col.name.to_lowercase() == FIVETRAN_SYSTEM_COLUMN_ID,
-            })
-        })
+        .map(ColumnMetadata::try_from)
         .collect::<Result<Vec<_>, OpError>>()?;
 
     let create_scratch_table = || async {
-        let defs = columns
-            .iter()
-            .map(|col| format!("{} {}", col.name, col.ty))
-            .join(",");
+        let defs = columns.iter().map(|col| col.to_column_def()).join(",");
         let create_table_stmt = format!("CREATE TABLE {qualified_scratch_table_name} ({defs})");
         client
             .execute(&create_table_stmt, &[])
@@ -671,17 +655,6 @@ async fn copy_files(
     tracing::info!(row_count, "copied rows into {temporary_table}");
 
     Ok(row_count)
-}
-
-/// Metadata about a column that is relevant to operations peformed by the destination.
-#[derive(Debug)]
-struct ColumnMetadata {
-    /// Name of the column in the destination table.
-    name: String,
-    /// Type of the column in the destination table.
-    ty: Cow<'static, str>,
-    /// Is this column a primary key.
-    is_primary: bool,
 }
 
 #[derive(Debug)]

--- a/test/fivetran-destination/test-supported-data-types/01-setup.json
+++ b/test/fivetran-destination/test-supported-data-types/01-setup.json
@@ -16,7 +16,7 @@
         "c12": "STRING",
         "c13": "JSON"
       },
-      "primary_key": ["c1"]
+      "primary_key": ["c12"]
     }
   },
   "ops": [

--- a/test/fivetran-destination/test-supported-data-types/02-verify.td
+++ b/test/fivetran-destination/test-supported-data-types/02-verify.td
@@ -21,7 +21,7 @@ c8                 true      "timestamp without time zone"
 c9                 true      "timestamp with time zone"
 c10                true      numeric
 c11                true      bytea
-c12                true      text
+c12                false     text
 c13                true      jsonb
 _fivetran_deleted  true      boolean
 _fivetran_synced   true      "timestamp with time zone"


### PR DESCRIPTION
This PR changes the Fivetran Destination to mark primary key columns as `NOT NULL`. Primary keys are not allowed to be `NULL` and adding this constraint allows us to plan queries that are currently a three-way join as a two-way join.

```
CREATE TABLE logs      (id text, ts int);
CREATE TABLE logs_temp (id text, ts int);

EXPLAIN SELECT FROM logs WHERE (id, ts) IN (SELECT id, ts FROM logs_temp);

Explained Query:
  Project () // { arity: 0 }
    Join on=(#0{id} = #2{id} = #4{id} AND #1{ts} = #3{ts} = #5{ts}) type=delta // { arity: 6 }
      ArrangeBy keys=[[#0{id}, #1{ts}]] // { arity: 2 }
        ReadStorage materialize.parker_timmerman.logs // { arity: 2 }
      ArrangeBy keys=[[#0{id}, #1{ts}]] // { arity: 2 }
        Distinct project=[#0{id}, #1{ts}] // { arity: 2 }
          Filter (#0{id}) IS NOT NULL AND (#1{ts}) IS NOT NULL // { arity: 2 }
            ReadStorage materialize.parker_timmerman.logs // { arity: 2 }
      ArrangeBy keys=[[#0{id}, #1{ts}]] // { arity: 2 }
        Distinct project=[#0{id}, #1{ts}] // { arity: 2 }
          ReadStorage materialize.parker_timmerman.logs_temp // { arity: 2 }
```

Now with the `NOT NULL` constraints

```
CREATE TABLE logs      (id text NOT NULL, ts int NOT NULL);
CREATE TABLE logs_temp (id text NOT NULL, ts int NOT NULL);

EXPLAIN SELECT FROM logs WHERE (id, ts) IN (SELECT id, ts FROM logs_temp);

Explained Query:
  Project () // { arity: 0 }
    Join on=(#0{id} = #2{id} AND #1{ts} = #3{ts}) type=differential // { arity: 4 }
      ArrangeBy keys=[[#0{id}, #1{ts}]] // { arity: 2 }
        ReadStorage materialize.parker_timmerman.logs // { arity: 2 }
      ArrangeBy keys=[[#0{id}, #1{ts}]] // { arity: 2 }
        Distinct project=[#0{id}, #1{ts}] // { arity: 2 }
          ReadStorage materialize.parker_timmerman.logs_temp // { arity: 2 }
```

Note: Frank currently has a draft PR that allows the optimizer to move the `Filter` in the first plan so even without these constraints we can plan the query as a two-way join. I put up this PR because making the change for the Fivetran Destination was faster.

### Motivation

Improve the performance of the destination, which should reduce the amount of time the global write lock gets held

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improve the performance of the Fivetran Destination
