### PR TITLE
storage: fix dyncfg updates for future clusters

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -147,7 +147,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
         enable_dependency_read_hold_asserts: config.enable_dependency_read_hold_asserts(),
         user_storage_managed_collections_batch_duration: config
             .user_storage_managed_collections_batch_duration(),
-        dyncfg_updates: Some(config.dyncfg_updates()),
+        dyncfg_updates: config.dyncfg_updates(),
     }
 }
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -264,9 +264,7 @@ where
     fn update_parameters(&mut self, config_params: StorageParameters) {
         // We serialize the dyncfg updates in StorageParameters, but configure
         // persist separately.
-        if let Some(updates) = &config_params.dyncfg_updates {
-            updates.apply(self.persist.cfg());
-        }
+        config_params.dyncfg_updates.apply(self.persist.cfg());
 
         for client in self.clients.values_mut() {
             client.send(StorageCommand::UpdateConfiguration(config_params.clone()));

--- a/src/storage-types/src/configuration.rs
+++ b/src/storage-types/src/configuration.rs
@@ -60,12 +60,10 @@ impl StorageConfiguration {
         &self.config_set
     }
 
-    pub fn update(&mut self, mut parameters: StorageParameters) {
+    pub fn update(&mut self, parameters: StorageParameters) {
         // We serialize the dyncfg updates in StorageParameters, but store the config set
         // top-level. Eventually, all of `StorageParameters` goes away.
-        if let Some(updates) = parameters.dyncfg_updates.take() {
-            updates.apply(&self.config_set);
-        }
+        parameters.dyncfg_updates.apply(&self.config_set);
         self.parameters.update(parameters);
     }
 }


### PR DESCRIPTION
I was being wrong with this option:

Roshan found #26189, and https://github.com/MaterializeInc/materialize/pull/26131 made me realize that future clusters wont get the new updates. 
### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
