### PR TITLE
sql: refactor REDACTED logic for `WITH` options

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use enum_kinds::EnumKind;
 use serde::{Deserialize, Serialize};
 
-use crate::ast::display::{self, AstDisplay, AstFormatter};
+use crate::ast::display::{self, AstDisplay, AstFormatter, WithOptionName};
 use crate::ast::{
     AstInfo, ColumnDef, ConnectionOption, ConnectionOptionName, CreateConnectionOption,
     CreateConnectionType, CreateSinkConnection, CreateSourceConnection, CreateSourceFormat,
@@ -374,21 +374,32 @@ impl AstDisplay for CopyOptionName {
     }
 }
 
+impl WithOptionName for CopyOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            CopyOptionName::Format
+            | CopyOptionName::Delimiter
+            | CopyOptionName::Null
+            | CopyOptionName::Escape
+            | CopyOptionName::Quote
+            | CopyOptionName::Header
+            | CopyOptionName::AwsConnection
+            | CopyOptionName::MaxFileSize => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CopyOption<T: AstInfo> {
     pub name: CopyOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for CopyOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(CopyOption);
 
 /// `COPY`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -618,21 +629,25 @@ impl AstDisplay for KafkaBrokerAwsPrivatelinkOptionName {
 }
 impl_display!(KafkaBrokerAwsPrivatelinkOptionName);
 
+impl WithOptionName for KafkaBrokerAwsPrivatelinkOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            Self::AvailabilityZone | Self::Port => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct KafkaBrokerAwsPrivatelinkOption<T: AstInfo> {
     pub name: KafkaBrokerAwsPrivatelinkOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for KafkaBrokerAwsPrivatelinkOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(value) = &self.value {
-            f.write_str(" ");
-            f.write_node(value);
-        }
-    }
-}
+impl_display_for_with_option!(KafkaBrokerAwsPrivatelinkOption);
 impl_display_t!(KafkaBrokerAwsPrivatelinkOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -1086,21 +1101,25 @@ impl AstDisplay for CreateSubsourceOptionName {
     }
 }
 
+impl WithOptionName for CreateSubsourceOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            CreateSubsourceOptionName::Progress | CreateSubsourceOptionName::References => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateSubsourceOption<T: AstInfo> {
     pub name: CreateSubsourceOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for CreateSubsourceOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(CreateSubsourceOption);
 
 /// `CREATE SUBSOURCE`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1152,21 +1171,25 @@ impl AstDisplay for CreateSinkOptionName {
     }
 }
 
+impl WithOptionName for CreateSinkOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            CreateSinkOptionName::Snapshot => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateSinkOption<T: AstInfo> {
     pub name: CreateSinkOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for CreateSinkOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(CreateSinkOption);
 
 /// `CREATE SINK`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1419,21 +1442,25 @@ impl AstDisplay for TableOptionName {
     }
 }
 
+impl WithOptionName for TableOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            TableOptionName::RetainHistory => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableOption<T: AstInfo> {
     pub name: TableOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for TableOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(TableOption);
 
 /// `CREATE INDEX`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1502,21 +1529,25 @@ impl AstDisplay for IndexOptionName {
     }
 }
 
+impl WithOptionName for IndexOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            IndexOptionName::RetainHistory => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct IndexOption<T: AstInfo> {
     pub name: IndexOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for IndexOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(IndexOption);
 
 /// A `CREATE ROLE` statement.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1716,22 +1747,34 @@ impl AstDisplay for ClusterOptionName {
     }
 }
 
+impl WithOptionName for ClusterOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            ClusterOptionName::AvailabilityZones
+            | ClusterOptionName::Disk
+            | ClusterOptionName::IdleArrangementMergeEffort
+            | ClusterOptionName::IntrospectionDebugging
+            | ClusterOptionName::IntrospectionInterval
+            | ClusterOptionName::Managed
+            | ClusterOptionName::Replicas
+            | ClusterOptionName::ReplicationFactor
+            | ClusterOptionName::Size => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// An option in a `CREATE CLUSTER` statement.
 pub struct ClusterOption<T: AstInfo> {
     pub name: ClusterOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for ClusterOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(ClusterOption);
 
 // Note: the `AstDisplay` implementation and `Parser::parse_` method for this
 // enum are generated automatically by this crate's `build.rs`.
@@ -1744,21 +1787,29 @@ pub enum ClusterFeatureName {
     EnableVariadicLeftJoinLowering,
 }
 
+impl WithOptionName for ClusterFeatureName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            ClusterFeatureName::ReoptimizeImportedViews
+            | ClusterFeatureName::EnableNewOuterJoinLowering
+            | ClusterFeatureName::EnableEagerDeltaJoins
+            | ClusterFeatureName::EnableEquivalencePropagation
+            | ClusterFeatureName::EnableVariadicLeftJoinLowering => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ClusterFeature<T: AstInfo> {
     pub name: ClusterFeatureName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for ClusterFeature<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(ClusterFeature);
 
 /// `CREATE CLUSTER ..`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1924,22 +1975,38 @@ impl AstDisplay for ReplicaOptionName {
     }
 }
 
+impl WithOptionName for ReplicaOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            ReplicaOptionName::BilledAs
+            | ReplicaOptionName::Size
+            | ReplicaOptionName::AvailabilityZone
+            | ReplicaOptionName::StorageAddresses
+            | ReplicaOptionName::StoragectlAddresses
+            | ReplicaOptionName::ComputectlAddresses
+            | ReplicaOptionName::ComputeAddresses
+            | ReplicaOptionName::Workers
+            | ReplicaOptionName::Internal
+            | ReplicaOptionName::IntrospectionInterval
+            | ReplicaOptionName::IntrospectionDebugging
+            | ReplicaOptionName::IdleArrangementMergeEffort
+            | ReplicaOptionName::Disk => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 /// An option in a `CREATE CLUSTER REPLICA` statement.
 pub struct ReplicaOption<T: AstInfo> {
     pub name: ReplicaOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for ReplicaOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(ReplicaOption);
 
 /// `CREATE TYPE .. AS <TYPE>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1979,21 +2046,25 @@ impl AstDisplay for CreateTypeListOptionName {
     }
 }
 
