### PR TITLE
dev docs: set noindex on public rustdocs

### DIFF
--- a/ci/deploy/devsite.sh
+++ b/ci/deploy/devsite.sh
@@ -17,12 +17,15 @@ cargo about generate ci/deploy/licenses.hbs > misc/www/licenses.html
 
 aws s3 cp --recursive misc/www/ s3://materialize-dev-website/
 
-bin/doc
+# We set `noindex` on our rustdocs to avoid burning crawl budget [1]
+# or diverting search results to internal docs rather than public-facing
+# content. Additionally, the private items docs have many broken links
+# that would actively harm our SEO score.
+#
+# [1]: https://developers.google.com/search/blog/2017/01/what-crawl-budget-means-for-googlebot
+RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc
 aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust
 
-# Documenting private items causes broken links in many crates we don't control.
-# So exclude all the pages from search engine indexes to avoid harming our
-# SEO score with a number of broken links.
 RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc --document-private-items
 aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust-private
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Follow-up to https://materializeinc.slack.com/archives/CM7ATT65S/p1709577118601519 -- sets `noindex` on our public-symbols Rust docs to improve SEO.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
