### PR TITLE
doc/user: MVP documentation for logical timestamp selection

### DIFF
--- a/doc/user/content/get-started/isolation-level.md
+++ b/doc/user/content/get-started/isolation-level.md
@@ -119,7 +119,8 @@ linearizable transactions, then you should downgrade to the Serializable isolati
 
 Strict Serializable provides stronger consistency guarantees but may have slower reads than Serializable. This is
 because Strict Serializable may need to wait for writes to propagate through materialized views and indexes, while
-Serializable does not.
+Serializable does not. For details about this behavior, consult the documentation
+on [logical timestamp selection](/sql/functions/now_and_mz_now#logical-timestamp-selection).
 
 In Serializable mode, a single auto-committed `SELECT` statement or a `SUBSCRIBE`
 statement that references a single object (which includes transactions against a single


### PR DESCRIPTION
I was noodling on this during our meeting and figured I'd just clean it up and send it y'alls way for review.

----

As part of the mz_now() improvements project [0], we agreed to lightly improve the documentation of logical timestamp selection. This PR is an attempt at those improvements.

There's still quite a bit more to explain about how logical timestamp selection works and its implications for performance, but, with this PR, at least we have *something* to point users at when they ask about how the logical timestamp is related to wall clock time.

[0]: https://www.notion.so/materialize/mz_now-braindump-3acde85e02d84cb09808d7c63dab009a#00a22a93afc24c468400bf0e656969ee

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR improves documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
