### PR TITLE
coord: Make it possible to dump state for debugging

### DIFF
--- a/src/adapter-types/src/compaction.rs
+++ b/src/adapter-types/src/compaction.rs
@@ -86,7 +86,7 @@ impl TryFrom<Duration> for CompactionWindow {
 ///
 /// This type tracks both a default policy, as well as various holds that may
 /// be expressed, as by transactions to ensure collections remain readable.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ReadCapability<T = mz_repr::Timestamp>
 where
     T: timely::progress::Timestamp,

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -664,6 +664,10 @@ impl SessionClient {
             })
     }
 
+    pub async fn dump_coordinator_state(&mut self) -> Result<serde_json::Value, anyhow::Error> {
+        self.send_without_session(|tx| Command::Dump { tx }).await
+    }
+
     /// Tells the coordinator a statement has finished execution, in the cases
     /// where we have no other reason to communicate with the coordinator.
     pub fn retire_execute(
@@ -806,7 +810,8 @@ impl SessionClient {
                 | Command::SetSystemVars { .. }
                 | Command::Terminate { .. }
                 | Command::RetireExecute { .. }
-                | Command::CheckConsistency { .. } => {}
+                | Command::CheckConsistency { .. }
+                | Command::Dump { .. } => {}
             };
             cmd
         });

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -122,6 +122,10 @@ pub enum Command {
     CheckConsistency {
         tx: oneshot::Sender<Result<(), CoordinatorInconsistencies>>,
     },
+
+    Dump {
+        tx: oneshot::Sender<Result<serde_json::Value, anyhow::Error>>,
+    },
 }
 
 impl Command {
@@ -137,7 +141,8 @@ impl Command {
             | Command::GetSystemVars { .. }
             | Command::SetSystemVars { .. }
             | Command::RetireExecute { .. }
-            | Command::CheckConsistency { .. } => None,
+            | Command::CheckConsistency { .. }
+            | Command::Dump { .. } => None,
         }
     }
 
