### PR TITLE
Revert "mzcompose: Only retry docker pulls"

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1831,8 +1831,9 @@ def workflow_test_compute_reconciliation_reuse(c: Composition) -> None:
     # can test reconciliation of system indexes too.
     c.sql(
         """
+        ALTER CLUSTER mz_introspection SET (MANAGED = false);
         DROP CLUSTER REPLICA mz_introspection.r1;
-        CREATE CLUSTER REPLICA mz_introspection.replica2 (
+        CREATE CLUSTER REPLICA mz_introspection.r1 (
             STORAGECTL ADDRESSES ['clusterd2:2100'],
             STORAGE ADDRESSES ['clusterd2:2103'],
             COMPUTECTL ADDRESSES ['clusterd2:2101'],

--- a/test/skip-version-upgrade/mzcompose.py
+++ b/test/skip-version-upgrade/mzcompose.py
@@ -68,7 +68,7 @@ def workflow_test_version_skips(c: Composition) -> None:
         # This will bring up version `0.X.0-dev`.
         # Note: We actually want to retry this 0 times, but we need to retry at least once so a
         # UIError is raised instead of an AssertionError
-        c.up("materialized", max_pull_tries=1)
+        c.up("materialized", max_tries=1)
         assert False, "skipping versions should fail"
     except UIError:
         # Noting useful in the error message to assert. Ideally we'd check that the error is due to


### PR DESCRIPTION
This caused problems, see https://materializeinc.slack.com/archives/C01LKF361MZ/p1711635515718939 I'll work on fixing them.

This reverts commit 5deaad2e880413a27ebf9f9385371b92e85b9f72.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
