### PR TITLE
storage: fix subsource frontier reconciliation

### DIFF
--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1076,7 +1076,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
 
                             false
                         } else {
-                            expected_objects.insert(ingestion.id);
+                            expected_objects.extend(ingestion.description.subsource_ids());
 
                             let running_ingestion =
                                 self.storage_state.ingestions.get(&ingestion.id);


### PR DESCRIPTION
Storage replicas only report frontiers of collections that are present in `reported_frontiers`. Entries for subsources are inserted there when a replica receives the `RunIngestions` command that creates them. However, the reconciliation logic would only retain the entries of top-level sources and remove entries of subsources from `reported_frontiers`, regardless of whether or not these subsources were still expected. The correct behavior is to keep around the entries for expected subsources as well.

### Motivation

  * This PR fixes a recognized bug.

Fixes #26215 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
