### PR TITLE
sql-parser: improve various RETAIN HISTORY parsing

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2092,8 +2092,9 @@ impl<T: AstInfo> AstDisplay for AlterRetainHistoryStatement<T> {
             f.write_str("IF EXISTS ");
         }
         f.write_node(&self.name);
-        f.write_str(" SET RETAIN HISTORY ");
+        f.write_str(" SET (RETAIN HISTORY ");
         f.write_node(&self.history);
+        f.write_str(")");
     }
 }
 impl_display_t!(AlterRetainHistoryStatement);

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2074,13 +2074,13 @@ impl AstDisplay for AlterObjectRenameStatement {
 }
 impl_display!(AlterObjectRenameStatement);
 
-/// `ALTER <OBJECT> ... RETAIN HISTORY FOR`
+/// `ALTER <OBJECT> ... [RE]SET (RETAIN HISTORY [FOR ...])`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlterRetainHistoryStatement<T: AstInfo> {
     pub object_type: ObjectType,
     pub if_exists: bool,
     pub name: UnresolvedObjectName,
-    pub history: WithOptionValue<T>,
+    pub history: Option<WithOptionValue<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for AlterRetainHistoryStatement<T> {
@@ -2092,8 +2092,12 @@ impl<T: AstInfo> AstDisplay for AlterRetainHistoryStatement<T> {
             f.write_str("IF EXISTS ");
         }
         f.write_node(&self.name);
-        f.write_str(" SET (RETAIN HISTORY ");
-        f.write_node(&self.history);
+        if let Some(history) = &self.history {
+            f.write_str(" SET (RETAIN HISTORY ");
+            f.write_node(history);
+        } else {
+            f.write_str(" RESET (RETAIN HISTORY");
+        }
         f.write_str(")");
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5133,7 +5133,7 @@ impl<'a> Parser<'a> {
         let if_exists = self.parse_if_exists().map_no_statement_parser_err()?;
         let name = self.parse_item_name().map_no_statement_parser_err()?;
         let action = self
-            .expect_one_of_keywords(&[SET, RENAME, OWNER])
+            .expect_one_of_keywords(&[SET, RENAME, OWNER, RESET])
             .map_no_statement_parser_err()?;
         match action {
             RENAME => {
@@ -5165,9 +5165,23 @@ impl<'a> Parser<'a> {
                         object_type,
                         if_exists,
                         name: UnresolvedObjectName::Item(name),
-                        history,
+                        history: Some(history),
                     }))
                 }
+            }
+            RESET => {
+                self.expect_token(&Token::LParen)
+                    .map_no_statement_parser_err()?;
+                self.expect_keywords(&[RETAIN, HISTORY])
+                    .map_parser_err(StatementKind::AlterRetainHistory)?;
+                self.expect_token(&Token::RParen)
+                    .map_no_statement_parser_err()?;
+                Ok(Statement::AlterRetainHistory(AlterRetainHistoryStatement {
+                    object_type,
+                    if_exists,
+                    name: UnresolvedObjectName::Item(name),
+                    history: None,
+                }))
             }
             OWNER => {
                 self.expect_keyword(TO).map_no_statement_parser_err()?;

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2919,4 +2919,11 @@ ALTER MATERIALIZED VIEW mv SET (RETAIN HISTORY FOR '3m')
 ----
 ALTER MATERIALIZED VIEW mv SET (RETAIN HISTORY FOR '3m')
 =>
-AlterRetainHistory(AlterRetainHistoryStatement { object_type: MaterializedView, if_exists: false, name: Item(UnresolvedItemName([Ident("mv")])), history: RetainHistoryFor(String("3m")) })
+AlterRetainHistory(AlterRetainHistoryStatement { object_type: MaterializedView, if_exists: false, name: Item(UnresolvedItemName([Ident("mv")])), history: Some(RetainHistoryFor(String("3m"))) })
+
+parse-statement
+ALTER MATERIALIZED VIEW mv RESET (RETAIN HISTORY)
+----
+ALTER MATERIALIZED VIEW mv RESET (RETAIN HISTORY)
+=>
+AlterRetainHistory(AlterRetainHistoryStatement { object_type: MaterializedView, if_exists: false, name: Item(UnresolvedItemName([Ident("mv")])), history: None })

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2927,3 +2927,50 @@ ALTER MATERIALIZED VIEW mv RESET (RETAIN HISTORY)
 ALTER MATERIALIZED VIEW mv RESET (RETAIN HISTORY)
 =>
 AlterRetainHistory(AlterRetainHistoryStatement { object_type: MaterializedView, if_exists: false, name: Item(UnresolvedItemName([Ident("mv")])), history: None })
+
+parse-statement
+ALTER SOURCE n RESET (RETAIN HISTORY)
+----
+ALTER SOURCE n RESET (RETAIN HISTORY)
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: ResetOptions([RetainHistory]) })
+
+
+parse-statement
+ALTER SOURCE n SET (RETAIN HISTORY FOR '1m')
+----
+ALTER SOURCE n SET (RETAIN HISTORY = FOR '1m')
+=>
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: SetOptions([CreateSourceOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1m"))) }]) })
+
+
+parse-statement
+ALTER TABLE n RESET (RETAIN HISTORY)
+----
+ALTER TABLE n RESET (RETAIN HISTORY)
+=>
+AlterRetainHistory(AlterRetainHistoryStatement { object_type: Table, if_exists: false, name: Item(UnresolvedItemName([Ident("n")])), history: None })
+
+
+parse-statement
+ALTER TABLE n SET (RETAIN HISTORY FOR '1m')
+----
+ALTER TABLE n SET (RETAIN HISTORY FOR '1m')
+=>
+AlterRetainHistory(AlterRetainHistoryStatement { object_type: Table, if_exists: false, name: Item(UnresolvedItemName([Ident("n")])), history: Some(RetainHistoryFor(String("1m"))) })
+
+
+parse-statement
+ALTER INDEX n RESET (RETAIN HISTORY)
+----
+ALTER INDEX n RESET (RETAIN HISTORY)
+=>
+AlterIndex(AlterIndexStatement { index_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: ResetOptions([RetainHistory]) })
+
+
+parse-statement
+ALTER INDEX n SET (RETAIN HISTORY FOR '1m')
+----
+ALTER INDEX n SET (RETAIN HISTORY = FOR '1m')
+=>
+AlterIndex(AlterIndexStatement { index_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: SetOptions([IndexOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1m"))) }]) })

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1431,16 +1431,16 @@ ALTER SOURCE IF EXISTS n ADD SOURCE a, b.c AS d
 parse-statement
 ALTER VIEW name SET (property = true)
 ----
-error: Expected one of CLUSTER or RETAIN, found left parenthesis
+error: Expected RETAIN, found identifier "property"
 ALTER VIEW name SET (property = true)
-                    ^
+                     ^
 
 parse-statement
 ALTER MATERIALIZED VIEW name SET (property = true)
 ----
-error: Expected one of CLUSTER or RETAIN, found left parenthesis
+error: Expected RETAIN, found identifier "property"
 ALTER MATERIALIZED VIEW name SET (property = true)
-                                 ^
+                                  ^
 
 parse-statement
 ALTER SINK name SET (property = true)
@@ -2915,8 +2915,8 @@ CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (RETAIN HISTORY = FOR '1s')
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("s")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1s"))) }], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
-ALTER MATERIALIZED VIEW mv SET RETAIN HISTORY FOR '3m'
+ALTER MATERIALIZED VIEW mv SET (RETAIN HISTORY FOR '3m')
 ----
-ALTER MATERIALIZED VIEW mv SET RETAIN HISTORY FOR '3m'
+ALTER MATERIALIZED VIEW mv SET (RETAIN HISTORY FOR '3m')
 =>
 AlterRetainHistory(AlterRetainHistoryStatement { object_type: MaterializedView, if_exists: false, name: Item(UnresolvedItemName([Ident("mv")])), history: RetainHistoryFor(String("3m")) })

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -15,6 +15,11 @@ ALTER SYSTEM SET enable_connection_validation_syntax TO true;
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_index_options = on;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;
 ----
 COMPLETE 0
@@ -84,3 +89,37 @@ ALTER MATERIALIZED VIEW v SET CLUSTER quickstart
 
 query error db error: ERROR: ALTER SINK SET CLUSTER not yet supported, see https://github\.com/MaterializeInc/materialize/issues/20841 for more details
 ALTER SINK v SET CLUSTER quickstart
+
+statement ok
+CREATE TABLE t (a INT)
+
+statement ok
+CREATE INDEX i ON t(a)
+
+statement ok
+CREATE SOURCE s FROM LOAD GENERATOR COUNTER
+
+statement error db error: ERROR: ALTER RETAIN HISTORY not yet supported
+ALTER MATERIALIZED VIEW mv SET (RETAIN HISTORY FOR '1m')
+
+statement error db error: ERROR: ALTER RETAIN HISTORY not yet supported
+ALTER MATERIALIZED VIEW mv RESET (RETAIN HISTORY)
+
+statement error db error: ERROR: ALTER RETAIN HISTORY not yet supported
+ALTER TABLE t SET (RETAIN HISTORY FOR '1m')
+
+statement error db error: ERROR: ALTER RETAIN HISTORY not yet supported
+ALTER TABLE t RESET (RETAIN HISTORY)
+
+# TODO: Change all SOURCE RETAIN HISTORY tests to not use load generators.
+statement error db error: ERROR: s is a load\-generator source, which does not support ALTER SOURCE\.
+ALTER SOURCE s SET (RETAIN HISTORY FOR '1m')
+
+statement error db error: ERROR: s is a load\-generator source, which does not support ALTER SOURCE\.
+ALTER SOURCE s RESET (RETAIN HISTORY)
+
+statement ok
+ALTER INDEX i SET (RETAIN HISTORY FOR '1m')
+
+statement ok
+ALTER INDEX i RESET (RETAIN HISTORY)


### PR DESCRIPTION
Fix `SET` syntax for `ALTER MATERIALIZED VIEW`. Implement `RESET` parsing. Add tests for `ALTER RETAIN HISTORY`.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

    * Can review commit-by-commit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a