### PR TITLE
dyncfg: deduplicate updates in ConfigUpdates::extend

### DIFF
--- a/src/dyncfg/src/dyncfg.proto
+++ b/src/dyncfg/src/dyncfg.proto
@@ -21,7 +21,8 @@ package mz_dyncfg;
 // Intentionally not named with the usual Proto prefix because we pass this
 // around directly.
 message ConfigUpdates {
-    repeated ProtoConfigVal updates = 1;
+    map<string, ProtoConfigVal> updates = 2;
+    reserved 1;
 }
 
 
@@ -29,7 +30,6 @@ message ConfigUpdates {
 //
 // This may be sent across processes, but may not be durably written down.
 message ProtoConfigVal {
-    string name = 1;
     oneof val {
         bool bool = 2;
         uint32 u32 = 6;
@@ -38,6 +38,7 @@ message ProtoConfigVal {
         string string = 4;
         mz_proto.ProtoDuration duration = 5;
     }
+    reserved 1;
 }
 
 message ProtoOptionU64 {

--- a/src/dyncfg/src/lib.rs
+++ b/src/dyncfg/src/lib.rs
@@ -281,10 +281,12 @@ impl ConfigUpdates {
     /// If a value of the same config has previously been added to these
     /// updates, replaces it.
     pub fn add(&mut self, config: &ConfigEntry) {
-        self.updates.push(ProtoConfigVal {
-            name: config.name.to_owned(),
-            val: config.val.into_proto(),
-        });
+        self.updates.insert(
+            config.name.to_owned(),
+            ProtoConfigVal {
+                val: config.val.into_proto(),
+            },
+        );
     }
 
     /// Adds the entries in `other` to `self`, with `other` taking precedence.
@@ -306,7 +308,7 @@ impl ConfigUpdates {
             T::set(dst, T::get(src))
         }
 
-        for ProtoConfigVal { name, val } in self.updates.iter() {
+        for (name, ProtoConfigVal { val }) in self.updates.iter() {
             let Some(config) = set.configs.get(name) else {
                 error!("config update {} {:?} not known set: {:?}", name, val, set);
                 continue;
@@ -594,5 +596,41 @@ mod tests {
         assert_eq!(USIZE.get(&c1), 3);
         updates.apply(&c1);
         assert_eq!(USIZE.get(&c1), 2);
+    }
+
+    #[mz_ore::test]
+    fn config_updates_extend() {
+        // Regression test for #26196.
+        //
+        // Construct two ConfigUpdates with overlapping, but not identical, sets
+        // of configs. Combine them and assert that the expected number of
+        // updates is present.
+        let mut u1 = {
+            let c = ConfigSet::default().add(&USIZE).add(&STRING);
+            let mut x = ConfigUpdates::default();
+            for e in c.entries() {
+                x.add(e);
+            }
+            x
+        };
+        let u2 = {
+            let c = ConfigSet::default().add(&USIZE).add(&DURATION);
+            usize::set(usize::shared(&USIZE, &c).unwrap(), 2);
+            let mut x = ConfigUpdates::default();
+            for e in c.entries() {
+                x.add(e);
+            }
+            x
+        };
+        assert_eq!(u1.updates.len(), 2);
+        assert_eq!(u2.updates.len(), 2);
+        u1.extend(u2);
+        assert_eq!(u1.updates.len(), 3);
+
+        // Assert that extend kept the correct (later) value for the overlapping
+        // config.
+        let c = ConfigSet::default().add(&USIZE);
+        u1.apply(&c);
+        assert_eq!(USIZE.get(&c), 2);
     }
 }


### PR DESCRIPTION
This is causing a slow memory leak in both the storage and compute controllers. (Also it seems like a good thing to do.)

The original reason for the vec instead of the map was [to save a level of nesting in the proto encoding](https://github.com/MaterializeInc/materialize/pull/24416#discussion_r1454035582), so no particular stress about switching back to the map.

Closes #26196

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
