### PR TITLE
coord: Guard against race condition between Coordinator and SessionClient

### DIFF
--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -1074,6 +1074,18 @@ class Database:
             )
             self.sqlsmith_state = result.stdout
 
+    def drop(self, exe: Executor) -> None:
+        for db in self.dbs:
+            print(f"Dropping database {db}")
+            db.drop(exe)
+
+        for src in self.kafka_sources:
+            src.executor.mz_conn.close()
+        for src in self.postgres_sources:
+            src.executor.mz_conn.close()
+        for src in self.mysql_sources:
+            src.executor.mz_conn.close()
+
     def update_sqlsmith_state(self, composition: Composition) -> None:
         if not self.fast_startup:
             result = composition.run(

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -366,9 +366,13 @@ def run(
         )
         sessions = cur.fetchall()
         if len(sessions) > 0:
-            raise ValueError(
+            # TODO: Switch back to exception when #26206 is fixed
+            print(
                 f"Sessions are still running even though all threads are done: {sessions}"
             )
+            # raise ValueError(
+            #     f"Sessions are still running even though all threads are done: {sessions}"
+            # )
 
         exe = Executor(rng, cur, database)
         for db in database.dbs:

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -361,23 +361,23 @@ def run(
     conn = pg8000.connect(host=host, port=ports["materialized"], user="materialize")
     conn.autocommit = True
     with conn.cursor() as cur:
-        cur.execute(
-            "SELECT * FROM mz_internal.mz_sessions WHERE now() - connected_at > '5s'"
-        )
-        sessions = cur.fetchall()
-        if len(sessions) > 0:
-            # TODO: Switch back to exception when #26206 is fixed
+        # Dropping the database also releases the long running connections
+        # used by database objects.
+        database.drop(Executor(rng, cur, database))
+
+        stopping_time = datetime.datetime.now() + datetime.timedelta(seconds=30)
+        while datetime.datetime.now() < stopping_time:
+            cur.execute(
+                "SELECT * FROM mz_internal.mz_sessions WHERE id <> pg_backend_pid()"
+            )
+            sessions = cur.fetchall()
+            if len(sessions) == 0:
+                break
             print(
                 f"Sessions are still running even though all threads are done: {sessions}"
             )
-            # raise ValueError(
-            #     f"Sessions are still running even though all threads are done: {sessions}"
-            # )
-
-        exe = Executor(rng, cur, database)
-        for db in database.dbs:
-            print(f"Dropping database {db}")
-            db.drop(exe)
+        else:
+            raise ValueError("Sessions did not clean up within 30s of threads stopping")
     conn.close()
 
     ignored_errors: defaultdict[str, Counter[type[Action]]] = defaultdict(Counter)

--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -114,3 +114,5 @@ class Worker:
                     self.failed_query_error = e
                     print(f"+++ [{thread_name}] Query failed: {e.query} {e.msg}")
                     raise
+
+        self.exe.cur._c.close()

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1046,10 +1046,10 @@ impl RecordFirstRowStream {
 }
 
 /// ~~SPOOKY ZONE~~
-/// 
+///
 /// There is a small race that can occur with [`tokio`], a [`SessionClient`], and the `Coordinator`
 /// that requires this Drop guard.
-/// 
+///
 /// 1. A [`SessionClient`] can execute a command, sending it's owned [`Session`] to the
 ///    Coordinator.
 /// 2. While processing this request, the user closes their connection to Materialize.
@@ -1058,7 +1058,7 @@ impl RecordFirstRowStream {
 ///    provided [`oneshot::Sender`].
 /// 4. [`tokio`] realizes the connection is closed and Drops the task which is awaiting the result
 ///    from the [`oneshot::Receiver`].
-/// 
+///
 ///    !!Problem!! The Coordinator successfully responded to the request, so it doesn't need to
 ///                terminate the [`Session`], but at the same time Future that is responsible for
 ///                listening to the Receiver and putting the [`Session`] back into the

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -3644,7 +3644,7 @@ def workflow_test_http_race_condition(
     for thread in threads:
         thread.join()
 
-    time.sleep(5)
+    time.sleep(10)
 
     result = c.sql_query(
         "SELECT * FROM mz_internal.mz_sessions WHERE now() - connected_at > '5s'"

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import json
+import random
 import re
 import time
 from collections.abc import Callable
@@ -3605,3 +3606,49 @@ def workflow_test_github_26215(c: Composition, parser: WorkflowArgumentParser) -
         c.up("materialized")
 
         check_frontiers_advance()
+
+
+def workflow_test_http_race_condition(
+    c: Composition, parser: WorkflowArgumentParser
+) -> None:
+    c.down(destroy_volumes=True)
+    c.up("materialized")
+
+    def worker() -> None:
+        end_time = time.time() + 60
+        while time.time() < end_time:
+            timeout = random.uniform(0.01, 1.0)
+            rows = random.uniform(1, 10000)
+            envd_port = c.port("materialized", 6876)
+            try:
+                result = requests.post(
+                    f"http://localhost:{envd_port}/api/sql",
+                    data=json.dumps(
+                        {"query": f"select generate_series(1, {rows}::int8)"}
+                    ),
+                    headers={"content-type": "application/json"},
+                    timeout=timeout,
+                )
+            except requests.exceptions.ReadTimeout:
+                continue
+            assert result.status_code == 200, result
+
+    threads = []
+    for j in range(100):
+        thread = Thread(name=f"worker_{j}", target=worker)
+        threads.append(thread)
+
+    for thread in threads:
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    time.sleep(5)
+
+    result = c.sql_query(
+        "SELECT * FROM mz_internal.mz_sessions WHERE now() - connected_at > '5s'"
+    )
+    assert (
+        not result
+    ), f"There are supposed to be now sessions remaining, but there are:\n{result}"


### PR DESCRIPTION
This PR should guard against a race condition where the `Coordinator` responds to a request successfully, but a `SessionClient` never observes the response and thus never gets back the `Session` for termination, effectively leaking the `Session`.

~~I haven't tried reproducing this race, but I think if we put a sleep [here](https://github.com/MaterializeInc/materialize/blob/main/src/adapter/src/client.rs#L818) on `main`, and then close the resulting connection, we should see the Session get leaked.~~

Was able to repro the original issue with Nikhil's test script after running for ~1 minute. After running the same script for ~10 minutes with this PR I could not reproduce the issue.

```
#!/usr/bin/env bash

while :; do
  timeout=$(python3 -c 'import random; print(random.uniform(0.01, 1.0))')
  rows=$(python3 -c 'import random; print(random.uniform(1, 100000))')
  echo "timeout: $timeout"
  echo "rows: $rows"
  curl localhost:6876/api/sql --data "{\"query\": \"select generate_series(1, $rows::int8)\"}" -H 'content-type: application/json' -m "$timeout" &
done
```

### Motivation

Possible solution for https://github.com/MaterializeInc/materialize/issues/26154

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
