### PR TITLE
persist: remove Blob::set atomicity argument

### DIFF
--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -19,9 +19,7 @@ use differential_dataflow::trace::Description;
 use futures::stream::{FuturesUnordered, StreamExt};
 use mz_ore::task::RuntimeExt;
 use mz_persist::indexed::encoding::BlobTraceBatchPart;
-use mz_persist::location::{
-    Atomicity, Blob, CaSResult, Consensus, ExternalError, SeqNo, VersionedData,
-};
+use mz_persist::location::{Blob, CaSResult, Consensus, ExternalError, SeqNo, VersionedData};
 use mz_persist::workload::{self, DataGenerator};
 use mz_persist_client::internals_bench::trace_push_batch_one_iter;
 use mz_persist_client::ShardId;
@@ -142,7 +140,7 @@ pub fn bench_blob_get(
     bench_all_blob(&mut g, runtime, data, |b, blob| {
         let key = ShardId::new().to_string();
         runtime
-            .block_on(blob.set(&key, Bytes::clone(&payload), Atomicity::RequireAtomic))
+            .block_on(blob.set(&key, Bytes::clone(&payload)))
             .expect("failed to set blob");
         b.iter(|| {
             runtime
@@ -182,8 +180,7 @@ pub fn bench_blob_set(
 
 async fn bench_blob_set_one_iter(blob: &dyn Blob, payload: &Bytes) -> Result<(), ExternalError> {
     let key = ShardId::new().to_string();
-    blob.set(&key, Bytes::clone(payload), Atomicity::RequireAtomic)
-        .await
+    blob.set(&key, Bytes::clone(payload)).await
 }
 
 pub fn bench_encode_batch(name: &str, throughput: bool, c: &mut Criterion, data: &DataGenerator) {

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -29,7 +29,7 @@ use mz_ore::instrument;
 use mz_ore::task::{JoinHandle, JoinHandleExt};
 use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsBuilder};
 use mz_persist::indexed::encoding::BlobTraceBatchPart;
-use mz_persist::location::{Atomicity, Blob};
+use mz_persist::location::Blob;
 use mz_persist_types::stats::{trim_to_budget, truncate_bytes, TruncateBound, TRUNCATE_LEN};
 use mz_persist_types::{Codec, Codec64};
 use mz_proto::RustType;
@@ -878,8 +878,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
                 let payload_len = buf.len();
                 let () = retry_external(&metrics.retries.external.batch_set, || async {
                     shard_metrics.blob_sets.inc();
-                    blob.set(&key, Bytes::clone(&buf), Atomicity::RequireAtomic)
-                        .await
+                    blob.set(&key, Bytes::clone(&buf)).await
                 })
                 .instrument(trace_span!("batch::set", payload_len))
                 .await;

--- a/src/persist-client/src/cli/args.rs
+++ b/src/persist-client/src/cli/args.rs
@@ -22,8 +22,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist::cfg::{BlobConfig, ConsensusConfig};
 use mz_persist::location::{
-    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, ExternalError, ResultStream, SeqNo,
-    VersionedData,
+    Blob, BlobMetadata, CaSResult, Consensus, ExternalError, ResultStream, SeqNo, VersionedData,
 };
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -211,7 +210,7 @@ impl Blob for ReadOnly<Arc<dyn Blob + Sync + Send>> {
         self.store.list_keys_and_metadata(key_prefix, f).await
     }
 
-    async fn set(&self, key: &str, _value: Bytes, _atomic: Atomicity) -> Result<(), ExternalError> {
+    async fn set(&self, key: &str, _value: Bytes) -> Result<(), ExternalError> {
         warn!("ignoring set({key}) in read-only mode");
         self.ignoring_write();
         Ok(())

--- a/src/persist-client/src/internal/cache.rs
+++ b/src/persist-client/src/internal/cache.rs
@@ -16,7 +16,7 @@ use bytes::Bytes;
 use mz_dyncfg::{Config, ConfigSet};
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastFrom;
-use mz_persist::location::{Atomicity, Blob, BlobMetadata, ExternalError};
+use mz_persist::location::{Blob, BlobMetadata, ExternalError};
 
 use crate::cfg::PersistConfig;
 use crate::internal::metrics::Metrics;
@@ -117,8 +117,8 @@ impl Blob for BlobMemCache {
         self.blob.list_keys_and_metadata(key_prefix, f).await
     }
 
-    async fn set(&self, key: &str, value: Bytes, atomic: Atomicity) -> Result<(), ExternalError> {
-        let () = self.blob.set(key, value.clone(), atomic).await?;
+    async fn set(&self, key: &str, value: Bytes) -> Result<(), ExternalError> {
+        let () = self.blob.set(key, value.clone()).await?;
         let weight = value.len();
         let mut cache = self.cache.lock().expect("lock poisoned");
         // If the weight of this single blob is greater than the capacity of

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -28,8 +28,7 @@ use mz_ore::metrics::{
 };
 use mz_ore::stats::histogram_seconds_buckets;
 use mz_persist::location::{
-    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, ExternalError, ResultStream, SeqNo,
-    VersionedData,
+    Blob, BlobMetadata, CaSResult, Consensus, ExternalError, ResultStream, SeqNo, VersionedData,
 };
 use mz_persist::metrics::{ColumnarMetrics, S3BlobMetrics};
 use mz_persist::retry::RetryStream;
@@ -2469,13 +2468,13 @@ impl Blob for MetricsBlob {
     }
 
     #[instrument(name = "blob::set", fields(shard=blob_key_shard_id(key)))]
-    async fn set(&self, key: &str, value: Bytes, atomic: Atomicity) -> Result<(), ExternalError> {
+    async fn set(&self, key: &str, value: Bytes) -> Result<(), ExternalError> {
         let bytes = value.len();
         let res = self
             .metrics
             .blob
             .set
-            .run_op(|| self.blob.set(key, value, atomic), Self::on_err)
+            .run_op(|| self.blob.set(key, value), Self::on_err)
             .await;
         if res.is_ok() {
             self.metrics.blob.set.bytes.inc_by(u64::cast_from(bytes));

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -22,7 +22,7 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use mz_ore::cast::CastFrom;
 use mz_persist::location::{
-    Atomicity, Blob, CaSResult, Consensus, Indeterminate, SeqNo, VersionedData, SCAN_ALL,
+    Blob, CaSResult, Consensus, Indeterminate, SeqNo, VersionedData, SCAN_ALL,
 };
 use mz_persist::retry::Retry;
 use mz_persist_types::{Codec, Codec64};
@@ -771,7 +771,6 @@ impl StateVersions {
                 .set(
                     &rollup.key.complete(&rollup.shard_id),
                     Bytes::clone(&rollup.buf),
-                    Atomicity::RequireAtomic,
                 )
                 .await
         })

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -730,7 +730,7 @@ impl std::fmt::Display for HumanBytes {
 mod tests {
     use crate::batch::BLOB_TARGET_SIZE;
     use bytes::Bytes;
-    use mz_persist::location::{Atomicity, SeqNo};
+    use mz_persist::location::SeqNo;
     use semver::Version;
     use timely::progress::Antichain;
 
@@ -1238,7 +1238,7 @@ mod tests {
         let key = key.complete(&shard_id);
         let () = client
             .blob
-            .set(&key, Bytes::from(vec![0, 1, 2]), Atomicity::RequireAtomic)
+            .set(&key, Bytes::from(vec![0, 1, 2]))
             .await
             .unwrap();
         let usage = StorageUsageClient::open(client);

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -348,7 +348,6 @@ mod tests {
 
     use crate::error::Error;
     use crate::indexed::columnar::ColumnarRecordsBuilder;
-    use crate::location::Atomicity;
     use crate::mem::{MemBlob, MemBlobConfig};
     use crate::metrics::ColumnarMetrics;
     use crate::workload::DataGenerator;
@@ -521,9 +520,7 @@ mod tests {
         batch.encode(&mut val);
         let val = Bytes::from(val);
         let val_len = u64::cast_from(val.len());
-        blob.set(key, val, Atomicity::AllowNonAtomic)
-            .await
-            .expect("failed to set trace batch");
+        blob.set(key, val).await.expect("failed to set trace batch");
         val_len
     }
 

--- a/src/persist/src/intercept.rs
+++ b/src/persist/src/intercept.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use mz_ore::bytes::SegmentedBytes;
 
-use crate::location::{Atomicity, Blob, BlobMetadata, ExternalError};
+use crate::location::{Blob, BlobMetadata, ExternalError};
 
 /// Post-op closure for [Blob::delete].
 pub type PostDeleteFn = Arc<
@@ -89,8 +89,8 @@ impl Blob for InterceptBlob {
         self.blob.list_keys_and_metadata(key_prefix, f).await
     }
 
-    async fn set(&self, key: &str, value: Bytes, atomic: Atomicity) -> Result<(), ExternalError> {
-        self.blob.set(key, value, atomic).await
+    async fn set(&self, key: &str, value: Bytes) -> Result<(), ExternalError> {
+        self.blob.set(key, value).await
     }
 
     async fn delete(&self, key: &str) -> Result<Option<usize>, ExternalError> {

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -24,8 +24,8 @@ use mz_ore::cast::CastFrom;
 
 use crate::error::Error;
 use crate::location::{
-    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, Determinate, ExternalError, ResultStream,
-    SeqNo, VersionedData,
+    Blob, BlobMetadata, CaSResult, Consensus, Determinate, ExternalError, ResultStream, SeqNo,
+    VersionedData,
 };
 
 // A snapshot of the old tokio::task::yield_now() implementation, from before it
@@ -208,7 +208,7 @@ impl Blob for MemBlob {
         self.core.lock().await.list_keys_and_metadata(key_prefix, f)
     }
 
-    async fn set(&self, key: &str, value: Bytes, _atomic: Atomicity) -> Result<(), ExternalError> {
+    async fn set(&self, key: &str, value: Bytes) -> Result<(), ExternalError> {
         // Yield to maximize our chances for getting interesting orderings.
         let () = yield_now().await;
         // NB: This is always atomic, so we're free to ignore the atomic param.

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -41,7 +41,7 @@ use uuid::Uuid;
 
 use crate::cfg::BlobKnobs;
 use crate::error::Error;
-use crate::location::{Atomicity, Blob, BlobMetadata, Determinate, ExternalError};
+use crate::location::{Blob, BlobMetadata, Determinate, ExternalError};
 use crate::metrics::S3BlobMetrics;
 
 /// Configuration for opening an [S3Blob].
@@ -579,8 +579,7 @@ impl Blob for S3Blob {
         Ok(())
     }
 
-    async fn set(&self, key: &str, value: Bytes, _atomic: Atomicity) -> Result<(), ExternalError> {
-        // NB: S3 is always atomic, so we're free to ignore the atomic param.
+    async fn set(&self, key: &str, value: Bytes) -> Result<(), ExternalError> {
         let value_len = value.len();
         if self
             .multipart_config

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -22,8 +22,8 @@ use rand::{Rng, SeedableRng};
 use tracing::trace;
 
 use crate::location::{
-    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, Determinate, ExternalError, ResultStream,
-    SeqNo, VersionedData,
+    Blob, BlobMetadata, CaSResult, Consensus, Determinate, ExternalError, ResultStream, SeqNo,
+    VersionedData,
 };
 
 #[derive(Debug)]
@@ -157,9 +157,9 @@ impl Blob for UnreliableBlob {
             .await
     }
 
-    async fn set(&self, key: &str, value: Bytes, atomic: Atomicity) -> Result<(), ExternalError> {
+    async fn set(&self, key: &str, value: Bytes) -> Result<(), ExternalError> {
         self.handle
-            .run_op("set", || self.blob.set(key, value, atomic))
+            .run_op("set", || self.blob.set(key, value))
             .await
     }
 


### PR DESCRIPTION
This is an artifact from the single-binary persist days, which only used Blob, not Consensus. It was introduced so that data blobs could be written without the file rename trick, and state blobs could be written atomically. Since the only way to find out about a blob key was through state, we didn't have to worry about partial writes for data blobs.

In single-binary persist, File was a reasonably supported production option, so we cared more about the performance. But in platform persist, we only use s3 for Blob, which is naturally atomic. Additionally, we've now added things like Blob::list_keys_and_metadata, which have introduced a way to find blobs that does not come via state.

I don't see us switching to non-atomic writes for data blobs, since it would add yet another thing to think about and only affect test performance. So, remove it.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
