### PR TITLE
buildkite search: change default of only-failed-builds param to false

### DIFF
--- a/misc/python/materialize/buildkite_insights/failure_search/search.py
+++ b/misc/python/materialize/buildkite_insights/failure_search/search.py
@@ -182,7 +182,7 @@ if __name__ == "__main__":
     parser.add_argument("--max-results", default=50, type=int)
     parser.add_argument(
         "--only-failed-builds",
-        default=True,
+        default=False,
         action="store_true",
     )
     parser.add_argument("--value", required=True, type=str)


### PR DESCRIPTION
True as default can be surprising here. Furthermore, successful builds may also contain annotations due to known errors in logs or retries.