### PR TITLE
[persist] Roundtrip spine structure through state

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -323,6 +323,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER)
         .add(&crate::internal::state::ROLLUP_THRESHOLD)
+        .add(&crate::internal::apply::ROUNDTRIP_SPINE)
         .add(&crate::operators::PERSIST_SINK_MINIMUM_BATCH_UPDATES)
         .add(&crate::operators::STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
         .add(&crate::operators::STORAGE_SOURCE_DECODE_FUEL)

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -304,7 +304,11 @@ where
             let req = CompactReq {
                 shard_id,
                 desc: req.desc,
-                inputs: req.inputs.iter().map(|b| b.batch.clone()).collect(),
+                inputs: req
+                    .inputs
+                    .into_iter()
+                    .map(|b| Arc::unwrap_or_clone(b.batch))
+                    .collect(),
             };
             let parts = req.inputs.iter().map(|x| x.parts.len()).sum::<usize>();
             let bytes = req

--- a/src/persist-client/src/internal/diff.proto
+++ b/src/persist-client/src/internal/diff.proto
@@ -20,7 +20,10 @@ enum ProtoStateField {
     CRITICAL_READERS = 6;
     WRITERS = 3;
     SINCE = 4;
-    SPINE = 5;
+    LEGACY_BATCHES = 5;
+    HOLLOW_BATCHES = 9;
+    SPINE_BATCHES = 10;
+    SPINE_MERGES = 11;
 }
 
 enum ProtoStateFieldDiffType {

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -20,7 +20,7 @@ use mz_ore::halt;
 use mz_persist::location::{SeqNo, VersionedData};
 use mz_persist_types::stats::{PartStats, ProtoStructStats};
 use mz_persist_types::{Codec, Codec64};
-use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoMapEntry, ProtoType, RustType, TryFromProtoError};
 use proptest::prelude::Arbitrary;
 use proptest::strategy::Strategy;
 use prost::Message;
@@ -37,17 +37,18 @@ use crate::internal::metrics::Metrics;
 use crate::internal::paths::{PartialBatchKey, PartialRollupKey};
 use crate::internal::state::{
     CriticalReaderState, HandleDebugState, HollowBatch, HollowBatchPart, HollowRollup,
-    IdempotencyToken, LeasedReaderState, OpaqueState, ProtoCriticalReaderState,
+    IdempotencyToken, LeasedReaderState, OpaqueState, ProtoCriticalReaderState, ProtoFuelingMerge,
     ProtoHandleDebugState, ProtoHollowBatch, ProtoHollowBatchPart, ProtoHollowRollup,
-    ProtoInlinedDiffs, ProtoLeasedReaderState, ProtoRollup, ProtoStateDiff, ProtoStateField,
-    ProtoStateFieldDiffType, ProtoStateFieldDiffs, ProtoTrace, ProtoU64Antichain,
+    ProtoIdFuelingMerge, ProtoIdHollowBatch, ProtoIdSpineBatch, ProtoInlinedDiffs,
+    ProtoLeasedReaderState, ProtoRollup, ProtoSpineBatch, ProtoSpineId, ProtoStateDiff,
+    ProtoStateField, ProtoStateFieldDiffType, ProtoStateFieldDiffs, ProtoTrace, ProtoU64Antichain,
     ProtoU64Description, ProtoVersionedData, ProtoWriterState, State, StateCollections, TypedState,
     WriterState,
 };
 use crate::internal::state_diff::{
     ProtoStateFieldDiff, ProtoStateFieldDiffsWriter, StateDiff, StateFieldDiff, StateFieldValDiff,
 };
-use crate::internal::trace::Trace;
+use crate::internal::trace::{FuelingMerge, SpineId, ThinSpineBatch, Trace};
 use crate::read::{LeasedReaderId, READER_LEASE_DURATION};
 use crate::{cfg, PersistConfig, ShardId, WriterId};
 
@@ -296,7 +297,10 @@ impl<T: Timestamp + Codec64> RustType<ProtoStateDiff> for StateDiff<T> {
             critical_readers,
             writers,
             since,
-            spine,
+            legacy_batches,
+            hollow_batches,
+            spine_batches,
+            fueling_merges,
         } = self;
 
         let proto = ProtoStateFieldDiffs::default();
@@ -315,7 +319,10 @@ impl<T: Timestamp + Codec64> RustType<ProtoStateDiff> for StateDiff<T> {
         );
         field_diffs_into_proto(ProtoStateField::Writers, writers, &mut writer);
         field_diffs_into_proto(ProtoStateField::Since, since, &mut writer);
-        field_diffs_into_proto(ProtoStateField::Spine, spine, &mut writer);
+        field_diffs_into_proto(ProtoStateField::LegacyBatches, legacy_batches, &mut writer);
+        field_diffs_into_proto(ProtoStateField::HollowBatches, hollow_batches, &mut writer);
+        field_diffs_into_proto(ProtoStateField::SpineBatches, spine_batches, &mut writer);
+        field_diffs_into_proto(ProtoStateField::SpineMerges, fueling_merges, &mut writer);
 
         // After encoding all of our data, convert back into the proto.
         let field_diffs = writer.into_proto();
@@ -425,12 +432,36 @@ impl<T: Timestamp + Codec64> RustType<ProtoStateDiff> for StateDiff<T> {
                             |v| v.into_rust(),
                         )?
                     }
