### PR TITLE
Respond to further discussion

### DIFF
--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -36,59 +36,34 @@ where
             let mut datums_mfp = DatumVec::new();
 
             move |(input_row, mut time, diff)| {
-                let mut table_func_output = Vec::new();
-
-                // Into which we accumulate result update triples.
-                let mut oks_output = Vec::new();
-                let mut err_output = Vec::new();
-
                 let temp_storage = RowArena::new();
+
+                // Buffer for extensions to `input_row`.
+                let mut table_func_output = Vec::new();
+                // Buffer for outputs of MFP on extended `input_row`.
+                let mut output_buffer = Vec::new();
 
                 // Unpack datums for expression evaluation.
                 let datums_local = datums.borrow_with(&input_row);
-                let exprs = exprs
+                let args = exprs
                     .iter()
                     .map(|e| e.eval(&datums_local, &temp_storage))
                     .collect::<Result<Vec<_>, _>>();
-                let exprs = match exprs {
-                    Ok(exprs) => exprs,
+                let args = match args {
+                    Ok(args) => args,
                     Err(e) => return vec![(Err((e.into(), time, diff)))],
                 };
-                let output_rows = match func.eval(&exprs, &temp_storage) {
-                    Ok(exprs) => exprs,
+                let mut extensions = match func.eval(&args, &temp_storage) {
+                    Ok(exts) => exts,
                     Err(e) => return vec![(Err((e.into(), time, diff)))],
-                };
-
-                // Draw rows out of the table func evaluation.
-                // Consolidate them as we acculumate them, and when we are "full" apply
-                // the MFP and record and perhaps consolidate the results.
-                for (output_row, r) in output_rows {
-                    table_func_output.push((output_row, r));
-                    if table_func_output.len() == table_func_output.capacity() {
-                        // Consolidate the collection of things we will append to `input_row`.
-                        differential_dataflow::consolidation::consolidate(&mut table_func_output);
-                        if table_func_output.len() > table_func_output.capacity() / 2 {
-                            drain_through_mfp(
-                                &input_row,
-                                &mut time,
-                                &diff,
-                                &mut datums_mfp,
-                                &table_func_output,
-                                &mfp_plan,
-                                &until,
-                                &mut oks_output,
-                                &mut err_output,
-                            );
-
-                            // Double the capacity of the table func output buffer.
-                            table_func_output.clear();
-                            table_func_output.reserve(2 * table_func_output.capacity());
-                        }
-                    }
                 }
+                .fuse();
 
-                // Drain any straggler extensions.
-                if !table_func_output.is_empty() {
+                // Draw additional columns out of the table func evaluation.
+                while let Some((extension, output_diff)) = extensions.next() {
+                    table_func_output.push((extension, output_diff));
+                    table_func_output.extend((&mut extensions).take(1023));
+                    // We could consolidate `table_func_output`, but it seems unlikely to be productive.
                     drain_through_mfp(
                         &input_row,
                         &mut time,
@@ -97,16 +72,18 @@ where
                         &table_func_output,
                         &mfp_plan,
                         &until,
-                        &mut oks_output,
-                        &mut err_output,
+                        &mut output_buffer,
                     );
+                    table_func_output.clear();
                 }
-                // About to be dropped, but here to remind us in case we ever re-use it.
-                table_func_output.clear();
 
-                let oks = oks_output.into_iter().map(Ok);
-                let err = err_output.into_iter().map(Err);
-                oks.chain(err).collect::<Vec<_>>()
+                output_buffer
+                    .into_iter()
+                    .map(|(data, time, diff)| match data {
+                        Ok(row) => Ok((row, time, diff)),
+                        Err(err) => Err((err, time, diff)),
+                    })
+                    .collect::<Vec<_>>()
             }
         });
 
@@ -124,6 +101,8 @@ use mz_repr::{Diff, Row, Timestamp};
 use timely::progress::Antichain;
 
 /// Drains a list of extensions to `input_row` through a supplied `MfpPlan` and into output buffers.
+///
+/// The method decodes `input_row`, and should be amortized across non-trivial `extensions`.
 fn drain_through_mfp<T>(
     input_row: &Row,
     input_time: &mut T,
@@ -132,8 +111,7 @@ fn drain_through_mfp<T>(
     extensions: &[(Row, Diff)],
     mfp_plan: &MfpPlan,
     until: &Antichain<Timestamp>,
-    oks_output: &mut Vec<(Row, T, Diff)>,
-    err_output: &mut Vec<(DataflowError, T, Diff)>,
+    output: &mut Vec<(Result<Row, DataflowError>, T, Diff)>,
 ) where
     T: crate::render::RenderTimestamp,
 {
@@ -141,6 +119,7 @@ fn drain_through_mfp<T>(
     let binding = SharedRow::get();
     let mut row_builder = binding.borrow_mut();
 
+    // This is not cheap, and is meant to be amortized across many `extensions`.
     let mut datums_local = datum_vec.borrow_with(input_row);
     let datums_len = datums_local.len();
 
@@ -161,30 +140,25 @@ fn drain_through_mfp<T>(
         );
 
         for result in results {
-            match result {
+            let update = match result {
                 Ok((row, event_time, diff)) => {
                     // Copy the whole time, and re-populate event time.
                     let mut time = input_time.clone();
                     *time.event_time() = event_time;
-                    oks_output.push((row, time, diff));
-                    if oks_output.len() == oks_output.capacity() {
-                        differential_dataflow::consolidation::consolidate_updates(oks_output);
-                        if oks_output.len() > oks_output.capacity() / 2 {
-                            oks_output.reserve(2 * oks_output.capacity() - oks_output.len());
-                        }
-                    }
+                    (Ok(row), time, diff)
                 }
                 Err((err, event_time, diff)) => {
                     // Copy the whole time, and re-populate event time.
                     let mut time = input_time.clone();
                     *time.event_time() = event_time;
-                    err_output.push((err, time, diff));
-                    if err_output.len() == err_output.capacity() {
-                        differential_dataflow::consolidation::consolidate_updates(err_output);
-                        if err_output.len() > err_output.capacity() / 2 {
-                            err_output.reserve(2 * err_output.capacity() - err_output.len());
-                        }
-                    }
+                    (Err(err), time, diff)
+                }
+            };
+            output.push(update);
+            if output.len() == output.capacity() {
+                differential_dataflow::consolidation::consolidate_updates(output);
+                if output.len() > output.capacity() / 2 {
+                    output.reserve(2 * output.capacity() - output.len());
                 }
             }
         }


### PR DESCRIPTION
This follows up #26020 with some light renaming, but an important consideration: consolidating and doubling the table function output seems not especially helpful. Yes if we had to produce it all as output, but no because we are moving it through `drain_through_mfp`. In that case, we really just want to bite off large enough chunks to amortize decoding `input_row`. This simplifies the code a bit, and should reduce its memory footprint for table functions with large outputs that nonetheless consolidate down (e.g. the `select count(*) from generate_series` this was meant to address).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
