### PR TITLE
catalog: Add metrics on total size

### DIFF
--- a/src/catalog/src/durable/metrics.rs
+++ b/src/catalog/src/durable/metrics.rs
@@ -11,7 +11,7 @@
 
 use mz_ore::metric;
 use mz_ore::metrics::{IntCounter, MetricsRegistry};
-use prometheus::Counter;
+use prometheus::{Counter, IntGaugeVec};
 
 #[derive(Debug, Clone)]
 pub struct Metrics {
@@ -22,6 +22,7 @@ pub struct Metrics {
     pub snapshot_latency_seconds: Counter,
     pub syncs: IntCounter,
     pub sync_latency_seconds: Counter,
+    pub collection_count: IntGaugeVec,
 }
 
 impl Metrics {
@@ -55,6 +56,11 @@ impl Metrics {
             sync_latency_seconds: registry.register(metric!(
                 name: "mz_catalog_sync_latency_seconds",
                 help: "Total latency for syncing the in-memory state of the durable catalog with the persisted contents.",
+            )),
+            collection_count: registry.register(metric!(
+                name: "mz_catalog_collection_count",
+                help: "Total number of entries, after consolidation, per catalog collection.",
+                var_labels: ["collection"],
             )),
         }
     }

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -9,6 +9,7 @@
 
 use std::fmt::Debug;
 
+use crate::durable::debug::CollectionType;
 use mz_proto::{RustType, TryFromProtoError};
 use mz_repr::adt::jsonb::Jsonb;
 use mz_repr::Diff;
@@ -217,6 +218,34 @@ pub enum StateUpdateKind {
     SystemObjectMapping(proto::GidMappingKey, proto::GidMappingValue),
     SystemPrivilege(proto::SystemPrivilegesKey, proto::SystemPrivilegesValue),
     Timestamp(proto::TimestampKey, proto::TimestampValue),
+}
+
+impl StateUpdateKind {
+    pub(crate) fn collection_type(&self) -> Option<CollectionType> {
+        match self {
+            StateUpdateKind::AuditLog(_, _) => Some(CollectionType::AuditLog),
+            StateUpdateKind::Cluster(_, _) => Some(CollectionType::ComputeInstance),
+            StateUpdateKind::ClusterReplica(_, _) => Some(CollectionType::ComputeReplicas),
+            StateUpdateKind::Comment(_, _) => Some(CollectionType::Comments),
+            StateUpdateKind::Config(_, _) => Some(CollectionType::Config),
+            StateUpdateKind::Database(_, _) => Some(CollectionType::Database),
+            StateUpdateKind::DefaultPrivilege(_, _) => Some(CollectionType::DefaultPrivileges),
+            StateUpdateKind::Epoch(_) => None,
+            StateUpdateKind::IdAllocator(_, _) => Some(CollectionType::IdAlloc),
+            StateUpdateKind::IntrospectionSourceIndex(_, _) => {
+                Some(CollectionType::ComputeIntrospectionSourceIndex)
+            }
+            StateUpdateKind::Item(_, _) => Some(CollectionType::Item),
+            StateUpdateKind::Role(_, _) => Some(CollectionType::Role),
+            StateUpdateKind::Schema(_, _) => Some(CollectionType::Schema),
+            StateUpdateKind::Setting(_, _) => Some(CollectionType::Setting),
+            StateUpdateKind::StorageUsage(_, _) => Some(CollectionType::StorageUsage),
+            StateUpdateKind::SystemConfiguration(_, _) => Some(CollectionType::SystemConfiguration),
+            StateUpdateKind::SystemObjectMapping(_, _) => Some(CollectionType::SystemGidMapping),
+            StateUpdateKind::SystemPrivilege(_, _) => Some(CollectionType::SystemPrivileges),
+            StateUpdateKind::Timestamp(_, _) => Some(CollectionType::Timestamp),
+        }
+    }
 }
 
 impl RustType<proto::StateUpdateKind> for StateUpdateKind {


### PR DESCRIPTION
This commit adds a metric to the durable catalog that tracks how many total entries, after consolidation, exist in each catalog collection

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
