### PR TITLE
doc/developer: Console with local environmentd

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -279,6 +279,21 @@ you can use the internal port with the `mz_system` user:
 psql -U mz_system -h localhost -p 6877 materialize
 ```
 
+## Console UI
+
+Console can point at your local environmentd. To use this feature, pass the
+internal console flag:
+
+```shell
+bin/environmentd -- --internal-console-redirect-url="https://local.console.materialize.com"
+```
+
+Then visit http://localhost:6878/internal-console/. This is a great way to
+dogfood the console, feedback is valuable.
+
+Note there is no frontegg login in this mode, so all frontegg features are
+disabled.
+
 ## Web UI
 
 Materialize embeds a web UI, which it serves from port 6876. If you're running


### PR DESCRIPTION
Adds a section to the developer guide about using console with `bin/environmentd`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
