### PR TITLE
storage/mysql: Switch back to upstream mysql-async and mysql-common crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,8 +217,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "zstd 0.13.0",
- "zstd-safe 7.0.0",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -3475,8 +3475,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_async"
-version = "0.33.0"
-source = "git+https://github.com/MaterializeInc/mysql_async.git?rev=5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc#5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfe87d7e35cb72363326216cc1712b865d8d4f70abf3b2d2e6b251fb6b2f427"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -3509,9 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_common"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06f19e4cfa0ab5a76b627cec2d81331c49b034988eaf302c3bafeada684eadef"
+checksum = "8a60cb978c0a1d654edcc1460f8d6092dacf21346ed6017d81fb76a23ef5a8de"
 dependencies = [
  "base64 0.21.5",
  "bindgen",
@@ -3539,7 +3540,7 @@ dependencies = [
  "subprocess",
  "thiserror",
  "uuid",
- "zstd 0.12.4",
+ "zstd",
 ]
 
 [[package]]
@@ -10226,6 +10227,8 @@ dependencies = [
  "url",
  "uuid",
  "zeroize",
+ "zstd",
+ "zstd-safe",
  "zstd-sys",
 ]
 
@@ -10279,30 +10282,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe 6.0.6",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
- "zstd-safe 7.0.0",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,10 +192,6 @@ postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres" }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
 
-# Waiting on https://github.com/blackbeam/mysql_async/pull/288 and
-# https://github.com/blackbeam/mysql_async/pull/289
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc" }
-
 # Waiting on https://github.com/MaterializeInc/serde-value/pull/35.
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -106,6 +106,16 @@ who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
 delta = "1.0.0 -> 1.0.0@git:df1440c8b93a192d50470d1b258615febe52f1f8"
 
+[[audits.mysql_async]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.34.1"
+
+[[audits.mysql_common]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.32.1"
+
 [[audits.nonzero_ext]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -838,10 +838,6 @@ criteria = "safe-to-deploy"
 version = "0.6.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.mysql_common]]
-version = "0.31.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.mz-avro]]
 version = "0.7.0"
 criteria = "safe-to-deploy"

--- a/src/mysql-util/Cargo.toml
+++ b/src/mysql-util/Cargo.toml
@@ -19,8 +19,8 @@ mz-ore = { path = "../ore", features = ["async"] }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-ssh-util = { path = "../ssh-util" }
-mysql_common = { version = "0.31.0", default-features = false, features = ["chrono"] }
-mysql_async = { version = "0.33.0", default-features = false, features = ["minimal", "tracing"] }
+mysql_common = { version = "0.32.1", default-features = false, features = ["chrono"] }
+mysql_async = { version = "0.34.1", default-features = false, features = ["minimal", "tracing"] }
 once_cell = "1.16.0"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/src/mysql-util/src/tunnel.rs
+++ b/src/mysql-util/src/tunnel.rs
@@ -251,7 +251,7 @@ impl Config {
                         // the TLS hostname back to the actual upstream host and not the hostname
                         // of the local SSH tunnel
                         opts_builder = opts_builder.ssl_opts(Some(
-                            ssl_opts.clone().with_tls_hostname_override(Some(
+                            ssl_opts.clone().with_danger_tls_hostname_override(Some(
                                 self.inner.ip_or_hostname().to_string(),
                             )),
                         ));
@@ -277,7 +277,7 @@ impl Config {
                         // the TLS hostname back to the actual upstream host and not the
                         // privatelink hostname.
                         opts_builder = opts_builder.ssl_opts(Some(
-                            ssl_opts.clone().with_tls_hostname_override(Some(
+                            ssl_opts.clone().with_danger_tls_hostname_override(Some(
                                 self.inner.ip_or_hostname().to_string(),
                             )),
                         ));

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -29,7 +29,7 @@ im = "15.1.0"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 maplit = "1.0.2"
-mysql_async = { version = "0.33.0", default-features = false, features = [
+mysql_async = { version = "0.34.1", default-features = false, features = [
     "minimal",
 ] }
 mz-adapter-types = { path = "../adapter-types" }

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -25,7 +25,7 @@ derivative = "2.2.0"
 differential-dataflow = "0.12.0"
 fail = { version = "0.5.1", features = ["failpoints"] }
 itertools = { version = "0.10.5" }
-mysql_async = { version = "0.33.0", default-features = false, features = ["minimal", "native-tls-tls"] }
+mysql_async = { version = "0.34.1", default-features = false, features = ["minimal", "native-tls-tls"] }
 mz-aws-util = { path = "../aws-util" }
 mz-ccsr = { path = "../ccsr" }
 mz-cloud-resources = { path = "../cloud-resources" }

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -1376,8 +1376,9 @@ impl MySqlConnection<InlinedConnection> {
         ) {
             if let Some(tls_root_cert) = &self.tls_root_cert {
                 let tls_root_cert = tls_root_cert.get_string(secrets_reader).await?;
-                ssl_opts = ssl_opts
-                    .map(|opts| opts.with_root_cert(Some(tls_root_cert.as_bytes().to_vec())));
+                ssl_opts = ssl_opts.map(|opts| {
+                    opts.with_root_certs(vec![tls_root_cert.as_bytes().to_vec().into()])
+                });
             }
         }
 
@@ -1390,7 +1391,7 @@ impl MySqlConnection<InlinedConnection> {
             // Add client identity to SSLOpts
             ssl_opts = ssl_opts.map(|opts| {
                 opts.with_client_identity(Some(
-                    mysql_async::ClientIdentity::new_from_bytes(der).with_password(pass),
+                    mysql_async::ClientIdentity::new(der.into()).with_password(pass),
                 ))
             });
         }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -34,8 +34,8 @@ http = "0.2.8"
 indexmap = { version = "2.0.0", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
 maplit = "1.0.2"
-mysql_async = { version = "0.33.0", default-features = false, features = ["minimal", "binlog"] }
-mysql_common = { version = "0.31.0", default-features = false, features = ["chrono"] }
+mysql_async = { version = "0.34.1", default-features = false, features = ["minimal", "binlog"] }
+mysql_common = { version = "0.32.1", default-features = false, features = ["chrono"] }
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util", features = ["s3"] }
 mz-build-info = { path = "../build-info" }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -33,7 +33,7 @@ junit-report = "0.8.3"
 once_cell = "1.16.0"
 maplit = "1.0.2"
 md-5 = "0.10.5"
-mysql_async = { version = "0.33.0",  default-features = false, features = ["minimal"] }
+mysql_async = { version = "0.34.1",  default-features = false, features = ["minimal"] }
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util", features = ["s3"] }
 mz-build-info = { path = "../build-info" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -68,8 +68,8 @@ log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.11", features = ["net", "os-ext"] }
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
-mysql_common = { version = "0.31.0", default-features = false, features = ["binlog", "chrono"] }
+mysql_async = { version = "0.34.1", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
+mysql_common = { version = "0.32.1", default-features = false, features = ["binlog", "chrono"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
@@ -130,6 +130,8 @@ unicode-normalization = { version = "0.1.23" }
 url = { version = "2.5.0", features = ["serde"] }
 uuid = { version = "1.7.0", features = ["serde", "v4", "v5"] }
 zeroize = { version = "1.5.7", features = ["serde"] }
+zstd = { version = "0.13.0" }
+zstd-safe = { version = "7.0.0", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2.0.9", features = ["std"] }
 
 [build-dependencies]
@@ -188,8 +190,8 @@ log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["use_std"] }
 mime_guess = { version = "2.0.3" }
 mio = { version = "0.8.11", features = ["net", "os-ext"] }
-mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git", rev = "5524ad80740334e51e49b6c0c3b06bbcc1dfe8dc", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
-mysql_common = { version = "0.31.0", default-features = false, features = ["binlog", "chrono"] }
+mysql_async = { version = "0.34.1", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
+mysql_common = { version = "0.32.1", default-features = false, features = ["binlog", "chrono"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
@@ -251,6 +253,8 @@ unicode-normalization = { version = "0.1.23" }
 url = { version = "2.5.0", features = ["serde"] }
 uuid = { version = "1.7.0", features = ["serde", "v4", "v5"] }
 zeroize = { version = "1.5.7", features = ["serde"] }
+zstd = { version = "0.13.0" }
+zstd-safe = { version = "7.0.0", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2.0.9", features = ["std"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Our upstream PRs were merged and new versions issued for the repos https://github.com/blackbeam/mysql_async and https://github.com/blackbeam/rust_mysql_common , so we can stop using our fork of `mysql-async`.

This will also allow us to work on #24630 since our [PR](https://github.com/blackbeam/rust_mysql_common/pull/126) to expose flags on the rows-events received from mysql is available in the new version.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
