### PR TITLE
storage: relax the KEY FORMAT requirement for kafka sources

### DIFF
--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -386,6 +386,11 @@ impl RelationDesc {
         }
     }
 
+    /// Return whether this `RelationDesc` is `empty`.
+    pub fn is_empty(&self) -> bool {
+        self == &RelationDesc::empty()
+    }
+
     /// Constructs a new `RelationDesc` from a `RelationType` and an iterator
     /// over column names.
     ///

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -37,20 +37,6 @@ $ kafka-ingest format=avro key-format=avro topic=avro-data key-schema=${conflict
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
-! CREATE SOURCE missing_key_format
-  IN CLUSTER ${arg.single-replica-cluster}
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-avro-data-${testdrive.seed}')
-  FORMAT AVRO USING SCHEMA '${schema}'
-  INCLUDE KEY
-contains:INCLUDE KEY requires specifying KEY FORMAT .. VALUE FORMAT, got bare FORMAT
-
-! CREATE SOURCE missing_key_format
-  IN CLUSTER ${arg.single-replica-cluster}
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-avro-data-${testdrive.seed}')
-  FORMAT AVRO USING SCHEMA '${schema}'
-  INCLUDE KEY AS key_col
-contains:INCLUDE KEY requires specifying KEY FORMAT .. VALUE FORMAT, got bare FORMAT
-
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
   );

--- a/test/testdrive/kafka-no-key-format.td
+++ b/test/testdrive/kafka-no-key-format.td
@@ -1,0 +1,116 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set-arg-default default-storage-size=1
+$ set-arg-default single-replica-cluster=quickstart
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "id", "type": "long"}
+    ]
+  }
+
+$ set schema={
+    "name": "row",
+    "type": "record",
+    "fields": [
+      {"name": "id", "type": "long"},
+      {"name": "b", "type": "long"}
+    ]
+  }
+
+$ kafka-create-topic topic=weird
+
+$ kafka-ingest format=avro key-format=avro topic=weird key-schema=${keyschema} schema=${schema}
+{"id": 1} {"id": 2, "b": 3}
+
+$ kafka-ingest format=avro key-format=bytes topic=weird schema=${schema} key-terminator=:
+weird:{"id": 2, "b": 3}
+
+$ kafka-ingest format=avro topic=weird schema=${schema} omit-key=true
+{"id": 2, "b": 3}
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE SOURCE no_key_format
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-weird-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${schema}'
+  INCLUDE KEY
+
+> SHOW COLUMNS FROM no_key_format;
+name  nullable  type
+-----------------------
+key   true     bytea
+id    false    bigint
+b     false    bigint
+
+> SELECT key IS NOT NULL as key, id, b from no_key_format
+key           id       b
+------------------------
+false        2        3
+true         2        3
+true         2        3
+
+> CREATE SOURCE just_format
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-weird-${testdrive.seed}')
+  FORMAT BYTES
+  INCLUDE KEY AS key_col
+
+> SHOW COLUMNS FROM just_format;
+name     nullable  type
+-----------------------
+key_col  true     bytea
+data     false    bytea
+
+> SELECT key_col IS NOT NULL as key_col from just_format
+key_col
+-------
+false
+true
+true
+
+$ kafka-create-topic topic=weird-upsert
+$ kafka-ingest format=bytes key-format=bytes topic=weird-upsert key-terminator=:
+one:one
+
+> CREATE SOURCE upsert_no_key_format
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-weird-upsert-${testdrive.seed}')
+  FORMAT BYTES
+  ENVELOPE UPSERT
+
+> SHOW COLUMNS FROM upsert_no_key_format
+name     nullable  type
+-----------------------
+key      false    bytea
+data     false    bytea
+
+> SELECT * from upsert_no_key_format
+key    data
+-----------
+one    one
+
+$ kafka-ingest format=bytes key-format=bytes topic=weird-upsert key-terminator=:
+:one
+
+! SELECT * from upsert_no_key_format
+contains: Null key
+
+$ kafka-ingest format=bytes key-format=bytes topic=weird-upsert key-terminator=:
+:
+
+> SELECT * from upsert_no_key_format
+key    data
+-----------
+one    one

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -102,7 +102,7 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
-contains:ENVELOPE [DEBEZIUM] UPSERT requires that KEY FORMAT be specified
+contains:ENVELOPE DEBEZIUM requires that KEY FORMAT be specified
 
 ! CREATE SOURCE doin_upsert
   IN CLUSTER ${arg.single-replica-cluster}

--- a/test/upsert/kafka-upsert-debezium-sources.td
+++ b/test/upsert/kafka-upsert-debezium-sources.td
@@ -95,12 +95,6 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
 {"id": 1} {"before": {"row": {"id": 1, "creature": "mudskipper"}}, "after": {"row": {"id": 1, "creature": "salamander"}}, "op": "u", "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 {"id": 1} {"before": {"row": {"id": 1, "creature": "salamander"}}, "after": {"row": {"id": 1, "creature": "lizard"}}, "op": "u", "source": {"file": "binlog3", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
-! CREATE SOURCE doin_upsert
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
-  FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
-contains:ENVELOPE [DEBEZIUM] UPSERT requires that KEY FORMAT be specified
-
 > CREATE SOURCE doin_upsert
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn


### PR DESCRIPTION
As part of the `LOAD GENERATOR KEY VALUE` pr, @petrosagg and I determined that some special-cases were dependent on us upholding a specific constraint: requiring `KEY FORMAT` on kafka/upsert sources.

This pr relaxes this contraint. It has sign off from the sql council in this thread: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1711059623768459. Its a niche feature, and likely doesn't need specific documentation.


@petrosagg as you know, `ddl.rs` and its interaction with source rendering is a thread of unlimited length, so I had to choose a bound on what work I completed in this pr. Namely:
- I consolidated logic into `get_key_envelope`, to clarify the various cases, but did not unify it with `UnplannedSourceEnvelope::desc`.
- I did not remove the distinction between `[Datum::Null]` and `None` in source rendering, even if I think we should someday.
- I did not pull the "what if some upsert sources could have nullable keys" thread.
- I did not resolve the `is_kafka && is_envelope_none` special case.
- In rendering, we probably should remove the concept of `Option<Decoder>`'s, and just use Bytes decoders as the "none" case, but I also avoided going this deep


I think that this pr represents a reasonable, mergeable, simplification of the constraints and logic we currently have.


### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - `KEY FORMAT` is no longer required for `UPSERT` and/or `INCLUDE KEY` sources that have a default key type (namely: Kafka, defaulting to nullable `bytea`)
