### PR TITLE
storage/mysql: Fix detection of mysql enum column value changes

### DIFF
--- a/test/mysql-cdc/types-enum.td
+++ b/test/mysql-cdc/types-enum.td
@@ -50,18 +50,34 @@ contains:referenced tables use unsupported types
 val1 val1
 val2 val2
 
+# Add an additional enum value type
 $ mysql-execute name=mysql
-ALTER TABLE enum_type CHANGE f1 f1 ENUM ('val2', 'val1', 'val3');
+ALTER TABLE enum_type CHANGE f1 f1 ENUM ('val1', 'val2', 'val3');
 INSERT INTO enum_type VALUES ('val1', 'val1');
 
-# TODO: #26022 (enum reordering)
-# > SELECT * FROM enum_type;
-# val1 val1
-# val2 val2
-# val1 val1
+> SELECT * FROM enum_type;
+val1 val1
+val2 val2
+val1 val1
 
 $ mysql-execute name=mysql
 INSERT INTO enum_type VALUES ('val3', 'val3');
 
 ! SELECT * FROM enum_type;
 contains:received invalid enum value: 3 for column f1
+
+$ mysql-execute name=mysql
+DELETE FROM enum_type WHERE f1 = 'val3';
+
+> SELECT * FROM enum_type;
+val1 val1
+val2 val2
+val1 val1
+
+# Add an additional enum value type and change the ordering
+$ mysql-execute name=mysql
+ALTER TABLE enum_type CHANGE f1 f1 ENUM ('val2', 'val1', 'val3', 'val4');
+INSERT INTO enum_type VALUES ('val1', 'val1');
+
+! SELECT * FROM enum_type;
+contains:incompatible schema change: column f1 in table enum_type has been altered


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/materialize/issues/26022

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
