### PR TITLE
WIP: Remove specialization of arrangements

### DIFF
--- a/src/compute/src/arrangement/manager.rs
+++ b/src/compute/src/arrangement/manager.rs
@@ -14,19 +14,12 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::time::Instant;
 
-use differential_dataflow::lattice::{antichain_join, Lattice};
-use differential_dataflow::operators::arrange::ShutdownButton;
+use differential_dataflow::lattice::antichain_join;
 use differential_dataflow::trace::TraceReader;
 use mz_repr::{Diff, GlobalId, Timestamp};
-use timely::dataflow::operators::CapabilitySet;
-use timely::dataflow::scopes::Child;
-use timely::dataflow::Scope;
 use timely::progress::frontier::{Antichain, AntichainRef};
-use timely::progress::timestamp::Refines;
 
-use crate::logging::compute::{LogImportFrontiers, Logger};
 use crate::metrics::TraceMetrics;
-use crate::render::context::SpecializedArrangementImport;
 use crate::typedefs::{ErrAgent, RowRowAgent};
 
 /// A `TraceManager` stores maps from global identifiers to the primary arranged
@@ -104,95 +97,19 @@ impl TraceManager {
     }
 }
 
-/// Represents a type-specialized trace handle for successful computations wherein keys or
-/// values were previously type-specialized via `render::context::SpecializedArrangementFlavor`.
-///
-/// The variants defined here must thus match the ones used in creating type-specialized
-/// arrangements.
-#[derive(Clone)]
-pub enum SpecializedTraceHandle {
-    RowRow(RowRowAgent<Timestamp, Diff>),
-}
-
-impl SpecializedTraceHandle {
-    /// Obtains the logical compaction frontier for the underlying trace handle.
-    fn get_logical_compaction(&mut self) -> AntichainRef<Timestamp> {
-        match self {
-            SpecializedTraceHandle::RowRow(handle) => handle.get_logical_compaction(),
-        }
-    }
-
-    /// Advances the logical compaction frontier for the underlying trace handle.
-    pub fn set_logical_compaction(&mut self, frontier: AntichainRef<Timestamp>) {
-        match self {
-            SpecializedTraceHandle::RowRow(handle) => handle.set_logical_compaction(frontier),
-        }
-    }
-
-    /// Advances the physical compaction frontier for the underlying trace handle.
-    pub fn set_physical_compaction(&mut self, frontier: AntichainRef<Timestamp>) {
-        match self {
-            SpecializedTraceHandle::RowRow(handle) => handle.set_physical_compaction(frontier),
-        }
-    }
-
-    /// Reads the upper frontier of the underlying trace handle.
-    pub fn read_upper(&mut self, target: &mut Antichain<Timestamp>) {
-        match self {
-            SpecializedTraceHandle::RowRow(handle) => handle.read_upper(target),
-        }
-    }
-
-    /// Maps the underlying trace handle to a `SpecializedArrangementImport`,
-    /// while readjusting times by `since` and `until`.
-    pub fn import_frontier_logged<'g, G, T>(
-        &mut self,
-        scope: &Child<'g, G, T>,
-        name: &str,
-        since: Antichain<Timestamp>,
-        until: Antichain<Timestamp>,
-        logger: Option<Logger>,
-        idx_id: GlobalId,
-        export_ids: Vec<GlobalId>,
-    ) -> (
-        SpecializedArrangementImport<Child<'g, G, T>, Timestamp>,
-        ShutdownButton<CapabilitySet<Timestamp>>,
-    )
-    where
-        G: Scope<Timestamp = Timestamp>,
-        T: Lattice + Refines<G::Timestamp>,
-    {
-        match self {
-            SpecializedTraceHandle::RowRow(handle) => {
-                let (oks, oks_button) =
-                    handle.import_frontier_core(&scope.parent, name, since, until);
-                let oks = if let Some(logger) = logger {
-                    oks.log_import_frontiers(logger, idx_id, export_ids)
-                } else {
-                    oks
-                };
-                (
-                    SpecializedArrangementImport::RowRow(oks.enter(scope)),
-                    oks_button,
-                )
-            }
-        }
-    }
-}
-
 /// Bundles together traces for the successful computations (`oks`), the
 /// failed computations (`errs`), additional tokens that should share
 /// the lifetime of the bundled traces (`to_drop`).
 #[derive(Clone)]
 pub struct TraceBundle {
-    oks: SpecializedTraceHandle,
+    oks: RowRowAgent<Timestamp, Diff>,
     errs: ErrAgent<Timestamp, Diff>,
     to_drop: Option<Rc<dyn Any>>,
 }
 
 impl TraceBundle {
     /// Constructs a new trace bundle out of an `oks` trace and `errs` trace.
-    pub fn new(oks: SpecializedTraceHandle, errs: ErrAgent<Timestamp, Diff>) -> TraceBundle {
+    pub fn new(oks: RowRowAgent<Timestamp, Diff>, errs: ErrAgent<Timestamp, Diff>) -> TraceBundle {
         TraceBundle {
             oks,
             errs,
@@ -212,7 +129,7 @@ impl TraceBundle {
     }
 
     /// Returns a mutable reference to the `oks` trace.
-    pub fn oks_mut(&mut self) -> &mut SpecializedTraceHandle {
+    pub fn oks_mut(&mut self) -> &mut RowRowAgent<Timestamp, Diff> {
         &mut self.oks
     }
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -57,7 +57,7 @@ use tokio::sync::oneshot;
 use tracing::{debug, error, info, span, warn, Level};
 use uuid::Uuid;
 
-use crate::arrangement::manager::{SpecializedTraceHandle, TraceBundle, TraceManager};
+use crate::arrangement::manager::{TraceBundle, TraceManager};
 use crate::logging;
 use crate::logging::compute::ComputeEvent;
 use crate::metrics::ComputeMetrics;
@@ -1105,29 +1105,11 @@ impl IndexPeek {
             cursor.step_key(&storage);
         }
 
-        self.dispatch_collect_ok_finished_data(max_result_size)
-    }
-
-    /// Dispatches peek finishing of data in the ok stream according to
-    /// arrangement key-value types.
-    fn dispatch_collect_ok_finished_data(
-        &mut self,
-        max_result_size: u64,
-    ) -> Result<Vec<(Row, NonZeroUsize)>, String> {
         let peek = &mut self.peek;
         let oks = self.trace_bundle.oks_mut();
-        match oks {
-            SpecializedTraceHandle::RowRow(oks_handle) => {
-                // Explicit types required due to Rust type inference limitations.
-                use crate::typedefs::RowRowSpine;
-                Self::collect_ok_finished_data::<RowRowSpine<_, _>>(
-                    peek,
-                    oks_handle,
-                    None,
-                    max_result_size,
-                )
-            }
-        }
+        // Explicit types required due to Rust type inference limitations.
+        use crate::typedefs::RowRowSpine;
+        Self::collect_ok_finished_data::<RowRowSpine<_, _>>(peek, oks, None, max_result_size)
     }
 
     /// Collects data for a known-complete peek from the ok stream.

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1117,16 +1117,6 @@ impl IndexPeek {
         let peek = &mut self.peek;
         let oks = self.trace_bundle.oks_mut();
         match oks {
-            SpecializedTraceHandle::RowUnit(oks_handle) => {
-                // Explicit types required due to Rust type inference limitations.
-                use crate::typedefs::RowSpine;
-                Self::collect_ok_finished_data::<RowSpine<_, _>>(
-                    peek,
-                    oks_handle,
-                    None,
-                    max_result_size,
-                )
-            }
             SpecializedTraceHandle::RowRow(oks_handle) => {
                 // Explicit types required due to Rust type inference limitations.
                 use crate::typedefs::RowRowSpine;

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -20,7 +20,7 @@ use timely::communication::Allocate;
 use timely::logging::{Logger, TimelyEvent};
 use timely::progress::reachability::logging::TrackerEvent;
 
-use crate::arrangement::manager::{SpecializedTraceHandle, TraceBundle};
+use crate::arrangement::manager::TraceBundle;
 use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::logging::compute::ComputeEvent;
 use crate::logging::reachability::ReachabilityEvent;
@@ -128,8 +128,7 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
         traces
             .into_iter()
             .map(|(log, (trace, token))| {
-                let bundle = TraceBundle::new(SpecializedTraceHandle::RowRow(trace), errs.clone())
-                    .with_drop(token);
+                let bundle = TraceBundle::new(trace, errs.clone()).with_drop(token);
                 (log, bundle)
             })
             .collect()

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -38,7 +38,7 @@ use crate::render::context::{
     SpecializedArrangementImport,
 };
 use crate::render::RenderTimestamp;
-use crate::typedefs::{RowAgent, RowEnter, RowRowAgent, RowRowEnter};
+use crate::typedefs::{RowRowAgent, RowRowEnter};
 
 impl<G> Context<G>
 where
@@ -326,16 +326,6 @@ where
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
 {
     match trace {
-        SpecializedArrangement::RowUnit(inner) => build_halfjoin::<_, RowAgent<_, _>, _>(
-            updates,
-            inner,
-            None,
-            prev_key,
-            prev_thinning,
-            comparison,
-            closure,
-            shutdown_token,
-        ),
         SpecializedArrangement::RowRow(inner) => build_halfjoin::<_, RowRowAgent<_, _>, _>(
             updates,
             inner,
@@ -369,16 +359,6 @@ where
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
 {
     match trace {
-        SpecializedArrangementImport::RowUnit(inner) => build_halfjoin::<_, RowEnter<_, _, _>, _>(
-            updates,
-            inner,
-            None,
-            prev_key,
-            prev_thinning,
-            comparison,
-            closure,
-            shutdown_token,
-        ),
         SpecializedArrangementImport::RowRow(inner) => {
             build_halfjoin::<_, RowRowEnter<_, _, _>, _>(
                 updates,
@@ -555,9 +535,6 @@ where
     G::Timestamp: crate::render::RenderTimestamp,
 {
     match trace {
-        SpecializedArrangement::RowUnit(inner) => {
-            build_update_stream::<_, RowAgent<_, _>>(inner, as_of, source_relation, initial_closure)
-        }
         SpecializedArrangement::RowRow(inner) => build_update_stream::<_, RowRowAgent<_, _>>(
             inner,
             as_of,
@@ -580,14 +557,6 @@ where
     G::Timestamp: Lattice + crate::render::RenderTimestamp + Refines<T> + Columnation,
 {
     match trace {
-        SpecializedArrangementImport::RowUnit(inner) => {
-            build_update_stream::<_, RowEnter<_, _, _>>(
-                inner,
-                as_of,
-                source_relation,
-                initial_closure,
-            )
-        }
         SpecializedArrangementImport::RowRow(inner) => {
             build_update_stream::<_, RowRowEnter<_, _, _>>(
                 inner,

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -37,7 +37,7 @@ use crate::render::context::{
 };
 use crate::render::join::mz_join_core::mz_join_core;
 use crate::row_spine::RowRowSpine;
-use crate::typedefs::{RowAgent, RowEnter, RowRowAgent, RowRowEnter};
+use crate::typedefs::{RowRowAgent, RowRowEnter};
 
 /// Available linear join implementations.
 ///
@@ -385,18 +385,6 @@ where
             JoinedFlavor::Local(local) => match arrangement {
                 ArrangementFlavor::Local(oks, errs1) => {
                     let (oks, errs2) = match (local, oks) {
-                        (A::RowUnit(prev_keyed), A::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowAgent<_, _>, RowAgent<_, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
-                        (A::RowUnit(prev_keyed), A::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowAgent<_, _>, RowRowAgent<_, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
-                        (A::RowRow(prev_keyed), A::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowRowAgent<_, _>, RowAgent<_, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
                         (A::RowRow(prev_keyed), A::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowRowAgent<_, _>, RowRowAgent<_, _>>(
                                 prev_keyed, next_input, closure,
@@ -409,18 +397,6 @@ where
                 }
                 ArrangementFlavor::Trace(_gid, oks, errs1) => {
                     let (oks, errs2) = match (local, oks) {
-                        (A::RowUnit(prev_keyed), I::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowAgent<_, _>, RowEnter<_, _, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
-                        (A::RowUnit(prev_keyed), I::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowAgent<_, _>, RowRowEnter<_, _, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
-                        (A::RowRow(prev_keyed), I::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowRowAgent<_, _>, RowEnter<_, _, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
                         (A::RowRow(prev_keyed), I::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowRowAgent<_, _>, RowRowEnter<_, _, _>>(
                                 prev_keyed, next_input, closure,
@@ -435,18 +411,6 @@ where
             JoinedFlavor::Trace(trace) => match arrangement {
                 ArrangementFlavor::Local(oks, errs1) => {
                     let (oks, errs2) = match (trace, oks) {
-                        (I::RowUnit(prev_keyed), A::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowEnter<_, _, _>, RowAgent<_, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
-                        (I::RowUnit(prev_keyed), A::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowEnter<_, _, _>, RowRowAgent<_, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
-                        (I::RowRow(prev_keyed), A::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowRowEnter<_, _, _>, RowAgent<_, _>>(
-                                prev_keyed, next_input, closure,
-                            ),
                         (I::RowRow(prev_keyed), A::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowAgent<_, _>>(
                                 prev_keyed, next_input, closure,
@@ -459,24 +423,6 @@ where
                 }
                 ArrangementFlavor::Trace(_gid, oks, errs1) => {
                     let (oks, errs2) = match (trace, oks) {
-                        (I::RowUnit(prev_keyed), I::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowEnter<_, _, _>, RowEnter<_, _, _>>(
-                                prev_keyed,
-                                next_input,
-                                closure,
-                            ),
-                        (I::RowUnit(prev_keyed), I::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowEnter<_, _, _>, RowRowEnter<_, _, _>>(
-                                prev_keyed,
-                                next_input,
-                                closure,
-                            ),
-                        (I::RowRow(prev_keyed), I::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowRowEnter<_, _, _>, RowEnter<_, _, _>>(
-                                prev_keyed,
-                                next_input,
-                                closure,
-                            ),
                         (I::RowRow(prev_keyed), I::RowRow(next_input)) => self
                             .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowEnter<_, _, _>>(
                                 prev_keyed, next_input, closure,

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -603,11 +603,6 @@ where
         name: &str,
     ) -> SpecializedArrangement<G> {
         match oks {
-            SpecializedArrangement::RowUnit(inner) => {
-                let name = format!("{} [val: empty]", name);
-                let oks = self.rearrange_iterative(inner, &name);
-                SpecializedArrangement::RowUnit(oks)
-            }
             SpecializedArrangement::RowRow(inner) => {
                 let oks = self.rearrange_iterative(inner, name);
                 SpecializedArrangement::RowRow(oks)
@@ -1009,13 +1004,7 @@ where
                     Local(A::RowRow(a), _) => {
                         a.stream = self.log_operator_hydration_inner(&a.stream, lir_id);
                     }
-                    Local(A::RowUnit(a), _) => {
-                        a.stream = self.log_operator_hydration_inner(&a.stream, lir_id);
-                    }
                     Trace(_, AI::RowRow(a), _) => {
-                        a.stream = self.log_operator_hydration_inner(&a.stream, lir_id);
-                    }
-                    Trace(_, AI::RowUnit(a), _) => {
                         a.stream = self.log_operator_hydration_inner(&a.stream, lir_id);
                     }
                 }

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -264,11 +264,6 @@ where
                         key_arity,
                         None,
                     ) {
-                        SpecializedArrangement::RowUnit(_) => {
-                            unreachable!(
-                                "Unexpected RowUnit arrangement in reduce collation rendering"
-                            )
-                        }
                         SpecializedArrangement::RowRow(arranged) => arranged,
                     };
                     to_collate.push((r#type, arrangement));
@@ -501,14 +496,14 @@ where
     {
         let collection = collection.map(|(k, v)| {
             assert!(v.is_empty());
-            (k, ())
+            (k, Row::default())
         });
-        let (arrangement, errs) = self.build_distinct::<RowSpine<_, _>, RowErrSpine<_, _>, _>(
+        let (arrangement, errs) = self.build_distinct::<RowRowSpine<_, _>, RowErrSpine<_, _>, _>(
             collection,
             " [val: empty]",
             mfp_after,
         );
-        (SpecializedArrangement::RowUnit(arrangement), errs)
+        (SpecializedArrangement::RowRow(arrangement), errs)
     }
 
     /// Build the dataflow to compute the set of distinct keys.

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -76,11 +76,6 @@ where
     L: Fn(&Diff) -> bool + 'static,
 {
     match oks {
-        SpecializedArrangement::RowUnit(inner) => {
-            let name = format!("{} [val: empty]", name);
-            let oks = threshold_arrangement(inner, &name, logic);
-            SpecializedArrangement::RowUnit(oks)
-        }
         SpecializedArrangement::RowRow(inner) => {
             let oks = threshold_arrangement(inner, name, logic);
             SpecializedArrangement::RowRow(oks)
@@ -101,11 +96,6 @@ where
     L: Fn(&Diff) -> bool + 'static,
 {
     match oks {
-        SpecializedArrangementImport::RowUnit(inner) => {
-            let name = format!("{} [val: empty]", name);
-            let oks = threshold_arrangement(inner, &name, logic);
-            SpecializedArrangement::RowUnit(oks)
-        }
         SpecializedArrangementImport::RowRow(inner) => {
             let oks = threshold_arrangement(inner, name, logic);
             SpecializedArrangement::RowRow(oks)

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -94,6 +94,8 @@ pub type RowValEnter<V, T, R, TEnter> = TraceEnter<TraceFrontier<RowValAgent<V, 
 pub type RowRowAgent<T, R> = TraceAgent<RowRowSpine<T, R>>;
 pub type RowRowArrangement<S> = Arranged<S, RowRowAgent<<S as ScopeParent>::Timestamp, Diff>>;
 pub type RowRowEnter<T, R, TEnter> = TraceEnter<TraceFrontier<RowRowAgent<T, R>>, TEnter>;
+pub type RowRowArrangementImport<S, T> =
+    Arranged<S, RowRowEnter<T, Diff, <S as ScopeParent>::Timestamp>>;
 // Row specialized spines and agents.
 pub type RowAgent<T, R> = TraceAgent<RowSpine<T, R>>;
 pub type RowArrangement<S> = Arranged<S, RowAgent<<S as ScopeParent>::Timestamp, Diff>>;


### PR DESCRIPTION
Arrangement specialization exists to reduce the memory overhead for arrangements that are statically known to have an empty value associated with their key. This reduces memory in cases such as `Distinct` that has no values, and doesn't need to record an empty `Row` for each key. 

However, this comes at a substantial cost in code complexity, and the memory requirements are believed to be matched by [the existing compact memory arrangements](https://github.com/MaterializeInc/materialize/pull/26084), which can use constant memory to record an unlimited number of empty rows.

---

NB: This is a WIP and progresses through a sequence of commits that are meant to make the extraction as painless as possible, though the intermediate states are not ones we want to end up in.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
