### PR TITLE
dyncfg: minor ergonomic improvements to API

### DIFF
--- a/src/dyncfg/src/lib.rs
+++ b/src/dyncfg/src/lib.rs
@@ -162,7 +162,7 @@ pub trait ConfigType: Sized {
     fn shared<'a>(config: &Config<Self>, vals: &'a ConfigSet) -> Option<&'a Arc<Self::Shared>>;
 
     /// Converts this type to its type-erased enum equivalent.
-    fn to_val(val: &Self) -> ConfigVal;
+    fn to_val(val: Self) -> ConfigVal;
 
     /// Retrieves the current config value of this type from a value of its
     /// corresponding sharable type.
@@ -196,8 +196,8 @@ impl ConfigSet {
         let config = ConfigEntry {
             name: config.name,
             desc: config.desc,
-            default: T::to_val(&Into::<T>::into(config.default.clone())),
-            val: T::to_val(&Into::<T>::into(config.default.clone())),
+            default: T::to_val(config.default.clone().into()),
+            val: T::to_val(config.default.clone().into()),
         };
         if let Some(prev) = self.configs.insert(config.name.to_owned(), config) {
             panic!("{} registered twice", prev.name);
@@ -353,8 +353,8 @@ mod impls {
                 x => panic!("expected bool value got {:?}", x),
             }
         }
-        fn to_val(val: &Self) -> ConfigVal {
-            ConfigVal::Bool(Arc::new((*val).into()))
+        fn to_val(val: Self) -> ConfigVal {
+            ConfigVal::Bool(Arc::new(AtomicBool::from(val)))
         }
         fn set(x: &Self::Shared, val: Self) {
             x.store(val, SeqCst);
@@ -375,8 +375,8 @@ mod impls {
                 x => panic!("expected u32 value got {:?}", x),
             }
         }
-        fn to_val(val: &Self) -> ConfigVal {
-            ConfigVal::U32(Arc::new((*val).into()))
+        fn to_val(val: Self) -> ConfigVal {
+            ConfigVal::U32(Arc::new(AtomicU32::from(val)))
         }
         fn set(x: &Self::Shared, val: Self) {
             x.store(val, SeqCst);
@@ -397,8 +397,8 @@ mod impls {
                 x => panic!("expected usize value got {:?}", x),
             }
         }
-        fn to_val(val: &Self) -> ConfigVal {
-            ConfigVal::Usize(Arc::new((*val).into()))
+        fn to_val(val: Self) -> ConfigVal {
+            ConfigVal::Usize(Arc::new(AtomicUsize::from(val)))
         }
         fn set(x: &Self::Shared, val: Self) {
             x.store(val, SeqCst);
@@ -419,8 +419,8 @@ mod impls {
                 x => panic!("expected usize value got {:?}", x),
             }
         }
-        fn to_val(val: &Self) -> ConfigVal {
-            ConfigVal::OptUsize(Arc::new(RwLock::new(*val)))
+        fn to_val(val: Self) -> ConfigVal {
+            ConfigVal::OptUsize(Arc::new(RwLock::new(val)))
         }
         fn set(x: &Self::Shared, val: Self) {
             *x.write().expect("lock poisoned") = val;
@@ -441,8 +441,8 @@ mod impls {
                 x => panic!("expected String value got {:?}", x),
             }
         }
-        fn to_val(val: &Self) -> ConfigVal {
-            ConfigVal::String(Arc::new(RwLock::new(val.clone())))
+        fn to_val(val: Self) -> ConfigVal {
+            ConfigVal::String(Arc::new(RwLock::new(val)))
         }
         fn set(x: &Self::Shared, val: Self) {
             *x.write().expect("lock poisoned") = val;
@@ -463,8 +463,8 @@ mod impls {
                 x => panic!("expected Duration value got {:?}", x),
             }
         }
-        fn to_val(val: &Self) -> ConfigVal {
-            ConfigVal::Duration(Arc::new(RwLock::new(val.clone())))
+        fn to_val(val: Self) -> ConfigVal {
+            ConfigVal::Duration(Arc::new(RwLock::new(val)))
         }
         fn set(x: &Self::Shared, val: Self) {
             *x.write().expect("lock poisoned") = val;

--- a/src/dyncfg/src/lib.rs
+++ b/src/dyncfg/src/lib.rs
@@ -119,19 +119,6 @@ impl<T: ConfigType> Config<T> {
         &self.default
     }
 
-    /// Adds this config to the given set.
-    ///
-    /// Names are required to be unique within a set, but each set is entirely
-    /// independent. The same `Config` may be registered to multiple
-    /// [ConfigSet]s and thus have independent values (e.g. imagine a units test
-    /// executing concurrently in the same process).
-    ///
-    /// Panics if a config with the same name has previously been registered to
-    /// this set.
-    pub fn register(&self, set: &mut ConfigSet) -> T {
-        T::get(T::shared(self, set).expect("config should be registered to set"))
-    }
-
     /// Returns the latest value of this config within the given set.
     ///
     /// Panics if this config was not previously registered to the set.
@@ -198,8 +185,13 @@ pub struct ConfigSet {
 impl ConfigSet {
     /// Adds the given config to this set.
     ///
-    /// An alias for [Config::register], but taking and returning `Self` to
-    /// allow for easy chaining.
+    /// Names are required to be unique within a set, but each set is entirely
+    /// independent. The same `Config` may be registered to multiple
+    /// [`ConfigSet`]s and thus have independent values (e.g. imagine a unit
+    /// test executing concurrently in the same process).
+    ///
+    /// Panics if a config with the same name has been previously registered
+    /// to this set.
     pub fn add<T: ConfigType>(mut self, config: &Config<T>) -> Self {
         let config = ConfigEntry {
             name: config.name,

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use mz_build_info::BuildInfo;
-use mz_dyncfg::{Config, ConfigSet, ConfigType};
+use mz_dyncfg::{Config, ConfigSet, ConfigType, ConfigUpdates};
 use mz_ore::now::NowFn;
 use mz_persist::cfg::BlobKnobs;
 use mz_persist::retry::Retry;
@@ -209,8 +209,9 @@ impl PersistConfig {
     }
 
     pub(crate) fn set_config<T: ConfigType>(&self, cfg: &Config<T>, val: T) {
-        let shared = cfg.shared(self);
-        T::set(&shared, val)
+        let mut updates = ConfigUpdates::default();
+        updates.add(cfg, val);
+        updates.apply(self)
     }
 
     /// The minimum number of updates that justify writing out a batch in `persist_sink`'s

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1840,14 +1840,18 @@ impl SystemVars {
         for entry in self.dyncfgs.entries() {
             let name = UncasedStr::new(entry.name());
             let val = match entry.val() {
-                ConfigVal::Bool(_) => bool::to_val(*self.expect_config_value(name)),
-                ConfigVal::U32(_) => u32::to_val(*self.expect_config_value(name)),
-                ConfigVal::Usize(_) => usize::to_val(*self.expect_config_value(name)),
-                ConfigVal::OptUsize(_) => Option::<usize>::to_val(*self.expect_config_value(name)),
-                ConfigVal::String(_) => {
-                    String::to_val(self.expect_config_value::<String>(name).clone())
+                ConfigVal::Bool(_) => ConfigVal::from(*self.expect_config_value::<bool>(name)),
+                ConfigVal::U32(_) => ConfigVal::from(*self.expect_config_value::<u32>(name)),
+                ConfigVal::Usize(_) => ConfigVal::from(*self.expect_config_value::<usize>(name)),
+                ConfigVal::OptUsize(_) => {
+                    ConfigVal::from(*self.expect_config_value::<Option<usize>>(name))
                 }
-                ConfigVal::Duration(_) => Duration::to_val(*self.expect_config_value(name)),
+                ConfigVal::String(_) => {
+                    ConfigVal::from(self.expect_config_value::<String>(name).clone())
+                }
+                ConfigVal::Duration(_) => {
+                    ConfigVal::from(*self.expect_config_value::<Duration>(name))
+                }
             };
             updates.add_dynamic(entry.name(), val);
         }


### PR DESCRIPTION
Split out from #25912. This PR is the foundational refactors that are believed to be unobjectionable. 

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