+impl WithOptionName for CreateTypeListOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            CreateTypeListOptionName::ElementType => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateTypeListOption<T: AstInfo> {
     pub name: CreateTypeListOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for CreateTypeListOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(CreateTypeListOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CreateTypeMapOptionName {
@@ -2010,21 +2081,25 @@ impl AstDisplay for CreateTypeMapOptionName {
     }
 }
 
+impl WithOptionName for CreateTypeMapOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            CreateTypeMapOptionName::KeyType | CreateTypeMapOptionName::ValueType => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateTypeMapOption<T: AstInfo> {
     pub name: CreateTypeMapOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for CreateTypeMapOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(CreateTypeMapOption);
 
 /// `ALTER <OBJECT> ... OWNER TO`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2217,22 +2292,26 @@ impl AstDisplay for AlterSourceAddSubsourceOptionName {
 }
 impl_display!(AlterSourceAddSubsourceOptionName);
 
+impl WithOptionName for AlterSourceAddSubsourceOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            AlterSourceAddSubsourceOptionName::TextColumns => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// An option in an `ALTER SOURCE...ADD SUBSOURCE` statement.
 pub struct AlterSourceAddSubsourceOption<T: AstInfo> {
     pub name: AlterSourceAddSubsourceOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for AlterSourceAddSubsourceOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(AlterSourceAddSubsourceOption);
 impl_display_t!(AlterSourceAddSubsourceOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2382,22 +2461,26 @@ impl AstDisplay for AlterConnectionOptionName {
 }
 impl_display!(AlterConnectionOptionName);
 
+impl WithOptionName for AlterConnectionOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            AlterConnectionOptionName::Validate => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// An option in an `ALTER CONNECTION...` statement.
 pub struct AlterConnectionOption<T: AstInfo> {
     pub name: AlterConnectionOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for AlterConnectionOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(AlterConnectionOption);
 impl_display_t!(AlterConnectionOption);
 
 /// `ALTER CONNECTION`
@@ -3017,21 +3100,25 @@ impl AstDisplay for SubscribeOptionName {
 }
 impl_display!(SubscribeOptionName);
 
+impl WithOptionName for SubscribeOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            SubscribeOptionName::Snapshot | SubscribeOptionName::Progress => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SubscribeOption<T: AstInfo> {
     pub name: SubscribeOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for SubscribeOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(SubscribeOption);
 impl_display_t!(SubscribeOption);
 
 /// `SUBSCRIBE`
@@ -3141,21 +3228,48 @@ pub enum ExplainPlanOptionName {
     EnableVariadicLeftJoinLowering,
 }
 
+impl WithOptionName for ExplainPlanOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            Self::Arity
+            | Self::Cardinality
+            | Self::ColumnNames
+            | Self::FilterPushdown
+            | Self::HumanizedExpressions
+            | Self::JoinImplementations
+            | Self::Keys
+            | Self::LinearChains
+            | Self::NonNegative
+            | Self::NoFastPath
+            | Self::NoNotices
+            | Self::NodeIdentifiers
+            | Self::RawPlans
+            | Self::RawSyntax
+            | Self::Raw
+            | Self::Redacted
+            | Self::SubtreeSize
+            | Self::Timing
+            | Self::Types
+            | Self::ReoptimizeImportedViews
+            | Self::EnableNewOuterJoinLowering
+            | Self::EnableEagerDeltaJoins
+            | Self::EnableEquivalencePropagation
+            | Self::EnableVariadicLeftJoinLowering => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ExplainPlanOption<T: AstInfo> {
     pub name: ExplainPlanOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for ExplainPlanOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(ExplainPlanOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ExplainSinkSchemaFor {
@@ -3832,21 +3946,25 @@ impl AstDisplay for FetchOptionName {
     }
 }
 
+impl WithOptionName for FetchOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            FetchOptionName::Timeout => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FetchOption<T: AstInfo> {
     pub name: FetchOptionName,
     pub value: Option<WithOptionValue<T>>,
 }
-
-impl<T: AstInfo> AstDisplay for FetchOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.name);
-        if let Some(v) = &self.value {
-            f.write_str(" = ");
-            f.write_node(v);
-        }
-    }
-}
+impl_display_for_with_option!(FetchOption);
 
 /// `FETCH ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3336,7 +3336,6 @@ impl_display_t!(ShowStatementFilter);
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum WithOptionValue<T: AstInfo> {
     Value(Value),
-    Ident(Ident),
     DataType(T::DataType),
     Secret(T::ItemName),
     Item(T::ItemName),
@@ -3362,19 +3361,16 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
                 | WithOptionValue::Refresh(_) => {
                     // These are redact-aware.
                 }
+                WithOptionValue::Secret(_) | WithOptionValue::ConnectionKafkaBroker(_) => {
+                    f.write_str("'<REDACTED>'");
+                    return;
+                }
                 WithOptionValue::DataType(_)
                 | WithOptionValue::Item(_)
                 | WithOptionValue::UnresolvedItemName(_)
                 | WithOptionValue::ConnectionAwsPrivatelink(_)
                 | WithOptionValue::ClusterReplicas(_) => {
-
                     // These do not need redaction.
-                }
-                WithOptionValue::Secret(_)
-                | WithOptionValue::ConnectionKafkaBroker(_)
-                | WithOptionValue::Ident(_) => {
-                    f.write_str("'<REDACTED>'");
-                    return;
                 }
             }
         }
@@ -3385,9 +3381,6 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
                 f.write_str(")");
             }
             WithOptionValue::Value(value) => f.write_node(value),
-            WithOptionValue::Ident(id) => {
-                f.write_node(id);
-            }
             WithOptionValue::DataType(typ) => f.write_node(typ),
             WithOptionValue::Secret(name) => {
                 f.write_str("SECRET ");

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1430,6 +1430,8 @@ impl_display_t!(CreateTableStatement);
 pub enum TableOptionName {
     // The `RETAIN HISTORY` option
     RetainHistory,
+    /// A special option to test that we do redact values.
+    RedactedTest,
 }
 
 impl AstDisplay for TableOptionName {
@@ -1437,6 +1439,9 @@ impl AstDisplay for TableOptionName {
         match self {
             TableOptionName::RetainHistory => {
                 f.write_str("RETAIN HISTORY");
+            }
+            TableOptionName::RedactedTest => {
+                f.write_str("REDACTED");
             }
         }
     }
@@ -1451,6 +1456,7 @@ impl WithOptionName for TableOptionName {
     fn redact_value(&self) -> bool {
         match self {
             TableOptionName::RetainHistory => false,
+            TableOptionName::RedactedTest => true,
         }
     }
 }

--- a/src/sql-parser/src/ast/display.rs
+++ b/src/sql-parser/src/ast/display.rs
@@ -117,6 +117,28 @@ where
         self.mode == FormatMode::SimpleRedacted
     }
 
+    /// Sets the current mode to a compatible version that does not redact
+    /// values; returns the current mode, which should be reset when the
+    /// unredacted printing is complete using [`Self::set_mode`].
+    ///
+    /// Note that this is the simplest means of unredacting values opt-out
+    /// rather than opt-in. We must monitor usage of this API carefully to
+    /// ensure we don't end up leaking values.
+    pub fn unredact(&mut self) -> FormatMode {
+        match self.mode {
+            FormatMode::Simple => FormatMode::Simple,
+            FormatMode::SimpleRedacted => {
+                self.mode = FormatMode::Simple;
+                FormatMode::SimpleRedacted
+            }
+            FormatMode::Stable => FormatMode::Stable,
+        }
+    }
+
+    pub fn set_mode(&mut self, mode: FormatMode) {
+        self.mode = mode;
+    }
+
     pub fn new(buf: W, mode: FormatMode) -> Self {
         AstFormatter { buf, mode }
     }
@@ -172,6 +194,76 @@ macro_rules! impl_display_t {
                 use crate::ast::display::{AstFormatter, FormatMode};
                 AstFormatter::new(f, FormatMode::Simple).write_node(self);
                 Ok(())
+            }
+        }
+    };
+}
+
+/// Functions that generalize to AST nodes representing the "name" of a `WITH`
+/// option.
+pub trait WithOptionName {
+    /// Expresses whether or not values should be redacted based on the option
+    /// name (i.e. the option's "key").
+    ///
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data.
+    ///
+    /// # Context
+    /// Many statements in MZ use the format `WITH (<options>...)` to modify the
+    /// resulting behavior of the statement. Most often these are modeled in the
+    /// AST as a struct with two fields: an option name and a value.
+    ///
+    /// We do not type check the values of the types until planning, so most
+    /// values represent arbitrary user input. To prevent leaking any PII in
+    /// that data, we default to replacing values with the string `<REDACTED>`.
+    ///
+    /// However, in some cases, the values do not need to be redacted. For our
+    /// `WITH` options, knowing which option we're dealing with should be
+    /// sufficient to understand if a value needs redaction––so this trait
+    /// controls redaction on a per-option basis.
+    ///
+    /// ## Genericizing `WITH` options
+    /// It would be nice to force every AST node we consider a `WITH` option to
+    /// conform to a particular structure––however, we have a proc macro that
+    /// generates visitors over all of our nodes that inhibits our ability to do
+    /// this easily. This means, unfortunately, that we cannot rely on
+    /// compilation guarantees for this and instead must use the honor system.
+    ///
+    /// ## Nothing is ever redacted...
+    ///
+    /// In the initial implementation of this trait, no option requires its
+    /// values to be redacted. That doesn't mean there won't be in the future.
+    /// When in doubt, take the more conservative approach.
+    fn redact_value(&self) -> bool {
+        // We conservatively assume that all values should be redacted.
+        true
+    }
+}
+
+/// To allow `WITH` option AST nodes to be printed without redaction, you should
+/// use this macro's implementation of `AstDisplay`. For more details, consult
+/// the doc strings on the functions used on its implementation.
+macro_rules! impl_display_for_with_option {
+    ($name:ident) => {
+        impl<T: AstInfo> AstDisplay for $name<T> {
+            fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+                f.write_node(&self.name);
+                if let Some(v) = &self.value {
+                    f.write_str(" = ");
+
+                    // If the formatter is redacted, but the name does not
+                    // require setting the value to be redacted, allow the value
+                    // to be printed without redaction.
+                    if f.redacted() && !self.name.redact_value() {
+                        let mode = f.unredact();
+                        f.write_node(v);
+                        f.set_mode(mode);
+                    } else {
+                        f.write_node(v);
+                    }
+                }
             }
         }
     };

--- a/src/sql-parser/src/ast/display.rs
+++ b/src/sql-parser/src/ast/display.rs
@@ -234,8 +234,9 @@ pub trait WithOptionName {
     /// ## Nothing is ever redacted...
     ///
     /// In the initial implementation of this trait, no option requires its
-    /// values to be redacted. That doesn't mean there won't be in the future.
-    /// When in doubt, take the more conservative approach.
+    /// values to be redacted (except for the one test case). That doesn't mean
+    /// there won't be in the future. When in doubt, take the more conservative
+    /// approach.
     fn redact_value(&self) -> bool {
         // We conservatively assume that all values should be redacted.
         true

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3486,6 +3486,11 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_table_option_name(&mut self) -> Result<TableOptionName, ParserError> {
+        // this is only so we can test redacted values, of which no other
+        // examples exist as of its introduction.
+        if self.parse_keyword(REDACTED) {
+            return Ok(TableOptionName::RedactedTest);
+        }
         self.expect_keywords(&[RETAIN, HISTORY])?;
         Ok(TableOptionName::RetainHistory)
     }
@@ -3494,6 +3499,7 @@ impl<'a> Parser<'a> {
         let name = self.parse_table_option_name()?;
         let value = match name {
             TableOptionName::RetainHistory => self.parse_option_retain_history(),
+            TableOptionName::RedactedTest => self.parse_optional_option_value(),
         }?;
         Ok(TableOption { name, value })
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4311,12 +4311,14 @@ impl<'a> Parser<'a> {
             if let Some(secret) = self.maybe_parse(Parser::parse_raw_name) {
                 Ok(WithOptionValue::Secret(secret))
             } else {
-                Ok(WithOptionValue::Ident(ident!("secret")))
+                Ok(WithOptionValue::UnresolvedItemName(UnresolvedItemName(
+                    vec![ident!("secret")],
+                )))
             }
         } else if let Some(value) = self.maybe_parse(Parser::parse_value) {
             Ok(WithOptionValue::Value(value))
-        } else if let Some(ident) = self.maybe_parse(Parser::parse_identifier) {
-            Ok(WithOptionValue::Ident(ident))
+        } else if let Some(item_name) = self.maybe_parse(Parser::parse_item_name) {
+            Ok(WithOptionValue::UnresolvedItemName(item_name))
         } else {
             self.expected(self.peek_pos(), "option value", self.peek_token())
         }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2797,6 +2797,7 @@ impl<'a> Parser<'a> {
     fn parse_source_option(&mut self) -> Result<CreateSourceOption<Raw>, ParserError> {
         let name = self.parse_source_option_name()?;
         if name == CreateSourceOptionName::RetainHistory {
+            let _ = self.consume_token(&Token::Eq);
             return Ok(CreateSourceOption {
                 name,
                 value: self.parse_option_retain_history()?,
@@ -3720,6 +3721,7 @@ impl<'a> Parser<'a> {
         let name = self.parse_cluster_option_name()?;
 
         if name == ClusterOptionName::Replicas {
+            let _ = self.consume_token(&Token::Eq);
             return self.parse_cluster_option_replicas();
         }
 

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -53,21 +53,21 @@ COPY t TO STDOUT WITH (FORMAT TEXT)
 ----
 COPY t TO STDOUT WITH (FORMAT = text)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Ident(Ident("text"))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("text")]))) }] })
 
 parse-statement
 COPY t FROM STDIN WITH (FORMAT CSV, DELIMITER '|', NULL 'NULL', QUOTE '"', ESCAPE '\\', HEADER false)
 ----
 COPY t FROM STDIN WITH (FORMAT = csv, DELIMITER = '|', NULL = 'NULL', QUOTE = '"', ESCAPE = '\\', HEADER = false)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [CopyOption { name: Format, value: Some(Ident(Ident("csv"))) }, CopyOption { name: Delimiter, value: Some(Value(String("|"))) }, CopyOption { name: Null, value: Some(Value(String("NULL"))) }, CopyOption { name: Quote, value: Some(Value(String("\""))) }, CopyOption { name: Escape, value: Some(Value(String("\\\\"))) }, CopyOption { name: Header, value: Some(Value(Boolean(false))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }, CopyOption { name: Delimiter, value: Some(Value(String("|"))) }, CopyOption { name: Null, value: Some(Value(String("NULL"))) }, CopyOption { name: Quote, value: Some(Value(String("\""))) }, CopyOption { name: Escape, value: Some(Value(String("\\\\"))) }, CopyOption { name: Header, value: Some(Value(Boolean(false))) }] })
 
 parse-statement
 COPY t TO STDOUT (format = text)
 ----
 COPY t TO STDOUT WITH (FORMAT = text)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Ident(Ident("text"))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("text")]))) }] })
 
 parse-statement
 COPY t TO STDOUT ()
