### PR TITLE
persist-txn: add dyncfg to apply_eager on init instead of forget_all

### DIFF
--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -24,6 +24,7 @@ use bytes::BufMut;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use mz_build_info::{build_info, BuildInfo};
+use mz_dyncfg::ConfigSet;
 use mz_ore::instrument;
 use mz_persist::location::{Blob, Consensus, ExternalError};
 use mz_persist_types::codec_impls::{SimpleDecoder, SimpleEncoder, SimpleSchema};
@@ -312,6 +313,11 @@ impl PersistClient {
             .open(PersistLocation::new_in_mem())
             .await
             .expect("in-mem location is valid")
+    }
+
+    /// Returns persist's [ConfigSet].
+    pub fn dyncfgs(&self) -> &ConfigSet {
+        &self.cfg.configs
     }
 
     async fn make_machine<K, V, T, D>(

--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -274,7 +274,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
 /// Used by storage controller as a temporary escape hatch for #25992.
 pub const INIT_FORGET_ALL: Config<bool> = Config::new(
     "persist_txn_init_forget_all",
-    true,
+    false,
     "Whether to call forget_all (true) or empty txn and apply_eager (false) at boot",
 );
 

--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -207,7 +207,7 @@ use std::fmt::Write;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::Hashable;
-use mz_dyncfg::ConfigSet;
+use mz_dyncfg::{Config, ConfigSet};
 use mz_ore::instrument;
 use mz_persist_client::critical::SinceHandle;
 use mz_persist_client::error::UpperMismatch;
@@ -265,10 +265,18 @@ mod proto {
 /// Adds the full set of all persist-txn `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
+        .add(&crate::INIT_FORGET_ALL)
+        .add(&crate::operator::DATA_SHARD_RETRYER_CLAMP)
         .add(&crate::operator::DATA_SHARD_RETRYER_INITIAL_BACKOFF)
         .add(&crate::operator::DATA_SHARD_RETRYER_MULTIPLIER)
-        .add(&crate::operator::DATA_SHARD_RETRYER_CLAMP)
 }
+
+/// Used by storage controller as a temporary escape hatch for #25992.
+pub const INIT_FORGET_ALL: Config<bool> = Config::new(
+    "persist_txn_init_forget_all",
+    true,
+    "Whether to call forget_all (true) or empty txn and apply_eager (false) at boot",
+);
 
 /// The in-mem representation of an update in the txns shard.
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
In #25992, we discovered that persist-txn forget records do not
consolidate out of the raw shard as intended (they work fine in-mem).
This combined with the forget_all call as part of boot creates a risk
that a crashlooping envd process will quickly increase the physical size
of the txns shard.

Luckily, the forget_all call was only needed as part of the story for
rollback back to the old tables implementation, which has since been
removed. We can now get away with a lesser set of invariants at boot.
Put this behind a dyncfg because it's occasionally useful to have the
forget_all.

Mechanically, I add the dyncfg with a default of the previous behavior
in this commit. In the next, I'll switch the default. This allows us to
potentially cherry-pick just this commit into the currently qualifying
0.92.x release to get the knob out sooner.

Touches #25992

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
