### PR TITLE
Stage flatmap execution to consolidate as it goes

### DIFF
--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -33,11 +33,18 @@ where
         let (ok_collection, err_collection) = input.as_specific_collection(input_key.as_deref());
         let (oks, errs) = ok_collection.inner.flat_map_fallible("FlatMapStage", {
             let mut datums = DatumVec::new();
+            let mut datums_mfp = DatumVec::new();
+            let mut table_func_output = Vec::with_capacity(1024);
+
+            // Into which we accumulate result update triples.
+            let mut oks_output = Vec::with_capacity(1024);
+            let mut err_output = Vec::with_capacity(1024);
+
             move |(input_row, mut time, diff)| {
                 let temp_storage = RowArena::new();
-                // Unpack datums and capture its length (to rewind MFP eval).
-                let mut datums_local = datums.borrow_with(&input_row);
-                let datums_len = datums_local.len();
+
+                // Unpack datums for expression evaluation.
+                let datums_local = datums.borrow_with(&input_row);
                 let exprs = exprs
                     .iter()
                     .map(|e| e.eval(&datums_local, &temp_storage))
@@ -51,51 +58,52 @@ where
                     Err(e) => return vec![(Err((e.into(), time, diff)))],
                 };
 
-                use crate::render::RenderTimestamp;
-                let event_time = time.event_time().clone();
+                // Draw rows out of the table func evaluation.
+                // Consolidate them as we acculumate them, and when we are "full" apply
+                // the MFP and record and perhaps consolidate the results.
+                for (output_row, r) in output_rows {
+                    table_func_output.push((output_row, r));
+                    if table_func_output.len() == table_func_output.capacity() {
+                        // Consolidate the collection of things we will append to `input_row`.
+                        differential_dataflow::consolidation::consolidate(&mut table_func_output);
+                        if table_func_output.len() > table_func_output.capacity() / 2 {
+                            drain_through_mfp(
+                                &input_row,
+                                &mut time,
+                                &diff,
+                                &mut datums_mfp,
+                                &table_func_output,
+                                &mfp_plan,
+                                &until,
+                                &mut oks_output,
+                                &mut err_output,
+                            );
 
-                // Declare borrows outside the closure so that appropriately lifetimed
-                // borrows are moved in and used by `mfp.evaluate`.
-                let until = &until;
-                let temp_storage = &temp_storage;
-                let mfp_plan = &mfp_plan;
-                let output_rows_vec: Vec<_> = output_rows.collect();
-                let binding = SharedRow::get();
-                let mut row_builder = binding.borrow_mut();
-                let row_builder = &mut row_builder;
-                output_rows_vec
-                    .iter()
-                    .flat_map(move |(output_row, r)| {
-                        // Remove any additional columns added in prior evaluation.
-                        datums_local.truncate(datums_len);
-                        // Extend datums with additional columns, replace some with dummy values.
-                        datums_local.extend(output_row.iter());
-                        mfp_plan
-                            .evaluate(
-                                &mut datums_local,
-                                temp_storage,
-                                event_time,
-                                diff * *r,
-                                |time| !until.less_equal(time),
-                                row_builder,
-                            )
-                            .collect::<Vec<_>>()
-                    })
-                    .map(|x| match x {
-                        Ok((row, event_time, diff)) => {
-                            // Copy the whole time, and re-populate event time.
-                            let mut time = time.clone();
-                            *time.event_time() = event_time;
-                            Ok((row, time, diff))
+                            // Double the capacity of the table func output buffer.
+                            table_func_output.clear();
+                            table_func_output.reserve(2 * table_func_output.capacity());
                         }
-                        Err((e, event_time, diff)) => {
-                            // Copy the whole time, and re-populate event time.
-                            let mut time = time.clone();
-                            *time.event_time() = event_time;
-                            Err((e, time, diff))
-                        }
-                    })
-                    .collect::<Vec<_>>()
+                    }
+                }
+
+                // Drain any straggler extensions.
+                if !table_func_output.is_empty() {
+                    drain_through_mfp(
+                        &input_row,
+                        &mut time,
+                        &diff,
+                        &mut datums_mfp,
+                        &table_func_output,
+                        &mfp_plan,
+                        &until,
+                        &mut oks_output,
+                        &mut err_output,
+                    );
+                }
+
+                let oks = oks_output.drain(..).map(|x| Ok(x));
+                let err = err_output.drain(..).map(|x| Err(x));
+                oks.chain(err).collect::<Vec<_>>()
             }
         });
 
