### PR TITLE
storage: fix + extend alter_compatible API

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -72,6 +72,7 @@ use mz_ssh_util::keys::SshKeyPairSet;
 use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::controller::StorageError;
+use mz_storage_types::AlterCompatible;
 use mz_transform::notice::{OptimizerNoticeApi, OptimizerNoticeKind, RawOptimizerNotice};
 use mz_transform::EmptyStatisticsOracle;
 use timely::progress::Antichain;
@@ -3041,6 +3042,16 @@ impl Coordinator {
                 ssh.public_keys = current_ssh.public_keys.clone();
             }
             _ => {}
+        };
+
+        match self.catalog.get_entry(&id).item() {
+            CatalogItem::Connection(curr_conn) => {
+                curr_conn
+                    .connection
+                    .alter_compatible(id, &connection.connection)
+                    .map_err(StorageError::from)?;
+            }
+            _ => unreachable!("known to be a connection"),
         };
 
         let ops = vec![catalog::Op::UpdateItem {

--- a/src/storage-types/src/connections/aws.rs
+++ b/src/storage-types/src/connections/aws.rs
@@ -24,6 +24,8 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
+use crate::controller::AlterError;
+use crate::AlterCompatible;
 use crate::{
     configuration::StorageConfiguration,
     connections::{ConnectionContext, StringOrSecret},
@@ -80,6 +82,13 @@ impl RustType<ProtoAwsConnection> for AwsConnection {
             region: proto.region,
             endpoint: proto.endpoint,
         })
+    }
+}
+
+impl AlterCompatible for AwsConnection {
+    fn alter_compatible(&self, _id: GlobalId, _other: &Self) -> Result<(), AlterError> {
+        // Every element of the AWS connection is configurable.
+        Ok(())
     }
 }
 

--- a/src/storage-types/src/connections/inline.rs
+++ b/src/storage-types/src/connections/inline.rs
@@ -23,6 +23,8 @@ use proptest::prelude::Arbitrary;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
+use crate::AlterCompatible;
+
 use super::Connection;
 
 /// Permits any struct to take a `GlobalId` into an inlined connection.
@@ -62,8 +64,17 @@ pub trait ConnectionAccess:
         + PartialEq
         + Hash
         + Serialize
-        + for<'a> Deserialize<'a>;
-    type Pg: Arbitrary + Clone + Debug + Eq + PartialEq + Hash + Serialize + for<'a> Deserialize<'a>;
+        + for<'a> Deserialize<'a>
+        + AlterCompatible;
+    type Pg: Arbitrary
+        + Clone
+        + Debug
+        + Eq
+        + PartialEq
+        + Hash
+        + Serialize
+        + for<'a> Deserialize<'a>
+        + AlterCompatible;
     type Ssh: Arbitrary
         + Clone
         + Debug
@@ -71,7 +82,8 @@ pub trait ConnectionAccess:
         + PartialEq
         + Hash
         + Serialize
-        + for<'a> Deserialize<'a>;
+        + for<'a> Deserialize<'a>
+        + AlterCompatible;
     type Csr: Arbitrary
         + Clone
         + Debug
@@ -79,7 +91,8 @@ pub trait ConnectionAccess:
         + PartialEq
         + Hash
         + Serialize
-        + for<'a> Deserialize<'a>;
+        + for<'a> Deserialize<'a>
+        + AlterCompatible;
     type MySql: Arbitrary
         + Clone
         + Debug
@@ -87,7 +100,8 @@ pub trait ConnectionAccess:
         + PartialEq
         + Hash
         + Serialize
-        + for<'a> Deserialize<'a>;
+        + for<'a> Deserialize<'a>
+        + AlterCompatible;
 }
 
 /// Expresses that the struct contains references to connections. Use a

--- a/src/storage-types/src/lib.rs
+++ b/src/storage-types/src/lib.rs
@@ -42,3 +42,5 @@ pub trait AlterCompatible: std::fmt::Debug + PartialEq {
         }
     }
 }
