### PR TITLE
catalog-debug: Add consolidate option to dump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3908,6 +3908,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-postgres",
+ "tracing",
  "url",
  "uuid",
  "workspace-hack",

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -27,7 +27,8 @@ once_cell = "1.16.0"
 serde = "1.0.152"
 serde_json = "1.0.89"
 tokio = "1.32.0"
-tokio-postgres = { version = "0.7.8", features = [ "with-serde_json-1" ] }
+tokio-postgres = { version = "0.7.8", features = ["with-serde_json-1"] }
+tracing = "0.1.37"
 url = "2.3.1"
 uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -51,6 +51,7 @@ use mz_sql::session::vars::ConnectionCounter;
 use mz_storage_types::connections::ConnectionContext;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use tracing::error;
 use url::Url;
 use uuid::Uuid;
 
@@ -366,12 +367,13 @@ async fn dump(
             retraction_count,
             entries,
         };
+        let name = T::name();
 
-        if consolidate {
-            assert_eq!(retraction_count, 0);
+        if consolidate && retraction_count != 0 {
+            error!("{name} catalog collection has corrupt entries, there should be no retractions in a consolidated catalog, but there are {retraction_count} retractions");
         }
 
-        data.insert(T::name(), dumped_col);
+        data.insert(name, dumped_col);
     }
 
     let mut data = BTreeMap::new();

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -147,7 +147,10 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError>;
 
     /// Generate an unconsolidated [`Trace`] of catalog contents.
-    async fn trace(&mut self) -> Result<Trace, CatalogError>;
+    async fn trace_unconsolidated(&mut self) -> Result<Trace, CatalogError>;
+
+    /// Generate a consolidated [`Trace`] of catalog contents.
+    async fn trace_consolidated(&mut self) -> Result<Trace, CatalogError>;
 
     /// Politely releases all external resources that can only be released in an async context.
     async fn expire(self: Box<Self>);


### PR DESCRIPTION
This commit adds a `--consolidate` option to the dump functionality of the catalog-debug tool. This option returns a consolidated dump instead of an unconsolidated dump, which is the default.

This is a mitigation for #26109 since a consolidated catalog can always be deserialized by a single protobuf version.

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
