### PR TITLE
testdrive: simplify implementation of arg defaults

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -407,6 +407,22 @@ $ set schema={
     }
 ```
 
+#### `$ set-arg-default name=value`
+
+Sets the default value for an argument variable passed on the command line. If
+`--var=name=cli-value` is specified on the command line, it will take precedence
+over the argument default.
+
+Note that the variable name should not include the `arg.` prefix. Testdrive will
+add that prefix automatically.
+
+```
+$ set cluster-size=small
+
+> CREATE CLUSTER (SIZE ${arg.size})
+```
+
+
 #### `$ set-from-file var=PATH`
 
 Sets the variable to the contents of the file at `PATH`.

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -342,7 +342,6 @@ pub async fn run_ingest(
             let row = action::substitute_vars(
                 row,
                 &btreemap! { "kafka-ingest.iteration".into() => iteration.to_string() },
-                &state.default_arg_vars.clone(),
                 &None,
                 false,
             )?;

--- a/src/testdrive/src/action/set.rs
+++ b/src/testdrive/src/action/set.rs
@@ -81,7 +81,7 @@ pub fn run_set_arg_default(
 ) -> Result<ControlFlow, anyhow::Error> {
     for (key, val) in cmd.args {
         let arg_key = format!("arg.{key}");
-        state.default_arg_vars.insert(arg_key, val);
+        state.cmd_vars.entry(arg_key).or_insert(val);
     }
 
     Ok(ControlFlow::Continue)


### PR DESCRIPTION
The argument defaults can be added directly to the vars map if the var is not already set. This avoids needing to keep track of argument defaults separately from other variable values.

Also add some documentation for the command.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
