### PR TITLE
sql: Refactor to statement logging history

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -761,7 +761,7 @@ impl Catalog {
             //
             // TODO(parkmycar): Remove after v0.92.
             const ACTIVITY_LOG_ONE_TIME_MIGRATION: &str = "activity_log_v_0_92_migration";
-            let ran_migration = txn.get_config(ACTIVITY_LOG_ONE_TIME_MIGRATION.to_string())?.is_some();
+            let ran_migration = txn.get_config(ACTIVITY_LOG_ONE_TIME_MIGRATION.to_string()).is_some();
             if !ran_migration {
                 let candidates = [
                     MZ_PREPARED_STATEMENT_HISTORY.name,

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 
 use futures::future::{BoxFuture, FutureExt};
 use mz_adapter_types::compaction::CompactionWindow;
+use mz_repr::namespaces::MZ_INTERNAL_SCHEMA;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use tracing::{info, warn, Instrument};
@@ -22,7 +23,8 @@ use uuid::Uuid;
 
 use mz_catalog::builtin::{
     Builtin, Fingerprint, BUILTINS, BUILTIN_CLUSTERS, BUILTIN_CLUSTER_REPLICAS, BUILTIN_PREFIXES,
-    BUILTIN_ROLES,
+    BUILTIN_ROLES, MZ_PREPARED_STATEMENT_HISTORY, MZ_SQL_TEXT, MZ_STATEMENT_EXECUTION_HISTORY,
+    MZ_STATEMENT_LIFECYCLE_HISTORY,
 };
 use mz_catalog::config::StateConfig;
 use mz_catalog::durable::objects::{
@@ -392,7 +394,7 @@ impl Catalog {
             let AllocatedBuiltinSystemIds {
                 all_builtins,
                 new_builtins,
-                migrated_builtins,
+                mut migrated_builtins,
             } = Catalog::allocate_system_ids(
                 &mut txn,
                 BUILTINS::iter()
@@ -754,6 +756,31 @@ impl Catalog {
             )?;
 
             let mut state = Catalog::load_catalog_items(&mut txn, &state)?;
+
+            // Run a one-time migration to clear the existing sources.
+            //
+            // TODO(parkmycar): Remove after v0.92.
+            const ACTIVITY_LOG_ONE_TIME_MIGRATION: &str = "activity_log_v_0_92_migration";
+            let ran_migration = txn.get_config(ACTIVITY_LOG_ONE_TIME_MIGRATION.to_string())?.is_some();
+            if !ran_migration {
+                let candidates = [
+                    MZ_PREPARED_STATEMENT_HISTORY.name,
+                    MZ_SQL_TEXT.name,
+                    MZ_STATEMENT_LIFECYCLE_HISTORY.name,
+                    MZ_STATEMENT_EXECUTION_HISTORY.name,
+                ];
+                let to_migrate: Vec<_> = txn
+                    .get_system_items()
+                    .filter(|mapping| {
+                        mapping.description.schema_name == MZ_INTERNAL_SCHEMA && candidates.contains(&mapping.description.object_name.as_str())
+                    })
+                    .map(|mapping| mapping.unique_identifier.id)
+                    .collect();
+                tracing::info!(?to_migrate, "running one time migration");
+                migrated_builtins.extend(to_migrate);
+
+                txn.set_config(ACTIVITY_LOG_ONE_TIME_MIGRATION.to_string(), Some(1))?;
+            }
 
             let mut builtin_migration_metadata = Catalog::generate_builtin_migration_metadata(
                 &state,

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -36,8 +36,6 @@ use mz_sql::session::hint::ApplicationNameHint;
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::user::SUPPORT_USER;
 use mz_sql::session::vars::{OwnedVarInput, Var, CLUSTER};
-use mz_sql_parser::ast::display::AstDisplay;
-use mz_sql_parser::ast::StatementKind;
 use mz_sql_parser::parser::{ParserStatementError, StatementParseResult};
 use prometheus::Histogram;
 use serde_json::json;
@@ -540,10 +538,7 @@ impl SessionClient {
         let params = vec![];
         let result_formats = vec![mz_pgwire_common::Format::Text; desc.arity()];
         let now = self.now();
-        let redacted_sql = stmt.to_ast_string_redacted();
-        let logging =
-            self.session()
-                .mint_logging(sql, redacted_sql, now, Some(StatementKind::from(&stmt)));
+        let logging = self.session().mint_logging(sql, Some(&stmt), now);
         self.session().set_portal(
             name,
             desc,

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -16,8 +16,7 @@ use mz_repr::{GlobalId, ScalarType};
 use mz_sql::names::{Aug, ResolvedIds};
 use mz_sql::plan::{Params, StatementDesc};
 use mz_sql::session::metadata::SessionMetadata;
-use mz_sql_parser::ast::display::AstDisplay;
-use mz_sql_parser::ast::{Raw, Statement, StatementKind};
+use mz_sql_parser::ast::{Raw, Statement};
 
 use crate::active_compute_sink::{ActiveComputeSink, ActiveComputeSinkRetireReason};
 use crate::catalog::Catalog;
@@ -76,9 +75,7 @@ impl Coordinator {
         let desc = describe(catalog, stmt.clone(), &param_types, session)?;
         let params = params.datums.into_iter().zip(params.types).collect();
         let result_formats = vec![mz_pgwire_common::Format::Text; desc.arity()];
-        let redacted_sql = stmt.to_ast_string_redacted();
-        let logging =
-            session.mint_logging(sql, redacted_sql, now, Some(StatementKind::from(&stmt)));
+        let logging = session.mint_logging(sql, Some(&stmt), now);
         session.set_portal(
             name,
             desc,

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -1217,11 +1217,7 @@ impl<'a> Transaction<'a> {
     }
 
     /// Set persisted configuration.
-    pub(crate) fn set_config(
-        &mut self,
-        key: String,
-        value: Option<u64>,
-    ) -> Result<(), CatalogError> {
+    pub fn set_config(&mut self, key: String, value: Option<u64>) -> Result<(), CatalogError> {
         match value {
             Some(value) => {
                 let config = Config { key, value };
@@ -1233,6 +1229,15 @@ impl<'a> Transaction<'a> {
             }
         }
         Ok(())
+    }
+
+    /// Get the value of a persisted config.
+    pub fn get_config(&mut self, key: String) -> Result<Option<u64>, CatalogError> {
+        let val = self
+            .configs
+            .get(&ConfigKey { key })
+            .map(|entry| entry.value);
+        Ok(val)
     }
 
     /// Updates the catalog `persist_txn_tables` "config" value to

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -1232,12 +1232,12 @@ impl<'a> Transaction<'a> {
     }
 
     /// Get the value of a persisted config.
-    pub fn get_config(&mut self, key: String) -> Result<Option<u64>, CatalogError> {
+    pub fn get_config(&mut self, key: String) -> Option<u64> {
         let val = self
             .configs
             .get(&ConfigKey { key })
             .map(|entry| entry.value);
-        Ok(val)
+        val
     }
 
     /// Updates the catalog `persist_txn_tables` "config" value to

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -279,10 +279,17 @@ ORDER BY mseh.began_at;",
             redacted_sql: r.get(6),
         };
         assert_eq!(r.sample_rate, 1.0);
-        assert_eq!(
-            r.sql,
+
+        let expected_sql = if r.sql.contains("SECRET") {
+            mz_sql::parse::parse(&r.sql)
+                .unwrap()
+                .into_element()
+                .ast
+                .to_ast_string_redacted()
+        } else {
             stmt.chars().filter(|&ch| ch != ';').collect::<String>()
-        );
+        };
+        assert_eq!(r.sql, expected_sql);
         assert_eq!(r.finished_status, "success");
         assert!(r.prepared_at <= r.began_at);
         assert!(r.began_at <= r.finished_at);

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1621,7 +1621,7 @@ impl<T: AstInfo> AstDisplay for CreateSecretStatement<T> {
         f.write_node(&self.name);
         f.write_str(" AS ");
 
-        if f.simple() {
+        if f.redacted() {
             f.write_str("'<REDACTED>'");
         } else {
             f.write_node(&self.value);
@@ -2299,7 +2299,7 @@ impl<T: AstInfo> AstDisplay for AlterSecretStatement<T> {
         f.write_node(&self.name);
         f.write_str(" AS ");
 
-        if f.simple() {
+        if f.redacted() {
             f.write_str("'<REDACTED>'");
         } else {
             f.write_node(&self.value);

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1620,7 +1620,12 @@ impl<T: AstInfo> AstDisplay for CreateSecretStatement<T> {
         }
         f.write_node(&self.name);
         f.write_str(" AS ");
-        f.write_node(&self.value);
+
+        if f.simple() {
+            f.write_str("'<REDACTED>'");
+        } else {
+            f.write_node(&self.value);
+        }
     }
 }
 impl_display_t!(CreateSecretStatement);
@@ -2293,7 +2298,12 @@ impl<T: AstInfo> AstDisplay for AlterSecretStatement<T> {
         }
         f.write_node(&self.name);
         f.write_str(" AS ");
-        f.write_node(&self.value);
+
+        if f.simple() {
+            f.write_str("'<REDACTED>'");
+        } else {
+            f.write_node(&self.value);
+        }
     }
 }
 

--- a/src/sql-parser/src/ast/display.rs
+++ b/src/sql-parser/src/ast/display.rs
@@ -70,7 +70,7 @@ where
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FormatMode {
     /// Simple is the normal way of printing for human consumption. Identifiers are quoted only if
-    /// necessary.
+    /// necessary and sensative information is redacted.
     Simple,
     /// SimpleRedacted is like Simple, but strips out string and number literals.
     /// This makes SQL queries be "usage data", rather than "customer data" according to our
@@ -105,6 +105,11 @@ where
     // Whether the AST should be optimized for persistence.
     pub fn stable(&self) -> bool {
         self.mode == FormatMode::Stable
+    }
+
+    /// Whether the AST should be printed out in a more human readable format.
+    pub fn simple(&self) -> bool {
+        matches!(self.mode, FormatMode::Simple | FormatMode::SimpleRedacted)
     }
 
     /// Whether the AST should be printed in redacted form

--- a/test/cluster/statement-logging/statement-logging.td
+++ b/test/cluster/statement-logging/statement-logging.td
@@ -240,3 +240,21 @@ COMMIT execution-finished
 "SELECT 'transaction statement 1'"
 "SELECT 'transaction statement 2'"
 ROLLBACK
+
+# Test that SECRETs have their values redacted.
+
+> CREATE SECRET my_super_secret AS '123';
+
+> SELECT redacted_sql FROM mz_internal.mz_recent_activity_log_redacted WHERE statement_type = 'create_secret';
+"CREATE SECRET my_super_secret AS '<REDACTED>'"
+
+> SELECT sql FROM mz_internal.mz_recent_activity_log WHERE statement_type = 'create_secret';
+"CREATE SECRET my_super_secret AS '<REDACTED>'"
+
+> ALTER SECRET my_super_secret AS '456';
+
+> SELECT redacted_sql FROM mz_internal.mz_recent_activity_log_redacted WHERE statement_type = 'alter_secret';
+"ALTER SECRET my_super_secret AS '<REDACTED>'"
+
+> SELECT sql FROM mz_internal.mz_recent_activity_log WHERE statement_type = 'alter_secret';
+"ALTER SECRET my_super_secret AS '<REDACTED>'"


### PR DESCRIPTION
Refactor statement logging history to do a bit of cleanup, and adds a (somewhat hacky) one time migration that should clear the necessary tables of their existing data.

### Motivation

Refactor/cleanup

### Tips for reviewer

This PR is separated into two commits:

1. The refactor to statement history
2. Introducing a one-time "migration" that should clear the existing sources

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
