### PR TITLE
storage/mysql: Implement privilege checks on MySQL tables, replication permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4745,6 +4745,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "fancy-regex",
  "indexmap 1.9.1",
  "itertools",
  "mysql_async",

--- a/misc/python/materialize/checks/all_checks/mysql_cdc.py
+++ b/misc/python/materialize/checks/all_checks/mysql_cdc.py
@@ -43,7 +43,6 @@ class MySqlCdcBase:
                 USE public;
 
                 CREATE USER mysql1{self.suffix} IDENTIFIED BY 'mysql';
-                GRANT SELECT ON performance_schema.replication_connection_configuration TO mysql1{self.suffix};
                 GRANT REPLICATION SLAVE ON *.* TO mysql1{self.suffix};
                 GRANT ALL ON public.* TO mysql1{self.suffix};
 
@@ -261,7 +260,6 @@ class MySqlCdcMzNow(Check):
                 USE public;
 
                 CREATE USER mysql2 IDENTIFIED BY 'mysql';
-                GRANT SELECT ON performance_schema.replication_connection_configuration TO mysql2;
                 GRANT REPLICATION SLAVE ON *.* TO mysql2;
                 GRANT ALL ON public.* TO mysql2;
 

--- a/src/mysql-util/Cargo.toml
+++ b/src/mysql-util/Cargo.toml
@@ -25,6 +25,7 @@ once_cell = "1.16.0"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+fancy-regex = "0.11.0"
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }

--- a/src/mysql-util/src/privileges.rs
+++ b/src/mysql-util/src/privileges.rs
@@ -1,0 +1,235 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use fancy_regex::Regex;
+use once_cell::sync::Lazy;
+use std::collections::{BTreeMap, BTreeSet};
+
+use mysql_async::prelude::Queryable;
+
+use crate::tunnel::MySqlConn;
+use crate::{MissingPrivilege, MySqlError, QualifiedTableRef};
+
+pub async fn validate_source_privileges(
+    conn: &mut MySqlConn,
+    tables: &[QualifiedTableRef<'_>],
+) -> Result<(), MySqlError> {
+    // MySQL doesn't have a great way to check privileges for the current user using SELECT
+    // statements on information_schema tables, since privileges are set at multiple levels
+    // and can be granted to users via roles, etc.
+    // Instead, the SHOW GRANTS statement coalesces these privileges and shows us what we have.
+
+    // First we need to see if we are using an account that is using any default-activated roles.
+    // This can return a comma-deliminated string of roles that we can use directly in the
+    // SHOW GRANTS query. This command is only possible on MySQL 8.0+, so we ignore any errors.
+    let roles: Option<String> = conn
+        .exec_first("SELECT CURRENT_ROLE()", ())
+        .await
+        .ok()
+        .and_then(|val: Option<String>| match val {
+            Some(inner) if inner != "NONE" => Some(inner),
+            _ => None,
+        });
+
+    // Obtain the privileges for the current user using any roles that are default activated.
+    let grant_query = match roles {
+        None => "SHOW GRANTS FOR CURRENT_USER()".to_string(),
+        Some(roles) => format!("SHOW GRANTS FOR CURRENT_USER() USING {}", roles),
+    };
+
+    // Parse and collect the grants into a map of schema -> table -> privileges
+    let mut grant_map = BTreeMap::new();
+    for grant in conn.exec(grant_query, ()).await? {
+        let grant: String = grant;
+        if let Some(object_grant) = get_object_grant(&grant) {
+            grant_map
+                .entry(object_grant.object_schema)
+                .or_insert_with(BTreeMap::new)
+                .entry(object_grant.object_name)
+                .or_insert_with(BTreeSet::new)
+                .extend(object_grant.privileges);
+        }
+    }
+
+    // Check that we have the LOCK TABLES and SELECT privileges for each table
+    let mut errors = tables
+        .iter()
+        .flat_map(|table| {
+            ["LOCK TABLES", "SELECT"].iter().filter_map(|privilege| {
+                // Check both the wildcard schema and the specific schema
+                let privileged = [grant_map.get("*"), grant_map.get(table.schema_name)]
+                    .iter()
+                    .any(|schema_map| {
+                        // Check both the wildcard table and the specific table
+                        schema_map.map_or(false, |schema_map| {
+                            [schema_map.get("*"), schema_map.get(table.table_name)]
+                                .iter()
+                                .any(|privs| {
+                                    privs.map_or(false, |privs| {
+                                        privs.contains(*privilege)
+                                            || privs.contains("ALL PRIVILEGES")
+                                    })
+                                })
+                        })
+                    });
+
+                if !privileged {
+                    Some(MissingPrivilege {
+                        privilege: privilege.to_string(),
+                        qualified_table_name: format!("{}.{}", table.schema_name, table.table_name),
+                    })
+                } else {
+                    None
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    // Check that we have REPLICATION SLAVE priviliges at the global level
+    if !grant_map
+        .get("*")
+        .and_then(|schema_map| schema_map.get("*"))
+        .map(|privs| privs.contains("REPLICATION SLAVE") || privs.contains("ALL PRIVILEGES"))
+        .unwrap_or(false)
+    {
+        errors.push(MissingPrivilege {
+            privilege: "REPLICATION SLAVE".to_string(),
+            qualified_table_name: "*.*".to_string(),
+        });
+    }
+
+    if !errors.is_empty() {
+        Err(MySqlError::MissingPrivileges(errors))
+    } else {
+        Ok(())
+    }
+}
+
+/// Regex to parse a SHOW GRANTS line. Inspired by several stack overflow posts and
+/// adjusted to account for the different quoting styles across MySQL versions.
+/// If this regex matches then this is a grant on an actual object which looks like:
+///     GRANT SELECT, INSERT, UPDATE ON `db1`.* TO `u1`@`localhost`
+///     GRANT SELECT ON `db1`.`table1` TO `my_user`@`localhost` WITH GRANT OPTION
+/// The regex needs to account for the possibility of a wildcard schema or table, and for the
+/// quote-char to be part of the table/schema name too.
+/// Group 1 is the list of privileges being granted
+/// Group 2 is either the wildcard * or a quoted database/schema
+/// Group 4 is the unquoted database/schema when the wildcard is not matched
+/// Group 5 is either the wildcard * or a quoted table
+/// Group 7 is the unquoted table when the wildcard is not matched
+/// Group 9 is the user being granted
+/// We use the `fancy_regex` crate to allow backreferences which are necessary to find the ending
+/// quote of each identifier since there are different quoting types across mysql versions.
+static GRANT_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"GRANT (.+) ON (\*|(['`"])(.*)\3).(\*|(['`"])(.*)\6) TO (['`"])(.*)\8@.*"#)
+        .expect("valid")
+});
+
+#[derive(Debug, PartialEq, Eq)]
+struct MySqlObjectGrant {
+    privileges: BTreeSet<String>,
+    object_schema: String,
+    object_name: String,
+}
+
+/// Parses a returned row of a SHOW GRANTS statement to return a MySqlObjectGrant
+/// If the grant is not on an object (e.g. a grant of a role to a user), returns None
+fn get_object_grant(grant: &str) -> Option<MySqlObjectGrant> {
+    match GRANT_REGEX.captures(grant) {
+        Ok(None) => None,
+        Err(err) => {
+            tracing::warn!("Error parsing privilege grant: {}", err);
+            None
+        }
+        Ok(Some(captures)) => {
+            let object_schema = if captures.get(2).expect("valid").as_str() == "*" {
+                "*".to_string()
+            } else {
+                captures.get(4).expect("valid").as_str().to_string()
+            };
+            let object_name = if captures.get(5).expect("valid").as_str() == "*" {
+                "*".to_string()
+            } else {
+                captures.get(7).expect("valid").as_str().to_string()
+            };
+            let privileges = captures.get(1).expect("valid").as_str();
+            Some(MySqlObjectGrant {
+                privileges: privileges.split(", ").map(|s| s.to_string()).collect(),
+                object_schema,
+                object_name,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn test_get_object_grant() {
+        // backticks and wildcard
+        let grant = "GRANT SELECT, INSERT, UPDATE ON `db1`.* TO `u1`@`localhost`";
+        let expected_grant = MySqlObjectGrant {
+            privileges: ["SELECT", "INSERT", "UPDATE"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            object_schema: "db1".to_string(),
+            object_name: "*".to_string(),
+        };
+        assert_eq!(get_object_grant(grant), Some(expected_grant));
+
+        // single-quotes
+        let grant = "GRANT SUPER, CREATE TEMPORARY TABLES, LOCK TABLES ON 'db1'.'table1' TO `u1`@`localhost`";
+        let expected_grant = MySqlObjectGrant {
+            privileges: ["SUPER", "CREATE TEMPORARY TABLES", "LOCK TABLES"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            object_schema: "db1".to_string(),
+            object_name: "table1".to_string(),
+        };
+        assert_eq!(get_object_grant(grant), Some(expected_grant));
+
+        // wildcards
+        let grant = "GRANT ALL PRIVILEGES ON *.* TO `u1`@`localhost`";
+        let expected_grant = MySqlObjectGrant {
+            privileges: ["ALL PRIVILEGES"].iter().map(|s| s.to_string()).collect(),
+            object_schema: "*".to_string(),
+            object_name: "*".to_string(),
+        };
+        assert_eq!(get_object_grant(grant), Some(expected_grant));
+
+        // special chars
+        let grant = "GRANT SELECT, INSERT, UPDATE ON `таблица`.`mixED_CAse` TO `u1`@`localhost`";
+        let expected_grant = MySqlObjectGrant {
+            privileges: ["SELECT", "INSERT", "UPDATE"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            object_schema: "таблица".to_string(),
+            object_name: "mixED_CAse".to_string(),
+        };
+
+        assert_eq!(get_object_grant(grant), Some(expected_grant));
+
+        // quotes in names
+        let grant = "GRANT SUPER, CREATE TEMPORARY TABLES, LOCK TABLES ON `r`w`.`'sd'` TO `u1`@`localhost` IDENTIFIED BY PASSWORD `test`";
+        let expected_grant = MySqlObjectGrant {
+            privileges: ["SUPER", "CREATE TEMPORARY TABLES", "LOCK TABLES"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            object_schema: "r`w".to_string(),
+            object_name: "'sd'".to_string(),
+        };
+        assert_eq!(get_object_grant(grant), Some(expected_grant));
+    }
+}

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -303,6 +303,7 @@ impl PlanError {
             Self::VarError(e) => e.detail(),
             Self::InternalFunctionCall => Some("This function is for the internal use of the database system and cannot be called directly.".into()),
             Self::PgSourcePurification(e) => e.detail(),
+            Self::MySqlSourcePurification(e) => e.detail(),
             Self::KafkaSourcePurification(e) => e.detail(),
             Self::LoadGeneratorSourcePurification(e) => e.detail(),
             Self::CsrPurification(e) => e.detail(),

--- a/test/mysql-cdc-resumption/configure-mysql.td
+++ b/test/mysql-cdc-resumption/configure-mysql.td
@@ -15,5 +15,4 @@ CREATE DATABASE public;
 USE public;
 
 CREATE USER materialize IDENTIFIED BY 'materialize';
-GRANT SELECT ON performance_schema.replication_connection_configuration TO materialize;
 GRANT ALL ON public.* TO materialize;

--- a/test/mysql-cdc/privileges.td
+++ b/test/mysql-cdc/privileges.td
@@ -30,12 +30,6 @@ CREATE TABLE other.s (a int);
 CREATE TABLE public.t (a int);
 # do not grant any privileges to priv
 
-# needed for creating a source
-GRANT SELECT ON performance_schema.replication_connection_configuration TO priv
-
-# needed to keep the source up to date
-GRANT REPLICATION SLAVE ON *.* TO priv
-
 #
 # no CONNECT error
 #
@@ -61,9 +55,7 @@ GRANT ALL ON public.* TO priv;
   FROM MYSQL CONNECTION mysql_conn
   FOR SCHEMAS (public, other);
 contains:No tables found in referenced schemas
-
-# TODO: #25412 (more error details when lacking permissions)
-# detail:user priv lacks USAGE privileges for schemas other
+detail:missing schemas: other
 
 #
 # SELECT errors
@@ -78,21 +70,84 @@ GRANT ALL ON other TO priv;
   FROM MYSQL CONNECTION mysql_conn
   FOR SCHEMAS (public, other);
 contains:No tables found in referenced schemas
+detail:missing schemas: other
 
 $ mysql-execute name=mysql
 CREATE TABLE other.u (a int);
 CREATE TABLE other.access_not_granted (a int);
 CREATE TABLE other.`select` (a INT);
 CREATE TABLE other.`"select"` (a INT);
-# privileges on at least one table in schema 'other' are now present
+# non-complete privileges on at least one table in schema 'other' are now present
 GRANT SELECT ON other.u TO priv;
+GRANT INDEX ON other.s TO priv;
+
+# A new error since the tables are now visible but we are missing some privileges
+! CREATE SOURCE mz_source
+  FROM MYSQL CONNECTION mysql_conn
+  FOR SCHEMAS (other);
+contains:User lacks required MySQL privileges
+detail:Missing MySQL privileges: 'LOCK TABLES' on 'other.s', 'SELECT' on 'other.s', 'LOCK TABLES' on 'other.u', 'REPLICATION SLAVE' on '*.*'
+
+
+# fix table privileges, use wildcard for LOCK TABLES
+$ mysql-execute name=mysql
+GRANT SELECT ON other.s TO priv;
+GRANT LOCK TABLES ON other.* TO priv;
+
+! CREATE SOURCE mz_source
+  FROM MYSQL CONNECTION mysql_conn
+  FOR SCHEMAS (other);
+contains:User lacks required MySQL privileges
+detail:Missing MySQL privileges: 'REPLICATION SLAVE' on '*.*'
 
 $ mysql-execute name=mysql
+GRANT REPLICATION SLAVE ON *.* TO priv;
 
-# This succeeds because at least one table in the schema is accessible.
 > CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_conn
   FOR SCHEMAS (other);
 
-! SELECT * FROM access_not_granted;
-contains:unknown catalog item 'access_not_granted'
+# confirm the source works
+$ mysql-execute name=mysql
+USE other;
+INSERT INTO u VALUES (2), (3), (4);
+
+> SELECT * FROM u;
+2
+3
+4
+
+# Verify privileges provided via default roles
+
+$ mysql-execute name=mysql
+CREATE ROLE 'r1';
+GRANT 'r1' TO 'priv';
+SET DEFAULT ROLE 'r1' TO 'priv';
+USE other;
+CREATE TABLE other.z (a int);
+INSERT INTO other.z VALUES (1);
+GRANT INDEX ON other.z TO 'priv';
+
+! CREATE SOURCE mz_source_other
+  FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (other.z);
+contains:User lacks required MySQL privileges
+detail:Missing MySQL privileges: 'SELECT' on 'other.z'
+
+# grant the privilege to the role not the user directly
+$ mysql-execute name=mysql
+GRANT SELECT ON other.z TO 'r1';
+
+> CREATE SOURCE mz_source_other
+  FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (other.z);
+
+> SELECT * FROM z;
+1
+
+# cleanup the 'other' database to avoid issues in other testdrive files
+> DROP SOURCE mz_source;
+> DROP SOURCE mz_source_other;
+
+$ mysql-execute name=mysql
+DROP DATABASE other;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/26071 , Fixes https://github.com/MaterializeInc/materialize/issues/25412 , Fixes https://github.com/MaterializeInc/materialize/issues/25519

This also removes the need for the `SELECT` privilege on `performance_schema.replication_connection_configuration` which seems like a weird permission to ask for, when we can approximate the same thing by being smarter about the replica settings (see comment in code for details).


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
