### PR TITLE
fivetran-destination: Allow users to specify `cluster` to connect to

### DIFF
--- a/src/fivetran-destination/src/destination/config.rs
+++ b/src/fivetran-destination/src/destination/config.rs
@@ -18,6 +18,7 @@ use crate::fivetran_sdk::form_field::Type;
 use crate::fivetran_sdk::{
     ConfigurationFormResponse, ConfigurationTest, FormField, TestRequest, TextField,
 };
+use crate::utils;
 
 pub const FIVETRAN_DESTINATION_APPLICATION_NAME: &str = "materialize_fivetran_destination";
 
@@ -156,8 +157,8 @@ pub async fn connect(
     let mut builder = SslConnector::builder(SslMethod::tls_client())?;
     builder.set_verify_cert_store(cert_store.build())?;
 
-    let options = if let Some(cluster) = cluster {
-        format!("--cluster={cluster}")
+    let options = if let Some(cluster) = cluster.as_ref() {
+        format!("--cluster={}", utils::escape_options(cluster))
     } else {
         String::new()
     };

--- a/src/fivetran-destination/src/destination/config.rs
+++ b/src/fivetran-destination/src/destination/config.rs
@@ -21,6 +21,8 @@ use crate::fivetran_sdk::{
 
 pub const FIVETRAN_DESTINATION_APPLICATION_NAME: &str = "materialize_fivetran_destination";
 
+/// Returns a [`ConfigurationFormResponse`] which defines what configuration fields are available
+/// for users of the destination to specify.
 pub fn handle_configuration_form_request() -> ConfigurationFormResponse {
     ConfigurationFormResponse {
         schema_selection_supported: true,
@@ -52,6 +54,13 @@ pub fn handle_configuration_form_request() -> ConfigurationFormResponse {
                 label: "Database".into(),
                 description: Some("The name of the database to connect to".into()),
                 required: true,
+                r#type: Some(Type::TextField(TextField::PlainText.into())),
+            },
+            FormField {
+                name: "cluster".into(),
+                label: "Cluster".into(),
+                description: Some("The cluster to run operations on".into()),
+                required: false,
                 r#type: Some(Type::TextField(TextField::PlainText.into())),
             },
         ],
@@ -126,6 +135,7 @@ pub async fn connect(
     let dbname = config
         .remove("dbname")
         .ok_or(OpErrorKind::FieldMissing("dbname"))?;
+    let cluster = config.remove("cluster");
 
     // Compile in the CA certificate bundle downloaded by the build script, and
     // configure the TLS connector to reference that compiled-in CA bundle,
@@ -146,6 +156,12 @@ pub async fn connect(
     let mut builder = SslConnector::builder(SslMethod::tls_client())?;
     builder.set_verify_cert_store(cert_store.build())?;
 
+    let options = if let Some(cluster) = cluster {
+        format!("--cluster={cluster}")
+    } else {
+        String::new()
+    };
+
     let tls_connector = MakeTlsConnector::new(builder.build());
     let (client, conn) = tokio_postgres::Config::new()
         .host(&host)
@@ -154,6 +170,7 @@ pub async fn connect(
         .password(app_password)
         .dbname(&dbname)
         .application_name(FIVETRAN_DESTINATION_APPLICATION_NAME)
+        .options(&options)
         .connect(tls_connector)
         .await?;
 

--- a/src/fivetran-destination/src/utils.rs
+++ b/src/fivetran-destination/src/utils.rs
@@ -104,6 +104,36 @@ pub fn to_fivetran_type(ty: Type) -> Result<(DataType, Option<DecimalParams>), O
     }
 }
 
+/// Escapes a string `s` so it can be used in a value in the `options` argument when connecting to
+/// Materialize.
+///
+/// See the [Postgres Docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS)
+/// for characters that need to be escaped.
+///
+/// ```
+/// use mz_fivetran_destination::utils::escape_options;
+///
+/// assert_eq!(escape_options("foo"), "foo");
+/// assert_eq!(escape_options("name with space"), r#"name\ with\ space"#);
+/// assert_eq!(escape_options(r#"\"#), r#"\\"#);
+/// assert_eq!(escape_options(r#"\ "#), r#"\\\ "#);
+/// ```
+pub fn escape_options(s: &str) -> String {
+    let mut escaped = String::with_capacity(s.len());
+
+    for c in s.chars() {
+        match c {
+            '\\' => escaped.push_str(r#"\\"#),
+            ' ' => {
+                escaped.push_str(r#"\ "#);
+            }
+            other => escaped.push(other),
+        }
+    }
+
+    escaped
+}
+
 /// Maps the column ordering of a CSV file, to the ordering of the provided table.
 ///
 /// The column ordering of a CSV provided by Fivetran is not guaranteed to match the column

--- a/test/fivetran-destination/data/configuration.json
+++ b/test/fivetran-destination/data/configuration.json
@@ -3,5 +3,5 @@
   "user": "materialize",
   "app_password": "ignored",
   "dbname": "test",
-  "cluster": "quickstart"
+  "cluster": "name with space"
 }

--- a/test/fivetran-destination/data/configuration.json
+++ b/test/fivetran-destination/data/configuration.json
@@ -2,5 +2,6 @@
   "host": "materialized",
   "user": "materialize",
   "app_password": "ignored",
-  "dbname": "test"
+  "dbname": "test",
+  "cluster": "quickstart"
 }

--- a/test/fivetran-destination/mzcompose.py
+++ b/test/fivetran-destination/mzcompose.py
@@ -103,6 +103,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 def _run_test_case(c: Composition, path: Path):
     c.sql("DROP DATABASE IF EXISTS test")
     c.sql("CREATE DATABASE test")
+    c.sql('DROP CLUSTER IF EXISTS "name with space" CASCADE')
+    c.sql("CREATE CLUSTER \"name with space\" SIZE '1'")
     for test_file in sorted(p for p in path.iterdir()):
         test_file = test_file.relative_to(ROOT)
         if test_file.suffix == ".td":


### PR DESCRIPTION
This PR updates the Fivetran Destination to add a 'cluster' option to the configuration page as an optional parameter. This will change the cluster that the Fivetran Destination uses to update the destination tables.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/24662

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