-                    ProtoStateField::Spine => {
+                    ProtoStateField::LegacyBatches => {
                         field_diff_into_rust::<ProtoHollowBatch, (), _, _, _, _>(
                             diff,
-                            &mut state_diff.spine,
+                            &mut state_diff.legacy_batches,
                             |k| k.into_rust(),
                             |()| Ok(()),
+                        )?
+                    }
+                    ProtoStateField::HollowBatches => {
+                        field_diff_into_rust::<ProtoSpineId, ProtoHollowBatch, _, _, _, _>(
+                            diff,
+                            &mut state_diff.hollow_batches,
+                            |k| k.into_rust(),
+                            |v| v.into_rust(),
+                        )?
+                    }
+                    ProtoStateField::SpineBatches => {
+                        field_diff_into_rust::<ProtoSpineId, ProtoSpineBatch, _, _, _, _>(
+                            diff,
+                            &mut state_diff.spine_batches,
+                            |k| k.into_rust(),
+                            |v| v.into_rust(),
+                        )?
+                    }
+                    ProtoStateField::SpineMerges => {
+                        field_diff_into_rust::<ProtoSpineId, ProtoFuelingMerge, _, _, _, _>(
+                            diff,
+                            &mut state_diff.fueling_merges,
+                            |k| k.into_rust(),
+                            |v| v.into_rust(),
                         )?
                     }
                 }
@@ -907,15 +938,113 @@ impl RustType<ProtoVersionedData> for VersionedData {
     }
 }
 
