### PR TITLE
move initial builtin clusters to be managed

### DIFF
--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -1149,6 +1149,8 @@ pub enum CatalogError {
     UnknownCluster(String),
     /// Unexpected builtin cluster.
     UnexpectedBuiltinCluster(String),
+    /// Unexpected builtin cluster.
+    UnexpectedBuiltinClusterType(String),
     /// Cluster already exists.
     ClusterAlreadyExists(String),
     /// Unknown cluster replica.
@@ -1217,6 +1219,7 @@ impl fmt::Display for CatalogError {
             Self::RoleAlreadyExists(name) => write!(f, "role '{name}' already exists"),
             Self::UnknownCluster(name) => write!(f, "unknown cluster '{}'", name),
             Self::UnexpectedBuiltinCluster(name) => write!(f, "Unexpected builtin cluster '{}'", name),
+            Self::UnexpectedBuiltinClusterType(name) => write!(f, "Unexpected builtin cluster type'{}'", name),
             Self::ClusterAlreadyExists(name) => write!(f, "cluster '{name}' already exists"),
             Self::UnknownClusterReplica(name) => {
                 write!(f, "unknown cluster replica '{}'", name)

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -53,8 +53,8 @@ ALTER CLUSTER foo SET (REPLICATION FACTOR 2)
 query TTTTT rowsort
 SELECT id, name, managed, replication_factor, size FROM mz_clusters
 ----
-s1  mz_system  false  NULL  NULL
-s2  mz_introspection  false  NULL  NULL
+s1  mz_system  true  1  2
+s2  mz_introspection  true  1  2
 u1  quickstart  true  1  2
 
 

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -493,7 +493,7 @@ COMPLETE 0
 statement error system cluster 'mz_introspection' cannot be modified
 CREATE MATERIALIZED VIEW live_keys AS ( SELECT key FROM bar );
 
-statement error system cluster 'mz_introspection' cannot be modified
+statement error  cannot modify managed cluster mz_introspection
 CREATE CLUSTER REPLICA mz_introspection.backup SIZE '1';
 
 statement error system cluster 'mz_introspection' cannot be modified

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -21,6 +21,11 @@ mz_system
 mz_introspection
 quickstart
 
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+> select managed from mz_catalog.mz_clusters where id like 's%';
+true
+true
+
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_rbac_checks TO false
 
@@ -43,10 +48,13 @@ $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-inter
 ALTER SYSTEM SET enable_rbac_checks TO false
 
 ! CREATE CLUSTER REPLICA mz_system.r2 SIZE '1';
-contains:system cluster 'mz_system' cannot be modified
+contains: cannot modify managed cluster mz_system
 
-! DROP CLUSTER REPLICA mz_system.r1
-contains:system cluster 'mz_system' cannot be modified
+! DROP CLUSTER REPLICA mz_system.r1;
+contains:cannot drop replica of managed cluster
+
+! ALTER CLUSTER mz_system SET (SIZE='2');
+contains: system cluster 'mz_system' cannot be modified
 
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_rbac_checks TO true
@@ -91,14 +99,3 @@ $ set-regex match=true|false replacement=<TRUE_OR_FALSE>
 
 > SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
 mz_system r1 1 <TRUE_OR_FALSE>
-
-$ postgres-execute connection=mz_system
-DROP CLUSTER REPLICA mz_system.r1
-
-> SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
-
-$ postgres-execute connection=mz_system
-CREATE CLUSTER REPLICA mz_system.r1 SIZE '${arg.default-replica-size}';
-
-> SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
-mz_system r1 ${arg.default-replica-size} <TRUE_OR_FALSE>


### PR DESCRIPTION
        switches the cluster creation from
        unmanaged to managed for builtin
        internal clusters.

        removes explicit replica creation for
        mz_system and mz_introspection clusters

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
  * This PR adds a known-desirable feature.
    https://github.com/MaterializeInc/materialize/issues/22326

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
