### PR TITLE
catalog: Add infrastructure for listening catalog

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -11,6 +11,7 @@
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fmt::Debug;
 use std::net::Ipv4Addr;
 use std::sync::Arc;
 use std::time::Instant;
@@ -37,7 +38,7 @@ use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, Cluster, ClusterConfig, ClusterReplica, ClusterReplicaProcessStatus,
     CommentsMap, Connection, DataSourceDesc, Database, DefaultPrivileges, Index, MaterializedView,
-    Role, Schema, Secret, Sink, Source, Table, Type, View,
+    Role, Schema, Secret, Sink, Source, StateUpdate, StateUpdateKind, Table, Type, View,
 };
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_controller::clusters::{
@@ -49,8 +50,8 @@ use mz_expr::MirScalarExpr;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::{to_datetime, EpochMillis, NOW_ZERO};
-use mz_ore::soft_assert_no_log;
 use mz_ore::str::StrExt;
+use mz_ore::{instrument, soft_assert_eq_or_log, soft_assert_no_log};
 use mz_pgrepr::oid::INVALID_OID;
 use mz_repr::adt::mz_acl_item::PrivilegeMap;
 use mz_repr::namespaces::{
@@ -58,7 +59,7 @@ use mz_repr::namespaces::{
     PG_CATALOG_SCHEMA,
 };
 use mz_repr::role_id::RoleId;
-use mz_repr::{GlobalId, RelationDesc};
+use mz_repr::{Diff, GlobalId, RelationDesc};
 use mz_secrets::InMemorySecretsController;
 use mz_sql::catalog::{
     CatalogCluster, CatalogClusterReplica, CatalogConfig, CatalogDatabase,
@@ -2261,6 +2262,63 @@ impl CatalogState {
                 SystemObjectType::Object(self.get_object_type(object_id))
             }
             SystemObjectId::System => SystemObjectType::System,
+        }
+    }
+
+    /// Update in-memory catalog state.
+    #[instrument]
+    pub(crate) fn apply_updates(&mut self, updates: Vec<StateUpdate>) {
+        fn apply<K, V>(map: &mut BTreeMap<K, V>, key: K, value: V, diff: Diff)
+        where
+            K: Ord + Debug,
+            V: PartialEq + Eq + Debug,
+        {
+            if diff == 1 {
+                let prev = map.insert(key, value);
+                soft_assert_eq_or_log!(
+                    prev,
+                    None,
+                    "values must be explicitly retracted before inserting a new value"
+                );
+            } else if diff == -1 {
+                let prev = map.remove(&key);
+                soft_assert_eq_or_log!(
+                    prev,
+                    Some(value),
+                    "retraction does not match existing value"
+                );
+            }
+        }
+
+        for StateUpdate { kind, diff } in updates {
+            assert!(
+                diff == 1 || diff == -1,
+                "invalid update in catalog updates: ({kind:?}, {diff:?})"
+            );
+            match kind {
+                StateUpdateKind::Database(database) => {
+                    apply(
+                        &mut self.database_by_id,
+                        database.id.clone(),
+                        Database {
+                            name: database.name.clone(),
+                            id: database.id.clone(),
+                            oid: database.oid,
+                            schemas_by_id: BTreeMap::new(),
+                            schemas_by_name: BTreeMap::new(),
+                            owner_id: database.owner_id,
+                            privileges: PrivilegeMap::from_mz_acl_items(database.privileges),
+                        },
+                        diff,
+                    );
+                    apply(
+                        &mut self.database_by_name,
+                        database.name,
+                        database.id.clone(),
+                        diff,
+                    );
+                }
+            }
         }
     }
 }

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -7,6 +7,24 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! The current types used to represent catalog data stored on disk. These objects generally fall
+//! into two categories.
+//!
+//! The key-value objects are a one-to-one mapping of the protobuf objects used to save catalog
+//! data durably. They can be converted to and from protobuf via the [`mz_proto::RustType`] trait.
+//! These objects should not be exposed anywhere outside the [`crate::durable`] module.
+//!
+//! The other type of objects combine the information from keys and values into a single struct,
+//! but are still a direct representation of the data stored on disk. They can be converted to and
+//! from the key-value objects via the [`DurableType`] trait. These objects are used to pass
+//! information to other modules in this crate and other catalog related code.
+//!
+//! All non-catalog code should interact with the objects in [`crate::memory::objects`] and never
+//! directly interact with the objects in this module.
+//!
+//! As an example, [`DatabaseKey`] and [`DatabaseValue`] are key-value objects, while [`Database`]
+//! is the non-key-value counterpart.
+
 pub mod serialization;
 pub(crate) mod state_update;
 


### PR DESCRIPTION
This commit adds the initial infrastructure for the in-memory catalog to update itself in reaction to changes made by the durable catalog. Additionally, it implements the update logic for databases. Future commits will add the update logic for all catalog objects.

The update logic is used when opening the catalog to initialize the in-memory catalog. A more obvious place to use the update logic might have been during catalog transactions. However, currently catalog transactions update both the in-memory catalog state and a durable transaction for each operation. The end goal is to have the catalog transaction only update a durable transaction and then update the in-memory state using the update logic after the durable transaction commits. Using the update logic in a catalog transaction before the update logic is complete for all objects means that for some objects we'd have to look in the durable transaction for the current state, while for other objects we'd have to look in the in-memory catalog for the current state. Getting this right would have been extremely hard and error-prone. Once the update logic is complete for all objects, we'll start using it in catalog transactions.

Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
