### PR TITLE
storage/pg: stream large transactions to persist

### DIFF
--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -896,15 +896,60 @@ where
             if as_of.iter().all(|t| !upper.less_equal(t)) {
                 let committed_upper = frontiers[1].frontier();
                 if as_of.iter().all(|t| !committed_upper.less_equal(t)) {
-                   // Compute the frontier of the binding that is *less than* the committed upper.
-                   let idx =
-                       ready_times.partition_point(|(_, t, _)| !committed_upper.less_than(t));
-                    let updates = ready_times
-                        .drain(0..idx)
-                        .map(|(from_time, _, diff)| (from_time, diff));
-                    source_upper.update_iter(updates);
-
-                    tx.send_replace(source_upper.frontier().to_owned());
+                    // We have committed this source up until `committed_upper`. Because we have
+                    // required that IntoTime is a total order this will be either a singleton set
+                    // or the empty set.
+                    //
+                    // * Case 1: committed_upper is the empty set {}
+                    //
+                    // There won't be any future IntoTime timestamps that we will produce so we can
+                    // provide feedback to the source that it can forget about everything.
+                    //
+                    // * Case 2: committed_upper is a singleton set {t_next}
+                    //
+                    // We know that t_next cannot be the minimum timestamp because we have required
+                    // that all times of the as_of frontier are not beyond some time of
+                    // committed_upper. Therefore t_next has a predecessor timestamp t_prev.
+                    //
+                    // We don't know what remap[t_next] is yet, but we do know that we will have to
+                    // emit all source updates `u: remap[t_prev] <= time(u) <= remap[t_next]`.
+                    // Since `t_next` is the minimum undetermined timestamp and we know that t1 <=
+                    // t2 => remap[t1] <= remap[t2] we know that we will never need any source
+                    // updates `u: !(remap[t_prev] <= time(u))`.
+                    //
+                    // Therefore we can provide feedback to the source that it can forget about any
+                    // updates that are not beyond remap[t_prev].
+                    //
+                    // Important: We are *NOT* saying that the source can *compact* its data using
+                    // remap[t_prev] as the compaction frontier. If the source were to compact its
+                    // collection to remap[t_prev] we would lose the distinction between updates
+                    // that happened *at* t_prev versus updates that happened ealier and were
+                    // advanced to t_prev. If the source needs to communicate a compaction frontier
+                    // upstream then the specific source implementation needs to further adjust the
+                    // reclocked committed_upper and calculate a suitable compaction frontier in
+                    // the same way we adjust uppers of collections in the controller with the
+                    // LagWriteFrontier read policy.
+                    //
+                    // == What about IntoTime times that are general lattices?
+                    //
+                    // Reversing the upper for a general lattice is much more involved but it boils
+                    // down to computing the meet of all the times in `committed_upper` and then
+                    // treating that as `t_next` (I think). Until we need to deal with that though
+                    // we can just assume TotalOrder.
+                    let reclocked_upper = match committed_upper.as_option() {
+                        Some(t_next) => {
+                            let idx = ready_times.partition_point(|(_, t, _)| t < t_next);
+                            let updates = ready_times
+                                .drain(0..idx)
+                                .map(|(from_time, _, diff)| (from_time, diff));
+                            source_upper.update_iter(updates);
+                            // At this point source_upper contains all updates that are less than
+                            // t_next, which is equal to remap[t_prev]
+                            source_upper.frontier().to_owned()
+                        }
+                        None => Antichain::new(),
+                    };
+                    tx.send_replace(reclocked_upper);
                 }
             }
 

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -896,9 +896,9 @@ where
             if as_of.iter().all(|t| !upper.less_equal(t)) {
                 let committed_upper = frontiers[1].frontier();
                 if as_of.iter().all(|t| !committed_upper.less_equal(t)) {
-                    // Compute the frontier of the binding that is *less than* the committed upper.
-                    let idx =
-                        ready_times.partition_point(|(_, t, _)| !committed_upper.less_than(t));
+                   // Compute the frontier of the binding that is *less than* the committed upper.
+                   let idx =
+                       ready_times.partition_point(|(_, t, _)| !committed_upper.less_than(t));
                     let updates = ready_times
                         .drain(0..idx)
                         .map(|(from_time, _, diff)| (from_time, diff));


### PR DESCRIPTION
This PR makes a slight modification to the capability management logic of the postgres source such that the capability that governs the minting of reclock bindings is advanced eagerly, before a transaction is ingested. This has the effect that the data of the transaction will not accumulate in the reclock operator and will instead be passed downstream, where the persist sink operator can stream it to S3 batches.

Fixes #26257

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
