### PR TITLE
ci: Only run miri test in nightly

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -186,44 +186,27 @@ steps:
           queue: linux-x86_64-small
         coverage: skip
 
-  - group: "Cargo tests"
-    key: cargo-tests
-    steps:
-      - id: cargo-test
-        label: Cargo test
-        timeout_in_minutes: 45
-        inputs:
-          - Cargo.lock
-          - ".config/nextest.toml"
-          - "**/Cargo.toml"
-          - "**/*.rs"
-          - "**/*.proto"
-          - "**/testdata/**"
-        depends_on: []
-        env:
-          AWS_DEFAULT_REGION: "us-east-1"
-          # cargo-test's coverage is handled separately by cargo-llvm-cov
-          BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_COVERAGE: "true"
-        plugins:
-          - ./ci/plugins/scratch-aws-access: ~
-          - ./ci/plugins/mzcompose:
-              composition: cargo-test
-        agents:
-          queue: builder-linux-aarch64
-
-      - id: miri-test
-        label: Miri test (fast)
-        inputs: [src]
-        depends_on: []
-        timeout_in_minutes: 45
-        plugins:
-          - ./ci/plugins/scratch-aws-access: ~
-          - ./ci/plugins/mzcompose:
-              composition: cargo-test
-              args: [--miri-fast]
-        agents:
-          queue: builder-linux-aarch64
-        coverage: skip
+  - id: cargo-test
+    label: Cargo test
+    timeout_in_minutes: 45
+    inputs:
+      - Cargo.lock
+      - ".config/nextest.toml"
+      - "**/Cargo.toml"
+      - "**/*.rs"
+      - "**/*.proto"
+      - "**/testdata/**"
+    depends_on: []
+    env:
+      AWS_DEFAULT_REGION: "us-east-1"
+      # cargo-test's coverage is handled separately by cargo-llvm-cov
+      BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_COVERAGE: "true"
+    plugins:
+      - ./ci/plugins/scratch-aws-access: ~
+      - ./ci/plugins/mzcompose:
+          composition: cargo-test
+    agents:
+      queue: builder-linux-aarch64
 
   - id: testdrive
     label: Testdrive %N


### PR DESCRIPTION
It is by far the slowest test. Since a full run is in Nightly, this might be ok, but we will see if it breaks often or not.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