@@ -104,7 +104,7 @@ COPY t TO 's3://path/' WITH (FORMAT = csv, MAX FILE SIZE = 10240, AWS CONNECTION
 ----
 COPY t TO 's3://path/' WITH (FORMAT = csv, MAX FILE SIZE = 10240, AWS CONNECTION = aws_conn)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Value(String("s3://path/"))), options: [CopyOption { name: Format, value: Some(Ident(Ident("csv"))) }, CopyOption { name: MaxFileSize, value: Some(Value(Number("10240"))) }, CopyOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("aws_conn")])))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Value(String("s3://path/"))), options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }, CopyOption { name: MaxFileSize, value: Some(Value(Number("10240"))) }, CopyOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("aws_conn")])))) }] })
 
 # S3 path can be a scalar expression
 parse-statement
@@ -112,7 +112,7 @@ COPY t TO 's3://path/' || mz_now() WITH (FORMAT = csv, MAX FILE SIZE = '100MB', 
 ----
 COPY t TO 's3://path/' || mz_now() WITH (FORMAT = csv, MAX FILE SIZE = '100MB', AWS CONNECTION = aws_conn)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("s3://path/")), expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("mz_now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) }), options: [CopyOption { name: Format, value: Some(Ident(Ident("csv"))) }, CopyOption { name: MaxFileSize, value: Some(Value(String("100MB"))) }, CopyOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("aws_conn")])))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("s3://path/")), expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("mz_now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) }), options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }, CopyOption { name: MaxFileSize, value: Some(Value(String("100MB"))) }, CopyOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("aws_conn")])))) }] })
 
 parse-statement
 COPY t TO 's3://path/' || repeat('1', 2)

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -386,14 +386,14 @@ CREATE MATERIALIZED VIEW v WITH (REFRESH EVERY '1 day', ASSERT NOT NULL x) AS SE
 ----
 CREATE MATERIALIZED VIEW v WITH (REFRESH = EVERY '1 day', ASSERT NOT NULL = x) AS SELECT * FROM t
 =>
-CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("v")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [MaterializedViewOption { name: Refresh, value: Some(Refresh(Every(RefreshEveryOptionValue { interval: IntervalValue { value: "1 day", precision_high: Year, precision_low: Second, fsec_max_precision: None }, aligned_to: None }))) }, MaterializedViewOption { name: AssertNotNull, value: Some(Ident(Ident("x"))) }] })
+CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("v")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [MaterializedViewOption { name: Refresh, value: Some(Refresh(Every(RefreshEveryOptionValue { interval: IntervalValue { value: "1 day", precision_high: Year, precision_low: Second, fsec_max_precision: None }, aligned_to: None }))) }, MaterializedViewOption { name: AssertNotNull, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("x")]))) }] })
 
 parse-statement
 CREATE OR REPLACE MATERIALIZED VIEW v IN CLUSTER [1] WITH (REFRESH EVERY '1 day' ALIGNED TO '2023-12-11 11:00', ASSERT NOT NULL x, REFRESH AT mz_now(), REFRESH ON COMMIT, REFRESH = AT CREATION) AS SELECT * FROM t;
 ----
 CREATE OR REPLACE MATERIALIZED VIEW v IN CLUSTER [1] WITH (REFRESH = EVERY '1 day' ALIGNED TO '2023-12-11 11:00', ASSERT NOT NULL = x, REFRESH = AT mz_now(), REFRESH = ON COMMIT, REFRESH = AT CREATION) AS SELECT * FROM t
 =>
-CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Replace, name: UnresolvedItemName([Ident("v")]), columns: [], in_cluster: Some(Resolved("1")), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [MaterializedViewOption { name: Refresh, value: Some(Refresh(Every(RefreshEveryOptionValue { interval: IntervalValue { value: "1 day", precision_high: Year, precision_low: Second, fsec_max_precision: None }, aligned_to: Some(Value(String("2023-12-11 11:00"))) }))) }, MaterializedViewOption { name: AssertNotNull, value: Some(Ident(Ident("x"))) }, MaterializedViewOption { name: Refresh, value: Some(Refresh(At(RefreshAtOptionValue { time: Function(Function { name: Name(UnresolvedItemName([Ident("mz_now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }) }))) }, MaterializedViewOption { name: Refresh, value: Some(Refresh(OnCommit)) }, MaterializedViewOption { name: Refresh, value: Some(Refresh(AtCreation)) }] })
+CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Replace, name: UnresolvedItemName([Ident("v")]), columns: [], in_cluster: Some(Resolved("1")), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [MaterializedViewOption { name: Refresh, value: Some(Refresh(Every(RefreshEveryOptionValue { interval: IntervalValue { value: "1 day", precision_high: Year, precision_low: Second, fsec_max_precision: None }, aligned_to: Some(Value(String("2023-12-11 11:00"))) }))) }, MaterializedViewOption { name: AssertNotNull, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("x")]))) }, MaterializedViewOption { name: Refresh, value: Some(Refresh(At(RefreshAtOptionValue { time: Function(Function { name: Name(UnresolvedItemName([Ident("mz_now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }) }))) }, MaterializedViewOption { name: Refresh, value: Some(Refresh(OnCommit)) }, MaterializedViewOption { name: Refresh, value: Some(Refresh(AtCreation)) }] })
 
 parse-statement roundtrip
 CREATE OR REPLACE MATERIALIZED VIEW v WITH (ASSERT NOT NULL a, ASSERT NOT NULL = b, RETAIN HISTORY = FOR '1s') AS SELECT 1
@@ -454,7 +454,7 @@ CREATE CONNECTION pgconn FOR postgres HOST foo, PORT 1234, SSL CERTIFICATE AUTHO
 ----
 CREATE CONNECTION pgconn TO POSTGRES (HOST = foo, PORT = 1234, SSL CERTIFICATE AUTHORITY = 'foo', SSH TUNNEL = tun, DATABASE = 'db', PASSWORD = 'pw', SSL CERTIFICATE = 'cert', SSL KEY = 'key', SSL MODE = 'mode', USER = 'postgres')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection_type: Postgres, if_not_exists: false, values: [ConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, ConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("tun")])))) }, ConnectionOption { name: Database, value: Some(Value(String("db"))) }, ConnectionOption { name: Password, value: Some(Value(String("pw"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }, ConnectionOption { name: SslMode, value: Some(Value(String("mode"))) }, ConnectionOption { name: User, value: Some(Value(String("postgres"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection_type: Postgres, if_not_exists: false, values: [ConnectionOption { name: Host, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("foo")]))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, ConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("tun")])))) }, ConnectionOption { name: Database, value: Some(Value(String("db"))) }, ConnectionOption { name: Password, value: Some(Value(String("pw"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }, ConnectionOption { name: SslMode, value: Some(Value(String("mode"))) }, ConnectionOption { name: User, value: Some(Value(String("postgres"))) }], with_options: [] })
 
 parse-statement
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK db.schema.item, PORT 1234)
@@ -468,14 +468,14 @@ CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK db.schema.item, PORT 1234,
 ----
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK = db.schema.item, PORT = 1234, HOST = foo, SSL CERTIFICATE = 'cert', SSL CERTIFICATE AUTHORITY = 'auth', SSL KEY = 'key')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection_type: Postgres, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])), port: None })) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("auth"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection_type: Postgres, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])), port: None })) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: Host, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("foo")]))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("auth"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }], with_options: [] })
 
 parse-statement
 CREATE CONNECTION mysqlconn FOR mysql HOST foo, PORT 1234, SSL CERTIFICATE AUTHORITY 'foo', SSH TUNNEL tun, PASSWORD 'pw', SSL CERTIFICATE 'cert', SSL KEY 'key', SSL MODE 'mode', USER 'root'
 ----
 CREATE CONNECTION mysqlconn TO MYSQL (HOST = foo, PORT = 1234, SSL CERTIFICATE AUTHORITY = 'foo', SSH TUNNEL = tun, PASSWORD = 'pw', SSL CERTIFICATE = 'cert', SSL KEY = 'key', SSL MODE = 'mode', USER = 'root')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("mysqlconn")]), connection_type: MySql, if_not_exists: false, values: [ConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, ConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("tun")])))) }, ConnectionOption { name: Password, value: Some(Value(String("pw"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }, ConnectionOption { name: SslMode, value: Some(Value(String("mode"))) }, ConnectionOption { name: User, value: Some(Value(String("root"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("mysqlconn")]), connection_type: MySql, if_not_exists: false, values: [ConnectionOption { name: Host, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("foo")]))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, ConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("tun")])))) }, ConnectionOption { name: Password, value: Some(Value(String("pw"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }, ConnectionOption { name: SslMode, value: Some(Value(String("mode"))) }, ConnectionOption { name: User, value: Some(Value(String("root"))) }], with_options: [] })
 
 parse-statement
 CREATE CONNECTION mysqlconn TO MYSQL (AWS PRIVATELINK db.schema.item, PORT 1234)
