### PR TITLE
Fix newline handling in regexes

### DIFF
--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -403,7 +403,7 @@ fn build_regex(subpatterns: &[Subpattern], case_insensitive: bool) -> Result<Reg
         sp.write_regex_to(&mut r);
     }
     r.push('$');
-    match Regex::new_dot_matches_new_line(r, case_insensitive, true) {
+    match Regex::new(r, case_insensitive) {
         Ok(regex) => Ok(regex),
         Err(regex::Error::CompiledTooBig(_)) => Err(EvalError::LikePatternTooLong),
         Err(e) => Err(EvalError::Internal(format!(

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -60,9 +60,11 @@ pub struct Regex {
 }
 
 impl Regex {
-    /// A simple constructor for the default setting of `dot_matches_new_line: false`.
+    /// A simple constructor for the default setting of `dot_matches_new_line: true`.
+    /// See <https://www.postgresql.org/docs/current/functions-matching.html#POSIX-MATCHING-RULES>
+    /// "newline-sensitive matching"
     pub fn new(pattern: String, case_insensitive: bool) -> Result<Regex, Error> {
-        Self::new_dot_matches_new_line(pattern, case_insensitive, false)
+        Self::new_dot_matches_new_line(pattern, case_insensitive, true)
     }
 
     /// Allows explicitly setting `dot_matches_new_line`.
@@ -143,8 +145,6 @@ impl RustType<ProtoRegex> for Regex {
         Ok(Regex::new_dot_matches_new_line(
             proto.pattern,
             proto.case_insensitive,
-            // We used to not have the following field. If we happen to deserialize an old object,
-            // this will default to false, which is exactly what we want.
             proto.dot_matches_new_line,
         )?)
     }
@@ -365,8 +365,8 @@ mod tests {
             let orig_regex = Regex::new("A.*B".to_string(), true).unwrap();
             let serialized: String = serde_json::to_string(&orig_regex).unwrap();
             let roundtrip_result: Regex = serde_json::from_str(&serialized).unwrap();
-            assert_eq!(orig_regex.regex.is_match("axxx\nxxxb"), false);
-            assert_eq!(roundtrip_result.regex.is_match("axxx\nxxxb"), false);
+            assert_eq!(orig_regex.regex.is_match("axxx\nxxxb"), true);
+            assert_eq!(roundtrip_result.regex.is_match("axxx\nxxxb"), true);
         }
     }
 }

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -5748,7 +5748,7 @@ SELECT s FROM t2 WHERE s ~ 'a.*';
                       "IsRegexpMatch": {
                         "pattern": "a.*",
                         "case_insensitive": false,
-                        "dot_matches_new_line": false
+                        "dot_matches_new_line": true
                       }
                     },
                     "expr": {
@@ -5782,7 +5782,7 @@ SELECT s FROM t2 WHERE s ~ 'a.*';
                   "IsRegexpMatch": {
                     "pattern": "a.*",
                     "case_insensitive": false,
-                    "dot_matches_new_line": false
+                    "dot_matches_new_line": true
                   }
                 },
                 "expr": {

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -125,6 +125,9 @@ CREATE TABLE t(s string, like_pat string, regex_pat string);
 statement ok
 INSERT INTO t VALUES ('abc', 'a%', 'a.*'), ('ABC', 'a%', 'a.*'), ('ccc', 'a%', 'a.*');
 
+# In Postgres' regexes, `.` matches newlines by default, so let's test this as well.
+# See https://www.postgresql.org/docs/current/functions-matching.html#POSIX-MATCHING-RULES
+# "newline-sensitive matching"
 statement ok
 INSERT INTO t VALUES (
   E'test line 1\ntest line 2',
@@ -273,6 +276,7 @@ query T
 SELECT replace(s, E'\n', '<newline>') FROM t WHERE s ~ regex_pat;
 ----
 abc
+test line 1<newline>test line 2
 
 query T multiline
 EXPLAIN
@@ -295,6 +299,7 @@ SELECT replace(s, E'\n', '<newline>') FROM t WHERE s ~* regex_pat;
 ----
 ABC
 abc
+test line 1<newline>test line 2
 
 query T multiline
 EXPLAIN
@@ -308,8 +313,9 @@ Explained Query:
 
 EOF
 
+# We need to also replace newlines in the output here to not confuse sqllogictest.
 query TTT
-SELECT replace(s, E'\n', '<newline>'), regex_pat, regexp_match(s, regex_pat) FROM t;
+SELECT replace(s, E'\n', '<newline>'), regex_pat, replace(regexp_match(s, regex_pat)::text, E'\n', '<newline>') FROM t;
 ----
 ABC
 a.*
@@ -317,12 +323,12 @@ NULL
 ccc
 a.*
 NULL
-test line 1<newline>test line 2
-1.*2
-NULL
 abc
 a.*
 {abc}
+test line 1<newline>test line 2
+1.*2
+{"1<newline>test line 2"}
 
 query T multiline
 EXPLAIN
@@ -337,13 +343,10 @@ Explained Query:
 EOF
 
 query TTT
-SELECT replace(s, E'\n', '<newline>'), regex_pat, regexp_match(s, regex_pat, 'i') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regex_pat, replace(regexp_match(s, regex_pat, 'i')::text, E'\n', '<newline>') FROM t;
 ----
 ccc
 a.*
-NULL
-test line 1<newline>test line 2
-1.*2
 NULL
 ABC
 a.*
@@ -351,9 +354,12 @@ a.*
 abc
 a.*
 {abc}
+test line 1<newline>test line 2
+1.*2
+{"1<newline>test line 2"}
 
 query TTT
-SELECT replace(s, E'\n', '<newline>'), regex_pat, regexp_match(s, regex_pat, 'ic') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regex_pat, replace(regexp_match(s, regex_pat, 'ic')::text, E'\n', '<newline>') FROM t;
 ----
 ABC
 a.*
@@ -361,21 +367,18 @@ NULL
 ccc
 a.*
 NULL
-test line 1<newline>test line 2
-1.*2
-NULL
 abc
 a.*
 {abc}
+test line 1<newline>test line 2
+1.*2
+{"1<newline>test line 2"}
 
 query TTT
-SELECT replace(s, E'\n', '<newline>'), regex_pat, regexp_match(s, regex_pat, 'ci') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regex_pat, replace(regexp_match(s, regex_pat, 'ci')::text, E'\n', '<newline>') FROM t;
 ----
 ccc
 a.*
-NULL
-test line 1<newline>test line 2
-1.*2
 NULL
 ABC
 a.*
@@ -383,6 +386,9 @@ a.*
 abc
 a.*
 {abc}
+test line 1<newline>test line 2
+1.*2
+{"1<newline>test line 2"}
 
 statement ok
 INSERT INTO T VALUES ('this is gonna be an invalid regex', '', '\');

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -125,14 +125,24 @@ CREATE TABLE t(s string, like_pat string, regex_pat string);
 statement ok
 INSERT INTO t VALUES ('abc', 'a%', 'a.*'), ('ABC', 'a%', 'a.*'), ('ccc', 'a%', 'a.*');
 
+statement ok
+INSERT INTO t VALUES (
+  E'test line 1\ntest line 2',
+  '%1%2%',
+  '1.*2'
+);
+
+# Note that sqllogictest can't handle newlines in string output, so replace those when displaying `s`
 query T multiline
 EXPLAIN
-SELECT s FROM t WHERE s~'a.*';
+SELECT replace(s, E'\n', '<newline>') FROM t WHERE s~'a.*';
 ----
 Explained Query:
-  Project (#0)
+  Project (#3)
     Filter is_regexp_match["a.*", case_insensitive=false](#0)
-      ReadStorage materialize.public.t
+      Map (replace(#0, "
+", "<newline>"))
+        ReadStorage materialize.public.t
 
 Source materialize.public.t
   filter=(is_regexp_match["a.*", case_insensitive=false](#0))
@@ -140,18 +150,20 @@ Source materialize.public.t
 EOF
 
 query T
-SELECT s FROM t WHERE s~'a.*';
+SELECT replace(s, E'\n', '<newline>') FROM t WHERE s~'a.*';
 ----
 abc
 
 query T multiline
 EXPLAIN
-SELECT s FROM t WHERE s~*'a.*';
+SELECT replace(s, E'\n', '<newline>') FROM t WHERE s~*'a.*';
 ----
 Explained Query:
-  Project (#0)
+  Project (#3)
     Filter is_regexp_match["a.*", case_insensitive=true](#0)
-      ReadStorage materialize.public.t
+      Map (replace(#0, "
+", "<newline>"))
+        ReadStorage materialize.public.t
 
 Source materialize.public.t
   filter=(is_regexp_match["a.*", case_insensitive=true](#0))
@@ -159,47 +171,53 @@ Source materialize.public.t
 EOF
 
 query T
-SELECT s FROM t WHERE s~*'a.*';
+SELECT replace(s, E'\n', '<newline>') FROM t WHERE s~*'a.*';
 ----
 ABC
 abc
 
 query T multiline
 EXPLAIN
-SELECT s, regexp_match(s, 'a.*') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regexp_match(s, 'a.*') FROM t;
 ----
 Explained Query:
-  Project (#0, #3)
-    Map (regexp_match["a.*", case_insensitive=false](#0))
+  Project (#3, #4)
+    Map (replace(#0, "
+", "<newline>"), regexp_match["a.*", case_insensitive=false](#0))
       ReadStorage materialize.public.t
 
 EOF
 
 query TT
-SELECT s, regexp_match(s, 'a.*') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regexp_match(s, 'a.*') FROM t;
 ----
 ABC
 NULL
 ccc
+NULL
+test line 1<newline>test line 2
 NULL
 abc
 {abc}
 
 query T multiline
 EXPLAIN
-SELECT s, regexp_match(s, 'a.*', 'i') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regexp_match(s, 'a.*', 'i') FROM t;
 ----
 Explained Query:
-  Project (#0, #3)
-    Map (regexp_match["a.*", case_insensitive=true](#0))
+  Project (#3, #4)
+    Map (replace(#0, "
+", "<newline>"), regexp_match["a.*", case_insensitive=true](#0))
       ReadStorage materialize.public.t
 
 EOF
 
 query TT
-SELECT s, regexp_match(s, 'a.*', 'i') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regexp_match(s, 'a.*', 'i') FROM t;
 ----
 ccc
+NULL
+test line 1<newline>test line 2
 NULL
 ABC
 {ABC}
@@ -207,19 +225,23 @@ abc
 {abc}
 
 query TT
-SELECT s, regexp_match(s, 'a.*', 'ic') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regexp_match(s, 'a.*', 'ic') FROM t;
 ----
 ABC
 NULL
 ccc
 NULL
+test line 1<newline>test line 2
+NULL
 abc
 {abc}
 
 query TT
-SELECT s, regexp_match(s, 'a.*', 'ci') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regexp_match(s, 'a.*', 'ci') FROM t;
 ----
 ccc
+NULL
+test line 1<newline>test line 2
 NULL
 ABC
 {ABC}
@@ -227,18 +249,20 @@ abc
 {abc}
 
 query error db error: ERROR: Evaluation error: invalid regular expression: regex parse error:
-SELECT s FROM t WHERE s ~ '\';
+SELECT replace(s, E'\n', '<newline>') FROM t WHERE s ~ '\';
 
 # Dynamic regexes (binary (or variadic) versions)
 
 query T multiline
 EXPLAIN
-SELECT s FROM t WHERE s ~ regex_pat;
+SELECT replace(s, E'\n', '<newline>') FROM t WHERE s ~ regex_pat;
 ----
 Explained Query:
-  Project (#0)
+  Project (#3)
     Filter (#0 ~ #2)
-      ReadStorage materialize.public.t
+      Map (replace(#0, "
+", "<newline>"))
+        ReadStorage materialize.public.t
 
 Source materialize.public.t
   filter=((#0 ~ #2))
@@ -246,18 +270,20 @@ Source materialize.public.t
 EOF
 
 query T
-SELECT s FROM t WHERE s ~ regex_pat;
+SELECT replace(s, E'\n', '<newline>') FROM t WHERE s ~ regex_pat;
 ----
 abc
 
 query T multiline
 EXPLAIN
-SELECT s FROM t WHERE s ~* regex_pat;
+SELECT replace(s, E'\n', '<newline>') FROM t WHERE s ~* regex_pat;
 ----
 Explained Query:
-  Project (#0)
+  Project (#3)
     Filter (#0 ~* #2)
-      ReadStorage materialize.public.t
+      Map (replace(#0, "
+", "<newline>"))
+        ReadStorage materialize.public.t
 
 Source materialize.public.t
   filter=((#0 ~* #2))
@@ -265,30 +291,34 @@ Source materialize.public.t
 EOF
 
 query T
-SELECT s FROM t WHERE s ~* regex_pat;
+SELECT replace(s, E'\n', '<newline>') FROM t WHERE s ~* regex_pat;
 ----
 ABC
 abc
 
 query T multiline
 EXPLAIN
-SELECT s, regex_pat, regexp_match(s, regex_pat) FROM t;
+SELECT replace(s, E'\n', '<newline>'), regex_pat, regexp_match(s, regex_pat) FROM t;
 ----
 Explained Query:
-  Project (#0, #2, #3)
-    Map (regexp_match(#0, #2))
+  Project (#3, #2, #4)
+    Map (replace(#0, "
+", "<newline>"), regexp_match(#0, #2))
       ReadStorage materialize.public.t
 
 EOF
 
 query TTT
-SELECT s, regex_pat, regexp_match(s, regex_pat) FROM t;
+SELECT replace(s, E'\n', '<newline>'), regex_pat, regexp_match(s, regex_pat) FROM t;
 ----
 ABC
 a.*
 NULL
 ccc
 a.*
+NULL
+test line 1<newline>test line 2
+1.*2
 NULL
 abc
 a.*
@@ -296,20 +326,24 @@ a.*
 
 query T multiline
 EXPLAIN
-SELECT s, regex_pat, regexp_match(s, regex_pat, 'i') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regex_pat, regexp_match(s, regex_pat, 'i') FROM t;
 ----
 Explained Query:
-  Project (#0, #2, #3)
-    Map (regexp_match(#0, #2, "i"))
+  Project (#3, #2, #4)
+    Map (replace(#0, "
+", "<newline>"), regexp_match(#0, #2, "i"))
       ReadStorage materialize.public.t
 
 EOF
 
 query TTT
-SELECT s, regex_pat, regexp_match(s, regex_pat, 'i') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regex_pat, regexp_match(s, regex_pat, 'i') FROM t;
 ----
 ccc
 a.*
+NULL
+test line 1<newline>test line 2
+1.*2
 NULL
 ABC
 a.*
@@ -319,7 +353,7 @@ a.*
 {abc}
 
 query TTT
-SELECT s, regex_pat, regexp_match(s, regex_pat, 'ic') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regex_pat, regexp_match(s, regex_pat, 'ic') FROM t;
 ----
 ABC
 a.*
@@ -327,15 +361,21 @@ NULL
 ccc
 a.*
 NULL
+test line 1<newline>test line 2
+1.*2
+NULL
 abc
 a.*
 {abc}
 
 query TTT
-SELECT s, regex_pat, regexp_match(s, regex_pat, 'ci') FROM t;
+SELECT replace(s, E'\n', '<newline>'), regex_pat, regexp_match(s, regex_pat, 'ci') FROM t;
 ----
 ccc
 a.*
+NULL
+test line 1<newline>test line 2
+1.*2
 NULL
 ABC
 a.*
@@ -350,7 +390,7 @@ INSERT INTO T VALUES ('this is gonna be an invalid regex', '', '\');
 # Note: The actual error msg shows the regex itself (as it should), but it seems sqllogictest can't handle multiline
 # error msgs.
 query error db error: ERROR: Evaluation error: invalid regular expression: regex parse error:
-SELECT s FROM t WHERE s ~* regex_pat;
+SELECT replace(s, E'\n', '<newline>') FROM t WHERE s ~* regex_pat;
 
 # TODO: multiline literal errors should be printed somehow differently in EXPLAIN
 query T multiline


### PR DESCRIPTION
Make `.` in regexes match newlines, to match the default in Postgres.

Note that this is on top of https://github.com/MaterializeInc/materialize/pull/26183, so just the last 2 commits are new.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/26188

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
