### PR TITLE
mzcompose: Only retry docker pulls

### DIFF
--- a/test/skip-version-upgrade/mzcompose.py
+++ b/test/skip-version-upgrade/mzcompose.py
@@ -68,7 +68,7 @@ def workflow_test_version_skips(c: Composition) -> None:
         # This will bring up version `0.X.0-dev`.
         # Note: We actually want to retry this 0 times, but we need to retry at least once so a
         # UIError is raised instead of an AssertionError
-        c.up("materialized", max_tries=1)
+        c.up("materialized", max_pull_tries=1)
         assert False, "skipping versions should fail"
     except UIError:
         # Noting useful in the error message to assert. Ideally we'd check that the error is due to


### PR DESCRIPTION
https://materializeinc.slack.com/archives/C01LKF361MZ/p1711452276830939

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
