### PR TITLE
miri test: Disable fivetran-destination tests

### DIFF
--- a/ci/test/cargo-test-miri.sh
+++ b/ci/test/cargo-test-miri.sh
@@ -23,4 +23,4 @@ PARTITION=$((${BUILDKITE_PARALLEL_JOB:-0}+1))
 TOTAL=${BUILDKITE_PARALLEL_JOB_COUNT:-1}
 
 # exclude network-based and more complex tests which run out of memory
-cargo miri nextest run -j"$(nproc)" --partition "count:$PARTITION/$TOTAL" --no-fail-fast --workspace --exclude 'mz-environmentd*' --exclude 'mz-compute-client*' --exclude 'mz-compute-types*' --exclude 'mz-ssh-util*' --exclude 'mz-rocksdb*'
+cargo miri nextest run -j"$(nproc)" --partition "count:$PARTITION/$TOTAL" --no-fail-fast --workspace --exclude 'mz-environmentd*' --exclude 'mz-compute-client*' --exclude 'mz-compute-types*' --exclude 'mz-ssh-util*' --exclude 'mz-rocksdb*' --exclude 'mz-fivetran-destination*'


### PR DESCRIPTION
All fail with

> error: unsupported operation: can't call foreign function `pipe2` on OS `linux`

Seen in https://buildkite.com/materialize/nightlies/builds/7059#018e7a87-8673-4505-a140-db6e24fc3106

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
