### PR TITLE
persist: avoid decoding persist data when data are ignored

### DIFF
--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1953,6 +1953,17 @@ pub mod plan {
                 || self.lower_bounds.iter().any(|e| e.could_error())
                 || self.upper_bounds.iter().any(|e| e.could_error())
         }
+
+        /// Indicates that `Self` ignores its input to the extent that it can be evaluated on `&[]`.
+        ///
+        /// At the moment, this is only true if it projects away all columns and applies no filters,
+        /// but it could be extended to plans that produce literals independent of the input.
+        pub fn ignores_input(&self) -> bool {
+            self.lower_bounds.is_empty()
+                && self.upper_bounds.is_empty()
+                && self.mfp.mfp.projection.is_empty()
+                && self.mfp.mfp.predicates.is_empty()
+        }
     }
 }
 

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -32,8 +32,8 @@ use crate::internal::machine::{
 };
 use crate::internal::state::ROLLUP_THRESHOLD;
 use crate::operators::{
-    PERSIST_SINK_MINIMUM_BATCH_UPDATES, STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES,
-    STORAGE_SOURCE_DECODE_FUEL,
+    OPTIMIZE_IGNORED_DATA_DECODE, PERSIST_SINK_MINIMUM_BATCH_UPDATES,
+    STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES, STORAGE_SOURCE_DECODE_FUEL,
 };
 use crate::read::READER_LEASE_DURATION;
 
@@ -268,6 +268,12 @@ impl PersistConfig {
         STORAGE_SOURCE_DECODE_FUEL.get(self)
     }
 
+    /// CYA to allow opt-out of a performance optimization to skip decoding
+    /// ignored data.
+    pub fn optimize_ignored_data_decode(&self) -> bool {
+        OPTIMIZE_IGNORED_DATA_DECODE.get(self)
+    }
+
     /// Overrides the value for "persist_reader_lease_duration".
     pub fn set_reader_lease_duration(&self, val: Duration) {
         self.set_config(&READER_LEASE_DURATION, val);
@@ -328,6 +334,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::internal::state::ROLLUP_THRESHOLD)
         .add(&crate::internal::apply::ROUNDTRIP_SPINE)
         .add(&crate::iter::SPLIT_OLD_RUNS)
+        .add(&crate::operators::OPTIMIZE_IGNORED_DATA_DECODE)
         .add(&crate::operators::PERSIST_SINK_MINIMUM_BATCH_UPDATES)
         .add(&crate::operators::STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
         .add(&crate::operators::STORAGE_SOURCE_DECODE_FUEL)

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -543,6 +543,14 @@ impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedBlob<K, V, 
             stats,
         )
     }
+
+    /// Decodes and returns the pushdown stats for this part, if known.
+    pub fn stats(&self) -> Option<PartStats> {
+        match &self.buf {
+            FetchedBlobBuf::Hollow { part, .. } => part.stats.as_ref().map(|x| x.decode()),
+            FetchedBlobBuf::Inline { .. } => None,
+        }
+    }
 }
 
 /// A [Blob] object that has been fetched, but not yet fully decoded.

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -635,10 +635,14 @@ where
     D: Semigroup + Codec64 + Send + Sync,
 {
     /// [Self::next] but optionally providing a `K` and `V` for alloc reuse.
+    ///
+    /// When `result_override` is specified, return it instead of decoding data.
+    /// This is used when we know the decoded result will be ignored.
     pub fn next_with_storage(
         &mut self,
         key: &mut Option<K>,
         val: &mut Option<V>,
+        result_override: Option<(K, V)>,
     ) -> Option<((Result<K, String>, Result<V, String>), T, D)> {
         while let Some((k, v, mut t, d)) = self.part_cursor.pop(&self.part) {
             if !self.ts_filter.filter_ts(&mut t) {
@@ -672,21 +676,25 @@ where
                 continue;
             }
 
-            let k = self.metrics.codecs.key.decode(|| match key.take() {
-                Some(mut key) => match K::decode_from(&mut key, k, &mut self.key_storage) {
-                    Ok(()) => Ok(key),
-                    Err(err) => Err(err),
-                },
-                None => K::decode(k),
-            });
-            let v = self.metrics.codecs.val.decode(|| match val.take() {
-                Some(mut val) => match V::decode_from(&mut val, v, &mut self.val_storage) {
-                    Ok(()) => Ok(val),
-                    Err(err) => Err(err),
-                },
-                None => V::decode(v),
-            });
-            return Some(((k, v), t, d));
+            if let Some((key, val)) = result_override {
+                return Some(((Ok(key), Ok(val)), t, d));
+            } else {
+                let k = self.metrics.codecs.key.decode(|| match key.take() {
+                    Some(mut key) => match K::decode_from(&mut key, k, &mut self.key_storage) {
+                        Ok(()) => Ok(key),
+                        Err(err) => Err(err),
+                    },
+                    None => K::decode(k),
+                });
+                let v = self.metrics.codecs.val.decode(|| match val.take() {
+                    Some(mut val) => match V::decode_from(&mut val, v, &mut self.val_storage) {
+                        Ok(()) => Ok(val),
+                        Err(err) => Err(err),
+                    },
+                    None => V::decode(v),
+                });
+                return Some(((k, v), t, d));
+            }
         }
         None
     }
@@ -702,7 +710,7 @@ where
     type Item = ((Result<K, String>, Result<V, String>), T, D);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.next_with_storage(&mut None, &mut None)
+        self.next_with_storage(&mut None, &mut None, None)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -103,6 +103,13 @@ pub mod operators {
         The maximum amount of work to do in the persist_source mfp_and_decode \
         operator before yielding.",
     );
+
+    // TODO(cfg): Move this next to the use.
+    pub(crate) const OPTIMIZE_IGNORED_DATA_DECODE: Config<bool> = Config::new(
+        "persist_optimize_ignored_data_decode",
+        true,
+        "CYA to allow opt-out of a performance optimization to skip decoding ignored data",
+    );
 }
 pub mod iter;
 pub mod read;

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -534,8 +534,13 @@ impl PendingWork {
         let fetched_part = self.part.part_mut();
         let is_filter_pushdown_audit = fetched_part.is_filter_pushdown_audit();
         let mut row_buf = None;
+        let row_override = map_filter_project
+            .as_ref()
+            .map(|p| p.ignores_input())
+            .unwrap_or(false)
+            .then(|| (SourceData(Ok(Row::default())), ()));
         while let Some(((key, val), time, diff)) =
-            fetched_part.next_with_storage(&mut row_buf, &mut None)
+            fetched_part.next_with_storage(&mut row_buf, &mut None, row_override.clone())
         {
             if until.less_equal(&time) {
                 continue;


### PR DESCRIPTION
Reviving #25994

Avoid decoding data when the `MfpPlan` tells us we will not read the results. This is a total hack, pending columnar data representations, but at the moment it reduces `main` from (release, local not cloud)
```
materialize=> select count(*) from bar;
  count   
----------
 10000000
(1 row)

Time: 2719.868 ms (00:02.720)
materialize=> 
```
to (in this branch)
```
materialize=> select count(*) from bar;
  count   
----------
 10000000
(1 row)

Time: 1153.915 ms (00:01.154)
materialize=> 
```

Touches #20618

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

The first commit is exactly Frank's original PR, except rebased.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
