### PR TITLE
cloudtest: Make copy-to-s3 with minio work

### DIFF
--- a/misc/python/materialize/checks/all_checks/copy_to_s3.py
+++ b/misc/python/materialize/checks/all_checks/copy_to_s3.py
@@ -25,8 +25,8 @@ class CopyToS3(Check):
         return Testdrive(
             dedent(
                 """
-                > CREATE SECRET minio AS 'minioadmin'
-                > CREATE CONNECTION aws_conn1 TO AWS (ENDPOINT 'http://minio:9000/', REGION 'minio', ACCESS KEY ID 'minioadmin', SECRET ACCESS KEY SECRET minio)
+                > CREATE SECRET minio AS '${arg.aws-secret-access-key}'
+                > CREATE CONNECTION aws_conn1 TO AWS (ENDPOINT '${arg.aws-endpoint}', REGION 'us-east-1', ACCESS KEY ID '${arg.aws-access-key-id}', SECRET ACCESS KEY SECRET minio)
                 > COPY (SELECT 1, 2, 3) TO 's3://copytos3/key1' WITH (AWS CONNECTION = aws_conn1, FORMAT = 'csv');
                 """
             )
@@ -37,12 +37,12 @@ class CopyToS3(Check):
             Testdrive(dedent(s))
             for s in [
                 """
-                > CREATE CONNECTION aws_conn2 TO AWS (ENDPOINT 'http://minio:9000/', REGION 'minio', ACCESS KEY ID 'minioadmin', SECRET ACCESS KEY SECRET minio)
+                > CREATE CONNECTION aws_conn2 TO AWS (ENDPOINT '${arg.aws-endpoint}', REGION 'us-east-1', ACCESS KEY ID '${arg.aws-access-key-id}', SECRET ACCESS KEY SECRET minio)
                 > COPY (SELECT 11, 12, 13) TO 's3://copytos3/key11' WITH (AWS CONNECTION = aws_conn1, FORMAT = 'csv');
                 > COPY (SELECT 11, 12, 13) TO 's3://copytos3/key12' WITH (AWS CONNECTION = aws_conn2, FORMAT = 'csv');
                 """,
                 """
-                > CREATE CONNECTION aws_conn3 TO AWS (ENDPOINT 'http://minio:9000/', REGION 'minio', ACCESS KEY ID 'minioadmin', SECRET ACCESS KEY SECRET minio)
+                > CREATE CONNECTION aws_conn3 TO AWS (ENDPOINT '${arg.aws-endpoint}', REGION 'us-east-1', ACCESS KEY ID '${arg.aws-access-key-id}', SECRET ACCESS KEY SECRET minio)
                 > COPY (SELECT 21, 22, 23) TO 's3://copytos3/key21' WITH (AWS CONNECTION = aws_conn1, FORMAT = 'csv');
                 > COPY (SELECT 21, 22, 23) TO 's3://copytos3/key22' WITH (AWS CONNECTION = aws_conn2, FORMAT = 'csv');
                 > COPY (SELECT 21, 22, 23) TO 's3://copytos3/key23' WITH (AWS CONNECTION = aws_conn3, FORMAT = 'csv');

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -42,7 +42,7 @@ class TestdriveBase:
         )
         self.kafka_addr = kafka_addr or "redpanda:9092"
         self.schema_registry_url = schema_registry_url or "http://redpanda:8081"
-        self.aws_endpoint = "http://minio:9000"
+        self.aws_endpoint = "http://minio-service.default:9000"
 
     def run(
         self,
@@ -73,10 +73,10 @@ class TestdriveBase:
                 [
                     f"--aws-endpoint={self.aws_endpoint}",
                     f"--var=aws-endpoint={self.aws_endpoint}",
-                    "--aws-access-key-id=minioadmin",
-                    "--var=aws-access-key-id=minioadmin",
-                    "--aws-secret-access-key=minioadmin",
-                    "--var=aws-secret-access-key=minioadmin",
+                    "--aws-access-key-id=minio",
+                    "--var=aws-access-key-id=minio",
+                    "--aws-secret-access-key=minio123",
+                    "--var=aws-secret-access-key=minio123",
                 ]
                 if not self.aws_region
                 else []

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -188,13 +188,10 @@ def td(c: Composition, *args: str) -> None:
                         f"sasl.password={CONFLUENT_API_SECRET}",
                     ]
                 ),
-                "VAR="
-                + ",".join(
-                    [
-                        f"confluent-api-key={CONFLUENT_API_KEY}",
-                        f"confluent-api-secret={CONFLUENT_API_SECRET}",
-                    ]
-                ),
+            ],
+            entrypoint_extra=[
+                f"--var=confluent-api-key={CONFLUENT_API_KEY}",
+                f"--var=confluent-api-secret={CONFLUENT_API_SECRET}",
             ],
         )
     ):

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -19,7 +19,6 @@ from materialize.checks.all_checks.alter_connection import (
     AlterConnectionToNonSsh,
     AlterConnectionToSsh,
 )
-from materialize.checks.all_checks.copy_to_s3 import CopyToS3
 from materialize.checks.all_checks.kafka_protocols import KafkaProtocols
 from materialize.checks.checks import Check
 from materialize.checks.cloudtest_actions import (
@@ -79,7 +78,6 @@ def test_upgrade(aws_region: str | None, log_filter: str | None, dev: bool) -> N
     executor = CloudtestExecutor(application=mz, version=last_released_version)
     # KafkaProtocols: No shared secrets directory
     # AlterConnection*: No second SSH host (other_ssh_bastion) set up
-    # CopyToS3: No minio running
     checks = list(
         all_subclasses(Check)
         - {
@@ -87,7 +85,6 @@ def test_upgrade(aws_region: str | None, log_filter: str | None, dev: bool) -> N
             AlterConnectionToSsh,
             AlterConnectionToNonSsh,
             AlterConnectionHost,
-            CopyToS3,
         }
     )
     scenario = CloudtestUpgrade(checks=checks, executor=executor)


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/7000

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
