### PR TITLE
ci: sharding: specify byteorder

### DIFF
--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -150,7 +150,9 @@ def accepted_by_shard(
     if parallelism_count is None:
         parallelism_count = get_parallelism_count()
 
-    hash_value = int.from_bytes(hashlib.md5(identifier.encode("utf-8")).digest())
+    hash_value = int.from_bytes(
+        hashlib.md5(identifier.encode("utf-8")).digest(), byteorder="big"
+    )
     return hash_value % parallelism_count == parallelism_index
 
 


### PR DESCRIPTION
This is needed for Python < 3.11 (used in scratch).