### PR TITLE
Redundant Distinct elision

### DIFF
--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -738,6 +738,8 @@ mod non_negative {
                 MirRelationExpr::Negate { .. } => false,
                 // Threshold ensures non-negativity.
                 MirRelationExpr::Threshold { .. } => true,
+                // Reduce errors on negative input.
+                MirRelationExpr::Reduce { .. } => true,
                 MirRelationExpr::Join { .. } => {
                     // If all inputs are non-negative, the join is non-negative.
                     depends

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -63,6 +63,7 @@ pub mod semijoin_idempotence;
 pub mod threshold_elision;
 pub mod typecheck;
 pub mod union_cancel;
+pub mod will_distinct;
 
 use crate::dataflow::DataflowMetainfo;
 use crate::typecheck::SharedContext;
@@ -480,6 +481,7 @@ impl Default for FuseAndCollapse {
                 Box::new(fusion::join::Join),
                 Box::new(normalize_lets::NormalizeLets::new(false)),
                 Box::new(fusion::reduce::Reduce),
+                Box::new(crate::will_distinct::WillDistinct),
                 Box::new(compound::UnionNegateFusion),
                 // This goes after union fusion so we can cancel out
                 // more branches at a time.

--- a/src/transform/src/will_distinct.rs
+++ b/src/transform/src/will_distinct.rs
@@ -1,0 +1,144 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Transform that pushes down the information that a collection will be subjected to a `Distinct` on specific columns.
+
+use mz_expr::{MirRelationExpr, MirScalarExpr};
+
+use crate::analysis::{DerivedView, NonNegative};
+
+use crate::{TransformCtx, TransformError};
+
+/// Pushes down the information that a collection will be subjected to a `Distinct` on specific columns.
+///
+/// This intends to recognize idiomatic stacks of `UNION` from SQL, which look like `Distinct` over `Union`, potentially
+/// over other `Distinct` expressions. It is only able to see patterns of `DISTINCT UNION DISTINCT, ..` and other operators
+/// in between will prevent the necessary insight to remove the second `DISTINCT`.
+///
+/// There are other potential optimizations, for example fusing multiple reads of the same source, where distinctness may
+/// mean they could be a single read (with additional requirements).
+#[derive(Debug, Default)]
+pub struct WillDistinct;
+
+impl crate::Transform for WillDistinct {
+    #[mz_ore::instrument(
+        target = "optimizer"
+        level = "trace",
+        fields(path.segment = "will_distinct")
+    )]
+    fn transform(
+        &self,
+        relation: &mut MirRelationExpr,
+        ctx: &mut TransformCtx,
+    ) -> Result<(), TransformError> {
+        // Perform bottom-up equivalence class analysis.
+        use crate::analysis::DerivedBuilder;
+        let mut builder = DerivedBuilder::new(ctx.features);
+        builder.require(NonNegative);
+        let derived = builder.visit(relation);
+        let derived = derived.as_view();
+
+        self.apply(relation, derived);
+
+        mz_repr::explain::trace_plan(&*relation);
+        Ok(())
+    }
+}
+
+impl WillDistinct {
+    fn apply(&self, expr: &mut MirRelationExpr, derived: DerivedView) {
+        // Record a list of expressions paired with optional "will distinct by" columns.
+        let mut todo = vec![(expr, derived, None::<&[MirScalarExpr]>)];
+        while let Some((expr, derived, distinct_by)) = todo.pop() {
+            // If we find a `Distinct` expression in the shadow of another `Distinct` that will apply to its key columns,
+            // we can remove this `Distinct` operator as the distinctness will be enforced by the other expression.
+            if let (
+                MirRelationExpr::Reduce {
+                    input,
+                    group_key,
+                    aggregates,
+                    ..
+                },
+                Some(columns),
+            ) = (&*expr, distinct_by)
+            {
+                if aggregates.is_empty()
+                    && columns
+                        .iter()
+                        .enumerate()
+                        .all(|(c, e)| e == &MirScalarExpr::Column(c))
+                    && columns.len() == group_key.len()
+                {
+                    let arity = input.arity();
+                    *expr = input
+                        .clone()
+                        .map(group_key.clone())
+                        .project((arity..arity + group_key.len()).collect::<Vec<_>>());
+                }
+            } else {
+                match (expr, distinct_by) {
+                    // A distinct expression whose keys are only column references can be communicated onward.
+                    (
+                        MirRelationExpr::Reduce {
+                            input,
+                            group_key,
+                            aggregates,
+                            ..
+                        },
+                        _,
+                    ) => {
+                        if aggregates.is_empty()
+                            && group_key.iter().all(|e| {
+                                if let MirScalarExpr::Column(_) = e {
+                                    true
+                                } else {
+                                    false
+                                }
+                            })
+                        {
+                            todo.push((input, derived.last_child(), Some(&*group_key)));
+                        } else {
+                            todo.push((input, derived.last_child(), None))
+                        }
+                    }
+                    // If all inputs to the union are non-negative, any distinct enforced above the expression can be
+                    // communicated on to each input.
+                    (MirRelationExpr::Union { base, inputs }, exprs) => {
+                        if derived
+                            .children_rev()
+                            .all(|v| *v.value::<NonNegative>().unwrap())
+                        {
+                            let children_rev = inputs.iter_mut().rev().chain(Some(&mut **base));
+                            todo.extend(
+                                children_rev
+                                    .zip(derived.children_rev())
+                                    .map(|(x, y)| (x, y, exprs.clone())),
+                            );
+                        } else {
+                            let children_rev = inputs.iter_mut().rev().chain(Some(&mut **base));
+                            todo.extend(
+                                children_rev
+                                    .zip(derived.children_rev())
+                                    .map(|(x, y)| (x, y, None)),
+                            );
+                        }
+                    }
+                    (x, _) => {
+                        todo.extend(
+                            x.children_mut()
+                                .rev()
+                                .zip(derived.children_rev())
+                                .map(|(x, y)| (x, y, None)),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/transform/src/will_distinct.rs
+++ b/src/transform/src/will_distinct.rs
@@ -9,7 +9,7 @@
 
 //! Transform that pushes down the information that a collection will be subjected to a `Distinct` on specific columns.
 
-use mz_expr::{MirRelationExpr, MirScalarExpr};
+use mz_expr::MirRelationExpr;
 
 use crate::analysis::{DerivedView, NonNegative};
 
@@ -54,7 +54,7 @@ impl crate::Transform for WillDistinct {
 impl WillDistinct {
     fn apply(&self, expr: &mut MirRelationExpr, derived: DerivedView) {
         // Record a list of expressions paired with optional "will distinct by" columns.
-        let mut todo = vec![(expr, derived, None::<&[MirScalarExpr]>)];
+        let mut todo = vec![(expr, derived, false)];
         while let Some((expr, derived, distinct_by)) = todo.pop() {
             // If we find a `Distinct` expression in the shadow of another `Distinct` that will apply to its key columns,
             // we can remove this `Distinct` operator as the distinctness will be enforced by the other expression.
@@ -65,51 +65,42 @@ impl WillDistinct {
                     aggregates,
                     ..
                 },
-                Some(columns),
-            ) = (&*expr, distinct_by)
+                true,
+            ) = (&mut *expr, distinct_by)
             {
-                if aggregates.is_empty()
-                    && columns
-                        .iter()
-                        .enumerate()
-                        .all(|(c, e)| e == &MirScalarExpr::Column(c))
-                    && columns.len() == group_key.len()
-                {
+                if aggregates.is_empty() {
                     let arity = input.arity();
                     *expr = input
-                        .clone()
+                        .take_dangerous()
                         .map(group_key.clone())
                         .project((arity..arity + group_key.len()).collect::<Vec<_>>());
+
+                    // Bail out of traversal at this point, on account of we've lost track of the shape of the expression.
+                } else {
+                    todo.extend(
+                        expr.children_mut()
+                            .rev()
+                            .zip(derived.children_rev())
+                            .map(|(x, y)| (x, y, false)),
+                    );
                 }
             } else {
                 match (expr, distinct_by) {
-                    // A distinct expression whose keys are only column references can be communicated onward.
                     (
                         MirRelationExpr::Reduce {
-                            input,
-                            group_key,
-                            aggregates,
-                            ..
+                            input, aggregates, ..
                         },
                         _,
                     ) => {
-                        if aggregates.is_empty()
-                            && group_key.iter().all(|e| {
-                                if let MirScalarExpr::Column(_) = e {
-                                    true
-                                } else {
-                                    false
-                                }
-                            })
-                        {
-                            todo.push((input, derived.last_child(), Some(&*group_key)));
+                        if aggregates.is_empty() {
+                            todo.push((input, derived.last_child(), true));
                         } else {
-                            todo.push((input, derived.last_child(), None))
+                            todo.push((input, derived.last_child(), false))
                         }
                     }
                     // If all inputs to the union are non-negative, any distinct enforced above the expression can be
                     // communicated on to each input.
-                    (MirRelationExpr::Union { base, inputs }, exprs) => {
+                    (MirRelationExpr::Union { base, inputs }, will_distinct) => {
                         if derived
                             .children_rev()
                             .all(|v| *v.value::<NonNegative>().unwrap())
@@ -118,14 +109,14 @@ impl WillDistinct {
                             todo.extend(
                                 children_rev
                                     .zip(derived.children_rev())
-                                    .map(|(x, y)| (x, y, exprs.clone())),
+                                    .map(|(x, y)| (x, y, will_distinct)),
                             );
                         } else {
                             let children_rev = inputs.iter_mut().rev().chain(Some(&mut **base));
                             todo.extend(
                                 children_rev
                                     .zip(derived.children_rev())
-                                    .map(|(x, y)| (x, y, None)),
+                                    .map(|(x, y)| (x, y, false)),
                             );
                         }
                     }
@@ -134,7 +125,7 @@ impl WillDistinct {
                             x.children_mut()
                                 .rev()
                                 .zip(derived.children_rev())
-                                .map(|(x, y)| (x, y, None)),
+                                .map(|(x, y)| (x, y, false)),
                         );
                     }
                 }

--- a/test/sqllogictest/advent-of-code/2023/aoc_1205.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1205.slt
@@ -1296,17 +1296,15 @@ Explained Query:
     cte l6 =
       Distinct project=[#0..=#2]
         Union
-          Distinct project=[#0..=#2]
-            Union
-              Project (#6, #4, #5)
-                Map (regexp_split_to_array[" ", case_insensitive=false](btrim(#0)), (2 * #1), text_to_bigint(array_index(#2, integer_to_bigint((#3 - 1)))), (#4 + text_to_bigint(array_index(#2, integer_to_bigint(#3)))), "seed")
-                  FlatMap generate_series(1, ((regexp_split_to_array[" ", case_insensitive=false](btrim(#0)) array_length 1) / 2), 1)
-                    Project (#1)
-                      Filter (#0 = "seeds")
-                        Get l0
-              Project (#1, #10, #11)
-                Map ((#8 - #4), (#6 + #9), (#7 + #9))
-                  Get l8
+          Project (#6, #4, #5)
+            Map (regexp_split_to_array[" ", case_insensitive=false](btrim(#0)), (2 * #1), text_to_bigint(array_index(#2, integer_to_bigint((#3 - 1)))), (#4 + text_to_bigint(array_index(#2, integer_to_bigint(#3)))), "seed")
+              FlatMap generate_series(1, ((regexp_split_to_array[" ", case_insensitive=false](btrim(#0)) array_length 1) / 2), 1)
+                Project (#1)
+                  Filter (#0 = "seeds")
+                    Get l0
+          Project (#1, #10, #11)
+            Map ((#8 - #4), (#6 + #9), (#7 + #9))
+              Get l8
           Get l16
     cte l5 =
       Reduce aggregates=[min(#0)]

--- a/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
@@ -266,40 +266,38 @@ Explained Query:
     cte l13 =
       Distinct project=[#0..=#3]
         Union
-          Distinct project=[#0, #1, #3, #2]
-            Union
-              Map (("r" || integer_to_text(#0)), "r")
-                CrossJoin type=differential
-                  Get l11
-                  ArrangeBy keys=[[]]
-                    Union
-                      Get l4
-                      Map (null)
-                        Union
-                          Negate
-                            Project ()
-                              Get l4
-                          Constant
-                            - ()
-              Map (("l" || integer_to_text(#0)), "l")
-                CrossJoin type=differential
-                  Get l11
-                  ArrangeBy keys=[[]]
-                    Union
-                      Get l6
-                      Map (null)
-                        Union
-                          Negate
-                            Project ()
-                              Get l6
-                          Constant
-                            - ()
-          Project (#2, #0, #3, #1)
-            Map ("d")
+          Project (#0, #1, #3, #2)
+            Map (("r" || integer_to_text(#0)), "r")
               CrossJoin type=differential
+                Get l11
                 ArrangeBy keys=[[]]
-                  Distinct project=[#0, ("d" || integer_to_text(#0))]
-                    Get l12
+                  Union
+                    Get l4
+                    Map (null)
+                      Union
+                        Negate
+                          Project ()
+                            Get l4
+                        Constant
+                          - ()
+          Project (#0, #1, #3, #2)
+            Map (("l" || integer_to_text(#0)), "l")
+              CrossJoin type=differential
+                Get l11
+                ArrangeBy keys=[[]]
+                  Union
+                    Get l6
+                    Map (null)
+                      Union
+                        Negate
+                          Project ()
+                            Get l6
+                        Constant
+                          - ()
+          Project (#1, #0, #3, #2)
+            Map (("d" || integer_to_text(#0)), "d")
+              CrossJoin type=differential
+                Get l12
                 ArrangeBy keys=[[]]
                   Union
                     Get l8
@@ -313,8 +311,7 @@ Explained Query:
           Project (#1, #0, #3, #2)
             Map (("u" || integer_to_text(#0)), "u")
               CrossJoin type=differential
-                ArrangeBy keys=[[]]
-                  Get l12
+                Get l12
                 ArrangeBy keys=[[]]
                   Union
                     Get l10
@@ -359,8 +356,9 @@ Explained Query:
                       - ("r", "-", 0, 1, "r")
                       - ("r", ".", 0, 1, "r")
     cte l12 =
-      Project (#1)
-        Get l0
+      ArrangeBy keys=[[]]
+        Project (#1)
+          Get l0
     cte l11 =
       ArrangeBy keys=[[]]
         Project (#0)

--- a/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1216.slt
@@ -266,74 +266,65 @@ Explained Query:
     cte l13 =
       Distinct project=[#0..=#3]
         Union
-          Distinct project=[#0..=#3]
+          Distinct project=[#0, #1, #3, #2]
             Union
-              Distinct project=[#0..=#3]
-                Union
-                  Distinct project=[#0, #2, #3, #1]
+              Map (("r" || integer_to_text(#0)), "r")
+                CrossJoin type=differential
+                  Get l11
+                  ArrangeBy keys=[[]]
                     Union
-                      Map ("r")
-                        CrossJoin type=differential
-                          ArrangeBy keys=[[]]
-                            Distinct project=[#0, ("r" || integer_to_text(#0))]
-                              Get l11
-                          ArrangeBy keys=[[]]
-                            Union
+                      Get l4
+                      Map (null)
+                        Union
+                          Negate
+                            Project ()
                               Get l4
-                              Map (null)
-                                Union
-                                  Negate
-                                    Project ()
-                                      Get l4
-                                  Constant
-                                    - ()
-                      Map ("l")
-                        CrossJoin type=differential
-                          ArrangeBy keys=[[]]
-                            Distinct project=[#0, ("l" || integer_to_text(#0))]
-                              Get l11
-                          ArrangeBy keys=[[]]
-                            Union
+                          Constant
+                            - ()
+              Map (("l" || integer_to_text(#0)), "l")
+                CrossJoin type=differential
+                  Get l11
+                  ArrangeBy keys=[[]]
+                    Union
+                      Get l6
+                      Map (null)
+                        Union
+                          Negate
+                            Project ()
                               Get l6
-                              Map (null)
-                                Union
-                                  Negate
-                                    Project ()
-                                      Get l6
-                                  Constant
-                                    - ()
-                  Project (#2, #0, #3, #1)
-                    Map ("d")
-                      CrossJoin type=differential
-                        ArrangeBy keys=[[]]
-                          Distinct project=[#0, ("d" || integer_to_text(#0))]
-                            Get l12
-                        ArrangeBy keys=[[]]
-                          Union
-                            Get l8
-                            Map (null)
-                              Union
-                                Negate
-                                  Project ()
-                                    Get l8
-                                Constant
-                                  - ()
-              Project (#2, #0, #3, #1)
-                Map ("u")
-                  CrossJoin type=differential
-                    ArrangeBy keys=[[]]
-                      Distinct project=[#0, ("u" || integer_to_text(#0))]
-                        Get l12
-                    ArrangeBy keys=[[]]
+                          Constant
+                            - ()
+          Project (#2, #0, #3, #1)
+            Map ("d")
+              CrossJoin type=differential
+                ArrangeBy keys=[[]]
+                  Distinct project=[#0, ("d" || integer_to_text(#0))]
+                    Get l12
+                ArrangeBy keys=[[]]
+                  Union
+                    Get l8
+                    Map (null)
                       Union
-                        Get l10
-                        Map (null)
-                          Union
-                            Negate
-                              Project ()
-                                Get l10
-                            Constant
-                              - ()
+                        Negate
+                          Project ()
+                            Get l8
+                        Constant
+                          - ()
+          Project (#1, #0, #3, #2)
+            Map (("u" || integer_to_text(#0)), "u")
+              CrossJoin type=differential
+                ArrangeBy keys=[[]]
+                  Get l12
+                ArrangeBy keys=[[]]
+                  Union
+                    Get l10
+                    Map (null)
+                      Union
+                        Negate
+                          Project ()
+                            Get l10
+                        Constant
+                          - ()
           Project (#12, #13, #11, #3)
             Map ((#0 + #9), (#1 + #10))
               Join on=(#0 = #4 AND #1 = #5 AND #2 = #7 AND #6 = #8) type=differential
@@ -371,8 +362,9 @@ Explained Query:
       Project (#1)
         Get l0
     cte l11 =
-      Project (#0)
-        Get l0
+      ArrangeBy keys=[[]]
+        Project (#0)
+          Get l0
     cte l10 =
       Union
         Get l9

--- a/test/sqllogictest/advent-of-code/2023/aoc_1220.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1220.slt
@@ -365,18 +365,16 @@ Explained Query:
     cte l2 =
       Distinct project=[#0, #1] monotonic
         Union
-          Distinct project=[#0, #1] monotonic
-            Union
-              Project (#0, #2)
-                Filter (#1 > 0)
-                  Map ((#1 - 1))
-                    Get l2
-              Constant
-                - (1, 1)
+          Project (#0, #2)
+            Filter (#1 > 0)
+              Map ((#1 - 1))
+                Get l2
           Project (#2, #3)
             Filter (#1 = 0) AND (#0 < 4100)
               Map ((#0 + 1), 20)
                 Get l2
+          Constant
+            - (1, 1)
     cte l1 =
       Project (#3, #4)
         Map (regexp_split_to_array[" ", case_insensitive=false](#0), substr(array_index(#2, 1), 2), btrim(array_index(#2, integer_to_bigint(#1)), ","))

--- a/test/sqllogictest/advent-of-code/2023/aoc_1223.slt
+++ b/test/sqllogictest/advent-of-code/2023/aoc_1223.slt
@@ -423,44 +423,42 @@ Explained Query:
       cte l3 =
         Distinct project=[#0..=#3]
           Union
-            Distinct project=[#0..=#3]
-              Union
-                Project (#0..=#2, #1)
-                  Distinct project=[#0..=#2]
-                    Union
-                      Project (#0, #1, #4)
-                        Map ((#0 + 1))
-                          Join on=(#0 = #2 AND #1 = #3) type=differential
-                            Get l2
-                            ArrangeBy keys=[[#0, #1]]
-                              Distinct project=[#0, #1]
-                                Project (#0, #1)
-                                  Join on=(#1 = #3 AND #2 = (#0 + 1)) type=differential
-                                    ArrangeBy keys=[[(#0 + 1), #1]]
-                                      Get l1
-                                    Get l2
-                      Project (#0, #1, #4)
-                        Map ((#0 - 1))
-                          Join on=(#0 = #2 AND #1 = #3) type=differential
-                            Get l2
-                            ArrangeBy keys=[[#0, #1]]
-                              Distinct project=[#0, #1]
-                                Project (#0, #1)
-                                  Join on=(#1 = #3 AND #2 = (#0 - 1)) type=differential
-                                    ArrangeBy keys=[[(#0 - 1), #1]]
-                                      Get l1
-                                    Get l2
-                Project (#0, #1, #0, #4)
-                  Map ((#1 + 1))
-                    Join on=(#0 = #2 AND #1 = #3) type=differential
-                      Get l2
-                      ArrangeBy keys=[[#0, #1]]
-                        Distinct project=[#0, #1]
-                          Project (#0, #1)
-                            Join on=(#0 = #2 AND #3 = (#1 + 1)) type=differential
-                              ArrangeBy keys=[[#0, (#1 + 1)]]
-                                Get l1
-                              Get l2
+            Project (#0..=#2, #1)
+              Distinct project=[#0..=#2]
+                Union
+                  Project (#0, #1, #4)
+                    Map ((#0 + 1))
+                      Join on=(#0 = #2 AND #1 = #3) type=differential
+                        Get l2
+                        ArrangeBy keys=[[#0, #1]]
+                          Distinct project=[#0, #1]
+                            Project (#0, #1)
+                              Join on=(#1 = #3 AND #2 = (#0 + 1)) type=differential
+                                ArrangeBy keys=[[(#0 + 1), #1]]
+                                  Get l1
+                                Get l2
+                  Project (#0, #1, #4)
+                    Map ((#0 - 1))
+                      Join on=(#0 = #2 AND #1 = #3) type=differential
+                        Get l2
+                        ArrangeBy keys=[[#0, #1]]
+                          Distinct project=[#0, #1]
+                            Project (#0, #1)
+                              Join on=(#1 = #3 AND #2 = (#0 - 1)) type=differential
+                                ArrangeBy keys=[[(#0 - 1), #1]]
+                                  Get l1
+                                Get l2
+            Project (#0, #1, #0, #4)
+              Map ((#1 + 1))
+                Join on=(#0 = #2 AND #1 = #3) type=differential
+                  Get l2
+                  ArrangeBy keys=[[#0, #1]]
+                    Distinct project=[#0, #1]
+                      Project (#0, #1)
+                        Join on=(#0 = #2 AND #3 = (#1 + 1)) type=differential
+                          ArrangeBy keys=[[#0, (#1 + 1)]]
+                            Get l1
+                          Get l2
             Project (#0, #1, #0, #4)
               Map ((#1 - 1))
                 Join on=(#0 = #2 AND #1 = #3) type=differential

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -165,21 +165,19 @@ Explained Query:
     cte l5 =
       Distinct project=[#0, #1]
         Union
-          Distinct project=[#0, #1]
-            Union
-              Project (#1, #0)
-                CrossJoin type=differential
-                  ArrangeBy keys=[[]]
-                    Get l2
-                  ArrangeBy keys=[[]]
-                    Union
-                      Negate
-                        Get l4
-                      Constant
-                        - ()
-              Project (#1, #0)
-                Map (true, -1)
-                  Get l4
+          Project (#1, #0)
+            CrossJoin type=differential
+              ArrangeBy keys=[[]]
+                Get l2
+              ArrangeBy keys=[[]]
+                Union
+                  Negate
+                    Get l4
+                  Constant
+                    - ()
+          Project (#1, #0)
+            Map (true, -1)
+              Get l4
           Constant
             - (1, true)
             - (2, false)
@@ -281,21 +279,19 @@ Explained Query:
     cte l5 =
       Distinct project=[#0, #1]
         Union
-          Distinct project=[#0, #1]
-            Union
-              Project (#1, #0)
-                CrossJoin type=differential
-                  ArrangeBy keys=[[]]
-                    Get l2
-                  ArrangeBy keys=[[]]
-                    Union
-                      Negate
-                        Get l4
-                      Constant
-                        - ()
-              Project (#1, #0)
-                Map (true, -1)
-                  Get l4
+          Project (#1, #0)
+            CrossJoin type=differential
+              ArrangeBy keys=[[]]
+                Get l2
+              ArrangeBy keys=[[]]
+                Union
+                  Negate
+                    Get l4
+                  Constant
+                    - ()
+          Project (#1, #0)
+            Map (true, -1)
+              Get l4
           Constant
             - (1, true)
             - (2, false)

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -2883,23 +2883,21 @@ Explained Query:
     cte l7 =
       Distinct project=[#0{person2id}, #1] // { arity: 2 }
         Union // { arity: 2 }
-          Distinct project=[#0{person2id}, #1] // { arity: 2 }
-            Union // { arity: 2 }
-              Project (#1, #0{person2id}) // { arity: 2 }
-                CrossJoin type=differential // { arity: 2 }
-                  implementation
-                    %0:l4[×] » %1[×]
-                  ArrangeBy keys=[[]] // { arity: 2 }
-                    Get l4 // { arity: 2 }
-                  ArrangeBy keys=[[]] // { arity: 0 }
-                    Union // { arity: 0 }
-                      Negate // { arity: 0 }
-                        Get l6 // { arity: 0 }
-                      Constant // { arity: 0 }
-                        - ()
-              Project (#1, #0) // { arity: 2 }
-                Map (true, -1) // { arity: 2 }
-                  Get l6 // { arity: 0 }
+          Project (#1, #0{person2id}) // { arity: 2 }
+            CrossJoin type=differential // { arity: 2 }
+              implementation
+                %0:l4[×] » %1[×]
+              ArrangeBy keys=[[]] // { arity: 2 }
+                Get l4 // { arity: 2 }
+              ArrangeBy keys=[[]] // { arity: 0 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Get l6 // { arity: 0 }
+                  Constant // { arity: 0 }
+                    - ()
+          Project (#1, #0) // { arity: 2 }
+            Map (true, -1) // { arity: 2 }
+              Get l6 // { arity: 0 }
           Constant // { arity: 2 }
             - (1450, true)
             - (15393162796819, false)

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -2890,23 +2890,21 @@ Explained Query:
     cte l7 =
       Distinct project=[#0{person2id}, #1] // { arity: 2 }
         Union // { arity: 2 }
-          Distinct project=[#0{person2id}, #1] // { arity: 2 }
-            Union // { arity: 2 }
-              Project (#1, #0{person2id}) // { arity: 2 }
-                CrossJoin type=differential // { arity: 2 }
-                  implementation
-                    %0:l4[×] » %1[×]
-                  ArrangeBy keys=[[]] // { arity: 2 }
-                    Get l4 // { arity: 2 }
-                  ArrangeBy keys=[[]] // { arity: 0 }
-                    Union // { arity: 0 }
-                      Negate // { arity: 0 }
-                        Get l6 // { arity: 0 }
-                      Constant // { arity: 0 }
-                        - ()
-              Project (#1, #0) // { arity: 2 }
-                Map (true, -1) // { arity: 2 }
-                  Get l6 // { arity: 0 }
+          Project (#1, #0{person2id}) // { arity: 2 }
+            CrossJoin type=differential // { arity: 2 }
+              implementation
+                %0:l4[×] » %1[×]
+              ArrangeBy keys=[[]] // { arity: 2 }
+                Get l4 // { arity: 2 }
+              ArrangeBy keys=[[]] // { arity: 0 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Get l6 // { arity: 0 }
+                  Constant // { arity: 0 }
+                    - ()
+          Project (#1, #0) // { arity: 2 }
+            Map (true, -1) // { arity: 2 }
+              Get l6 // { arity: 0 }
           Constant // { arity: 2 }
             - (1450, true)
             - (15393162796819, false)

--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -100,20 +100,14 @@ Explained Query:
     cte l0 =
       Distinct project=[#0, #1] monotonic // { arity: 2 }
         Union // { arity: 2 }
-          Distinct project=[#0, #1] monotonic // { arity: 2 }
-            Union // { arity: 2 }
-              Distinct project=[#0, #1] monotonic // { arity: 2 }
-                Union // { arity: 2 }
-                  Get l0 // { arity: 2 }
-                  Constant // { arity: 2 }
-                    - (62, 64)
-                    - (66, 68)
-              Constant // { arity: 2 }
-                - (42, 43)
-                - (44, 45)
+          Get l0 // { arity: 2 }
           Constant // { arity: 2 }
+            - (42, 43)
+            - (44, 45)
             - (51, 53)
             - (52, 54)
+            - (62, 64)
+            - (66, 68)
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/literal_lifting.slt
+++ b/test/sqllogictest/transform/literal_lifting.slt
@@ -40,12 +40,10 @@ Explained Query:
       Map (42) // { arity: 2 }
         Distinct project=[#0] // { arity: 1 }
           Union // { arity: 1 }
-            Distinct project=[#0] // { arity: 1 }
-              Union // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Get l0 // { arity: 2 }
-                Project (#0) // { arity: 1 }
-                  ReadStorage materialize.public.t1 // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Get l0 // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
             Project (#1) // { arity: 1 }
               ReadStorage materialize.public.t1 // { arity: 2 }
 

--- a/test/sqllogictest/transform/reduce_elision.slt
+++ b/test/sqllogictest/transform/reduce_elision.slt
@@ -123,14 +123,13 @@ Explained Query:
     cte l0 =
       Distinct project=[#0..=#3] // { arity: 4, keys: "([0, 1, 2, 3])" }
         Union // { arity: 4, keys: "()" }
-          Project (#0..=#2, #1) // { arity: 4, keys: "([0, 1])" }
-            Join on=(#1 = #3) type=differential // { arity: 4, keys: "([0, 1])" }
+          Project (#0..=#2, #1) // { arity: 4, keys: "()" }
+            Join on=(#1 = #3) type=differential // { arity: 4, keys: "()" }
               implementation
-                %1:y[#1]UK » %0[#1]K
-              ArrangeBy keys=[[#1]] // { arity: 2, keys: "([0, 1])" }
-                Distinct project=[#0, #1] // { arity: 2, keys: "([0, 1])" }
-                  Filter (#1) IS NOT NULL // { arity: 2, keys: "()" }
-                    ReadStorage materialize.public.x // { arity: 2, keys: "()" }
+                %1:y[#1]UK » %0:x[#1]K
+              ArrangeBy keys=[[#1]] // { arity: 2, keys: "()" }
+                Filter (#1) IS NOT NULL // { arity: 2, keys: "()" }
+                  ReadStorage materialize.public.x // { arity: 2, keys: "()" }
               ArrangeBy keys=[[#1]] // { arity: 2, keys: "([1])" }
                 ReadStorage materialize.public.y // { arity: 2, keys: "([1])" }
           Get l0 // { arity: 4, keys: "([0, 1, 2, 3])" }

--- a/test/sqllogictest/transform/redundant_join.slt
+++ b/test/sqllogictest/transform/redundant_join.slt
@@ -151,11 +151,9 @@ Explained Query:
     cte l1 =
       Distinct project=[#0..=#2] // { arity: 3 }
         Union // { arity: 3 }
-          Distinct project=[#0..=#2] // { arity: 3 }
-            Union // { arity: 3 }
-              Get l1 // { arity: 3 }
-              Project (#0, #0, #0) // { arity: 3 }
-                Get l0 // { arity: 1 }
+          Get l1 // { arity: 3 }
+          Project (#0, #0, #0) // { arity: 3 }
+            Get l0 // { arity: 1 }
           Join on=(#2 = (#0 % 2)) type=differential // { arity: 3 }
             implementation
               %1:l0[#0]UK » %0:t2[(#0 % 2)]K

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -479,27 +479,27 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c1
 ----
 Explained Query:
-  Return // { non_negative: false }
-    Get l0 // { non_negative: false }
+  Return // { non_negative: true }
+    Get l0 // { non_negative: true }
   With Mutually Recursive
     cte l1 =
-      Union // { non_negative: false }
-        Get l0 // { non_negative: false }
+      Union // { non_negative: true }
+        Get l0 // { non_negative: true }
         Negate // { non_negative: false }
-          Filter (#0 > 2) // { non_negative: false }
-            Get l0 // { non_negative: false }
+          Filter (#0 > 2) // { non_negative: true }
+            Get l0 // { non_negative: true }
     cte l0 =
-      Distinct project=[#0, #1] // { non_negative: false }
+      Distinct project=[#0, #1] // { non_negative: true }
         Union // { non_negative: false }
           Project (#0, #4) // { non_negative: true }
             Map ((#1 || "_init")) // { non_negative: true }
               ReadStorage materialize.public.people // { non_negative: true }
-          Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
-            Get l1 // { non_negative: false }
+          Distinct project=[#0, (#1 || "_iter")] // { non_negative: true }
+            Get l1 // { non_negative: true }
           Negate // { non_negative: false }
-            Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
-              Filter (#0 > 1) // { non_negative: false }
-                Get l1 // { non_negative: false }
+            Distinct project=[#0, (#1 || "_iter")] // { non_negative: true }
+              Filter (#0 > 1) // { non_negative: true }
+                Get l1 // { non_negative: true }
 
 Source materialize.public.people
 
@@ -523,21 +523,21 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c0
 ----
 Explained Query:
-  Return // { non_negative: false }
-    Get l0 // { non_negative: false }
+  Return // { non_negative: true }
+    Get l0 // { non_negative: true }
   With Mutually Recursive
     cte l0 =
-      Distinct project=[#0, #1] // { non_negative: false }
+      Distinct project=[#0, #1] // { non_negative: true }
         Union // { non_negative: false }
           Project (#0, #4) // { non_negative: true }
             Map ((#1 || "_init")) // { non_negative: true }
               ReadStorage materialize.public.people // { non_negative: true }
-          Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
-            Get l0 // { non_negative: false }
+          Distinct project=[#0, (#1 || "_iter")] // { non_negative: true }
+            Get l0 // { non_negative: true }
           Negate // { non_negative: false }
-            Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
-              Filter (#0 > 1) // { non_negative: false }
-                Get l0 // { non_negative: false }
+            Distinct project=[#0, (#1 || "_iter")] // { non_negative: true }
+              Filter (#0 > 1) // { non_negative: true }
+                Get l0 // { non_negative: true }
 
 Source materialize.public.people
 

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -327,7 +327,7 @@ true true true true true
   SELECT * FROM term;
 
 > SELECT
-    records > 12 * 1000,
+    records > 0,
     records < 2 * 12 * 1000,
     size > 0,
     size < 4 * 1000 * 1000,


### PR DESCRIPTION
This PR does a very preliminary job of removing `Distinct` operators that are in the shadow of another distinct operator. This happens commonly in SQL when one chains `UNION` clauses:
```sql
SELECT * FROM foo
UNION
SELECT * FROM bar
UNION
SELECT * FROM baz
```
This is naively planned as a stack of binary `Distinct { Union { .. } }` operators, which includes in the example above two `Distinct` operators, one of which (the innermost one) is redundant in the presence of the outermost one.

One can detect this by moving down the AST keeping notes on whether there is a pending outer `Distinct` (and on which columns), and if one finds an inner `Distinct` (on the same columns) one can prune that `Distinct` (well, replace by a projection to put the right columns in place).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