@@ -153,7 +158,8 @@ impl Command {
             | Command::GetSystemVars { .. }
             | Command::SetSystemVars { .. }
             | Command::RetireExecute { .. }
-            | Command::CheckConsistency { .. } => None,
+            | Command::CheckConsistency { .. }
+            | Command::Dump { .. } => None,
         }
     }
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2737,7 +2737,7 @@ impl Coordinator {
             .iter()
             .map(|(id, peek)| (id.to_string(), peek))
             .collect();
-        let pending_real_time_recenty_timestamp: BTreeMap<_, _> = self
+        let pending_real_time_recency_timestamp: BTreeMap<_, _> = self
             .pending_real_time_recency_timestamp
             .iter()
             .map(|(id, timestamp)| (id.unhandled().to_string(), format!("{timestamp:#?}")))
@@ -2778,8 +2778,8 @@ impl Coordinator {
                 serde_json::to_value(client_pending_peeks)?,
             ),
             (
-                "pending_real_time_recenty_timestamp".to_string(),
-                serde_json::to_value(pending_real_time_recenty_timestamp)?,
+                "pending_real_time_recency_timestamp".to_string(),
+                serde_json::to_value(pending_real_time_recency_timestamp)?,
             ),
             (
                 "pending_linearize_read_txns".to_string(),

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -131,6 +131,7 @@ use mz_storage_types::sources::Timeline;
 use mz_timestamp_oracle::WriteTimestamp;
 use mz_transform::dataflow::DataflowMetainfo;
 use opentelemetry::trace::TraceContextExt;
+use serde::Serialize;
 use timely::progress::{Antichain, Timestamp as _};
 use timely::PartialOrder;
 use tokio::runtime::Handle as TokioHandle;
@@ -284,6 +285,7 @@ impl Message {
                 Command::Terminate { .. } => "command-terminate",
                 Command::RetireExecute { .. } => "command-retire_execute",
                 Command::CheckConsistency { .. } => "command-check_consistency",
+                Command::Dump { .. } => "command-dump",
             },
             Message::ControllerReady => "controller_ready",
             Message::PurifiedStatementReady(_) => "purified_statement_ready",
@@ -870,7 +872,7 @@ pub struct ReplicaMetadata {
 }
 
 /// Metadata about an active connection.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ConnMeta {
     /// Pgwire specifies that every connection have a 32-bit secret associated
     /// with it, that is known to both the client and the server. Cancellation
@@ -889,6 +891,7 @@ pub struct ConnMeta {
     drop_sinks: BTreeSet<GlobalId>,
 
     /// Channel on which to send notices to a session.
+    #[serde(skip)]
     notice_tx: mpsc::UnboundedSender<AdapterNotice>,
 
     /// The role that initiated the database context. Fixed for the duration of the connection.
@@ -2698,6 +2701,92 @@ impl Coordinator {
 
         self.initialize_compute_read_policies(export_ids, instance, CompactionWindow::Default)
             .await;
+    }
+
+    /// Returns the state of the [`Coordinator`] formatted as JSON.
+    ///
+    /// The returned value is not guaranteed to be stable and may change at any point in time.
+    pub fn dump(&self) -> Result<serde_json::Value, anyhow::Error> {
+        let active_conns: BTreeMap<_, _> = self
+            .active_conns
+            .iter()
+            .map(|(id, meta)| (id.unhandled().to_string(), meta))
+            .collect();
+        let storage_read_capabilities: BTreeMap<_, _> = self
+            .storage_read_capabilities
+            .iter()
+            .map(|(id, capability)| (id.to_string(), capability))
+            .collect();
+        let compute_read_capabilities: BTreeMap<_, _> = self
+            .compute_read_capabilities
+            .iter()
+            .map(|(id, capability)| (id.to_string(), capability))
+            .collect();
+        let txn_read_holds: BTreeMap<_, _> = self
+            .txn_read_holds
+            .iter()
+            .map(|(id, capability)| (id.unhandled().to_string(), capability))
+            .collect();
+        let pending_peeks: BTreeMap<_, _> = self
+            .pending_peeks
+            .iter()
+            .map(|(id, peek)| (id.to_string(), format!("{peek:#?}")))
+            .collect();
+        let client_pending_peeks: BTreeMap<_, _> = self
+            .client_pending_peeks
+            .iter()
+            .map(|(id, peek)| (id.to_string(), peek))
+            .collect();
+        let pending_real_time_recenty_timestamp: BTreeMap<_, _> = self
+            .pending_real_time_recency_timestamp
+            .iter()
+            .map(|(id, timestamp)| (id.unhandled().to_string(), format!("{timestamp:#?}")))
+            .collect();
+        let pending_linearize_read_txns: BTreeMap<_, _> = self
+            .pending_linearize_read_txns
+            .iter()
+            .map(|(id, read_txn)| (id.unhandled().to_string(), format!("{read_txn:#?}")))
+            .collect();
+
+        let map = serde_json::Map::from_iter([
+            (
+                "transient_id_counter".to_string(),
+                serde_json::to_value(self.transient_id_counter)?,
+            ),
+            (
+                "active_conns".to_string(),
+                serde_json::to_value(active_conns)?,
+            ),
+            (
+                "storage_read_capabilities".to_string(),
+                serde_json::to_value(storage_read_capabilities)?,
+            ),
+            (
+                "compute_read_capabilities".to_string(),
+                serde_json::to_value(compute_read_capabilities)?,
+            ),
+            (
+                "txn_read_holds".to_string(),
+                serde_json::to_value(txn_read_holds)?,
+            ),
+            (
+                "pending_peeks".to_string(),
+                serde_json::to_value(pending_peeks)?,
+            ),
+            (
+                "client_pending_peeks".to_string(),
+                serde_json::to_value(client_pending_peeks)?,
+            ),
+            (
+                "pending_real_time_recenty_timestamp".to_string(),
+                serde_json::to_value(pending_real_time_recenty_timestamp)?,
+            ),
+            (
+                "pending_linearize_read_txns".to_string(),
+                serde_json::to_value(pending_linearize_read_txns)?,
+            ),
+        ]);
+        Ok(serde_json::Value::Object(map))
     }
 }
 

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -219,6 +219,10 @@ impl Coordinator {
                 Command::CheckConsistency { tx } => {
                     let _ = tx.send(self.check_consistency());
                 }
+
+                Command::Dump { tx } => {
+                    let _ = tx.send(self.dump());
+                }
             }
         }
         .instrument(debug_span!("handle_command"))

--- a/src/adapter/src/coord/id_bundle.rs
+++ b/src/adapter/src/coord/id_bundle.rs
@@ -12,13 +12,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use mz_compute_types::ComputeInstanceId;
 use mz_repr::GlobalId;
 use mz_sql::session::metadata::SessionMetadata;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::coord::Coordinator;
 use crate::session::Session;
 
 /// A bundle of storage and compute collection identifiers.
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Deserialize, Debug, Default, Clone, Serialize)]
 pub struct CollectionIdBundle {
     /// The identifiers for sources in the storage layer.
     pub storage_ids: BTreeSet<GlobalId>,

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -31,6 +31,7 @@ use mz_ore::instrument;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::session::metadata::SessionMetadata;
 use mz_storage_types::read_policy::ReadPolicy;
+use serde::Serialize;
 use timely::progress::Antichain;
 
 use crate::coord::id_bundle::CollectionIdBundle;
@@ -39,7 +40,7 @@ use crate::session::Session;
 use crate::util::ResultExt;
 
 /// Relevant information for acquiring or releasing a bundle of read holds.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct ReadHolds<T> {
     holds: HashMap<Antichain<T>, CollectionIdBundle>,
 }

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -441,6 +441,10 @@ impl InternalHttpServer {
                 routing::get(catalog::handle_coordinator_check),
             )
             .route(
+                "/api/coordinator/dump",
+                routing::get(catalog::handle_coordinator_dump),
+            )
+            .route(
                 "/internal-console",
                 routing::get(|| async { Redirect::temporary("/internal-console/") }),
             )

