### PR TITLE
clusterd: ensure system vars apply to persist PubSub connection (redux)

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -357,7 +357,10 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         tracing.apply(self.compute_state.tracing_handle.as_ref());
 
         dyncfg_updates.apply(&self.compute_state.worker_config);
-        dyncfg_updates.apply(&self.compute_state.persist_clients.cfg().configs);
+        self.compute_state
+            .persist_clients
+            .cfg()
+            .apply_from(&dyncfg_updates);
 
         self.compute_state.apply_worker_config();
     }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -267,7 +267,7 @@ where
     fn update_parameters(&mut self, config_params: StorageParameters) {
         // We serialize the dyncfg updates in StorageParameters, but configure
         // persist separately.
-        config_params.dyncfg_updates.apply(self.persist.cfg());
+        self.persist.cfg().apply_from(&config_params.dyncfg_updates);
 
         for client in self.clients.values_mut() {
             client.send(StorageCommand::UpdateConfiguration(config_params.clone()));

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1210,7 +1210,9 @@ impl StorageState {
 
                 // We serialize the dyncfg updates in StorageParameters, but configure
                 // persist separately.
-                params.dyncfg_updates.apply(self.persist_clients.cfg());
+                self.persist_clients
+                    .cfg()
+                    .apply_from(&params.dyncfg_updates);
 
                 params.tracing.apply(self.tracing_handle.as_ref());
 


### PR DESCRIPTION
Alternative to https://github.com/MaterializeInc/materialize/pull/25912.

This commit keeps `clusterd` from establishing its persist PubSub
connection until `environmentd` sends over its initial batch of
configuration values. This ensures that any parameters that should apply
to the connection (e.g., timeouts) actually take effect.

The implementation is kept as simple as possible: a boolean value in
`PersistConfig` indicating whether at least once sync with
`environmentd` has taken place.

Fix https://github.com/MaterializeInc/materialize/issues/23869.

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

This is an alternative to https://github.com/MaterializeInc/materialize/pull/25912. The implementation is simpler, but plausibly more error prone, as it relies on users of `PersistConfig` to set `configs_synced_once` when appropriate.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
