### PR TITLE
sql: error instead of panic when failing to lower casts

### DIFF
--- a/test/pg-cdc/types-reg.td
+++ b/test/pg-cdc/types-reg.td
@@ -1,0 +1,56 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test reg* data types
+#
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+
+# Insert data pre-snapshot
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (f1 REGTYPE);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+
+INSERT INTO t1 VALUES (1::regtype),(0::regtype);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR ALL TABLES;
+
+> SELECT COUNT(*) > 0 FROM t1;
+true
+
+# Insert the same data post-snapshot
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t1 SELECT * FROM t1;
+
+> SELECT pg_typeof(f1) FROM t1 LIMIT 1;
+regtype
+
+> SELECT * FROM t1;
+1
+0
+1
+0

--- a/test/pg-cdc/types-reg.td
+++ b/test/pg-cdc/types-reg.td
@@ -28,29 +28,51 @@ DROP PUBLICATION IF EXISTS mz_source;
 
 CREATE SCHEMA public;
 
-CREATE TABLE t1 (f1 REGTYPE);
-ALTER TABLE t1 REPLICA IDENTITY FULL;
+CREATE TABLE regtype_table (f1 REGTYPE);
+ALTER TABLE regtype_table REPLICA IDENTITY FULL;
 
-INSERT INTO t1 VALUES (1::regtype),(0::regtype);
+INSERT INTO regtype_table VALUES (1::regtype),(0::regtype);
 
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
-> CREATE SOURCE mz_source
+!CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
-  FOR ALL TABLES;
+  FOR TABLES (regtype_table);
+contains:publication mz_source contains column regtype_table.f1 of type regtype which Materialize cannot currently ingest
 
-> SELECT COUNT(*) > 0 FROM t1;
-true
-
-# Insert the same data post-snapshot
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-INSERT INTO t1 SELECT * FROM t1;
+DROP TABLE regtype_table CASCADE;
 
-> SELECT pg_typeof(f1) FROM t1 LIMIT 1;
-regtype
+CREATE TABLE regclass_table (f1 REGCLASS);
+ALTER TABLE regclass_table REPLICA IDENTITY FULL;
 
-> SELECT * FROM t1;
+INSERT INTO regclass_table VALUES (1::regclass),(0::regclass);
+
+!CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES (regclass_table);
+contains:publication mz_source contains column regclass_table.f1 of type regclass which Materialize cannot currently ingest
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP TABLE regclass_table CASCADE;
+
+CREATE TABLE regproc_table (f1 REGPROC);
+ALTER TABLE regproc_table REPLICA IDENTITY FULL;
+
+INSERT INTO regproc_table VALUES (1::regproc),(2::regproc);
+
+!CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES (regproc_table);
+contains:publication mz_source contains column regproc_table.f1 of type regproc which Materialize cannot currently ingest
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS (regproc_table.f1)
+  )
+  FOR TABLES (regproc_table);
+
+> SELECT * FROM regproc_table;
 1
-0
-1
-0
+2


### PR DESCRIPTION
Fixes #26100

### Motivation

 This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Error when trying to set up a PostgreSQL source asking MZ to ingest `regtype`, `regclass`, or `regproc` data. MZ does not yet offer enough support for those types to let us ingest them and, additionally, user-specified objects' OIDs cannot be meaningfully used in Materialize.