### PR TITLE
[DNM] persist: remove WriteHandle::{append,append_batch}

### DIFF
--- a/src/persist-cli/src/open_loop.rs
+++ b/src/persist-cli/src/open_loop.rs
@@ -607,11 +607,11 @@ mod raw_persist_benchmark {
             let handle = mz_ore::task::spawn(
                 || format!("appender-{}", idx),
                 async move {
-                    while let Some(batch) = batch_rx.recv().await {
+                    while let Some(mut batch) = batch_rx.recv().await {
                         let lower = batch.lower().clone();
                         let upper = batch.upper().clone();
                         write
-                            .append_batch(batch, lower, upper)
+                            .compare_and_append_batch(&mut [&mut batch], lower, upper)
                             .await
                             .expect("invalid usage")
                             .expect("unexpected upper");

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1039,13 +1039,17 @@ mod tests {
 
         // Finish off the batch and verify that the keys and such get plumbed
         // correctly by reading the data back.
-        let batch = builder
+        let mut batch = builder
             .finish(&schemas, Antichain::from_elem(4))
             .await
             .expect("invalid usage");
         assert_eq!(batch.batch.parts.len(), 3);
         write
-            .append_batch(batch, Antichain::from_elem(0), Antichain::from_elem(4))
+            .compare_and_append_batch(
+                &mut [&mut batch],
+                Antichain::from_elem(0),
+                Antichain::from_elem(4),
+            )
             .await
             .expect("invalid usage")
             .expect("unexpected upper");

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -759,20 +759,20 @@ mod tests {
         let (mut write, _) = client
             .expect_open::<String, String, u64, i64>(shard_id_one)
             .await;
-        write.expect_append(&data[..1], vec![0], vec![2]).await;
+        write.expect_compare_and_append(&data[..1], 0, 2).await;
 
         // write two rows into shard 2 from writer 1
         let (mut write, _) = client
             .expect_open::<String, String, u64, i64>(shard_id_two)
             .await;
-        write.expect_append(&data[1..3], vec![0], vec![4]).await;
+        write.expect_compare_and_append(&data[1..3], 0, 4).await;
         let writer_one = WriterKey::Id(write.writer_id.clone());
 
         // write one row into shard 2 from writer 2
         let (mut write, _) = client
             .expect_open::<String, String, u64, i64>(shard_id_two)
             .await;
-        write.expect_append(&data[4..], vec![0], vec![5]).await;
+        write.expect_compare_and_append(&data[4..], 4, 5).await;
         let writer_two = WriterKey::Id(write.writer_id.clone());
 
         let usage = StorageUsageClient::open(client);

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -232,64 +232,14 @@ where
     }
 
     /// Applies `updates` to this shard and downgrades this handle's upper to
-    /// `upper`.
-    ///
-    /// The innermost `Result` is `Ok` if the updates were successfully written.
-    /// If not, an `Upper` err containing the current writer upper is returned.
-    /// If that happens, we also update our local `upper` to match the current
-    /// upper. This is useful in cases where a timeout happens in between a
-    /// successful write and returning that to the client.
-    ///
-    /// In contrast to [Self::compare_and_append], multiple [WriteHandle]s may
-    /// be used concurrently to write to the same shard, but in this case, the
-    /// data being written must be identical (in the sense of "definite"-ness).
-    /// It's intended for replicated use by source ingestion, sinks, etc.
-    ///
-    /// All times in `updates` must be greater or equal to `lower` and not
-    /// greater or equal to `upper`. A `upper` of the empty antichain "finishes"
-    /// this shard, promising that no more data is ever incoming.
-    ///
-    /// `updates` may be empty, which allows for downgrading `upper` to
-    /// communicate progress. It is possible to call this with `upper` equal to
-    /// `self.upper()` and an empty `updates` (making the call a no-op).
-    ///
-    /// This uses a bounded amount of memory, even when `updates` is very large.
-    /// Individual records, however, should be small enough that we can
-    /// reasonably chunk them up: O(KB) is definitely fine, O(MB) come talk to
-    /// us.
-    ///
-    /// The clunky multi-level Result is to enable more obvious error handling
-    /// in the caller. See <http://sled.rs/errors.html> for details.
-    #[instrument(level = "trace", fields(shard = %self.machine.shard_id()))]
-    pub async fn append<SB, KB, VB, TB, DB, I>(
-        &mut self,
-        updates: I,
-        lower: Antichain<T>,
-        upper: Antichain<T>,
-    ) -> Result<Result<(), UpperMismatch<T>>, InvalidUsage<T>>
-    where
-        SB: Borrow<((KB, VB), TB, DB)>,
-        KB: Borrow<K>,
-        VB: Borrow<V>,
-        TB: Borrow<T>,
-        DB: Borrow<D>,
-        I: IntoIterator<Item = SB>,
-        D: Send + Sync,
-    {
-        let batch = self.batch(updates, lower.clone(), upper.clone()).await?;
-        self.append_batch(batch, lower, upper).await
-    }
-
-    /// Applies `updates` to this shard and downgrades this handle's upper to
     /// `new_upper` iff the current global upper of this shard is
     /// `expected_upper`.
     ///
     /// The innermost `Result` is `Ok` if the updates were successfully written.
     /// If not, an `Upper` err containing the current global upper is returned.
     ///
-    /// In contrast to [Self::append], this linearizes mutations from all
-    /// writers. It's intended for use as an atomic primitive for timestamp
-    /// bindings, SQL tables, etc.
+    /// This linearizes mutations from all writers. It's intended for use as an
+    /// atomic primitive for timestamp bindings, SQL tables, etc.
     ///
     /// All times in `updates` must be greater or equal to `expected_upper` and
     /// not greater or equal to `new_upper`. A `new_upper` of the empty
@@ -344,91 +294,14 @@ where
     }
 
     /// Appends the batch of updates to the shard and downgrades this handle's
-    /// upper to `upper`.
-    ///
-    /// The innermost `Result` is `Ok` if the updates were successfully written.
-    /// If not, an `Upper` err containing the current writer upper is returned.
-    /// If that happens, we also update our local `upper` to match the current
-    /// upper. This is useful in cases where a timeout happens in between a
-    /// successful write and returning that to the client.
-    ///
-    /// In contrast to [Self::compare_and_append_batch], multiple [WriteHandle]s
-    /// may be used concurrently to write to the same shard, but in this case,
-    /// the data being written must be identical (in the sense of
-    /// "definite"-ness). It's intended for replicated use by source ingestion,
-    /// sinks, etc.
-    ///
-    /// A `upper` of the empty antichain "finishes" this shard, promising that
-    /// no more data is ever incoming.
-    ///
-    /// The batch may be empty, which allows for downgrading `upper` to
-    /// communicate progress. It is possible to heartbeat a writer lease by
-    /// calling this with `upper` equal to `self.upper()` and an empty `updates`
-    /// (making the call a no-op).
-    ///
-    /// The clunky multi-level Result is to enable more obvious error handling
-    /// in the caller. See <http://sled.rs/errors.html> for details.
-    #[instrument(level = "trace", fields(shard = %self.machine.shard_id()))]
-    pub async fn append_batch(
-        &mut self,
-        mut batch: Batch<K, V, T, D>,
-        mut lower: Antichain<T>,
-        upper: Antichain<T>,
-    ) -> Result<Result<(), UpperMismatch<T>>, InvalidUsage<T>>
-    where
-        D: Send + Sync,
-    {
-        loop {
-            let res = self
-                .compare_and_append_batch(&mut [&mut batch], lower.clone(), upper.clone())
-                .await?;
-            match res {
-                Ok(()) => {
-                    self.upper = upper;
-                    return Ok(Ok(()));
-                }
-                Err(mismatch) => {
-                    // We tried to to a non-contiguous append, that won't work.
-                    if PartialOrder::less_than(&mismatch.current, &lower) {
-                        self.upper = mismatch.current.clone();
-
-                        batch.delete().await;
-
-                        return Ok(Err(mismatch));
-                    } else if PartialOrder::less_than(&mismatch.current, &upper) {
-                        // Cut down the Description by advancing its lower to the current shard
-                        // upper and try again. IMPORTANT: We can only advance the lower, meaning
-                        // we cut updates away, we must not "extend" the batch by changing to a
-                        // lower that is not beyond the current lower. This invariant is checked by
-                        // the first if branch: if `!(current_upper < lower)` then it holds that
-                        // `lower <= current_upper`.
-                        lower = mismatch.current;
-                    } else {
-                        // We already have updates past this batch's upper, the append is a no-op.
-                        self.upper = mismatch.current;
-
-                        // Because we return a success result, the caller will
-                        // think that the batch was consumed or otherwise used,
-                        // so we have to delete it here.
-                        batch.delete().await;
-
-                        return Ok(Ok(()));
-                    }
-                }
-            }
-        }
-    }
-
-    /// Appends the batch of updates to the shard and downgrades this handle's
     /// upper to `new_upper` iff the current global upper of this shard is
     /// `expected_upper`.
     ///
     /// The innermost `Result` is `Ok` if the batch was successfully written. If
     /// not, an `Upper` err containing the current global upper is returned.
     ///
-    /// In contrast to [Self::append_batch], this linearizes mutations from all
-    /// writers. It's intended for use as an atomic primitive for timestamp
-    /// bindings, SQL tables, etc.
+    /// This linearizes mutations from all writers. It's intended for use as an
+    /// atomic primitive for timestamp bindings, SQL tables, etc.
     ///
     /// A `new_upper` of the empty antichain "finishes" this shard, promising
     /// that no more data is ever incoming.
@@ -557,11 +430,10 @@ where
 
     /// Returns a [BatchBuilder] that can be used to write a batch of updates to
     /// blob storage which can then be appended to this shard using
-    /// [Self::compare_and_append_batch] or [Self::append_batch].
+    /// [Self::compare_and_append_batch].
     ///
     /// It is correct to create an empty batch, which allows for downgrading
-    /// `upper` to communicate progress. (see [Self::compare_and_append_batch]
-    /// or [Self::append_batch])
+    /// `upper` to communicate progress. (see [Self::compare_and_append_batch])
     ///
     /// The builder uses a bounded amount of memory, even when the number of
     /// updates is very large. Individual records, however, should be small
@@ -648,21 +520,6 @@ where
         let (_, maintenance) = self.machine.expire_writer(&self.writer_id).await;
         maintenance.start_performing(&self.machine, &self.gc);
         self.explicitly_expired = true;
-    }
-
-    /// Test helper for an [Self::append] call that is expected to succeed.
-    #[cfg(test)]
-    #[track_caller]
-    pub async fn expect_append<L, U>(&mut self, updates: &[((K, V), T, D)], lower: L, new_upper: U)
-    where
-        L: Into<Antichain<T>>,
-        U: Into<Antichain<T>>,
-        D: Send + Sync,
-    {
-        self.append(updates.iter(), lower.into(), new_upper.into())
-            .await
-            .expect("invalid usage")
-            .expect("unexpected upper");
     }
 
     /// Test helper for a [Self::compare_and_append] call that is expected to
@@ -798,7 +655,7 @@ mod tests {
 
         // Write an initial batch.
         let mut upper = 3;
-        write.expect_append(&data[..2], vec![0], vec![upper]).await;
+        write.expect_compare_and_append(&data[..2], 0, upper).await;
 
         // Write a bunch of empty batches. This shouldn't write blobs, so the count should stay the same.
         let mut count_before = 0;

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -3070,9 +3070,12 @@ where
                             let upper = write_handle.upper();
                             if !upper.is_empty() {
                                 let append = write_handle
-                                    .append(empty_batch, upper.clone(), Antichain::new())
+                                    .compare_and_append(
+                                        empty_batch,
+                                        upper.clone(),
+                                        Antichain::new(),
+                                    )
                                     .await?;
-
                                 if let Err(e) = append {
                                     warn!(
                                         "tried to finalize a shard with an advancing upper: {e:?}"


### PR DESCRIPTION
The original inclusion of `append` in the persist API was targeted at multi-replica clusters. The thinking was that each replica could assume the other was writing the same data (definite inputs => definite outputs) so if it was writing `[X, X+2)` and found that the upper of the shard was `X=1`, it could simply truncate to `[X+1,X=2)` and try again.

To support this truncation in an efficient way (i.e. without writing it back out to s3), persist had an internal optimization for append. We'd link the same s3 data in, but with metadata indicating that irrelevant data should be filtered out.

This internal performance optimization is the source of some considerable complexity in persist. Furthermore, the imagined usage was replaced by the self-correcting persist sink. The only callers of `append` in production code were giving it an empty set of updates, which is efficient _without_ the complex optimization.

So, remove it. Existing callers are replaced by manually unrolling the CaA expectation-mismatch loop. I considered leaving an `append_empty` in persist to DRY, but I've always found the semantics of `append` tricky to explain and reason about and IMO the callers read more clearly with the small bit of duplication.

This removes the API of `append`, but because of backward compatibility, does not yet remove the truncation optimization. The code at HEAD doesn't use append in any meaningful way, but it's possible that a previous version did and that we have these sitting in prod. We'll have to figure out a way to confirm their non-existence before we can do the rest of the cleanup.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Gotta see if anyone outside persist objects before moving forward with this.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
