### PR TITLE
tests: Assert correct values for double-encoded JSON

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -4254,7 +4254,7 @@ async fn test_double_encoded_json() {
     };
     let _starting = read_msg();
     let _columns = read_msg();
-    
+
     let row_1 = read_msg();
     insta::assert_debug_snapshot!(row_1, @r###"
     Row(


### PR DESCRIPTION
This PR asserts we return the correct format for double-encoded JSON values from the HTTP and websocket endpoints.

### Motivation

A customer tripped over this recently, just want to make sure we return the correct values so the Console can render them appropriately.

Console issue: https://github.com/MaterializeInc/console/issues/1928

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds a new test
