### PR TITLE
storage: avoid sentry errors on known offset_known regressions

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -774,6 +774,7 @@ where
                                 prev,
                                 self.config.parameters.statistics_interval,
                                 self.statistics_interval_sender.subscribe(),
+                                self.metrics.clone(),
                             );
                             let web_token = statistics::spawn_webhook_statistics_scraper(
                                 Arc::clone(&self.source_statistics),
@@ -798,6 +799,7 @@ where
                                     prev,
                                     self.config.parameters.statistics_interval,
                                     self.statistics_interval_sender.subscribe(),
+                                    self.metrics.clone(),
                                 );
 
                             // Make sure this is dropped when the controller is
@@ -1728,7 +1730,9 @@ where
                             .entry(stat.id)
                             .and_modify(|current| match current {
                                 Some(ref mut current) => current.incorporate(stat),
-                                None => *current = Some(stat),
+                                None => {
+                                    *current = Some(stat.with_metrics(&self.metrics));
+                                }
                             });
                     }
                 }

--- a/src/storage-controller/src/statistics.rs
+++ b/src/storage-controller/src/statistics.rs
@@ -53,6 +53,7 @@ pub(super) fn spawn_statistics_scraper<StatsWrapper, Stats, T>(
     previous_values: Vec<Row>,
     initial_interval: Duration,
     mut interval_updated: Receiver<Duration>,
+    metrics: mz_storage_client::metrics::StorageControllerMetrics,
 ) -> Box<dyn Any + Send + Sync>
 where
     StatsWrapper: AsStats<Stats> + Debug + Send + 'static,
@@ -74,7 +75,8 @@ where
             let mut shared_stats = shared_stats.lock().expect("poisoned");
             for row in previous_values {
                 current_metrics.update(row.clone(), 1);
-                let current = Stats::unpack(row);
+                let current = Stats::unpack(row, &metrics);
+
                 shared_stats
                     .as_mut_stats()
                     .insert(current.0, Some(current.1));

--- a/src/storage/src/statistics.rs
+++ b/src/storage/src/statistics.rs
@@ -8,6 +8,19 @@
 // by the Apache License, Version 2.0.
 
 //! Helpers for managing storage statistics.
+//!
+//!
+//! This module collects statistics related to sources and sinks. Statistics, as exposed
+//! to their respective system tables have strong semantics, defined within the
+//! `mz_storage_types::statistics` module. This module collects and aggregates metrics
+//! across workers according to those semantics.
+//!
+//! Note that it _simultaneously_ collect prometheus metrics for the given statistics. Those
+//! metrics _do not have the same strong semantics_, which is _by design_ to ensure we
+//! are able to categorically debug sources and sinks during complex failures (or bugs
+//! with statistics collection itself). Prometheus metrics are
+//! - Never dropped or reset until a source/sink is dropped.
+//! - Entirely independent across workers.
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;

--- a/src/storage/src/statistics.rs
+++ b/src/storage/src/statistics.rs
@@ -20,9 +20,7 @@ use mz_ore::metrics::{
     MetricsRegistry, UIntGaugeVec,
 };
 use mz_repr::{GlobalId, Timestamp};
-use mz_storage_client::statistics::{
-    Gauge, SinkStatisticsUpdate, SkippableGauge, SourceStatisticsUpdate,
-};
+use mz_storage_client::statistics::{Gauge, SinkStatisticsUpdate, SourceStatisticsUpdate};
 use mz_storage_types::sources::SourceEnvelope;
 use prometheus::core::{AtomicI64, AtomicU64};
 use serde::{Deserialize, Serialize};
@@ -444,8 +442,8 @@ impl SourceStatisticsRecord {
             snapshot_records_known: Gauge::gauge(snapshot_records_known.unwrap()),
             snapshot_records_staged: Gauge::gauge(snapshot_records_staged.unwrap()),
             snapshot_committed: Gauge::gauge(snapshot_committed.unwrap()),
-            offset_known: SkippableGauge::gauge(offset_known.unwrap()),
-            offset_committed: SkippableGauge::gauge(offset_committed.unwrap()),
+            offset_known: Gauge::gauge(offset_known.unwrap()),
+            offset_committed: Gauge::gauge(offset_committed.unwrap()),
         }
     }
 }


### PR DESCRIPTION
There is a long-form justification of this choice and implementation inline within the code. I recommend reviewing the commits separately, as the first commit is cleanup!

Closes https://github.com/MaterializeInc/materialize/issues/25802

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