+
+impl AlterCompatible for mz_repr::GlobalId {}

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -475,7 +475,10 @@ impl<C: ConnectionAccess> KafkaSinkConnection<C> {
 
         let compatibility_checks = [
             (connection_id == &other.connection_id, "connection_id"),
-            (connection == &other.connection, "connection"),
+            (
+                connection.alter_compatible(id, &other.connection).is_ok(),
+                "connection",
+            ),
             (format.alter_compatible(id, &other.format).is_ok(), "format"),
             (
                 relation_key_indices == &other.relation_key_indices,

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -22,13 +22,13 @@ use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
 use timely::PartialOrder;
 
-use crate::connections::ConnectionContext;
-use crate::controller::{AlterError, CollectionMetadata};
-
 use crate::connections::inline::{
     ConnectionAccess, ConnectionResolver, InlinedConnection, IntoInlineConnection,
     ReferencedConnection,
 };
+use crate::connections::ConnectionContext;
+use crate::controller::{AlterError, CollectionMetadata};
+use crate::AlterCompatible;
 
 include!(concat!(env!("OUT_DIR"), "/mz_storage_types.sinks.rs"));
 
@@ -46,7 +46,7 @@ pub struct StorageSinkDesc<S: StorageSinkDescFillState, T = mz_repr::Timestamp> 
 }
 
 impl<S: Debug + StorageSinkDescFillState + PartialEq, T: Debug + PartialEq + PartialOrder>
-    crate::AlterCompatible for StorageSinkDesc<S, T>
+    AlterCompatible for StorageSinkDesc<S, T>
 {
     /// Determines if `self` is compatible with another `StorageSinkDesc`, in
     /// such a way that it is possible to turn `self` into `other` through a
@@ -462,8 +462,7 @@ impl<C: ConnectionAccess> KafkaSinkConnection<C> {
         }
         let KafkaSinkConnection {
             connection_id,
-            // The details of the Kafka connection itself may change
-            connection: _,
+            connection,
             format,
             relation_key_indices,
             key_desc_and_indices,
@@ -476,6 +475,7 @@ impl<C: ConnectionAccess> KafkaSinkConnection<C> {
 
         let compatibility_checks = [
             (connection_id == &other.connection_id, "connection_id"),
+            (connection == &other.connection, "connection"),
             (format.alter_compatible(id, &other.format).is_ok(), "format"),
             (
                 relation_key_indices == &other.relation_key_indices,
@@ -674,18 +674,23 @@ impl<C: ConnectionAccess> KafkaSinkFormat<C> {
                 Self::Avro {
                     key_schema,
                     value_schema,
-                    // Connections may change
-                    csr_connection: _,
+                    csr_connection,
                 },
                 Self::Avro {
                     key_schema: other_key_schema,
                     value_schema: other_value_schema,
-                    csr_connection: _,
+                    csr_connection: other_csr_connection,
                 },
             ) => {
                 let compatibility_checks = [
                     (key_schema == other_key_schema, "key_schema"),
                     (value_schema == other_value_schema, "value_schema"),
+                    (
+                        csr_connection
+                            .alter_compatible(id, other_csr_connection)
+                            .is_ok(),
+                        "csr_connection",
+                    ),
                 ];
                 for (compatible, field) in compatibility_checks {
                     if !compatible {

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -898,6 +898,7 @@ impl<C: ConnectionAccess> crate::AlterCompatible for GenericSourceConnection<C> 
         let r = match (self, other) {
             (Self::Kafka(conn), Self::Kafka(other)) => conn.alter_compatible(id, other),
             (Self::Postgres(conn), Self::Postgres(other)) => conn.alter_compatible(id, other),
+            (Self::MySql(conn), Self::MySql(other)) => conn.alter_compatible(id, other),
             (Self::LoadGenerator(conn), Self::LoadGenerator(other)) => {
                 conn.alter_compatible(id, other)
             }

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -107,9 +107,7 @@ impl<S> IngestionDescription<S> {
     }
 }
 
-impl<S: Debug + Eq + PartialEq + crate::AlterCompatible> AlterCompatible
-    for IngestionDescription<S>
-{
+impl<S: Debug + Eq + PartialEq + AlterCompatible> AlterCompatible for IngestionDescription<S> {
     fn alter_compatible(
         &self,
         id: GlobalId,
@@ -562,7 +560,7 @@ impl FromStr for Timeline {
 }
 
 /// A connection to an external system
-pub trait SourceConnection: Debug + Clone + PartialEq + crate::AlterCompatible {
+pub trait SourceConnection: Debug + Clone + PartialEq + AlterCompatible {
     /// The name of the external system (e.g kafka, postgres, etc).
     fn name(&self) -> &'static str;
 
@@ -724,7 +722,7 @@ impl<C: ConnectionAccess> SourceDesc<C> {
     }
 }
 
-impl<C: ConnectionAccess> crate::AlterCompatible for SourceDesc<C> {
+impl<C: ConnectionAccess> AlterCompatible for SourceDesc<C> {
     /// Determines if `self` is compatible with another `SourceDesc`, in such a
     /// way that it is possible to turn `self` into `other` through a valid
     /// series of transformations (e.g. no transformation or `ALTER SOURCE`).
@@ -744,7 +742,13 @@ impl<C: ConnectionAccess> crate::AlterCompatible for SourceDesc<C> {
                 connection.alter_compatible(id, &other.connection).is_ok(),
                 "connection",
             ),
-            (encoding == &other.encoding, "encoding"),
+            (
+                match (encoding, &other.encoding) {
+                    (Some(s), Some(o)) => s.alter_compatible(id, o).is_ok(),
+                    (s, o) => s == o,
+                },
+                "encoding",
+            ),
             (envelope == &other.envelope, "envelope"),
             (
                 timestamp_interval == &other.timestamp_interval,

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -125,7 +125,7 @@ impl<S: Debug + Eq + PartialEq + AlterCompatible> AlterCompatible for IngestionD
         } = self;
 
         let compatibility_checks = [
-            (self.desc.alter_compatible(id, desc).is_ok(), "desc"),
+            (desc.alter_compatible(id, &other.desc).is_ok(), "desc"),
             (
                 ingestion_metadata == &other.ingestion_metadata,
                 "ingestion_metadata",

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -190,8 +190,7 @@ impl<C: ConnectionAccess> crate::AlterCompatible for KafkaSourceConnection<C> {
         }
 
         let KafkaSourceConnection {
-            // Connection details may change
-            connection: _,
+            connection,
             connection_id,
             topic,
             start_offsets,
@@ -201,6 +200,10 @@ impl<C: ConnectionAccess> crate::AlterCompatible for KafkaSourceConnection<C> {
         } = self;
 
         let compatibility_checks = [
+            (
+                connection.alter_compatible(id, &other.connection).is_ok(),
+                "connection",
+            ),
             (connection_id == &other.connection_id, "connection_id"),
             (topic == &other.topic, "topic"),
             (start_offsets == &other.start_offsets, "start_offsets"),

--- a/src/storage-types/src/sources/postgres.rs
+++ b/src/storage-types/src/sources/postgres.rs
@@ -11,7 +11,6 @@
 
 use std::collections::BTreeMap;
 
-use itertools::EitherOrBoth::Both;
 use itertools::Itertools;
 use mz_expr::MirScalarExpr;
 use mz_postgres_util::desc::PostgresTableDesc;
@@ -28,6 +27,7 @@ use crate::connections::inline::{
 };
 use crate::controller::AlterError;
 use crate::sources::SourceConnection;
+use crate::AlterCompatible;
 
 include!(concat!(
     env!("OUT_DIR"),
@@ -113,9 +113,16 @@ impl<C: ConnectionAccess> crate::AlterCompatible for PostgresSourceConnection<C>
 
         let PostgresSourceConnection {
             connection_id,
-            // Connection details may change
-            connection: _,
-            table_casts,
+            connection,
+            // Table casts may change and we will not, in the long term, have a
+            // means of understanding which tables are actually being used by
+            // the source so it's unclear if these changes will be breaking or
+            // not. This suggests that we might not want to maintain this
+            // information here statically––we could, instead, derive these
+            // casts dynamically from the table's schema for the subsource, and
+            // then the subsource itself understands how to cast its data from
+            // the source.
+            table_casts: _,
             publication,
             publication_details,
         } = self;
@@ -123,20 +130,14 @@ impl<C: ConnectionAccess> crate::AlterCompatible for PostgresSourceConnection<C>
         let compatibility_checks = [
             (connection_id == &other.connection_id, "connection_id"),
             (
-                table_casts
-                    .iter()
-                    .merge_join_by(&other.table_casts, |(l_key, _), (r_key, _)| {
-                        l_key.cmp(r_key)
-                    })
-                    .all(|r| match r {
-                        Both((_, l_val), (_, r_val)) => l_val == r_val,
-                        _ => true,
-                    }),
-                "table_casts",
+                connection.alter_compatible(id, &other.connection).is_ok(),
+                "connection",
             ),
             (publication == &other.publication, "publication"),
             (
-                publication_details == &other.publication_details,
+                publication_details
+                    .alter_compatible(id, &other.publication_details)
+                    .is_ok(),
                 "publication_details",
             ),
         ];
@@ -300,5 +301,34 @@ impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicati
             slot: proto.slot,
             timeline_id: proto.timeline_id,
         })
+    }
+}
+
+impl AlterCompatible for PostgresSourcePublicationDetails {
+    fn alter_compatible(&self, id: mz_repr::GlobalId, other: &Self) -> Result<(), AlterError> {
+        let PostgresSourcePublicationDetails {
+            tables: _,
+            slot,
+            timeline_id,
+        } = self;
+
+        let compatibility_checks = [
+            (slot == &other.slot, "slot"),
+            (timeline_id == &other.timeline_id, "timeline_id"),
+        ];
+
+        for (compatible, field) in compatibility_checks {
+            if !compatible {
+                tracing::warn!(
+                    "PostgresSourcePublicationDetails incompatible at {field}:\nself:\n{:#?}\n\nother\n{:#?}",
+                    self,
+                    other
+                );
+
+                return Err(AlterError { id });
+            }
+        }
+
+        Ok(())
     }
 }

--- a/test/mysql-cdc-resumption/alter-source-connection.td
+++ b/test/mysql-cdc-resumption/alter-source-connection.td
@@ -7,4 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+> ALTER CONNECTION mysql_conn SET (HOST = 'dne') WITH (validate = false);
+
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
+stalled
+
 > ALTER CONNECTION mysql_conn SET (HOST = '${arg.mysql-source-host}');


### PR DESCRIPTION
Discovered a few issues:

- We were not properly checking if the `SourceDesc` in an `IngestionDescription` was alter compatible. We were instead inadvertently checking whether a the field was equal to itself. Fixing this necessitated building out more implementations of `alter_compatible`.
- MySQL connection were not altered whatsoever in any test, which would have failed if they had been.
- I realized that the `ConnectionAccess` types could also be tested for alter compatibility somewhat easily.

The only real harm that could have been done with this bug was a user changing their Kafka connection's progress topic, which we've already disallowed in planning. This change is just adding safeguards.

### Motivation

- This PR fixes a previously unreported bug.
  - Altering a source's connection should have always failed the alter compatibility test because we were not using the `SourceDesc::alter_compatibile` implementation.
  - Altering a MySQL connection should have always failed because it expected total equality during an `ALTER`. However, the aforementioned bug prevented that from occurring.
- This PR refactors existing code.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * 

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
