### PR TITLE
Tidy `IntoRowByTypes` and `FromRowByTypes`

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -1079,7 +1079,7 @@ where
                 // Emtpy value specialization.
                 let (oks, errs) = oks.map_fallible(
                     "FormArrangementKey [val: empty]",
-                    specialized_arrangement_key(key.clone(), thinning.clone(), None, Some(vec![])),
+                    specialized_arrangement_key(key.clone(), thinning.clone()),
                 );
                 let name = &format!("{} [val: empty]", name);
                 let oks = oks.mz_arrange::<RowSpine<_, _>>(name);
@@ -1094,7 +1094,7 @@ where
         // Catch-all: Just use RowRow.
         let (oks, errs) = oks.map_fallible(
             "FormArrangementKey",
-            specialized_arrangement_key(key.clone(), thinning.clone(), None, None),
+            specialized_arrangement_key(key.clone(), thinning.clone()),
         );
         let oks = oks.mz_arrange::<RowRowSpine<_, _>>(name);
         (SpecializedArrangement::RowRow(oks), errs)
@@ -1130,8 +1130,6 @@ fn derive_key_val_types(
 fn specialized_arrangement_key<K, V>(
     key: Vec<MirScalarExpr>,
     thinning: Vec<usize>,
-    key_types: Option<Vec<ColumnType>>,
-    val_types: Option<Vec<ColumnType>>,
 ) -> impl FnMut(Row) -> Result<(K, V), DataflowError>
 where
     K: Columnation + Data + FromRowByTypes,
@@ -1146,11 +1144,8 @@ where
         let temp_storage = RowArena::new();
         let val_datum_iter = thinning.iter().map(|c| datums[*c]);
         Ok::<(K, V), DataflowError>((
-            key_buf.try_from_datum_iter(
-                key.iter().map(|k| k.eval(&datums, &temp_storage)),
-                key_types.as_deref(),
-            )?,
-            val_buf.from_datum_iter(val_datum_iter, val_types.as_deref()),
+            key_buf.try_from_datum_iter(key.iter().map(|k| k.eval(&datums, &temp_storage)))?,
+            val_buf.from_datum_iter(val_datum_iter),
         ))
     }
 }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -22,7 +22,7 @@ use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::AvailableCollections;
 use mz_dyncfg::ConfigSet;
 use mz_expr::{Id, MapFilterProject, MirScalarExpr};
-use mz_repr::fixed_length::{FromRowByTypes, IntoRowByTypes};
+use mz_repr::fixed_length::{FromDatumIter, ToDatumIter};
 use mz_repr::{ColumnType, DatumVec, DatumVecBorrow, Diff, GlobalId, Row, RowArena, SharedRow};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
@@ -303,14 +303,14 @@ where
         match self {
             SpecializedArrangement::RowUnit(inner) => inner.as_collection(move |k, v| {
                 let mut datums_borrow = datums.borrow();
-                datums_borrow.extend(k.into_datum_iter());
-                datums_borrow.extend(v.into_datum_iter());
+                datums_borrow.extend(k.to_datum_iter());
+                datums_borrow.extend(v.to_datum_iter());
                 logic(&datums_borrow)
             }),
             SpecializedArrangement::RowRow(inner) => inner.as_collection(move |k, v| {
                 let mut datums_borrow = datums.borrow();
-                datums_borrow.extend(k.into_datum_iter());
-                datums_borrow.extend(v.into_datum_iter());
+                datums_borrow.extend(k.to_datum_iter());
+                datums_borrow.extend(v.to_datum_iter());
                 logic(&datums_borrow)
             }),
         }
@@ -339,8 +339,8 @@ where
                     key,
                     move |k, v, t, d| {
                         let mut datums_borrow = datums.borrow();
-                        datums_borrow.extend(k.into_datum_iter());
-                        datums_borrow.extend(v.into_datum_iter());
+                        datums_borrow.extend(k.to_datum_iter());
+                        datums_borrow.extend(v.to_datum_iter());
                         logic(&mut datums_borrow, t, d)
                     },
                     refuel,
@@ -352,8 +352,8 @@ where
                     key,
                     move |k, v, t, d| {
                         let mut datums_borrow = datums.borrow();
-                        datums_borrow.extend(k.into_datum_iter());
-                        datums_borrow.extend(v.into_datum_iter());
+                        datums_borrow.extend(k.to_datum_iter());
+                        datums_borrow.extend(v.to_datum_iter());
                         logic(&mut datums_borrow, t, d)
                     },
                     refuel,
