### PR TITLE
persist/columnar: Add Data impl for "OpaqueData"

### DIFF
--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -269,7 +269,6 @@ pub trait Schema<T>: Debug + Send + Sync {
 pub fn validate_roundtrip<T: Codec + Default + PartialEq + Debug>(
     schema: &T::Schema,
     val: &T,
-    skip_decode: bool,
 ) -> Result<(), String> {
     let mut part = PartBuilder::new(schema, &UnitSchema);
     {
@@ -282,10 +281,6 @@ pub fn validate_roundtrip<T: Codec + Default + PartialEq + Debug>(
 
     // Sanity check that we can compute stats.
     let _stats = part.key_stats().expect("stats should be compute-able");
-
-    if skip_decode {
-        return Ok(());
-    }
 
     let mut actual = T::default();
     assert_eq!(part.len(), 1);

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -221,6 +221,8 @@ pub enum ColumnFormat {
     String,
     /// A column of type [crate::dyn_struct::DynStruct].
     Struct(DynStructCfg),
+    /// A column of type [`Vec<u8>`] that contains opaque bytes.
+    OpaqueData,
     // TODO: FixedSizedBytes for UUIDs?
 }
 
@@ -298,3 +300,7 @@ pub fn validate_roundtrip<T: Codec + Default + PartialEq + Debug>(
         Ok(())
     }
 }
+
+/// Opaque binary encoded data.
+#[derive(Debug)]
+pub struct OpaqueData;

--- a/src/persist-types/src/dyn_col.rs
+++ b/src/persist-types/src/dyn_col.rs
@@ -16,7 +16,7 @@ use arrow2::array::Array;
 use arrow2::io::parquet::write::Encoding;
 
 use crate::columnar::sealed::{ColumnMut, ColumnRef};
-use crate::columnar::{ColumnCfg, ColumnFormat, ColumnGet, ColumnPush, Data, DataType};
+use crate::columnar::{ColumnCfg, ColumnFormat, ColumnGet, ColumnPush, Data, DataType, OpaqueData};
 use crate::dyn_struct::{DynStruct, ValidityRef};
 use crate::stats::{DynStats, StatsFrom};
 
@@ -243,6 +243,8 @@ impl DataType {
             (true, ColumnFormat::String) => logic.call::<Option<String>>(&()),
             (false, ColumnFormat::Struct(cfg)) => logic.call::<DynStruct>(cfg),
             (true, ColumnFormat::Struct(cfg)) => logic.call::<Option<DynStruct>>(cfg),
+            (false, ColumnFormat::OpaqueData) => logic.call::<OpaqueData>(&()),
+            (true, ColumnFormat::OpaqueData) => logic.call::<Option<OpaqueData>>(&()),
         }
     }
 }

--- a/src/persist-types/src/stats.proto
+++ b/src/persist-types/src/stats.proto
@@ -31,6 +31,7 @@ message ProtoDynStats {
         ProtoStructStats struct = 2;
         ProtoPrimitiveStats primitive = 3;
         ProtoBytesStats bytes = 4;
+        ProtoNoneStats none = 5;
     }
 }
 
@@ -110,4 +111,8 @@ message ProtoBytesStats {
 message ProtoAtomicBytesStats {
     bytes lower = 1;
     bytes upper = 2;
+}
+
+message ProtoNoneStats {
+    // Purposefully empty.
 }

--- a/src/persist-types/src/stats.proto
+++ b/src/persist-types/src/stats.proto
@@ -31,7 +31,7 @@ message ProtoDynStats {
         ProtoStructStats struct = 2;
         ProtoPrimitiveStats primitive = 3;
         ProtoBytesStats bytes = 4;
-        ProtoNoneStats none = 5;
+        google.protobuf.Empty none = 5;
     }
 }
 
