### PR TITLE
enviromentd: tracing tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4380,6 +4380,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-core",
+ "tracing-fluent-assertions",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tungstenite",
@@ -4863,6 +4864,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "derivative",
  "futures-core",
  "http",
  "humantime",
@@ -4876,6 +4878,7 @@ dependencies = [
  "opentelemetry_sdk",
  "sentry-tracing",
  "tracing",
+ "tracing-fluent-assertions",
  "tracing-subscriber",
  "workspace-hack",
 ]
@@ -4894,6 +4897,7 @@ dependencies = [
  "console-subscriber",
  "criterion",
  "ctor",
+ "derivative",
  "either",
  "futures",
  "hibitset",
@@ -4928,6 +4932,7 @@ dependencies = [
  "tokio-test",
  "tonic",
  "tracing",
+ "tracing-fluent-assertions",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
@@ -9405,6 +9410,17 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-fluent-assertions"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12de1a8c6bcfee614305e836308b596bbac831137a04c61f7e5b0b0bf2cfeaf6"
+dependencies = [
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,6 +2737,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,8 +4385,8 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-capture",
  "tracing-core",
- "tracing-fluent-assertions",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tungstenite",
@@ -4878,7 +4884,7 @@ dependencies = [
  "opentelemetry_sdk",
  "sentry-tracing",
  "tracing",
- "tracing-fluent-assertions",
+ "tracing-capture",
  "tracing-subscriber",
  "workspace-hack",
 ]
@@ -4932,7 +4938,7 @@ dependencies = [
  "tokio-test",
  "tonic",
  "tracing",
- "tracing-fluent-assertions",
+ "tracing-capture",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
@@ -5189,6 +5195,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "bytesize",
+ "enum-kinds",
  "futures",
  "itertools",
  "mz-adapter",
@@ -9403,6 +9410,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-capture"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3b1b84b84d7f95504091cb9518dea662eacba7a3bc23f23e98fe5fafede344"
+dependencies = [
+ "id-arena",
+ "predicates",
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-tunnel",
+]
+
+[[package]]
 name = "tracing-core"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9410,17 +9430,6 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-fluent-assertions"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de1a8c6bcfee614305e836308b596bbac831137a04c61f7e5b0b0bf2cfeaf6"
-dependencies = [
- "tracing",
- "tracing-core",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -9480,6 +9489,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-tunnel"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507bbab1fc2c9e606543558f5656b62e8014ba7e0ffa68b9484511b6871019c5"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -80,6 +80,11 @@ who = "Matt Jibson <matt.jibson@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.6.4"
 
+[[audits.id-arena]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.2.1"
+
 [[audits.im]]
 who = "Matt Jibson <matt.jibson@gmail.com>"
 criteria = "safe-to-deploy"
@@ -240,6 +245,11 @@ who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.12.0@git:9208396d1d86becbcc91c76e780ffe61fd51e65e"
 
+[[audits.tracing-capture]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+
 [[audits.tracing-fluent-assertions]]
 who = "Matt Jibson <matt.jibson@gmail.com>"
 criteria = "safe-to-deploy"
@@ -264,6 +274,11 @@ version = "0.22.0@git:7035e641b683985cc3b8630f3b61d53c96f83695"
 who = "Gus Wynn <gus@materialize.com>"
 criteria = "maintained-and-necessary"
 version = "0.3.18"
+
+[[audits.tracing-tunnel]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
 
 [[audits.untrusted]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -240,6 +240,11 @@ who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.12.0@git:9208396d1d86becbcc91c76e780ffe61fd51e65e"
 
+[[audits.tracing-fluent-assertions]]
+who = "Matt Jibson <matt.jibson@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+
 [[audits.tracing-log]]
 who = "Gus Wynn <gus@materialize.com>"
 criteria = "maintained-and-necessary"

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -333,7 +333,6 @@ impl Coordinator {
 
     #[mz_ore::instrument(level = "debug")]
     async fn message_command(&mut self, cmd: Command) {
-        event!(Level::TRACE, cmd = format!("{:?}", cmd));
         self.handle_command(cmd).await;
     }
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -74,7 +74,6 @@ impl Coordinator {
         resolved_ids: ResolvedIds,
     ) -> LocalBoxFuture<'_, ()> {
         async move {
-            event!(Level::TRACE, plan = format!("{:?}", plan));
             let responses = ExecuteResponse::generated_from(&PlanKind::from(&plan));
             ctx.tx_mut().set_allowed(responses);
 

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -17,8 +17,8 @@ use itertools::Either;
 use maplit::btreemap;
 use mz_controller_types::ClusterId;
 use mz_expr::{CollectionPlan, ResultSpec};
-use mz_ore::task;
 use mz_ore::tracing::OpenTelemetryContext;
+use mz_ore::{instrument, task};
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_repr::optimize::OverrideFrom;
 use mz_repr::{Datum, GlobalId, Row, RowArena, Timestamp};
@@ -65,7 +65,7 @@ impl Coordinator {
     /// deploying the most efficient evaluation plan. The peek could evaluate to a constant,
     /// be a simple read out of an existing arrangement, or required a new dataflow to build
     /// the results to return.
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     pub(crate) async fn sequence_peek(
         &mut self,
         ctx: ExecuteContext,
@@ -87,7 +87,7 @@ impl Coordinator {
         .await;
     }
 
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     pub(crate) async fn sequence_copy_to(
         &mut self,
         ctx: ExecuteContext,
@@ -149,7 +149,7 @@ impl Coordinator {
         .await;
     }
 
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     pub(crate) async fn explain_peek(
         &mut self,
         ctx: ExecuteContext,
@@ -198,7 +198,7 @@ impl Coordinator {
     }
 
     /// Processes as many `peek` stages as possible.
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     pub(crate) async fn execute_peek_stage(
         &mut self,
         mut ctx: ExecuteContext,
@@ -275,7 +275,7 @@ impl Coordinator {
     }
 
     /// Do some simple validation. We must defer most of it until after any off-thread work.
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     fn peek_stage_validate(
         &mut self,
         session: &Session,
@@ -386,7 +386,7 @@ impl Coordinator {
     }
 
     /// Possibly linearize a timestamp from a `TimestampOracle`.
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     async fn peek_stage_linearize_timestamp(
         &mut self,
         ctx: ExecuteContext,
@@ -453,7 +453,7 @@ impl Coordinator {
     }
 
     /// Determine a read timestamp and create appropriate read holds.
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     async fn peek_stage_timestamp_read_hold(
         &mut self,
         session: &mut Session,
@@ -507,7 +507,7 @@ impl Coordinator {
         })
     }
 
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     async fn peek_stage_optimize(
         &mut self,
         ctx: ExecuteContext,
@@ -670,7 +670,7 @@ impl Coordinator {
         );
     }
 
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     fn peek_stage_real_time_recency(
         &mut self,
         ctx: ExecuteContext,
@@ -735,7 +735,7 @@ impl Coordinator {
         }
     }
 
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     async fn peek_stage_finish(
         &mut self,
         ctx: &mut ExecuteContext,
@@ -841,7 +841,7 @@ impl Coordinator {
         }
     }
 
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     async fn peek_stage_copy_to_dataflow(
         &mut self,
         ctx: ExecuteContext,
@@ -874,6 +874,7 @@ impl Coordinator {
         self.ship_dataflow(df_desc, cluster_id).await;
     }
 
+    #[instrument]
     fn peek_stage_explain_plan(
         &mut self,
         ctx: &mut ExecuteContext,
@@ -931,6 +932,7 @@ impl Coordinator {
         Ok(Self::send_immediate_rows(rows))
     }
 
+    #[instrument]
     async fn peek_stage_explain_pushdown(
         &mut self,
         ctx: &mut ExecuteContext,
@@ -1021,7 +1023,7 @@ impl Coordinator {
 
     /// Determines the query timestamp and acquires read holds on dependent sources
     /// if necessary.
-    #[mz_ore::instrument(level = "debug")]
+    #[instrument]
     pub(super) async fn sequence_peek_timestamp(
         &mut self,
         session: &mut Session,

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -113,6 +113,7 @@ tower = { version = "0.4.13", features = ["buffer", "limit", "load-shed"] }
 tower-http = { version = "0.4.2", features = ["cors"] }
 tracing = "0.1.37"
 tracing-core = "0.1.30"
+tracing-fluent-assertions = { version = "0.3.0", optional = true }
 tracing-opentelemetry = { version = "0.22.0" }
 tracing-subscriber = "0.3.16"
 tungstenite = { version = "0.20.0" }
@@ -139,10 +140,10 @@ postgres_array = { version = "0.11.0" }
 predicates = "2.1.4"
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 rdkafka = { version = "0.29.0", features = [
-    "cmake-build",
-    "ssl-vendored",
-    "libz-static",
-    "zstd",
+  "cmake-build",
+  "ssl-vendored",
+  "libz-static",
+  "zstd",
 ] }
 reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.89"
@@ -174,6 +175,8 @@ test = [
   "postgres-openssl",
   "mz-tracing",
   "mz-frontegg-mock",
+  "tracing-fluent-assertions",
+  "mz-orchestrator-tracing/fluent-assertions",
 ]
 tokio-console = [
   "mz-ore/tokio-console",

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -113,7 +113,7 @@ tower = { version = "0.4.13", features = ["buffer", "limit", "load-shed"] }
 tower-http = { version = "0.4.2", features = ["cors"] }
 tracing = "0.1.37"
 tracing-core = "0.1.30"
-tracing-fluent-assertions = { version = "0.3.0", optional = true }
+tracing-capture = { version = "0.1.0", optional = true }
 tracing-opentelemetry = { version = "0.22.0" }
 tracing-subscriber = "0.3.16"
 tungstenite = { version = "0.20.0" }
@@ -175,8 +175,8 @@ test = [
   "postgres-openssl",
   "mz-tracing",
   "mz-frontegg-mock",
-  "tracing-fluent-assertions",
-  "mz-orchestrator-tracing/fluent-assertions",
+  "tracing-capture",
+  "mz-orchestrator-tracing/capture",
 ]
 tokio-console = [
   "mz-ore/tokio-console",

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -69,7 +69,7 @@ use tokio_postgres::{AsyncMessage, Client};
 use tokio_stream::wrappers::TcpListenerStream;
 use tower_http::cors::AllowOrigin;
 use tracing::Level;
-use tracing_fluent_assertions::AssertionRegistry;
+use tracing_capture::SharedStorage;
 use tracing_subscriber::EnvFilter;
 use tungstenite::stream::MaybeTlsStream;
 use tungstenite::{Message, WebSocket};
@@ -105,7 +105,7 @@ pub struct TestHarness {
     internal_console_redirect_url: Option<String>,
     metrics_registry: Option<MetricsRegistry>,
     code_version: semver::Version,
-    fluent_assertions: Option<AssertionRegistry>,
+    capture: Option<SharedStorage>,
     pub environment_id: EnvironmentId,
 }
 
@@ -141,7 +141,7 @@ impl Default for TestHarness {
             },
             code_version: crate::BUILD_INFO.semver_version(),
             environment_id: EnvironmentId::for_tests(),
-            fluent_assertions: None,
+            capture: None,
         }
     }
 }
@@ -277,8 +277,8 @@ impl TestHarness {
         self
     }
 
-    pub fn with_fluent_assertions(mut self, registry: AssertionRegistry) -> Self {
-        self.fluent_assertions = Some(registry);
+    pub fn with_capture(mut self, storage: SharedStorage) -> Self {
+        self.capture = Some(storage);
         self
     }
 }
@@ -410,7 +410,7 @@ impl Listeners {
                 build_sha: crate::BUILD_INFO.sha,
                 build_time: crate::BUILD_INFO.time,
                 registry: metrics_registry.clone(),
-                fluent_assertions: config.fluent_assertions,
+                capture: config.capture,
             };
             let (tracing_handle, tracing_guard) = mz_ore::tracing::configure(config).await?;
             (tracing_handle, Some(tracing_guard))

--- a/src/environmentd/tests/tracing.rs
+++ b/src/environmentd/tests/tracing.rs
@@ -8,15 +8,16 @@
 // by the Apache License, Version 2.0.
 
 use mz_environmentd::test_util;
-use tracing_fluent_assertions::AssertionRegistry;
+use mz_ore::collections::CollectionExt;
+use tracing_capture::SharedStorage;
 
 // Test that expected spans are generated for various queries.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)] // allow(test-attribute)
 #[cfg_attr(miri, ignore)] // too slow
 async fn test_expected_spans() {
-    let registry = AssertionRegistry::default();
+    let storage = SharedStorage::default();
     // Sets of expected span names and SQL statements that should produce that span.
-    let tests = vec![
+    let tests = &[
         // TODO: Tests that call create_collections have a race condition.
         // ("sequence_create_table", "CREATE TABLE t (i INT)"),
         // ("sequence_insert", "INSERT INTO t VALUES (1)"),
@@ -30,37 +31,146 @@ async fn test_expected_spans() {
         ("peek_stage_finish", "SELECT 1"),
         ("peek_stage_explain_plan", "EXPLAIN SELECT 1"),
     ];
-    let asserts = tests
-        .iter()
-        .map(|(name, _)| {
-            (
-                *name,
-                registry
-                    .build()
-                    .with_name(*name)
-                    .was_closed_exactly(1)
-                    .finalize(),
-            )
-        })
-        .collect::<Vec<_>>();
 
     let server = test_util::TestHarness::default()
         .with_enable_tracing(true)
-        .with_fluent_assertions(registry)
+        .with_capture(storage.clone())
         .with_system_parameter_default("opentelemetry_filter".to_string(), "info".to_string())
         .start()
         .await;
+
     let client = server.connect().await.unwrap();
+
+    // Assert that there are no expected spans.
+    {
+        let storage = storage.lock();
+        for (name, _) in tests {
+            let stats = storage
+                .all_spans()
+                .filter_map(|span| (span.metadata().name() == *name).then(|| span.stats()))
+                .collect::<Vec<_>>();
+            assert!(stats.is_empty(), "{stats:?}");
+        }
+    }
 
     for (_, sql) in tests {
         client.batch_execute(sql).await.unwrap();
     }
-    for (name, assert) in asserts {
-        if !assert.try_assert() {
-            // Try one more time and print the name. Use .assert here because it prints a deeper
-            // cause than try_assert.
-            println!("assert failed for {name}");
-            assert.assert();
+
+    {
+        let storage = storage.lock();
+        for (name, _) in tests {
+            let stats = storage
+                .all_spans()
+                .filter_map(|span| (span.metadata().name() == *name).then(|| span.stats()))
+                .collect::<Vec<_>>();
+            let stat = stats.into_element();
+            // TODO: entered and exited can sometimes be > 1 (and so we can't assert == 1). Why does
+            // this happen? It's not bootstrapping, which we know because of the empty span assert
+            // above.
+            assert!(stat.entered > 0, "{name}: {stat:?}");
+            assert!(stat.exited > 0, "{name}: {stat:?}");
+            assert_eq!(stat.is_closed, true, "{name}: {stat:?}");
+        }
+    }
+}
+
+// Test that secrets are not leaked in tracing. Send many kinds of queries that should execute many
+// of the most common code paths. This is not guaranteed to exhaustively test all of our tracing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)] // allow(test-attribute)
+#[cfg_attr(miri, ignore)] // too slow
+async fn test_secrets() {
+    let storage = SharedStorage::default();
+
+    let server = test_util::TestHarness::default()
+        .with_enable_tracing(true)
+        .with_capture(storage.clone())
+        .with_system_parameter_default("opentelemetry_filter".to_string(), "trace".to_string())
+        .start()
+        .await;
+    let client = server.connect().await.unwrap();
+
+    const SENTINEL: &str = "MUST_NOT_APPEAR";
+
+    // pgwire simple.
+    client
+        .batch_execute(&format!("CREATE SECRET s1 AS '{SENTINEL}'"))
+        .await
+        .unwrap();
+    // pgwire extended.
+    client
+        .execute(&format!("CREATE SECRET s2 AS '{SENTINEL}'"), &[])
+        .await
+        .unwrap();
+    // Lex error.
+    client
+        .batch_execute(&format!("CREATE SECRET _er AS '{SENTINEL}"))
+        .await
+        .unwrap_err();
+    // Parse error.
+    client
+        .batch_execute(&format!("CREATE SECRET _er AS 1 '{SENTINEL}'"))
+        .await
+        .unwrap_err();
+    // Plan error.
+    client
+        .batch_execute(&format!("CREATE SECRET _er AS 1 + '{SENTINEL}'"))
+        .await
+        .unwrap_err();
+    client
+        .batch_execute(&format!("ALTER SECRET s1 AS 'new_{SENTINEL}'"))
+        .await
+        .unwrap();
+
+    // TODO: Query via HTTP.
+
+    // TODO: Check event values.
+
+    // TODO: Search through span fields. Span metadata contains the names of fields, but I've been
+    // unable to find the values of those fields.
+
+    let storage = storage.lock();
+    for ev in storage.all_events() {
+        let assert_no_sentinel = |msg: Option<&str>| {
+            if let Some(msg) = msg {
+                if !msg.contains(SENTINEL) {
+                    return;
+                }
+                let meta = ev.metadata();
+                if let Some(mp) = meta.module_path() {
+                    if !mp.starts_with("mz_") {
+                        // TODO: Remove this.
+                        return;
+                    }
+                } else {
+                    return;
+                }
+                assert!(
+                    !msg.contains(SENTINEL),
+                    "event contains sentinel: {msg} at {}",
+                    ev.metadata().name()
+                );
+            }
+        };
+
+        assert_no_sentinel(ev.message());
+        for (_, v) in ev.values() {
+            assert_no_sentinel(v.as_str());
+        }
+    }
+    for span in storage.all_spans() {
+        for (name, v) in span.values() {
+            let Some(msg) = v.as_str() else {
+                continue;
+            };
+            if !msg.contains(SENTINEL) {
+                continue;
+            }
+            assert!(
+                !msg.contains(SENTINEL),
+                "span value {name} contains sentinel: {msg} at {}",
+                span.metadata().name()
+            );
         }
     }
 }

--- a/src/environmentd/tests/tracing.rs
+++ b/src/environmentd/tests/tracing.rs
@@ -1,0 +1,66 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use mz_environmentd::test_util;
+use tracing_fluent_assertions::AssertionRegistry;
+
+// Test that expected spans are generated for various queries.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)] // allow(test-attribute)
+#[cfg_attr(miri, ignore)] // too slow
+async fn test_expected_spans() {
+    let registry = AssertionRegistry::default();
+    // Sets of expected span names and SQL statements that should produce that span.
+    let tests = vec![
+        // TODO: Tests that call create_collections have a race condition.
+        // ("sequence_create_table", "CREATE TABLE t (i INT)"),
+        // ("sequence_insert", "INSERT INTO t VALUES (1)"),
+        // (
+        //     "create_materialized_view_finish",
+        //     "CREATE MATERIALIZED VIEW MV AS SELECT 1",
+        // ),
+        ("create_view_finish", "CREATE VIEW V AS SELECT 1"),
+        ("create_index_finish", "CREATE DEFAULT INDEX i ON v"),
+        ("subscribe_finish", "SUBSCRIBE (SELECT 1)"),
+        ("peek_stage_finish", "SELECT 1"),
+        ("peek_stage_explain_plan", "EXPLAIN SELECT 1"),
+    ];
+    let asserts = tests
+        .iter()
+        .map(|(name, _)| {
+            (
+                *name,
+                registry
+                    .build()
+                    .with_name(*name)
+                    .was_closed_exactly(1)
+                    .finalize(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let server = test_util::TestHarness::default()
+        .with_enable_tracing(true)
+        .with_fluent_assertions(registry)
+        .with_system_parameter_default("opentelemetry_filter".to_string(), "info".to_string())
+        .start()
+        .await;
+    let client = server.connect().await.unwrap();
+
+    for (_, sql) in tests {
+        client.batch_execute(sql).await.unwrap();
+    }
+    for (name, assert) in asserts {
+        if !assert.try_assert() {
+            // Try one more time and print the name. Use .assert here because it prints a deeper
+            // cause than try_assert.
+            println!("assert failed for {name}");
+            assert.assert();
+        }
+    }
+}

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anyhow = "1.0.66"
 async-trait = "0.1.68"
 clap = { version = "3.2.24", features = ["env", "derive"] }
+derivative = "2.2.0"
 futures-core = "0.3.21"
 http = "0.2.8"
 humantime = { version = "2.1.0", optional = true }
@@ -24,6 +25,7 @@ mz-service = { path = "../service" }
 mz-tracing = { path = "../tracing" }
 sentry-tracing = { version = "0.29.1" }
 tracing = { version = "0.1.37" }
+tracing-fluent-assertions = { version = "0.3.0", optional = true }
 tracing-subscriber = { version = "0.3.16", default-features = false }
 opentelemetry = { version = "0.21.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.21.2", features = ["rt-tokio"] }
@@ -35,6 +37,7 @@ mz-ore = { path = "../ore", features = ["network", "test"] }
 [features]
 default = ["tokio-console"]
 tokio-console = ["mz-ore/tokio-console", "mz-repr", "humantime"]
+fluent-assertions = ["tracing-fluent-assertions", "mz-ore/fluent-assertions"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -25,7 +25,7 @@ mz-service = { path = "../service" }
 mz-tracing = { path = "../tracing" }
 sentry-tracing = { version = "0.29.1" }
 tracing = { version = "0.1.37" }
-tracing-fluent-assertions = { version = "0.3.0", optional = true }
+tracing-capture = { version = "0.1.0", optional = true }
 tracing-subscriber = { version = "0.3.16", default-features = false }
 opentelemetry = { version = "0.21.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.21.2", features = ["rt-tokio"] }
@@ -37,7 +37,7 @@ mz-ore = { path = "../ore", features = ["network", "test"] }
 [features]
 default = ["tokio-console"]
 tokio-console = ["mz-ore/tokio-console", "mz-repr", "humantime"]
-fluent-assertions = ["tracing-fluent-assertions", "mz-ore/fluent-assertions"]
+capture = ["tracing-capture", "mz-ore/capture"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -195,10 +195,10 @@ pub struct TracingCliArgs {
     )]
     pub sentry_tag: Vec<KeyValueArg<String, String>>,
     /// Test-only feature to enable tracing assertions.
-    #[cfg(feature = "fluent-assertions")]
+    #[cfg(feature = "capture")]
     #[derivative(Debug = "ignore")]
     #[clap(skip)]
-    pub fluent_assertions: Option<tracing_fluent_assertions::AssertionRegistry>,
+    pub capture: Option<tracing_capture::SharedStorage>,
 }
 
 impl Default for TracingCliArgs {
@@ -270,8 +270,8 @@ impl TracingCliArgs {
             build_sha: build_info.sha,
             build_time: build_info.time,
             registry,
-            #[cfg(feature = "fluent-assertions")]
-            fluent_assertions: self.fluent_assertions.clone(),
+            #[cfg(feature = "capture")]
+            capture: self.capture.clone(),
         })
         .await
     }
@@ -361,8 +361,8 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
                 sentry_dsn,
                 sentry_environment,
                 sentry_tag,
-                #[cfg(feature = "fluent-assertions")]
-                    fluent_assertions: _,
+                #[cfg(feature = "capture")]
+                    capture: _,
             } = &self.tracing_args;
             args.push(format!("--startup-log-filter={startup_log_filter}"));
             args.push(format!("--log-format={log_format}"));

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use clap::{FromArgMatches, IntoApp};
+use derivative::Derivative;
 use futures_core::stream::BoxStream;
 use http::header::{HeaderName, HeaderValue};
 use mz_build_info::BuildInfo;
@@ -50,7 +51,8 @@ use opentelemetry_sdk::resource::Resource;
 /// This logic is separated from `mz_ore::tracing` because the details of how
 /// these command-line arguments are parsed and unparsed is specific to
 /// orchestrators and does not belong in a foundational crate like `mz_ore`.
-#[derive(Debug, Clone, clap::Parser)]
+#[derive(Derivative, Clone, clap::Parser)]
+#[derivative(Debug)]
 pub struct TracingCliArgs {
     /// Which tracing events to log to stderr.
     ///
@@ -192,6 +194,11 @@ pub struct TracingCliArgs {
         use_value_delimiter = true
     )]
     pub sentry_tag: Vec<KeyValueArg<String, String>>,
+    /// Test-only feature to enable tracing assertions.
+    #[cfg(feature = "fluent-assertions")]
+    #[derivative(Debug = "ignore")]
+    #[clap(skip)]
+    pub fluent_assertions: Option<tracing_fluent_assertions::AssertionRegistry>,
 }
 
 impl Default for TracingCliArgs {
@@ -263,6 +270,8 @@ impl TracingCliArgs {
             build_sha: build_info.sha,
             build_time: build_info.time,
             registry,
+            #[cfg(feature = "fluent-assertions")]
+            fluent_assertions: self.fluent_assertions.clone(),
         })
         .await
     }
@@ -352,6 +361,8 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
                 sentry_dsn,
                 sentry_environment,
                 sentry_tag,
+                #[cfg(feature = "fluent-assertions")]
+                    fluent_assertions: _,
             } = &self.tracing_args;
             args.push(format!("--startup-log-filter={startup_log_filter}"));
             args.push(format!("--log-format={log_format}"));

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -26,6 +26,7 @@ chrono = { version = "0.4.23", default-features = false, features = [
 clap = { version = "3.2.24", features = ["env"], optional = true }
 compact_bytes = { version = "0.1.1", optional = true }
 ctor = { version = "0.1.26", optional = true }
+derivative = { version = "2.2.0", optional = true }
 either = "1.8.0"
 futures = { version = "0.3.25", optional = true }
 hibitset = { version = "0.6.4", optional = true }
@@ -54,6 +55,7 @@ tokio = { version = "1.32.0", features = [
   "time",
 ], optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
+tracing-fluent-assertions = { version = "0.3.0", optional = true }
 # TODO(guswynn): determine, when, if ever, we can remove `tracing-log`
 # The `tracing-log` feature here is load-bearing: While our busiest-logging dependency (`rdkafka`) is now hooked-up
 # to use `tracing`, we cannot remove this feature until we guarantee no dependencies log using the `log` crate, for
@@ -141,9 +143,10 @@ tracing_ = [
 tokio-console = ["console-subscriber", "tokio", "tokio/tracing", "network"]
 cli = ["clap"]
 stack = ["stacker"]
-test = ["anyhow", "ctor", "tracing-subscriber"]
+test = ["anyhow", "ctor", "tracing-subscriber", "derivative"]
 metrics = ["prometheus"]
 id_gen = ["hibitset", "rand", "uuid"]
+fluent-assertions = ["tracing-fluent-assertions"]
 
 [[test]]
 name = "future"

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -55,7 +55,7 @@ tokio = { version = "1.32.0", features = [
   "time",
 ], optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
-tracing-fluent-assertions = { version = "0.3.0", optional = true }
+tracing-capture = { version = "0.1.0", optional = true }
 # TODO(guswynn): determine, when, if ever, we can remove `tracing-log`
 # The `tracing-log` feature here is load-bearing: While our busiest-logging dependency (`rdkafka`) is now hooked-up
 # to use `tracing`, we cannot remove this feature until we guarantee no dependencies log using the `log` crate, for
@@ -102,11 +102,7 @@ tokio-test = "0.4.2"
 tracing-subscriber = "0.3.16"
 
 [features]
-default = [
-  "tokio-console",
-  "workspace-hack",
-  "mz-ore-proc/workspace-hack",
-]
+default = ["tokio-console", "workspace-hack", "mz-ore-proc/workspace-hack"]
 async = [
   "async-trait",
   "futures",
@@ -146,7 +142,7 @@ stack = ["stacker"]
 test = ["anyhow", "ctor", "tracing-subscriber", "derivative"]
 metrics = ["prometheus"]
 id_gen = ["hibitset", "rand", "uuid"]
-fluent-assertions = ["tracing-fluent-assertions"]
+capture = ["tracing-capture"]
 
 [[test]]
 name = "future"

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = "0.1.68"
 byteorder = "1.4.3"
 bytes = "1.3.0"
 bytesize = "1.1.0"
+enum-kinds = "0.5.1"
 futures = "0.3.25"
 itertools = "0.10.5"
 mz-adapter = { path = "../adapter" }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use enum_kinds::EnumKind;
 use itertools::Itertools;
 use mz_adapter::session::TransactionCode;
 use mz_pgwire_common::ErrorResponse;
@@ -15,7 +16,8 @@ use mz_repr::{ColumnName, RelationDesc};
 /// Internal representation of a backend [message]
 ///
 /// [message]: https://www.postgresql.org/docs/11/protocol-message-formats.html
-#[derive(Debug)]
+#[derive(Debug, EnumKind)]
+#[enum_kind(BackendMessageKind)]
 pub enum BackendMessage {
     AuthenticationOk,
     AuthenticationCleartextPassword,

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -2187,10 +2187,9 @@ where
     async fn error(&mut self, err: ErrorResponse) -> Result<State, io::Error> {
         assert!(err.severity.is_error());
         debug!(
-            "cid={} error code={} message={}",
+            "cid={} error code={}",
             self.adapter_client.session().conn_id(),
-            err.code.code(),
-            err.message
+            err.code.code()
         );
         let is_fatal = err.severity.is_fatal();
         self.send(BackendMessage::ErrorResponse(err)).await?;

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -29,7 +29,7 @@ use crate::names::{
     CommentObjectId, ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds,
     SystemObjectId,
 };
-use crate::plan;
+use crate::plan::{self, PlanKind};
 use crate::plan::{
     DataSourceDesc, Explainee, MutationKind, Plan, SideEffectingFunc, UpdatePrivilege,
 };
@@ -295,7 +295,10 @@ pub fn check_plan(
         target_cluster_id,
         session.role_metadata().current_role,
     );
-    debug!("rbac requirements {rbac_requirements:?} for plan {plan:?}");
+    debug!(
+        "rbac requirements {rbac_requirements:?} for plan {:?}",
+        PlanKind::from(plan)
+    );
     rbac_requirements.validate(catalog, session, resolved_ids)
 }
 


### PR DESCRIPTION
Add tracing tests to assert certain traces do or don't happen. For normal queries, assert that some do. For secrets, assert that we don't leak bad raw sql in any trace or event.

Supersedes #25181

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a