### PR TITLE
persist: replace SerdeLeasedBatchPart internals with a proto

### DIFF
--- a/src/persist-client/src/batch.proto
+++ b/src/persist-client/src/batch.proto
@@ -20,3 +20,37 @@ message ProtoBatch {
 
     reserved 4;
 }
+
+// This is only to impl ExchangeData, and so used between processes running the
+// same version of code. It's not durably written down anywhere.
+message ProtoLeasedBatchPart {
+    string shard_id = 1;
+    ProtoFetchBatchFilter filter = 2;
+    mz_persist_client.internal.state.ProtoU64Description desc = 3;
+    mz_persist_client.internal.state.ProtoHollowBatchPart part = 4;
+    ProtoLease lease = 5;
+    bool filter_pushdown_audit = 6;
+}
+
+message ProtoFetchBatchFilter {
+    oneof kind {
+        // Apply snapshot-style semantics to the fetched batch part.
+        //
+        // Return all values with time leq `as_of`.
+        mz_persist_client.internal.state.ProtoU64Antichain snapshot = 1;
+        // Apply listen-style semantics to the fetched batch part.
+        ProtoFetchBatchFilterListen listen = 2;
+    }
+}
+
+message ProtoFetchBatchFilterListen {
+    // Return all values with time in advance of `as_of`.
+    mz_persist_client.internal.state.ProtoU64Antichain as_of = 1;
+    // Return all values with `lower` leq time.
+    mz_persist_client.internal.state.ProtoU64Antichain lower = 2;
+}
+
+message ProtoLease {
+    string reader_id = 1;
+    optional uint64 seqno = 2;
+}


### PR DESCRIPTION
SerdeLeasedBatchPart was causing us to invent two serializations for a bunch of things. Instead, base the ExchangeData impl on the proto serialization that already exists.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Pulled out of the inline writes branch, but seemed worthwhile on its own. That said, just as happy to close in favor of keeping it as a commit in the inline writes PR if you'd find the context helpful!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
