### PR TITLE
adapter: acquire read holds before making assumptions about collection sinces

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -149,6 +149,7 @@ use crate::config::{SynchronizedParameters, SystemParameterFrontend, SystemParam
 use crate::coord::appends::{Deferred, GroupCommitPermit, PendingWriteTxn};
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::peek::PendingPeek;
+use crate::coord::read_policy::InternalReadHolds;
 use crate::coord::timeline::{TimelineContext, TimelineState};
 use crate::coord::timestamp_selection::{TimestampContext, TimestampDetermination};
 use crate::error::AdapterError;
@@ -163,7 +164,7 @@ use crate::session::{EndTransactionAction, Session};
 use crate::statement_logging::StatementEndedExecutionReason;
 use crate::util::{ClientTransmitter, CompletedClientTransmitter, ResultExt};
 use crate::webhook::{WebhookAppenderInvalidator, WebhookConcurrencyLimiter};
-use crate::{flags, AdapterNotice, TimestampProvider};
+use crate::{flags, AdapterNotice, ReadHolds, TimestampProvider};
 use mz_catalog::builtin::BUILTINS;
 use mz_catalog::durable::OpenableDurableCatalogState;
 use mz_ore::future::TimeoutError;
@@ -188,7 +189,7 @@ mod indexes;
 mod introspection;
 mod message_handler;
 mod privatelink_status;
-mod read_policy;
+pub mod read_policy;
 mod sequencer;
 mod sql;
 
@@ -214,6 +215,7 @@ pub enum Message<T = mz_repr::Timestamp> {
         Option<GroupCommitPermit>,
     ),
     AdvanceTimelines,
+    DropReadHolds(Vec<InternalReadHolds<Timestamp>>),
     ClusterEvent(ClusterEvent),
     CancelPendingPeeks {
         conn_id: ConnectionId,
@@ -296,6 +298,7 @@ impl Message {
             Message::GroupCommitInitiate(..) => "group_commit_initiate",
             Message::GroupCommitApply(..) => "group_commit_apply",
             Message::AdvanceTimelines => "advance_timelines",
+            Message::DropReadHolds(_) => "drop_read_holds",
             Message::ClusterEvent(_) => "cluster_event",
             Message::CancelPendingPeeks { .. } => "cancel_pending_peeks",
             Message::LinearizeReads => "linearize_reads",
@@ -1266,6 +1269,14 @@ pub struct Coordinator {
     /// Channel for strict serializable reads ready to commit.
     strict_serializable_reads_tx: mpsc::UnboundedSender<(ConnectionId, PendingReadTxn)>,
 
+    /// Channel for returning/releasing [InternalReadHolds](InternalReadHolds).
+    ///
+    /// We're using a special purpose channel rather than using
+    /// `internal_cmd_tx` so that we can control the priority of working off
+    /// dropped read holds. If we sent them as [Message] on the internal cmd
+    /// channel, these would always get top priority, which is not necessary.
+    dropped_read_holds_tx: mpsc::UnboundedSender<InternalReadHolds<Timestamp>>,
+
     /// Mechanism for totally ordering write and read timestamps, so that all reads
     /// reflect exactly the set of writes that precede them, and no writes that follow.
     global_timelines: BTreeMap<Timeline, TimelineState<Timestamp>>,
@@ -1630,7 +1641,7 @@ impl Coordinator {
                             idx.custom_logical_compaction_window.unwrap_or_default()
                         };
 
-                        let as_of = self.bootstrap_dataflow_as_of(
+                        let (as_of, read_holds) = self.bootstrap_dataflow_as_of(
                             &df_desc,
                             idx.cluster_id,
                             storage_constraints,
@@ -1664,6 +1675,10 @@ impl Coordinator {
                             .active_compute()
                             .create_dataflow(idx.cluster_id, df_desc)
                             .unwrap_or_terminate("cannot fail to create dataflows");
+
+                        // Drop read holds after the dataflow has been shipped, at which
+                        // point compute will have put in its own read holds.
+                        drop(read_holds);
                     }
                 }
                 CatalogItem::View(_) => (),
@@ -1685,7 +1700,7 @@ impl Coordinator {
                         .remove(&entry.id())
                         .expect("all dataflow storage constraints were collected");
 
-                    let as_of = self.bootstrap_dataflow_as_of(
+                    let (as_of, read_holds) = self.bootstrap_dataflow_as_of(
                         &df_desc,
                         mview.cluster_id,
                         storage_constraints,
@@ -1718,6 +1733,10 @@ impl Coordinator {
                     }
 
                     self.ship_dataflow(df_desc, mview.cluster_id).await;
+
+                    // Drop read holds after the dataflow has been shipped, at which
+                    // point compute will have put in its own read holds.
+                    drop(read_holds);
                 }
                 CatalogItem::Sink(sink) => {
                     let id = entry.id();
@@ -2196,18 +2215,19 @@ impl Coordinator {
     }
 
     /// Returns an `as_of` suitable for bootstrapping the given index or materialized view
-    /// dataflow.
+    /// dataflow, along with a [ReadHolds] that ensures the sinces of involved collections
+    /// stay in place.
     ///
     /// # Panics
     ///
     /// Panics if the given dataflow exports neither an index nor a materialized view.
     fn bootstrap_dataflow_as_of(
-        &self,
+        &mut self,
         dataflow: &DataflowDescription<Plan>,
         cluster_id: ComputeInstanceId,
         storage_constraints: StorageConstraints,
         compaction_window: CompactionWindow,
-    ) -> Antichain<Timestamp> {
+    ) -> (Antichain<Timestamp>, ReadHolds<Timestamp>) {
         // Supporting multi-export dataflows is not impossible but complicates the logic, so we
         // punt on it until we actually want to create such dataflows.
         assert!(
@@ -2218,6 +2238,14 @@ impl Coordinator {
         // All inputs must be readable at the chosen `as_of`, so it must be at least the join of
         // the `since`s of all dependencies.
         let direct_dependencies = dataflow_import_id_bundle(dataflow, cluster_id);
+
+        // We're putting in place read holds, to prevent the since of
+        // dependencies moving along concurrently, pulling the rug from under
+        // us!
+        let read_holds = self
+            .acquire_read_holds(mz_repr::Timestamp::minimum(), &direct_dependencies, false)
+            .expect("can acquire un-precise read holds");
+
         let min_as_of = self.least_valid_read(&direct_dependencies);
 
         // We must not select an `as_of` that is beyond any times that have not yet been written to
@@ -2343,7 +2371,7 @@ impl Coordinator {
             "bootstrapping dataflow `as_of`",
         );
 
-        as_of
+        (as_of, read_holds)
     }
 
     /// Serves the coordinator, receiving commands from users over `cmd_rx`
@@ -2358,6 +2386,7 @@ impl Coordinator {
         mut self,
         mut internal_cmd_rx: mpsc::UnboundedReceiver<Message>,
         mut strict_serializable_reads_rx: mpsc::UnboundedReceiver<(ConnectionId, PendingReadTxn)>,
+        mut dropped_read_holds_rx: mpsc::UnboundedReceiver<InternalReadHolds<Timestamp>>,
         mut cmd_rx: mpsc::UnboundedReceiver<(OpenTelemetryContext, Command)>,
         group_commit_rx: appends::GroupCommitWaiter,
     ) -> LocalBoxFuture<'static, ()> {
@@ -2501,6 +2530,15 @@ impl Coordinator {
                             )
                         }
                         Message::LinearizeReads
+                    }
+                    // `recv()` on `UnboundedReceiver` is cancellation safe:
+                    // https://docs.rs/tokio/1.8.0/tokio/sync/mpsc/struct.UnboundedReceiver.html#cancel-safety
+                    Some(dropped_read_hold) = dropped_read_holds_rx.recv() => {
+                        let mut dropped_read_holds = vec![dropped_read_hold];
+                        while let Ok(dropped_read_hold) = dropped_read_holds_rx.try_recv() {
+                            dropped_read_holds.push(dropped_read_hold);
+                        }
+                        Message::DropReadHolds(dropped_read_holds)
                     }
                     // `tick()` on `Interval` is cancel-safe:
                     // https://docs.rs/tokio/1.19.2/tokio/time/struct.Interval.html#cancel-safety
@@ -2886,6 +2924,7 @@ pub fn serve(
         let (group_commit_tx, group_commit_rx) = appends::notifier();
         let (strict_serializable_reads_tx, strict_serializable_reads_rx) =
             mpsc::unbounded_channel();
+        let (dropped_read_holds_tx, dropped_read_holds_rx) = mpsc::unbounded_channel();
 
         // Validate and process availability zones.
         if !availability_zones.iter().all_unique() {
@@ -3026,6 +3065,7 @@ pub fn serve(
                     internal_cmd_tx,
                     group_commit_tx,
                     strict_serializable_reads_tx,
+                    dropped_read_holds_tx,
                     global_timelines: timestamp_oracles,
                     transient_id_counter: 1,
                     active_conns: BTreeMap::new(),
@@ -3079,6 +3119,7 @@ pub fn serve(
                     handle.block_on(coord.serve(
                         internal_cmd_rx,
                         strict_serializable_reads_rx,
+                        dropped_read_holds_rx,
                         cmd_rx,
                         group_commit_rx,
                     ));

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -105,6 +105,10 @@ impl Coordinator {
                 Message::AdvanceTimelines => {
                     self.advance_timelines().await;
                 }
+                Message::DropReadHolds(dropped_read_holds) => {
+                    tracing::debug!(?dropped_read_holds, "releasing dropped read holds!");
+                    self.release_read_holds(dropped_read_holds);
+                }
                 Message::ClusterEvent(event) => self.message_cluster_event(event).await,
                 Message::CancelPendingPeeks { conn_id } => {
                     self.cancel_pending_peeks(&conn_id);

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -40,7 +40,7 @@ use crate::session::Session;
 use crate::util::ResultExt;
 
 /// Relevant information for acquiring or releasing a bundle of read holds.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Debug, Serialize)]
 pub(crate) struct ReadHolds<T> {
     holds: HashMap<Antichain<T>, CollectionIdBundle>,
 }

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -29,6 +29,7 @@ use mz_sql_parser::ast;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};
 use timely::progress::Antichain;
+use timely::progress::Timestamp;
 use tracing::Span;
 
 use crate::command::ExecuteResponse;
@@ -46,6 +47,7 @@ use crate::optimize::dataflows::dataflow_import_id_bundle;
 use crate::optimize::{self, Optimize};
 use crate::session::Session;
 use crate::util::ResultExt;
+use crate::ReadHolds;
 use crate::{catalog, AdapterNotice, CollectionIdBundle, ExecuteContext, TimestampProvider};
 
 impl Staged for CreateMaterializedViewStage {
@@ -530,7 +532,7 @@ impl Coordinator {
     ) -> Result<StageResult<Box<CreateMaterializedViewStage>>, AdapterError> {
         // Timestamp selection
         let id_bundle = dataflow_import_id_bundle(global_lir_plan.df_desc(), cluster_id);
-        let (dataflow_as_of, storage_as_of, until) =
+        let (read_holds, dataflow_as_of, storage_as_of, until) =
             self.select_timestamps(id_bundle, refresh_schedule.as_ref())?;
         tracing::info!(
             dataflow_as_of = ?dataflow_as_of,
@@ -666,6 +668,10 @@ impl Coordinator {
             })
             .await;
 
+        // Only drop the read holds once the dataflow has been installed,
+        // which acquires its own read holds.
+        drop(read_holds);
+
         match transact_result {
             Ok(_) => Ok(ExecuteResponse::CreatedMaterializedView),
             Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
@@ -687,17 +693,25 @@ impl Coordinator {
     /// Select the initial `dataflow_as_of`, `storage_as_of`, and `until` frontiers for a
     /// materialized view.
     fn select_timestamps(
-        &self,
+        &mut self,
         id_bundle: CollectionIdBundle,
         refresh_schedule: Option<&RefreshSchedule>,
     ) -> Result<
         (
+            ReadHolds<mz_repr::Timestamp>,
             Antichain<mz_repr::Timestamp>,
             Antichain<mz_repr::Timestamp>,
             Antichain<mz_repr::Timestamp>,
         ),
         AdapterError,
     > {
+        // Acquire read holds _before_ determining the least valid read.
+        // Otherwise the frontier might advance away from under us,
+        // concurrently.
+        let read_holds = self
+            .acquire_read_holds(mz_repr::Timestamp::minimum(), &id_bundle, false)
+            .expect("can always acquire non-precise read holds");
+
         // For non-REFRESH MVs both the `dataflow_as_of` and the `storage_as_of` should be simply
         // `least_valid_read`.
         let least_valid_read = self.least_valid_read(&id_bundle);
@@ -728,6 +742,7 @@ impl Coordinator {
                     let last_refresh = refresh_schedule.last_refresh().expect(
                         "if round_up_timestamp returned None, then there should be a last refresh",
                     );
+
                     return Err(AdapterError::MaterializedViewWouldNeverRefresh(
                         last_refresh,
                         *least_valid_read_ts,
@@ -747,7 +762,7 @@ impl Coordinator {
             .and_then(|r| r.try_step_forward());
         let until = Antichain::from_iter(until_ts);
 
-        Ok((dataflow_as_of, storage_as_of, until))
+        Ok((read_holds, dataflow_as_of, storage_as_of, until))
     }
 
     #[instrument]

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -203,7 +203,11 @@ impl Coordinator {
 
         // Release this transaction's compaction hold on collections.
         if let Some(txn_reads) = self.txn_read_holds.remove(conn_id) {
-            self.release_read_holds(txn_reads);
+            tracing::debug!(?txn_reads, "releasing txn read holds");
+
+            // Make it explicit that we're dropping these read holds. Dropping
+            // them will release them at the Coordinator.
+            drop(txn_reads);
         }
     }
 

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -38,7 +38,7 @@ use timely::progress::Timestamp as TimelyTimestamp;
 use tracing::{debug, error, info, Instrument};
 
 use crate::coord::id_bundle::CollectionIdBundle;
-use crate::coord::read_policy::ReadHolds;
+use crate::coord::read_policy::InternalReadHolds;
 use crate::coord::timestamp_selection::TimestampProvider;
 use crate::coord::Coordinator;
 use crate::AdapterError;
@@ -79,7 +79,7 @@ impl TimelineContext {
 /// guarantee that those read timestamps are valid.
 pub(crate) struct TimelineState<T> {
     pub(crate) oracle: Arc<dyn TimestampOracle<T> + Send + Sync>,
-    pub(crate) read_holds: ReadHolds<T>,
+    pub(crate) read_holds: InternalReadHolds<T>,
 }
 
 impl<T: fmt::Debug> fmt::Debug for TimelineState<T> {
@@ -238,7 +238,7 @@ impl Coordinator {
                 timeline.clone(),
                 TimelineState {
                     oracle,
-                    read_holds: ReadHolds::new(),
+                    read_holds: InternalReadHolds::new(),
                 },
             );
         }

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -61,6 +61,8 @@ pub use crate::client::{Client, Handle, SessionClient};
 pub use crate::command::{ExecuteResponse, ExecuteResponseKind, RowsFuture, StartupResponse};
 pub use crate::coord::id_bundle::CollectionIdBundle;
 pub use crate::coord::peek::PeekResponseUnary;
+pub use crate::coord::read_policy::InternalReadHolds;
+pub use crate::coord::read_policy::ReadHolds;
 pub use crate::coord::timeline::TimelineContext;
 pub use crate::coord::timestamp_selection::{
     TimestampContext, TimestampExplanation, TimestampProvider,


### PR DESCRIPTION
This is preparatory work for #24845, where we
factor a `StorageCollections` out of present-day `StorageController`.
And this `StorageCollections` will be shareable and will come with the
possibility of fontiers advancing concurrently.

We therefore need to guard places where we make assumptions about
frontiers by first acquiring read holds. This will "lock" sinces in
place where they currently are and then look at those sinces.

### Tips for reviewer

**NOTE:** There's a known bug with dropping `ReadHolds` that I still have to figure out, and I have to rebase across a slightly more involved conflict. But I wanted to get the basic structure out for review now, to see how you like and and if you prefer one of the approaches I mention below.

I implemented two solutions which I'll call _static read holds_ and _runtime read holds_ (or _dynamic read holds_). The former is everything up to the last commit, and the last commit changes it to the dynamic approach. So if you just look at this PR here on GH, you will only see the dynamic approach.

This is the commit message from that last commit:

```
adapter: dynamic lifetimes for ReadHolds 

As opposed to the previous approach, which I'd retroactively call static
lifetimes for read holds.

Before, we were using ReadHoldsGuard to ensure that ReadHolds were being
dropped when the guard went out of scope. This made for a clunky API,
though.

Now, we give each ReadHolds a channel on which it sends itself when it
is dropped. And the Coordinator works off that channel and releases
dropped read holds.

The new approach will make tracing/debugging problems slightly harder,
because there is more messaging and more state going around. But I think
we will need something like this for a more concurrent, future
Coordinator where we can acquire read holds, ferry them off to other
tasks and eventually release them there, without mutable access the the
Coordinator.
```

@teskje Added you as a reviewer because it's interesting pre-requisites for the controller refactoring PR.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
