### PR TITLE
Remove some RTTI

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1124,7 +1124,6 @@ impl IndexPeek {
                     peek,
                     oks_handle,
                     None,
-                    Some(&[]),
                     max_result_size,
                 )
             }
@@ -1134,7 +1133,6 @@ impl IndexPeek {
                 Self::collect_ok_finished_data::<RowRowSpine<_, _>>(
                     peek,
                     oks_handle,
-                    None,
                     None,
                     max_result_size,
                 )
@@ -1147,7 +1145,6 @@ impl IndexPeek {
         peek: &mut Peek<Timestamp>,
         oks_handle: &mut TraceAgent<Tr>,
         key_types: Option<&[ColumnType]>,
-        val_types: Option<&[ColumnType]>,
         max_result_size: u64,
     ) -> Result<Vec<(Row, NonZeroUsize)>, String>
     where
@@ -1231,9 +1228,9 @@ impl IndexPeek {
                 let arena = RowArena::new();
 
                 let key_item = cursor.key(&storage);
-                let key = key_item.into_datum_iter(key_types);
+                let key = key_item.into_datum_iter();
                 let row_item = cursor.val(&storage);
-                let row = row_item.into_datum_iter(val_types);
+                let row = row_item.into_datum_iter();
 
                 let mut borrow = datum_vec.borrow();
                 borrow.extend(key);

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -303,14 +303,14 @@ where
         match self {
             SpecializedArrangement::RowUnit(inner) => inner.as_collection(move |k, v| {
                 let mut datums_borrow = datums.borrow();
-                datums_borrow.extend(k.into_datum_iter(None));
-                datums_borrow.extend(v.into_datum_iter(Some(&[])));
+                datums_borrow.extend(k.into_datum_iter());
+                datums_borrow.extend(v.into_datum_iter());
                 logic(&datums_borrow)
             }),
             SpecializedArrangement::RowRow(inner) => inner.as_collection(move |k, v| {
                 let mut datums_borrow = datums.borrow();
-                datums_borrow.extend(k.into_datum_iter(None));
-                datums_borrow.extend(v.into_datum_iter(None));
+                datums_borrow.extend(k.into_datum_iter());
+                datums_borrow.extend(v.into_datum_iter());
                 logic(&datums_borrow)
             }),
         }
@@ -339,8 +339,8 @@ where
                     key,
                     move |k, v, t, d| {
                         let mut datums_borrow = datums.borrow();
-                        datums_borrow.extend(k.into_datum_iter(None));
-                        datums_borrow.extend(v.into_datum_iter(Some(&[])));
+                        datums_borrow.extend(k.into_datum_iter());
+                        datums_borrow.extend(v.into_datum_iter());
                         logic(&mut datums_borrow, t, d)
                     },
                     refuel,
@@ -352,8 +352,8 @@ where
                     key,
                     move |k, v, t, d| {
                         let mut datums_borrow = datums.borrow();
-                        datums_borrow.extend(k.into_datum_iter(None));
-                        datums_borrow.extend(v.into_datum_iter(None));
+                        datums_borrow.extend(k.into_datum_iter());
+                        datums_borrow.extend(v.into_datum_iter());
                         logic(&mut datums_borrow, t, d)
                     },
                     refuel,
@@ -446,14 +446,14 @@ where
         match self {
             SpecializedArrangementImport::RowUnit(inner) => inner.as_collection(move |k, v| {
                 let mut datums_borrow = datums.borrow();
-                datums_borrow.extend(k.into_datum_iter(None));
-                datums_borrow.extend(v.into_datum_iter(Some(&[])));
+                datums_borrow.extend(k.into_datum_iter());
+                datums_borrow.extend(v.into_datum_iter());
                 logic(&datums_borrow)
             }),
             SpecializedArrangementImport::RowRow(inner) => inner.as_collection(move |k, v| {
                 let mut datums_borrow = datums.borrow();
-                datums_borrow.extend(k.into_datum_iter(None));
-                datums_borrow.extend(v.into_datum_iter(None));
+                datums_borrow.extend(k.into_datum_iter());
+                datums_borrow.extend(v.into_datum_iter());
                 logic(&datums_borrow)
             }),
         }
@@ -479,8 +479,8 @@ where
                     key,
                     move |k, v, t, d| {
                         let mut datums_borrow = datums.borrow();
-                        datums_borrow.extend(k.into_datum_iter(None));
-                        datums_borrow.extend(v.into_datum_iter(Some(&[])));
+                        datums_borrow.extend(k.into_datum_iter());
+                        datums_borrow.extend(v.into_datum_iter());
                         logic(&mut datums_borrow, t, d)
                     },
                     refuel,
@@ -492,8 +492,8 @@ where
                     key,
                     move |k, v, t, d| {
                         let mut datums_borrow = datums.borrow();
-                        datums_borrow.extend(k.into_datum_iter(None));
-                        datums_borrow.extend(v.into_datum_iter(None));
+                        datums_borrow.extend(k.into_datum_iter());
+                        datums_borrow.extend(v.into_datum_iter());
                         logic(&mut datums_borrow, t, d)
                     },
                     refuel,

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -22,7 +22,7 @@ use mz_compute_types::plan::join::linear_join::{LinearJoinPlan, LinearStagePlan}
 use mz_compute_types::plan::join::JoinClosure;
 use mz_dyncfg::ConfigSet;
 use mz_repr::fixed_length::IntoRowByTypes;
-use mz_repr::{ColumnType, DatumVec, Diff, Row, RowArena, SharedRow};
+use mz_repr::{DatumVec, Diff, Row, RowArena, SharedRow};
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
 use timely::container::columnation::Columnation;
@@ -387,34 +387,19 @@ where
                     let (oks, errs2) = match (local, oks) {
                         (A::RowUnit(prev_keyed), A::RowUnit(next_input)) => self
                             .differential_join_inner::<_, RowAgent<_, _>, RowAgent<_, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                Some(vec![]),
-                                closure,
+                                prev_keyed, next_input, closure,
                             ),
                         (A::RowUnit(prev_keyed), A::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowAgent<_, _>, RowRowAgent<_, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                None,
-                                closure,
+                                prev_keyed, next_input, closure,
                             ),
                         (A::RowRow(prev_keyed), A::RowUnit(next_input)) => self
                             .differential_join_inner::<_, RowRowAgent<_, _>, RowAgent<_, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                None,
-                                Some(vec![]),
-                                closure,
+                                prev_keyed, next_input, closure,
                             ),
                         (A::RowRow(prev_keyed), A::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowRowAgent<_, _>, RowRowAgent<_, _>>(
-                                prev_keyed, next_input, None, None, None, closure,
+                                prev_keyed, next_input, closure,
                             ),
                     };
 
@@ -426,34 +411,19 @@ where
                     let (oks, errs2) = match (local, oks) {
                         (A::RowUnit(prev_keyed), I::RowUnit(next_input)) => self
                             .differential_join_inner::<_, RowAgent<_, _>, RowEnter<_, _, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                Some(vec![]),
-                                closure,
+                                prev_keyed, next_input, closure,
                             ),
                         (A::RowUnit(prev_keyed), I::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowAgent<_, _>, RowRowEnter<_, _, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                None,
-                                closure,
+                                prev_keyed, next_input, closure,
                             ),
                         (A::RowRow(prev_keyed), I::RowUnit(next_input)) => self
                             .differential_join_inner::<_, RowRowAgent<_, _>, RowEnter<_, _, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                None,
-                                Some(vec![]),
-                                closure,
+                                prev_keyed, next_input, closure,
                             ),
                         (A::RowRow(prev_keyed), I::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowRowAgent<_, _>, RowRowEnter<_, _, _>>(
-                                prev_keyed, next_input, None, None, None, closure,
+                                prev_keyed, next_input, closure,
                             ),
                     };
 
