### PR TITLE
catalog: Refactor persist catalog to use traces

### DIFF
--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -997,6 +997,14 @@ impl PersistCatalogState {
     }
 
     fn consolidate(&mut self) {
+        soft_assert_no_log!(
+            self.snapshot
+                .windows(2)
+                .all(|updates| updates[0].1 <= updates[1].1),
+            "snapshot should be sorted by timestamp, {:?}",
+            self.snapshot
+        );
+
         let new_ts = self
             .snapshot
             .last()


### PR DESCRIPTION
This commit refactors the persist catalog implementation to store a trace of all catalog updates in memory instead of a map of all catalog contents. This simplifies the persist implementation slightly and will allow further refactors to combine the pre and post open catalog implementations.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