@@ -489,7 +489,7 @@ CREATE CONNECTION mysqlconn TO MYSQL (AWS PRIVATELINK db.schema.item, PORT 1234,
 ----
 CREATE CONNECTION mysqlconn TO MYSQL (AWS PRIVATELINK = db.schema.item, PORT = 1234, HOST = foo, SSL CERTIFICATE = 'cert', SSL CERTIFICATE AUTHORITY = 'auth', SSL KEY = 'key')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("mysqlconn")]), connection_type: MySql, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])), port: None })) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("auth"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("mysqlconn")]), connection_type: MySql, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(ConnectionAwsPrivatelink(ConnectionDefaultAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])), port: None })) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: Host, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("foo")]))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("auth"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }], with_options: [] })
 
 parse-statement
 CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn FOR TABLES (foo, bar as qux, baz into zop);
@@ -538,7 +538,7 @@ CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic', PROGRESS GROU
 ----
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic', PROGRESS GROUP ID PREFIX = 'prefix', COMPRESSION TYPE = gzip) FORMAT BYTES
 =>
-CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("foo")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaSinkConfigOption { name: Topic, value: Some(Value(String("topic"))) }, KafkaSinkConfigOption { name: ProgressGroupIdPrefix, value: Some(Value(String("prefix"))) }, KafkaSinkConfigOption { name: CompressionType, value: Some(Ident(Ident("gzip"))) }], key: None }, format: Some(Bytes), envelope: None, with_options: [] })
+CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("foo")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaSinkConfigOption { name: Topic, value: Some(Value(String("topic"))) }, KafkaSinkConfigOption { name: ProgressGroupIdPrefix, value: Some(Value(String("prefix"))) }, KafkaSinkConfigOption { name: CompressionType, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("gzip")]))) }], key: None }, format: Some(Bytes), envelope: None, with_options: [] })
 
 parse-statement
 CREATE SINK FROM bar INTO KAFKA CONNECTION baz
@@ -1501,7 +1501,7 @@ AlterObjectRename(AlterObjectRenameStatement { object_type: MaterializedView, if
 parse-statement
 CREATE CLUSTER cluster REPLICAS ()
 ----
-CREATE CLUSTER cluster (REPLICAS ())
+CREATE CLUSTER cluster (REPLICAS = ())
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([])) }], features: [] })
 
@@ -1522,91 +1522,91 @@ CREATE CLUSTER cluster REPLICAS (), BADOPT
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (STORAGECTL ADDRESSES ['host1']))
 ----
-CREATE CLUSTER cluster (REPLICAS (a (STORAGECTL ADDRESSES = ('host1'))))
+CREATE CLUSTER cluster (REPLICAS = (a (STORAGECTL ADDRESSES = ('host1'))))
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: StoragectlAddresses, value: Some(Sequence([Value(String("host1"))])) }] }])) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (COMPUTECTL ADDRESSES ['host1']), b (SIZE '1'))
 ----
