### PR TITLE
[persist] Remove some unused code & cases in Persist's Spine

### DIFF
--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -268,28 +268,6 @@ impl<T: Timestamp + Lattice> Trace<T> {
         }
         ret
     }
-
-    #[allow(dead_code)]
-    pub fn describe(&self) -> String {
-        let mut s = Vec::new();
-        for b in self.spine.merging.iter().rev() {
-            match b {
-                MergeState::Vacant
-                | MergeState::Single(None)
-                | MergeState::Double(MergeVariant::Complete(None)) => s.push("_".to_owned()),
-                MergeState::Single(Some(x))
-                | MergeState::Double(MergeVariant::Complete(Some(x))) => s.push(x.describe(false)),
-                MergeState::Double(MergeVariant::InProgress(b0, b1, m)) => s.push(format!(
-                    "f{}/{}({}+{})",
-                    m.remaining_work,
-                    b0.len() + b1.len(),
-                    b0.describe(false),
-                    b1.describe(false),
-                )),
-            }
-        }
-        s.join(" ")
-    }
 }
 
 /// A log of what transitively happened during a Spine operation: e.g.
@@ -515,6 +493,7 @@ impl<T: Timestamp + Lattice> SpineBatch<T> {
         }
     }
 
+    #[cfg(test)]
     fn describe(&self, extended: bool) -> String {
         match (extended, self) {
             (false, SpineBatch::Merged(x)) => format!(

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -128,7 +128,7 @@ impl<T> Trace<T> {
     }
 
     #[must_use]
-    pub fn batches<'a>(&'a self) -> impl IntoIterator<Item = &'a HollowBatch<T>> {
+    pub fn batches(&self) -> impl IntoIterator<Item = &HollowBatch<T>> {
         // It should be possible to do this without the Vec.
         let mut batches = Vec::new();
         self.map_batches(|b| batches.push(b));
@@ -238,7 +238,7 @@ impl<T: Timestamp + Lattice> Trace<T> {
 
     // This is only called with the results of one `insert` and so the length of
     // `merge_reqs` is bounded by the number of levels in the spine (or possibly
-    // some small constant multiple?). The number of levels is logarithmic in
+    // some small constant multiple?). The number of levels is logarithmic in the
     // number of updates in the spine, so this number should stay very small. As
     // a result, we simply use the naive O(n^2) algorithm here instead of doing
     // anything fancy with e.g. interval trees.
@@ -1256,7 +1256,7 @@ impl<T: Timestamp + Lattice> MergeState<T> {
     }
 
     /// True iff the layer is a complete merge, ready for extraction.
-    fn is_complete(&mut self) -> bool {
+    fn is_complete(&self) -> bool {
         if let MergeState::Double(MergeVariant::Complete(_)) = self {
             true
         } else {


### PR DESCRIPTION
### Motivation

Refactoring, motivated by: #16607. In the short term, simplifying the structure of Spine means I have fewer cases to account for when roundtripping the structure. In the medium term, having fewer cases to account for in the Spine structure should make future work on Compaction 2.0 easier to reason about.

### Tips for reviewer

This is structured as a series of smallish changes, one per commit, in case it's easier to review that way also.

It was slightly trickier to remove the `None` case than I expected, even though we are not introducing structurally-empty batches, because it was also used as a placeholder value in some cases. Let me know if anything doesn't make sense!

`cargo bench` suggests that this is performance-neutral. I'll give nightlies a go at it as well.

I appreciate that this takes us away from the upstream Spine a bit. I think on balance it's worth it to make reasoning about the Persist case more straightforward, but I appreciate others may feel differently on this one!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
