### PR TITLE
Allow configuring opentelemetry batch settings

### DIFF
--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -394,6 +394,11 @@ impl Listeners {
                     headers: http::HeaderMap::new(),
                     filter: EnvFilter::default().add_directive(Level::DEBUG.into()),
                     resource: opentelemetry_sdk::resource::Resource::default(),
+                    max_batch_queue_size: 2048,
+                    max_export_batch_size: 512,
+                    max_concurrent_exports: 1,
+                    batch_scheduled_delay: Duration::from_millis(5000),
+                    max_export_timeout: Duration::from_secs(30),
                 }),
                 #[cfg(feature = "tokio-console")]
                 tokio_console: None,


### PR DESCRIPTION
### Motivation
  * This PR adds a feature that has not yet been specified.
 Allow specifying different values for handling of opentelemetry trace span batches. Specifically, during periods of dysfunction when traces can't be sent, we sometimes see spans being dropped due to the buffer queue being full. Allow optionally increasing the size for debugging purposes.

### Tips for reviewer
The argument defaults are the defaults currently set for these values by [BatchConfig](https://docs.rs/opentelemetry_sdk/0.21.2/opentelemetry_sdk/trace/struct.BatchConfig.html)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. --> None
