### PR TITLE
doc: add known limitation around PG source publication membership

### DIFF
--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -195,6 +195,23 @@ ingestion progress and debugging related issues, see [Troubleshooting](/ops/trou
 
 {{% postgres-direct/postgres-schema-changes %}}
 
+#### Publication membership
+
+PostgreSQL's logical replication API does not provide a signal when users remove
+tables from publications. Because of this, Materialize relies on periodic checks
+to determine if a table has been removed from a publication, at which time it
+generates an irrevocable error, preventing any values from being read from the
+table.
+
+However, it is possible to remove a table from a publication and then re-add it
+before Materialize notices that the table was removed. In this case, Materialize
+can no longer provide any consistency guarantees about the data we present from
+the table and, unfortunately, is wholly unaware that this occurred.
+
+To mitigate this issue, if you need to drop and re-add a table to a publication,
+ensure that you remove the table/subsource from the source _before_ re-adding it
+(i.e. [`ALTER SOURCE...DROP SUBSOURCE`](/sql/alter-source/#context)).
+
 ##### Supported types
 
 Materialize natively supports the following PostgreSQL types (including the


### PR DESCRIPTION
Documents a known limitation of PostgreSQL sources.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
