### PR TITLE
adapter: Provide linearizable boot timestamp

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -584,6 +584,7 @@ impl Catalog {
                     build_info: &DUMMY_BUILD_INFO,
                     environment_id: environment_id.unwrap_or(EnvironmentId::for_tests()),
                     now,
+                    boot_ts: previous_ts,
                     skip_migrations: true,
                     cluster_replica_sizes: Default::default(),
                     builtin_system_cluster_replica_size: "1".into(),

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -16,7 +16,7 @@ use tracing::info;
 use mz_catalog::durable::Transaction;
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::{EpochMillis, NowFn};
-use mz_repr::GlobalId;
+use mz_repr::{GlobalId, Timestamp};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql_parser::ast::{Raw, Statement};
 use mz_storage_types::connections::ConnectionContext;
@@ -79,6 +79,7 @@ pub(crate) async fn migrate(
     state: &CatalogState,
     tx: &mut Transaction<'_>,
     _now: NowFn,
+    _boot_ts: Timestamp,
     _connection_context: &ConnectionContext,
 ) -> Result<(), anyhow::Error> {
     let catalog_version = tx.get_catalog_content_version();

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2938,7 +2938,7 @@ pub fn serve(
         let mut initial_timestamps =
             get_initial_oracle_timestamps(&pg_timestamp_oracle_config).await?;
 
-        // Insert an entry for the `EpochMilliseconds` timeline if one doesn't,
+        // Insert an entry for the `EpochMilliseconds` timeline if one doesn't exist,
         // which will ensure that the timeline is initialized since it's required
         // by the system.
         initial_timestamps

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -119,7 +119,7 @@ use mz_sql::names::{Aug, ResolvedIds};
 use mz_sql::plan::{self, CreateConnectionPlan, Params, QueryWhen};
 use mz_sql::rbac::UnauthorizedError;
 use mz_sql::session::user::{RoleMetadata, User};
-use mz_sql::session::vars::{self, ConnectionCounter, OwnedVarInput, SystemVars};
+use mz_sql::session::vars::{ConnectionCounter, OwnedVarInput, SystemVars};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::ExplainStage;
 use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};
@@ -1377,11 +1377,6 @@ pub struct Coordinator {
 
     /// Limit for how many conncurrent webhook requests we allow.
     webhook_concurrency_limit: WebhookConcurrencyLimiter,
-
-    /// Implementation of
-    /// [`TimestampOracle`](mz_timestamp_oracle::TimestampOracle) to
-    /// use.
-    timestamp_oracle_impl: vars::TimestampOracleImpl,
 
     /// Optional config for the Postgres-backed timestamp oracle. This is
     /// _required_ when `postgres` is configured using the `timestamp_oracle`
@@ -2943,39 +2938,35 @@ pub fn serve(
         let mut initial_timestamps =
             get_initial_oracle_timestamps(&pg_timestamp_oracle_config).await?;
 
-        // A candidate for the boot_ts. Catalog::open will further advance this,
-        // based on the "now" timestamp, if/when needed.
-        let previous_ts = initial_timestamps
-            .get(&Timeline::EpochMilliseconds)
-            .cloned()
-            .unwrap_or_else(mz_repr::Timestamp::minimum);
-
+        // Insert an entry for the `EpochMilliseconds` timeline if one doesn't,
+        // which will ensure that the timeline is initialized since it's required
+        // by the system.
+        initial_timestamps
+            .entry(Timeline::EpochMilliseconds)
+            .or_insert_with(mz_repr::Timestamp::minimum);
+        let mut timestamp_oracles = BTreeMap::new();
+        for (timeline, initial_timestamp) in initial_timestamps {
+            Coordinator::ensure_timeline_state_with_initial_time(
+                &timeline,
+                initial_timestamp,
+                now.clone(),
+                pg_timestamp_oracle_config.clone(),
+                &mut timestamp_oracles,
+            )
+            .await;
+        }
         // Choose a time at which to boot. This is used, for example, to prune
-        // old storage usage data. Crucially, it is _not_ linearizable, we do
-        // not persist this timestamp before using it. Think hard about this
-        // fact if you ever feel the need to use this for something that needs
-        // to be linearizable.
+        // old storage usage data or migrate audit log entries.
         //
         // This time is usually the current system time, but with protection
         // against backwards time jumps, even across restarts.
-        let boot_ts_not_linearizable = {
-            let now_ts: Timestamp = now().into();
-            let boot_ts = std::cmp::max(now_ts, previous_ts);
-            info!(%previous_ts, %now_ts, %boot_ts, "determining boot_ts");
-
-            boot_ts
-        };
-
-        // We need to patch up the EpochMilliseconds timestamp, which will in
-        // turn make sure that we initialize timestamp oracles at the `boot_ts`,
-        // which in turn will make sure that the next `boot_ts` is beyond the
-        // current boot_ts.
-        initial_timestamps
-            .entry(Timeline::EpochMilliseconds)
-            .and_modify(|ts| {
-                *ts = std::cmp::max(*ts, boot_ts_not_linearizable);
-            })
-            .or_insert(boot_ts_not_linearizable);
+        let boot_ts = timestamp_oracles
+            .get(&Timeline::EpochMilliseconds)
+            .expect("inserted above")
+            .oracle
+            .write_ts()
+            .await
+            .timestamp;
 
         info!("coordinator init: opening catalog");
         let (catalog, builtin_migration_metadata, builtin_table_updates, _last_catalog_version) =
@@ -2990,6 +2981,7 @@ pub fn serve(
                         build_info,
                         environment_id: environment_id.clone(),
                         now: now.clone(),
+                        boot_ts: boot_ts.clone(),
                         skip_migrations: false,
                         cluster_replica_sizes,
                         builtin_system_cluster_replica_size,
@@ -3005,7 +2997,7 @@ pub fn serve(
                         http_host_name,
                     },
                 },
-                boot_ts_not_linearizable,
+                boot_ts,
             )
             .await?;
         let session_id = catalog.config().session_id;
@@ -3023,11 +3015,6 @@ pub fn serve(
         let segment_client_clone = segment_client.clone();
         let coord_now = now.clone();
         let advance_timelines_interval = tokio::time::interval(catalog.config().timestamp_interval);
-
-        // We get the timestamp oracle impl once on startup, to ensure that it
-        // doesn't change in between when the system var changes: all oracles must
-        // use the same impl!
-        let timestamp_oracle_impl = catalog.system_config().timestamp_oracle_impl();
 
         if let Some(config) = pg_timestamp_oracle_config.as_ref() {
             // Apply settings from system vars as early as possible because some
@@ -3047,18 +3034,6 @@ pub fn serve(
             .spawn(move || {
                 let span = info_span!(parent: parent_span, "coord::coordinator").entered();
                 let catalog = Arc::new(catalog);
-
-                let mut timestamp_oracles = BTreeMap::new();
-                for (timeline, initial_timestamp) in initial_timestamps {
-                    handle.block_on(Coordinator::ensure_timeline_state_with_initial_time(
-                        &timeline,
-                        initial_timestamp,
-                        coord_now.clone(),
-                        timestamp_oracle_impl,
-                        pg_timestamp_oracle_config.clone(),
-                        &mut timestamp_oracles,
-                    ));
-                }
 
                 let controller = handle.block_on(
                     mz_controller::Controller::new(
@@ -3104,7 +3079,6 @@ pub fn serve(
                     tracing_handle,
                     statement_logging: StatementLogging::new(coord_now.clone()),
                     webhook_concurrency_limit,
-                    timestamp_oracle_impl,
                     pg_timestamp_oracle_config,
                 };
                 let bootstrap = handle.block_on(async {

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -195,7 +195,10 @@ impl Coordinator {
         global_timelines: &'a mut BTreeMap<Timeline, TimelineState<Timestamp>>,
     ) -> &'a mut TimelineState<Timestamp> {
         if !global_timelines.contains_key(timeline) {
-            info!("opening a new TimestampOracle for timeline {:?}", timeline,);
+            info!(
+                "opening a new CRDB/postgres TimestampOracle for timeline {:?}",
+                timeline,
+            );
 
             let now_fn = if timeline == &Timeline::EpochMilliseconds {
                 now

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -27,7 +27,6 @@ use mz_ore::now::{to_datetime, EpochMillis, NowFn};
 use mz_ore::vec::VecExt;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::names::{ResolvedDatabaseSpecifier, SchemaSpecifier};
-use mz_sql::session::vars::TimestampOracleImpl;
 use mz_storage_types::sources::Timeline;
 use mz_timestamp_oracle::batching_oracle::BatchingTimestampOracle;
 use mz_timestamp_oracle::postgres_oracle::{
@@ -179,7 +178,6 @@ impl Coordinator {
             timeline,
             Timestamp::minimum(),
             self.catalog().config().now.clone(),
-            self.timestamp_oracle_impl,
             self.pg_timestamp_oracle_config.clone(),
             &mut self.global_timelines,
         )
@@ -193,15 +191,11 @@ impl Coordinator {
         timeline: &'a Timeline,
         initially: Timestamp,
         now: NowFn,
-        timestamp_oracle_impl: TimestampOracleImpl,
         pg_oracle_config: Option<PostgresTimestampOracleConfig>,
         global_timelines: &'a mut BTreeMap<Timeline, TimelineState<Timestamp>>,
     ) -> &'a mut TimelineState<Timestamp> {
         if !global_timelines.contains_key(timeline) {
-            info!(
-                "opening a new {:?} TimestampOracle for timeline {:?}",
-                timestamp_oracle_impl, timeline,
-            );
+            info!("opening a new TimestampOracle for timeline {:?}", timeline,);
 
             let now_fn = if timeline == &Timeline::EpochMilliseconds {
                 now
@@ -217,32 +211,25 @@ impl Coordinator {
                 NowFn::from(|| Timestamp::minimum().into())
             };
 
-            let oracle = match timestamp_oracle_impl {
-                TimestampOracleImpl::Postgres => {
-                    let pg_oracle_config = pg_oracle_config.expect(
+            let pg_oracle_config = pg_oracle_config.expect(
                         "missing --timestamp-oracle-url even though the crdb-backed timestamp oracle was configured");
 
-                    let batching_metrics = Arc::clone(&pg_oracle_config.metrics);
+            let batching_metrics = Arc::clone(&pg_oracle_config.metrics);
 
-                    let pg_oracle: Arc<dyn TimestampOracle<mz_repr::Timestamp> + Send + Sync> =
-                        Arc::new(
-                            PostgresTimestampOracle::open(
-                                pg_oracle_config,
-                                timeline.to_string(),
-                                initially,
-                                now_fn,
-                            )
-                            .await,
-                        );
+            let pg_oracle: Arc<dyn TimestampOracle<mz_repr::Timestamp> + Send + Sync> = Arc::new(
+                PostgresTimestampOracle::open(
+                    pg_oracle_config,
+                    timeline.to_string(),
+                    initially,
+                    now_fn,
+                )
+                .await,
+            );
 
-                    let batching_oracle = BatchingTimestampOracle::new(batching_metrics, pg_oracle);
+            let batching_oracle = BatchingTimestampOracle::new(batching_metrics, pg_oracle);
 
-                    let oracle: Arc<dyn TimestampOracle<mz_repr::Timestamp> + Send + Sync> =
-                        Arc::new(batching_oracle);
-
-                    oracle
-                }
-            };
+            let oracle: Arc<dyn TimestampOracle<mz_repr::Timestamp> + Send + Sync> =
+                Arc::new(batching_oracle);
 
             global_timelines.insert(
                 timeline.clone(),

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -499,6 +499,7 @@ async fn upgrade_check(
         .0
         .clone();
 
+    let boot_ts = now().into();
     let (_catalog, _, last_catalog_version) = Catalog::initialize_state(
         StateConfig {
             unsafe_mode: true,
@@ -506,6 +507,7 @@ async fn upgrade_check(
             build_info: &BUILD_INFO,
             environment_id: EnvironmentId::for_tests(),
             now,
+            boot_ts,
             skip_migrations: false,
             cluster_replica_sizes,
             builtin_system_cluster_replica_size: builtin_clusters_replica_size.clone(),

--- a/src/catalog/src/config.rs
+++ b/src/catalog/src/config.rs
@@ -50,6 +50,8 @@ pub struct StateConfig {
     pub environment_id: EnvironmentId,
     /// Function to generate wall clock now; can be mocked.
     pub now: mz_ore::now::NowFn,
+    /// Linearizable timestamp of when this environment booted.
+    pub boot_ts: mz_repr::Timestamp,
     /// Whether or not to skip catalog migrations.
     pub skip_migrations: bool,
     /// Map of strings to corresponding compute replica sizes.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1192,7 +1192,6 @@ impl SystemVars {
             &PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE,
             &WEBHOOK_CONCURRENT_REQUEST_LIMIT,
             &ENABLE_DEPENDENCY_READ_HOLD_ASSERTS,
-            &TIMESTAMP_ORACLE_IMPL,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_SIZE,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_MAX_WAIT,
             &PG_TIMESTAMP_ORACLE_CONNECTION_POOL_TTL,
@@ -2074,11 +2073,6 @@ impl SystemVars {
     /// Returns the `webhook_concurrent_request_limit` configuration parameter.
     pub fn webhook_concurrent_request_limit(&self) -> usize {
         *self.expect_value(&WEBHOOK_CONCURRENT_REQUEST_LIMIT)
-    }
-
-    /// Returns the `timestamp_oracle` configuration parameter.
-    pub fn timestamp_oracle_impl(&self) -> TimestampOracleImpl {
-        *self.expect_value(&TIMESTAMP_ORACLE_IMPL)
     }
 
     /// Returns the `pg_timestamp_oracle_connection_pool_max_size` configuration parameter.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -38,8 +38,8 @@ use crate::session::vars::constraints::{
 use crate::session::vars::errors::VarError;
 use crate::session::vars::polyfill::{lazy_value, value, LazyValueFn};
 use crate::session::vars::value::{
-    ClientEncoding, ClientSeverity, Failpoints, IntervalStyle, IsolationLevel, TimeZone,
-    TimestampOracleImpl, Value, DEFAULT_DATE_STYLE,
+    ClientEncoding, ClientSeverity, Failpoints, IntervalStyle, IsolationLevel, TimeZone, Value,
+    DEFAULT_DATE_STYLE,
 };
 use crate::session::vars::{FeatureFlag, Var, VarInput, VarParseError};
 use crate::{DEFAULT_SCHEMA, WEBHOOK_CONCURRENCY_LIMIT};
@@ -600,13 +600,6 @@ pub static PERSIST_TXN_TABLES: VarDefinition = VarDefinition::new(
     This value is also configurable via a Launch Darkly parameter of the \
     same name, but we keep the flag to make testing easier. If specified, \
     the flag takes precedence over the Launch Darkly param.",
-    true,
-);
-
-pub static TIMESTAMP_ORACLE_IMPL: VarDefinition = VarDefinition::new(
-    "timestamp_oracle",
-    value!(TimestampOracleImpl; TimestampOracleImpl::Postgres),
-    "Backing implementation of TimestampOracle.",
     true,
 );
 

--- a/src/sql/src/session/vars/value.rs
+++ b/src/sql/src/session/vars/value.rs
@@ -1053,60 +1053,6 @@ impl Value for IntervalStyle {
     }
 }
 
-/// List of valid TimestampOracle implementations
-///
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum TimestampOracleImpl {
-    /// Timestamp oracle backed by Postgres/CRDB.
-    Postgres,
-}
-
-impl TimestampOracleImpl {
-    fn as_str(&self) -> &'static str {
-        match self {
-            TimestampOracleImpl::Postgres => "postgres",
-        }
-    }
-
-    fn valid_values() -> Vec<&'static str> {
-        vec![Self::Postgres.as_str()]
-    }
-}
-
-impl Value for TimestampOracleImpl {
-    fn type_name() -> Cow<'static, str>
-    where
-        Self: Sized,
-    {
-        "string".into()
-    }
-
-    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
-    where
-        Self: Sized,
-    {
-        let s = extract_single_value(input)?;
-        let s = UncasedStr::new(s);
-
-        if s == TimestampOracleImpl::Postgres.as_str() {
-            Ok(TimestampOracleImpl::Postgres)
-        } else {
-            Err(VarParseError::ConstrainedParameter {
-                invalid_values: input.to_vec(),
-                valid_values: Some(TimestampOracleImpl::valid_values()),
-            })
-        }
-    }
-
-    fn box_clone(&self) -> Box<dyn Value> {
-        Box::new(self.clone())
-    }
-
-    fn format(&self) -> String {
-        self.as_str().into()
-    }
-}
-
 impl Value for PersistTxnTablesImpl {
     fn type_name() -> Cow<'static, str>
     where


### PR DESCRIPTION
Previously, we would provide a non-linearizable boot timestamp to `Catalog::open`. A non-linearizable timestamp is not written down, and therefore it's possible that a later environment boots up with a lower timestamp. We were unable to provide a linearizable timestamp due to a bootstrapping problem. We needed to look in the catalog to see what timestamp oracle implementation to use, but we needed to know which timestamp oracle implementation to use to get a linearizable timestamp to open the catalog.

Now that there's only a single timestamp oracle implementation, this bootstrapping problem has gone away. This commit updates the bootstrap process so that a linearizable timestamp is passed to `Catalog::open`. This is useful for things like adding audit log events in a migration, which require linearizable timestamps.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