@@ -446,14 +446,14 @@ where
         match self {
             SpecializedArrangementImport::RowUnit(inner) => inner.as_collection(move |k, v| {
                 let mut datums_borrow = datums.borrow();
-                datums_borrow.extend(k.into_datum_iter());
-                datums_borrow.extend(v.into_datum_iter());
+                datums_borrow.extend(k.to_datum_iter());
+                datums_borrow.extend(v.to_datum_iter());
                 logic(&datums_borrow)
             }),
             SpecializedArrangementImport::RowRow(inner) => inner.as_collection(move |k, v| {
                 let mut datums_borrow = datums.borrow();
-                datums_borrow.extend(k.into_datum_iter());
-                datums_borrow.extend(v.into_datum_iter());
+                datums_borrow.extend(k.to_datum_iter());
+                datums_borrow.extend(v.to_datum_iter());
                 logic(&datums_borrow)
             }),
         }
@@ -479,8 +479,8 @@ where
                     key,
                     move |k, v, t, d| {
                         let mut datums_borrow = datums.borrow();
-                        datums_borrow.extend(k.into_datum_iter());
-                        datums_borrow.extend(v.into_datum_iter());
+                        datums_borrow.extend(k.to_datum_iter());
+                        datums_borrow.extend(v.to_datum_iter());
                         logic(&mut datums_borrow, t, d)
                     },
                     refuel,
@@ -492,8 +492,8 @@ where
                     key,
                     move |k, v, t, d| {
                         let mut datums_borrow = datums.borrow();
-                        datums_borrow.extend(k.into_datum_iter());
-                        datums_borrow.extend(v.into_datum_iter());
+                        datums_borrow.extend(k.to_datum_iter());
+                        datums_borrow.extend(v.to_datum_iter());
                         logic(&mut datums_borrow, t, d)
                     },
                     refuel,
@@ -864,8 +864,8 @@ where
         refuel: usize,
     ) -> timely::dataflow::Stream<S, I::Item>
     where
-        for<'a> Tr::Key<'a>: IntoRowByTypes,
-        for<'a> Tr::Val<'a>: IntoRowByTypes,
+        for<'a> Tr::Key<'a>: ToDatumIter,
+        for<'a> Tr::Val<'a>: ToDatumIter,
         Tr: TraceReader<Time = S::Timestamp, Diff = mz_repr::Diff> + Clone + 'static,
         I: IntoIterator,
         I::Item: Data,
@@ -1132,8 +1132,8 @@ fn specialized_arrangement_key<K, V>(
     thinning: Vec<usize>,
 ) -> impl FnMut(Row) -> Result<(K, V), DataflowError>
 where