--- a/src/environmentd/src/http/catalog.rs
+++ b/src/environmentd/src/http/catalog.rs
@@ -38,3 +38,11 @@ pub async fn handle_coordinator_check(mut client: AuthedClient) -> impl IntoResp
     };
     (TypedHeader(ContentType::json()), response.to_string())
 }
+
+pub async fn handle_coordinator_dump(mut client: AuthedClient) -> impl IntoResponse {
+    let result = match client.client.dump_coordinator_state().await {
+        Ok(dump) => dump,
+        Err(e) => serde_json::json!({ "err": e.to_string() }),
+    };
+    (TypedHeader(ContentType::json()), result.to_string())
+}

--- a/src/repr/src/user.rs
+++ b/src/repr/src/user.rs
@@ -7,10 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use serde::Serialize;
 use uuid::Uuid;
 
 /// Metadata about a user in an external system.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ExternalUserMetadata {
     /// The ID of the user in the external system.
     pub user_id: Uuid,

--- a/src/sql/src/session/user.rs
+++ b/src/sql/src/session/user.rs
@@ -12,6 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use mz_repr::role_id::RoleId;
 use mz_repr::user::ExternalUserMetadata;
 use once_cell::sync::Lazy;
+use serde::Serialize;
 
 pub const SYSTEM_USER_NAME: &str = "mz_system";
 pub static SYSTEM_USER: Lazy<User> = Lazy::new(|| User {
@@ -49,7 +50,7 @@ pub static HTTP_DEFAULT_USER: Lazy<User> = Lazy::new(|| User {
 });
 
 /// Identifies a user.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct User {
     /// The name of the user within the system.
     pub name: String,

--- a/src/storage-types/src/read_policy.rs
+++ b/src/storage-types/src/read_policy.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use derivative::Derivative;
 use itertools::Itertools;
 use mz_repr::TimestampManipulation;
+use serde::Serialize;
 use timely::progress::frontier::AntichainRef;
 use timely::progress::{Antichain, Timestamp};
 
@@ -19,7 +20,7 @@ use timely::progress::{Antichain, Timestamp};
 ///
 /// NOTE(benesch): this might want to live somewhere besides the storage crate,
 /// because it is fundamental to both storage and compute.
-#[derive(Clone, Derivative)]
+#[derive(Clone, Derivative, Serialize)]
 #[derivative(Debug)]
 pub enum ReadPolicy<T> {
     /// No-one has yet requested a `ReadPolicy` from us, which means that we can
@@ -36,7 +37,9 @@ pub enum ReadPolicy<T> {
     ///
     /// The `Arc` makes the function cloneable.
     LagWriteFrontier(
-        #[derivative(Debug = "ignore")] Arc<dyn Fn(AntichainRef<T>) -> Antichain<T> + Send + Sync>,
+        #[derivative(Debug = "ignore")]
+        #[serde(skip)]
+        Arc<dyn Fn(AntichainRef<T>) -> Antichain<T> + Send + Sync>,
     ),
     /// Allows one to express multiple read policies, taking the least of
     /// the resulting frontiers.

--- a/src/testdrive/src/action/consistency.rs
+++ b/src/testdrive/src/action/consistency.rs
@@ -111,7 +111,8 @@ async fn check_coordinator(state: &State) -> Result<(), anyhow::Error> {
         state.materialize_internal_http_addr
     ))
     .await?;
-    if !response.status().is_success() {
+    // We allow NOT_FOUND to support upgrade tests where this endpoint doesn't yet exist.
+    if !response.status().is_success() && response.status() != StatusCode::NOT_FOUND {
         bail!("Coordinator failed to dump state: {:?}", response);
     }
 

--- a/src/testdrive/src/action/consistency.rs
+++ b/src/testdrive/src/action/consistency.rs
@@ -105,6 +105,17 @@ pub async fn run_check_shard_tombstoned(
 
 /// Asks the Coordinator to run it's own internal consistency checks.
 async fn check_coordinator(state: &State) -> Result<(), anyhow::Error> {
+    // Make sure we can dump the Coordinator state.
+    let response = reqwest::get(&format!(
+        "http://{}/api/coordinator/dump",
+        state.materialize_internal_http_addr
+    ))
+    .await?;
+    if !response.status().is_success() {
+        bail!("Coordinator failed to dump state: {:?}", response);
+    }
+
+    // Run the consistency checks.
     let response = Retry::default()
         .max_duration(Duration::from_secs(2))
         .retry_async(|_| async {


### PR DESCRIPTION
Follow up to an incident, it would be nice to be able to dump some of the Coordinator's state so we can determine what read holds are currently outstanding. This PR adds a new endpoint to the internal HTTP server `/api/coordinator/dump` that will return part of the Coordinator's state as a JSON object.

It also updates the read holds consistency check to make sure the connection exists for all txn related read holds.

### Motivation

Debugging tool

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
