### PR TITLE
mysql-cdc-resumption test: Disable short-bin-log-retention workflow temporarily

### DIFF
--- a/test/mysql-cdc-resumption/mzcompose.py
+++ b/test/mysql-cdc-resumption/mzcompose.py
@@ -47,7 +47,7 @@ def workflow_default(c: Composition) -> None:
             continue
 
         # TODO(def-): Reenable when #26127 is fixed
-        if name == "bin-log-manipulations":
+        if name in ("bin-log-manipulations", "short-bin-log-retention"):
             continue
 
         with c.test_case(name):


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/tests/builds/79209#018e7dbe-7715-4391-aef3-c2278b5e8b66

To keep tests pipeline green

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
