### PR TITLE
[testing] Upgrade datadriven and log the filename in some persist tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,12 +1679,12 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "datadriven"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c496e3277b660041bd6a2c0618593e99c3ba450b30d5f8d89035f78c87b4106"
+checksum = "e6922deacb7b9c86bb7f8ce1fb565212f4e6a9427aad6ce3bd14a2622adf520f"
 dependencies = [
- "anyhow",
  "futures",
+ "thiserror",
 ]
 
 [[package]]

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -40,6 +40,12 @@ who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
 version = "1.2.6"
 
+[[audits.datadriven]]
+who = "Ben Kirwin <bkirwi@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.8.0"
+notes = "Reads and writes files under a prefix controlled by the caller."
+
 [[audits.differential-dataflow]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -32,6 +32,10 @@ audit-as-crates-io = true
 [policy.mz-avro]
 audit-as-crates-io = true
 
+[policy.mz-pgtest]
+criteria = "safe-to-run"
+notes = "This crate is only depended on in tests."
+
 [policy.openssh]
 audit-as-crates-io = true
 

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -28,7 +28,7 @@ http = "0.2.8"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 launchdarkly-server-sdk = { version = "1.0.0", default_features = false, features = [
-  "hypertls",
+    "hypertls",
 ] }
 maplit = "1.0.2"
 mz-adapter-types = { path = "../adapter-types" }
@@ -78,10 +78,10 @@ qcell = "0.5"
 rand = "0.8.5"
 rand_chacha = "0.3"
 rdkafka = { version = "0.29.0", features = [
-  "cmake-build",
-  "ssl-vendored",
-  "libz-static",
-  "zstd",
+    "cmake-build",
+    "ssl-vendored",
+    "libz-static",
+    "zstd",
 ] }
 regex = "1.7.0"
 reqwest = "0.11.13"
@@ -93,7 +93,7 @@ sha2 = "0.10.6"
 smallvec = { version = "1.10.0", features = ["union"] }
 static_assertions = "1.1"
 timely = { version = "0.12.0", default-features = false, features = [
-  "bincode",
+    "bincode",
 ] }
 tokio = { version = "1.32.0", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
@@ -110,7 +110,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 
 
 [[bench]]

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -14,8 +14,8 @@ workspace = true
 [dependencies]
 anyhow = "1.0.66"
 askama = { version = "0.11.1", default-features = false, features = [
-  "config",
-  "serde-json",
+    "config",
+    "serde-json",
 ] }
 async-trait = "0.1.68"
 axum = { version = "0.6.20", features = ["headers", "ws"] }
@@ -87,10 +87,10 @@ postgres = { version = "0.19.5", optional = true }
 postgres-openssl = { version = "0.5.0", optional = true }
 prometheus = { version = "0.13.3", default-features = false }
 rdkafka-sys = { version = "4.3.0", features = [
-  "cmake-build",
-  "ssl-vendored",
-  "libz-static",
-  "zstd",
+    "cmake-build",
+    "ssl-vendored",
+    "libz-static",
+    "zstd",
 ] }
 rand = "0.8.5"
 regex = { version = "1.7.0", optional = true }
@@ -124,7 +124,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [dev-dependencies]
 assert_cmd = "2.0.5"
 bytes = "1.3.0"
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 fallible-iterator = "0.2.0"
 insta = { version = "1.32", features = ["json"] }
 itertools = "0.10.5"
@@ -140,17 +140,17 @@ postgres_array = { version = "0.11.0" }
 predicates = "2.1.4"
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 rdkafka = { version = "0.29.0", features = [
-  "cmake-build",
-  "ssl-vendored",
-  "libz-static",
-  "zstd",
+    "cmake-build",
+    "ssl-vendored",
+    "libz-static",
+    "zstd",
 ] }
 reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.89"
 serde_urlencoded = "0.7.1"
 similar-asserts = "1.4"
 timely = { version = "0.12.0", default-features = false, features = [
-  "bincode",
+    "bincode",
 ] }
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4"] }
 
@@ -170,17 +170,17 @@ default = ["tokio-console", "jemalloc"]
 dev-web = []
 jemalloc = ["mz-alloc/jemalloc"]
 test = [
-  "postgres",
-  "regex",
-  "postgres-openssl",
-  "mz-tracing",
-  "mz-frontegg-mock",
-  "tracing-capture",
-  "mz-orchestrator-tracing/capture",
+    "postgres",
+    "regex",
+    "postgres-openssl",
+    "mz-tracing",
+    "mz-frontegg-mock",
+    "tracing-capture",
+    "mz-orchestrator-tracing/capture",
 ]
 tokio-console = [
-  "mz-ore/tokio-console",
-  "mz-orchestrator-tracing/tokio-console",
+    "mz-ore/tokio-console",
+    "mz-orchestrator-tracing/tokio-console",
 ]
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/expr-parser/Cargo.toml
+++ b/src/expr-parser/Cargo.toml
@@ -18,7 +18,7 @@ syn = { version = "2.0.18", features = ["full"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/expr-test-util/Cargo.toml
+++ b/src/expr-test-util/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0.89"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -54,7 +54,7 @@ sha1 = "0.10.5"
 sha2 = "0.10.6"
 subtle = "2.4.1"
 timely = { version = "0.12.0", default-features = false, features = [
-  "bincode",
+    "bincode",
 ] }
 tracing = "0.1.37"
 uncased = "0.9.7"
@@ -65,7 +65,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0" }
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 mz-expr-test-util = { path = "../expr-test-util" }
 mz-ore = { path = "../ore" }
 proc-macro2 = "1.0.60"

--- a/src/lowertest/Cargo.toml
+++ b/src/lowertest/Cargo.toml
@@ -19,7 +19,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 anyhow = "1.0.66"
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = { version = "1.0.66", features = ["backtrace"] }
 async-stream = "0.3.3"
 async-trait = "0.1.68"
 bytes = { version = "1.3.0", features = ["serde"] }
-clap = { version = "3.2.24", features = [ "derive" ] }
+clap = { version = "3.2.24", features = ["derive"] }
 differential-dataflow = "0.12.0"
 futures = "0.3.25"
 futures-util = "0.3"
@@ -50,7 +50,7 @@ num_cpus = "1.14.0"
 once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 sentry-tracing = "0.29.1"
 semver = { version = "1.0.16", features = ["serde"] }
@@ -68,7 +68,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }
-datadriven = { version = "0.6.0", features = ["async"] }
+datadriven = { version = "0.8.0", features = ["async"] }
 futures-task = "0.3.21"
 num_cpus = "1.14.0"
 tempfile = "3.8.1"

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -151,6 +151,7 @@ mod tests {
         use crate::internal::trace::datadriven as trace_dd;
 
         datadriven::walk("tests/trace", |f| {
+            println!("running datadriven file: {}", f.filename);
             let mut state = trace_dd::TraceState::default();
             f.run(move |tc| -> String {
                 let args = DirectiveArgs {
@@ -183,6 +184,7 @@ mod tests {
         ::datadriven::walk_async("tests/machine", |mut f| {
             let initial_state_fut = machine_dd::MachineState::new();
             async move {
+                println!("running datadriven file: {}", f.filename);
                 let state = Arc::new(Mutex::new(initial_state_fut.await));
                 f.run_async(move |tc| {
                     let state = Arc::clone(&state);

--- a/src/pgtest/Cargo.toml
+++ b/src/pgtest/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = "1.0.66"
 bytes = "1.3.0"
 clap = { version = "3.2.24", features = ["derive"] }
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 fallible-iterator = "0.2.0"
 mz-ore = { path = "../ore", features = ["cli"] }
 postgres-protocol = { version = "0.6.5" }

--- a/src/repr-test-util/Cargo.toml
+++ b/src/repr-test-util/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro2 = "1.0.60"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/sql-lexer/Cargo.toml
+++ b/src/sql-lexer/Cargo.toml
@@ -17,7 +17,7 @@ phf = { version = "0.11.1", features = ["uncased"] }
 uncased = "0.9.7"
 
 [dev-dependencies]
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 
 [build-dependencies]

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 bytesize = "1.1.0"
-datadriven = { version = "0.6.0", optional = true }
+datadriven = { version = "0.8.0", optional = true }
 enum-kinds = "0.5.1"
 itertools = "0.10.5"
 mz-ore = { path = "../ore", default-features = false, features = ["stack", "test"] }

--- a/src/sql-pretty/Cargo.toml
+++ b/src/sql-pretty/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1.0.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 mz-sql-parser = { path = "../sql-parser", features = ["test"] }
 

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -88,7 +88,7 @@ uuid = { version = "1.7.0", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 mz-lowertest = { path = "../lowertest" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -107,7 +107,7 @@ tonic-build = "0.9.2"
 async-trait = "0.1.68"
 axum = { version = "0.6.20" }
 clap = { version = "3.2.24", features = ["derive", "env"] }
-datadriven = { version = "0.6.0", features = ["async"] }
+datadriven = { version = "0.8.0", features = ["async"] }
 humantime = "2.1.0"
 mz-http-util = { path = "../http-util" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -25,7 +25,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 anyhow = "1.0.66"
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 mz-expr-parser = { path = "../expr-parser" }
 mz-expr-test-util = { path = "../expr-test-util" }
 mz-lowertest = { path = "../lowertest" }

--- a/src/walkabout/Cargo.toml
+++ b/src/walkabout/Cargo.toml
@@ -18,7 +18,7 @@ syn = { version = "1.0.107", features = ["extra-traits", "full", "parsing"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
-datadriven = "0.6.0"
+datadriven = "0.8.0"
 tempfile = "3.8.1"
 
 [features]


### PR DESCRIPTION
### Motivation

We've got a lot of datadriven checks now; this helps narrow down which one is causing a panic.

(We could probably try and catch the panic / log more judiciously, but I'll leave that for future work unless someone feels strongly.)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
