### PR TITLE
ci: reduce `compute_hydration_concurrency`

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -56,7 +56,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     # Others (ordered by name)
     "cluster_always_use_disk": "true",
     "compute_dataflow_max_inflight_bytes": "134217728",  # 128 MiB
-    "compute_hydration_concurrency": 4,
+    "compute_hydration_concurrency": 2,
     "default_arrangement_exert_proportionality": "16",
     "default_idle_arrangement_merge_effort": "0",
     "disk_cluster_replicas_default": "true",


### PR DESCRIPTION
Now that #26016 is merged we can further reduce the hydration concurrency in CI to stress-test sequential hydration more.

### Motivation

  * This PR adds a known-desirable feature.

 Part of #25271

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
