### PR TITLE
storage: await on table register call in create_collections

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -651,7 +651,9 @@ where
             // it in create_collections, so just do that now.
             let advance_to = mz_persist_types::StepForward::step_forward(&register_ts);
             self.persist_table_worker
-                .register(register_ts, table_registers);
+                .register(register_ts, table_registers)
+                .await
+                .expect("table worker unexpectedly shut down");
             for (id, mut collection_state) in collection_states {
                 if let PersistTxns::EnabledLazy { .. } = &self.txns {
                     if collection_state.write_frontier.less_than(&advance_to) {


### PR DESCRIPTION
This persist_table_worker.register call is idempotent and re-run on envd restart, so it's ~fine if it doesn't succeed before a crash, but also probably feels better to await on it anyway. This was discovered while eyeballing traces.

While I'm in here, also clean up the name of the span: PersistTableWorkerInner::Send -> PersistTableWriteCmd::Register

Closes #25742

Before:

<img width="1766" alt="image" src="https://github.com/MaterializeInc/materialize/assets/52528/3dad288f-5e93-487a-bced-7ca0ad2fd845">

After:

<img width="1733" alt="image" src="https://github.com/MaterializeInc/materialize/assets/52528/f1e26977-0333-4312-b500-00e85bb4b83e">

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
