### PR TITLE
adapter: change parse_item to take a &str

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3131,7 +3131,7 @@ impl Catalog {
     fn parse_item(
         &self,
         id: GlobalId,
-        create_sql: String,
+        create_sql: &str,
         pcx: Option<&PlanContext>,
         is_retained_metrics_object: bool,
         custom_logical_compaction_window: Option<CompactionWindow>,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -807,7 +807,7 @@ impl CatalogState {
     pub(crate) fn deserialize_plan(
         &self,
         id: GlobalId,
-        create_sql: String,
+        create_sql: &str,
         force_if_exists_skip: bool,
     ) -> Result<(Plan, ResolvedIds), AdapterError> {
         // TODO - The `None` needs to be changed if we ever allow custom
@@ -823,7 +823,7 @@ impl CatalogState {
     #[mz_ore::instrument]
     pub(crate) fn parse_plan(
         &self,
-        create_sql: String,
+        create_sql: &str,
         pcx: Option<&PlanContext>,
         catalog: &mut ConnCatalog,
     ) -> Result<(Plan, ResolvedIds), AdapterError> {
@@ -839,7 +839,7 @@ impl CatalogState {
         //    overridden.
         catalog.system_vars_mut().enable_for_item_parsing();
 
-        let stmt = mz_sql::parse::parse(&create_sql)?.into_element().ast;
+        let stmt = mz_sql::parse::parse(create_sql)?.into_element().ast;
         let (stmt, resolved_ids) = mz_sql::names::resolve(catalog, stmt)?;
         let plan = mz_sql::plan::plan(pcx, catalog, stmt, &Params::empty(), &resolved_ids)?;
 
@@ -849,7 +849,7 @@ impl CatalogState {
     pub(crate) fn deserialize_item(
         &self,
         id: GlobalId,
-        create_sql: String,
+        create_sql: &str,
     ) -> Result<CatalogItem, AdapterError> {
         // TODO - The `None` needs to be changed if we ever allow custom
         // logical compaction windows in user-defined objects.
@@ -862,7 +862,7 @@ impl CatalogState {
     pub(crate) fn parse_item(
         &self,
         id: GlobalId,
-        create_sql: String,
+        create_sql: &str,
         pcx: Option<&PlanContext>,
         is_retained_metrics_object: bool,
         custom_logical_compaction_window: Option<CompactionWindow>,

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -147,7 +147,7 @@ impl Coordinator {
         };
 
         let state = self.catalog().state();
-        let plan_result = state.deserialize_plan(id, item.create_sql.clone(), true);
+        let plan_result = state.deserialize_plan(id, &item.create_sql, true);
         let (plan, resolved_ids) = return_if_err!(plan_result, ctx);
 
         let plan::Plan::CreateIndex(plan) = plan else {

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -170,7 +170,7 @@ impl Coordinator {
         };
 
         let state = self.catalog().state();
-        let plan_result = state.deserialize_plan(id, item.create_sql.clone(), true);
+        let plan_result = state.deserialize_plan(id, &item.create_sql, true);
         let (plan, resolved_ids) = return_if_err!(plan_result, ctx);
 
         let plan::Plan::CreateMaterializedView(plan) = plan else {

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -142,7 +142,7 @@ impl Coordinator {
         };
 
         let state = self.catalog().state();
-        let plan_result = state.deserialize_plan(id, item.create_sql.clone(), true);
+        let plan_result = state.deserialize_plan(id, &item.create_sql, true);
         let (plan, resolved_ids) = return_if_err!(plan_result, ctx);
 
         let plan::Plan::CreateView(plan) = plan else {


### PR DESCRIPTION
Refactor to simplify some calling.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a