### PR TITLE
Update auto-routing adapter notice

### DIFF
--- a/ci/deploy_website/website.sh
+++ b/ci/deploy_website/website.sh
@@ -34,6 +34,7 @@ declare -A shortlinks=(
     [aws-connection-role-trust-policy]="https://materialize.com/docs/sql/create-connection/#permissions"
     [chat]="https://join.slack.com/t/materializecommunity/shared_invite/zt-2bad5ce4i-ZsiPWI5jd7Q9pRDGYj3dkw"
     [pricing]="https://materialize.com/pdfs/pricing.pdf"
+    [auto-routing]="https://materialize.com/docs/sql/show-clusters/#mz_introspection-system-cluster"
 )
 
 cd doc/user

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -180,7 +180,7 @@ impl AdapterNotice {
             AdapterNotice::RbacUserDisabled => Severity::Notice,
             AdapterNotice::RoleMembershipAlreadyExists { .. } => Severity::Notice,
             AdapterNotice::RoleMembershipDoesNotExists { .. } => Severity::Warning,
-            AdapterNotice::AutoRunOnIntrospectionCluster => Severity::Debug,
+            AdapterNotice::AutoRunOnIntrospectionCluster => Severity::Notice,
             AdapterNotice::AlterIndexOwner { .. } => Severity::Warning,
             AdapterNotice::CannotRevoke { .. } => Severity::Warning,
             AdapterNotice::NonApplicablePrivilegeTypes { .. } => Severity::Notice,
@@ -230,6 +230,7 @@ impl AdapterNotice {
                 }
             },
             AdapterNotice::RbacUserDisabled => Some("To enable RBAC globally run `ALTER SYSTEM SET enable_rbac_checks TO TRUE` as a superuser. TO enable RBAC for just this session run `SET enable_session_rbac_checks TO TRUE`.".into()),
+            AdapterNotice::AutoRunOnIntrospectionCluster => Some("See: https://materialize.com/s/auto-routing".into()),
             AdapterNotice::AlterIndexOwner {name: _} => Some("Change the ownership of the index's relation, instead.".into()),
             AdapterNotice::UnknownSessionDatabase(_) => Some(
                 "Create the database with CREATE DATABASE \
@@ -405,7 +406,7 @@ impl fmt::Display for AdapterNotice {
             ),
             AdapterNotice::AutoRunOnIntrospectionCluster => write!(
                 f,
-                "query was automatically run on the \"mz_introspection\" cluster"
+                "query was automatically run on the \"mz_introspection\" cluster to improve performance"
             ),
             AdapterNotice::AlterIndexOwner { name } => {
                 write!(f, "cannot change owner of {}", name.quoted())

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2858,7 +2858,7 @@ fn test_auto_run_on_introspection_feature_enabled() {
         match (rx.try_next(), expected) {
             (Ok(Some(notice)), true) => {
                 let msg = notice.message();
-                let expected = "query was automatically run on the \"mz_introspection\" cluster";
+                let expected = "query was automatically run on the \"mz_introspection\" cluster to improve performance";
                 assert_eq!(msg, expected);
             }
             (Err(_), false) => (),


### PR DESCRIPTION
Make the main text more clear, add a hint with a shortlink to docs, and upgrade severity from 'debug' to 'notice'.
Closes https://github.com/MaterializeInc/materialize/issues/21307

I'm a little concerned this is going to be spammy/noisy for some power users, so we should consider turning the severity back down if that is indeed the case.

### Motivation
  * This PR adds a known-desirable feature. https://github.com/MaterializeInc/materialize/issues/21307


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
