### PR TITLE
Fix ILIKE with multiprocess clusters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4455,7 +4455,6 @@ dependencies = [
  "regex-syntax",
  "serde",
  "serde_json",
- "serde_regex",
  "sha1",
  "sha2",
  "subtle",
@@ -8286,16 +8285,6 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6018081315db179d0ce57b1fe4b62a12a0028c9cf9bbef868c9cf477b3c34ae"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_regex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
-dependencies = [
- "regex",
  "serde",
 ]
 

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -1314,10 +1314,6 @@ criteria = "safe-to-deploy"
 version = "1.0.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.serde_regex]]
-version = "1.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.serde_urlencoded]]
 version = "0.7.1"
 criteria = "safe-to-deploy"

--- a/misc/python/materialize/output_consistency/input_data/operations/text_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/text_operations_provider.py
@@ -114,8 +114,6 @@ TEXT_OPERATION_TYPES.append(
         "$ ILIKE $",
         [TextOperationParam(), LIKE_PARAM],
         BooleanReturnTypeSpec(),
-        # TODO: #26177 (ILIKE in data-flow rendering produces incorrect results when used with multiple replicas)
-        is_enabled=False,
     )
 )
 
@@ -134,8 +132,6 @@ TEXT_OPERATION_TYPES.append(
         "$ NOT ILIKE $",
         [TextOperationParam(), LIKE_PARAM],
         BooleanReturnTypeSpec(),
-        # TODO: #26177 (ILIKE in data-flow rendering produces incorrect results when used with multiple replicas)
-        is_enabled=False,
     )
 )
 

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -50,7 +50,6 @@ regex = "1.7.0"
 regex-syntax = "0.6.28"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
-serde_regex = "1.1.0"
 sha1 = "0.10.5"
 sha2 = "0.10.6"
 subtle = "2.4.1"

--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -14,8 +14,8 @@ use derivative::Derivative;
 use mz_lowertest::MzReflect;
 use mz_ore::fmt::FormatBuffer;
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
+use mz_repr::adt::regex::Regex;
 use proptest::prelude::{Arbitrary, Strategy};
-use regex::{Regex, RegexBuilder};
 use serde::{Deserialize, Serialize};
 
 use crate::scalar::EvalError;
@@ -151,7 +151,7 @@ mod matcher {
     #[derive(Debug, Clone, Deserialize, Serialize, MzReflect)]
     pub(super) enum MatcherImpl {
         String(Vec<Subpattern>),
-        Regex(#[serde(with = "serde_regex")] Regex),
+        Regex(Regex),
     }
 }
 
@@ -403,10 +403,7 @@ fn build_regex(subpatterns: &[Subpattern], case_insensitive: bool) -> Result<Reg
         sp.write_regex_to(&mut r);
     }
     r.push('$');
-    let mut rb = RegexBuilder::new(&r);
-    rb.dot_matches_new_line(true);
-    rb.case_insensitive(case_insensitive);
-    match rb.build() {
+    match Regex::new_dot_matches_new_line(r, case_insensitive, true) {
         Ok(regex) => Ok(regex),
         Err(regex::Error::CompiledTooBig(_)) => Err(EvalError::LikePatternTooLong),
         Err(e) => Err(EvalError::Internal(format!(

--- a/src/repr/src/adt/regex.proto
+++ b/src/repr/src/adt/regex.proto
@@ -14,4 +14,5 @@ package mz_repr.adt.regex;
 message ProtoRegex {
     string pattern = 1;
     bool case_insensitive = 2;
+    bool dot_matches_new_line = 3;
 }

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -5747,7 +5747,8 @@ SELECT s FROM t2 WHERE s ~ 'a.*';
                     "func": {
                       "IsRegexpMatch": {
                         "pattern": "a.*",
-                        "case_insensitive": false
+                        "case_insensitive": false,
+                        "dot_matches_new_line": false
                       }
                     },
                     "expr": {
@@ -5780,7 +5781,8 @@ SELECT s FROM t2 WHERE s ~ 'a.*';
                 "func": {
                   "IsRegexpMatch": {
                     "pattern": "a.*",
-                    "case_insensitive": false
+                    "case_insensitive": false,
+                    "dot_matches_new_line": false
                   }
                 },
                 "expr": {

--- a/test/sqllogictest/like.slt
+++ b/test/sqllogictest/like.slt
@@ -130,3 +130,52 @@ SELECT s FROM t WHERE s ILIKE like_pat;
 ----
 ABC
 abc
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/26177
+
+statement ok
+CREATE TABLE t2 (text_val TEXT);
+
+statement ok
+INSERT INTO t2 VALUES ('abc');
+
+statement ok
+CREATE CLUSTER test SIZE '2-1';
+
+statement ok
+SET cluster = test;
+
+query B
+SELECT text_val NOT ILIKE '%A%' FROM t2;
+----
+false
+
+query B
+SELECT text_val NOT ILIKE '%A%' FROM t2;
+----
+false
+
+query B
+SELECT text_val NOT ILIKE '%A%' FROM t2;
+----
+false
+
+query B
+SELECT text_val NOT ILIKE '%A%' FROM t2;
+----
+false
+
+query B
+SELECT text_val NOT ILIKE '%A%' FROM t2;
+----
+false
+
+query B
+SELECT text_val NOT ILIKE '%A%' FROM t2;
+----
+false
+
+query B
+SELECT text_val NOT ILIKE '%A%' FROM t2;
+----
+false

--- a/test/sqllogictest/like.slt
+++ b/test/sqllogictest/like.slt
@@ -179,3 +179,18 @@ query B
 SELECT text_val NOT ILIKE '%A%' FROM t2;
 ----
 false
+
+# Test that % matches \n
+query B
+SELECT E'test line 1\ntest line 2' LIKE '%1%2%';
+----
+true
+
+statement ok
+INSERT INTO t2 VALUES ('test line 1\ntest line 2');
+
+query B
+SELECT text_val LIKE '%1%2%' FROM t2;
+----
+false
+true


### PR DESCRIPTION
`serde_regex`, the serialization library that we were originally using for serializing `Regex` is broken (see https://github.com/tailhook/serde-regex/issues/14). Some time ago, https://github.com/MaterializeInc/materialize/pull/20602 made us stop using it in certain places. Unfortunately, `MatcherImpl` was still using it, impacting `ILIKE` for multiprocess clusters.

This PR makes `MatcherImpl` also use our wrapper class around `Regex`. (Our wrapper class has manually written serializers, both for `Serialize`/`Deserialize` and Protobuf, which don't attempt to serialize the `Regex` object itself, but just serializes the information that is necessary to rebuild the `Regex` object upon deserialization.) Additionally, it records in `cargo-vet/audits.toml` that `serde_regex` is _not_ `safe-to-deploy` (Edit: I've removed this in the meantime from this PR, we can do this as a follow-up when I figure out how `cargo vet` works.). The biggest commit is the one that adds `dot_matches_new_line` to `RegexWrapper`, which is used when building a `MatcherImpl` (in `like_pattern.rs:build_regex`).

Unfortunately, I found one more bug while writing tests for this: Our regexes (but not LIKE) treat newlines incorrectly.
```
SELECT E'test line 1\ntest line 2'~'1.*2';
```
return true in Postgres but false in Materialize. This is not fixed in this PR, but I'll open an issue for that one as well shortly, and start working on it.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/26177

### Tips for reviewer

Review the commits one by one.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
