### PR TITLE
Revert "Merge pull request #26006 from guswynn/loadgen-outstanding"

### DIFF
--- a/misc/python/materialize/checks/all_checks/cluster_unification.py
+++ b/misc/python/materialize/checks/all_checks/cluster_unification.py
@@ -35,7 +35,7 @@ class UnifiedCluster(Check):
                 """
                 > CREATE SOURCE shared_cluster_storage_first_source
                   IN CLUSTER shared_cluster_storage_first
-                  FROM LOAD GENERATOR COUNTER
+                  FROM LOAD GENERATOR COUNTER (SCALE FACTOR 0.01)
 
                 > CREATE MATERIALIZED VIEW shared_cluster_compute_first_mv
                   IN CLUSTER shared_cluster_compute_first
@@ -52,7 +52,7 @@ class UnifiedCluster(Check):
                 """
                 > CREATE SOURCE shared_cluster_compute_first_source
                   IN CLUSTER shared_cluster_compute_first
-                  FROM LOAD GENERATOR COUNTER
+                  FROM LOAD GENERATOR COUNTER (SCALE FACTOR 0.01)
 
                 > CREATE MATERIALIZED VIEW shared_cluster_storage_first_mv
                   IN CLUSTER shared_cluster_storage_first

--- a/misc/python/materialize/checks/all_checks/owners.py
+++ b/misc/python/materialize/checks/all_checks/owners.py
@@ -42,7 +42,7 @@ class Owners(Check):
         if expensive:
             s += dedent(
                 f"""
-                CREATE SOURCE owner_source{i} FROM LOAD GENERATOR COUNTER
+                CREATE SOURCE owner_source{i} FROM LOAD GENERATOR COUNTER (SCALE FACTOR 0.01)
                 CREATE SINK owner_sink{i} FROM owner_mv{i} INTO KAFKA CONNECTION owner_kafka_conn{i} (TOPIC 'sink-sink-owner{i}') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION owner_csr_conn{i} ENVELOPE DEBEZIUM
                 CREATE CLUSTER owner_cluster{i} REPLICAS (owner_cluster_r{i} (SIZE '4'))
                 """

--- a/misc/python/materialize/checks/all_checks/privileges.py
+++ b/misc/python/materialize/checks/all_checks/privileges.py
@@ -34,7 +34,7 @@ class Privileges(Check):
         if expensive:
             s += dedent(
                 f"""
-                CREATE SOURCE privilege_source{i} FROM LOAD GENERATOR COUNTER
+                CREATE SOURCE privilege_source{i} FROM LOAD GENERATOR COUNTER (SCALE FACTOR 0.01)
                 CREATE SINK privilege_sink{i} FROM privilege_mv{i} INTO KAFKA CONNECTION privilege_kafka_conn{i} (TOPIC 'sink-sink-privilege{i}') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION privilege_csr_conn{i} ENVELOPE DEBEZIUM
                 CREATE CLUSTER privilege_cluster{i} REPLICAS (privilege_cluster_r{i} (SIZE '4'))
                 """

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1594,39 +1594,6 @@ generate_extracted_config!(
     (MaxCardinality, u64)
 );
 
-impl LoadGeneratorOptionExtracted {
-    pub(super) fn ensure_only_valid_options(
-        &self,
-        loadgen: &ast::LoadGenerator,
-    ) -> Result<(), PlanError> {
-        use mz_sql_parser::ast::LoadGeneratorOptionName::*;
-
-        let mut options = self.seen.clone();
-
-        let permitted_options: &[_] = match loadgen {
-            ast::LoadGenerator::Auction => &[TickInterval],
-            ast::LoadGenerator::Counter => &[TickInterval, MaxCardinality],
-            ast::LoadGenerator::Marketing => &[TickInterval],
-            ast::LoadGenerator::Datums => &[TickInterval],
-            ast::LoadGenerator::Tpch => &[TickInterval, ScaleFactor],
-        };
-
-        for o in permitted_options {
-            options.remove(o);
-        }
-
-        if !options.is_empty() {
-            sql_bail!(
-                "{} load generators do not support {} values",
-                loadgen,
-                options.iter().join(", ")
-            )
-        }
-
-        Ok(())
-    }
-}
-
 pub(crate) fn load_generator_ast_to_generator(
     loadgen: &ast::LoadGenerator,
     options: &[LoadGeneratorOption<Aug>],
@@ -1637,21 +1604,18 @@ pub(crate) fn load_generator_ast_to_generator(
     ),
     PlanError,
 > {
-    let extracted: LoadGeneratorOptionExtracted = options.to_vec().try_into()?;
-    extracted.ensure_only_valid_options(loadgen)?;
-
     let load_generator = match loadgen {
         ast::LoadGenerator::Auction => LoadGenerator::Auction,
         ast::LoadGenerator::Counter => {
             let LoadGeneratorOptionExtracted {
                 max_cardinality, ..
-            } = extracted;
+            } = options.to_vec().try_into()?;
             LoadGenerator::Counter { max_cardinality }
         }
         ast::LoadGenerator::Marketing => LoadGenerator::Marketing,
         ast::LoadGenerator::Datums => LoadGenerator::Datums,
         ast::LoadGenerator::Tpch => {
-            let LoadGeneratorOptionExtracted { scale_factor, .. } = extracted;
+            let LoadGeneratorOptionExtracted { scale_factor, .. } = options.to_vec().try_into()?;
 
             // Default to 0.01 scale factor (=10MB).
             let sf: f64 = scale_factor.unwrap_or(0.01);

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -10,11 +10,6 @@
 $ set-arg-default default-replica-size=1
 $ set-arg-default single-replica-cluster=quickstart
 
-! CREATE SOURCE counter
-  IN CLUSTER ${arg.single-replica-cluster}
-  FROM LOAD GENERATOR COUNTER (SCALE FACTOR 1)
-exact:COUNTER load generators do not support SCALE FACTOR values
-
 > CREATE SOURCE auction_house
   IN CLUSTER ${arg.single-replica-cluster}
   FROM LOAD GENERATOR AUCTION FOR ALL TABLES;


### PR DESCRIPTION
This reverts commit 3d9437258de68906e14e39a5cf35a6c833ef8cd4, reversing changes made to 1caee1ca6e5a57f4a56e9efee9d902de9b4d09ea.

The migration written for this doesn't work so we have to revert it.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add `SCALE FACTOR` back to load generator sources.
