### PR TITLE
output-consistency: Fix regexp_replace return type

### DIFF
--- a/misc/python/materialize/output_consistency/input_data/operations/text_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/text_operations_provider.py
@@ -291,7 +291,7 @@ TEXT_OPERATION_TYPES.append(
     DbFunction(
         "regexp_replace",
         [TextOperationParam(), REGEX_PARAM, TextOperationParam()],
-        ArrayReturnTypeSpec(DataTypeCategory.TEXT),
+        TextReturnTypeSpec(),
         tags={TAG_REGEX},
     )
 )


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/7050#018e76aa-9017-44a9-919d-de12edfe3b5e

Via documentation: https://materialize.com/docs/sql/functions/
```
regexp_replace(source: str, pattern: str, replacement: str [, flags: str]]) -> str
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
