### PR TITLE
coord: Fix the new dump endpoint

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2712,7 +2712,7 @@ impl Coordinator {
     pub fn dump(&self) -> Result<serde_json::Value, anyhow::Error> {
         // Note: We purposefully use the `Debug` formatting for the value of all fields in the
         // returned object as a tradeoff between usability and stability. `serde_json` will fail
-        // to serailize an object if the keys aren't strings, so `Debug` formatting the values
+        // to serialize an object if the keys aren't strings, so `Debug` formatting the values
         // prevents a future unrelated change from silently breaking this method.
 
         let active_conns: BTreeMap<_, _> = self

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2710,45 +2710,56 @@ impl Coordinator {
     ///
     /// The returned value is not guaranteed to be stable and may change at any point in time.
     pub fn dump(&self) -> Result<serde_json::Value, anyhow::Error> {
+        // Note: We purposefully use the `Debug` formatting for the value of all fields in the
+        // returned object as a tradeoff between usability and stability. `serde_json` will fail
+        // to serailize an object if the keys aren't strings, so `Debug` formatting the values
+        // prevents a future unrelated change from silently breaking this method.
+
         let active_conns: BTreeMap<_, _> = self
             .active_conns
             .iter()
-            .map(|(id, meta)| (id.unhandled().to_string(), meta))
+            .map(|(id, meta)| (id.unhandled().to_string(), format!("{meta:?}")))
             .collect();
         let storage_read_capabilities: BTreeMap<_, _> = self
             .storage_read_capabilities
             .iter()
-            .map(|(id, capability)| (id.to_string(), capability))
+            .map(|(id, capability)| (id.to_string(), format!("{capability:?}")))
             .collect();
         let compute_read_capabilities: BTreeMap<_, _> = self
             .compute_read_capabilities
             .iter()
-            .map(|(id, capability)| (id.to_string(), capability))
+            .map(|(id, capability)| (id.to_string(), format!("{capability:?}")))
             .collect();
         let txn_read_holds: BTreeMap<_, _> = self
             .txn_read_holds
             .iter()
-            .map(|(id, capability)| (id.unhandled().to_string(), capability))
+            .map(|(id, capability)| (id.unhandled().to_string(), format!("{capability:?}")))
             .collect();
         let pending_peeks: BTreeMap<_, _> = self
             .pending_peeks
             .iter()
-            .map(|(id, peek)| (id.to_string(), format!("{peek:#?}")))
+            .map(|(id, peek)| (id.to_string(), format!("{peek:?}")))
             .collect();
         let client_pending_peeks: BTreeMap<_, _> = self
             .client_pending_peeks
             .iter()
-            .map(|(id, peek)| (id.to_string(), peek))
+            .map(|(id, peek)| {
+                let peek: BTreeMap<_, _> = peek
+                    .iter()
+                    .map(|(uuid, storage_id)| (uuid.to_string(), storage_id))
+                    .collect();
+                (id.to_string(), peek)
+            })
             .collect();
         let pending_real_time_recency_timestamp: BTreeMap<_, _> = self
             .pending_real_time_recency_timestamp
             .iter()
-            .map(|(id, timestamp)| (id.unhandled().to_string(), format!("{timestamp:#?}")))
+            .map(|(id, timestamp)| (id.unhandled().to_string(), format!("{timestamp:?}")))
             .collect();
         let pending_linearize_read_txns: BTreeMap<_, _> = self
             .pending_linearize_read_txns
             .iter()
-            .map(|(id, read_txn)| (id.unhandled().to_string(), format!("{read_txn:#?}")))
+            .map(|(id, read_txn)| (id.unhandled().to_string(), format!("{read_txn:?}")))
             .collect();
 
         let map = serde_json::Map::from_iter([

--- a/src/environmentd/src/http/catalog.rs
+++ b/src/environmentd/src/http/catalog.rs
@@ -40,9 +40,12 @@ pub async fn handle_coordinator_check(mut client: AuthedClient) -> impl IntoResp
 }
 
 pub async fn handle_coordinator_dump(mut client: AuthedClient) -> impl IntoResponse {
-    let result = match client.client.dump_coordinator_state().await {
-        Ok(dump) => dump,
-        Err(e) => serde_json::json!({ "err": e.to_string() }),
+    let (status, result) = match client.client.dump_coordinator_state().await {
+        Ok(dump) => (StatusCode::OK, dump),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            serde_json::json!({ "err": e.to_string() }),
+        ),
     };
-    (TypedHeader(ContentType::json()), result.to_string())
+    (status, TypedHeader(ContentType::json()), result.to_string())
 }

--- a/src/testdrive/src/action/consistency.rs
+++ b/src/testdrive/src/action/consistency.rs
@@ -113,6 +113,7 @@ async fn check_coordinator(state: &State) -> Result<(), anyhow::Error> {
     .await?;
     // We allow NOT_FOUND to support upgrade tests where this endpoint doesn't yet exist.
     if !response.status().is_success() && response.status() != StatusCode::NOT_FOUND {
+        let response: Result<serde_json::Value, _> = response.json().await;
         bail!("Coordinator failed to dump state: {:?}", response);
     }
 


### PR DESCRIPTION
@teskje pointed out that the Coordinator's new `.../dump` endpoint breaks in practice because a few maps have keys that are not `String`s, which breaks the JSON serialization. I added a check for this in testdrive which didn't work because even on errors we would return a 200.

This PR changes the endpoint to return a 500 if we fail to serialize the state, which should fix the check. It also updates the dump impl to use the `Debug` format for fields to prevent this method from silently breaking in the future

### Motivation

Fix the Coordinator's new state dump API

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