@@ -467,34 +437,19 @@ where
                     let (oks, errs2) = match (trace, oks) {
                         (I::RowUnit(prev_keyed), A::RowUnit(next_input)) => self
                             .differential_join_inner::<_, RowEnter<_, _, _>, RowAgent<_, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                Some(vec![]),
-                                closure,
+                                prev_keyed, next_input, closure,
                             ),
                         (I::RowUnit(prev_keyed), A::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowEnter<_, _, _>, RowRowAgent<_, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                None,
-                                closure,
+                                prev_keyed, next_input, closure,
                             ),
                         (I::RowRow(prev_keyed), A::RowUnit(next_input)) => self
                             .differential_join_inner::<_, RowRowEnter<_, _, _>, RowAgent<_, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                None,
-                                Some(vec![]),
-                                closure,
+                                prev_keyed, next_input, closure,
                             ),
                         (I::RowRow(prev_keyed), A::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowAgent<_, _>>(
-                                prev_keyed, next_input, None, None, None, closure,
+                                prev_keyed, next_input, closure,
                             ),
                     };
 
@@ -508,32 +463,23 @@ where
                             .differential_join_inner::<_, RowEnter<_, _, _>, RowEnter<_, _, _>>(
                                 prev_keyed,
                                 next_input,
-                                None,
-                                Some(vec![]),
-                                Some(vec![]),
                                 closure,
                             ),
                         (I::RowUnit(prev_keyed), I::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowEnter<_, _, _>, RowRowEnter<_, _, _>>(
                                 prev_keyed,
                                 next_input,
-                                None,
-                                Some(vec![]),
-                                None,
                                 closure,
                             ),
                         (I::RowRow(prev_keyed), I::RowUnit(next_input)) => self
                             .differential_join_inner::<_, RowRowEnter<_, _, _>, RowEnter<_, _, _>>(
                                 prev_keyed,
                                 next_input,
-                                None,
-                                None,
-                                Some(vec![]),
                                 closure,
                             ),
                         (I::RowRow(prev_keyed), I::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowEnter<_, _, _>>(
-                                prev_keyed, next_input, None, None, None, closure,
+                                prev_keyed, next_input, closure,
                             ),
                     };
 
@@ -555,9 +501,6 @@ where
         &self,
         prev_keyed: Arranged<S, Tr1>,
         next_input: Arranged<S, Tr2>,
-        key_types: Option<Vec<ColumnType>>,
-        prev_types: Option<Vec<ColumnType>>,
-        next_types: Option<Vec<ColumnType>>,
         closure: JoinClosure,
     ) -> (
         Collection<S, Row, Diff>,
@@ -588,9 +531,9 @@ where
                         let mut row_builder = binding.borrow_mut();
                         let temp_storage = RowArena::new();
 
-                        let key = key.into_datum_iter(key_types.as_deref());
-                        let old = old.into_datum_iter(prev_types.as_deref());
-                        let new = new.into_datum_iter(next_types.as_deref());
+                        let key = key.into_datum_iter();
+                        let old = old.into_datum_iter();
+                        let new = new.into_datum_iter();
 
                         let mut datums_local = datums.borrow();
                         datums_local.extend(key);
@@ -623,9 +566,9 @@ where
                     let mut row_builder = binding.borrow_mut();
                     let temp_storage = RowArena::new();
 
-                    let key = key.into_datum_iter(key_types.as_deref());
-                    let old = old.into_datum_iter(prev_types.as_deref());
-                    let new = new.into_datum_iter(next_types.as_deref());
+                    let key = key.into_datum_iter();
+                    let old = old.into_datum_iter();
+                    let new = new.into_datum_iter();
 
                     let mut datums_local = datums.borrow();
                     datums_local.extend(key);

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -377,7 +377,7 @@ where
                         }
 
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter(None);
+                        let datum_iter = key.into_datum_iter();
                         let mut datums_local = datums1.borrow();
                         datums_local.extend(datum_iter);
                         let key_len = datums_local.len();
