### PR TITLE
version consistency: test both DFR and CTF

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1080,8 +1080,8 @@ steps:
               composition: postgres-consistency
               args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200"]
 
-      - id: output-consistency-version
-        label: "Output consistency (version)"
+      - id: output-consistency-version-dfr
+        label: "Output consistency (version for DFR)"
         depends_on: build-aarch64
         timeout_in_minutes: 58
         agents:
@@ -1089,7 +1089,19 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: version-consistency
-              args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200"]
+              args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200", "--evaluation-strategy=dataflow_rendering"]
+
+      - id: output-consistency-version-ctf
+        label: "Output consistency (version for CTF)"
+        depends_on: build-aarch64
+        timeout_in_minutes: 58
+        agents:
+          queue: linux-aarch64-small
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: version-consistency
+              args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200", "--evaluation-strategy=constant_folding"]
+
 
   - group: SQLsmith
     key: sqlsmith-group

--- a/test/version-consistency/mzcompose.py
+++ b/test/version-consistency/mzcompose.py
@@ -6,7 +6,6 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-from random import Random
 
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.cockroach import Cockroach
@@ -17,6 +16,7 @@ from materialize.version_ancestor_overrides import (
     ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS,
 )
 from materialize.version_consistency.version_consistency_test import (
+    EVALUATION_STRATEGY_NAME_DFR,
     EVALUATION_STRATEGY_NAMES,
     VersionConsistencyTest,
 )
@@ -39,23 +39,14 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     test = VersionConsistencyTest()
 
-    evaluation_strategy_name_random = "random"
-    extended_evaluation_strategy_names = EVALUATION_STRATEGY_NAMES + [
-        evaluation_strategy_name_random
-    ]
     parser.add_argument(
         "--evaluation-strategy",
-        default=evaluation_strategy_name_random,
+        default=EVALUATION_STRATEGY_NAME_DFR,
         type=str,
-        choices=extended_evaluation_strategy_names,
+        choices=EVALUATION_STRATEGY_NAMES,
     )
 
     args = test.parse_output_consistency_input_args(parser)
-
-    if args.evaluation_strategy == evaluation_strategy_name_random:
-        evaluation_strategy_name = Random(args.seed).choice(EVALUATION_STRATEGY_NAMES)
-    else:
-        evaluation_strategy_name = args.evaluation_strategy
 
     name_mz_this, name_mz_other = "mz_this", "mz_other"
     port_mz_internal, port_mz_this, port_mz_other = 6875, 6875, 16875
@@ -86,7 +77,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         test.mz2_connection = c.sql_connection(
             service=name_mz_other, port=port_mz_internal
         )
-        test.evaluation_strategy_name = evaluation_strategy_name
+        test.evaluation_strategy_name = args.evaluation_strategy
 
         test_summary = test.run_output_consistency_tests(connection, args)
 


### PR DESCRIPTION
The current behavior, which randomly chooses a strategy, confused me a bit today during an analysis.
I suggest to either test only
* against one fixed strategy (would be perfectly sufficient if there were no ignores between both strategies)
* or against both (more comprehensive but not sure if necessary / worthy / justified).