### PR TITLE
catalog: Refactor durable code visibility

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -34,9 +34,7 @@ use mz_catalog::builtin::{
     BUILTIN_PREFIXES, MZ_INTROSPECTION_CLUSTER,
 };
 use mz_catalog::config::{ClusterReplicaSizeMap, Config, StateConfig};
-use mz_catalog::durable::{
-    test_bootstrap_args, DurableCatalogState, OpenableDurableCatalogState, Transaction,
-};
+use mz_catalog::durable::{test_bootstrap_args, DurableCatalogState, Transaction};
 use mz_catalog::memory::error::{AmbiguousRename, Error, ErrorKind};
 use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, Cluster, ClusterConfig, ClusterReplica, ClusterReplicaProcessStatus,
@@ -519,10 +517,9 @@ impl Catalog {
         now: NowFn,
         environment_id: Option<EnvironmentId>,
     ) -> Result<Catalog, anyhow::Error> {
-        let openable_storage = Box::new(
+        let openable_storage =
             mz_catalog::durable::test_persist_backed_catalog_state(persist_client, organization_id)
-                .await,
-        );
+                .await;
         let storage = openable_storage
             .open(now(), &test_bootstrap_args(), None, None)
             .await?;
@@ -541,13 +538,11 @@ impl Catalog {
         environment_id: EnvironmentId,
         system_parameter_defaults: BTreeMap<String, String>,
     ) -> Result<Catalog, anyhow::Error> {
-        let openable_storage = Box::new(
-            mz_catalog::durable::test_persist_backed_catalog_state(
-                persist_client,
-                environment_id.organization_id(),
-            )
-            .await,
-        );
+        let openable_storage = mz_catalog::durable::test_persist_backed_catalog_state(
+            persist_client,
+            environment_id.organization_id(),
+        )
+        .await;
         let storage = openable_storage
             .open_read_only(&test_bootstrap_args())
             .await?;

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -179,15 +179,13 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     let persist_client = persist_clients.open(persist_location).await?;
     let organization_id = args.organization_id;
     let metrics = Arc::new(mz_catalog::durable::Metrics::new(&metrics_registry));
-    let openable_state: Box<dyn OpenableDurableCatalogState> = Box::new(
-        persist_backed_catalog_state(
-            persist_client,
-            organization_id,
-            BUILD_INFO.semver_version(),
-            metrics,
-        )
-        .await?,
-    );
+    let openable_state = persist_backed_catalog_state(
+        persist_client,
+        organization_id,
+        BUILD_INFO.semver_version(),
+        metrics,
+    )
+    .await?;
 
     match args.action {
         Action::Dump {

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -279,8 +279,10 @@ pub async fn persist_backed_catalog_state(
     organization_id: Uuid,
     version: semver::Version,
     metrics: Arc<Metrics>,
-) -> Result<UnopenedPersistCatalogState, DurableCatalogError> {
-    UnopenedPersistCatalogState::new(persist_client, organization_id, version, metrics).await
+) -> Result<Box<dyn OpenableDurableCatalogState>, DurableCatalogError> {
+    let state =
+        UnopenedPersistCatalogState::new(persist_client, organization_id, version, metrics).await?;
+    Ok(Box::new(state))
 }
 
 /// Creates an openable durable catalog state implemented using persist that is meant to be used in
@@ -288,7 +290,7 @@ pub async fn persist_backed_catalog_state(
 pub async fn test_persist_backed_catalog_state(
     persist_client: PersistClient,
     organization_id: Uuid,
-) -> UnopenedPersistCatalogState {
+) -> Box<dyn OpenableDurableCatalogState> {
     test_persist_backed_catalog_state_with_version(
         persist_client,
         organization_id,
@@ -304,7 +306,7 @@ pub async fn test_persist_backed_catalog_state_with_version(
     persist_client: PersistClient,
     organization_id: Uuid,
     version: semver::Version,
-) -> Result<UnopenedPersistCatalogState, DurableCatalogError> {
+) -> Result<Box<dyn OpenableDurableCatalogState>, DurableCatalogError> {
     let metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
     persist_backed_catalog_state(persist_client, organization_id, version, metrics).await
 }

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -77,7 +77,7 @@ const DEFAULT_ALLOCATOR_ID: u64 = 1;
 
 /// Initializes the Catalog with some default objects.
 #[mz_ore::instrument]
-pub async fn initialize(
+pub(crate) async fn initialize(
     tx: &mut Transaction<'_>,
     options: &BootstrapArgs,
     initial_ts: EpochMillis,

--- a/src/catalog/src/durable/objects/serialization.rs
+++ b/src/catalog/src/durable/objects/serialization.rs
@@ -2158,12 +2158,6 @@ impl RustType<proto::storage_usage_key::Usage> for VersionedStorageUsage {
     }
 }
 
-impl proto::Duration {
-    pub const fn from_secs(secs: u64) -> proto::Duration {
-        proto::Duration { secs, nanos: 0 }
-    }
-}
-
 impl From<String> for proto::StringWrapper {
     fn from(value: String) -> Self {
         proto::StringWrapper { inner: value }

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -22,7 +22,7 @@ use crate::durable::transaction::TransactionBatch;
 use crate::durable::Epoch;
 
 /// Trait for objects that can be converted to/from a [`StateUpdateKindRaw`].
-pub trait IntoStateUpdateKindRaw:
+pub(crate) trait IntoStateUpdateKindRaw:
     Into<StateUpdateKindRaw> + PartialEq + Eq + PartialOrd + Ord + Debug + Clone
 {
     type Error: Debug;
@@ -50,7 +50,7 @@ where
 }
 
 /// Trait for objects that can be converted to/from a [`StateUpdateKind`].
-pub trait TryIntoStateUpdateKind: IntoStateUpdateKindRaw {
+pub(crate) trait TryIntoStateUpdateKind: IntoStateUpdateKindRaw {
     type Error: Debug;
 
     fn try_into(self) -> Result<StateUpdateKind, <Self as TryIntoStateUpdateKind>::Error>;
@@ -68,7 +68,7 @@ where
 
 /// A single update to the catalog state.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct StateUpdate<T: IntoStateUpdateKindRaw = StateUpdateKind> {
+pub(crate) struct StateUpdate<T: IntoStateUpdateKindRaw = StateUpdateKind> {
     /// They kind and contents of the state update.
     pub(crate) kind: T,
     /// The timestamp at which the update occurred.
@@ -595,7 +595,7 @@ impl RustType<proto::StateUpdateKind> for StateUpdateKind {
 
 /// Version of [`StateUpdateKind`] to allow reading/writing raw json from/to persist.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct StateUpdateKindRaw(Jsonb);
+pub(crate) struct StateUpdateKindRaw(Jsonb);
 
 impl From<StateUpdateKind> for StateUpdateKindRaw {
     fn from(value: StateUpdateKind) -> Self {
@@ -631,18 +631,18 @@ impl From<SourceData> for StateUpdateKindRaw {
 }
 
 impl StateUpdateKindRaw {
-    pub fn from_serde<S: serde::Serialize>(s: &S) -> Self {
+    pub(crate) fn from_serde<S: serde::Serialize>(s: &S) -> Self {
         let serde_value = serde_json::to_value(s).expect("valid json");
         let row =
             Jsonb::from_serde_json(serde_value).expect("contained integers should fit in f64");
         StateUpdateKindRaw(row)
     }
 
-    pub fn to_serde<D: serde::de::DeserializeOwned>(&self) -> D {
+    pub(crate) fn to_serde<D: serde::de::DeserializeOwned>(&self) -> D {
         self.try_to_serde().expect("jsonb should roundtrip")
     }
 
-    pub fn try_to_serde<D: serde::de::DeserializeOwned>(
+    pub(crate) fn try_to_serde<D: serde::de::DeserializeOwned>(
         &self,
     ) -> Result<D, serde_json::error::Error> {
         let serde_value = self.0.as_ref().to_serde_json();

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -124,7 +124,7 @@ pub(crate) enum Mode {
 
 /// Enum representing a potentially fenced epoch.
 #[derive(Debug)]
-pub enum FenceableEpoch {
+pub(crate) enum FenceableEpoch {
     /// The current epoch, if one exists, has not been fenced.
     Unfenced(Option<Epoch>),
     /// The current epoch has been fenced.
@@ -185,7 +185,7 @@ impl FenceableEpoch {
     }
 }
 
-pub trait ApplyUpdate<T: IntoStateUpdateKindRaw> {
+pub(crate) trait ApplyUpdate<T: IntoStateUpdateKindRaw> {
     /// Process and apply `update`.
     ///
     /// Returns `Some` if `update` should be cached in memory and `None` otherwise.
@@ -199,7 +199,7 @@ pub trait ApplyUpdate<T: IntoStateUpdateKindRaw> {
 
 /// A handle for interacting with the persist catalog shard.
 #[derive(Debug)]
-pub struct PersistHandle<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> {
+pub(crate) struct PersistHandle<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> {
     /// Since handle to control compaction.
     since_handle: SinceHandle<SourceData, (), Timestamp, Diff, i64>,
     /// Write handle to persist.
@@ -622,7 +622,7 @@ impl<U: ApplyUpdate<StateUpdateKind>> PersistHandle<StateUpdateKind, U> {
 }
 
 #[derive(Debug)]
-pub struct UnopenedCatalogStateInner {
+pub(crate) struct UnopenedCatalogStateInner {
     /// The organization ID of the environment.
     organization_id: Uuid,
     /// A cache of the config collection of the catalog.
@@ -684,7 +684,8 @@ impl ApplyUpdate<StateUpdateKindRaw> for UnopenedCatalogStateInner {
 ///
 /// Production users should call [`Self::expire`] before dropping a [`UnopenedPersistCatalogState`]
 /// so that it can expire its leases. If/when rust gets AsyncDrop, this will be done automatically.
-pub type UnopenedPersistCatalogState = PersistHandle<StateUpdateKindRaw, UnopenedCatalogStateInner>;
+pub(crate) type UnopenedPersistCatalogState =
+    PersistHandle<StateUpdateKindRaw, UnopenedCatalogStateInner>;
 
 impl UnopenedPersistCatalogState {
     /// Create a new [`UnopenedPersistCatalogState`] to the catalog state associated with
@@ -1119,7 +1120,7 @@ impl<T: Ord> LargeCollectionStartupCache<T> {
 }
 
 #[derive(Debug)]
-pub struct CatalogStateInner {
+struct CatalogStateInner {
     /// The [`Mode`] that this catalog was opened in.
     mode: Mode,
     /// A cache of audit logs that is only populated during startup.
@@ -1175,7 +1176,7 @@ impl ApplyUpdate<StateUpdateKind> for CatalogStateInner {
 }
 
 /// A durable store of the catalog state using Persist as an implementation.
-pub type PersistCatalogState = PersistHandle<StateUpdateKind, CatalogStateInner>;
+type PersistCatalogState = PersistHandle<StateUpdateKind, CatalogStateInner>;
 
 #[async_trait]
 impl ReadOnlyDurableCatalogState for PersistCatalogState {

--- a/src/catalog/src/durable/persist/tests.rs
+++ b/src/catalog/src/durable/persist/tests.rs
@@ -13,10 +13,7 @@ use mz_persist_client::PersistLocation;
 use uuid::Uuid;
 
 use crate::durable::persist::{fetch_catalog_upgrade_shard_version, shard_id, UPGRADE_SEED};
-use crate::durable::{
-    test_bootstrap_args, test_persist_backed_catalog_state_with_version,
-    OpenableDurableCatalogState,
-};
+use crate::durable::{test_bootstrap_args, test_persist_backed_catalog_state_with_version};
 
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
@@ -45,7 +42,7 @@ async fn test_upgrade_shard() {
     )
     .await
     .expect("failed to create persist catalog");
-    let _persist_state = Box::new(persist_openable_state)
+    let _persist_state = persist_openable_state
         .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
         .await
         .expect("failed to open persist catalog");
@@ -68,7 +65,7 @@ async fn test_upgrade_shard() {
     )
     .await
     .expect("failed to create persist catalog");
-    let _persist_state = Box::new(persist_openable_state)
+    let _persist_state = persist_openable_state
         .open_savepoint(NOW_ZERO(), &test_bootstrap_args(), None, None)
         .await
         .expect("failed to open savepoint persist catalog");
@@ -86,7 +83,7 @@ async fn test_upgrade_shard() {
     )
     .await
     .expect("failed to create persist catalog");
-    let _persist_state = Box::new(persist_openable_state)
+    let _persist_state = persist_openable_state
         .open_read_only(&test_bootstrap_args())
         .await
         .expect("failed to open readonly persist catalog");

--- a/src/catalog/src/durable/upgrade.rs
+++ b/src/catalog/src/durable/upgrade.rs
@@ -72,7 +72,7 @@ macro_rules! objects {
     ( $( $x:ident ),* ) => {
         paste! {
             $(
-                pub mod [<objects_ $x>] {
+                pub(crate) mod [<objects_ $x>] {
                     include!(concat!(env!("OUT_DIR"), "/objects_", stringify!($x), ".rs"));
 
                     use crate::durable::objects::state_update::StateUpdateKindRaw;

--- a/src/catalog/src/durable/upgrade/v42_to_v43.rs
+++ b/src/catalog/src/durable/upgrade/v42_to_v43.rs
@@ -11,7 +11,7 @@ use crate::durable::upgrade::MigrationAction;
 use crate::durable::upgrade::{objects_v42 as v42, objects_v43 as v43};
 
 /// No-op migration for removing storage objects.
-pub fn upgrade(
+pub(crate) fn upgrade(
     _snapshot: Vec<v42::StateUpdateKind>,
 ) -> Vec<MigrationAction<v42::StateUpdateKind, v43::StateUpdateKind>> {
     Vec::new()

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -109,9 +109,9 @@ async fn test_persist_debug() {
     .await;
 }
 
-async fn test_debug<'a, T: OpenableDurableCatalogState>(
-    mut openable_state1: impl OpenableDurableCatalogState,
-    openable_state_generator: impl Fn() -> BoxFuture<'a, T>,
+async fn test_debug<'a>(
+    mut openable_state1: Box<dyn OpenableDurableCatalogState>,
+    openable_state_generator: impl Fn() -> BoxFuture<'a, Box<dyn OpenableDurableCatalogState>>,
 ) {
     // Check initial empty trace.
     let err = openable_state1.trace_unconsolidated().await.unwrap_err();
@@ -128,7 +128,7 @@ async fn test_debug<'a, T: OpenableDurableCatalogState>(
     );
 
     // Use `NOW_ZERO` for consistent timestamps in the snapshots.
-    let _ = Box::new(openable_state1)
+    let _ = openable_state1
         .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
@@ -152,7 +152,7 @@ async fn test_debug<'a, T: OpenableDurableCatalogState>(
         insta::assert_debug_snapshot!("opened_trace".to_string(), test_trace);
     }
 
-    let mut debug_state = Box::new(openable_state2).open_debug().await.unwrap();
+    let mut debug_state = openable_state2.open_debug().await.unwrap();
 
     let mut openable_state_reader = openable_state_generator().await;
     assert_eq!(

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -99,15 +99,15 @@ async fn test_persist_is_initialized() {
 }
 
 async fn test_is_initialized(
-    mut openable_state1: impl OpenableDurableCatalogState,
-    openable_state2: BoxFuture<'_, impl OpenableDurableCatalogState>,
+    mut openable_state1: Box<dyn OpenableDurableCatalogState>,
+    openable_state2: BoxFuture<'_, Box<dyn OpenableDurableCatalogState>>,
 ) {
     assert!(
         !openable_state1.is_initialized().await.unwrap(),
         "catalog has not been opened yet"
     );
 
-    let state = Box::new(openable_state1)
+    let state = openable_state1
         .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
@@ -138,8 +138,8 @@ async fn test_persist_get_deployment_generation() {
 }
 
 async fn test_get_deployment_generation(
-    mut openable_state1: impl OpenableDurableCatalogState,
-    openable_state2: BoxFuture<'_, impl OpenableDurableCatalogState>,
+    mut openable_state1: Box<dyn OpenableDurableCatalogState>,
+    openable_state2: BoxFuture<'_, Box<dyn OpenableDurableCatalogState>>,
 ) {
     assert_eq!(
         openable_state1.get_deployment_generation().await.unwrap(),
@@ -147,7 +147,7 @@ async fn test_get_deployment_generation(
         "deployment generation has not been set"
     );
 
-    let state = Box::new(openable_state1)
+    let state = openable_state1
         .open(SYSTEM_TIME(), &test_bootstrap_args(), Some(42), None)
         .await
         .unwrap();
@@ -190,14 +190,14 @@ async fn test_persist_open_savepoint() {
 }
 
 async fn test_open_savepoint(
-    openable_state1: impl OpenableDurableCatalogState,
-    openable_state2: impl OpenableDurableCatalogState,
-    openable_state3: impl OpenableDurableCatalogState,
-    openable_state4: impl OpenableDurableCatalogState,
+    openable_state1: Box<dyn OpenableDurableCatalogState>,
+    openable_state2: Box<dyn OpenableDurableCatalogState>,
+    openable_state3: Box<dyn OpenableDurableCatalogState>,
+    openable_state4: Box<dyn OpenableDurableCatalogState>,
 ) {
     {
         // Can't open a savepoint catalog until it's been initialized.
-        let err = Box::new(openable_state1)
+        let err = openable_state1
             .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
             .await
             .unwrap_err();
@@ -209,7 +209,7 @@ async fn test_open_savepoint(
 
     // Initialize the catalog.
     {
-        let state = Box::new(openable_state2)
+        let state = openable_state2
             .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
@@ -219,7 +219,7 @@ async fn test_open_savepoint(
 
     {
         // Open catalog in savepoint mode.
-        let mut state = Box::new(openable_state3)
+        let mut state = openable_state3
             .open_savepoint(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
@@ -299,7 +299,7 @@ async fn test_open_savepoint(
 
     {
         // Open catalog normally.
-        let mut state = Box::new(openable_state4)
+        let mut state = openable_state4
             .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
@@ -336,12 +336,12 @@ async fn test_persist_open_read_only() {
 }
 
 async fn test_open_read_only(
-    openable_state1: impl OpenableDurableCatalogState,
-    openable_state2: impl OpenableDurableCatalogState,
-    openable_state3: impl OpenableDurableCatalogState,
+    openable_state1: Box<dyn OpenableDurableCatalogState>,
+    openable_state2: Box<dyn OpenableDurableCatalogState>,
+    openable_state3: Box<dyn OpenableDurableCatalogState>,
 ) {
     // Can't open a read-only catalog until it's been initialized.
-    let err = Box::new(openable_state1)
+    let err = openable_state1
         .open_read_only(&test_bootstrap_args())
         .await
         .unwrap_err();
@@ -351,13 +351,13 @@ async fn test_open_read_only(
     }
 
     // Initialize the catalog.
-    let mut state = Box::new(openable_state2)
+    let mut state = openable_state2
         .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
     assert_eq!(state.epoch(), Epoch::new(2).expect("known to be non-zero"));
 
-    let mut read_only_state = Box::new(openable_state3)
+    let mut read_only_state = openable_state3
         .open_read_only(&test_bootstrap_args())
         .await
         .unwrap();
@@ -414,12 +414,12 @@ async fn test_persist_open() {
 }
 
 async fn test_open(
-    openable_state1: impl OpenableDurableCatalogState,
-    openable_state2: BoxFuture<'_, impl OpenableDurableCatalogState>,
-    openable_state3: BoxFuture<'_, impl OpenableDurableCatalogState>,
+    openable_state1: Box<dyn OpenableDurableCatalogState>,
+    openable_state2: BoxFuture<'_, Box<dyn OpenableDurableCatalogState>>,
+    openable_state3: BoxFuture<'_, Box<dyn OpenableDurableCatalogState>>,
 ) {
     let (snapshot, audit_log) = {
-        let mut state = Box::new(openable_state1)
+        let mut state = openable_state1
             // Use `NOW_ZERO` for consistent timestamps in the snapshots.
             .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
@@ -441,7 +441,8 @@ async fn test_open(
     };
     // Reopening the catalog will increment the epoch, but shouldn't change the initial snapshot.
     {
-        let mut state = Box::new(openable_state2.await)
+        let mut state = openable_state2
+            .await
             .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
@@ -453,7 +454,8 @@ async fn test_open(
     }
     // Reopen the catalog a third time for good measure.
     {
-        let mut state = Box::new(openable_state3.await)
+        let mut state = openable_state3
+            .await
             .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();
@@ -485,15 +487,15 @@ async fn test_persist_unopened_fencing() {
 }
 
 async fn test_unopened_fencing(
-    openable_state1: impl OpenableDurableCatalogState,
-    openable_state2: BoxFuture<'_, impl OpenableDurableCatalogState>,
-    openable_state3: impl OpenableDurableCatalogState,
+    openable_state1: Box<dyn OpenableDurableCatalogState>,
+    openable_state2: BoxFuture<'_, Box<dyn OpenableDurableCatalogState>>,
+    openable_state3: Box<dyn OpenableDurableCatalogState>,
 ) {
     let deployment_generation = 42;
 
     // Initialize catalog.
     {
-        let _ = Box::new(openable_state1)
+        let _ = openable_state1
             // Use `NOW_ZERO` for consistent timestamps in the snapshots.
             .open(
                 NOW_ZERO(),
@@ -513,7 +515,7 @@ async fn test_unopened_fencing(
     );
 
     // Open catalog, which should bump the epoch.
-    let _state = Box::new(openable_state3)
+    let _state = openable_state3
         // Use `NOW_ZERO` for consistent timestamps in the snapshots.
         .open(
             NOW_ZERO(),
@@ -562,7 +564,7 @@ async fn test_persist_fencing() {
         )
         .await
         .unwrap();
-        let _persist_state = Box::new(persist_openable_state)
+        let _persist_state = persist_openable_state
             .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
             .await
             .unwrap();

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -39,16 +39,16 @@ async fn test_persist_confirm_leadership() {
 }
 
 async fn test_confirm_leadership(
-    openable_state1: impl OpenableDurableCatalogState,
-    openable_state2: impl OpenableDurableCatalogState,
+    openable_state1: Box<dyn OpenableDurableCatalogState>,
+    openable_state2: Box<dyn OpenableDurableCatalogState>,
 ) {
-    let mut state1 = Box::new(openable_state1)
+    let mut state1 = openable_state1
         .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
     assert!(state1.confirm_leadership().await.is_ok());
 
-    let mut state2 = Box::new(openable_state2)
+    let mut state2 = openable_state2
         .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
@@ -83,7 +83,7 @@ async fn test_persist_get_and_prune_storage_usage() {
     test_get_and_prune_storage_usage(openable_state).await;
 }
 
-async fn test_get_and_prune_storage_usage(openable_state: impl OpenableDurableCatalogState) {
+async fn test_get_and_prune_storage_usage(openable_state: Box<dyn OpenableDurableCatalogState>) {
     let old_event = VersionedStorageUsage::V1(StorageUsageV1 {
         id: 1,
         shard_id: Some("recent".to_string()),
@@ -98,7 +98,7 @@ async fn test_get_and_prune_storage_usage(openable_state: impl OpenableDurableCa
     });
     let boot_ts = mz_repr::Timestamp::new(23);
 
-    let mut state = Box::new(openable_state)
+    let mut state = openable_state
         .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
@@ -136,9 +136,9 @@ async fn test_persist_allocate_id() {
     test_allocate_id(openable_state).await;
 }
 
-async fn test_allocate_id(openable_state: impl OpenableDurableCatalogState) {
+async fn test_allocate_id(openable_state: Box<dyn OpenableDurableCatalogState>) {
     let id_type = USER_ITEM_ALLOC_KEY;
-    let mut state = Box::new(openable_state)
+    let mut state = openable_state
         .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
@@ -174,7 +174,7 @@ async fn test_persist_audit_logs() {
     test_audit_logs(openable_state).await;
 }
 
-async fn test_audit_logs(openable_state: impl OpenableDurableCatalogState) {
+async fn test_audit_logs(openable_state: Box<dyn OpenableDurableCatalogState>) {
     let audit_logs = [
         VersionedEvent::V1(EventV1 {
             id: 100,
@@ -206,7 +206,7 @@ async fn test_audit_logs(openable_state: impl OpenableDurableCatalogState) {
         }),
     ];
 
-    let mut state = Box::new(openable_state)
+    let mut state = openable_state
         .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();
@@ -233,7 +233,7 @@ async fn test_persist_items() {
     test_items(openable_state).await;
 }
 
-async fn test_items(openable_state: impl OpenableDurableCatalogState) {
+async fn test_items(openable_state: Box<dyn OpenableDurableCatalogState>) {
     let items = [
         Item {
             id: GlobalId::User(100),
@@ -255,7 +255,7 @@ async fn test_items(openable_state: impl OpenableDurableCatalogState) {
         },
     ];
 
-    let mut state = Box::new(openable_state)
+    let mut state = openable_state
         .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
         .await
         .unwrap();

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -28,7 +28,7 @@ use mz_adapter::load_remote_system_parameters;
 use mz_adapter::webhook::WebhookConcurrencyLimiter;
 use mz_build_info::{build_info, BuildInfo};
 use mz_catalog::config::ClusterReplicaSizeMap;
-use mz_catalog::durable::{BootstrapArgs, CatalogError, OpenableDurableCatalogState};
+use mz_catalog::durable::{BootstrapArgs, CatalogError};
 use mz_cloud_resources::CloudResourceController;
 use mz_controller::ControllerConfig;
 use mz_frontegg_auth::Authenticator as FronteggAuthentication;
@@ -313,15 +313,13 @@ impl Listeners {
             .persist_clients
             .open(config.controller.persist_location.clone())
             .await?;
-        let mut openable_adapter_storage: Box<dyn OpenableDurableCatalogState> = Box::new(
-            mz_catalog::durable::persist_backed_catalog_state(
-                persist_client.clone(),
-                config.environment_id.organization_id(),
-                BUILD_INFO.semver_version(),
-                Arc::clone(&config.catalog_config.metrics),
-            )
-            .await?,
-        );
+        let mut openable_adapter_storage = mz_catalog::durable::persist_backed_catalog_state(
+            persist_client.clone(),
+            config.environment_id.organization_id(),
+            BUILD_INFO.semver_version(),
+            Arc::clone(&config.catalog_config.metrics),
+        )
+        .await?;
 
         // Initialize the system parameter frontend if `launchdarkly_sdk_key` is set.
         let system_parameter_sync_config = if let Some(ld_sdk_key) = config.launchdarkly_sdk_key {
@@ -381,15 +379,14 @@ impl Listeners {
                         // implementation. Still it's easy to protect against this and worth it in
                         // case things change in the future.
                         tracing::warn!("Unable to perform upgrade test because the target implementation is uninitialized");
-                        openable_adapter_storage = Box::new(
+                        openable_adapter_storage =
                             mz_catalog::durable::persist_backed_catalog_state(
                                 persist_client,
                                 config.environment_id.organization_id(),
                                 BUILD_INFO.semver_version(),
                                 Arc::clone(&config.catalog_config.metrics),
                             )
-                            .await?,
-                        );
+                            .await?;
                         break 'leader_promotion;
                     }
                     Err(e) => {
@@ -412,15 +409,13 @@ impl Listeners {
                     ));
                 }
 
-                openable_adapter_storage = Box::new(
-                    mz_catalog::durable::persist_backed_catalog_state(
-                        persist_client,
-                        config.environment_id.organization_id(),
-                        BUILD_INFO.semver_version(),
-                        Arc::clone(&config.catalog_config.metrics),
-                    )
-                    .await?,
-                );
+                openable_adapter_storage = mz_catalog::durable::persist_backed_catalog_state(
+                    persist_client,
+                    config.environment_id.organization_id(),
+                    BUILD_INFO.semver_version(),
+                    Arc::clone(&config.catalog_config.metrics),
+                )
+                .await?;
             } else if catalog_generation == Some(deploy_generation) {
                 tracing::info!("Server requested generation {deploy_generation} which is equal to catalog's generation");
             } else {


### PR DESCRIPTION
Previously, all usages of the DurableCatalogState and OpenableDurableCatalogState used dynamic dispatch. However, the APIs in `mz_catalog::durable` returned a concrete struct on the stack and required callers to box the struct. This resulted in `mz_catalog::durable` making a lot of unnecessary implementation details public to outside crates.

This commit updates the `mz_catalog::durable` APIs to directly return boxed trait objects, so that the implementation details can be hidden from outside crates.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
