### PR TITLE
environmentd: improve bootstrap tracing

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -63,7 +63,7 @@ use mz_storage_types::controller::PersistTxnTablesImpl;
 use once_cell::sync::Lazy;
 use opentelemetry::trace::TraceContextExt;
 use prometheus::IntGauge;
-use tracing::{error, info, Instrument};
+use tracing::{error, info, info_span, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use url::Url;
 
@@ -644,6 +644,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     let cors_allowed_origin = mz_http_util::build_cors_allowed_origin(&allowed_origins);
 
     // Configure controller.
+    let entered = info_span!("environmentd::configure_controller").entered();
     let (orchestrator, secrets_controller, cloud_resource_controller): (
         Arc<dyn Orchestrator>,
         Arc<dyn SecretsController>,
@@ -781,6 +782,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             (orchestrator, secrets_controller, None)
         }
     };
+    drop(entered);
     let cloud_resource_reader = cloud_resource_controller.as_ref().map(|c| c.reader());
     let secrets_reader = secrets_controller.reader();
     let now = SYSTEM_TIME.clone();

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -35,8 +35,8 @@ use mz_frontegg_auth::Authenticator as FronteggAuthentication;
 use mz_ore::future::OreFutureExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
-use mz_ore::task;
 use mz_ore::tracing::TracingHandle;
+use mz_ore::{instrument, task};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::usage::StorageUsageClient;
 use mz_secrets::SecretsController;
@@ -253,7 +253,7 @@ impl Listeners {
     /// Starts an `environmentd` server.
     ///
     /// Returns a handle to the server once it is fully booted.
-    #[mz_ore::instrument(name = "environmentd::serve", level = "info")]
+    #[instrument(name = "environmentd::serve")]
     pub async fn serve(self, config: Config) -> Result<Server, anyhow::Error> {
         let Listeners {
             sql: (sql_listener, sql_conns),
@@ -542,7 +542,7 @@ impl Listeners {
             http_host_name: config.http_host_name,
             tracing_handle: config.tracing_handle,
         })
-        .instrument(info_span!(parent: None, "adapter::serve"))
+        .instrument(info_span!("adapter::serve"))
         .await?;
 
         // Install an adapter client in the internal HTTP server.


### PR DESCRIPTION
The real win here is removing `parent: None` so that the printed `Root trace ID` is hooked up to catalog init. That span does exit after full envd bootstrap (not a long-running span).

This will be used to make envd startup faster.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a