### PR TITLE
code owners: Add testing team as owners for some misc directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,22 @@
 /doc/developer/reference/compute    @MaterializeInc/compute
 /doc/developer/reference/storage    @MaterializeInc/storage
 /misc/dbt-materialize               @morsapaes
+/misc/python/materialize/benches    @MaterializeInc/testing
+/misc/python/materialize/buildkite_insights @MaterializeInc/testing
+/misc/python/materialize/checks     @MaterializeInc/testing
+/misc/python/materialize/ci_util    @MaterializeInc/testing
+/misc/python/materialize/cli/ci_annotate_errors.py @MaterializeInc/testing
+/misc/python/materialize/cli/ci_closed_issues_detect.py @MaterializeInc/testing
+/misc/python/materialize/cli/ci_coverage_pr_report.py @MaterializeInc/testing
+/misc/python/materialize/cli/ci_upload_heap_profiles.py @MaterializeInc/testing
+/misc/python/materialize/cloudtest  @MaterializeInc/cloud @MaterializeInc/testing
+/misc/python/materialize/data_ingest @MaterializeInc/testing
+/misc/python/materialize/parallel_workload @MaterializeInc/testing
+/misc/python/materialize/postgres_consistency @MaterializeInc/testing
+/misc/python/materialize/scalability @MaterializeInc/testing
+/misc/python/materialize/sqlsmith.py @MaterializeInc/testing
+/misc/python/materialize/version_consistency @MaterializeInc/testing
+/misc/python/materialize/zippy      @MaterializeInc/testing
 /src/adapter                        @MaterializeInc/adapter
 /src/adapter-types                  @MaterializeInc/adapter
 /src/adapter/src/explain            @MaterializeInc/compute
@@ -114,5 +130,3 @@
 /src/walkabout                      @benesch
 /src/workspace-hack                 @benesch
 /test
-/misc/python/materialize/cli/ci_closed_issues_detect.py @MaterializeInc/testing
-/misc/python/materialize/cloudtest  @MaterializeInc/cloud @MaterializeInc/testing


### PR DESCRIPTION
Maybe this is going overboard? Mainly motivated by https://materializeinc.slack.com/archives/C01CFKM1QRF/p1710512681174499?thread_ts=1710505017.833349&cid=C01CFKM1QRF

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
