### PR TITLE
catalog: Abstract common persist functionality

### DIFF
--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -49,6 +49,23 @@ where
     }
 }
 
+/// Trait for objects that can be converted to/from a [`StateUpdateKind`].
+pub(crate) trait TryIntoStateUpdateKind: IntoStateUpdateKindRaw {
+    type Error: Debug;
+
+    fn try_into(self) -> Result<StateUpdateKind, <Self as TryIntoStateUpdateKind>::Error>;
+}
+impl<T: IntoStateUpdateKindRaw + TryInto<StateUpdateKind>> TryIntoStateUpdateKind for T
+where
+    <T as TryInto<StateUpdateKind>>::Error: Debug,
+{
+    type Error = <T as TryInto<StateUpdateKind>>::Error;
+
+    fn try_into(self) -> Result<StateUpdateKind, <T as TryInto<StateUpdateKind>>::Error> {
+        <T as TryInto<StateUpdateKind>>::try_into(self)
+    }
+}
+
 /// A single update to the catalog state.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StateUpdate<T: IntoStateUpdateKindRaw = StateUpdateKind> {
@@ -178,7 +195,7 @@ impl TryFrom<StateUpdate<StateUpdateKindRaw>> for StateUpdate<StateUpdateKind> {
 
     fn try_from(update: StateUpdate<StateUpdateKindRaw>) -> Result<Self, Self::Error> {
         Ok(StateUpdate {
-            kind: update.kind.try_into()?,
+            kind: TryInto::try_into(update.kind)?,
             ts: update.ts,
             diff: update.diff,
         })

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -62,17 +62,24 @@ pub struct StateUpdate<T: IntoStateUpdateKindRaw = StateUpdateKind> {
 
 impl StateUpdate {
     /// Convert a [`TransactionBatch`] to a list of [`StateUpdate`]s at timestamp `ts`.
-    pub(crate) fn from_txn_batch(txn_batch: TransactionBatch, ts: Timestamp) -> Vec<StateUpdate> {
+    pub(crate) fn from_txn_batch_ts(
+        txn_batch: TransactionBatch,
+        ts: Timestamp,
+    ) -> impl Iterator<Item = StateUpdate> {
+        Self::from_txn_batch(txn_batch).map(move |(kind, diff)| StateUpdate { kind, ts, diff })
+    }
+
+    /// Convert a [`TransactionBatch`] to a list of [`StateUpdate`]s and [`Diff`]s.
+    pub(crate) fn from_txn_batch(
+        txn_batch: TransactionBatch,
+    ) -> impl Iterator<Item = (StateUpdateKind, Diff)> {
         fn from_batch<K, V>(
             batch: Vec<(K, V, Diff)>,
-            ts: Timestamp,
             kind: fn(K, V) -> StateUpdateKind,
-        ) -> impl Iterator<Item = StateUpdate> {
-            batch.into_iter().map(move |(k, v, diff)| StateUpdate {
-                kind: kind(k, v),
-                ts,
-                diff,
-            })
+        ) -> impl Iterator<Item = (StateUpdateKind, Diff)> {
+            batch
+                .into_iter()
+                .map(move |(k, v, diff)| (kind(k, v), diff))
         }
         let TransactionBatch {
             databases,
@@ -93,34 +100,29 @@ impl StateUpdate {
             audit_log_updates,
             storage_usage_updates,
         } = txn_batch;
-        let databases = from_batch(databases, ts, StateUpdateKind::Database);
-        let schemas = from_batch(schemas, ts, StateUpdateKind::Schema);
-        let items = from_batch(items, ts, StateUpdateKind::Item);
-        let comments = from_batch(comments, ts, StateUpdateKind::Comment);
-        let roles = from_batch(roles, ts, StateUpdateKind::Role);
-        let clusters = from_batch(clusters, ts, StateUpdateKind::Cluster);
-        let cluster_replicas = from_batch(cluster_replicas, ts, StateUpdateKind::ClusterReplica);
+        let databases = from_batch(databases, StateUpdateKind::Database);
+        let schemas = from_batch(schemas, StateUpdateKind::Schema);
+        let items = from_batch(items, StateUpdateKind::Item);
+        let comments = from_batch(comments, StateUpdateKind::Comment);
+        let roles = from_batch(roles, StateUpdateKind::Role);
+        let clusters = from_batch(clusters, StateUpdateKind::Cluster);
+        let cluster_replicas = from_batch(cluster_replicas, StateUpdateKind::ClusterReplica);
         let introspection_sources = from_batch(
             introspection_sources,
-            ts,
             StateUpdateKind::IntrospectionSourceIndex,
         );
-        let id_allocators = from_batch(id_allocator, ts, StateUpdateKind::IdAllocator);
-        let configs = from_batch(configs, ts, StateUpdateKind::Config);
-        let settings = from_batch(settings, ts, StateUpdateKind::Setting);
+        let id_allocators = from_batch(id_allocator, StateUpdateKind::IdAllocator);
+        let configs = from_batch(configs, StateUpdateKind::Config);
+        let settings = from_batch(settings, StateUpdateKind::Setting);
         let system_object_mappings =
-            from_batch(system_gid_mapping, ts, StateUpdateKind::SystemObjectMapping);
-        let system_configurations = from_batch(
-            system_configurations,
-            ts,
-            StateUpdateKind::SystemConfiguration,
-        );
-        let default_privileges =
-            from_batch(default_privileges, ts, StateUpdateKind::DefaultPrivilege);
-        let system_privileges = from_batch(system_privileges, ts, StateUpdateKind::SystemPrivilege);
-        let audit_logs = from_batch(audit_log_updates, ts, StateUpdateKind::AuditLog);
+            from_batch(system_gid_mapping, StateUpdateKind::SystemObjectMapping);
+        let system_configurations =
+            from_batch(system_configurations, StateUpdateKind::SystemConfiguration);
+        let default_privileges = from_batch(default_privileges, StateUpdateKind::DefaultPrivilege);
+        let system_privileges = from_batch(system_privileges, StateUpdateKind::SystemPrivilege);
+        let audit_logs = from_batch(audit_log_updates, StateUpdateKind::AuditLog);
         let storage_usage_updates =
-            from_batch(storage_usage_updates, ts, StateUpdateKind::StorageUsage);
+            from_batch(storage_usage_updates, StateUpdateKind::StorageUsage);
 
         databases
             .chain(schemas)
@@ -139,7 +141,6 @@ impl StateUpdate {
             .chain(system_privileges)
             .chain(audit_logs)
             .chain(storage_usage_updates)
-            .collect()
     }
 }
 

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -269,23 +269,46 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<StateUpdate<T>>> PersistHandle<T,
         &mut self,
         updates: Vec<(S, Diff)>,
     ) -> Result<(), CatalogError> {
-        let updates = updates
-            .into_iter()
-            .map(|(kind, diff)| StateUpdate {
-                kind,
-                ts: self.upper,
-                diff,
-            })
-            .collect();
+        let updates = updates.into_iter().map(|(kind, diff)| {
+            let kind: StateUpdateKindRaw = kind.into();
+            ((Into::<SourceData>::into(kind), ()), self.upper, diff)
+        });
         let next_upper = self.upper.step_forward();
-        compare_and_append(
-            &mut self.since_handle,
-            &mut self.write_handle,
-            updates,
-            self.upper,
-            next_upper,
-        )
-        .await?;
+        self.write_handle
+            .compare_and_append(
+                updates,
+                Antichain::from_elem(self.upper),
+                Antichain::from_elem(next_upper),
+            )
+            .await
+            .expect("invalid usage")
+            .map_err(|upper_mismatch| {
+                DurableCatalogError::Fence(format!(
+                    "current catalog upper {:?} fenced by new catalog upper {:?}",
+                    upper_mismatch.expected, upper_mismatch.current
+                ))
+            })?;
+
+        // Lag the shard's upper by 1 to keep it readable.
+        let downgrade_to = Antichain::from_elem(next_upper.saturating_sub(1));
+
+        // The since handle gives us the ability to fence out other writes using an opaque token.
+        // (See the method documentation for details.)
+        // That's not needed here, so we use a constant opaque token to avoid any comparison failures.
+        let opaque = i64::initial();
+        let downgrade = self
+            .since_handle
+            .maybe_compare_and_downgrade_since(&opaque, (&opaque, &downgrade_to))
+            .await;
+
+        match downgrade {
+            None => {}
+            Some(Err(e)) => soft_panic_or_log!("found opaque value {e}, but expected {opaque}"),
+            Some(Ok(updated)) => soft_assert_or_log!(
+                updated == downgrade_to,
+                "updated bound should match expected"
+            ),
+        }
         self.sync(next_upper).await?;
         Ok(())
     }
@@ -343,7 +366,36 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<StateUpdate<T>>> PersistHandle<T,
     #[mz_ore::instrument(level = "debug")]
     async fn sync_inner(&mut self, target_upper: Timestamp) -> Result<(), DurableCatalogError> {
         self.epoch.validate()?;
-        let updates = sync(&mut self.listen, &mut self.upper, target_upper).await;
+        let mut updates = Vec::new();
+
+        while self.upper < target_upper {
+            let listen_events = self.listen.fetch_next().await;
+            for listen_event in listen_events {
+                match listen_event {
+                    ListenEvent::Progress(upper) => {
+                        debug!("synced up to {upper:?}");
+                        self.upper = upper
+                            .as_option()
+                            .cloned()
+                            .expect("we use a totally ordered time and never finalize the shard");
+                    }
+                    ListenEvent::Updates(batch_updates) => {
+                        debug!("syncing updates {batch_updates:?}");
+                        let batch_updates = batch_updates
+                            .into_iter()
+                            .map(Into::<StateUpdate<StateUpdateKindRaw>>::into)
+                            .map(|update| {
+                                let kind = T::try_from(update.kind).expect("kind decoding error");
+                                (kind, update.ts, update.diff)
+                            });
+                        updates.extend(batch_updates);
+                    }
+                }
+            }
+        }
+        let updates = updates
+            .into_iter()
+            .map(|(kind, ts, diff)| StateUpdate { kind, ts, diff });
         self.apply_updates(updates)?;
         Ok(())
     }
@@ -673,9 +725,21 @@ impl<U: ApplyUpdate<StateUpdate<StateUpdateKind>>> PersistHandle<StateUpdateKind
     ) -> impl Iterator<Item = StateUpdate> + DoubleEndedIterator {
         let mut read_handle = self.read_handle().await;
         let as_of = as_of(&read_handle, self.upper);
-        let snapshot = snapshot(&mut read_handle, as_of, &self.metrics).await;
+        let snapshot = self.snapshot(&mut read_handle, as_of).await;
         read_handle.expire().await;
         snapshot
+    }
+
+    /// TODO(jkosh44)
+    #[mz_ore::instrument(level = "debug")]
+    async fn snapshot(
+        &mut self,
+        read_handle: &mut ReadHandle<SourceData, (), Timestamp, Diff>,
+        as_of: Timestamp,
+    ) -> impl Iterator<Item = StateUpdate<StateUpdateKind>> + DoubleEndedIterator {
+        snapshot_binary(read_handle, as_of, &self.metrics)
+            .await
+            .map(|update| update.try_into().expect("kind decoding error"))
     }
 }
 
@@ -1430,68 +1494,6 @@ fn as_of(read_handle: &ReadHandle<SourceData, (), Timestamp, Diff>, upper: Times
     as_of
 }
 
-/// Appends `updates` to the catalog state and downgrades the catalog's upper to `next_upper`
-/// iff the current global upper of the catalog is `current_upper`.
-async fn compare_and_append<T: IntoStateUpdateKindRaw>(
-    since_handle: &mut SinceHandle<SourceData, (), Timestamp, Diff, i64>,
-    write_handle: &mut WriteHandle<SourceData, (), Timestamp, Diff>,
-    updates: Vec<StateUpdate<T>>,
-    current_upper: Timestamp,
-    next_upper: Timestamp,
-) -> Result<(), CatalogError> {
-    let updates = updates.into_iter().map(|update| {
-        let kind: StateUpdateKindRaw = update.kind.into();
-        ((Into::<SourceData>::into(kind), ()), update.ts, update.diff)
-    });
-    write_handle
-        .compare_and_append(
-            updates,
-            Antichain::from_elem(current_upper),
-            Antichain::from_elem(next_upper),
-        )
-        .await
-        .expect("invalid usage")
-        .map_err(|upper_mismatch| {
-            DurableCatalogError::Fence(format!(
-                "current catalog upper {:?} fenced by new catalog upper {:?}",
-                upper_mismatch.expected, upper_mismatch.current
-            ))
-        })?;
-
-    // Lag the shard's upper by 1 to keep it readable.
-    let downgrade_to = Antichain::from_elem(next_upper.saturating_sub(1));
-
-    // The since handle gives us the ability to fence out other writes using an opaque token.
-    // (See the method documentation for details.)
-    // That's not needed here, so we use a constant opaque token to avoid any comparison failures.
-    let opaque = i64::initial();
-    let downgrade = since_handle
-        .maybe_compare_and_downgrade_since(&opaque, (&opaque, &downgrade_to))
-        .await;
-
-    match downgrade {
-        None => {}
-        Some(Err(e)) => soft_panic_or_log!("found opaque value {e}, but expected {opaque}"),
-        Some(Ok(updated)) => soft_assert_or_log!(
-            updated == downgrade_to,
-            "updated bound should match expected"
-        ),
-    }
-
-    Ok(())
-}
-
-#[mz_ore::instrument(level = "debug")]
-async fn snapshot(
-    read_handle: &mut ReadHandle<SourceData, (), Timestamp, Diff>,
-    as_of: Timestamp,
-    metrics: &Arc<Metrics>,
-) -> impl Iterator<Item = StateUpdate<StateUpdateKind>> + DoubleEndedIterator {
-    snapshot_binary(read_handle, as_of, metrics)
-        .await
-        .map(|update| update.try_into().expect("kind decoding error"))
-}
-
 /// Generates an iterator of [`StateUpdate`] that contain all updates to the catalog
 /// state up to, and including, `as_of`.
 ///
@@ -1531,48 +1533,6 @@ async fn snapshot_binary_inner(
         .into_iter()
         .map(Into::<StateUpdate<StateUpdateKindRaw>>::into)
         .sorted_by(|a, b| Ord::cmp(&b.ts, &a.ts))
-}
-
-/// Listen for all updates up to `target_upper`.
-///
-/// Results are guaranteed to be consolidated and sorted by timestamp then diff.
-#[mz_ore::instrument(level = "debug")]
-async fn sync<T: IntoStateUpdateKindRaw>(
-    listen: &mut Listen<SourceData, (), Timestamp, Diff>,
-    current_upper: &mut Timestamp,
-    target_upper: Timestamp,
-) -> Vec<StateUpdate<T>> {
-    let mut updates = Vec::new();
-
-    while *current_upper < target_upper {
-        let listen_events = listen.fetch_next().await;
-        for listen_event in listen_events {
-            match listen_event {
-                ListenEvent::Progress(upper) => {
-                    debug!("synced up to {upper:?}");
-                    *current_upper = upper
-                        .as_option()
-                        .cloned()
-                        .expect("we use a totally ordered time and never finalize the shard");
-                }
-                ListenEvent::Updates(batch_updates) => {
-                    debug!("syncing updates {batch_updates:?}");
-                    let batch_updates = batch_updates
-                        .into_iter()
-                        .map(Into::<StateUpdate<StateUpdateKindRaw>>::into)
-                        .map(|update| {
-                            let kind = T::try_from(update.kind).expect("kind decoding error");
-                            (kind, update.ts, update.diff)
-                        });
-                    updates.extend(batch_updates);
-                }
-            }
-        }
-    }
-    updates
-        .into_iter()
-        .map(|(kind, ts, diff)| StateUpdate { kind, ts, diff })
-        .collect()
 }
 
 // Debug methods.

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -265,9 +265,9 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<StateUpdate<T>>> PersistHandle<T,
     /// Appends `updates` to the catalog state and downgrades the catalog's upper to `next_upper`
     /// iff the current global upper of the catalog is `current_upper`.
     #[mz_ore::instrument]
-    pub(crate) async fn compare_and_append(
+    pub(crate) async fn compare_and_append<S: IntoStateUpdateKindRaw>(
         &mut self,
-        updates: Vec<(T, Diff)>,
+        updates: Vec<(S, Diff)>,
     ) -> Result<(), CatalogError> {
         let updates = updates
             .into_iter()
@@ -679,6 +679,56 @@ impl<U: ApplyUpdate<StateUpdate<StateUpdateKind>>> PersistHandle<StateUpdateKind
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct ConfigsCache {
+    /// TODO(jkosh44)
+    /// The config collection of the catalog. This information is also included in `snapshot`,
+    /// but it's useful to have quick access to these fields without parsing through all updates.
+    configs: BTreeMap<String, u64>,
+}
+
+impl ConfigsCache {
+    fn new() -> ConfigsCache {
+        ConfigsCache {
+            configs: BTreeMap::new(),
+        }
+    }
+}
+
+impl ApplyUpdate<StateUpdate<StateUpdateKindRaw>> for ConfigsCache {
+    fn apply_update(
+        &mut self,
+        update: StateUpdate<StateUpdateKindRaw>,
+        _metrics: &Arc<Metrics>,
+    ) -> Option<StateUpdate<StateUpdateKindRaw>> {
+        if let Ok(kind) =
+            <StateUpdateKindRaw as TryIntoStateUpdateKind>::try_into(update.kind.clone())
+        {
+            match (kind, update.diff) {
+                (StateUpdateKind::Config(key, value), 1) => {
+                    let prev = self.configs.insert(key.key, value.value);
+                    soft_assert_eq_or_log!(
+                        prev,
+                        None,
+                        "values must be explicitly retracted before inserting a new value"
+                    );
+                }
+                (StateUpdateKind::Config(key, value), -1) => {
+                    let prev = self.configs.remove(&key.key);
+                    soft_assert_eq_or_log!(
+                        prev,
+                        Some(value.value),
+                        "retraction does not match existing value"
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        Some(update)
+    }
+}
+
 /// A Handle to an unopened catalog stored in persist. The unopened catalog can serve `Config` data
 /// or the current epoch. All other catalog data may be un-migrated and should not be read until the
 /// catalog has been opened. The [`UnopenedPersistCatalogState`] is responsible for opening the
@@ -688,32 +738,10 @@ impl<U: ApplyUpdate<StateUpdate<StateUpdateKind>>> PersistHandle<StateUpdateKind
 /// so that it can expire its leases. If/when rust gets AsyncDrop, this will be done automatically.
 #[derive(Debug)]
 pub struct UnopenedPersistCatalogState {
-    /// Since handle to control compaction.
-    since_handle: SinceHandle<SourceData, (), Timestamp, Diff, i64>,
-    /// Write handle to persist.
-    write_handle: WriteHandle<SourceData, (), Timestamp, Diff>,
-    /// Listener to catalog changes.
-    listen: Listen<SourceData, (), Timestamp, Diff>,
-    /// Handle for connecting to persist.
-    persist_client: PersistClient,
-    /// Catalog shard ID.
-    shard_id: ShardId,
-    /// Cache of the most recent catalog snapshot.
-    ///
-    /// We use a tuple instead of [`StateUpdate`] to make consolidation easier.
-    pub(crate) snapshot: Vec<(StateUpdateKindRaw, Timestamp, Diff)>,
-    /// The current upper of the persist shard.
-    pub(crate) upper: Timestamp,
-    /// The epoch of the catalog, if one exists. This information is also included in `snapshot`,
-    /// but it's useful to have quick access to this field without parsing through all updates.
-    epoch: FenceableEpoch,
-    /// The config collection of the catalog. This information is also included in `snapshot`,
-    /// but it's useful to have quick access to these fields without parsing through all updates.
-    configs: BTreeMap<String, u64>,
+    /// TODO(jkosh44)
+    pub(crate) persist_handle: PersistHandle<StateUpdateKindRaw, ConfigsCache>,
     /// The organization ID of the environment.
     organization_id: Uuid,
-    /// Metrics for the persist catalog.
-    metrics: Arc<Metrics>,
 }
 
 impl UnopenedPersistCatalogState {
@@ -729,134 +757,18 @@ impl UnopenedPersistCatalogState {
         version: semver::Version,
         metrics: Arc<Metrics>,
     ) -> Result<UnopenedPersistCatalogState, DurableCatalogError> {
-        let catalog_shard_id = shard_id(organization_id, CATALOG_SEED);
-        let upgrade_shard_id = shard_id(organization_id, UPGRADE_SEED);
-        debug!(
-            ?catalog_shard_id,
-            ?upgrade_shard_id,
-            "new persist backed catalog state"
-        );
-
-        // Check the catalog upgrade shard to see ensure that we don't fence anyone out of persist.
-        let upgrade_version =
-            Self::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await;
-        // If this is `None`, no version was found in the upgrade shard. Either this is a brand new
-        // environment and we don't need to worry about fencing existing users or we're upgrading
-        // from a version that doesn't contain the catalog upgrade shard and we need to proceed
-        // with caution for that one week until the catalog upgrade shard exists in all
-        // environments.
-        if let Some(upgrade_version) = upgrade_version {
-            if mz_persist_client::cfg::check_data_version(&upgrade_version, &version).is_err() {
-                return Err(DurableCatalogError::IncompatiblePersistVersion {
-                    found_version: upgrade_version,
-                    catalog_version: version,
-                });
-            }
-        }
-
-        let since_handle = persist_client
-            .open_critical_since(
-                catalog_shard_id,
-                // TODO: We may need to use a different critical reader
-                // id for this if we want to be able to introspect it via SQL.
-                PersistClient::CONTROLLER_CRITICAL_SINCE,
-                Diagnostics {
-                    shard_name: CATALOG_SHARD_NAME.to_string(),
-                    handle_purpose: "durable catalog state critical since".to_string(),
-                },
-            )
-            .await
-            .expect("invalid usage");
-        let (mut write_handle, mut read_handle) = persist_client
-            .open(
-                catalog_shard_id,
-                Arc::new(desc()),
-                Arc::new(UnitSchema::default()),
-                Diagnostics {
-                    shard_name: CATALOG_SHARD_NAME.to_string(),
-                    handle_purpose: "durable catalog state handles".to_string(),
-                },
-            )
-            .await
-            .expect("invalid usage");
-
-        // Commit an empty write at the minimum timestamp so the catalog is always readable.
-        const EMPTY_UPDATES: &[((SourceData, ()), Timestamp, Diff)] = &[];
-        let _ = write_handle
-            .compare_and_append(
-                EMPTY_UPDATES,
-                Antichain::from_elem(Timestamp::minimum()),
-                Antichain::from_elem(Timestamp::minimum().step_forward()),
-            )
-            .await
-            .expect("invalid usage");
-
-        let upper = current_upper(&mut write_handle).await;
-        let as_of = as_of(&mut read_handle, upper);
-        let snapshot: Vec<_> = snapshot_binary(&mut read_handle, as_of, &metrics)
-            .await
-            .map(|StateUpdate { kind, ts, diff }| (kind, ts, diff))
-            .collect();
-        let listen = read_handle
-            .listen(Antichain::from_elem(as_of))
-            .await
-            .expect("invalid usage");
-        let mut epoch = FenceableEpoch::Unfenced(None);
-        let mut configs = BTreeMap::new();
-        for (kind, _, diff) in &snapshot {
-            soft_assert_eq_or_log!(*diff, 1, "snapshot should be consolidated");
-            if let Ok(kind) = <StateUpdateKindRaw as TryIntoStateUpdateKind>::try_into(kind.clone())
-            {
-                match kind {
-                    StateUpdateKind::Epoch(current_epoch) => {
-                        epoch = FenceableEpoch::Unfenced(Some(current_epoch));
-                    }
-                    StateUpdateKind::Config(key, value) => {
-                        configs.insert(key.key, value.value);
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        Ok(UnopenedPersistCatalogState {
-            since_handle,
-            write_handle,
-            listen,
+        let persist_handle = PersistHandle::new(
             persist_client,
-            shard_id: catalog_shard_id,
-            snapshot,
-            upper,
-            epoch,
-            configs,
-            organization_id,
+            organization_id.clone(),
+            version,
+            ConfigsCache::new(),
             metrics,
+        )
+        .await?;
+        Ok(UnopenedPersistCatalogState {
+            persist_handle,
+            organization_id,
         })
-    }
-
-    /// Fetch the persist version of the catalog upgrade shard, if one exists. A version will not
-    /// exist if the catalog upgrade shard itself doesn't exist which could happen in the following
-    /// scenarios:
-    ///
-    ///   - We are creating a brand new environment.
-    ///   - We are upgrading from a version of the code where the catalog upgrade shard didn't
-    ///   exist.
-    async fn fetch_catalog_upgrade_shard_version(
-        persist_client: &PersistClient,
-        upgrade_shard_id: ShardId,
-    ) -> Option<semver::Version> {
-        let shard_state = persist_client
-            .inspect_shard::<Timestamp>(&upgrade_shard_id)
-            .await
-            .ok()?;
-        let json_state = serde_json::to_value(shard_state).expect("state serialization error");
-        let upgrade_version = json_state
-            .get("applier_version")
-            .cloned()
-            .expect("missing applier_version");
-        let upgrade_version =
-            serde_json::from_value(upgrade_version).expect("version deserialization error");
-        Some(upgrade_version)
     }
 
     #[mz_ore::instrument]
@@ -870,8 +782,8 @@ impl UnopenedPersistCatalogState {
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         let read_only = matches!(mode, Mode::Readonly);
 
-        self.sync_to_current_upper().await?;
-        let prev_epoch = self.epoch.validate()?;
+        self.persist_handle.sync_to_current_upper().await?;
+        let prev_epoch = self.persist_handle.epoch.validate()?;
         // Fence out previous catalogs.
         let mut fence_updates = Vec::with_capacity(2);
         if let Some(prev_epoch) = prev_epoch {
@@ -893,15 +805,17 @@ impl UnopenedPersistCatalogState {
         fence_updates.push((StateUpdateKind::Epoch(current_epoch), 1));
         let current_epoch = FenceableEpoch::Unfenced(Some(current_epoch));
         debug!(
-            ?self.upper,
+            ?self.persist_handle.upper,
             ?prev_epoch,
             ?epoch_lower_bound,
             ?current_epoch,
             "fencing previous catalogs"
         );
-        self.epoch = current_epoch;
+        self.persist_handle.epoch = current_epoch;
         if matches!(mode, Mode::Writable) {
-            self.compare_and_append(fence_updates).await?;
+            self.persist_handle
+                .compare_and_append(fence_updates)
+                .await?;
         }
 
         let is_initialized = self.is_initialized_inner();
@@ -910,7 +824,7 @@ impl UnopenedPersistCatalogState {
                 format!("catalog tables do not exist; will not create in {mode:?} mode"),
             )));
         }
-        soft_assert_ne_or_log!(self.upper, Timestamp::minimum());
+        soft_assert_ne_or_log!(self.persist_handle.upper, Timestamp::minimum());
 
         // Perform data migrations.
         if is_initialized && !read_only {
@@ -919,30 +833,34 @@ impl UnopenedPersistCatalogState {
 
         debug!(
             ?is_initialized,
-            ?self.upper,
+            ?self.persist_handle.upper,
             "initializing catalog state"
         );
         let mut catalog = PersistCatalogState {
             mode: mode.clone(),
             persist_handle: PersistHandle {
-                since_handle: self.since_handle,
-                write_handle: self.write_handle,
-                listen: self.listen,
-                persist_client: self.persist_client,
-                shard_id: self.shard_id,
-                upper: self.upper,
-                epoch: self.epoch,
+                since_handle: self.persist_handle.since_handle,
+                write_handle: self.persist_handle.write_handle,
+                listen: self.persist_handle.listen,
+                persist_client: self.persist_handle.persist_client,
+                shard_id: self.persist_handle.shard_id,
+                upper: self.persist_handle.upper,
+                epoch: self.persist_handle.epoch,
                 // Initialize empty in-memory state.
                 snapshot: Vec::new(),
                 update_applier: LargeCollectionStartupCaches::new_open(),
-                metrics: self.metrics,
+                metrics: self.persist_handle.metrics,
             },
         };
         catalog.persist_handle.metrics.collection_entries.reset();
-        let updates = self.snapshot.into_iter().map(|(kind, ts, diff)| {
-            let kind = TryIntoStateUpdateKind::try_into(kind).expect("kind decoding error");
-            StateUpdate { kind, ts, diff }
-        });
+        let updates = self
+            .persist_handle
+            .snapshot
+            .into_iter()
+            .map(|(kind, ts, diff)| {
+                let kind = TryIntoStateUpdateKind::try_into(kind).expect("kind decoding error");
+                StateUpdate { kind, ts, diff }
+            });
         catalog.persist_handle.apply_updates(updates)?;
 
         let txn = if is_initialized {
@@ -990,182 +908,13 @@ impl UnopenedPersistCatalogState {
         Ok(Box::new(catalog))
     }
 
-    #[mz_ore::instrument]
-    async fn current_upper(&mut self) -> Timestamp {
-        current_upper(&mut self.write_handle).await
-    }
-
-    /// Appends `updates` to the catalog state and downgrades the catalog's upper to `next_upper`
-    /// iff the current global upper of the catalog is `current_upper`.
-    #[mz_ore::instrument]
-    pub(crate) async fn compare_and_append<T: IntoStateUpdateKindRaw>(
-        &mut self,
-        updates: Vec<(T, Diff)>,
-    ) -> Result<(), CatalogError> {
-        let updates = updates
-            .into_iter()
-            .map(|(kind, diff)| StateUpdate {
-                kind,
-                ts: self.upper,
-                diff,
-            })
-            .collect();
-        let next_upper = self.upper.step_forward();
-        compare_and_append(
-            &mut self.since_handle,
-            &mut self.write_handle,
-            updates,
-            self.upper,
-            next_upper,
-        )
-        .await?;
-        self.sync(next_upper).await?;
-        Ok(())
-    }
-
-    /// Generates an iterator of [`StateUpdate`] that contain all unconsolidated updates to the
-    /// catalog state up to, and including, `as_of`.
-    #[mz_ore::instrument]
-    async fn snapshot_unconsolidated(&mut self) -> Vec<StateUpdate<StateUpdateKind>> {
-        let current_upper = self.current_upper().await;
-
-        let mut snapshot = Vec::new();
-        let mut read_handle = self.read_handle().await;
-        let as_of = as_of(&read_handle, current_upper);
-        let mut stream = Box::pin(
-            // We use `snapshot_and_stream` because it guarantees unconsolidated output.
-            read_handle
-                .snapshot_and_stream(Antichain::from_elem(as_of))
-                .await
-                .expect("we have advanced the restart_as_of by the since"),
-        );
-        while let Some(update) = stream.next().await {
-            snapshot.push(update)
-        }
-        read_handle.expire().await;
-        snapshot
-            .into_iter()
-            .map(Into::<StateUpdate<StateUpdateKindRaw>>::into)
-            .map(|state_update| state_update.try_into().expect("kind decoding error"))
-            .collect()
-    }
-
-    /// Listen and apply all updates that are currently in persist.
-    #[mz_ore::instrument]
-    pub(crate) async fn sync_to_current_upper(&mut self) -> Result<(), DurableCatalogError> {
-        let upper = self.current_upper().await;
-        self.sync(upper).await
-    }
-
-    /// Listen and apply all updates up to `target_upper`.
-    #[mz_ore::instrument]
-    pub(crate) async fn sync(
-        &mut self,
-        target_upper: Timestamp,
-    ) -> Result<(), DurableCatalogError> {
-        self.epoch.validate()?;
-        let updates: Vec<StateUpdate<StateUpdateKindRaw>> =
-            sync(&mut self.listen, &mut self.upper, target_upper).await;
-        self.apply_updates(updates)?;
-
-        Ok(())
-    }
-
-    #[mz_ore::instrument(level = "debug")]
-    pub(crate) fn apply_updates(
-        &mut self,
-        updates: Vec<StateUpdate<StateUpdateKindRaw>>,
-    ) -> Result<(), DurableCatalogError> {
-        for update in updates {
-            let StateUpdate { kind, ts, diff } = update;
-            if diff != 1 && diff != -1 {
-                panic!("invalid update in consolidated trace: ({kind:?}, {ts:?}, {diff:?})");
-            }
-
-            if let Ok(kind) = <StateUpdateKindRaw as TryIntoStateUpdateKind>::try_into(kind.clone())
-            {
-                match (kind, diff) {
-                    (StateUpdateKind::Epoch(epoch), 1) => match self.epoch {
-                        FenceableEpoch::Unfenced(Some(current_epoch)) => {
-                            if epoch > current_epoch {
-                                self.epoch = FenceableEpoch::Fenced {
-                                    current_epoch,
-                                    fence_epoch: epoch,
-                                };
-                                self.epoch.validate()?;
-                            } else if epoch < current_epoch {
-                                panic!("Epoch went backwards from {current_epoch:?} to {epoch:?}");
-                            }
-                        }
-                        FenceableEpoch::Unfenced(None) => {
-                            self.epoch = FenceableEpoch::Unfenced(Some(epoch));
-                        }
-                        FenceableEpoch::Fenced { .. } => {}
-                    },
-                    (StateUpdateKind::Epoch(_), -1) => {
-                        // Nothing to do, we're about to get fenced.
-                    }
-                    (StateUpdateKind::Config(key, value), 1) => {
-                        let prev = self.configs.insert(key.key, value.value);
-                        soft_assert_eq_or_log!(
-                            prev,
-                            None,
-                            "values must be explicitly retracted before inserting a new value"
-                        );
-                    }
-                    (StateUpdateKind::Config(key, value), -1) => {
-                        let prev = self.configs.remove(&key.key);
-                        soft_assert_eq_or_log!(
-                            prev,
-                            Some(value.value),
-                            "retraction does not match existing value"
-                        );
-                    }
-                    _ => {}
-                }
-            }
-
-            self.snapshot.push((kind, ts, diff));
-        }
-        Ok(())
-    }
-
-    #[mz_ore::instrument]
-    pub(crate) fn consolidate(&mut self) {
-        let new_ts = self
-            .snapshot
-            .last()
-            .map(|(_, ts, _)| *ts)
-            .unwrap_or_else(Timestamp::minimum);
-        for (_, ts, _) in &mut self.snapshot {
-            *ts = new_ts;
-        }
-        differential_dataflow::consolidation::consolidate_updates(&mut self.snapshot);
-    }
-
-    /// Open a read handle to the catalog.
-    async fn read_handle(&mut self) -> ReadHandle<SourceData, (), Timestamp, Diff> {
-        self.persist_client
-            .open_leased_reader(
-                self.shard_id,
-                Arc::new(desc()),
-                Arc::new(UnitSchema::default()),
-                Diagnostics {
-                    shard_name: CATALOG_SHARD_NAME.to_string(),
-                    handle_purpose: "openable durable catalog state temporary reader".to_string(),
-                },
-            )
-            .await
-            .expect("invalid usage")
-    }
-
     /// Reports if the catalog state has been initialized.
     ///
-    /// NOTE: This is the answer as of the last call to [`Self::sync`] or [`Self::sync_to_current_upper`],
+    /// NOTE: This is the answer as of the last call to [`PersistHandle::sync`] or [`PersistHandle::sync_to_current_upper`],
     /// not necessarily what is currently in persist.
     #[mz_ore::instrument]
     fn is_initialized_inner(&self) -> bool {
-        !self.configs.is_empty()
+        !self.persist_handle.update_applier.configs.is_empty()
     }
 
     /// Get the current value of config `key`.
@@ -1173,8 +922,8 @@ impl UnopenedPersistCatalogState {
     /// Some configs need to be read before the catalog is opened for bootstrapping.
     #[mz_ore::instrument]
     async fn get_current_config(&mut self, key: &str) -> Result<Option<u64>, CatalogError> {
-        self.sync_to_current_upper().await?;
-        Ok(self.configs.get(key).cloned())
+        self.persist_handle.sync_to_current_upper().await?;
+        Ok(self.persist_handle.update_applier.configs.get(key).cloned())
     }
 
     /// Get the user version of this instance.
@@ -1243,14 +992,15 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
 
     #[mz_ore::instrument]
     async fn is_initialized(&mut self) -> Result<bool, CatalogError> {
-        self.sync_to_current_upper().await?;
-        Ok(!self.configs.is_empty())
+        self.persist_handle.sync_to_current_upper().await?;
+        Ok(self.is_initialized_inner())
     }
 
     #[mz_ore::instrument]
     async fn epoch(&mut self) -> Result<Epoch, CatalogError> {
-        self.sync_to_current_upper().await?;
-        self.epoch
+        self.persist_handle.sync_to_current_upper().await?;
+        self.persist_handle
+            .epoch
             .validate()?
             .ok_or(CatalogError::Durable(DurableCatalogError::Uninitialized))
     }
@@ -1269,9 +1019,9 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
 
     #[mz_ore::instrument]
     async fn trace_unconsolidated(&mut self) -> Result<Trace, CatalogError> {
-        self.sync_to_current_upper().await?;
+        self.persist_handle.sync_to_current_upper().await?;
         if self.is_initialized_inner() {
-            let snapshot = self.snapshot_unconsolidated().await;
+            let snapshot = self.persist_handle.snapshot_unconsolidated().await;
             Ok(Trace::from_snapshot(snapshot))
         } else {
             Err(CatalogError::Durable(DurableCatalogError::Uninitialized))
@@ -1280,7 +1030,7 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
 
     #[mz_ore::instrument]
     async fn trace_consolidated(&mut self) -> Result<Trace, CatalogError> {
-        self.sync_to_current_upper().await?;
+        self.persist_handle.sync_to_current_upper().await?;
         if self.is_initialized_inner() {
             let snapshot = self.current_snapshot().await?;
             Ok(Trace::from_snapshot(snapshot))
@@ -1291,8 +1041,7 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
 
     #[mz_ore::instrument(level = "debug")]
     async fn expire(self: Box<Self>) {
-        self.listen.expire().await;
-        self.write_handle.expire().await;
+        self.persist_handle.expire().await
     }
 }
 
@@ -1935,7 +1684,7 @@ impl UnopenedPersistCatalogState {
         // We must fence out all other catalogs since we are writing.
         let fence_updates = self.increment_epoch()?;
         updates.extend(fence_updates);
-        self.compare_and_append(updates).await?;
+        self.persist_handle.compare_and_append(updates).await?;
         Ok(prev_value)
     }
 
@@ -1982,7 +1731,7 @@ impl UnopenedPersistCatalogState {
         // We must fence out all other catalogs since we are writing.
         let fence_updates = self.increment_epoch()?;
         retractions.extend(fence_updates);
-        self.compare_and_append(retractions).await?;
+        self.persist_handle.compare_and_append(retractions).await?;
         Ok(())
     }
 
@@ -1993,12 +1742,17 @@ impl UnopenedPersistCatalogState {
     async fn current_snapshot(
         &mut self,
     ) -> Result<impl IntoIterator<Item = StateUpdate> + '_, CatalogError> {
-        self.sync_to_current_upper().await?;
-        self.consolidate();
-        Ok(self.snapshot.iter().cloned().map(|(kind, ts, diff)| {
-            let kind = TryIntoStateUpdateKind::try_into(kind).expect("kind decoding error");
-            StateUpdate { kind, ts, diff }
-        }))
+        self.persist_handle.sync_to_current_upper().await?;
+        self.persist_handle.consolidate();
+        Ok(self
+            .persist_handle
+            .snapshot
+            .iter()
+            .cloned()
+            .map(|(kind, ts, diff)| {
+                let kind = TryIntoStateUpdateKind::try_into(kind).expect("kind decoding error");
+                StateUpdate { kind, ts, diff }
+            }))
     }
 
     /// Increment `self.epoch` and return the updates needed to make this change durable.
@@ -2006,12 +1760,13 @@ impl UnopenedPersistCatalogState {
     /// The caller is expected to compare and append these updates promptly.
     fn increment_epoch(&mut self) -> Result<[(StateUpdateKind, Diff); 2], DurableCatalogError> {
         let current_epoch = self
+            .persist_handle
             .epoch
             .validate()?
             .expect("cannot edit/delete from unopened catalog");
         let next_epoch =
             Epoch::new(current_epoch.get() + 1).expect("non-zero epoch plus 1 is always non-zero");
-        self.epoch = FenceableEpoch::Unfenced(Some(next_epoch));
+        self.persist_handle.epoch = FenceableEpoch::Unfenced(Some(next_epoch));
         Ok([
             (StateUpdateKind::Epoch(current_epoch), -1),
             (StateUpdateKind::Epoch(next_epoch), 1),

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -463,6 +463,73 @@ impl UnopenedPersistCatalogState {
         Ok(Box::new(catalog))
     }
 
+    #[mz_ore::instrument]
+    async fn current_upper(&mut self) -> Timestamp {
+        current_upper(&mut self.write_handle).await
+    }
+
+    /// Appends `updates` to the catalog state and downgrades the catalog's upper to `next_upper`
+    /// iff the current global upper of the catalog is `current_upper`.
+    #[mz_ore::instrument]
+    pub(crate) async fn compare_and_append<T: IntoStateUpdateKindRaw>(
+        &mut self,
+        updates: Vec<(T, Diff)>,
+    ) -> Result<(), CatalogError> {
+        let updates = updates
+            .into_iter()
+            .map(|(kind, diff)| StateUpdate {
+                kind,
+                ts: self.upper,
+                diff,
+            })
+            .collect();
+        let next_upper = self.upper.step_forward();
+        compare_and_append(
+            &mut self.since_handle,
+            &mut self.write_handle,
+            updates,
+            self.upper,
+            next_upper,
+        )
+        .await?;
+        self.sync(next_upper).await?;
+        Ok(())
+    }
+
+    /// Generates an iterator of [`StateUpdate`] that contain all unconsolidated updates to the
+    /// catalog state up to, and including, `as_of`.
+    #[mz_ore::instrument]
+    async fn snapshot_unconsolidated(&mut self) -> Vec<StateUpdate<StateUpdateKind>> {
+        let current_upper = self.current_upper().await;
+
+        let mut snapshot = Vec::new();
+        let mut read_handle = self.read_handle().await;
+        let as_of = as_of(&read_handle, current_upper);
+        let mut stream = Box::pin(
+            // We use `snapshot_and_stream` because it guarantees unconsolidated output.
+            read_handle
+                .snapshot_and_stream(Antichain::from_elem(as_of))
+                .await
+                .expect("we have advanced the restart_as_of by the since"),
+        );
+        while let Some(update) = stream.next().await {
+            snapshot.push(update)
+        }
+        read_handle.expire().await;
+        snapshot
+            .into_iter()
+            .map(Into::<StateUpdate<StateUpdateKindRaw>>::into)
+            .map(|state_update| state_update.try_into().expect("kind decoding error"))
+            .collect()
+    }
+
+    /// Listen and apply all updates that are currently in persist.
+    #[mz_ore::instrument]
+    pub(crate) async fn sync_to_current_upper(&mut self) -> Result<(), DurableCatalogError> {
+        let upper = self.current_upper().await;
+        self.sync(upper).await
+    }
+
     /// Listen and apply all updates up to `target_upper`.
     #[mz_ore::instrument]
     pub(crate) async fn sync(
@@ -535,40 +602,6 @@ impl UnopenedPersistCatalogState {
         Ok(())
     }
 
-    /// Listen and apply all updates that are currently in persist.
-    #[mz_ore::instrument]
-    pub(crate) async fn sync_to_current_upper(&mut self) -> Result<(), DurableCatalogError> {
-        let upper = self.current_upper().await;
-        self.sync(upper).await
-    }
-
-    /// Generates an iterator of [`StateUpdate`] that contain all unconsolidated updates to the
-    /// catalog state up to, and including, `as_of`.
-    #[mz_ore::instrument]
-    async fn snapshot_unconsolidated(&mut self) -> Vec<StateUpdate<StateUpdateKind>> {
-        let current_upper = self.current_upper().await;
-
-        let mut snapshot = Vec::new();
-        let mut read_handle = self.read_handle().await;
-        let as_of = as_of(&read_handle, current_upper);
-        let mut stream = Box::pin(
-            // We use `snapshot_and_stream` because it guarantees unconsolidated output.
-            read_handle
-                .snapshot_and_stream(Antichain::from_elem(as_of))
-                .await
-                .expect("we have advanced the restart_as_of by the since"),
-        );
-        while let Some(update) = stream.next().await {
-            snapshot.push(update)
-        }
-        read_handle.expire().await;
-        snapshot
-            .into_iter()
-            .map(Into::<StateUpdate<StateUpdateKindRaw>>::into)
-            .map(|state_update| state_update.try_into().expect("kind decoding error"))
-            .collect()
-    }
-
     #[mz_ore::instrument]
     pub(crate) fn consolidate(&mut self) {
         let snapshot = std::mem::take(&mut self.snapshot);
@@ -612,11 +645,6 @@ impl UnopenedPersistCatalogState {
         !self.configs.is_empty()
     }
 
-    #[mz_ore::instrument]
-    async fn current_upper(&mut self) -> Timestamp {
-        current_upper(&mut self.write_handle).await
-    }
-
     /// Get the current value of config `key`.
     ///
     /// Some configs need to be read before the catalog is opened for bootstrapping.
@@ -632,34 +660,6 @@ impl UnopenedPersistCatalogState {
     #[mz_ore::instrument]
     pub(crate) async fn get_user_version(&mut self) -> Result<Option<u64>, CatalogError> {
         self.get_current_config(USER_VERSION_KEY).await
-    }
-
-    /// Appends `updates` to the catalog state and downgrades the catalog's upper to `next_upper`
-    /// iff the current global upper of the catalog is `current_upper`.
-    #[mz_ore::instrument]
-    pub(crate) async fn compare_and_append<T: IntoStateUpdateKindRaw>(
-        &mut self,
-        updates: Vec<(T, Diff)>,
-    ) -> Result<(), CatalogError> {
-        let updates = updates
-            .into_iter()
-            .map(|(kind, diff)| StateUpdate {
-                kind,
-                ts: self.upper,
-                diff,
-            })
-            .collect();
-        let next_upper = self.upper.step_forward();
-        compare_and_append(
-            &mut self.since_handle,
-            &mut self.write_handle,
-            updates,
-            self.upper,
-            next_upper,
-        )
-        .await?;
-        self.sync(next_upper).await?;
-        Ok(())
     }
 }
 

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -196,31 +196,6 @@ pub struct PersistHandle<T: TryIntoStateUpdateKind, U: ApplyUpdate<StateUpdate<T
 }
 
 impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<StateUpdate<T>>> PersistHandle<T, U> {
-    /// Fetch the persist version of the catalog upgrade shard, if one exists. A version will not
-    /// exist if the catalog upgrade shard itself doesn't exist which could happen in the following
-    /// scenarios:
-    ///
-    ///   - We are creating a brand new environment.
-    ///   - We are upgrading from a version of the code where the catalog upgrade shard didn't
-    ///   exist.
-    async fn fetch_catalog_upgrade_shard_version(
-        persist_client: &PersistClient,
-        upgrade_shard_id: ShardId,
-    ) -> Option<semver::Version> {
-        let shard_state = persist_client
-            .inspect_shard::<Timestamp>(&upgrade_shard_id)
-            .await
-            .ok()?;
-        let json_state = serde_json::to_value(shard_state).expect("state serialization error");
-        let upgrade_version = json_state
-            .get("applier_version")
-            .cloned()
-            .expect("missing applier_version");
-        let upgrade_version =
-            serde_json::from_value(upgrade_version).expect("version deserialization error");
-        Some(upgrade_version)
-    }
-
     /// Increment the version in the catalog upgrade shard to the code's current version.
     async fn increment_catalog_upgrade_shard_version(&mut self, organization_id: Uuid) {
         let upgrade_shard_id = shard_id(organization_id, UPGRADE_SEED);
@@ -522,7 +497,7 @@ impl<U: ApplyUpdate<StateUpdate<StateUpdateKindRaw>>> PersistHandle<StateUpdateK
 
         // Check the catalog upgrade shard to see ensure that we don't fence anyone out of persist.
         let upgrade_version =
-            Self::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await;
+            fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await;
         // If this is `None`, no version was found in the upgrade shard. Either this is a brand new
         // environment and we don't need to worry about fencing existing users or we're upgrading
         // from a version that doesn't contain the catalog upgrade shard and we need to proceed
@@ -1492,6 +1467,31 @@ fn as_of(read_handle: &ReadHandle<SourceData, (), Timestamp, Diff>, upper: Times
     let mut as_of = upper.saturating_sub(1);
     as_of.advance_by(since.borrow());
     as_of
+}
+
+/// Fetch the persist version of the catalog upgrade shard, if one exists. A version will not
+/// exist if the catalog upgrade shard itself doesn't exist which could happen in the following
+/// scenarios:
+///
+///   - We are creating a brand new environment.
+///   - We are upgrading from a version of the code where the catalog upgrade shard didn't
+///   exist.
+async fn fetch_catalog_upgrade_shard_version(
+    persist_client: &PersistClient,
+    upgrade_shard_id: ShardId,
+) -> Option<semver::Version> {
+    let shard_state = persist_client
+        .inspect_shard::<Timestamp>(&upgrade_shard_id)
+        .await
+        .ok()?;
+    let json_state = serde_json::to_value(shard_state).expect("state serialization error");
+    let upgrade_version = json_state
+        .get("applier_version")
+        .cloned()
+        .expect("missing applier_version");
+    let upgrade_version =
+        serde_json::from_value(upgrade_version).expect("version deserialization error");
+    Some(upgrade_version)
 }
 
 /// Generates an iterator of [`StateUpdate`] that contain all updates to the catalog

--- a/src/catalog/src/durable/persist/tests.rs
+++ b/src/catalog/src/durable/persist/tests.rs
@@ -12,7 +12,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::PersistLocation;
 use uuid::Uuid;
 
-use crate::durable::persist::{shard_id, UnopenedPersistCatalogState, UPGRADE_SEED};
+use crate::durable::persist::{shard_id, PersistHandle, UnopenedPersistCatalogState, UPGRADE_SEED};
 use crate::durable::{
     test_bootstrap_args, test_persist_backed_catalog_state_with_version,
     OpenableDurableCatalogState,
@@ -35,11 +35,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         None,
-        UnopenedPersistCatalogState::fetch_catalog_upgrade_shard_version(
-            &persist_client,
-            upgrade_shard_id
-        )
-        .await
+        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await
     );
 
     let persist_openable_state = test_persist_backed_catalog_state_with_version(
@@ -56,11 +52,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         Some(first_version.clone()),
-        UnopenedPersistCatalogState::fetch_catalog_upgrade_shard_version(
-            &persist_client,
-            upgrade_shard_id
-        )
-        .await,
+        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
         "opening the catalog should increment the upgrade version"
     );
 
@@ -83,11 +75,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         Some(first_version.clone()),
-        UnopenedPersistCatalogState::fetch_catalog_upgrade_shard_version(
-            &persist_client,
-            upgrade_shard_id
-        )
-        .await,
+        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
         "opening a savepoint catalog should not increment the upgrade version"
     );
 
@@ -105,11 +93,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         Some(first_version),
-        UnopenedPersistCatalogState::fetch_catalog_upgrade_shard_version(
-            &persist_client,
-            upgrade_shard_id
-        )
-        .await,
+        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
         "opening a readonly catalog should not increment the upgrade version"
     );
 }

--- a/src/catalog/src/durable/persist/tests.rs
+++ b/src/catalog/src/durable/persist/tests.rs
@@ -12,7 +12,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::PersistLocation;
 use uuid::Uuid;
 
-use crate::durable::persist::{shard_id, PersistHandle, UnopenedPersistCatalogState, UPGRADE_SEED};
+use crate::durable::persist::{fetch_catalog_upgrade_shard_version, shard_id, UPGRADE_SEED};
 use crate::durable::{
     test_bootstrap_args, test_persist_backed_catalog_state_with_version,
     OpenableDurableCatalogState,
@@ -35,7 +35,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         None,
-        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await
+        fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await
     );
 
     let persist_openable_state = test_persist_backed_catalog_state_with_version(
@@ -52,7 +52,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         Some(first_version.clone()),
-        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
+        fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
         "opening the catalog should increment the upgrade version"
     );
 
@@ -75,7 +75,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         Some(first_version.clone()),
-        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
+        fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
         "opening a savepoint catalog should not increment the upgrade version"
     );
 
@@ -93,7 +93,7 @@ async fn test_upgrade_shard() {
 
     assert_eq!(
         Some(first_version),
-        PersistHandle::fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
+        fetch_catalog_upgrade_shard_version(&persist_client, upgrade_shard_id).await,
         "opening a readonly catalog should not increment the upgrade version"
     );
 }

--- a/src/catalog/src/durable/upgrade.rs
+++ b/src/catalog/src/durable/upgrade.rs
@@ -236,13 +236,13 @@ pub(crate) async fn upgrade(
     mode: Mode,
 ) -> Result<(), CatalogError> {
     soft_assert_ne_or_log!(
-        persist_handle.upper,
+        persist_handle.persist_handle.upper,
         Timestamp::minimum(),
         "cannot upgrade uninitialized catalog"
     );
 
     // Consolidate to avoid migrating old state.
-    persist_handle.consolidate();
+    persist_handle.persist_handle.consolidate();
     let mut version = persist_handle
         .get_user_version()
         .await?
@@ -321,6 +321,7 @@ async fn run_versioned_upgrade<V1: IntoStateUpdateKindRaw, V2: IntoStateUpdateKi
 ) -> Result<u64, CatalogError> {
     // 1. Use the V1 to deserialize the contents of the current snapshot.
     let snapshot: Vec<_> = unopened_catalog_state
+        .persist_handle
         .snapshot
         .iter()
         .map(|(kind, ts, diff)| {
@@ -349,21 +350,22 @@ async fn run_versioned_upgrade<V1: IntoStateUpdateKindRaw, V2: IntoStateUpdateKi
 
     // 4. Apply migration to catalog.
     if matches!(mode, Mode::Writable) {
-        unopened_catalog_state.compare_and_append(updates).await?;
+        unopened_catalog_state
+            .persist_handle
+            .compare_and_append(updates)
+            .await?;
     } else {
+        let ts = unopened_catalog_state.persist_handle.upper;
         let updates = updates
             .into_iter()
-            .map(|(kind, diff)| StateUpdate {
-                kind,
-                ts: unopened_catalog_state.upper,
-                diff,
-            })
-            .collect();
-        unopened_catalog_state.apply_updates(updates)?;
+            .map(|(kind, diff)| StateUpdate { kind, ts, diff });
+        unopened_catalog_state
+            .persist_handle
+            .apply_updates(updates)?;
     }
 
     // 5. Consolidate snapshot to remove old versions.
-    unopened_catalog_state.consolidate();
+    unopened_catalog_state.persist_handle.consolidate();
 
     Ok(next_version)
 }

--- a/src/catalog/src/durable/upgrade.rs
+++ b/src/catalog/src/durable/upgrade.rs
@@ -323,9 +323,13 @@ async fn run_versioned_upgrade<V1: IntoStateUpdateKindRaw, V2: IntoStateUpdateKi
     let snapshot: Vec<_> = unopened_catalog_state
         .snapshot
         .iter()
-        .map(|update| {
-            soft_assert_eq_or_log!(1, update.diff, "snapshot is consolidated, {update:?}");
-            V1::try_from(update.clone().kind).expect("invalid catalog data persisted")
+        .map(|(kind, ts, diff)| {
+            soft_assert_eq_or_log!(
+                1,
+                *diff,
+                "snapshot is consolidated, ({kind:?}, {ts:?}, {diff:?})"
+            );
+            V1::try_from(kind.clone()).expect("invalid catalog data persisted")
         })
         .collect();
 


### PR DESCRIPTION
The implementations of `UnopenedPersistCatalogState` and
`PersistCatalogState` have slowly converged to the point that they
are extremely similar and duplicate a lot of logic and
methods. This commit abstracts the common functionality into a new
struct called `PersistHandle` and implements
`UnopenedPersistCatalogState` and `PersistCatalogState` using a
`PersistHandle`.

### Motivation
This PR refactors existing code.

### Tips for reviewer

* Review the PR commit by commit. Each commit has a commit message explaining and the changes. Some commits are purely/mostly code movement and don't require in-depth review.
* The diff is smaller if viewed with whitespace hidden.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