-CREATE CLUSTER cluster (REPLICAS (a (COMPUTECTL ADDRESSES = ('host1')), b (SIZE = '1')))
+CREATE CLUSTER cluster (REPLICAS = (a (COMPUTECTL ADDRESSES = ('host1')), b (SIZE = '1')))
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: ComputectlAddresses, value: Some(Sequence([Value(String("host1"))])) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (COMPUTE ADDRESSES ['host1'], INTROSPECTION INTERVAL '1s', INTROSPECTION DEBUGGING true), b (SIZE '1', INTROSPECTION INTERVAL 0))
 ----
-CREATE CLUSTER cluster (REPLICAS (a (COMPUTE ADDRESSES = ('host1'), INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = true), b (SIZE = '1', INTROSPECTION INTERVAL = 0)))
+CREATE CLUSTER cluster (REPLICAS = (a (COMPUTE ADDRESSES = ('host1'), INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = true), b (SIZE = '1', INTROSPECTION INTERVAL = 0)))
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: ComputeAddresses, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(String("1s"))) }, ReplicaOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Number("0"))) }] }])) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (IDLE ARRANGEMENT MERGE EFFORT = 100), b (SIZE '1', IDLE ARRANGEMENT MERGE EFFORT 0))
 ----
-CREATE CLUSTER cluster (REPLICAS (a (IDLE ARRANGEMENT MERGE EFFORT = 100), b (SIZE = '1', IDLE ARRANGEMENT MERGE EFFORT = 0)))
+CREATE CLUSTER cluster (REPLICAS = (a (IDLE ARRANGEMENT MERGE EFFORT = 100), b (SIZE = '1', IDLE ARRANGEMENT MERGE EFFORT = 0)))
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: IdleArrangementMergeEffort, value: Some(Value(Number("100"))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }, ReplicaOption { name: IdleArrangementMergeEffort, value: Some(Value(Number("0"))) }] }])) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (IDLE ARRANGEMENT MERGE EFFORT = 100), b (SIZE '1', DISK = true))
 ----
-CREATE CLUSTER cluster (REPLICAS (a (IDLE ARRANGEMENT MERGE EFFORT = 100), b (SIZE = '1', DISK = true)))
+CREATE CLUSTER cluster (REPLICAS = (a (IDLE ARRANGEMENT MERGE EFFORT = 100), b (SIZE = '1', DISK = true)))
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: IdleArrangementMergeEffort, value: Some(Value(Number("100"))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }, ReplicaOption { name: Disk, value: Some(Value(Boolean(true))) }] }])) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (SIZE '1'))
 ----
-CREATE CLUSTER cluster (REPLICAS (a (SIZE = '1')))
+CREATE CLUSTER cluster (REPLICAS = (a (SIZE = '1')))
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (STORAGECTL ADDRESSES ['123'], STORAGE ADDRESSES ['124'], COMPUTECTL ADDRESSES ['host1:2400', 'host2:2400'], COMPUTE ADDRESSES ['host1:2401', 'host2:2401'], WORKERS '1'))
 ----
-CREATE CLUSTER cluster (REPLICAS (a (STORAGECTL ADDRESSES = ('123'), STORAGE ADDRESSES = ('124'), COMPUTECTL ADDRESSES = ('host1:2400', 'host2:2400'), COMPUTE ADDRESSES = ('host1:2401', 'host2:2401'), WORKERS = '1')))
+CREATE CLUSTER cluster (REPLICAS = (a (STORAGECTL ADDRESSES = ('123'), STORAGE ADDRESSES = ('124'), COMPUTECTL ADDRESSES = ('host1:2400', 'host2:2400'), COMPUTE ADDRESSES = ('host1:2401', 'host2:2401'), WORKERS = '1')))
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: StoragectlAddresses, value: Some(Sequence([Value(String("123"))])) }, ReplicaOption { name: StorageAddresses, value: Some(Sequence([Value(String("124"))])) }, ReplicaOption { name: ComputectlAddresses, value: Some(Sequence([Value(String("host1:2400")), Value(String("host2:2400"))])) }, ReplicaOption { name: ComputeAddresses, value: Some(Sequence([Value(String("host1:2401")), Value(String("host2:2401"))])) }, ReplicaOption { name: Workers, value: Some(Value(String("1"))) }] }])) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster SIZE '1'
 ----
-CREATE CLUSTER cluster (SIZE '1')
+CREATE CLUSTER cluster (SIZE = '1')
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster (SIZE '1') FEATURES (enable eager delta joins = true)
 ----
-CREATE CLUSTER cluster (SIZE '1') FEATURES (ENABLE EAGER DELTA JOINS = true)
+CREATE CLUSTER cluster (SIZE = '1') FEATURES (ENABLE EAGER DELTA JOINS = true)
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }], features: [ClusterFeature { name: EnableEagerDeltaJoins, value: Some(Value(Boolean(true))) }] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICATION FACTOR 1
 ----
-CREATE CLUSTER cluster (REPLICATION FACTOR 1)
+CREATE CLUSTER cluster (REPLICATION FACTOR = 1)
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: ReplicationFactor, value: Some(Value(Number("1"))) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster AVAILABILITY ZONES ('1')
 ----
-CREATE CLUSTER cluster (AVAILABILITY ZONES ('1'))
+CREATE CLUSTER cluster (AVAILABILITY ZONES = ('1'))
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: AvailabilityZones, value: Some(Sequence([Value(String("1"))])) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster IDLE ARRANGEMENT MERGE EFFORT 1000
 ----
-CREATE CLUSTER cluster (IDLE ARRANGEMENT MERGE EFFORT 1000)
+CREATE CLUSTER cluster (IDLE ARRANGEMENT MERGE EFFORT = 1000)
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: IdleArrangementMergeEffort, value: Some(Value(Number("1000"))) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster MANAGED true
 ----
-CREATE CLUSTER cluster (MANAGED true)
+CREATE CLUSTER cluster (MANAGED = true)
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Managed, value: Some(Value(Boolean(true))) }], features: [] })
 
@@ -1620,35 +1620,35 @@ CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Cluster
 parse-statement
 CREATE CLUSTER cluster MANAGED, DISK = true
 ----
-CREATE CLUSTER cluster (MANAGED, DISK true)
+CREATE CLUSTER cluster (MANAGED, DISK = true)
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Managed, value: None }, ClusterOption { name: Disk, value: Some(Value(Boolean(true))) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster (MANAGED, DISK = true)
 ----
-CREATE CLUSTER cluster (MANAGED, DISK true)
+CREATE CLUSTER cluster (MANAGED, DISK = true)
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Managed, value: None }, ClusterOption { name: Disk, value: Some(Value(Boolean(true))) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster INTROSPECTION INTERVAL '1'
 ----
-CREATE CLUSTER cluster (INTROSPECTION INTERVAL '1')
+CREATE CLUSTER cluster (INTROSPECTION INTERVAL = '1')
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: IntrospectionInterval, value: Some(Value(String("1"))) }], features: [] })
 
 parse-statement
 CREATE CLUSTER cluster INTROSPECTION DEBUGGING true
 ----
