### PR TITLE
adapter: remove confirm_leadership

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3110,11 +3110,6 @@ impl Catalog {
         *privileges = PrivilegeMap::from_mz_acl_items(flat_privileges);
     }
 
-    #[mz_ore::instrument(level = "debug")]
-    pub async fn confirm_leadership(&self) -> Result<(), AdapterError> {
-        Ok(self.storage().await.confirm_leadership().await?)
-    }
-
     /// Parses the given SQL string into a `CatalogItem`.
     #[mz_ore::instrument]
     fn parse_item(

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -273,20 +273,6 @@ impl Coordinator {
             advance_to,
         } = self.get_local_write_ts().await;
 
-        // While we're flipping on the feature flags for persist-txn tables and
-        // the separated Postgres timestamp oracle, we also need to confirm
-        // leadership on writes _after_ getting the timestamp and _before_
-        // writing anything to table shards. See the big comment on `init_txns`
-        // in the Storage controller for details.
-        //
-        // TODO: Remove this after both (either?) of the above features are on
-        // for good and no possibility of running the old code.
-        let () = self
-            .catalog
-            .confirm_leadership()
-            .await
-            .unwrap_or_terminate("unable to confirm leadership");
-
         let mut appends: BTreeMap<GlobalId, Vec<(Row, Diff)>> = BTreeMap::new();
         let mut responses = Vec::with_capacity(self.pending_writes.len());
         let mut notifies = Vec::new();

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -757,16 +757,10 @@ impl Coordinator {
 
         if !ready_txns.is_empty() {
             // Sniff out one ctx, this is where tracing breaks down because we
-            // do one confirm_leadership for multiple peeks.
+            // process all outstanding txns as a batch here.
             let otel_ctx = ready_txns.first().expect("known to exist").otel_ctx.clone();
             let mut span = tracing::debug_span!("message_linearize_reads");
             otel_ctx.attach_as_parent_to(&mut span);
-
-            self.catalog_mut()
-                .confirm_leadership()
-                .instrument(span)
-                .await
-                .unwrap_or_terminate("unable to confirm leadership");
 
             let now = Instant::now();
             for ready_txn in ready_txns {

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -217,11 +217,6 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     async fn commit_transaction(&mut self, txn_batch: TransactionBatch)
         -> Result<(), CatalogError>;
 
-    /// Confirms that this catalog is connected as the current leader.
-    ///
-    /// NB: We may remove this in later iterations of Pv2.
-    async fn confirm_leadership(&mut self) -> Result<(), CatalogError>;
-
     /// Gets all storage usage events and permanently deletes from the catalog those
     /// that happened more than the retention period ago from boot_ts.
     ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -1060,15 +1060,6 @@ impl Stash {
             .await
     }
 
-    /// Returns Ok if the stash is the current leader and an error otherwise.
-    ///
-    /// Note: This can be optimized to not increment the version, which is done automatically via
-    /// `with_commit`. It will probably be more efficient to retry an in-determinate read-only
-    /// transaction than relying on incrementing the version.
-    pub async fn confirm_leadership(&mut self) -> Result<(), StashError> {
-        self.with_transaction(|_| Box::pin(async { Ok(()) })).await
-    }
-
     pub fn is_writeable(&self) -> bool {
         matches!(self.txn_mode, TransactionMode::Writeable)
     }

--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -606,8 +606,6 @@ async fn test_stash_readonly() {
         BTreeMap::from([(1, 2)])
     );
 
-    // The previous stash should still be the leader.
-    assert!(stash_rw.confirm_leadership().await.is_ok());
     stash_rw.verify().await.unwrap();
     factory.drop().await;
 }
@@ -658,8 +656,6 @@ async fn test_stash_savepoint() {
 
     drop(stash_sp);
 
-    // The previous stash should still be the leader.
-    assert!(stash_rw.confirm_leadership().await.is_ok());
     // Verify c1 didn't change.
     assert_eq!(
         C1.peek_one(&mut stash_rw).await.unwrap(),

--- a/test/persist-txn-fencing/mzcompose.py
+++ b/test/persist-txn-fencing/mzcompose.py
@@ -229,8 +229,7 @@ def run_workload(c: Composition, workload: Workload) -> None:
         # Confirm that the first Mz has properly given up the ghost
         mz_first_log = c.invoke("logs", "mz_first", capture=True)
         assert (
-            "unable to confirm leadership" in mz_first_log.stdout
-            or "unexpected fence epoch" in mz_first_log.stdout
+            "unexpected fence epoch" in mz_first_log.stdout
             or "fenced by new catalog upper" in mz_first_log.stdout
         )
 


### PR DESCRIPTION
Now that we rolled out persist-txn and the crdb-backed timestamp oracle we don't need it for correctness anymore.

### Tips for reviewer

We should think hard about whether we really don't need this for correctness!

- We initially only had this because the catalog-backed timestamp oracle was reserving timestamp ranges and serving timestamps from memory. `confirm_leadership` was needed to make sure that no-one serves outdated timestamps from memory -> we don't have that anymore
- We then additionally relied on `confirm_leadership` to guard against consistency issues when switching persist-txn on and off -> we can't do that anymore

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
