### PR TITLE
bootstrap: fix collection of dependent MVs

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2193,10 +2193,11 @@ impl Coordinator {
                 }
 
                 for dep_id in idx_deps {
-                    if let Some(ids) = dependants.get_mut(dep_id) {
-                        changed |= mv_ids.iter().any(|mv_id| ids.insert(*mv_id));
-                    } else {
-                        // `dep_id` references a source import.
+                    let Some(ids) = dependants.get_mut(dep_id) else {
+                        continue; // `dep_id` references a source import
+                    };
+                    for mv_id in &mv_ids {
+                        changed |= ids.insert(*mv_id);
                     }
                 }
             }


### PR DESCRIPTION
Collection of MVs depending on compute indexes had a bug where it uses `Iterator::any` to determine if any of a number of inserts into a `BTreeSet` changed the contents of the set. This didn't consider the fact that `any` is short-circuiting, so if any one insert would return `true`, subsequent ones would be skipped.

This is fixed here by replacing the use of `any` with a `for` loop.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A