-CREATE CLUSTER cluster (INTROSPECTION DEBUGGING true)
+CREATE CLUSTER cluster (INTROSPECTION DEBUGGING = true)
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }], features: [] })
 
 parse-statement
 ALTER CLUSTER cluster SET (SIZE '1')
 ----
-ALTER CLUSTER cluster SET (SIZE '1')
+ALTER CLUSTER cluster SET (SIZE = '1')
 =>
 AlterCluster(AlterClusterStatement { if_exists: false, name: Ident("cluster"), action: SetOptions([ClusterOption { name: Size, value: Some(Value(String("1"))) }]) })
 
@@ -1662,28 +1662,28 @@ AlterCluster(AlterClusterStatement { if_exists: true, name: Ident("cluster"), ac
 parse-statement
 ALTER CLUSTER cluster SET (REPLICATION FACTOR 1)
 ----
-ALTER CLUSTER cluster SET (REPLICATION FACTOR 1)
+ALTER CLUSTER cluster SET (REPLICATION FACTOR = 1)
 =>
 AlterCluster(AlterClusterStatement { if_exists: false, name: Ident("cluster"), action: SetOptions([ClusterOption { name: ReplicationFactor, value: Some(Value(Number("1"))) }]) })
 
 parse-statement
 ALTER CLUSTER cluster SET (AVAILABILITY ZONES ('1', '2'))
 ----
-ALTER CLUSTER cluster SET (AVAILABILITY ZONES ('1', '2'))
+ALTER CLUSTER cluster SET (AVAILABILITY ZONES = ('1', '2'))
 =>
 AlterCluster(AlterClusterStatement { if_exists: false, name: Ident("cluster"), action: SetOptions([ClusterOption { name: AvailabilityZones, value: Some(Sequence([Value(String("1")), Value(String("2"))])) }]) })
 
 parse-statement
 ALTER CLUSTER cluster SET (IDLE ARRANGEMENT MERGE EFFORT 1000)
 ----
-ALTER CLUSTER cluster SET (IDLE ARRANGEMENT MERGE EFFORT 1000)
+ALTER CLUSTER cluster SET (IDLE ARRANGEMENT MERGE EFFORT = 1000)
 =>
 AlterCluster(AlterClusterStatement { if_exists: false, name: Ident("cluster"), action: SetOptions([ClusterOption { name: IdleArrangementMergeEffort, value: Some(Value(Number("1000"))) }]) })
 
 parse-statement
 ALTER CLUSTER cluster SET (MANAGED true)
 ----
-ALTER CLUSTER cluster SET (MANAGED true)
+ALTER CLUSTER cluster SET (MANAGED = true)
 =>
 AlterCluster(AlterClusterStatement { if_exists: false, name: Ident("cluster"), action: SetOptions([ClusterOption { name: Managed, value: Some(Value(Boolean(true))) }]) })
 
@@ -1697,21 +1697,21 @@ AlterCluster(AlterClusterStatement { if_exists: false, name: Ident("cluster"), a
 parse-statement
 ALTER CLUSTER cluster SET (INTROSPECTION INTERVAL '1')
 ----
-ALTER CLUSTER cluster SET (INTROSPECTION INTERVAL '1')
+ALTER CLUSTER cluster SET (INTROSPECTION INTERVAL = '1')
 =>
 AlterCluster(AlterClusterStatement { if_exists: false, name: Ident("cluster"), action: SetOptions([ClusterOption { name: IntrospectionInterval, value: Some(Value(String("1"))) }]) })
 
 parse-statement
 ALTER CLUSTER cluster SET (INTROSPECTION DEBUGGING true)
 ----
-ALTER CLUSTER cluster SET (INTROSPECTION DEBUGGING true)
+ALTER CLUSTER cluster SET (INTROSPECTION DEBUGGING = true)
 =>
 AlterCluster(AlterClusterStatement { if_exists: false, name: Ident("cluster"), action: SetOptions([ClusterOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }]) })
 
 parse-statement
 ALTER CLUSTER cluster SET (AVAILABILITY ZONES ('a'), IDLE ARRANGEMENT MERGE EFFORT 1, INTROSPECTION INTERVAL 1, INTROSPECTION DEBUGGING 1, MANAGED, REPLICAS (), REPLICATION FACTOR 0, SIZE 1)
 ----
-ALTER CLUSTER cluster SET (AVAILABILITY ZONES ('a'), IDLE ARRANGEMENT MERGE EFFORT 1, INTROSPECTION INTERVAL 1, INTROSPECTION DEBUGGING 1, MANAGED, REPLICAS (), REPLICATION FACTOR 0, SIZE 1)
+ALTER CLUSTER cluster SET (AVAILABILITY ZONES = ('a'), IDLE ARRANGEMENT MERGE EFFORT = 1, INTROSPECTION INTERVAL = 1, INTROSPECTION DEBUGGING = 1, MANAGED, REPLICAS = (), REPLICATION FACTOR = 0, SIZE = 1)
 =>
 AlterCluster(AlterClusterStatement { if_exists: false, name: Ident("cluster"), action: SetOptions([ClusterOption { name: AvailabilityZones, value: Some(Sequence([Value(String("a"))])) }, ClusterOption { name: IdleArrangementMergeEffort, value: Some(Value(Number("1"))) }, ClusterOption { name: IntrospectionInterval, value: Some(Value(Number("1"))) }, ClusterOption { name: IntrospectionDebugging, value: Some(Value(Number("1"))) }, ClusterOption { name: Managed, value: None }, ClusterOption { name: Replicas, value: Some(ClusterReplicas([])) }, ClusterOption { name: ReplicationFactor, value: Some(Value(Number("0"))) }, ClusterOption { name: Size, value: Some(Value(Number("1"))) }]) })
 
@@ -2037,7 +2037,7 @@ CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("co
 parse-statement
 CREATE CONNECTION conn1 TO KAFKA (BROKER 'kafka:1234' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9093, AVAILABILITY ZONE 'az1'));
 ----
-CREATE CONNECTION conn1 TO KAFKA (BROKER = 'kafka:1234' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9093, AVAILABILITY ZONE 'az1'))
+CREATE CONNECTION conn1 TO KAFKA (BROKER = 'kafka:1234' USING AWS PRIVATELINK aws.privatelink.c1 (PORT = 9093, AVAILABILITY ZONE = 'az1'))
 =>
 CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Kafka, if_not_exists: false, values: [ConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }, KafkaBrokerAwsPrivatelinkOption { name: AvailabilityZone, value: Some(Value(String("az1"))) }] }) })) }], with_options: [] })
 
