### PR TITLE
tests: mysql concurrent inserts: collapse log

### DIFF
--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -236,6 +236,7 @@ def workflow_many_inserts(c: Composition, parser: WorkflowArgumentParser) -> Non
         c.testdrive(args=["--no-reset"], input=x)
 
     insert_thread = threading.Thread(target=do_inserts, args=(c,))
+    print("--- Start many concurrent inserts")
     insert_thread.start()
 
     # Create the source.
@@ -252,6 +253,8 @@ def workflow_many_inserts(c: Composition, parser: WorkflowArgumentParser) -> Non
 
     # Ensure the source eventually sees the right number of records.
     insert_thread.join()
+
+    print("--- Validate concurrent inserts")
     c.testdrive(
         args=["--no-reset"],
         input=dedent(


### PR DESCRIPTION
Collapse all those log lines:
```
>> SET @i:=0;
>> INSERT INTO many_inserts (f2) SELECT @i:=@i+1 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 100;
>> SET @i:=0;
>> INSERT INTO many_inserts (f2) SELECT @i:=@i+1 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 100;
>> SET @i:=0;
>> INSERT INTO many_inserts (f2) SELECT @i:=@i+1 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 100;
>> SET @i:=0;
>> INSERT INTO many_inserts (f2) SELECT @i:=@i+1 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 100;
>> SET @i:=0;
>> INSERT INTO many_inserts (f2) SELECT @i:=@i+1 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 100;
>> SET @i:=0;
[...]
```