### PR TITLE
sql: expand `variadic_left::decompose_equations` coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -111,7 +111,7 @@
 /src/sql/src/plan/expr.rs           @MaterializeInc/adapter @MaterializeInc/compute
 # The lowering of HirRelationExpr to MirRelationExpr is part of the compute
 # layer, despite being located in the `sql` crate.
-/src/sql/src/plan/lowering.rs       @MaterializeInc/compute
+/src/sql/src/plan/lowering          @MaterializeInc/compute
 /src/sql-lexer                      @MaterializeInc/adapter
 /src/sql-parser                     @MaterializeInc/adapter
 /src/sqllogictest                   @MaterializeInc/adapter

--- a/src/sql/src/plan/lowering/variadic_left.rs
+++ b/src/sql/src/plan/lowering/variadic_left.rs
@@ -343,6 +343,7 @@ fn decompose_equations(predicate: &MirScalarExpr) -> Option<Vec<(usize, usize)>>
                     return None;
                 }
             }
+            e if e.is_literal_true() => (), // `USING(c1,...,cN)` translates to `true && c1 = c1 ... cN = cN`.
             _ => return None,
         }
     }


### PR DESCRIPTION
Support trivial `true` conjuncts, which occur when planning `USING(...)` clauses.


### Motivation

  * This PR adds a known-desirable feature.

Builds up on #24345 by expanding the set of cases supported in #25340.

### Tips for reviewer

TODO

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