@@ -111,8 +111,4 @@ message ProtoBytesStats {
 message ProtoAtomicBytesStats {
     bytes lower = 1;
     bytes upper = 2;
-}
-
-message ProtoNoneStats {
-    // Purposefully empty.
 }

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -551,8 +551,7 @@ impl TrimStats for ProtoStructStats {
                 Some(Kind::Primitive(stats)) => stats.trim(),
                 Some(Kind::Bytes(stats)) => stats.trim(),
                 Some(Kind::Struct(stats)) => stats.trim(),
-                // Nothing to trim for NoneStats.
-                Some(Kind::None(_)) => (),
+                Some(Kind::None(())) => (),
                 None => {}
             }
         }
@@ -764,9 +763,8 @@ mod impls {
         truncate_bytes, truncate_string, AtomicBytesStats, BytesStats, ColumnStats, DynStats,
         JsonMapElementStats, JsonStats, NoneStats, OptionStats, PrimitiveStats,
         ProtoAtomicBytesStats, ProtoBytesStats, ProtoDynStats, ProtoJsonMapElementStats,
-        ProtoJsonMapStats, ProtoJsonStats, ProtoNoneStats, ProtoOptionStats,
-        ProtoPrimitiveBytesStats, ProtoPrimitiveStats, ProtoStructStats, StatsFrom, StructStats,
-        TruncateBound, TRUNCATE_LEN,
+        ProtoJsonMapStats, ProtoJsonStats, ProtoOptionStats, ProtoPrimitiveBytesStats,
+        ProtoPrimitiveStats, ProtoStructStats, StatsFrom, StructStats, TruncateBound, TRUNCATE_LEN,
     };
 
     impl<T: Serialize> Debug for PrimitiveStats<T>
@@ -1359,12 +1357,12 @@ mod impls {
         }
     }
 
-    impl RustType<ProtoNoneStats> for NoneStats {
-        fn into_proto(&self) -> ProtoNoneStats {
-            ProtoNoneStats::default()
+    impl RustType<()> for NoneStats {
+        fn into_proto(&self) -> () {
+            ()
         }
 
-        fn from_proto(_proto: ProtoNoneStats) -> Result<Self, TryFromProtoError> {
+        fn from_proto(_proto: ()) -> Result<Self, TryFromProtoError> {
             Ok(NoneStats)
         }
     }

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -351,6 +351,11 @@ impl AtomicBytesStats {
     }
 }
 
+/// Empty set of statistics.
+#[derive(Debug)]
+#[cfg_attr(any(test), derive(Clone))]
+pub struct NoneStats;
+
 /// The length to truncate `Vec<u8>` and `String` stats to.
 //
 // Ideally, this would be in LaunchDarkly, but the plumbing is tough.
@@ -546,6 +551,8 @@ impl TrimStats for ProtoStructStats {
                 Some(Kind::Primitive(stats)) => stats.trim(),
                 Some(Kind::Bytes(stats)) => stats.trim(),
                 Some(Kind::Struct(stats)) => stats.trim(),
+                // Nothing to trim for NoneStats.
+                Some(Kind::None(_)) => (),
                 None => {}
             }
         }
@@ -755,10 +762,11 @@ mod impls {
     use crate::stats::{
         proto_bytes_stats, proto_dyn_stats, proto_json_stats, proto_primitive_stats,
         truncate_bytes, truncate_string, AtomicBytesStats, BytesStats, ColumnStats, DynStats,
-        JsonMapElementStats, JsonStats, OptionStats, PrimitiveStats, ProtoAtomicBytesStats,
-        ProtoBytesStats, ProtoDynStats, ProtoJsonMapElementStats, ProtoJsonMapStats,
-        ProtoJsonStats, ProtoOptionStats, ProtoPrimitiveBytesStats, ProtoPrimitiveStats,
-        ProtoStructStats, StatsFrom, StructStats, TruncateBound, TRUNCATE_LEN,
+        JsonMapElementStats, JsonStats, NoneStats, OptionStats, PrimitiveStats,
+        ProtoAtomicBytesStats, ProtoBytesStats, ProtoDynStats, ProtoJsonMapElementStats,
+        ProtoJsonMapStats, ProtoJsonStats, ProtoNoneStats, ProtoOptionStats,
+        ProtoPrimitiveBytesStats, ProtoPrimitiveStats, ProtoStructStats, StatsFrom, StructStats,
+        TruncateBound, TRUNCATE_LEN,
     };
 
     impl<T: Serialize> Debug for PrimitiveStats<T>
@@ -900,6 +908,23 @@ mod impls {
         }
     }
 
+    impl DynStats for NoneStats {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn into_proto(&self) -> ProtoDynStats {
+            ProtoDynStats {
+                option: None,
+                kind: Some(proto_dyn_stats::Kind::None(RustType::into_proto(self))),
+            }
+        }
+
+        fn debug_json(&self) -> serde_json::Value {
+            serde_json::Value::String(format!("{self:?}"))
+        }
+    }
+
     macro_rules! stats_primitive {
         ($data:ty, $ref:ident) => {
             impl ColumnStats<$data> for PrimitiveStats<$data> {
@@ -995,6 +1020,37 @@ mod impls {
         fn upper<'a>(&'a self) -> Option<<Option<DynStruct> as Data>::Ref<'a>> {
             self.some.upper().map(Some)
         }
+        fn none_count(&self) -> usize {
+            self.none
+        }
+    }
+
+    impl<T: Data> ColumnStats<T> for NoneStats {
+        fn lower<'a>(&'a self) -> Option<<T as Data>::Ref<'a>> {
+            None
+        }
+
+        fn upper<'a>(&'a self) -> Option<<T as Data>::Ref<'a>> {
+            None
+        }
+
+        fn none_count(&self) -> usize {
+            0
+        }
+    }
+
+    impl<T> ColumnStats<Option<T>> for OptionStats<NoneStats>
+    where
+        Option<T>: Data,
+    {
+        fn lower<'a>(&'a self) -> Option<<Option<T> as Data>::Ref<'a>> {
+            None
+        }
+
+        fn upper<'a>(&'a self) -> Option<<Option<T> as Data>::Ref<'a>> {
+            None
+        }
+
         fn none_count(&self) -> usize {
             self.none
         }
