### PR TITLE
adapter: Remove old migartion

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -142,7 +142,6 @@ pub(crate) async fn migrate(
     //
     // Each migration should be a function that takes `tx` and `conn_cat` as
     // input and stages arbitrary transformations to the catalog on `tx`.
-    catalog_clean_up_stash_state_v_0_92_0(tx)?;
     info!(
         "migration from catalog version {:?} complete",
         catalog_version
@@ -159,12 +158,6 @@ pub(crate) async fn migrate(
 //
 // Please include the adapter team on any code reviews that add or edit
 // migrations.
-
-// Removes any stash specific state from the catalog.
-fn catalog_clean_up_stash_state_v_0_92_0(tx: &mut Transaction) -> Result<(), anyhow::Error> {
-    tx.clean_up_stash_catalog()?;
-    Ok(())
-}
 
 fn _add_to_audit_log(
     tx: &mut Transaction,

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -1431,29 +1431,6 @@ impl<'a> Transaction<'a> {
             .map(|value| value.value.clone())
     }
 
-    // TODO(jkosh44) Can be removed after v0.92.X
-    pub fn clean_up_stash_catalog(&mut self) -> Result<(), CatalogError> {
-        self.configs.set(
-            ConfigKey {
-                key: "tombstone".to_string(),
-            },
-            None,
-        )?;
-        self.configs.set(
-            ConfigKey {
-                key: "catalog_kind".to_string(),
-            },
-            None,
-        )?;
-        self.system_configurations.set(
-            ServerConfigurationKey {
-                name: "catalog_kind".to_string(),
-            },
-            None,
-        )?;
-        Ok(())
-    }
-
     pub(crate) fn into_parts(self) -> (TransactionBatch, &'a mut dyn DurableCatalogState) {
         let txn_batch = TransactionBatch {
             databases: self.databases.pending(),


### PR DESCRIPTION
### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
