### PR TITLE
Use less memory in `materialized-view-refresh-options.td`

### DIFF
--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -173,19 +173,21 @@ ALTER SYSTEM SET enable_refresh_every_mvs = true
 ## Turn the replica off _during_ the first refresh, and then turn the replica back on immediately.
 
 > CREATE TABLE tg (a int);
-> INSERT INTO tg VALUES (10000000);
+> INSERT INTO tg VALUES (1000000);
 
 # Refreshing this will take a non-trivial amount of time.
+# The `*2/2` stuff is to make it take more CPU time without increasing memory consumption.
 > CREATE MATERIALIZED VIEW mv_gs
   IN CLUSTER refresh_cluster
   WITH (REFRESH AT CREATION) AS
-  SELECT count(*) FROM (SELECT generate_series(1,a) FROM tg);
+  SELECT sum(x*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2)
+  FROM (SELECT generate_series(1,a) as x FROM tg);
 
 > ALTER CLUSTER refresh_cluster SET (REPLICATION FACTOR 0);
 > ALTER CLUSTER refresh_cluster SET (REPLICATION FACTOR 1);
 
 > SELECT * FROM mv_gs;
-10000000
+500000500000
 
 # `mv_gs` consumes a non-trivial amount of memory because of the big `generate_series`, so let's drop it.
 > DROP MATERIALIZED VIEW mv_gs;
@@ -203,7 +205,8 @@ ALTER SYSTEM SET enable_refresh_every_mvs = true
 > CREATE MATERIALIZED VIEW mv_gs2
   IN CLUSTER refresh_cluster
   WITH (REFRESH EVERY '4 sec') AS
-  SELECT count(*) FROM (SELECT generate_series(1,a) FROM tg);
+  SELECT sum(x*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2)
+  FROM (SELECT generate_series(1,a) as x FROM tg);
 
 > CREATE DEFAULT INDEX
   IN CLUSTER refresh_cluster
@@ -211,15 +214,16 @@ ALTER SYSTEM SET enable_refresh_every_mvs = true
 > CREATE MATERIALIZED VIEW mv_gs2_index
   IN CLUSTER refresh_cluster
   WITH (REFRESH EVERY '4 sec') AS
-  SELECT count(*) FROM (SELECT generate_series(1,a) FROM tg);
+  SELECT sum(x*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2*2/2)
+  FROM (SELECT generate_series(1,a) as x FROM tg);
 
 # Wait for the first refresh.
 > SELECT * FROM mv_gs2;
-100
+5050
 > SELECT * FROM mv_gs2_index;
-100
+5050
 
-> INSERT INTO tg VALUES (10000000);
+> INSERT INTO tg VALUES (1000000);
 
 # Mess with the replicas before the MV could catch up with the above insert.
 > ALTER CLUSTER refresh_cluster SET (REPLICATION FACTOR 0);
@@ -232,9 +236,12 @@ ALTER SYSTEM SET enable_refresh_every_mvs = true
 
 # Check that we recover.
 > SELECT * FROM mv_gs2;
-10000100
+500000505050
 > SELECT * FROM mv_gs2_index;
-10000100
+500000505050
+
+> DROP MATERIALIZED VIEW mv_gs2;
+> DROP MATERIALIZED VIEW mv_gs2_index;
 
 ## REFRESH AT + REFRESH EVERY
 
@@ -375,3 +382,5 @@ true
   FROM mz_internal.mz_compute_operator_hydration_statuses h JOIN mz_objects o ON (h.object_id = o.id)
   WHERE name = 'mv10';
 true
+
+> DROP DATABASE materialized_view_refresh_options;


### PR DESCRIPTION
The test was still OOMing, see discussion [here](https://materializeinc.slack.com/archives/C01LKF361MZ/p1710405419068639?thread_ts=1710351761.364519&cid=C01LKF361MZ). This PR makes the test's mem usage about 10x less but keeps CPU time roughly the same as before, by having a 10x smaller `generate_series` but exercising the CPU with a series of `*2/2` at each output element of the `generate_series`.

I also added a cleanup at the end of the `.td`.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
