### PR TITLE
fivetran-destination: Use AsyncWriter to serialize mapped ByteRecords

### DIFF
--- a/test/fivetran-destination/test-odd-writes/00-README
+++ b/test/fivetran-destination/test-odd-writes/00-README
@@ -1,0 +1,1 @@
+Verifies that various kinds of writes work correctly.

--- a/test/fivetran-destination/test-odd-writes/01-setup.json
+++ b/test/fivetran-destination/test-odd-writes/01-setup.json
@@ -1,0 +1,42 @@
+{
+    "create_table": {
+        "test_odd_writes": {
+            "columns": {
+                "a": "INT",
+                "b": "STRING"
+            },
+            "primary_key": [
+                "a",
+                "b"
+            ]
+        }
+    },
+    "ops": [
+        {
+            "upsert": {
+                "test_odd_writes": [
+                    {
+                        "a": 1,
+                        "b": ",,"
+                    },
+                    {
+                        "a": 2,
+                        "b": ",\t,"
+                    },
+                    {
+                        "a": 3,
+                        "b": ","
+                    },
+                    {
+                        "a": 4,
+                        "b": "'\","
+                    },
+                    {
+                        "a": 5,
+                        "b": "     \n  '\t,,,\",,\""
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/test/fivetran-destination/test-odd-writes/02-verify.td
+++ b/test/fivetran-destination/test-odd-writes/02-verify.td
@@ -1,0 +1,17 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT a, b FROM test.tester.test_odd_writes
+a   b
+------
+1   ,,
+2   ",\t,"
+3   ,
+4   "'\","
+5   "     \n  '\t,,,\",,\""

--- a/test/fivetran-destination/test-writes/00-README
+++ b/test/fivetran-destination/test-writes/00-README
@@ -1,1 +1,1 @@
-Verifies that various kinds of writes work correctly.
+Verifies that various kinds of writes work correctly even with odd data.


### PR DESCRIPTION
Previously I had assumed that a `ByteRecord` contained the raw bytes of a row from a CSV file, specifically that it contained escaped values, this is not the case.

This PR changes how we write mapped `ByteRecord`s into the `COPY FROM` sink, instead of manually adding `,` and newlines we create a `csv_async::AsyncWriter` and use that to serialize the records, which properly escapes all necessary values (e.g. `,`s).

Note: I think this highlights a larger need for more testing of the Fivetran Destination. I have a local branch that adds support for the Fivetran Destination to testdive, and will reach out to the QA team about support.

### Motivation

The Fivetran Destination currently fails to sync data that contains a `,` since it doesn't get properly escaped.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes an issue with the Fivetran Destination