@@ -1162,6 +1218,24 @@ mod impls {
         }
     }
 
+    impl<T: arrow2::array::Array> StatsFrom<T> for NoneStats {
+        fn stats_from(col: &T, _validity: ValidityRef<'_>) -> Self {
+            assert!(col.validity().is_none());
+            NoneStats
+        }
+    }
+
+    impl<T: arrow2::array::Array> StatsFrom<T> for OptionStats<NoneStats> {
+        fn stats_from(col: &T, validity: ValidityRef<'_>) -> Self {
+            debug_assert!(validity.is_superset(col.validity()));
+            let none = col.validity().map_or(0, |x| x.unset_bits());
+            OptionStats {
+                none,
+                some: NoneStats,
+            }
+        }
+    }
+
     impl RustType<ProtoStructStats> for StructStats {
         fn into_proto(&self) -> ProtoStructStats {
             ProtoStructStats {
@@ -1285,6 +1359,16 @@ mod impls {
         }
     }
 
+    impl RustType<ProtoNoneStats> for NoneStats {
+        fn into_proto(&self) -> ProtoNoneStats {
+            ProtoNoneStats::default()
+        }
+
+        fn from_proto(_proto: ProtoNoneStats) -> Result<Self, TryFromProtoError> {
+            Ok(NoneStats)
+        }
+    }
+
     impl RustType<ProtoDynStats> for Box<dyn DynStats> {
         fn into_proto(&self) -> ProtoDynStats {
             DynStats::into_proto(self.as_ref())
@@ -1376,6 +1460,7 @@ mod impls {
             },
             proto_dyn_stats::Kind::Struct(x) => f.call(StructStats::from_proto(x)?),
             proto_dyn_stats::Kind::Bytes(x) => f.call(BytesStats::from_proto(x)?),
+            proto_dyn_stats::Kind::None(x) => f.call(NoneStats::from_proto(x)?),
         }
     }
 

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -52,8 +52,7 @@ pub use crate::relation::{
     ProtoRelationType, RelationDesc, RelationType,
 };
 pub use crate::row::encoding::{
-    is_no_stats_type, DatumDecoderT, DatumEncoderT, DatumToPersist, DatumToPersistFn, RowDecoder,
-    RowEncoder,
+    DatumDecoderT, DatumEncoderT, DatumToPersist, DatumToPersistFn, RowDecoder, RowEncoder,
 };
 pub use crate::row::{
     datum_list_size, datum_size, datums_size, read_datum, row_size, DatumList, DatumMap, ProtoRow,

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -177,7 +177,6 @@ mod tests {
     use mz_proto::RustType;
     use proptest::prelude::*;
 
-    use crate::row::encoding::is_no_stats_type;
     use crate::{Datum, DatumToPersist, DatumToPersistFn, RelationDesc, Row, RowArena, ScalarType};
 
     fn datum_stats_roundtrip_trim<'a>(
@@ -229,11 +228,6 @@ mod tests {
     }
 
     fn scalar_type_stats_roundtrip_trim(scalar_type: ScalarType) {
-        // Skip types that we don't keep stats for (yet).
-        if is_no_stats_type(&scalar_type) {
-            return;
-        }
-
         let mut rows = Vec::new();
         for datum in scalar_type.interesting_datums() {
             rows.push(Row::pack(std::iter::once(datum)));

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1187,7 +1187,7 @@ impl Schema<SourceData> for RelationDesc {
 
 #[cfg(test)]
 mod tests {
-    use mz_repr::{is_no_stats_type, ScalarType};
+    use mz_repr::ScalarType;
     use proptest::prelude::*;
     use proptest::strategy::ValueTree;
 
@@ -1209,8 +1209,6 @@ mod tests {
     }
 
     fn scalar_type_columnar_roundtrip(scalar_type: ScalarType) {
-        let skip_decode = is_no_stats_type(&scalar_type);
-
         use mz_persist_types::columnar::validate_roundtrip;
         let mut rows = Vec::new();
         for datum in scalar_type.interesting_datums() {
@@ -1221,14 +1219,14 @@ mod tests {
         // Non-nullable version of the column.
         let schema = RelationDesc::empty().with_column("col", scalar_type.clone().nullable(false));
         for row in rows.iter() {
-            assert_eq!(validate_roundtrip(&schema, row, skip_decode), Ok(()));
+            assert_eq!(validate_roundtrip(&schema, row), Ok(()));
         }
 
         // Nullable version of the column.
         let schema = RelationDesc::empty().with_column("col", scalar_type.nullable(true));
         rows.push(SourceData(Ok(Row::pack(std::iter::once(Datum::Null)))));
         for row in rows.iter() {
-            assert_eq!(validate_roundtrip(&schema, row, skip_decode), Ok(()));
+            assert_eq!(validate_roundtrip(&schema, row), Ok(()));
         }
     }
 


### PR DESCRIPTION
This PR adds a V0 Arrow encoding for the following `Datum`s:

* `Array`
* `List`
* `Record`
* `Map`
* `Int2Vector`
* `Range`
* `MzAclItem`
* `AclItem`

The V0 format is a `BinaryArray` that contains an encoded ProtoDatum` and does not collect any stats other than `null_count`.

TODO: I'll benchmark the performance to make sure this doesn't slowdown the stats collection codepath too much.

### Motivation

Unblocks writing structured columnar data because now we have _a_ way to encode all datums.

### Tips for reviewer

I split this PR into three separate commits which could be reviewed independently:

1. Add `NoneStats` type
2. Implement the `Data` trait for a new `OpaqueData` type.
3. Update `Datum` encoding for above listed types.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