@@ -104,5 +112,78 @@ where
         let new_err_collection = errs.as_collection();
         let err_collection = err_collection.concat(&new_err_collection);
         CollectionBundle::from_collections(ok_collection, err_collection)
+    }
+}
+
+use crate::render::DataflowError;
+use mz_expr::MfpPlan;
+use mz_repr::{Diff, Row, Timestamp};
+use timely::progress::Antichain;
+
+/// Drains a list of extensions to `input_row` through a supplied `MfpPlan` and into output buffers.
+fn drain_through_mfp<T>(
+    input_row: &Row,
+    input_time: &mut T,
+    input_diff: &Diff,
+    datum_vec: &mut DatumVec,
+    extensions: &[(Row, Diff)],
+    mfp_plan: &MfpPlan,
+    until: &Antichain<Timestamp>,
+    oks_output: &mut Vec<(Row, T, Diff)>,
+    err_output: &mut Vec<(DataflowError, T, Diff)>,
+) where
+    T: crate::render::RenderTimestamp,
+{
+    let temp_storage = RowArena::new();
+    let binding = SharedRow::get();
+    let mut row_builder = binding.borrow_mut();
+
+    let mut datums_local = datum_vec.borrow_with(&input_row);
+    let datums_len = datums_local.len();
+
+    let event_time = input_time.event_time().clone();
+
+    for (cols, diff) in extensions.iter() {
+        // Arrange `datums_local` to reflect the intended output pre-mfp.
+        datums_local.truncate(datums_len);
+        datums_local.extend(cols.iter());
+
+        let results = mfp_plan.evaluate(
+            &mut datums_local,
+            &temp_storage,
+            event_time,
+            diff * *input_diff,
+            |time| !until.less_equal(time),
+            &mut row_builder,
+        );
+
+        for result in results {
+            match result {
+                Ok((row, event_time, diff)) => {
+                    // Copy the whole time, and re-populate event time.
+                    let mut time = input_time.clone();
+                    *time.event_time() = event_time;
+                    oks_output.push((row, time, diff));
+                    if oks_output.len() == oks_output.capacity() {
+                        differential_dataflow::consolidation::consolidate_updates(oks_output);
+                        if oks_output.len() > oks_output.capacity() / 2 {
+                            oks_output.reserve(2 * oks_output.capacity() - oks_output.len());
+                        }
+                    }
+                }
+                Err((err, event_time, diff)) => {
+                    // Copy the whole time, and re-populate event time.
+                    let mut time = input_time.clone();
+                    *time.event_time() = event_time;
+                    err_output.push((err, time, diff));
+                    if err_output.len() == err_output.capacity() {
+                        differential_dataflow::consolidation::consolidate_updates(err_output);
+                        if err_output.len() > err_output.capacity() / 2 {
+                            err_output.reserve(2 * err_output.capacity() - err_output.len());
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -101,8 +101,8 @@ where
                     );
                 }
 
-                let oks = oks_output.drain(..).map(|x| Ok(x));
-                let err = err_output.drain(..).map(|x| Err(x));
+                let oks = oks_output.drain(..).map(Ok);
+                let err = err_output.drain(..).map(Err);
                 oks.chain(err).collect::<Vec<_>>()
             }
         });
@@ -138,7 +138,7 @@ fn drain_through_mfp<T>(
     let binding = SharedRow::get();
     let mut row_builder = binding.borrow_mut();
 
-    let mut datums_local = datum_vec.borrow_with(&input_row);
+    let mut datums_local = datum_vec.borrow_with(input_row);
     let datums_len = datums_local.len();
 
     let event_time = input_time.event_time().clone();


### PR DESCRIPTION
Our implementation of flatmap completely evaluates all extensions as it goes, and only then applies its `MfpPlan` which may reduce the data back down. In no case does it consolidate anything, shipping a large volume of data for e.g.
```sql
select count(*) from generate_series(1, 1000000000)
```

This PR draws data out of the `TableFunc::eval` iterator, consolidating as it goes and when necessary applying the `MfpPlan` and consolidating the results. On the query above it keeps a buffer of at most four elements (bumped up a bit because we set some minimums, but it is four when we do not).

cc: @ggevay 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