@@ -446,7 +446,7 @@ where
                     }
 
                     let temp_storage = RowArena::new();
-                    let datum_iter = key.into_datum_iter(None);
+                    let datum_iter = key.into_datum_iter();
                     let mut datums_local = datums2.borrow();
                     datums_local.extend(datum_iter);
 
@@ -561,7 +561,7 @@ where
                 move |key, _input, output| {
                     let temp_storage = RowArena::new();
                     let mut datums_local = datums1.borrow();
-                    datums_local.extend(key.into_datum_iter(None));
+                    datums_local.extend(key.into_datum_iter());
 
                     // Note that the key contains all the columns in a `Distinct` and that `mfp_after` is
                     // required to preserve the key. Therefore, if `mfp_after` maps, then it must project
@@ -591,7 +591,7 @@ where
                     // If `mfp_after` can error, then evaluate it here.
                     let Some(mfp) = &mfp_after2 else { return };
                     let temp_storage = RowArena::new();
-                    let datum_iter = key.into_datum_iter(None);
+                    let datum_iter = key.into_datum_iter();
                     let mut datums_local = datums2.borrow();
                     datums_local.extend(datum_iter);
 
@@ -660,7 +660,7 @@ where
         let output = arranged.mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceFuseBasic", {
             move |key, input, output| {
                 let temp_storage = RowArena::new();
-                let datum_iter = key.into_datum_iter(None);
+                let datum_iter = key.into_datum_iter();
                 let mut datums_local = datums1.borrow();
                 datums_local.extend(datum_iter);
                 let key_len = datums_local.len();
@@ -689,7 +689,7 @@ where
                         // Since negative accumulations are checked in at least one component
                         // aggregate, we only need to look for MFP errors here.
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter(None);
+                        let datum_iter = key.into_datum_iter();
                         let mut datums_local = datums2.borrow();
                         datums_local.extend(datum_iter);
 
@@ -787,11 +787,11 @@ where
                     // Note that in the non-positive case, this is wrong, but harmless because
                     // our other reduction will produce an error.
                     let count = usize::try_from(*w).unwrap_or(0);
-                    std::iter::repeat(v.into_datum_iter(None).next().unwrap()).take(count)
+                    std::iter::repeat(v.into_datum_iter().next().unwrap()).take(count)
                 });
 
                 let temp_storage = RowArena::new();
