### PR TITLE
compute: add warning for unsuccessful reconciliation

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -39,7 +39,7 @@ use timely::scheduling::{Scheduler, SyncActivator};
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::SendError;
-use tracing::{info, trace};
+use tracing::{info, trace, warn};
 
 use crate::compute_state::{ActiveComputeState, ComputeState, ReportedFrontier};
 use crate::logging::compute::ComputeEvent;
@@ -654,6 +654,15 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                                 }
                                 retain_ids.extend(export_ids);
                             } else {
+                                warn!(
+                                    ?export_ids,
+                                    ?compatible,
+                                    ?uncompacted,
+                                    ?subscribe_free,
+                                    old_as_of = ?old_dataflow.as_of,
+                                    new_as_of = ?as_of,
+                                    "dataflow reconciliation failed",
+                                );
                                 todo_commands
                                     .push(ComputeCommand::CreateDataflow(dataflow.clone()));
                             }


### PR DESCRIPTION
Hopefully this will help us debug issues with reconciliation in the future.

### Motivation

  * This PR fixes a recognized bug.

Part of #26155 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
