### PR TITLE
storage: prevent load generators with unused options, try #2

### DIFF
--- a/misc/python/materialize/checks/all_checks/cluster_unification.py
+++ b/misc/python/materialize/checks/all_checks/cluster_unification.py
@@ -33,9 +33,12 @@ class UnifiedCluster(Check):
             # Create either a source or a view as first object in cluster
             Testdrive(
                 """
-                > CREATE SOURCE shared_cluster_storage_first_source
+                >[version<9300] CREATE SOURCE shared_cluster_storage_first_source
                   IN CLUSTER shared_cluster_storage_first
                   FROM LOAD GENERATOR COUNTER (SCALE FACTOR 0.01)
+                >[version>=9300] CREATE SOURCE shared_cluster_storage_first_source
+                  IN CLUSTER shared_cluster_storage_first
+                  FROM LOAD GENERATOR COUNTER
 
                 > CREATE MATERIALIZED VIEW shared_cluster_compute_first_mv
                   IN CLUSTER shared_cluster_compute_first
@@ -50,9 +53,12 @@ class UnifiedCluster(Check):
             # now already contains an object
             Testdrive(
                 """
-                > CREATE SOURCE shared_cluster_compute_first_source
+                >[version<9300] CREATE SOURCE shared_cluster_compute_first_source
                   IN CLUSTER shared_cluster_compute_first
                   FROM LOAD GENERATOR COUNTER (SCALE FACTOR 0.01)
+                >[version>=9300] CREATE SOURCE shared_cluster_compute_first_source
+                  IN CLUSTER shared_cluster_compute_first
+                  FROM LOAD GENERATOR COUNTER
 
                 > CREATE MATERIALIZED VIEW shared_cluster_storage_first_mv
                   IN CLUSTER shared_cluster_storage_first

--- a/misc/python/materialize/checks/all_checks/owners.py
+++ b/misc/python/materialize/checks/all_checks/owners.py
@@ -42,7 +42,11 @@ class Owners(Check):
         if expensive:
             s += dedent(
                 f"""
+                $[version<9300] postgres-execute connection=postgres://{role}@${{testdrive.materialize-sql-addr}}
                 CREATE SOURCE owner_source{i} FROM LOAD GENERATOR COUNTER (SCALE FACTOR 0.01)
+                $[version>=9300] postgres-execute connection=postgres://{role}@${{testdrive.materialize-sql-addr}}
+                CREATE SOURCE owner_source{i} FROM LOAD GENERATOR COUNTER
+                $ postgres-execute connection=postgres://{role}@${{testdrive.materialize-sql-addr}}
                 CREATE SINK owner_sink{i} FROM owner_mv{i} INTO KAFKA CONNECTION owner_kafka_conn{i} (TOPIC 'sink-sink-owner{i}') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION owner_csr_conn{i} ENVELOPE DEBEZIUM
                 CREATE CLUSTER owner_cluster{i} REPLICAS (owner_cluster_r{i} (SIZE '4'))
                 """

--- a/misc/python/materialize/checks/all_checks/privileges.py
+++ b/misc/python/materialize/checks/all_checks/privileges.py
@@ -34,7 +34,11 @@ class Privileges(Check):
         if expensive:
             s += dedent(
                 f"""
+                $[version<9300] postgres-execute connection=postgres://materialize@${{testdrive.materialize-sql-addr}}
                 CREATE SOURCE privilege_source{i} FROM LOAD GENERATOR COUNTER (SCALE FACTOR 0.01)
+                $[version>=9300] postgres-execute connection=postgres://materialize@${{testdrive.materialize-sql-addr}}
+                CREATE SOURCE privilege_source{i} FROM LOAD GENERATOR COUNTER
+                $ postgres-execute connection=postgres://materialize@${{testdrive.materialize-sql-addr}}
                 CREATE SINK privilege_sink{i} FROM privilege_mv{i} INTO KAFKA CONNECTION privilege_kafka_conn{i} (TOPIC 'sink-sink-privilege{i}') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION privilege_csr_conn{i} ENVELOPE DEBEZIUM
                 CREATE CLUSTER privilege_cluster{i} REPLICAS (privilege_cluster_r{i} (SIZE '4'))
                 """

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -24,6 +24,29 @@ use mz_storage_types::connections::ConnectionContext;
 // DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::catalog::{Catalog, CatalogState, ConnCatalog};
 
+async fn rewrite_ast_items<F>(tx: &mut Transaction<'_>, mut f: F) -> Result<(), anyhow::Error>
+where
+    F: for<'a> FnMut(
+        &'a mut Transaction<'_>,
+        GlobalId,
+        &'a mut Statement<Raw>,
+    ) -> BoxFuture<'a, Result<(), anyhow::Error>>,
+{
+    let mut updated_items = BTreeMap::new();
+    let items = tx.loaded_items();
+    for mut item in items {
+        let mut stmt = mz_sql::parse::parse(&item.create_sql)?.into_element().ast;
+
+        f(tx, item.id, &mut stmt).await?;
+
+        item.create_sql = stmt.to_ast_string_stable();
+
+        updated_items.insert(item.id, item);
+    }
+    tx.update_items(updated_items)?;
+    Ok(())
+}
+
 async fn rewrite_items<F>(
     tx: &mut Transaction<'_>,
     cat: &ConnCatalog<'_>,
@@ -64,17 +87,40 @@ pub(crate) async fn migrate(
         None => Version::new(0, 0, 0),
     };
 
-    info!("migrating from catalog version {:?}", catalog_version);
+    info!(
+        "migrating statements from catalog version {:?}",
+        catalog_version
+    );
+
+    rewrite_ast_items(tx, |_tx, _id, stmt| {
+        let _catalog_version = catalog_version.clone();
+        Box::pin(async move {
+            // Add per-item AST migrations below.
+            //
+            // Each migration should be a function that takes `item` (the AST
+            // representing the creation SQL for the item) as input. Any
+            // mutations to `item` will be staged for commit to the catalog.
+            //
+            // Migration functions may also take `tx` as input to stage
+            // arbitrary changes to the catalog.
+            ast_rewrite_create_source_loadgen_options_0_92_0(stmt)?;
+            Ok(())
+        })
+    })
+    .await?;
 
     // Load up a temporary catalog.
     let state = Catalog::load_catalog_items(tx, state)?;
 
-    // Perform per-item AST migrations.
+    info!("migrating from catalog version {:?}", catalog_version);
+
     let conn_cat = state.for_system_session();
+
     rewrite_items(tx, &conn_cat, |_tx, _conn_cat, _id, _stmt| {
         let _catalog_version = catalog_version.clone();
         Box::pin(async move {
-            // Add per-item AST migrations below.
+            // Add per-item, post-planning AST migrations below. Most
+            // migrations should be in the above `rewrite_ast_items` block.
             //
             // Each migration should be a function that takes `item` (the AST
             // representing the creation SQL for the item) as input. Any
@@ -131,5 +177,42 @@ fn _add_to_audit_log(
     let event =
         mz_audit_log::VersionedEvent::new(id, event_type, object_type, details, None, occurred_at);
     tx.insert_audit_log_event(event);
+    Ok(())
+}
+
+fn ast_rewrite_create_source_loadgen_options_0_92_0(
+    stmt: &mut Statement<Raw>,
+) -> Result<(), anyhow::Error> {
+    use mz_sql::ast::visit_mut::VisitMut;
+    use mz_sql::ast::{
+        CreateSourceConnection, CreateSourceStatement, LoadGenerator, LoadGeneratorOptionName::*,
+    };
+
+    struct Rewriter;
+
+    impl<'ast> VisitMut<'ast, Raw> for Rewriter {
+        fn visit_create_source_statement_mut(
+            &mut self,
+            node: &'ast mut CreateSourceStatement<Raw>,
+        ) {
+            match &mut node.connection {
+                CreateSourceConnection::LoadGenerator { generator, options } => {
+                    let permitted_options: &[_] = match generator {
+                        LoadGenerator::Auction => &[TickInterval],
+                        LoadGenerator::Counter => &[TickInterval, MaxCardinality],
+                        LoadGenerator::Marketing => &[TickInterval],
+                        LoadGenerator::Datums => &[TickInterval],
+                        LoadGenerator::Tpch => &[TickInterval, ScaleFactor],
+                    };
+
+                    options.retain(|o| permitted_options.contains(&o.name));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Rewriter.visit_statement_mut(stmt);
+
     Ok(())
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1594,6 +1594,39 @@ generate_extracted_config!(
     (MaxCardinality, u64)
 );
 
+impl LoadGeneratorOptionExtracted {
+    pub(super) fn ensure_only_valid_options(
+        &self,
+        loadgen: &ast::LoadGenerator,
+    ) -> Result<(), PlanError> {
+        use mz_sql_parser::ast::LoadGeneratorOptionName::*;
+
+        let mut options = self.seen.clone();
+
+        let permitted_options: &[_] = match loadgen {
+            ast::LoadGenerator::Auction => &[TickInterval],
+            ast::LoadGenerator::Counter => &[TickInterval, MaxCardinality],
+            ast::LoadGenerator::Marketing => &[TickInterval],
+            ast::LoadGenerator::Datums => &[TickInterval],
+            ast::LoadGenerator::Tpch => &[TickInterval, ScaleFactor],
+        };
+
+        for o in permitted_options {
+            options.remove(o);
+        }
+
+        if !options.is_empty() {
+            sql_bail!(
+                "{} load generators do not support {} values",
+                loadgen,
+                options.iter().join(", ")
+            )
+        }
+
+        Ok(())
+    }
+}
+
 pub(crate) fn load_generator_ast_to_generator(
     loadgen: &ast::LoadGenerator,
     options: &[LoadGeneratorOption<Aug>],
@@ -1604,18 +1637,21 @@ pub(crate) fn load_generator_ast_to_generator(
     ),
     PlanError,
 > {
+    let extracted: LoadGeneratorOptionExtracted = options.to_vec().try_into()?;
+    extracted.ensure_only_valid_options(loadgen)?;
+
     let load_generator = match loadgen {
         ast::LoadGenerator::Auction => LoadGenerator::Auction,
         ast::LoadGenerator::Counter => {
             let LoadGeneratorOptionExtracted {
                 max_cardinality, ..
-            } = options.to_vec().try_into()?;
+            } = extracted;
             LoadGenerator::Counter { max_cardinality }
         }
         ast::LoadGenerator::Marketing => LoadGenerator::Marketing,
         ast::LoadGenerator::Datums => LoadGenerator::Datums,
         ast::LoadGenerator::Tpch => {
-            let LoadGeneratorOptionExtracted { scale_factor, .. } = options.to_vec().try_into()?;
+            let LoadGeneratorOptionExtracted { scale_factor, .. } = extracted;
 
             // Default to 0.01 scale factor (=10MB).
             let sf: f64 = scale_factor.unwrap_or(0.01);

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -10,6 +10,11 @@
 $ set-arg-default default-replica-size=1
 $ set-arg-default single-replica-cluster=quickstart
 
+! CREATE SOURCE counter
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM LOAD GENERATOR COUNTER (SCALE FACTOR 1)
+exact:COUNTER load generators do not support SCALE FACTOR values
+
 > CREATE SOURCE auction_house
   IN CLUSTER ${arg.single-replica-cluster}
   FROM LOAD GENERATOR AUCTION FOR ALL TABLES;


### PR DESCRIPTION
This is https://github.com/MaterializeInc/materialize/pull/26006, but with tests fixed with version checks (thanks @def- for the good docs!), as well as a fixed migration. Because some migrations want to happen pre-planning, but some need a catalog connection, we split the migration code into two phases.

### Motivation
  * This PR fixes a recognized bug.

  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
