### PR TITLE
Push down predicates even if only one input

### DIFF
--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -424,7 +424,17 @@ impl ReduceBuilder {
             }
         }
         let input = if inputs.len() == 1 {
-            inputs.pop().unwrap()
+            let mut predicates = Vec::new();
+            for class in component.constraints {
+                for expr in class[1..].iter() {
+                    predicates.push(
+                        class[0]
+                            .clone()
+                            .call_binary(expr.clone(), mz_expr::BinaryFunc::Eq),
+                    );
+                }
+            }
+            inputs.pop().unwrap().filter(predicates)
         } else {
             MirRelationExpr::join_scalars(inputs, component.constraints)
         };

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -191,6 +191,11 @@ fn handle_apply(
             let transform = NormalizeLets::new(false);
             apply_transform(transform, catalog, input)
         }
+        "reduction_pushdown" => {
+            use mz_transform::reduction_pushdown::ReductionPushdown;
+            let transform = ReductionPushdown;
+            apply_transform(transform, catalog, input)
+        }
         "redundant_join" => {
             use mz_transform::redundant_join::RedundantJoin;
             let transform = RedundantJoin::default();

--- a/src/transform/tests/test_transforms/reduction_pushdown.spec
+++ b/src/transform/tests/test_transforms/reduction_pushdown.spec
@@ -1,0 +1,45 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Source definitions
+# ------------------
+
+# Define x source
+define
+DefSource name=x
+  - c0: bigint
+  - c1: bigint
+----
+Source defined as t0
+
+# Define y source
+define
+DefSource name=y keys=[[#0]]
+  - c0: bigint
+  - c1: bigint
+----
+Source defined as t1
+
+
+# Regression test for #25015.
+#
+# The Join has a contition that is a local predicate
+# and was lost prior to #25015.
+apply pipeline=reduction_pushdown
+Distinct project=[#1]
+  Join on=((#1 + #1) = #0)
+    Get x
+    Get y
+----
+Project (#0)
+  CrossJoin
+    Distinct project=[#1]
+      Get x
+    Distinct project=[]
+      Get y

--- a/src/transform/tests/test_transforms/reduction_pushdown.spec
+++ b/src/transform/tests/test_transforms/reduction_pushdown.spec
@@ -40,6 +40,7 @@ Distinct project=[#1]
 Project (#0)
   CrossJoin
     Distinct project=[#1]
-      Get x
+      Filter ((#1 + #1) = #0)
+        Get x
     Distinct project=[]
       Get y

--- a/test/rqg/Dockerfile
+++ b/test/rqg/Dockerfile
@@ -28,7 +28,7 @@ ADD https://api.github.com/repos/MaterializeInc/RQG/git/refs/heads/main version.
 
 RUN git clone --single-branch https://github.com/MaterializeInc/RQG.git \
     && cd RQG \
-    && git checkout 69a0e7b910d2d0ee22e7f25edd16648d7ea4fcb4
+    && git checkout d00f4c44c425782ea4485d26fcb6aa9bc5734de4
 
 ENTRYPOINT ["/usr/bin/perl"]
 

--- a/test/sqllogictest/github-25015.slt
+++ b/test/sqllogictest/github-25015.slt
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for #25015.
+
+# The schema is a simplified version of
+# https://github.com/MaterializeInc/RQG/blob/main/conf/mz/simple.sql
+
+statement ok
+CREATE TABLE t1 (f1 INT, f2 INT NOT NULL);
+
+statement ok
+INSERT INTO t1 VALUES (2, 2), (2, 2), (3, 3);
+
+statement ok
+CREATE TABLE t2 (f1 INT, f2 INT NOT NULL);
+
+statement ok
+INSERT INTO t2 VALUES (NULL, 0);
+
+# Prior to the bugfix for #25015 this query was (wrongly) returning a single
+# row.
+query II
+SELECT DISTINCT
+  (a1.f1) AS c1,
+  (a1.f2) AS c2
+FROM
+  t1 AS a1
+  JOIN (VALUES(1, 2)) AS a2(f1, f2) ON (a2.f2 = a1.f1)
+WHERE
+  a1.f2 + a2.f2 > (SELECT DISTINCT 0 c2 FROM t2 AS a1) AND a2.f2 IS NULL
+  OR NULLIF (a2.f2, a2.f1) = a1.f2 + a1.f2;
+----
+2
+2

--- a/test/sqllogictest/github-25015.slt
+++ b/test/sqllogictest/github-25015.slt
@@ -37,5 +37,3 @@ WHERE
   a1.f2 + a2.f2 > (SELECT DISTINCT 0 c2 FROM t2 AS a1) AND a2.f2 IS NULL
   OR NULLIF (a2.f2, a2.f1) = a1.f2 + a1.f2;
 ----
-2
-2


### PR DESCRIPTION
Our `ReductionPushdown` transform would lose track of join equivalences that involve only one input. In principle they could have been pushed down to that input, but if they have not for some reason, we still need to handle them.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
