### PR TITLE
compute: controller-controlled sequential hydration

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -760,6 +760,9 @@ pub struct CollectionState<T> {
     /// `dropped == true`. Otherwise, clients might still expect to be able to query information
     /// about this collection.
     dropped: bool,
+    /// Whether this collection has been scheduled, i.e., the controller has sent a `Schedule`
+    /// command for it.
+    scheduled: bool,
 
     /// Accumulation of read capabilities for the collection.
     ///
@@ -841,6 +844,7 @@ impl<T: Timestamp> CollectionState<T> {
         Self {
             log_collection: false,
             dropped: false,
+            scheduled: false,
             read_capabilities,
             implied_capability,
             warmup_capability,
@@ -852,11 +856,13 @@ impl<T: Timestamp> CollectionState<T> {
         }
     }
 
-    /// TODO(#25239): Add documentation.
+    /// Creates a new collection state for a log collection.
     pub fn new_log_collection() -> Self {
         let since = Antichain::from_elem(Timestamp::minimum());
         let mut state = Self::new(since, Vec::new(), Vec::new());
         state.log_collection = true;
+        // Log collections are created and scheduled implicitly as part of replica initialization.
+        state.scheduled = true;
         state
     }
 }

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1113,8 +1113,14 @@ where
                 "not sending `CreateDataflow`, because of empty `as_of`",
             );
         } else {
+            let collections: Vec<_> = augmented_dataflow.export_ids().collect();
             self.compute
                 .send(ComputeCommand::CreateDataflow(augmented_dataflow));
+
+            // TODO: defer scheduling until inputs are ready
+            for id in collections {
+                self.compute.send(ComputeCommand::Schedule(id));
+            }
         }
 
         Ok(())

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -397,21 +397,23 @@ pub(crate) struct ReplicaCollectionMetrics {
 /// Metrics keyed by `ComputeCommand` type.
 #[derive(Debug)]
 pub struct CommandMetrics<M> {
-    /// TODO(#25239): Add documentation.
+    /// Metrics for `CreateTimely`.
     pub create_timely: M,
-    /// TODO(#25239): Add documentation.
+    /// Metrics for `CreateInstance`.
     pub create_instance: M,
-    /// TODO(#25239): Add documentation.
+    /// Metrics for `CreateDataflow`.
     pub create_dataflow: M,
-    /// TODO(#25239): Add documentation.
+    /// Metrics for `Schedule`.
+    pub schedule: M,
+    /// Metrics for `AllowCompaction`.
     pub allow_compaction: M,
-    /// TODO(#25239): Add documentation.
+    /// Metrics for `Peek`.
     pub peek: M,
-    /// TODO(#25239): Add documentation.
+    /// Metrics for `CancelPeek`.
     pub cancel_peek: M,
-    /// TODO(#25239): Add documentation.
+    /// Metrics for `InitializationComplete`.
     pub initialization_complete: M,
-    /// TODO(#25239): Add documentation.
+    /// Metrics for `UpdateConfiguration`.
     pub update_configuration: M,
 }
 
@@ -425,6 +427,7 @@ impl<M> CommandMetrics<M> {
             create_timely: build_metric("create_timely"),
             create_instance: build_metric("create_instance"),
             create_dataflow: build_metric("create_dataflow"),
+            schedule: build_metric("schedule"),
             allow_compaction: build_metric("allow_compaction"),
             peek: build_metric("peek"),
             cancel_peek: build_metric("cancel_peek"),
@@ -442,6 +445,7 @@ impl<M> CommandMetrics<M> {
         f(&self.initialization_complete);
         f(&self.update_configuration);
         f(&self.create_dataflow);
+        f(&self.schedule);
         f(&self.allow_compaction);
         f(&self.peek);
         f(&self.cancel_peek);
@@ -457,6 +461,7 @@ impl<M> CommandMetrics<M> {
             InitializationComplete => &self.initialization_complete,
             UpdateConfiguration(_) => &self.update_configuration,
             CreateDataflow(_) => &self.create_dataflow,
+            Schedule(_) => &self.schedule,
             AllowCompaction { .. } => &self.allow_compaction,
             Peek(_) => &self.peek,
             CancelPeek { .. } => &self.cancel_peek,
@@ -470,6 +475,7 @@ impl<M> CommandMetrics<M> {
             CreateTimely(_) => &self.create_timely,
             CreateInstance(_) => &self.create_instance,
             CreateDataflow(_) => &self.create_dataflow,
+            Schedule(_) => &self.schedule,
             AllowCompaction(_) => &self.allow_compaction,
             Peek(_) => &self.peek,
             CancelPeek(_) => &self.cancel_peek,

--- a/src/compute-client/src/protocol.rs
+++ b/src/compute-client/src/protocol.rs
@@ -86,6 +86,7 @@
 //! The compute controller may send any number of computation commands:
 //!
 //!   - [`CreateDataflow`]
+//!   - [`Schedule`]
 //!   - [`AllowCompaction`]
 //!   - [`Peek`]
 //!   - [`CancelPeek`]
@@ -103,6 +104,7 @@
 //! [`CreateInstance`]: self::command::ComputeCommand::CreateInstance
 //! [`InitializationComplete`]: self::command::ComputeCommand::InitializationComplete
 //! [`CreateDataflow`]: self::command::ComputeCommand::CreateDataflow
+//! [`Schedule`]: self::command::ComputeCommand::Schedule
 //! [`AllowCompaction`]: self::command::ComputeCommand::AllowCompaction
 //! [`Peek`]: self::command::ComputeCommand::Peek
 //! [`CancelPeek`]: self::command::ComputeCommand::CancelPeek

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -44,6 +44,7 @@ message ProtoComputeCommand {
         mz_proto.ProtoU128 cancel_peek = 6;
         google.protobuf.Empty initialization_complete = 7;
         ProtoComputeParameters update_configuration = 8;
+        mz_repr.global_id.ProtoGlobalId schedule = 9;
     }
 }
 

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -60,10 +60,23 @@ pub const ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING: Config<bool> = Config::new(
 );
 
 /// Enable usage of a pre-correction stash in the `persist_sink`.
+///
+/// Introduced to derisk the rollout of the `persist_sink` stash.
+/// TODO(teskje): remove after successful validation in prod
 pub const ENABLE_PERSIST_SINK_STASH: Config<bool> = Config::new(
     "enable_compute_persist_sink_stash",
     true,
     "Enable usage of a pre-correction stash in the compute `persist_sink`.",
+);
+
+/// Enable controller-controlled dataflow scheduling.
+///
+/// Introduced to derisk the rollout of the `Schedule` compute command.
+/// TODO(teskje): remove after successful validation in prod
+pub const ENABLE_CONTROLLER_DATAFLOW_SCHEDULING: Config<bool> = Config::new(
+    "enable_compute_controller_dataflow_scheduling",
+    true,
+    "Enable compute controller-controlled dataflow scheduling.",
 );
 
 /// Maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
@@ -116,6 +129,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_CHUNKED_STACK)
         .add(&ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING)
         .add(&ENABLE_PERSIST_SINK_STASH)
+        .add(&ENABLE_CONTROLLER_DATAFLOW_SCHEDULING)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)
         .add(&LGALLOC_BACKGROUND_INTERVAL)

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -317,6 +317,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             InitializationComplete => (),
             UpdateConfiguration(params) => self.handle_update_configuration(params),
             CreateDataflow(dataflow) => self.handle_create_dataflow(dataflow),
+            Schedule(id) => { /* TODO */ }
             AllowCompaction { id, frontier } => self.handle_allow_compaction(id, frontier),
             Peek(peek) => {
                 peek.otel_ctx.attach_as_parent();

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -131,12 +131,17 @@ pub struct ComputeState {
     /// Copies of this sender are passed to the hydration logging operators.
     pub hydration_tx: mpsc::Sender<HydrationEvent>,
 
+    /// Collections awaiting schedule instruction by the controller.
+    ///
+    /// Each entry stores a reference to a token that can be dropped to unsuspend the collection's
+    /// dataflow. Multiple collections can reference the same token if they are exported by the
+    /// same dataflow.
+    waiting_collections: BTreeMap<GlobalId, Rc<Box<dyn Any>>>,
     /// Collections in the process of hydrating.
     hydrating_collections: BTreeSet<GlobalId>,
     /// Queue of dataflows awaiting hydration.
     ///
     /// Each entry is a dataflow ID and a token that can be dropped to unsuspend the dataflow.
-    /// Entries are `Option`s to enable efficient removal of dropped collections.
     hydration_queue: VecDeque<(usize, Box<dyn Any>)>,
 }
 
@@ -171,8 +176,9 @@ impl ComputeState {
             worker_config: mz_dyncfgs::all_dyncfgs(),
             hydration_rx,
             hydration_tx,
-            hydrating_collections: Default::default(),
+            waiting_collections: Default::default(),
             hydration_queue: Default::default(),
+            hydrating_collections: Default::default(),
         }
     }
 
@@ -317,7 +323,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             InitializationComplete => (),
             UpdateConfiguration(params) => self.handle_update_configuration(params),
             CreateDataflow(dataflow) => self.handle_create_dataflow(dataflow),
-            Schedule(id) => { /* TODO */ }
+            Schedule(id) => self.handle_schedule(id),
             AllowCompaction { id, frontier } => self.handle_allow_compaction(id, frontier),
             Peek(peek) => {
                 peek.otel_ctx.attach_as_parent();
@@ -417,16 +423,20 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             }
         }
 
-        // If this is a non-transient dataflow, suspend it until we have capacity to start its
-        // hydration. See `process_sequential_hydration`.
+        // Schedule transient dataflows immediately, under the assumption that they are created for
+        // interactive user queries. Suspend non-transient dataflows, to enforce the configured
+        // `hydration_concurrency`.
         let (start_signal, suspension_token) = StartSignal::new();
         if dataflow.is_transient() {
             drop(suspension_token);
         } else {
-            self.compute_state
-                .hydration_queue
-                .push_back((dataflow_index, suspension_token));
-        };
+            let token = Rc::new(suspension_token);
+            for id in dataflow.export_ids() {
+                self.compute_state
+                    .waiting_collections
+                    .insert(id, Rc::clone(&token));
+            }
+        }
 
         crate::render::build_compute_dataflow(
             self.timely_worker,
@@ -434,6 +444,33 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             dataflow,
             start_signal,
         );
