### PR TITLE
platform-checks: Fix MySQL upgrade tests

### DIFF
--- a/misc/python/materialize/checks/all_checks/mysql_cdc.py
+++ b/misc/python/materialize/checks/all_checks/mysql_cdc.py
@@ -57,6 +57,9 @@ class MySqlCdcBase:
 
                 INSERT INTO mysql_source_table{self.suffix} SELECT 'A', i, REPEAT('A', {self.repeats} - i) FROM sequence{self.suffix} WHERE i <= 100;
 
+                $[version<9300] mysql-execute name=mysql
+                GRANT SELECT ON performance_schema.replication_connection_configuration TO mysql1{self.suffix};
+
                 > CREATE SECRET mysqlpass1{self.suffix} AS 'mysql';
 
                 > CREATE CONNECTION mysql1{self.suffix} TO MYSQL (
@@ -92,7 +95,7 @@ class MySqlCdcBase:
                 > CREATE CONNECTION mysql2{self.suffix} TO MYSQL (
                     HOST 'mysql',
                     USER mysql1{self.suffix},
-                    PASSWORD SECRET mysqlpass1{self.suffix}
+                    PASSWORD SECRET mysqlpass2{self.suffix}
                   )
 
                 $ mysql-execute name=mysql
@@ -272,6 +275,9 @@ class MySqlCdcMzNow(Check):
                 INSERT INTO mysql_mz_now_table VALUES (NOW(), 'C1');
                 INSERT INTO mysql_mz_now_table VALUES (NOW(), 'D1');
                 INSERT INTO mysql_mz_now_table VALUES (NOW(), 'E1');
+
+                $[version<9300] mysql-execute name=mysql
+                GRANT SELECT ON performance_schema.replication_connection_configuration TO mysql2;
 
                 > CREATE SECRET mysql_mz_now_pass AS 'mysql';
                 > CREATE CONNECTION mysql_mz_now_conn TO MYSQL (


### PR DESCRIPTION
Since old versions won't implicitly run the grant implemented in https://github.com/MaterializeInc/materialize/pull/26074 we have to still run it manually for these versions.

Fixes: #26146

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
