### PR TITLE
blue/green: Update items in the transaction all at once

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2501,7 +2501,7 @@ impl Catalog {
                                 }))
                             })?;
 
-                        // Update the catalog storage and Builtin Tables.
+                        // Queue updates for Catalog storage and Builtin Tables.
                         if !new_entry.item().is_temporary() {
                             items_to_update.insert(*id, new_entry.clone().into());
                         }

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -50,7 +50,6 @@ use mz_controller::clusters::{
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_expr::OptimizedMirRelationExpr;
 use mz_ore::cast::CastFrom;
-use mz_ore::collections::HashSet;
 use mz_ore::instrument;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
@@ -2478,10 +2477,10 @@ impl Catalog {
                     let database_name = &database.name;
 
                     let mut updates = Vec::new();
-                    let mut already_updated = HashSet::new();
+                    let mut items_to_update = BTreeMap::new();
 
                     let mut update_item = |id| {
-                        if already_updated.contains(id) {
+                        if items_to_update.contains_key(id) {
                             return Ok(());
                         }
 
@@ -2504,13 +2503,10 @@ impl Catalog {
 
                         // Update the catalog storage and Builtin Tables.
                         if !new_entry.item().is_temporary() {
-                            tx.update_item(*id, new_entry.clone().into())?;
+                            items_to_update.insert(*id, new_entry.clone().into());
                         }
                         builtin_table_updates.extend(state.pack_item_update(*id, -1));
                         updates.push((id.clone(), entry.name().clone(), new_entry.item));
-
-                        // Track which IDs we update.
-                        already_updated.insert(id);
 
                         Ok::<_, AdapterError>(())
                     };
@@ -2525,6 +2521,7 @@ impl Catalog {
                             update_item(id)?;
                         }
                     }
+                    tx.update_items(items_to_update)?;
 
                     // Renaming temporary schemas is not supported.
                     let SchemaSpecifier::Id(schema_id) = *schema.id() else {

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2521,6 +2521,8 @@ impl Catalog {
                             update_item(id)?;
                         }
                     }
+                    // Note: When updating the transaction it's very important that we update the
+                    // items as a whole group, otherwise we exhibit quadratic behavior.
                     tx.update_items(items_to_update)?;
 
                     // Renaming temporary schemas is not supported.


### PR DESCRIPTION
This PR slightly refactors the `RenameSchema` op to update the durable transaction with the new items all at once instead of calling `tx.update_item(...)` for each item. `update_item(...)` iterates through the entire catalog every time it's called so it can be quite slow.

Creating two schemas with 100 views each, and then 500 views depending on the 100 views in a schema we exhibit the following performance.

`main`
```
materialize=> ALTER SCHEMA blue SWAP WITH green;
ALTER SCHEMA
Time: 37301.170 ms (00:37.301)
```

This PR
```
materialize=> ALTER SCHEMA blue SWAP WITH green;
ALTER SCHEMA
Time: 470.736 ms
```

### Motivation

_Greatly_ improves the speed of `ALTER SCHEMA ... SWAP WITH ...`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Performance improvement for `ALTER SCHEMA ... SWAP WITH ...`
