### PR TITLE
storage/mysql: Use transaction Xid event to advance frontier beyond current GTID

### DIFF
--- a/test/mysql-cdc/alter-table-after-source.td
+++ b/test/mysql-cdc/alter-table-after-source.td
@@ -107,8 +107,7 @@ INSERT INTO add_columns VALUES (2, 'ab');
 
 > SELECT * from add_columns;
 1
-# TODO: #24630 (refresh delay)
-# 2
+2
 
 
 #
@@ -178,10 +177,9 @@ $ mysql-execute name=mysql
 ALTER TABLE alter_add_nullability MODIFY f1 INTEGER NOT NULL;
 INSERT INTO alter_add_nullability VALUES (1);
 
-# TODO: #24630 (refresh delay)
-# > select * from alter_add_nullability;
-# 1
-# 1
+> select * from alter_add_nullability;
+1
+1
 
 # TODO: #25040 (changes to columns)
 # ? EXPLAIN SELECT * FROM alter_add_nullability WHERE f1 IS NULL;
@@ -212,10 +210,9 @@ $ mysql-execute name=mysql
 ALTER TABLE alter_add_pk ADD PRIMARY KEY(f1);
 INSERT INTO alter_add_pk VALUES (2);
 
-# TODO: #24630 (refresh delay)
-# > SELECT * FROM alter_add_pk;
-# 1
-# 2
+> SELECT * FROM alter_add_pk;
+1
+2
 
 
 #
@@ -244,11 +241,9 @@ ALTER TABLE alter_cycle_pk_off ADD PRIMARY KEY(f1);
 ALTER TABLE alter_cycle_pk_off DROP PRIMARY KEY;
 INSERT INTO alter_cycle_pk_off VALUES (1);
 
-# TODO: #24630 (refresh delay)
-# > SELECT * FROM alter_cycle_pk_off;
-# 1
-# 1
-
+> SELECT * FROM alter_cycle_pk_off;
+1
+1
 
 #
 # Drop unique
@@ -273,10 +268,9 @@ $ mysql-execute name=mysql
 ALTER TABLE alter_add_unique MODIFY f1 INTEGER UNIQUE;
 INSERT INTO alter_add_unique VALUES (2);
 
-# TODO: #24630 (refresh delay)
-# > SELECT * FROM alter_add_unique;
-# 1
-# 2
+> SELECT * FROM alter_add_unique;
+1
+2
 
 
 #
@@ -365,25 +359,18 @@ $ mysql-execute name=mysql
 ALTER TABLE alter_table_supported ADD COLUMN f3 int;
 INSERT INTO alter_table_supported (f1, f2, f3) VALUES (2, 2, 2);
 
-# TODO: #24630 (refresh delay): remove when the statement after this one works
-> SELECT * from alter_table_supported WHERE f1 = 1;
+> SELECT * from alter_table_supported;
 1 1
-
-# TODO: #24630 (refresh delay)
-# > SELECT * from alter_table_supported;
-# 1 1
-# 2 2
-
+2 2
 
 $ mysql-execute name=mysql
 ALTER TABLE alter_table_supported DROP COLUMN f3;
 INSERT INTO alter_table_supported (f1, f2) VALUES (3, 3);
 
-# TODO: #24630 (refresh delay)
-# > SELECT * from alter_table_supported;
-# 1 1
-# 2 2
-# 3 3
+> SELECT * from alter_table_supported;
+1 1
+2 2
+3 3
 
 $ mysql-execute name=mysql
 ALTER TABLE alter_table_supported DROP COLUMN f2;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/materialize/issues/24630

After we realized #26223 wouldn't work, @benesch [discovered](https://github.com/MaterializeInc/materialize/issues/24630#issuecomment-2018082249) that the [`Xid` ](https://dev.mysql.com/doc/dev/mysql-server/latest/classXid__log__event.html)event should be more reliable for signifying the end of the current transaction. So we can now use this in addition to the heartbeat-event to know that we are done receiving updates for the current GTID, avoiding the heartbeat delay in most cases (when using the common mysql storage engine).

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I plan to trigger the nightlies on this PR to ensure it behaves correctly with the zippy tests, etc.



<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
