### PR TITLE
Add longest and shortest distance to mz_object_transitive_dependencies

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -422,6 +422,8 @@ The view is defined as the transitive closure of [`mz_object_dependencies`](#mz_
 | ----------------------- | ------------ | --------                                                                                                              |
 | `object_id`             | [`text`]     | The ID of the dependent object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects).                          |
 | `referenced_object_id`  | [`text`]     | The ID of the (possibly transitively) referenced object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects). |
+| `shortest_distance`     | [`bigint`]   | The minumum number of dependencies between the dependent object and the referenced object                             |
+| `longest_distance`      | [`bigint`]   | The maximumm number of dependencies between the dependent object and the referenced object                            |
 
 ### `mz_notices`
 

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -3341,20 +3341,25 @@ WHERE worker_id = 0",
     access: vec![PUBLIC_SELECT],
 });
 
-pub static MZ_OBJECT_TRANSITIVE_DEPENDENCIES: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
+pub static MZ_OBJECT_TRANSITIVE_DEPENDENCIES: Lazy<BuiltinView> = Lazy::new(|| {
+    BuiltinView {
     name: "mz_object_transitive_dependencies",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::VIEW_MZ_OBJECT_TRANSITIVE_DEPENDENCIES_OID,
     column_defs: None,
     sql: "
 WITH MUTUALLY RECURSIVE
-  reach(object_id text, referenced_object_id text) AS (
-    SELECT object_id, referenced_object_id FROM mz_internal.mz_object_dependencies
+  reach(object_id text, referenced_object_id text, depth bigint) AS (
+    SELECT object_id, referenced_object_id, 1 FROM mz_internal.mz_object_dependencies
     UNION
-    SELECT x, z FROM reach r1(x, y) JOIN reach r2(y, z) USING(y)
+    SELECT x, z, d1 + d2 FROM reach r1(x, y, d1) JOIN reach r2(y, z, d2) USING(y)
   )
-SELECT object_id, referenced_object_id FROM reach;",
+
+SELECT object_id, referenced_object_id, MIN(depth) AS shortest_distance, MAX(depth) AS longest_distance FROM reach
+GROUP BY object_id, referenced_object_id
+OPTIONS (AGGREGATE INPUT GROUP SIZE = 256);",
     access: vec![PUBLIC_SELECT],
+}
 });
 
 pub static MZ_COMPUTE_EXPORTS: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -246,6 +246,8 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 ----
 1  object_id  text
 2  referenced_object_id  text
+3  shortest_distance  bigint
+4  longest_distance  bigint
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_notices' ORDER BY position


### PR DESCRIPTION
### Motivation

Adds the shortest and longest transitive distances to mz_object_transitive_dependencies. This may be useful when debugging deep dags and needing to be thoughtful about search order. 

Slack discussion: https://materializeinc.slack.com/archives/C063H5S7NKE/p1711380094986439

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
