### PR TITLE
bounded memory: parallelize

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -305,6 +305,7 @@ steps:
         label: "Bounded Memory"
         depends_on: build-aarch64
         timeout_in_minutes: 3600
+        parallelism: 2
         agents:
           queue: linux-aarch64
         plugins:


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/26372. Still parallelize bounded-memory because of recent issues (gets sometimes stuck due to increased load with additional scenarios).