### PR TITLE
version consistency: add ignores

### DIFF
--- a/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
@@ -106,3 +106,10 @@ def involves_data_type_category(
     expression: Expression, data_type_category: DataTypeCategory
 ) -> bool:
     return expression.resolve_return_type_category() == data_type_category
+
+
+def is_operation_tagged(expression: Expression, tag: str) -> bool:
+    if isinstance(expression, ExpressionWithArgs):
+        return expression.operation.is_tagged(tag)
+
+    return False

--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -18,6 +18,7 @@ from materialize.output_consistency.expression.expression_with_args import (
     ExpressionWithArgs,
 )
 from materialize.output_consistency.ignore_filter.expression_matchers import (
+    is_operation_tagged,
     matches_fun_by_any_name,
     matches_fun_by_name,
     matches_op_by_any_pattern,
@@ -35,6 +36,9 @@ from materialize.output_consistency.ignore_filter.internal_output_inconsistency_
 )
 from materialize.output_consistency.input_data.operations.date_time_operations_provider import (
     DATE_TIME_OPERATION_TYPES,
+)
+from materialize.output_consistency.input_data.operations.text_operations_provider import (
+    TAG_REGEX,
 )
 from materialize.output_consistency.operation.operation import (
     DbFunction,
@@ -147,6 +151,15 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
             )
         ):
             return YesIgnore("ILIKE fixed in PR 26183")
+
+        if (
+            self.lower_version < MZ_VERSION_0_93_0 <= self.higher_version
+            and expression.matches(
+                partial(is_operation_tagged, tag=TAG_REGEX),
+                True,
+            )
+        ):
+            return YesIgnore("Newline handling in regex fixed in PR 26191")
 
         return super().shall_ignore_expression(expression, row_selection)
 


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightlies/builds/7000#018e6211-1221-423e-bf1e-bf81e0b6c139 and https://buildkite.com/materialize/nightlies/builds/7012#018e635a-7374-4148-8fb7-732f2ce950f0. It fixes https://github.com/MaterializeInc/materialize/issues/26204.

It replaces https://github.com/MaterializeInc/materialize/pull/26205.