### PR TITLE
mysql-cdc tests: Disable bin-log-manipulations workflow

### DIFF
--- a/test/mysql-cdc-resumption/mzcompose.py
+++ b/test/mysql-cdc-resumption/mzcompose.py
@@ -46,6 +46,10 @@ def workflow_default(c: Composition) -> None:
         if name == "default":
             continue
 
+        # TODO(def-): Reenable when #26127 is fixed
+        if name == "bin-log-manipulations":
+            continue
+
         with c.test_case(name):
             c.workflow(name)
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/tests/builds/79036#018e7632-5a5e-481a-b5f4-396ad2b9f994 (again)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
