### PR TITLE
ci-builder: Fix static linking on macOS

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -286,13 +286,13 @@ ENV RANLIB=$ARCH_GCC-unknown-linux-gnu-ranlib
 ENV CPP=$ARCH_GCC-unknown-linux-gnu-cpp
 ENV CC=$ARCH_GCC-unknown-linux-gnu-cc
 ENV CXX=$ARCH_GCC-unknown-linux-gnu-c++
-ENV CXXSTDLIB=stdc++
+ENV CXXSTDLIB=static=stdc++
 ENV LDFLAGS="-fuse-ld=lld -static-libstdc++"
 ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zlib -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/ -Csymbol-mangling-version=v0 -Ctarget-cpu=$RUST_CPU_TARGET -Ctarget-feature=$RUST_TARGET_FEATURES --cfg=tokio_unstable"
 ENV TARGET_AR=$AR
 ENV TARGET_CC=$CC
 ENV TARGET_CXX=$CXX
-ENV TARGET_CXXSTDLIB=stdc++
+ENV TARGET_CXXSTDLIB=static=stdc++
 ENV TARGET_RANLIB=$RANLIB
 ENV PATH=/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/bin:$PATH
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-unknown-linux-gnu-cc

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -948,7 +948,7 @@ steps:
     steps:
       - id: persist-maelstrom
         label: Maelstrom coverage of persist
-        depends_on: []
+        depends_on: build-aarch64
         timeout_in_minutes: 30
         artifact_paths: [test/persist/maelstrom/**/*.log]
         plugins:
@@ -960,7 +960,7 @@ steps:
 
       - id: persist-maelstrom-single-node
         label: Long single-node Maelstrom coverage of persist
-        depends_on: []
+        depends_on: build-aarch64
         timeout_in_minutes: 20
         agents:
           queue: linux-aarch64-small
@@ -972,7 +972,7 @@ steps:
 
       - id: persist-maelstrom-multi-node
         label: Long multi-node Maelstrom coverage of persist with postgres consensus
-        depends_on: []
+        depends_on: build-aarch64
         timeout_in_minutes: 20
         agents:
           queue: linux-aarch64-small
@@ -984,7 +984,7 @@ steps:
 
       - id: persist-txn-maelstrom
         label: Maelstrom coverage of persist-txn
-        depends_on: []
+        depends_on: build-aarch64
         timeout_in_minutes: 30
         agents:
           queue: linux-aarch64-small
@@ -996,7 +996,7 @@ steps:
 
       - id: persistence-failpoints
         label: Persistence failpoints
-        depends_on: []
+        depends_on: build-aarch64
         timeout_in_minutes: 30
         agents:
           queue: linux-aarch64-small


### PR DESCRIPTION
As reported in https://materializeinc.slack.com/archives/C01LKF361MZ/p1711029258676969

Follow-up to https://github.com/MaterializeInc/materialize/pull/26047

I believe this should fix it and keep Sanitizers working, but have to wait for ci-builder to be built first.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
