### PR TITLE
mzcompose: Run sanity check only on release branches

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -83,6 +83,12 @@ For additional details on mzcompose, consult doc/developer/mzbuild.md.""",
         metavar="PROJECT_NAME",
         help="Use a different project name than the directory name",
     )
+    parser.add_argument(
+        "--sanity-restart-mz",
+        action="store_true",
+        default=os.getenv("BUILDKITE_TAG", "") != "",
+        help="Whether to restart Materialized at the end of test cases and tests, enabled by default on release branches",
+    )
     parser.add_argument("--ignore-docker-version", action="store_true")
     mzbuild.Repository.install_arguments(parser)
 
@@ -175,6 +181,7 @@ def load_composition(args: argparse.Namespace) -> Composition:
             name=args.find or Path.cwd().name,
             preserve_ports=args.preserve_ports,
             project_name=args.project_name,
+            sanity_restart_mz=args.sanity_restart_mz,
         )
     except UnknownCompositionError as e:
         if args.find:

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -103,6 +103,7 @@ class Composition:
         silent: bool = False,
         munge_services: bool = True,
         project_name: str | None = None,
+        sanity_restart_mz: bool = False,
     ):
         self.name = name
         self.description = None
@@ -114,6 +115,7 @@ class Composition:
         self.test_results: OrderedDict[str, TestResult] = OrderedDict()
         self.files = {}
         self.sources_and_sinks_ignored_from_validation = set()
+        self.is_sanity_restart_mz = sanity_restart_mz
 
         if name in self.repo.compositions:
             self.path = self.repo.compositions[name]
@@ -453,7 +455,7 @@ class Composition:
                 func(self)
             if os.getenv("CI_FINAL_PREFLIGHT_CHECK_VERSION") is not None:
                 self.final_preflight_check()
-            else:
+            elif self.is_sanity_restart_mz:
                 self.sanity_restart_mz()
         finally:
             loader.composition_path = None
@@ -1041,7 +1043,7 @@ class Composition:
         """
         if os.getenv("CI_FINAL_PREFLIGHT_CHECK_VERSION") is not None:
             self.final_preflight_check()
-        elif sanity_restart_mz:
+        elif sanity_restart_mz and self.is_sanity_restart_mz:
             self.sanity_restart_mz()
         self.capture_logs()
         self.invoke(


### PR DESCRIPTION
I'm guessing BUILDKITE_TAG is better since BUILDKITE_BRANCH can be manually set to anything

This should save us some resources in CI and locally since restarting Mz is already so slow (~20 seconds!)

(The preferred fix would be to make restarting Mz faster)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
