### PR TITLE
catalog: Rename collection entry count metric

### DIFF
--- a/src/catalog/src/durable/metrics.rs
+++ b/src/catalog/src/durable/metrics.rs
@@ -22,7 +22,7 @@ pub struct Metrics {
     pub snapshot_latency_seconds: Counter,
     pub syncs: IntCounter,
     pub sync_latency_seconds: Counter,
-    pub collection_count: IntGaugeVec,
+    pub collection_entries: IntGaugeVec,
 }
 
 impl Metrics {
@@ -57,8 +57,8 @@ impl Metrics {
                 name: "mz_catalog_sync_latency_seconds",
                 help: "Total latency for syncing the in-memory state of the durable catalog with the persisted contents.",
             )),
-            collection_count: registry.register(metric!(
-                name: "mz_catalog_collection_count",
+            collection_entries: registry.register(metric!(
+                name: "mz_catalog_collection_entries",
                 help: "Total number of entries, after consolidation, per catalog collection.",
                 var_labels: ["collection"],
             )),

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -401,7 +401,7 @@ impl UnopenedPersistCatalogState {
             storage_usage_events: LargeCollectionStartupCache::new_open(),
             metrics: self.metrics,
         };
-        catalog.metrics.collection_count.reset();
+        catalog.metrics.collection_entries.reset();
         let updates = self
             .snapshot
             .into_iter()
@@ -991,7 +991,7 @@ impl PersistCatalogState {
 
             if let Some(collection_type) = kind.collection_type() {
                 self.metrics
-                    .collection_count
+                    .collection_entries
                     .with_label_values(&[&collection_type.to_string()])
                     .add(diff);
             }


### PR DESCRIPTION
This commit renames the mz_catalog_collection_count metric to mz_catalog_collection_entries since `_count` is a reserved suffix in Grafana/Prometheus.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
