### PR TITLE
parallel-workload: Make sure to close all connections

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1502,6 +1502,7 @@ class DropKafkaSourceAction(Action):
             query = f"DROP SOURCE {source}"
             exe.execute(query)
             exe.db.kafka_sources.remove(source)
+            source.executor.mz_conn.close()
         return True
 
 
@@ -1568,6 +1569,7 @@ class DropMySqlSourceAction(Action):
             query = f"DROP SOURCE {source.executor.source}"
             exe.execute(query)
             exe.db.mysql_sources.remove(source)
+            source.executor.mz_conn.close()
         return True
 
 
@@ -1634,6 +1636,7 @@ class DropPostgresSourceAction(Action):
             query = f"DROP SOURCE {source.executor.source}"
             exe.execute(query)
             exe.db.postgres_sources.remove(source)
+            source.executor.mz_conn.close()
         return True
 
 

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -9,6 +9,7 @@
 
 import argparse
 import datetime
+import gc
 import os
 import random
 import sys
@@ -364,6 +365,9 @@ def run(
         # Dropping the database also releases the long running connections
         # used by database objects.
         database.drop(Executor(rng, cur, database))
+
+        # Make sure all unreachable connections are closed too
+        gc.collect()
 
         stopping_time = datetime.datetime.now() + datetime.timedelta(seconds=30)
         while datetime.datetime.now() < stopping_time:


### PR DESCRIPTION
Fixes: #26206

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