-    K: Columnation + Data + FromRowByTypes,
-    V: Columnation + Data + FromRowByTypes,
+    K: Columnation + Data + FromDatumIter,
+    V: Columnation + Data + FromDatumIter,
 {
     let mut key_buf = K::default();
     let mut val_buf = V::default();

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -21,7 +21,7 @@ use mz_compute_types::dyncfgs::{ENABLE_MZ_JOIN_CORE, LINEAR_JOIN_YIELDING};
 use mz_compute_types::plan::join::linear_join::{LinearJoinPlan, LinearStagePlan};
 use mz_compute_types::plan::join::JoinClosure;
 use mz_dyncfg::ConfigSet;
-use mz_repr::fixed_length::IntoRowByTypes;
+use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::{DatumVec, Diff, Row, RowArena, SharedRow};
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
@@ -512,9 +512,9 @@ where
         Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = G::Timestamp, Diff = Diff>
             + Clone
             + 'static,
-        for<'a> Tr1::Key<'a>: IntoRowByTypes,
-        for<'a> Tr1::Val<'a>: IntoRowByTypes,
-        for<'a> Tr2::Val<'a>: IntoRowByTypes,
+        for<'a> Tr1::Key<'a>: ToDatumIter,
+        for<'a> Tr1::Val<'a>: ToDatumIter,
+        for<'a> Tr2::Val<'a>: ToDatumIter,
     {
         // Reuseable allocation for unpacking.
         let mut datums = DatumVec::new();
@@ -531,9 +531,9 @@ where
                         let mut row_builder = binding.borrow_mut();
                         let temp_storage = RowArena::new();
 
-                        let key = key.into_datum_iter();
-                        let old = old.into_datum_iter();
-                        let new = new.into_datum_iter();
+                        let key = key.to_datum_iter();
+                        let old = old.to_datum_iter();
+                        let new = new.to_datum_iter();
 
                         let mut datums_local = datums.borrow();
                         datums_local.extend(key);
@@ -566,9 +566,9 @@ where
                     let mut row_builder = binding.borrow_mut();
                     let temp_storage = RowArena::new();
 
-                    let key = key.into_datum_iter();
-                    let old = old.into_datum_iter();
-                    let new = new.into_datum_iter();
+                    let key = key.to_datum_iter();
+                    let old = old.to_datum_iter();
+                    let new = new.to_datum_iter();
 
                     let mut datums_local = datums.borrow();
                     datums_local.extend(key);

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -30,7 +30,7 @@ use mz_expr::{
     AggregateExpr, AggregateFunc, EvalError, MapFilterProject, MirScalarExpr, SafeMfpPlan,
 };
 use mz_repr::adt::numeric::{self, Numeric, NumericAgg};
-use mz_repr::fixed_length::IntoRowByTypes;
+use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::{Datum, DatumList, DatumVec, Diff, Row, RowArena, SharedRow};
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
@@ -377,7 +377,7 @@ where
                         }
 
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter();
+                        let datum_iter = key.to_datum_iter();
                         let mut datums_local = datums1.borrow();
                         datums_local.extend(datum_iter);
                         let key_len = datums_local.len();
@@ -446,7 +446,7 @@ where
                     }
 
                     let temp_storage = RowArena::new();
-                    let datum_iter = key.into_datum_iter();
+                    let datum_iter = key.to_datum_iter();
                     let mut datums_local = datums2.borrow();
                     datums_local.extend(datum_iter);
 
@@ -526,7 +526,7 @@ where
         T1: Trace<KeyOwned = Row, Time = G::Timestamp, Diff = Diff> + 'static,
         T1::Batch: Batch,
         T1::Batcher: Batcher<Item = ((Row, T1::ValOwned), G::Timestamp, Diff)>,
-        for<'a> T1::Key<'a>: std::fmt::Debug + IntoRowByTypes,
+        for<'a> T1::Key<'a>: std::fmt::Debug + ToDatumIter,
         T1::ValOwned: Columnation + ExchangeData + Default,
         Arranged<S, TraceAgent<T1>>: ArrangementSize,
         T2: for<'a> Trace<
@@ -561,7 +561,7 @@ where
                 move |key, _input, output| {
                     let temp_storage = RowArena::new();
                     let mut datums_local = datums1.borrow();
-                    datums_local.extend(key.into_datum_iter());
+                    datums_local.extend(key.to_datum_iter());
 
                     // Note that the key contains all the columns in a `Distinct` and that `mfp_after` is
                     // required to preserve the key. Therefore, if `mfp_after` maps, then it must project
@@ -591,7 +591,7 @@ where
                     // If `mfp_after` can error, then evaluate it here.
                     let Some(mfp) = &mfp_after2 else { return };
                     let temp_storage = RowArena::new();
-                    let datum_iter = key.into_datum_iter();
+                    let datum_iter = key.to_datum_iter();
                     let mut datums_local = datums2.borrow();
                     datums_local.extend(datum_iter);
 
@@ -660,7 +660,7 @@ where
         let output = arranged.mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceFuseBasic", {
             move |key, input, output| {
                 let temp_storage = RowArena::new();
-                let datum_iter = key.into_datum_iter();
+                let datum_iter = key.to_datum_iter();
                 let mut datums_local = datums1.borrow();
                 datums_local.extend(datum_iter);
                 let key_len = datums_local.len();
@@ -689,7 +689,7 @@ where
                         // Since negative accumulations are checked in at least one component
                         // aggregate, we only need to look for MFP errors here.
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter();
+                        let datum_iter = key.to_datum_iter();
                         let mut datums_local = datums2.borrow();
                         datums_local.extend(datum_iter);
 
@@ -787,11 +787,11 @@ where
                     // Note that in the non-positive case, this is wrong, but harmless because
                     // our other reduction will produce an error.
                     let count = usize::try_from(*w).unwrap_or(0);
-                    std::iter::repeat(v.into_datum_iter().next().unwrap()).take(count)
+                    std::iter::repeat(v.to_datum_iter().next().unwrap()).take(count)
                 });
 
                 let temp_storage = RowArena::new();
