### PR TITLE
bounded memory: allow parallelization

### DIFF
--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -150,6 +150,9 @@ def accepted_by_shard(
     if parallelism_count is None:
         parallelism_count = get_parallelism_count()
 
+    if parallelism_count == 1:
+        return True
+
     hash_value = int.from_bytes(
         hashlib.md5(identifier.encode("utf-8")).digest(), byteorder="big"
     )

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from string import ascii_lowercase
 from textwrap import dedent
 
+from materialize.buildkite import accepted_by_shard
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.cockroach import Cockroach
@@ -652,6 +653,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         if scenario.disabled:
             print(f"+++ Scenario {scenario.name} is disabled, skipping.")
+            continue
+        if not accepted_by_shard(scenario.name):
             continue
         else:
             print(f"+++ Running scenario {scenario.name} ...")


### PR DESCRIPTION
Allow running bounded-memory with parallelization (e.g., in special builds searching for closer memory limits) but do not enable it by default since the build only takes 30 minutes.