### PR TITLE
storage/pg: do not error if OID of `TEXT COLUMNS` column changes

### DIFF
--- a/src/storage-types/src/sources/postgres.proto
+++ b/src/storage-types/src/sources/postgres.proto
@@ -9,6 +9,7 @@
 
 syntax = "proto3";
 
+import "google/protobuf/empty.proto";
 import "postgres-util/src/desc.proto";
 import "repr/src/global_id.proto";
 import "storage-types/src/connections.proto";
@@ -17,8 +18,16 @@ import "expr/src/scalar.proto";
 package mz_storage_types.sources.postgres;
 
 message ProtoPostgresSourceConnection {
+    message ProtoCastType {
+        oneof kind {
+            google.protobuf.Empty natural = 1;
+            google.protobuf.Empty text = 2;
+        }
+    }
+
     message ProtoPostgresTableCast {
         repeated mz_expr.scalar.ProtoMirScalarExpr column_casts = 1;
+        repeated ProtoCastType column_cast_types = 2;
     }
 
     mz_repr.global_id.ProtoGlobalId connection_id = 6;

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -79,7 +79,7 @@
 //!             v                  v
 //! ```
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::Infallible;
 use std::rc::Rc;
 use std::time::Duration;
@@ -384,10 +384,11 @@ fn verify_schema(
     oid: u32,
     expected_desc: &PostgresTableDesc,
     upstream_info: &BTreeMap<u32, PostgresTableDesc>,
+    allow_type_to_change_by_col_num: &BTreeSet<u16>,
 ) -> Result<(), DefiniteError> {
     let current_desc = upstream_info.get(&oid).ok_or(DefiniteError::TableDropped)?;
 
-    match expected_desc.determine_compatibility(current_desc) {
+    match expected_desc.determine_compatibility(current_desc, allow_type_to_change_by_col_num) {
         Ok(()) => Ok(()),
         Err(err) => Err(DefiniteError::IncompatibleSchema(err.to_string())),
     }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -79,12 +79,13 @@
 //!             v                  v
 //! ```
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::rc::Rc;
 use std::time::Duration;
 
 use differential_dataflow::Collection;
+use itertools::Itertools as _;
 use mz_expr::{EvalError, MirScalarExpr};
 use mz_ore::error::ErrorExt;
 use mz_postgres_util::desc::PostgresTableDesc;
@@ -92,6 +93,7 @@ use mz_postgres_util::{simple_query_opt, PostgresError};
 use mz_repr::{Datum, Diff, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_storage_types::errors::SourceErrorDetails;
+use mz_storage_types::sources::postgres::CastType;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection, SourceTimestamp};
 use mz_timely_util::builder_async::PressOnDropButton;
 use serde::{Deserialize, Serialize};
@@ -384,11 +386,21 @@ fn verify_schema(
     oid: u32,
     expected_desc: &PostgresTableDesc,
     upstream_info: &BTreeMap<u32, PostgresTableDesc>,
-    allow_type_to_change_by_col_num: &BTreeSet<u16>,
+    casts: &[(CastType, MirScalarExpr)],
 ) -> Result<(), DefiniteError> {
     let current_desc = upstream_info.get(&oid).ok_or(DefiniteError::TableDropped)?;
 
-    match expected_desc.determine_compatibility(current_desc, allow_type_to_change_by_col_num) {
+    let allow_oids_to_change_by_col_num = expected_desc
+        .columns
+        .iter()
+        .zip_eq(casts.iter())
+        .flat_map(|(col, (cast_type, _))| match cast_type {
+            CastType::Text => Some(col.col_num),
+            CastType::Natural => None,
+        })
+        .collect();
+
+    match expected_desc.determine_compatibility(current_desc, &allow_oids_to_change_by_col_num) {
         Ok(()) => Ok(()),
         Err(err) => Err(DefiniteError::IncompatibleSchema(err.to_string())),
     }
@@ -396,13 +408,13 @@ fn verify_schema(
 
 /// Casts a text row into the target types
 fn cast_row(
-    casts: &[MirScalarExpr],
+    casts: &[(CastType, MirScalarExpr)],
     datums: &[Datum<'_>],
     row: &mut Row,
 ) -> Result<(), DefiniteError> {
     let arena = mz_repr::RowArena::new();
     let mut packer = row.packer();
-    for column_cast in casts {
+    for (_, column_cast) in casts {
         let datum = column_cast
             .eval(datums, &arena)
             .map_err(DefiniteError::CastError)?;

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -69,7 +69,7 @@
 //! [1]: https://www.postgresql.org/docs/15/protocol-replication.html#PROTOCOL-REPLICATION-START-REPLICATION
 //! [2]: https://www.postgresql.org/message-id/CAFPTHDZS9O9WG02EfayBd6oONzK%2BqfUxS6AbVLJ7W%2BKECza2gg%40mail.gmail.com
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::Infallible;
 use std::pin::pin;
 use std::rc::Rc;
@@ -678,7 +678,9 @@ fn extract_transaction<'a>(
                         .await?;
                         let upstream_info = upstream_info.into_iter().map(|t| (t.oid, t)).collect();
 
-                        if let Err(err) = verify_schema(rel_id, expected_desc, &upstream_info) {
+                        if let Err(err) =
+                            verify_schema(rel_id, expected_desc, &upstream_info, &BTreeSet::new())
+                        {
                             errored_tables.insert(rel_id);
                             yield (rel_id, Err(err), 1);
                         }

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -69,7 +69,7 @@
 //! [1]: https://www.postgresql.org/docs/15/protocol-replication.html#PROTOCOL-REPLICATION-START-REPLICATION
 //! [2]: https://www.postgresql.org/message-id/CAFPTHDZS9O9WG02EfayBd6oONzK%2BqfUxS6AbVLJ7W%2BKECza2gg%40mail.gmail.com
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::pin::pin;
 use std::rc::Rc;
@@ -87,6 +87,7 @@ use mz_postgres_util::desc::PostgresTableDesc;
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_ssh_util::tunnel_manager::SshTunnelManager;
+use mz_storage_types::sources::postgres::CastType;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
 use mz_timely_util::builder_async::{
     AsyncOutputHandle, Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder,
@@ -146,7 +147,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
     config: RawSourceCreationConfig,
     connection: PostgresSourceConnection,
     subsource_resume_uppers: BTreeMap<GlobalId, Antichain<MzOffset>>,
-    table_info: BTreeMap<u32, (usize, PostgresTableDesc, Vec<MirScalarExpr>)>,
+    table_info: BTreeMap<u32, (usize, PostgresTableDesc, Vec<(CastType, MirScalarExpr)>)>,
     rewind_stream: &Stream<G, RewindRequest>,
     committed_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
     metrics: PgSourceMetrics,
@@ -600,7 +601,7 @@ fn extract_transaction<'a>(
     stream: impl AsyncStream<Item = Result<ReplicationMessage<LogicalReplicationMessage>, TransientError>>
         + 'a,
     commit_lsn: MzOffset,
-    table_info: &'a BTreeMap<u32, (usize, PostgresTableDesc, Vec<MirScalarExpr>)>,
+    table_info: &'a BTreeMap<u32, (usize, PostgresTableDesc, Vec<(CastType, MirScalarExpr)>)>,
     connection_config: &'a mz_postgres_util::Config,
     ssh_tunnel_manager: &'a SshTunnelManager,
     metrics: &'a PgSourceMetrics,
@@ -664,7 +665,7 @@ fn extract_transaction<'a>(
                 },
                 Relation(body) => {
                     let rel_id = body.rel_id();
-                    if let Some((_, expected_desc, _)) = table_info.get(&rel_id) {
+                    if let Some((_, expected_desc, casts)) = table_info.get(&rel_id) {
                         // Because the replication stream doesn't include columns' attnums, we need
                         // to check the current local schema against the current remote schema to
                         // ensure e.g. we haven't received a schema update with the same terminal
@@ -679,7 +680,7 @@ fn extract_transaction<'a>(
                         let upstream_info = upstream_info.into_iter().map(|t| (t.oid, t)).collect();
 
                         if let Err(err) =
-                            verify_schema(rel_id, expected_desc, &upstream_info, &BTreeSet::new())
+                            verify_schema(rel_id, expected_desc, &upstream_info, casts)
                         {
                             errored_tables.insert(rel_id);
                             yield (rel_id, Err(err), 1);

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -421,7 +421,8 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
 
             let mut snapshot_staged = 0;
             for (&oid, (_, expected_desc, _)) in reader_snapshot_table_info.iter() {
-                let desc = match verify_schema(oid, expected_desc, &upstream_info) {
+                let desc = match verify_schema(oid, expected_desc, &upstream_info, &BTreeSet::new())
+                {
                     Ok(()) => expected_desc,
                     Err(err) => {
                         raw_handle

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -147,6 +147,7 @@ use mz_postgres_util::desc::PostgresTableDesc;
 use mz_postgres_util::{simple_query_opt, PostgresError};
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
+use mz_storage_types::sources::postgres::CastType;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
 use mz_timely_util::builder_async::{
     Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
@@ -173,7 +174,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
     config: RawSourceCreationConfig,
     connection: PostgresSourceConnection,
     subsource_resume_uppers: BTreeMap<GlobalId, Antichain<MzOffset>>,
-    table_info: BTreeMap<u32, (usize, PostgresTableDesc, Vec<MirScalarExpr>)>,
+    table_info: BTreeMap<u32, (usize, PostgresTableDesc, Vec<(CastType, MirScalarExpr)>)>,
     metrics: PgSnapshotMetrics,
 ) -> (
     Collection<G, (usize, Result<Row, SourceReaderError>), Diff>,
@@ -420,9 +421,8 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 .await;
 
             let mut snapshot_staged = 0;
-            for (&oid, (_, expected_desc, _)) in reader_snapshot_table_info.iter() {
-                let desc = match verify_schema(oid, expected_desc, &upstream_info, &BTreeSet::new())
-                {
+            for (&oid, (_, expected_desc, casts)) in reader_snapshot_table_info.iter() {
+                let desc = match verify_schema(oid, expected_desc, &upstream_info, casts) {
                     Ok(()) => expected_desc,
                     Err(err) => {
                         raw_handle

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -757,6 +757,22 @@ enum_table              subsource <null> <null>
 var0
 var1
 
+# Test that TEXT COLUMN types can change
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+BEGIN;
+ALTER TYPE an_enum RENAME TO an_enum_old;
+CREATE TYPE an_enum AS ENUM ('var0', 'var1', 'var2');
+ALTER TABLE enum_table ALTER COLUMN a TYPE an_enum USING a::text::an_enum;
+DROP TYPE an_enum_old;
+COMMIT;
+
+INSERT INTO enum_table VALUES ('var2');
+
+> SELECT * FROM enum_table
+var0
+var1
+var2
+
 > SELECT "колона" FROM another_enum_table
 var2
 var3


### PR DESCRIPTION
If we are ingesting data as a text column, we do not need to error if its OID changes. Not erroring here lets us support schema evolutions of `enum` types, which we couldn't otherwise.

cc @rjobanp I didn't dig into supporting this for MySQL. You want to let me know if you want to make it happen on this branch?

### Motivation

This PR adds a known-desirable feature. https://materializeinc.slack.com/archives/C06KYARK95Z/p1709762490445319

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - When using the `TEXT COLUMNS` option to ingest data as `text` from a PostgreSQL database, sources will no longer error if the `oid` or `typmod` of a column changes. For example, this lets users evolve the structure of `enum` columns by using `ALTER TABLE <table> ALTER COLUMN <enum column> TYPE...` without Materialize erroring.