-                let datum_iter = key.into_datum_iter(None);
+                let datum_iter = key.into_datum_iter();
                 let mut datums_local = datums1.borrow();
                 datums_local.extend(datum_iter);
                 let key_len = datums_local.len();
@@ -850,7 +850,7 @@ where
                         });
 
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter(None);
+                        let datum_iter = key.into_datum_iter();
                         let mut datums_local = datums2.borrow();
                         datums_local.extend(datum_iter);
                         datums_local.push(
@@ -1073,7 +1073,7 @@ where
                             // We know that `mfp_after` can error if it exists, so try to evaluate it here.
                             let Some(mfp) = &mfp_after2 else { return };
                             let temp_storage = RowArena::new();
-                            let datum_iter = key.into_datum_iter(None);
+                            let datum_iter = key.into_datum_iter();
                             let mut datums_local = datums2.borrow();
                             datums_local.extend(datum_iter);
 
@@ -1105,7 +1105,7 @@ where
                 .mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceMinsMaxes", {
                     move |key, source, target| {
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter(None);
+                        let datum_iter = key.into_datum_iter();
                         let mut datums_local = datums1.borrow();
                         datums_local.extend(datum_iter);
                         let key_len = datums_local.len();
@@ -1288,7 +1288,7 @@ where
         let output = arranged.mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceMonotonic", {
             move |key, input, output| {
                 let temp_storage = RowArena::new();
-                let datum_iter = key.into_datum_iter(None);
+                let datum_iter = key.into_datum_iter();
                 let mut datums_local = datums1.borrow();
                 datums_local.extend(datum_iter);
                 let key_len = datums_local.len();
@@ -1314,7 +1314,7 @@ where
                 .mz_reduce_abelian::<_, RowErrSpine<_, _>>("ReduceMonotonic Error Check", {
                     move |key, input, output| {
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter(None);
+                        let datum_iter = key.into_datum_iter();
                         let mut datums_local = datums2.borrow();
                         datums_local.extend(datum_iter);
                         let accum = &input[0].1;
@@ -1467,7 +1467,7 @@ where
                         let (ref accums, total) = input[0].1;
 
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter(None);
+                        let datum_iter = key.into_datum_iter();
                         let mut datums_local = datums1.borrow();
                         datums_local.extend(datum_iter);
                         let key_len = datums_local.len();
@@ -1526,7 +1526,7 @@ where
                     // If `mfp_after` can error, then evaluate it here.
                     let Some(mfp) = &mfp_after2 else { return };
                     let temp_storage = RowArena::new();
-                    let datum_iter = key.into_datum_iter(None);
+                    let datum_iter = key.into_datum_iter();
                     let mut datums_local = datums2.borrow();
                     datums_local.extend(datum_iter);
                     for (aggr, accum) in full_aggrs2.iter().zip(accums) {

--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -291,13 +291,9 @@ mod container {
     }
 
     use mz_repr::fixed_length::IntoRowByTypes;
-    use mz_repr::ColumnType;
     impl<'long> IntoRowByTypes for DatumSeq<'long> {
         type DatumIter<'short> = DatumSeq<'short> where Self: 'short;
-        fn into_datum_iter<'short>(
-            &'short self,
-            _types: Option<&[ColumnType]>,
-        ) -> Self::DatumIter<'short> {
+        fn into_datum_iter<'short>(&'short self) -> Self::DatumIter<'short> {
             *self
         }
     }


### PR DESCRIPTION
This PR removes some RTTI infrastructure that was introduced when we had potential ambiguities in the representation of information. We do not have those ambiguities now, and there is no plan (at the moment) to continue towards them. The likely outcome is that the compressed representation they meant to support will emerge through containers that wrap specialization, rather than through exposing new containers.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