+    }
+
+    fn handle_schedule(&mut self, id: GlobalId) {
+        // A `Schedule` command instructs us to begin dataflow computation for a collection, so
+        // we should unsuspend it by dropping the corresponding suspension token. Note that a
+        // dataflow can export multiple collections and they all share one suspension token, so the
+        // computation of a dataflow will only start once all its exported collections have been
+        // scheduled.
+        //
+        // Instead of immediately dropping the suspension token, we add it to the
+        // `hydration_queue`, to enforce the configured `hydration_concurrency`.
+
+        let Some(suspension_token) = self.compute_state.waiting_collections.remove(&id) else {
+            // During reconciliation we might reuse already running dataflows, for which we will
+            // then receive `Schedule` commands even though they are not suspended.
+            return;
+        };
+        let Some(suspension_token) = Rc::into_inner(suspension_token) else {
+            // The dataflow exports other collections that are still unscheduled.
+            return;
+        };
+
+        let collection = self.compute_state.expect_collection(id);
+        let dataflow_id = collection.dataflow_id.expect("must be known");
+        self.compute_state
+            .hydration_queue
+            .push_back((dataflow_id, suspension_token));
     }
 
     fn handle_allow_compaction(&mut self, id: GlobalId, frontier: Antichain<Timestamp>) {
@@ -490,7 +527,9 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
 
         // If this collection is an index, remove its trace.
         self.compute_state.traces.del_trace(&id);
-        // If the collection is hydrating, remove its tracking state.
+
+        // Remove scheduling and hydration tracking state.
+        self.compute_state.waiting_collections.remove(&id);
         self.compute_state.hydrating_collections.remove(&id);
 
         // Remove frontier logging.

--- a/test/testdrive/sequential-hydration.td
+++ b/test/testdrive/sequential-hydration.td
@@ -1,0 +1,68 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests for sequential dataflow hydration in Compute.
+
+# Test that dataflows that are unable to hydrate because their source data is
+# not yet available don't block hydration of other dataflows.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET compute_hydration_concurrency = 1;
+
+> CREATE CLUSTER source1 SIZE '1', REPLICATION FACTOR 0
+> CREATE CLUSTER source2 SIZE '1', REPLICATION FACTOR 0
+> CREATE CLUSTER source3 SIZE '1', REPLICATION FACTOR 1
+
+> CREATE TABLE t (a int);
+> CREATE MATERIALIZED VIEW mv1 IN CLUSTER source1 AS SELECT * FROM t
+> CREATE MATERIALIZED VIEW mv2 IN CLUSTER source2 AS SELECT * FROM t
+> CREATE MATERIALIZED VIEW mv3 IN CLUSTER source3 AS SELECT * FROM t
+
+> CREATE INDEX idx1 ON mv1 (a)
+> SELECT DISTINCT name, hydrated
+  FROM mz_internal.mz_hydration_statuses
+  JOIN mz_indexes ON (id = object_id)
+  WHERE id LIKE 'u%'
+idx1  false
+
+> CREATE VIEW v12 AS SELECT * FROM mv1 JOIN mv2 USING (a)
+> CREATE INDEX idx12 ON v12 (a)
+> SELECT DISTINCT name, hydrated
+  FROM mz_internal.mz_hydration_statuses
+  JOIN mz_indexes ON (id = object_id)
+  WHERE id LIKE 'u%'
+idx1  false
+idx12 false
+
+> CREATE INDEX idx3 ON mv3 (a)
+> SELECT DISTINCT name, hydrated
+  FROM mz_internal.mz_hydration_statuses
+  JOIN mz_indexes ON (id = object_id)
+  WHERE id LIKE 'u%'
+idx1  false
+idx12 false
+idx3  true
+
+> ALTER CLUSTER source1 SET (REPLICATION FACTOR 1)
+> SELECT DISTINCT name, hydrated
+  FROM mz_internal.mz_hydration_statuses
+  JOIN mz_indexes ON (id = object_id)
+  WHERE id LIKE 'u%'
+idx1  true
+idx12 false
+idx3  true
+
+> ALTER CLUSTER source2 SET (REPLICATION FACTOR 1)
+> SELECT DISTINCT name, hydrated
+  FROM mz_internal.mz_hydration_statuses
+  JOIN mz_indexes ON (id = object_id)
+  WHERE id LIKE 'u%'
+idx1  true
+idx12 true
+idx3  true


### PR DESCRIPTION
This PR adds a new `Schedule` compute command that allows the controller to control when dataflows should be started, independently from their creation. The controller uses this ability to delay the starting of dataflows that don't have their input data available yet, fixing an issue with sequential hydration where replicas could become stuck waiting for input data even when the hydration queue contained dataflows that were ready to hydrate.

On the replica-side, transient dataflows are still handled specially in that the replica doesn't wait for `Schedule` commands before unsuspending them. This is a bit of a smell as ideally, replicas would just verbatim apply `Schedule` commands they receive. I think we can fix this in a follow-up by moving the sequential hydration logic out of the replica code and into a `SequentialHydration` client that sits between the controller and the `PartitionedState` and holds back `Schedule` commands to enforce sequential hydration. Such a client would also exempt transient dataflows from sequential hydration by not delaying their `Schedule` commands.

### Motivation

  * This PR adds a known-desirable feature.

Part of #25271 

### Tips for reviewer

The commits can be reviewed separately.

The replica-side state tracking is a bit awkward because of the 1-to-n mapping of dataflows to collections. The current approach is to unsuspend a dataflow only when all its collections have been scheduled. This decision was mostly made because it was easiest to implement, but we could alternatively consider unsuspending a dataflow immediately when its first collection is scheduled. This doesn't matter much today, since we only ever create dataflows with a single export, but it might matter in the future.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A