### PR TITLE
canary-load: Add api/sql load

### DIFF
--- a/misc/python/materialize/cloudtest/util/jwt_key.py
+++ b/misc/python/materialize/cloudtest/util/jwt_key.py
@@ -17,7 +17,9 @@ from materialize.cloudtest.util.common import retry
 LOGGER = logging.getLogger(__name__)
 
 
-def fetch_jwt(email: str, password: str, host: str, scheme: str) -> str:
+def fetch_jwt(
+    email: str, password: str, host: str, scheme: str, max_tries: int = 10
+) -> str:
     def fetch():
         res = requests.post(
             f"{scheme}://{host}/identity/resources/auth/v1/user",
@@ -28,7 +30,7 @@ def fetch_jwt(email: str, password: str, host: str, scheme: str) -> str:
         return res
 
     try:
-        res = retry(fetch, 10, [requests.exceptions.HTTPError])
+        res = retry(fetch, max_tries, [requests.exceptions.HTTPError])
     except requests.exceptions.HTTPError as e:
         res = e.response
         LOGGER.error(

--- a/test/canary-environment/dbt_project.yml
+++ b/test/canary-environment/dbt_project.yml
@@ -26,19 +26,19 @@ models:
   canary_environment:
     loadgen:
       schema: loadgen
-      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\""
+      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\", \"infra+qacanaryload@materialize.io\""
     tpch:
       schema: tpch
-      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\""
+      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\", \"infra+qacanaryload@materialize.io\""
     pg_cdc:
       schema: pg_cdc
-      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\""
+      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\", \"infra+qacanaryload@materialize.io\""
     mysql_cdc:
       schema: mysql_cdc
-      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\""
+      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\", \"infra+qacanaryload@materialize.io\""
     simple_table:
       schema: simple_table
-      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\""
+      post-hook: "GRANT ALL PRIVILEGES ON TABLE {{ this }} TO \"infra+bot@materialize.com\", \"infra+qacanaryload@materialize.io\""
 
 tests:
     +cluster: qa_canary_environment_compute


### PR DESCRIPTION
Requires new infra+qacanaryload@materialize.io user to allow using that endpoint without having to go through SSO: https://github.com/MaterializeInc/i2/pull/1780

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
