### PR TITLE
fivetran-destination: Upgrade tester

### DIFF
--- a/misc/images/fivetran-destination-tester/Dockerfile
+++ b/misc/images/fivetran-destination-tester/Dockerfile
@@ -11,4 +11,4 @@
 #       and decouple ourselves from Fivetran's Dockerhub, incase Fivetran removes the image that we
 #       depend on.
 
-FROM fivetrandocker/sdk-destination-tester:024.0222.002
+FROM fivetrandocker/sdk-destination-tester:024.0314.001

--- a/test/fivetran-destination/test-deletes-no-primary/01-setup.json
+++ b/test/fivetran-destination/test-deletes-no-primary/01-setup.json
@@ -18,7 +18,7 @@
       }
     },
     {
-      "delete": {
+      "soft_delete": {
         "test_deletes_no_primary": [
           {"v1": "2", "v2": "a", "_fivetran_id": "2a"}
         ]

--- a/test/fivetran-destination/test-multi-table/01-workflow.json
+++ b/test/fivetran-destination/test-multi-table/01-workflow.json
@@ -72,7 +72,7 @@
             }
         },
         {
-            "truncate": [
+            "soft_truncate_before": [
                 "blue"
             ]
         },

--- a/test/fivetran-destination/test-multi-table/02-verify.td
+++ b/test/fivetran-destination/test-multi-table/02-verify.td
@@ -10,9 +10,9 @@
 > SELECT k, v1, v2, _fivetran_deleted FROM test.tester.green
 k   v1       v2             _fivetran_deleted
 ---------------------------------------------
-1   "hello"  "world"        false
+1   "hello"  "world"        <null>
 2   "foo"    "bar"          true
-3   "bing!"  "whomp whomp"  false
+3   "bing!"  "whomp whomp"  <null>
 
 > SELECT a, b, c, _fivetran_deleted FROM test.tester.blue
 a     b       c             _fivetran_deleted

--- a/test/fivetran-destination/test-writes/02-verify.td
+++ b/test/fivetran-destination/test-writes/02-verify.td
@@ -10,9 +10,6 @@
 > SELECT k1, k2, v1, v2, _fivetran_deleted FROM test.tester.test_writes
 k1  k2  v1     v2               _fivetran_deleted
 -------------------------------------------------
-1   a   12.78  "{\"x\":\"y\"}"  false
-1   b   91.28  {}               false
-2   a   34.21  null             false
-
-> SELECT COUNT(DISTINCT(_fivetran_synced)) FROM test.tester.test_writes
-1
+1   a   12.78  "{\"x\":\"y\"}"  <null>
+1   b   91.28  {}               <null>
+2   a   34.21  null             <null>

--- a/test/fivetran-destination/test-writes/04-verify.td
+++ b/test/fivetran-destination/test-writes/04-verify.td
@@ -11,8 +11,5 @@
 k1  k2  v1     v2               _fivetran_deleted
 -------------------------------------------------
 1   a   12.78  "{\"x\":\"y\"}"  true
-1   b   91.28  {}               false
-2   a   34.21  null             false
-
-> SELECT COUNT(DISTINCT(_fivetran_synced)) FROM test.tester.test_writes
-2
+1   b   91.28  {}               <null>
+2   a   34.21  null             <null>

--- a/test/fivetran-destination/test-writes/07-soft-truncate.json
+++ b/test/fivetran-destination/test-writes/07-soft-truncate.json
@@ -4,7 +4,7 @@
     ],
     "ops": [
         {
-            "truncate": [
+            "soft_truncate_before": [
                 "test_writes"
             ]
         }

--- a/test/fivetran-destination/test-writes/08-verify.td
+++ b/test/fivetran-destination/test-writes/08-verify.td
@@ -13,8 +13,3 @@ k1  k2  v1     v2               _fivetran_deleted
 1   a   12.78  "{\"x\":\"y\"}"  true
 1   b   91.28  {}               true
 2   a   34.21  "{\"x\":\"z\"}"  true
-
-# Note: Truncate does not update the _fivetran_synced column, which is why we still have 3 distinct
-# values.
-> SELECT COUNT(DISTINCT(_fivetran_synced)) FROM test.tester.test_writes
-3

--- a/test/fivetran-destination/test-writes/10-verify.td
+++ b/test/fivetran-destination/test-writes/10-verify.td
@@ -14,8 +14,3 @@ k1  k2  v1      v2                     _fivetran_deleted
 1   b   91.28   "{\"foo\":\"green\"}"  false
 2   a   0       null                   false
 3   a   11.11   {}                     false
-
-# We do an update for values with k1 = 1, and an upsert for the rest. These are two separate
-# operations that will have two different synced times.
-> SELECT COUNT(DISTINCT(_fivetran_synced)) FROM test.tester.test_writes
-2

--- a/test/fivetran-destination/test-writes/11-truncate.json
+++ b/test/fivetran-destination/test-writes/11-truncate.json
@@ -1,0 +1,12 @@
+{
+    "describe_table": [
+        "test_writes"
+    ],
+    "ops": [
+        {
+            "truncate_before": [
+                "test_writes"
+            ]
+        }
+    ]
+}

--- a/test/fivetran-destination/test-writes/12-verify.td
+++ b/test/fivetran-destination/test-writes/12-verify.td
@@ -7,9 +7,5 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> SELECT k1, k2, v1, v2, _fivetran_deleted FROM test.tester.test_writes
-k1  k2  v1     v2               _fivetran_deleted
--------------------------------------------------
-1   a   12.78  "{\"x\":\"y\"}"  true
-1   b   91.28  {}               <null>
-2   a   34.21  "{\"x\":\"z\"}"  false
+> SELECT COUNT(*) FROM test.tester.test_writes
+0


### PR DESCRIPTION
This PR upgrades the Fivetran Destination tester to the latest one provided, updates our tests based on changes to the tester, and adds a new hard truncate test case.

Note: This PR is stacked on top of https://github.com/MaterializeInc/materialize/pull/26230, will wait for that to merge first

### Motivation

Better testing of the Fivetran Destination

Fixes https://github.com/MaterializeInc/materialize/issues/26176

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
