### PR TITLE
compute-client: metrics for sequential hydration

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -384,12 +384,18 @@ impl<T: Timestamp> Instance<T> {
     /// This method is invoked by `ActiveComputeController::process`, which we expect to
     /// be periodically called during normal operation.
     fn refresh_state_metrics(&self) {
+        let unscheduled_collections_count =
+            self.collections.values().filter(|c| !c.scheduled).count();
+
         self.metrics
             .replica_count
             .set(u64::cast_from(self.replicas.len()));
         self.metrics
             .collection_count
             .set(u64::cast_from(self.collections.len()));
+        self.metrics
+            .collection_unscheduled_count
+            .set(u64::cast_from(unscheduled_collections_count));
         self.metrics
             .peek_count
             .set(u64::cast_from(self.peeks.len()));

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -190,7 +190,8 @@ where
                     {
                         Ok(client) => {
                             let dyncfg = Arc::clone(&self.dyncfg);
-                            Ok(SequentialHydration::new(client, dyncfg))
+                            let metrics = self.metrics.clone();
+                            Ok(SequentialHydration::new(client, dyncfg, metrics))
                         }
                         Err(e) => {
                             if state.i >= mz_service::retry::INFO_MIN_RETRIES {

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -17,9 +17,10 @@ use mz_cluster_client::ReplicaId;
 use mz_compute_types::ComputeInstanceId;
 use mz_ore::cast::CastFrom;
 use mz_ore::metric;
+use mz_ore::metrics::raw::UIntGaugeVec;
 use mz_ore::metrics::{
     CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, DeleteOnDropHistogram, GaugeVec,
-    GaugeVecExt, HistogramVec, HistogramVecExt, IntCounterVec, MetricsRegistry, UIntGaugeVec,
+    GaugeVecExt, HistogramVec, HistogramVecExt, IntCounterVec, MetricsRegistry,
 };
 use mz_ore::stats::histogram_seconds_buckets;
 use mz_repr::GlobalId;
@@ -35,7 +36,7 @@ type Gauge = DeleteOnDropGauge<'static, AtomicF64, Vec<String>>;
 pub type UIntGauge = DeleteOnDropGauge<'static, AtomicU64, Vec<String>>;
 type Histogram = DeleteOnDropHistogram<'static, Vec<String>>;
 
-/// Compute controller metrics
+/// Compute controller metrics.
 #[derive(Debug, Clone)]
 pub struct ComputeControllerMetrics {
     // compute protocol
@@ -47,11 +48,13 @@ pub struct ComputeControllerMetrics {
     // controller state
     replica_count: UIntGaugeVec,
     collection_count: UIntGaugeVec,
+    collection_unscheduled_count: UIntGaugeVec,
     peek_count: UIntGaugeVec,
     subscribe_count: UIntGaugeVec,
     copy_to_count: UIntGaugeVec,
     command_queue_size: UIntGaugeVec,
     response_queue_size: UIntGaugeVec,
+    hydration_queue_size: UIntGaugeVec,
 
     // command history
     history_command_count: UIntGaugeVec,
@@ -66,7 +69,7 @@ pub struct ComputeControllerMetrics {
 }
 
 impl ComputeControllerMetrics {
-    /// TODO(#25239): Add documentation.
+    /// Create a metrics instance registered into the given registry.
     pub fn new(metrics_registry: MetricsRegistry) -> Self {
         ComputeControllerMetrics {
             commands_total: metrics_registry.register(metric!(
@@ -99,6 +102,11 @@ impl ComputeControllerMetrics {
                 help: "The number of installed compute collections.",
                 var_labels: ["instance_id"],
             )),
+            collection_unscheduled_count: metrics_registry.register(metric!(
+                name: "mz_compute_controller_collection_unscheduled_count",
+                help: "The number of installed but unscheduled compute collections.",
+                var_labels: ["instance_id"],
+            )),
             peek_count: metrics_registry.register(metric!(
                 name: "mz_compute_controller_peek_count",
                 help: "The number of pending peeks.",
@@ -122,6 +130,11 @@ impl ComputeControllerMetrics {
             response_queue_size: metrics_registry.register(metric!(
                 name: "mz_compute_controller_response_queue_size",
                 help: "The size of the compute response queue.",
+                var_labels: ["instance_id", "replica_id"],
+            )),
+            hydration_queue_size: metrics_registry.register(metric!(
+                name: "mz_compute_controller_hydration_queue_size",
+                help: "The size of the compute hydration queue.",
                 var_labels: ["instance_id", "replica_id"],
             )),
             history_command_count: metrics_registry.register(metric!(
@@ -153,12 +166,15 @@ impl ComputeControllerMetrics {
         }
     }
 
-    /// TODO(#25239): Add documentation.
+    /// Return an object suitable for tracking metrics for the given compute instance.
     pub fn for_instance(&self, instance_id: ComputeInstanceId) -> InstanceMetrics {
         let labels = vec![instance_id.to_string()];
         let replica_count = self.replica_count.get_delete_on_drop_gauge(labels.clone());
         let collection_count = self
             .collection_count
+            .get_delete_on_drop_gauge(labels.clone());
+        let collection_unscheduled_count = self
+            .collection_unscheduled_count
             .get_delete_on_drop_gauge(labels.clone());
         let peek_count = self.peek_count.get_delete_on_drop_gauge(labels.clone());
         let subscribe_count = self
@@ -187,6 +203,7 @@ impl ComputeControllerMetrics {
             metrics: self.clone(),
             replica_count,
             collection_count,
+            collection_unscheduled_count,
             copy_to_count,
             peek_count,
             subscribe_count,
@@ -204,23 +221,25 @@ pub struct InstanceMetrics {
     instance_id: ComputeInstanceId,
     metrics: ComputeControllerMetrics,
 
-    /// TODO(#25239): Add documentation.
+    /// Gauge tracking the number of replicas.
     pub replica_count: UIntGauge,
-    /// TODO(#25239): Add documentation.
+    /// Gauge tracking the number of installed compute collections.
     pub collection_count: UIntGauge,
-    /// TODO(#25239): Add documentation.
+    /// Gauge tracking the number of installed but unscheduled compute collections.
+    pub collection_unscheduled_count: UIntGauge,
+    /// Gauge tracking the number of pending peeks.
     pub peek_count: UIntGauge,
-    /// TODO(#25239): Add documentation.
+    /// Gauge tracking the number of active subscribes.
     pub subscribe_count: UIntGauge,
-    /// A counter to keep track of the number of active COPY TO queries in progress.
+    /// Gauge tracking the number of active COPY TO queries.
     pub copy_to_count: UIntGauge,
-    /// TODO(#25239): Add documentation.
+    /// Gauges tracking the number of commands in the command history.
     pub history_command_count: CommandMetrics<UIntGauge>,
-    /// TODO(#25239): Add documentation.
+    /// Gauge tracking the number of dataflows in the command history.
     pub history_dataflow_count: UIntGauge,
-    /// TODO(#25239): Add documentation.
+    /// Counter tracking the total number of peeks served.
     pub peeks_total: PeekMetrics<IntCounter>,
-    /// TODO(#25239): Add documentation.
+    /// Histogram tracking peek durations.
     pub peek_duration_seconds: PeekMetrics<Histogram>,
 }
 
@@ -269,6 +288,10 @@ impl InstanceMetrics {
             .metrics
             .response_queue_size
             .get_delete_on_drop_gauge(labels.clone());
+        let hydration_queue_size = self
+            .metrics
+            .hydration_queue_size
+            .get_delete_on_drop_gauge(labels.clone());
 
         ReplicaMetrics {
             instance_id: self.instance_id,
@@ -281,6 +304,7 @@ impl InstanceMetrics {
                 response_message_bytes_total,
                 command_queue_size,
                 response_queue_size,
+                hydration_queue_size,
             }),
         }
     }
@@ -321,11 +345,11 @@ pub struct ReplicaMetrics {
     replica_id: ReplicaId,
     metrics: ComputeControllerMetrics,
 
-    /// TODO(#25239): Add documentation.
+    /// Metrics counters, wrapped in an `Arc` to be shareable between threads.
     pub inner: Arc<ReplicaMetricsInner>,
 }
 
-/// TODO(#25239): Add documentation.
+/// Per-replica metrics counters.
 #[derive(Debug)]
 pub struct ReplicaMetricsInner {
     commands_total: CommandMetrics<IntCounter>,
@@ -333,10 +357,12 @@ pub struct ReplicaMetricsInner {
     responses_total: ResponseMetrics<IntCounter>,
     response_message_bytes_total: ResponseMetrics<IntCounter>,
 
-    /// TODO(#25239): Add documentation.
+    /// Gauge tracking the size of the compute command queue.
     pub command_queue_size: UIntGauge,
-    /// TODO(#25239): Add documentation.
+    /// Gauge tracking the size of the compute response queue.
     pub response_queue_size: UIntGauge,
+    /// Gauge tracking the size of the hydration queue.
+    pub hydration_queue_size: UIntGauge,
 }
 
 impl ReplicaMetrics {

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2519,6 +2519,8 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     assert count == 1, f"got {count}"
     count = metrics.get_value("mz_compute_controller_collection_count")
     assert count > 0, f"got {count}"
+    count = metrics.get_value("mz_compute_controller_collection_unscheduled_count")
+    assert count == 0, f"got {count}"
     count = metrics.get_value("mz_compute_controller_peek_count")
     assert count == 0, f"got {count}"
     count = metrics.get_value("mz_compute_controller_subscribe_count")
@@ -2527,6 +2529,8 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     assert count < 10, f"got {count}"
     count = metrics.get_value("mz_compute_controller_response_queue_size")
     assert count < 10, f"got {count}"
+    count = metrics.get_value("mz_compute_controller_hydration_queue_size")
+    assert count == 0, f"got {count}"
 
     # mz_compute_controller_history_command_count
     count = metrics.get_controller_history_command_count("create_timely")


### PR DESCRIPTION
This PR adds two metrics in support of the sequential hydration feature:

* `mz_compute_controller_collections_unscheduled_count` counts the number of collections for which the controller has not yet sent a `Schedule` command.
* `mz_compute_controller_hydration_queue_size` counts the size of the hydration queue in the `SequentialHydration` client.

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/materialize/issues/25271

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