-                let datum_iter = key.into_datum_iter();
+                let datum_iter = key.to_datum_iter();
                 let mut datums_local = datums1.borrow();
                 datums_local.extend(datum_iter);
                 let key_len = datums_local.len();
@@ -844,13 +844,13 @@ where
                         let Some(mfp) = &mfp_after2 else { return };
                         let iter = source.iter().flat_map(|(mut v, w)| {
                             let count = usize::try_from(*w).unwrap_or(0);
-                            // This would ideally use `into_datum_iter` but we cannot as it needs to
+                            // This would ideally use `to_datum_iter` but we cannot as it needs to
                             // borrow `v` and only presents datums with that lifetime, not any longer.
                             std::iter::repeat(v.next().unwrap()).take(count)
                         });
 
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter();
+                        let datum_iter = key.to_datum_iter();
                         let mut datums_local = datums2.borrow();
                         datums_local.extend(datum_iter);
                         datums_local.push(
@@ -1073,7 +1073,7 @@ where
                             // We know that `mfp_after` can error if it exists, so try to evaluate it here.
                             let Some(mfp) = &mfp_after2 else { return };
                             let temp_storage = RowArena::new();
-                            let datum_iter = key.into_datum_iter();
+                            let datum_iter = key.to_datum_iter();
                             let mut datums_local = datums2.borrow();
                             datums_local.extend(datum_iter);
 
@@ -1105,7 +1105,7 @@ where
                 .mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceMinsMaxes", {
                     move |key, source, target| {
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter();
+                        let datum_iter = key.to_datum_iter();
                         let mut datums_local = datums1.borrow();
                         datums_local.extend(datum_iter);
                         let key_len = datums_local.len();
@@ -1288,7 +1288,7 @@ where
         let output = arranged.mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceMonotonic", {
             move |key, input, output| {
                 let temp_storage = RowArena::new();
-                let datum_iter = key.into_datum_iter();
+                let datum_iter = key.to_datum_iter();
                 let mut datums_local = datums1.borrow();
                 datums_local.extend(datum_iter);
                 let key_len = datums_local.len();
@@ -1314,7 +1314,7 @@ where
                 .mz_reduce_abelian::<_, RowErrSpine<_, _>>("ReduceMonotonic Error Check", {
                     move |key, input, output| {
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter();
+                        let datum_iter = key.to_datum_iter();
                         let mut datums_local = datums2.borrow();
                         datums_local.extend(datum_iter);
                         let accum = &input[0].1;
@@ -1467,7 +1467,7 @@ where
                         let (ref accums, total) = input[0].1;
 
                         let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter();
+                        let datum_iter = key.to_datum_iter();
                         let mut datums_local = datums1.borrow();
                         datums_local.extend(datum_iter);
                         let key_len = datums_local.len();
@@ -1526,7 +1526,7 @@ where
                     // If `mfp_after` can error, then evaluate it here.
                     let Some(mfp) = &mfp_after2 else { return };
                     let temp_storage = RowArena::new();
-                    let datum_iter = key.into_datum_iter();
+                    let datum_iter = key.to_datum_iter();
                     let mut datums_local = datums2.borrow();
                     datums_local.extend(datum_iter);
                     for (aggr, accum) in full_aggrs2.iter().zip(accums) {

--- a/src/compute/src/row_spine.rs
+++ b/src/compute/src/row_spine.rs
@@ -290,10 +290,10 @@ mod container {
         }
     }
 
-    use mz_repr::fixed_length::IntoRowByTypes;
-    impl<'long> IntoRowByTypes for DatumSeq<'long> {
+    use mz_repr::fixed_length::ToDatumIter;
+    impl<'long> ToDatumIter for DatumSeq<'long> {
         type DatumIter<'short> = DatumSeq<'short> where Self: 'short;
-        fn into_datum_iter<'short>(&'short self) -> Self::DatumIter<'short> {
+        fn to_datum_iter<'short>(&'short self) -> Self::DatumIter<'short> {
             *self
         }
     }


### PR DESCRIPTION
We don't use the type information, and at the moment it is only a run-time validation of something that should be enforced by the type system / partial validation that we aren't shipping around malformed rows. No urgency to merge, but also complexity that results from needing to carry the correct arguments around.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
