### PR TITLE
upgrade checks: Skip current minor version

### DIFF
--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -34,7 +34,9 @@ _previous_version: MzVersion | None = None
 def get_minor_versions() -> list[MzVersion]:
     global _minor_versions
     if _minor_versions is None:
-        _minor_versions = get_published_minor_mz_versions(limit=4)
+        _minor_versions = get_published_minor_mz_versions(
+            limit=4, exclude_current_minor_version=True
+        )
     return _minor_versions
 
 
@@ -85,9 +87,7 @@ class UpgradeEntireMzTwoVersions(Scenario):
         return get_previous_version()
 
     def actions(self) -> list[Action]:
-        print(
-            f"Upgrading starting from tag {self.base_version()} going through {get_last_version()}"
-        )
+        print(f"Upgrade path: {self.base_version()} -> {get_last_version()} -> current")
         return [
             # Start with previous_version
             StartMz(self, tag=self.base_version()),
@@ -122,7 +122,7 @@ class UpgradeEntireMzFourVersions(Scenario):
 
     def actions(self) -> list[Action]:
         print(
-            f"Upgrading going through {self.minor_versions[3]} -> {self.minor_versions[2]} -> {get_previous_version()} -> {get_last_version()}"
+            f"Upgrade path: {self.minor_versions[3]} -> {self.minor_versions[2]} -> {get_previous_version()} -> {get_last_version()} -> current"
         )
         return [
             StartMz(self, tag=self.minor_versions[3]),

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -258,6 +258,7 @@ def get_published_minor_mz_versions(
     newest_first: bool = True,
     limit: int | None = None,
     include_filter: Callable[[MzVersion], bool] | None = None,
+    exclude_current_minor_version: bool = False,
 ) -> list[MzVersion]:
     """
     Get the latest patch version for every minor version.
@@ -270,6 +271,9 @@ def get_published_minor_mz_versions(
     all_versions = get_all_mz_versions(newest_first=True)
     minor_versions: dict[str, MzVersion] = {}
 
+    version = MzVersion.parse_cargo()
+    current_version = f"{version.major}.{version.minor}"
+
     # Note that this method must not apply limit_to_published_versions to a created list
     # because in that case minor versions may get lost.
     for version in all_versions:
@@ -278,6 +282,10 @@ def get_published_minor_mz_versions(
             continue
 
         minor_version = f"{version.major}.{version.minor}"
+
+        if exclude_current_minor_version and minor_version == current_version:
+            continue
+
         if minor_version in minor_versions.keys():
             # we already have a more recent version for this minor version
             continue

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -200,9 +200,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     checks.sort(key=lambda ch: ch.__name__)
     checks = buildkite.shard_list(checks, lambda ch: ch.__name__)
-    print(
-        f"Checks in shard with index {buildkite.get_parallelism_index()}: {[s.__name__ for s in scenarios]}"
-    )
+    if buildkite.get_parallelism_index() != 0 or buildkite.get_parallelism_count() != 1:
+        print(
+            f"Checks in shard with index {buildkite.get_parallelism_index()}: {[c.__name__ for c in checks]}"
+        )
 
     executor = MzcomposeExecutor(composition=c)
     for scenario_class in scenarios:


### PR DESCRIPTION
As this is (mostly) not what we want to test, but the upgrade from the previous minor. See https://materializeinc.slack.com/archives/CTESPM7FU/p1710542034279119?thread_ts=1710518433.695219&cid=CTESPM7FU

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