@@ -2050,7 +2050,7 @@ CREATE CONNECTION IF NOT EXISTS conn1 TO KAFKA (
     )
 );
 ----
-CREATE CONNECTION IF NOT EXISTS conn1 TO KAFKA (BROKERS = ('kafka:9092' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9092), 'kafka:9093' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9093), 'kafka:9094' USING AWS PRIVATELINK aws.privatelink.c1))
+CREATE CONNECTION IF NOT EXISTS conn1 TO KAFKA (BROKERS = ('kafka:9092' USING AWS PRIVATELINK aws.privatelink.c1 (PORT = 9092), 'kafka:9093' USING AWS PRIVATELINK aws.privatelink.c1 (PORT = 9093), 'kafka:9094' USING AWS PRIVATELINK aws.privatelink.c1))
 =>
 CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Kafka, if_not_exists: true, values: [ConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9092"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9094", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })])) }], with_options: [] })
 
@@ -2063,7 +2063,7 @@ CREATE CONNECTION conn1 TO KAFKA (
     ]
 );
 ----
-CREATE CONNECTION conn1 TO KAFKA (BROKERS = ('kafka:9092' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9092), 'kafka:9093' USING AWS PRIVATELINK aws.privatelink.c1 (PORT 9093), 'kafka:9094' USING AWS PRIVATELINK aws.privatelink.c1))
+CREATE CONNECTION conn1 TO KAFKA (BROKERS = ('kafka:9092' USING AWS PRIVATELINK aws.privatelink.c1 (PORT = 9092), 'kafka:9093' USING AWS PRIVATELINK aws.privatelink.c1 (PORT = 9093), 'kafka:9094' USING AWS PRIVATELINK aws.privatelink.c1))
 =>
 CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Kafka, if_not_exists: false, values: [ConnectionOption { name: Brokers, value: Some(Sequence([ConnectionKafkaBroker(KafkaBroker { address: "kafka:9092", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9092"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9093", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [KafkaBrokerAwsPrivatelinkOption { name: Port, value: Some(Value(Number("9093"))) }] }) }), ConnectionKafkaBroker(KafkaBroker { address: "kafka:9094", tunnel: AwsPrivatelink(KafkaBrokerAwsPrivatelink { connection: Name(UnresolvedItemName([Ident("aws"), Ident("privatelink"), Ident("c1")])), options: [] }) })])) }], with_options: [] })
 

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1759,7 +1759,6 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                     .collect(),
             ),
             Value(v) => Value(self.fold_value(v)),
-            Ident(i) => Ident(self.fold_ident(i)),
             DataType(dt) => DataType(self.fold_data_type(dt)),
             Secret(secret) => {
                 let item_name = self.fold_item_name(secret);

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4456,13 +4456,25 @@ fn plan_index_options(
     Ok(out)
 }
 
-generate_extracted_config!(TableOption, (RetainHistory, OptionalDuration));
+generate_extracted_config!(
+    TableOption,
+    (RetainHistory, OptionalDuration),
+    (RedactedTest, String)
+);
 
 fn plan_table_options(
     scx: &StatementContext,
     with_opts: Vec<TableOption<Aug>>,
 ) -> Result<Vec<crate::plan::TableOption>, PlanError> {
-    let TableOptionExtracted { retain_history, .. }: TableOptionExtracted = with_opts.try_into()?;
+    let TableOptionExtracted {
+        retain_history,
+        redacted_test,
+        ..
+    }: TableOptionExtracted = with_opts.try_into()?;
+
+    if redacted_test.is_some() {
+        scx.require_feature_flag(&vars::ENABLE_REDACTED_TEST_OPTION)?;
+    }
 
     let mut out = Vec::with_capacity(1);
     if let Some(cw) = plan_retain_history_option(scx, retain_history)? {

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2081,6 +2081,13 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_redacted_test_option,
+        desc: "Enable useless option to test value redaction",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {

--- a/test/sqllogictest/redacted.slt
+++ b/test/sqllogictest/redacted.slt
@@ -21,13 +21,33 @@ CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'localhost:9092', SECURITY PROTOCO
 query T multiline
 SELECT redacted_create_sql FROM mz_connections WHERE name = 'kafka_conn'
 ----
-CREATE CONNECTION materialize.public.kafka_conn TO KAFKA (BROKER = '<REDACTED>', SECURITY PROTOCOL = '<REDACTED>')
+CREATE CONNECTION materialize.public.kafka_conn TO KAFKA (BROKER = 'localhost:9092', SECURITY PROTOCOL = plaintext)
 EOF
 
 query T multiline
 SELECT pretty_sql(redacted_create_sql) FROM mz_connections WHERE name = 'kafka_conn'
 ----
-CREATE CONNECTION materialize.public.kafka_conn TO KAFKA (BROKER = '<REDACTED>', SECURITY PROTOCOL = '<REDACTED>');
+CREATE CONNECTION materialize.public.kafka_conn TO KAFKA (BROKER = 'localhost:9092', SECURITY PROTOCOL = plaintext);
+EOF
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_redacted_test_option TO true;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE redactable_t (a int) WITH (RETAIN HISTORY = FOR '1ms', REDACTED = 'pii');
+
+query T multiline
+SELECT redacted_create_sql FROM mz_tables WHERE name = 'redactable_t'
+----
+CREATE TABLE materialize.public.redactable_t (a [s20 AS pg_catalog.int4]) WITH (RETAIN HISTORY = FOR '1ms', REDACTED = '<REDACTED>')
+EOF
+
+query T multiline
+SELECT pretty_sql(redacted_create_sql) FROM mz_tables WHERE name = 'redactable_t'
+----
+CREATE TABLE materialize.public.redactable_t (a [s20 AS pg_catalog.int4]) WITH (RETAIN HISTORY = FOR '1ms', REDACTED = '<REDACTED>');
 EOF
 
 statement ok


### PR DESCRIPTION
As part of fixing the inverted subsource dependency structure, I plan to use `UnresolvedItemName` as a `WITH` option value. However, this conflicted with the previous use of `Ident` as a `WithOptionValue`, so I refactored the code to support the more complex type.

However, in doing this, I encountered some odd behavior with how we redacted values––literal values in `WITH` options could be redacted. In digging into this, I believe the right call is not to always redact values, but instead redact them strategically––this lets us reveal them in uncontroversial contexts (i.e. in `WITH` options).

### Motivation

This PR refactors existing code.

### Tips for reviewer

Most of the code is boilerplate. The code to read is in `src/sql-parser/src/ast/display.rs`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
