### PR TITLE
[persist] Add some context to the consolidator for logging purposes

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -695,6 +695,12 @@ where
         );
 
         let mut consolidator = Consolidator::new(
+            format!(
+                "{}[lower={:?},upper={:?}]",
+                shard_id,
+                desc.lower(),
+                desc.upper()
+            ),
             Arc::clone(&metrics),
             FetchBatchFilter::Compaction {
                 since: desc.since().clone(),

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1044,6 +1044,7 @@ where
         let batches = self.machine.snapshot(&as_of).await?;
 
         let mut consolidator = Consolidator::new(
+            format!("{}[as_of={:?}]", self.shard_id(), as_of),
             Arc::clone(&self.metrics),
             FetchBatchFilter::Snapshot {
                 as_of: as_of.clone(),


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/materialize/issues/26170

We don't have enough information to debug this rare issue - threading through some context for the log.

### Tips for reviewer

Open to additional suggestions for metadata here!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
