### PR TITLE
catalog: give default cluster disk if cc size

### DIFF
--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use itertools::max;
 use mz_audit_log::{EventV1, VersionedEvent};
 use mz_controller::clusters::ReplicaLogging;
-use mz_controller_types::{ClusterId, ReplicaId};
+use mz_controller_types::{is_cluster_size_v2, ClusterId, ReplicaId};
 use mz_ore::now::EpochMillis;
 use mz_pgrepr::oid::{
     FIRST_USER_OID, ROLE_PUBLIC_OID, SCHEMA_INFORMATION_SCHEMA_OID, SCHEMA_MZ_CATALOG_OID,
@@ -555,7 +555,7 @@ pub async fn initialize(
             replica_name: DEFAULT_USER_REPLICA_NAME.to_string(),
             replica_id: Some(DEFAULT_USER_REPLICA_ID.to_string()),
             logical_size: options.default_cluster_replica_size.to_string(),
-            disk: false,
+            disk: is_cluster_size_v2(&options.default_cluster_replica_size),
             billed_as: None,
             internal: false,
         }),
@@ -631,7 +631,7 @@ fn default_cluster_config(args: &BootstrapArgs) -> ClusterConfig {
                 interval: Some(Duration::from_secs(1)),
             },
             idle_arrangement_merge_effort: None,
-            disk: false,
+            disk: is_cluster_size_v2(&args.default_cluster_replica_size),
             optimizer_feature_overrides: Default::default(),
             schedule: Default::default(),
         }),
@@ -644,7 +644,7 @@ fn default_replica_config(args: &BootstrapArgs) -> ReplicaConfig {
         location: ReplicaLocation::Managed {
             size: args.default_cluster_replica_size.to_string(),
             availability_zone: None,
-            disk: false,
+            disk: is_cluster_size_v2(&args.default_cluster_replica_size),
             internal: false,
             billed_as: None,
         },


### PR DESCRIPTION
The default cluster should be created with disk if it is using a cc size. This brings the logic in line with how all other clusters are created.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
