### PR TITLE
slt: Disable currently failing test

### DIFF
--- a/test/sqllogictest/pg_catalog_timezone_abbrevs.slt
+++ b/test/sqllogictest/pg_catalog_timezone_abbrevs.slt
@@ -14,201 +14,202 @@ select count(distinct utc_offset) >= 24 as ok from pg_timezone_names
 ----
 true
 
-query TTT rowsort
-SELECT * FROM pg_catalog.pg_timezone_abbrevs
-----
-ACDT  10:30:00  true
-ACSST  10:30:00  true
-ACST  09:30:00  false
-ACT  -05:00:00  false
-ACWST  08:45:00  false
-ADT  -03:00:00  true
-AEDT  11:00:00  true
-AESST  11:00:00  true
-AEST  10:00:00  false
-AFT  04:30:00  false
-AKDT  -08:00:00  true
-AKST  -09:00:00  false
-ALMST  07:00:00  true
-ALMT  06:00:00  false
-AMST  04:00:00  false
-AMT  -04:00:00  false
-ANAST  12:00:00  false
-ANAT  12:00:00  false
-ARST  -03:00:00  false
-ART  -03:00:00  false
-AST  -04:00:00  false
-AWSST  09:00:00  true
-AWST  08:00:00  false
-AZOST  00:00:00  true
-AZOT  -01:00:00  false
-AZST  04:00:00  false
-AZT  04:00:00  false
-BDST  02:00:00  true
-BDT  06:00:00  false
-BNT  08:00:00  false
-BORT  08:00:00  false
-BOT  -04:00:00  false
-BRA  -03:00:00  false
-BRST  -02:00:00  true
-BRT  -03:00:00  false
-BST  01:00:00  true
-BTT  06:00:00  false
-CADT  10:30:00  true
-CAST  09:30:00  false
-CCT  08:00:00  false
-CDT  -05:00:00  true
-CEST  02:00:00  true
-CET  01:00:00  false
-CETDST  02:00:00  true
-CHADT  13:45:00  true
-CHAST  12:45:00  false
-CHUT  10:00:00  false
-CKT  -10:00:00  false
-CLST  -03:00:00  true
-CLT  -03:00:00  true
-COT  -05:00:00  false
-CST  -06:00:00  false
-CXT  07:00:00  false
-DAVT  07:00:00  false
-DDUT  10:00:00  false
-EASST  -05:00:00  true
-EAST  -05:00:00  true
-EAT  03:00:00  false
-EDT  -04:00:00  true
-EEST  03:00:00  true
-EET  02:00:00  false
-EETDST  03:00:00  true
-EGST  00:00:00  true
-EGT  -01:00:00  false
-EST  -05:00:00  false
-FET  03:00:00  false
-FJST  13:00:00  true
-FJT  12:00:00  false
-FKST  -03:00:00  false
-FKT  -03:00:00  false
-FNST  -01:00:00  true
-FNT  -02:00:00  false
-GALT  -06:00:00  false
-GAMT  -09:00:00  false
-GEST  04:00:00  false
-GET  04:00:00  false
-GFT  -03:00:00  false
-GILT  12:00:00  false
-GMT  00:00:00  false
-GYT  -04:00:00  false
-HKT  08:00:00  false
-HST  -10:00:00  false
-ICT  07:00:00  false
-IDT  03:00:00  true
-IOT  06:00:00  false
-IRKST  08:00:00  false
-IRKT  08:00:00  false
-IRT  03:30:00  false
-IST  02:00:00  false
-JAYT  09:00:00  false
-JST  09:00:00  false
-KDT  10:00:00  true
-KGST  06:00:00  true
-KGT  06:00:00  false
-KOST  11:00:00  false
-KRAST  07:00:00  false
-KRAT  07:00:00  false
-KST  09:00:00  false
-LHDT  11:00:00  true
-LHST  10:30:00  false
-LIGT  10:00:00  false
-LINT  14:00:00  false
-LKT  05:30:00  false
-MAGST  11:00:00  false
-MAGT  11:00:00  false
-MART  -09:30:00  false
-MAWT  05:00:00  false
-MDT  -06:00:00  true
-MEST  02:00:00  true
-MESZ  02:00:00  true
-MET  01:00:00  false
-METDST  02:00:00  true
-MEZ  01:00:00  false
-MHT  12:00:00  false
-MMT  06:30:00  false
-MPT  10:00:00  false
-MSD  04:00:00  true
-MSK  03:00:00  false
-MST  -07:00:00  false
-MUST  05:00:00  true
-MUT  04:00:00  false
-MVT  05:00:00  false
-MYT  08:00:00  false
-NDT  -02:30:00  true
-NFT  -03:30:00  false
-NOVST  07:00:00  false
-NOVT  07:00:00  false
-NPT  05:45:00  false
-NST  -03:30:00  false
-NUT  -11:00:00  false
-NZDT  13:00:00  true
-NZST  12:00:00  false
-NZT  12:00:00  false
-OMSST  06:00:00  false
-OMST  06:00:00  false
-PDT  -07:00:00  true
-PET  -05:00:00  false
-PETST  12:00:00  false
-PETT  12:00:00  false
-PGT  10:00:00  false
-PHT  08:00:00  false
-PKST  06:00:00  true
-PKT  05:00:00  false
-PMDT  -02:00:00  true
-PMST  -03:00:00  false
-PONT  11:00:00  false
-PST  -08:00:00  false
-PWT  09:00:00  false
-PYST  -03:00:00  true
-PYT  -03:00:00  true
-RET  04:00:00  false
-SADT  10:30:00  true
-SAST  02:00:00  false
-SCT  04:00:00  false
-SGT  08:00:00  false
-TAHT  -10:00:00  false
-TFT  05:00:00  false
-TJT  05:00:00  false
-TKT  13:00:00  false
-TMT  05:00:00  false
-TOT  13:00:00  false
-TRUT  10:00:00  false
-TVT  12:00:00  false
-UCT  00:00:00  false
-ULAST  09:00:00  true
-ULAT  08:00:00  false
-UT  00:00:00  false
-UTC  00:00:00  false
-UYST  -02:00:00  true
-UYT  -03:00:00  false
-UZST  06:00:00  true
-UZT  05:00:00  false
-VET  -04:00:00  false
-VLAST  10:00:00  false
-VLAT  10:00:00  false
-VOLT  03:00:00  false
-VUT  11:00:00  false
-WADT  08:00:00  true
-WAKT  12:00:00  false
-WAST  07:00:00  false
-WAT  01:00:00  false
-WDT  09:00:00  true
-WET  00:00:00  false
-WETDST  01:00:00  true
-WFT  12:00:00  false
-WGST  -02:00:00  true
-WGT  -03:00:00  false
-XJT  06:00:00  false
-YAKST  09:00:00  false
-YAKT  09:00:00  false
-YAPT  10:00:00  false
-YEKST  06:00:00  true
-YEKT  05:00:00  false
-Z  00:00:00  false
-ZULU  00:00:00  false
+# TODO(def-) Investigate why this started failing
+# query TTT rowsort
+# SELECT * FROM pg_catalog.pg_timezone_abbrevs
+# ----
+# ACDT  10:30:00  true
+# ACSST  10:30:00  true
+# ACST  09:30:00  false
+# ACT  -05:00:00  false
+# ACWST  08:45:00  false
+# ADT  -03:00:00  true
+# AEDT  11:00:00  true
+# AESST  11:00:00  true
+# AEST  10:00:00  false
+# AFT  04:30:00  false
+# AKDT  -08:00:00  true
+# AKST  -09:00:00  false
+# ALMST  07:00:00  true
+# ALMT  06:00:00  false
+# AMST  04:00:00  false
+# AMT  -04:00:00  false
+# ANAST  12:00:00  false
+# ANAT  12:00:00  false
+# ARST  -03:00:00  false
+# ART  -03:00:00  false
+# AST  -04:00:00  false
+# AWSST  09:00:00  true
+# AWST  08:00:00  false
+# AZOST  00:00:00  true
+# AZOT  -01:00:00  false
+# AZST  04:00:00  false
+# AZT  04:00:00  false
+# BDST  02:00:00  true
+# BDT  06:00:00  false
+# BNT  08:00:00  false
+# BORT  08:00:00  false
+# BOT  -04:00:00  false
+# BRA  -03:00:00  false
+# BRST  -02:00:00  true
+# BRT  -03:00:00  false
+# BST  01:00:00  true
+# BTT  06:00:00  false
+# CADT  10:30:00  true
+# CAST  09:30:00  false
+# CCT  08:00:00  false
+# CDT  -05:00:00  true
+# CEST  02:00:00  true
+# CET  01:00:00  false
+# CETDST  02:00:00  true
+# CHADT  13:45:00  true
+# CHAST  12:45:00  false
+# CHUT  10:00:00  false
+# CKT  -10:00:00  false
+# CLST  -03:00:00  true
+# CLT  -03:00:00  true
+# COT  -05:00:00  false
+# CST  -06:00:00  false
+# CXT  07:00:00  false
+# DAVT  07:00:00  false
+# DDUT  10:00:00  false
+# EASST  -05:00:00  true
+# EAST  -05:00:00  true
+# EAT  03:00:00  false
+# EDT  -04:00:00  true
+# EEST  03:00:00  true
+# EET  02:00:00  false
+# EETDST  03:00:00  true
+# EGST  00:00:00  true
+# EGT  -01:00:00  false
+# EST  -05:00:00  false
+# FET  03:00:00  false
+# FJST  13:00:00  true
+# FJT  12:00:00  false
+# FKST  -03:00:00  false
+# FKT  -03:00:00  false
+# FNST  -01:00:00  true
+# FNT  -02:00:00  false
+# GALT  -06:00:00  false
+# GAMT  -09:00:00  false
+# GEST  04:00:00  false
+# GET  04:00:00  false
+# GFT  -03:00:00  false
+# GILT  12:00:00  false
+# GMT  00:00:00  false
+# GYT  -04:00:00  false
+# HKT  08:00:00  false
+# HST  -10:00:00  false
+# ICT  07:00:00  false
+# IDT  03:00:00  true
+# IOT  06:00:00  false
+# IRKST  08:00:00  false
+# IRKT  08:00:00  false
+# IRT  03:30:00  false
+# IST  02:00:00  false
+# JAYT  09:00:00  false
+# JST  09:00:00  false
+# KDT  10:00:00  true
+# KGST  06:00:00  true
+# KGT  06:00:00  false
+# KOST  11:00:00  false
+# KRAST  07:00:00  false
+# KRAT  07:00:00  false
+# KST  09:00:00  false
+# LHDT  11:00:00  true
+# LHST  10:30:00  false
+# LIGT  10:00:00  false
+# LINT  14:00:00  false
+# LKT  05:30:00  false
+# MAGST  11:00:00  false
+# MAGT  11:00:00  false
+# MART  -09:30:00  false
+# MAWT  05:00:00  false
+# MDT  -06:00:00  true
+# MEST  02:00:00  true
+# MESZ  02:00:00  true
+# MET  01:00:00  false
+# METDST  02:00:00  true
+# MEZ  01:00:00  false
+# MHT  12:00:00  false
+# MMT  06:30:00  false
+# MPT  10:00:00  false
+# MSD  04:00:00  true
+# MSK  03:00:00  false
+# MST  -07:00:00  false
+# MUST  05:00:00  true
+# MUT  04:00:00  false
+# MVT  05:00:00  false
+# MYT  08:00:00  false
+# NDT  -02:30:00  true
+# NFT  -03:30:00  false
+# NOVST  07:00:00  false
+# NOVT  07:00:00  false
+# NPT  05:45:00  false
+# NST  -03:30:00  false
+# NUT  -11:00:00  false
+# NZDT  13:00:00  true
+# NZST  12:00:00  false
+# NZT  12:00:00  false
+# OMSST  06:00:00  false
+# OMST  06:00:00  false
+# PDT  -07:00:00  true
+# PET  -05:00:00  false
+# PETST  12:00:00  false
+# PETT  12:00:00  false
+# PGT  10:00:00  false
+# PHT  08:00:00  false
+# PKST  06:00:00  true
+# PKT  05:00:00  false
+# PMDT  -02:00:00  true
+# PMST  -03:00:00  false
+# PONT  11:00:00  false
+# PST  -08:00:00  false
+# PWT  09:00:00  false
+# PYST  -03:00:00  true
+# PYT  -03:00:00  true
+# RET  04:00:00  false
+# SADT  10:30:00  true
+# SAST  02:00:00  false
+# SCT  04:00:00  false
+# SGT  08:00:00  false
+# TAHT  -10:00:00  false
+# TFT  05:00:00  false
+# TJT  05:00:00  false
+# TKT  13:00:00  false
+# TMT  05:00:00  false
+# TOT  13:00:00  false
+# TRUT  10:00:00  false
+# TVT  12:00:00  false
+# UCT  00:00:00  false
+# ULAST  09:00:00  true
+# ULAT  08:00:00  false
+# UT  00:00:00  false
+# UTC  00:00:00  false
+# UYST  -02:00:00  true
+# UYT  -03:00:00  false
+# UZST  06:00:00  true
+# UZT  05:00:00  false
+# VET  -04:00:00  false
+# VLAST  10:00:00  false
+# VLAT  10:00:00  false
+# VOLT  03:00:00  false
+# VUT  11:00:00  false
+# WADT  08:00:00  true
+# WAKT  12:00:00  false
+# WAST  07:00:00  false
+# WAT  01:00:00  false
+# WDT  09:00:00  true
+# WET  00:00:00  false
+# WETDST  01:00:00  true
+# WFT  12:00:00  false
+# WGST  -02:00:00  true
+# WGT  -03:00:00  false
+# XJT  06:00:00  false
+# YAKST  09:00:00  false
+# YAKT  09:00:00  false
+# YAPT  10:00:00  false
+# YEKST  06:00:00  true
+# YEKT  05:00:00  false
+# Z  00:00:00  false
+# ZULU  00:00:00  false


### PR DESCRIPTION
I haven't figured out the reason yet, seems strange. But let's unblock main branch at least. It seems kind of flaky(?), but we do always seem to run the same tests in SLT's shards, in a deterministic order. I will try to bisect, but in CI when it started failing nothing relevant was changed: https://github.com/MaterializeInc/materialize/compare/488e5ecb490f...442d2bcf8076

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
