### PR TITLE
mzcompose: Only retry docker pulls (2nd attempt)

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -270,7 +270,7 @@ class Composition:
         capture_and_print: bool = False,
         stdin: str | None = None,
         check: bool = True,
-        max_tries: int = 1,
+        max_pull_tries: int = 1,
         silent: bool = False,
     ) -> subprocess.CompletedProcess:
         """Invoke `docker compose` on the rendered composition.
@@ -284,6 +284,8 @@ class Composition:
             capture_and_print: Print during execution and capture the stdout and
                 stderr of the `docker compose` invocation.
             input: A string to provide as stdin for the command.
+            max_pull_tries: How many times to try, if the command failed with a
+                problem in `docker pull`.
         """
 
         if not self.silent and not silent:
@@ -323,7 +325,7 @@ class Composition:
             *args,
         ]
 
-        for retry in range(1, max_tries + 1):
+        for retry in range(1, max_pull_tries + 1):
             stdout_result = ""
             stderr_result = ""
             file.seek(0)
@@ -391,7 +393,10 @@ class Composition:
                 if e.stderr and not capture_and_print:
                     print(e.stderr, file=sys.stderr)
 
-                if retry < max_tries:
+                if (
+                    "unexpected HTTP status" in str(e.stdout) + str(e.stderr)
+                    or "net/http" in str(e.stdout) + str(e.stderr)
+                ) and retry < max_pull_tries:
                     print("Retrying ...")
                     time.sleep(3)
                     continue
@@ -803,7 +808,7 @@ class Composition:
     def pull_single_image_by_service_name(
         self, service_name: str, max_tries: int
     ) -> None:
-        self.invoke("pull", service_name, max_tries=max_tries)
+        self.invoke("pull", service_name, max_pull_tries=max_tries)
 
     def try_pull_service_image(self, service: Service, max_tries: int = 2) -> bool:
         """Tries to pull the specified image and returns if this was successful."""
@@ -822,7 +827,7 @@ class Composition:
         detach: bool = True,
         wait: bool = True,
         persistent: bool = False,
-        max_tries: int = 5,  # increased since quay.io returns 502 sometimes
+        max_pull_tries: int = 5,  # increased since quay.io returns 502 sometimes
     ) -> None:
         """Build, (re)create, and start the named services.
 
@@ -836,7 +841,7 @@ class Composition:
             persistent: Replace the container's entrypoint and command with
                 `sleep infinity` so that additional commands can be scheduled
                 on the container with `Composition.exec`.
-            max_tries: Number of tries on failure.
+            max_pull_tries: Number of tries on failure for pulls.
         """
         if persistent:
             old_compose = copy.deepcopy(self.compose)
@@ -850,7 +855,7 @@ class Composition:
             *(["--detach"] if detach else []),
             *(["--wait"] if wait else []),
             *services,
-            max_tries=max_tries,
+            max_pull_tries=max_pull_tries,
         )
 
         if persistent:

--- a/test/skip-version-upgrade/mzcompose.py
+++ b/test/skip-version-upgrade/mzcompose.py
@@ -66,9 +66,7 @@ def workflow_test_version_skips(c: Composition) -> None:
 
     try:
         # This will bring up version `0.X.0-dev`.
-        # Note: We actually want to retry this 0 times, but we need to retry at least once so a
-        # UIError is raised instead of an AssertionError
-        c.up("materialized", max_tries=1)
+        c.up("materialized")
         assert False, "skipping versions should fail"
     except UIError:
         # Noting useful in the error message to assert. Ideally we'd check that the error is due to


### PR DESCRIPTION
Maybe it's smarter to do this way, no additional `docker pull` calls, just check the error messages

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
