### PR TITLE
cloudtest: Restart docker before tests

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -29,7 +29,9 @@ fi
 date +"%Y-%m-%d %H:%M:%S" > step_start_timestamp
 
 ci_collapsed_heading ":docker: Purging all existing docker containers and volumes, regardless of origin"
+sudo systemctl restart docker
 docker ps --all --quiet | xargs --no-run-if-empty docker rm --force --volumes
+killall -9 clusterd || true # There might be remaining processes from a previous cargo-test run
 
 ci_collapsed_heading "kind: Increase system limits..."
 sudo sysctl fs.inotify.max_user_watches=524288


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/7059#018e7a9e-0717-4cf3-9ef0-0a4261e3a50f

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
