### PR TITLE
Fix stash-debug tool

### DIFF
--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -160,6 +160,8 @@ macro_rules! for_collections {
         match $usage {
             Usage::Storage => {
                 $macro!(storage::METADATA_COLLECTION);
+                $macro!(storage::PERSIST_TXNS_SHARD);
+                $macro!(storage::command_wals::SHARD_FINALIZATION);
             }
         }
     };

--- a/src/storage-controller/src/command_wals.rs
+++ b/src/storage-controller/src/command_wals.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 pub(super) type ProtoShardId = String;
-pub(super) static SHARD_FINALIZATION: TypedCollection<ProtoShardId, ()> =
+pub static SHARD_FINALIZATION: TypedCollection<ProtoShardId, ()> =
     TypedCollection::new("storage-shards-to-finalize");
 
 impl<T> Controller<T>

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -87,7 +87,7 @@ use crate::persist_handles::SnapshotStatsAsOf;
 use crate::rehydration::RehydratingStorageClient;
 mod collection_mgmt;
 mod collection_status;
-mod command_wals;
+pub mod command_wals;
 mod persist_handles;
 mod rehydration;
 mod statistics;


### PR DESCRIPTION
### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
