### PR TITLE
adapter: Use system replica ID for system replica

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -653,13 +653,13 @@ impl Catalog {
             .err_into()
     }
 
-    pub async fn allocate_user_replica_id(&self) -> Result<ReplicaId, Error> {
-        self.storage()
-            .await
-            .allocate_user_replica_id()
-            .await
-            .maybe_terminate("allocating user replica ids")
-            .err_into()
+    pub async fn allocate_replica_id(&self, cluster_id: &ClusterId) -> Result<ReplicaId, Error> {
+        let mut storage = self.storage().await;
+        let id = match cluster_id {
+            ClusterId::User(_) => storage.allocate_user_replica_id().await,
+            ClusterId::System(_) => storage.allocate_system_replica_id().await,
+        };
+        id.maybe_terminate("allocating replica ids").err_into()
     }
 
     /// Get the next system replica id without allocating it.

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -653,11 +653,19 @@ impl Catalog {
             .err_into()
     }
 
-    pub async fn allocate_replica_id(&self, cluster_id: &ClusterId) -> Result<ReplicaId, Error> {
+    pub async fn allocate_replica_id(
+        &self,
+        cluster_id: &ClusterId,
+        internal: bool,
+    ) -> Result<ReplicaId, Error> {
         let mut storage = self.storage().await;
-        let id = match cluster_id {
-            ClusterId::User(_) => storage.allocate_user_replica_id().await,
-            ClusterId::System(_) => storage.allocate_system_replica_id().await,
+        let id = if internal {
+            storage.allocate_system_replica_id().await
+        } else {
+            match cluster_id {
+                ClusterId::User(_) => storage.allocate_user_replica_id().await,
+                ClusterId::System(_) => storage.allocate_system_replica_id().await,
+            }
         };
         id.maybe_terminate("allocating replica ids").err_into()
     }

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -226,3 +226,20 @@ fn ast_rewrite_create_source_loadgen_options_0_92_0(
 
     Ok(())
 }
+
+// Durable migrations
+
+/// Migrations that run only on the durable catalog before any data is loaded into memory.
+pub(crate) fn durable_migrate(tx: &mut Transaction<'_>) -> Result<(), anyhow::Error> {
+    Ok(())
+}
+
+// Add new migrations below their appropriate heading, and precede them with a
+// short summary of the migration's purpose and optional additional commentary
+// about safety or approach.
+//
+// The convention is to name the migration function using snake case:
+// > <category>_<description>_<version>
+//
+// Please include the adapter team on any code reviews that add or edit
+// migrations.

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -230,7 +230,8 @@ fn ast_rewrite_create_source_loadgen_options_0_92_0(
 // Durable migrations
 
 /// Migrations that run only on the durable catalog before any data is loaded into memory.
-pub(crate) fn durable_migrate(tx: &mut Transaction<'_>) -> Result<(), anyhow::Error> {
+pub(crate) fn durable_migrate(tx: &mut Transaction) -> Result<(), anyhow::Error> {
+    catalog_fix_system_cluster_replica_ids_v_0_95_0(tx)?;
     Ok(())
 }
 
@@ -243,3 +244,26 @@ pub(crate) fn durable_migrate(tx: &mut Transaction<'_>) -> Result<(), anyhow::Er
 //
 // Please include the adapter team on any code reviews that add or edit
 // migrations.
+
+fn catalog_fix_system_cluster_replica_ids_v_0_95_0(
+    tx: &mut Transaction,
+) -> Result<(), anyhow::Error> {
+    let updated_replicas: Vec<_> = tx
+        .get_cluster_replicas()
+        .filter(|replica| replica.cluster_id.is_system() && replica.replica_id.is_user())
+        .map(|replica| (replica.replica_id, replica))
+        .collect();
+    for (replica_id, mut updated_replica) in updated_replicas {
+        let sys_id = tx.allocate_system_replica_id()?;
+        updated_replica.replica_id = sys_id;
+        tx.remove_cluster_replica(replica_id)?;
+        tx.insert_cluster_replica(
+            updated_replica.cluster_id,
+            updated_replica.replica_id,
+            &updated_replica.name,
+            updated_replica.config,
+            updated_replica.owner_id,
+        )?;
+    }
+    Ok(())
+}

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -256,6 +256,8 @@ impl Catalog {
             let is_read_only = storage.is_read_only();
             let mut txn = storage.transaction().await?;
 
+            migrate::durable_migrate(&mut txn)?;
+
             state.create_temporary_schema(&SYSTEM_CONN_ID, MZ_SYSTEM_ROLE_ID)?;
 
             let databases = txn.get_databases();

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -147,7 +147,7 @@ impl Coordinator {
         }
 
         for replica_name in (0..replication_factor).map(managed_cluster_replica_name) {
-            let id = self.catalog_mut().allocate_user_replica_id().await?;
+            let id = self.catalog_mut().allocate_replica_id(&cluster_id).await?;
             self.create_managed_cluster_replica_op(
                 cluster_id,
                 id,
@@ -349,9 +349,10 @@ impl Coordinator {
                 },
             };
 
+            let replica_id = self.catalog_mut().allocate_replica_id(&id).await?;
             ops.push(catalog::Op::CreateClusterReplica {
                 cluster_id: id,
-                id: self.catalog_mut().allocate_user_replica_id().await?,
+                id: replica_id,
                 name: replica_name.clone(),
                 config,
                 owner_id: *session.current_role_id(),
@@ -506,7 +507,7 @@ impl Coordinator {
 
         // Replicas have the same owner as their cluster.
         let owner_id = cluster.owner_id();
-        let id = self.catalog_mut().allocate_user_replica_id().await?;
+        let id = self.catalog_mut().allocate_replica_id(&cluster_id).await?;
         let op = catalog::Op::CreateClusterReplica {
             cluster_id,
             id,
@@ -805,7 +806,7 @@ impl Coordinator {
                 }
             }
             for name in (0..*new_replication_factor).map(managed_cluster_replica_name) {
-                let id = self.catalog_mut().allocate_user_replica_id().await?;
+                let id = self.catalog_mut().allocate_replica_id(&cluster_id).await?;
                 self.create_managed_cluster_replica_op(
                     cluster_id,
                     id,
@@ -837,7 +838,7 @@ impl Coordinator {
             for name in
                 (*replication_factor..*new_replication_factor).map(managed_cluster_replica_name)
             {
-                let id = self.catalog_mut().allocate_user_replica_id().await?;
+                let id = self.catalog_mut().allocate_replica_id(&cluster_id).await?;
                 self.create_managed_cluster_replica_op(
                     cluster_id,
                     id,

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -271,6 +271,13 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         let id = id.into_element();
         Ok(ReplicaId::User(id))
     }
+
+    /// Allocates and returns a system [`ReplicaId`].
+    async fn allocate_system_replica_id(&mut self) -> Result<ReplicaId, CatalogError> {
+        let id = self.allocate_id(SYSTEM_REPLICA_ID_ALLOC_KEY, 1).await?;
+        let id = id.into_element();
+        Ok(ReplicaId::System(id))
+    }
 }
 
 /// Creates an openable durable catalog state implemented using persist.

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -50,7 +50,8 @@ use crate::durable::objects::{
 use crate::durable::{
     CatalogError, Comment, DefaultPrivilege, DurableCatalogError, DurableCatalogState, Snapshot,
     SystemConfiguration, CATALOG_CONTENT_VERSION_KEY, DATABASE_ID_ALLOC_KEY, OID_ALLOC_KEY,
-    SCHEMA_ID_ALLOC_KEY, SYSTEM_ITEM_ALLOC_KEY, USER_ITEM_ALLOC_KEY, USER_ROLE_ID_ALLOC_KEY,
+    SCHEMA_ID_ALLOC_KEY, SYSTEM_ITEM_ALLOC_KEY, SYSTEM_REPLICA_ID_ALLOC_KEY, USER_ITEM_ALLOC_KEY,
+    USER_ROLE_ID_ALLOC_KEY,
 };
 
 /// A [`Transaction`] batches multiple catalog operations together and commits them atomically.
@@ -603,6 +604,13 @@ impl<'a> Transaction<'a> {
             .into_iter()
             .map(GlobalId::User)
             .collect())
+    }
+
+    pub fn allocate_system_replica_id(&mut self) -> Result<ReplicaId, CatalogError> {
+        let id = self
+            .get_and_increment_id_by(SYSTEM_REPLICA_ID_ALLOC_KEY.to_string(), 1)?
+            .into_element();
+        Ok(ReplicaId::System(id))
     }
 
     /// Allocates `amount` OIDs. OIDs can be recycled if they aren't currently assigned to any

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -61,6 +61,15 @@ pub struct ReplicaConfig {
     pub compute: ComputeReplicaConfig,
 }
 
+impl ReplicaConfig {
+    pub fn is_internal(&self) -> bool {
+        match &self.location {
+            ReplicaLocation::Unmanaged(_) => false,
+            ReplicaLocation::Managed(location) => location.internal,
+        }
+    }
+}
+
 /// Configures the resource allocation for a cluster replica.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ReplicaAllocation {

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -834,4 +834,19 @@ DROP CLUSTER t1
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER CLUSTER mz_system SET (SIZE = '2')
+----
+COMPLETE 0
+
+query I
+SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'mz_system') AND id LIKE 's%';
+----
+1
+
+query I
+SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'mz_system') AND id LIKE 'u%';
+----
+0
+
 reset-server

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -693,7 +693,7 @@ db error: ERROR: cannot modify managed cluster t1
 query TTTT
 SELECT event_type, object_type, details, user FROM mz_audit_events ORDER BY occurred_at DESC LIMIT 1;
 ----
-create  cluster-replica  {"billed_as":"free","cluster_id":"u2","cluster_name":"t1","disk":true,"internal":true,"logical_size":"2","replica_id":"u4","replica_name":"free"}  mz_system
+create  cluster-replica  {"billed_as":"free","cluster_id":"u2","cluster_name":"t1","disk":true,"internal":true,"logical_size":"2","replica_id":"s4","replica_name":"free"}  mz_system
 
 simple conn=mz_system,user=mz_system
 CREATE CLUSTER REPLICA t1.r123 SIZE '2', BILLED AS 'free'
@@ -705,14 +705,18 @@ SELECT id, name, cluster_id, size, owner_id FROM mz_cluster_replicas WHERE clust
 ----
 u1  r1  u1  2  s1
 u2  r1  u2  1  u1
-u4  free  u2  2  u1
-u3  billed  u2  2  u1
+s4  free  u2  2  u1
+s3  billed  u2  2  u1
 
 query T
 SELECT id FROM mz_internal.mz_internal_cluster_replicas WHERE id LIKE 'u%'
 ----
-u3
-u4
+
+query T
+SELECT id FROM mz_internal.mz_internal_cluster_replicas WHERE id LIKE 's%'
+----
+s3
+s4
 
 statement error db error: ERROR: cannot modify managed cluster t1
 CREATE CLUSTER REPLICA t1.free2 SIZE '2', BILLED AS 'free'
@@ -754,7 +758,7 @@ COMPLETE 0
 query TTTT
 SELECT event_type, object_type, details, user FROM mz_audit_events ORDER BY occurred_at DESC LIMIT 1;
 ----
-create  cluster-replica  {"billed_as":"free","cluster_id":"u4","cluster_name":"t1","disk":true,"internal":true,"logical_size":"2","replica_id":"u8","replica_name":"free"}  mz_system
+create  cluster-replica  {"billed_as":"free","cluster_id":"u4","cluster_name":"t1","disk":true,"internal":true,"logical_size":"2","replica_id":"s6","replica_name":"free"}  mz_system
 
 simple conn=mz_system,user=mz_system
 CREATE CLUSTER REPLICA t1.internal_r2 SIZE '2', INTERNAL
@@ -776,8 +780,8 @@ query TTTTT
 SELECT id, name, cluster_id, size, owner_id FROM mz_cluster_replicas WHERE cluster_id LIKE 'u%'
 ----
 u1  r1  u1  2  s1
-u7  r1  u4  1  u1
-u8  free  u4  2  u1
+u4  r1  u4  1  u1
+s6  free  u4  2  u1
 
 simple conn=mz_system,user=mz_system
 CREATE CLUSTER REPLICA t1.r3 SIZE '2', BILLED AS 'free'
@@ -834,8 +838,10 @@ DROP CLUSTER t1
 ----
 COMPLETE 0
 
+# Test that system replicas get system IDs.
+
 simple conn=mz_system,user=mz_system
-ALTER CLUSTER mz_system SET (SIZE = '2')
+ALTER CLUSTER mz_system SET (SIZE = '2');
 ----
 COMPLETE 0
 
@@ -846,6 +852,44 @@ SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_c
 
 query I
 SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'mz_system') AND id LIKE 'u%';
+----
+0
+
+statement ok
+CREATE CLUSTER c REPLICAS (r1 (SIZE '1'));
+
+query I
+SELECT COUNT(*) FROM mz_clusters WHERE name = 'c' AND id LIKE 's%';
+----
+0
+
+query I
+SELECT COUNT(*) FROM mz_clusters WHERE name = 'c' AND id LIKE 'u%';
+----
+1
+
+query I
+SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'c') AND name = 'r1' AND id LIKE 's%';
+----
+0
+
+query I
+SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'c') AND name = 'r1' AND id LIKE 'u%';
+----
+1
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA c.rr (SIZE = '1', INTERNAL);
+----
+COMPLETE 0
+
+query I
+SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'c') AND name = 'rr' AND id LIKE 's%';
+----
+1
+
+query I
+SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'c') AND name = 'rr' AND id LIKE 'u%';
 ----
 0
 


### PR DESCRIPTION
Previously, if a system user created a replica in a user cluster, then
the replica would get a user replica ID. This commit updates that so
the replica gets a system ID. This will prevent users from altering any
replica that we create in their cluster for support of experimentation.

Works towards resolving #25134

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
