### PR TITLE
output consistency: prioritize value check over type check

### DIFF
--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -303,14 +303,15 @@ class ResultComparator:
                 col_index
             ].to_sql(SqlDialectAdjuster(), True)
 
-            if not self.is_type_equal(result_value1, result_value2):
+            if not self.is_value_equal(result_value1, result_value2):
+                error_type = ValidationErrorType.CONTENT_MISMATCH
+                error_message = "Value differs"
+            elif not self.is_type_equal(result_value1, result_value2):
+                # check the type after the value because it has a lower relevance
                 error_type = ValidationErrorType.CONTENT_TYPE_MISMATCH
                 result_value1 = type(result_value1)
                 result_value2 = type(result_value2)
                 error_message = "Value type differs"
-            elif not self.is_value_equal(result_value1, result_value2):
-                error_type = ValidationErrorType.CONTENT_MISMATCH
-                error_message = "Value differs"
             else:
                 continue
 


### PR DESCRIPTION
This is to avoid that the value does not get compared if the type does not match.