### PR TITLE
adapter: Make fencing more robust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3867,7 +3867,6 @@ dependencies = [
  "mz-sql",
  "mz-sql-parser",
  "mz-stash",
- "mz-stash-types",
  "mz-storage-client",
  "mz-storage-types",
  "once_cell",

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -624,7 +624,12 @@ impl Catalog {
     }
 
     pub async fn allocate_user_id(&self) -> Result<GlobalId, Error> {
-        self.storage().await.allocate_user_id().await.err_into()
+        self.storage()
+            .await
+            .allocate_user_id()
+            .await
+            .maybe_terminate("allocating user ids")
+            .err_into()
     }
 
     #[cfg(test)]
@@ -634,6 +639,7 @@ impl Catalog {
             .await
             .allocate_system_ids(1)
             .await
+            .maybe_terminate("allocating system ids")
             .map(|ids| ids.into_element())
             .err_into()
     }
@@ -643,6 +649,7 @@ impl Catalog {
             .await
             .allocate_user_cluster_id()
             .await
+            .maybe_terminate("allocating user cluster ids")
             .err_into()
     }
 
@@ -651,6 +658,7 @@ impl Catalog {
             .await
             .allocate_user_replica_id()
             .await
+            .maybe_terminate("allocating user replica ids")
             .err_into()
     }
 
@@ -1076,7 +1084,10 @@ impl Catalog {
         let mut builtin_table_updates = vec![];
         let mut audit_events = vec![];
         let mut storage = self.storage().await;
-        let mut tx = storage.transaction().await?;
+        let mut tx = storage
+            .transaction()
+            .await
+            .unwrap_or_terminate("starting catalog transaction");
         // Prepare a candidate catalog state.
         let mut state = self.state.clone();
 

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -266,7 +266,7 @@ pub fn describe(
 
 pub trait ResultExt<T> {
     /// Like [`Result::expect`], but terminates the process with `halt` instead
-    /// of `panic` if the underlying error is a condition that should halt the
+    /// of `panic` if the underlying error is a condition that should halt,
     /// rather than panic the process.
     fn unwrap_or_terminate(self, context: &str) -> T;
 

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -41,7 +41,6 @@ mz-secrets = { path = "../secrets" }
 mz-sql = { path = "../sql" }
 mz-sql-parser = { path = "../sql-parser" }
 mz-stash = { path = "../stash" }
-mz-stash-types = { path = "../stash-types" }
 mz-storage-client = { path = "../storage-client" }
 mz-storage-types = { path = "../storage-types" }
 paste = "1.0.11"

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -258,13 +258,6 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         Ok(GlobalId::User(id))
     }
 
-    /// Allocates and returns a system [`ClusterId`].
-    async fn allocate_system_cluster_id(&mut self) -> Result<ClusterId, CatalogError> {
-        let id = self.allocate_id(SYSTEM_CLUSTER_ID_ALLOC_KEY, 1).await?;
-        let id = id.into_element();
-        Ok(ClusterId::System(id))
-    }
-
     /// Allocates and returns a user [`ClusterId`].
     async fn allocate_user_cluster_id(&mut self) -> Result<ClusterId, CatalogError> {
         let id = self.allocate_id(USER_CLUSTER_ID_ALLOC_KEY, 1).await?;


### PR DESCRIPTION
Previously, there were a couple of places in the code where the adapter should have halted in response to a fence error from the catalog, but instead was returning a user error. This commit fixes those spots by halting the adapter in response to a fencing error from the catalog.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
