### PR TITLE
adapter: Temporarily remove migration assert

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -49,7 +49,6 @@ use mz_ore::instrument;
 use mz_ore::now::to_datetime;
 use mz_pgrepr::oid::INVALID_OID;
 use mz_repr::adt::mz_acl_item::PrivilegeMap;
-use mz_repr::namespaces::MZ_INTERNAL_SCHEMA;
 use mz_repr::role_id::RoleId;
 use mz_repr::GlobalId;
 use mz_sql::catalog::{
@@ -1334,14 +1333,15 @@ impl Catalog {
         // TODO(jkosh44) Technically we could support changing the type of a builtin object outside
         // of `mz_internal` (i.e. from a table to a view). However, these migrations don't
         // currently handle that scenario correctly.
-        assert!(
-            migration_metadata
-                .deleted_system_objects
-                .iter()
-                .all(|deleted_object| deleted_object.schema_name == MZ_INTERNAL_SCHEMA),
-            "only mz_internal objects can be deleted, deleted objects: {:?}",
-            migration_metadata.deleted_system_objects
-        );
+        // TODO(jkosh44) Uncomment this assert after v0.94.X is deployed.
+        // assert!(
+        //     migration_metadata
+        //         .deleted_system_objects
+        //         .iter()
+        //         .all(|deleted_object| deleted_object.schema_name == MZ_INTERNAL_SCHEMA),
+        //     "only mz_internal objects can be deleted, deleted objects: {:?}",
+        //     migration_metadata.deleted_system_objects
+        // );
 
         Ok(migration_metadata)
     }


### PR DESCRIPTION
a88879f21c942bf8cd81464ea12b81fe29952035 fixed a bug to remove builtin objects from the durable catalog if they've been removed from Materialize. Previously, the objects would leak and sit around in the durable catalog after they were removed from Materialize.

As part of that commit, we added an assert to make sure all deleted objects were in the `mz_internal` schema. Deleting system objects that are not in the `mz_internal` schema is a breaking change and can result in losing user data.

As it turns out, at multiple points in the past we have deleted system objects that weren't in the `mz_internal` schema. All production (and staging) environments that have been around long enough to have those deleted non-`mz_internal` objects will trigger the added assert and fail to upgrade.

This commit temporarily removes the assert so those environments can be upgraded successfully.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
