### PR TITLE
dbt-materialize: release 1.7.5

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.7.5 - 2024-03-15
 
 * `deploy_init(ignore_existing_objects)` now automatically copies the default
-   privileges and exisitng grants of exisiting clusters and schemas to their
+   privileges and existing grants of existing clusters and schemas to their
    deployment counterparts.
 
 ## 1.7.4 - 2024-02-27

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,11 @@
 # dbt-materialize Changelog
 
+## 1.7.5 - 2024-03-15
+
+* `deploy_init(ignore_existing_objects)` now automatically copies the default
+   privileges and exisitng grants of exisiting clusters and schemas to their
+   deployment counterparts.
+
 ## 1.7.4 - 2024-02-27
 
 * Add macros to automate blue/green deployments, which help minimize downtime

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.7.4"
+version = "1.7.5"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,7 +26,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.7.4",
+    version="1.7.5",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### Motivation

Release dbt-materialize 1.7.5 with support for copying grants and default privileges 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
