### PR TITLE
fivetran: Update handling of optional params

### DIFF
--- a/src/fivetran-destination/src/destination/config.rs
+++ b/src/fivetran-destination/src/destination/config.rs
@@ -124,6 +124,7 @@ async fn test_permissions(config: BTreeMap<String, String>) -> Result<(), OpErro
 pub async fn connect(
     mut config: BTreeMap<String, String>,
 ) -> Result<(String, tokio_postgres::Client), OpError> {
+    tracing::info!(?config, "Connecting to Materialize");
     let host = config
         .remove("host")
         .ok_or(OpErrorKind::FieldMissing("host"))?;
@@ -136,7 +137,10 @@ pub async fn connect(
     let dbname = config
         .remove("dbname")
         .ok_or(OpErrorKind::FieldMissing("dbname"))?;
-    let cluster = config.remove("cluster");
+    let cluster = config
+        .remove("cluster")
+        // Fivetran provides an empty string for optional parameters.
+        .and_then(|val| if val.is_empty() { None } else { Some(val) });
 
     // Compile in the CA certificate bundle downloaded by the build script, and
     // configure the TLS connector to reference that compiled-in CA bundle,


### PR DESCRIPTION
The Fivetran Destination has an optional `cluster` param, sometimes ([maybe always?](https://materializeinc.slack.com/archives/C060KAR4802/p1712066689976429?thread_ts=1712066017.988619&cid=C060KAR4802)) optional parameters get provided as an empty string which is meant to indicate `None`. This PR adds handling to map the empty string for the `cluster` param to `None`.

Note: I locally rebased this on top of https://github.com/MaterializeInc/materialize/pull/26334 and manually made sure the empty string case gets correctly handled.

### Motivation

Fixes a bug in the destination

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