+impl RustType<ProtoSpineId> for SpineId {
+    fn into_proto(&self) -> ProtoSpineId {
+        ProtoSpineId {
+            lo: self.0.into_proto(),
+            hi: self.1.into_proto(),
+        }
+    }
+
+    fn from_proto(proto: ProtoSpineId) -> Result<Self, TryFromProtoError> {
+        Ok(SpineId(proto.lo.into_rust()?, proto.hi.into_rust()?))
+    }
+}
+
+impl<T: Timestamp + Codec64> ProtoMapEntry<SpineId, Arc<HollowBatch<T>>> for ProtoIdHollowBatch {
+    fn from_rust<'a>(entry: (&'a SpineId, &'a Arc<HollowBatch<T>>)) -> Self {
+        let (id, batch) = entry;
+        ProtoIdHollowBatch {
+            id: Some(id.into_proto()),
+            batch: Some(batch.into_proto()),
+        }
+    }
+
+    fn into_rust(self) -> Result<(SpineId, Arc<HollowBatch<T>>), TryFromProtoError> {
+        let id = self.id.into_rust_if_some("ProtoIdHollowBatch::id")?;
+        let batch = Arc::new(self.batch.into_rust_if_some("ProtoIdHollowBatch::batch")?);
+        Ok((id, batch))
+    }
+}
+
+impl<T: Timestamp + Codec64> RustType<ProtoSpineBatch> for ThinSpineBatch<T> {
+    fn into_proto(&self) -> ProtoSpineBatch {
+        ProtoSpineBatch {
+            desc: Some(self.desc.into_proto()),
+            parts: self.parts.into_proto(),
+            level: self.level.into_proto(),
+        }
+    }
+
+    fn from_proto(proto: ProtoSpineBatch) -> Result<Self, TryFromProtoError> {
+        let level = proto.level.into_rust()?;
+        let desc = proto.desc.into_rust_if_some("ProtoSpineBatch::desc")?;
+        let parts = proto.parts.into_rust()?;
+        Ok(ThinSpineBatch { level, desc, parts })
+    }
+}
+
+impl<T: Timestamp + Codec64> ProtoMapEntry<SpineId, ThinSpineBatch<T>> for ProtoIdSpineBatch {
+    fn from_rust<'a>(entry: (&'a SpineId, &'a ThinSpineBatch<T>)) -> Self {
+        let (id, batch) = entry;
+        ProtoIdSpineBatch {
+            id: Some(id.into_proto()),
+            batch: Some(batch.into_proto()),
+        }
+    }
+
+    fn into_rust(self) -> Result<(SpineId, ThinSpineBatch<T>), TryFromProtoError> {
+        let id = self.id.into_rust_if_some("ProtoHollowBatch::id")?;
+        let batch = self.batch.into_rust_if_some("ProtoHollowBatch::batch")?;
+        Ok((id, batch))
+    }
+}
+
+impl<T: Timestamp + Codec64> RustType<ProtoFuelingMerge> for FuelingMerge<T> {
+    fn into_proto(&self) -> ProtoFuelingMerge {
+        ProtoFuelingMerge {
+            since: Some(self.since.into_proto()),
+            remaining_work: self.remaining_work.into_proto(),
+        }
+    }
+
+    fn from_proto(proto: ProtoFuelingMerge) -> Result<Self, TryFromProtoError> {
+        let since = proto.since.into_rust_if_some("ProtoFuelingMerge::since")?;
+        let remaining_work = proto.remaining_work.into_rust()?;
+        Ok(Self {
+            since,
+            remaining_work,
+        })
+    }
+}
+
+impl<T: Timestamp + Codec64> ProtoMapEntry<SpineId, FuelingMerge<T>> for ProtoIdFuelingMerge {
+    fn from_rust<'a>((id, merge): (&'a SpineId, &'a FuelingMerge<T>)) -> Self {
+        ProtoIdFuelingMerge {
+            id: Some(id.into_proto()),
+            merge: Some(merge.into_proto()),
+        }
+    }
+
+    fn into_rust(self) -> Result<(SpineId, FuelingMerge<T>), TryFromProtoError> {
+        let id = self.id.into_rust_if_some("ProtoIdFuelingMerge::id")?;
+        let merge = self.merge.into_rust_if_some("ProtoIdFuelingMerge::merge")?;
+        Ok((id, merge))
+    }
+}
+
 impl<T: Timestamp + Lattice + Codec64> RustType<ProtoTrace> for Trace<T> {
     fn into_proto(&self) -> ProtoTrace {
-        let mut spine = Vec::new();
+        let mut legacy_batches = Vec::new();
         self.map_batches(|b| {
-            spine.push(b.into_proto());
+            legacy_batches.push(b.into_proto());
         });
         ProtoTrace {
             since: Some(self.since().into_proto()),
-            spine,
+            legacy_batches,
+            hollow_batches: vec![],
+            spine_batches: vec![],
+            merges: vec![],
         }
     }
 
@@ -923,7 +1052,7 @@ impl<T: Timestamp + Lattice + Codec64> RustType<ProtoTrace> for Trace<T> {
         let mut ret = Trace::default();
         ret.downgrade_since(&proto.since.into_rust_if_some("since")?);
         let mut batches_pushed = 0;
-        for batch in proto.spine.into_iter() {
+        for batch in proto.legacy_batches.into_iter() {
             let batch: HollowBatch<T> = batch.into_rust()?;
             if PartialOrder::less_than(ret.since(), batch.desc.since()) {
                 return Err(TryFromProtoError::InvalidPersistState(format!(
@@ -950,7 +1079,6 @@ impl<T: Timestamp + Lattice + Codec64> RustType<ProtoTrace> for Trace<T> {
                 debug!("Decoded and pushed {batches_pushed} batches; trace size {batch_count}");
             }
         }
-        debug_assert_eq!(ret.validate(), Ok(()), "{:?}", ret);
         Ok(ret)
     }
 }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -408,7 +408,11 @@ where
                         let req = CompactReq {
                             shard_id: self.shard_id(),
                             desc: req.desc,
-                            inputs: req.inputs.iter().map(|b| b.batch.clone()).collect(),
+                            inputs: req
+                                .inputs
+                                .into_iter()
+                                .map(|b| Arc::unwrap_or_clone(b.batch))
+                                .collect(),
                         };
                         compact_reqs.push(req);
                     }

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1072,6 +1072,7 @@ pub struct StateMetrics {
     pub(crate) apply_spine_slow_path_lenient: IntCounter,
     pub(crate) apply_spine_slow_path_lenient_adjustment: IntCounter,
     pub(crate) apply_spine_slow_path_with_reconstruction: IntCounter,
+    pub(crate) apply_spine_flattened: IntCounter,
     pub(crate) update_state_noop_path: IntCounter,
     pub(crate) update_state_empty_path: IntCounter,
     pub(crate) update_state_fast_path: IntCounter,
@@ -1115,6 +1116,10 @@ impl StateMetrics {
             apply_spine_slow_path_with_reconstruction: registry.register(metric!(
                 name: "mz_persist_state_apply_spine_slow_path_with_reconstruction",
                 help: "count of spine diff applications that hit the slow path with extra spine reconstruction step",
+            )),
+            apply_spine_flattened: registry.register(metric!(
+                name: "mz_persist_state_apply_spine_flattened",
+                help: "count of spine diff applications that flatten the trace",
             )),
             update_state_noop_path: registry.register(metric!(
                 name: "mz_persist_state_update_state_noop_path",

--- a/src/persist-client/src/internal/restore.rs
+++ b/src/persist-client/src/internal/restore.rs
@@ -91,7 +91,7 @@ pub(crate) async fn restore_blob(
                 }
             }
         }
-        for batch in diff.spine {
+        for batch in diff.legacy_batches {
             if let Some(_) = after(batch.val) {
                 for part in batch.key.parts {
                     let key = part.key.complete(&shard_id);

--- a/src/persist-client/src/internal/restore.rs
+++ b/src/persist-client/src/internal/restore.rs
@@ -49,8 +49,8 @@ pub(crate) async fn restore_blob(
     };
 
     for diff in diffs.0 {
-        let diff: StateDiff<u64> = StateDiff::decode(build_version, diff.data);
-        for rollup in diff.rollups {
+        let mut diff: StateDiff<u64> = StateDiff::decode(build_version, diff.data);
+        for rollup in std::mem::take(&mut diff.rollups) {
             // We never actually reference rollups from before the first live diff.
             if rollup.key < first_live_seqno {
                 continue;
@@ -91,9 +91,9 @@ pub(crate) async fn restore_blob(
                 }
             }
         }
-        for batch in diff.legacy_batches {
-            if let Some(_) = after(batch.val) {
-                for part in batch.key.parts {
+        for diff in diff.referenced_batches() {
+            if let Some(after) = after(diff) {
+                for part in &after.parts {
                     let key = part.key.complete(&shard_id);
                     check_restored(&key, blob.restore(&key).await);
                 }

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -41,6 +41,37 @@ message ProtoHollowBatch {
     repeated string deprecated_keys = 2;
 }
 
+message ProtoSpineId {
+    uint64 lo = 1;
+    uint64 hi = 2;
+}
+
+message ProtoIdHollowBatch {
+    ProtoSpineId id = 1;
+    ProtoHollowBatch batch = 2;
+}
+
+message ProtoSpineBatch {
+    uint64 level = 1;
+    ProtoU64Description desc = 2;
+    repeated ProtoSpineId parts = 3;
+}
+
+message ProtoIdSpineBatch {
+    ProtoSpineId id = 1;
+    ProtoSpineBatch batch = 2;
+}
+
+message ProtoFuelingMerge {
+    ProtoU64Antichain since = 1;
+    uint64 remaining_work = 2;
+}
+
+message ProtoIdFuelingMerge {
+    ProtoSpineId id = 1;
+    ProtoFuelingMerge merge = 2;
+}
+
 message ProtoHollowRollup {
     string key = 1;
     optional uint64 encoded_size_bytes = 2;
@@ -48,7 +79,10 @@ message ProtoHollowRollup {
 
 message ProtoTrace {
     ProtoU64Antichain since = 1;
-    repeated ProtoHollowBatch spine = 2;
+    repeated ProtoHollowBatch legacy_batches = 2;
+    repeated ProtoIdHollowBatch hollow_batches = 3;
+    repeated ProtoIdSpineBatch spine_batches = 4;
+    repeated ProtoIdFuelingMerge merges = 5;
 }
 
 message ProtoLeasedReaderState {

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -427,6 +427,7 @@ impl<T: Timestamp + Lattice + Codec64> State<T> {
 
         if trace.roundtrip_structure || !structure_unchanged {
             if !spine_unchanged {
+                metrics.state.apply_spine_flattened.inc();
                 let mut flat = trace.flatten();
                 apply_diffs_single("since", diff_since, &mut flat.since)?;
                 apply_diffs_map(

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -10,6 +10,7 @@
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use bytes::{Bytes, BytesMut};
 use differential_dataflow::lattice::Lattice;
@@ -29,7 +30,7 @@ use crate::internal::state::{
     ProtoStateField, ProtoStateFieldDiffType, ProtoStateFieldDiffs, State, StateCollections,
     WriterState,
 };
-use crate::internal::trace::{FueledMergeRes, Trace};
+use crate::internal::trace::{FueledMergeRes, FuelingMerge, SpineId, ThinSpineBatch, Trace};
 use crate::read::LeasedReaderId;
 use crate::write::WriterId;
 use crate::{Metrics, PersistConfig, ShardId};
@@ -77,7 +78,10 @@ pub struct StateDiff<T> {
     pub(crate) critical_readers: Vec<StateFieldDiff<CriticalReaderId, CriticalReaderState<T>>>,
     pub(crate) writers: Vec<StateFieldDiff<WriterId, WriterState<T>>>,
     pub(crate) since: Vec<StateFieldDiff<(), Antichain<T>>>,
-    pub(crate) spine: Vec<StateFieldDiff<HollowBatch<T>, ()>>,
+    pub(crate) legacy_batches: Vec<StateFieldDiff<HollowBatch<T>, ()>>,
+    pub(crate) hollow_batches: Vec<StateFieldDiff<SpineId, Arc<HollowBatch<T>>>>,
+    pub(crate) spine_batches: Vec<StateFieldDiff<SpineId, ThinSpineBatch<T>>>,
+    pub(crate) fueling_merges: Vec<StateFieldDiff<SpineId, FuelingMerge<T>>>,
 }
 
 impl<T: Timestamp + Codec64> StateDiff<T> {
@@ -101,7 +105,10 @@ impl<T: Timestamp + Codec64> StateDiff<T> {
             critical_readers: Vec::default(),
             writers: Vec::default(),
             since: Vec::default(),
-            spine: Vec::default(),
+            legacy_batches: Vec::default(),
+            hollow_batches: Vec::default(),
+            spine_batches: Vec::default(),
+            fueling_merges: Vec::default(),
         }
     }
 }
@@ -167,12 +174,12 @@ impl<T: Timestamp + Lattice + Codec64> StateDiff<T> {
         );
         diff_field_sorted_iter(from_writers.iter(), to_writers, &mut diffs.writers);
         diff_field_single(from_trace.since(), to_trace.since(), &mut diffs.since);
-        diff_field_spine(from_trace, to_trace, &mut diffs.spine);
+        diff_field_spine(from_trace, to_trace, &mut diffs.legacy_batches);
         diffs
     }
 
     pub(crate) fn map_blob_inserts<F: for<'a> FnMut(HollowBlobRef<'a, T>)>(&self, mut f: F) {
-        for spine_diff in self.spine.iter() {
+        for spine_diff in self.legacy_batches.iter() {
             match &spine_diff.val {
                 StateFieldValDiff::Insert(()) => {
                     f(HollowBlobRef::Batch(&spine_diff.key));
@@ -196,7 +203,7 @@ impl<T: Timestamp + Lattice + Codec64> StateDiff<T> {
     }
 
     pub(crate) fn map_blob_deletes<F: for<'a> FnMut(HollowBlobRef<'a, T>)>(&self, mut f: F) {
-        for spine_diff in self.spine.iter() {
+        for spine_diff in self.legacy_batches.iter() {
             match &spine_diff.val {
                 StateFieldValDiff::Insert(()) => {} // No-op
                 StateFieldValDiff::Update((), ()) => {
@@ -340,7 +347,10 @@ impl<T: Timestamp + Lattice + Codec64> State<T> {
             critical_readers: diff_critical_readers,
             writers: diff_writers,
             since: diff_since,
-            spine: diff_spine,
+            legacy_batches: diff_legacy_batches,
+            hollow_batches,
+            spine_batches,
+            fueling_merges: spine_merges,
         } = diff;
         if self.seqno == diff_seqno_to {
             return Ok(());
@@ -396,8 +406,8 @@ impl<T: Timestamp + Lattice + Codec64> State<T> {
                 Delete(_) => return Err("cannot delete since field".to_string()),
             }
         }
-        if !diff_spine.is_empty() {
-            apply_diffs_spine(metrics, diff_spine, trace)?;
+        if !diff_legacy_batches.is_empty() {
+            apply_diffs_spine(metrics, diff_legacy_batches, trace)?;
             debug_assert_eq!(trace.validate(), Ok(()), "{:?}", trace);
         }
 

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -107,6 +107,13 @@ impl<T: Timestamp + Lattice> Default for Trace<T> {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ThinSpineBatch<T> {
+    pub(crate) level: usize,
+    pub(crate) desc: Description<T>,
+    pub(crate) parts: Vec<SpineId>,
+}
+
 impl<T> Trace<T> {
     pub fn since(&self) -> &Antichain<T> {
         &self.spine.since
@@ -560,10 +567,10 @@ impl<T: Timestamp + Lattice> SpineBatch<T> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FuelingMerge<T> {
-    since: Antichain<T>,
-    remaining_work: usize,
+    pub(crate) since: Antichain<T>,
+    pub(crate) remaining_work: usize,
 }
 
 impl<T: Timestamp + Lattice> FuelingMerge<T> {

--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -14,6 +14,7 @@ use std::char::CharTryFromError;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::num::{NonZeroU64, TryFromIntError};
+use std::sync::Arc;
 
 use mz_ore::cast::CastFrom;
 use mz_ore::num::{NonNeg, NonNegError};
@@ -357,6 +358,19 @@ where
 
     fn from_proto(proto: Box<P>) -> Result<Self, TryFromProtoError> {
         (*proto).into_rust().map(Box::new)
+    }
+}
+
+impl<R, P> RustType<P> for Arc<R>
+where
+    R: RustType<P>,
+{
+    fn into_proto(&self) -> P {
+        (**self).into_proto()
+    }
+
+    fn from_proto(proto: P) -> Result<Self, TryFromProtoError> {
+        proto.into_rust().map(Arc::new)
     }
 }
 


### PR DESCRIPTION
Previously, while we'd write down the _contents_ of the spine, we did not write down the _structure_ -- including any details about fuel or the level that various batches were at.

This PR adds some new state metadata that preserves this information -- while also taking care to keep the "legacy" hollow batches stored in the same way to preserve compat and avoid large diffs.

### Motivation

This is the foundational change for: #16607 

### Tips for reviewer

This is mostly organized commit-by-commit, in case that helps with review.

There were a lot of degrees of freedom with this change; please let me know what doesn't feel obvious, and I'll either change it to make more sense or add some comments. (`FlatTrace` certainly needs more comments, and I'll follow up with those.) 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
