### PR TITLE
doc: remove timetz from list of supported PostgreSQL types

### DIFF
--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -228,7 +228,6 @@ array type for each of the types):
 <li><code>time</code></li>
 <li><code>timestamp</code></li>
 <li><code>timestamptz</code></li>
-<li><code>timetz</code></li>
 <li><code>tsrange</code></li>
 <li><code>tstzrange</code></li>
 <li><code>uuid</code></li>


### PR DESCRIPTION
We don't currently support the `timetz` type, removing it from our docs [until we do](https://github.com/MaterializeInc/materialize/blame/77e15f543b754e1f410f97a8d0189ad717475513/test/sqllogictest/cockroach/alter_column_type.slt#L42)!

h/t to @ParkMyCar for [noticing this](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1710883553354169).