### PR TITLE
Revert "persist-txn: Use efficient timestamp rewrites (#26316)"

### DIFF
--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -314,7 +314,7 @@ impl Transactor {
         data_ids: impl Iterator<Item = &ShardId>,
     ) {
         debug!("unblock_and_read_at {}", read_ts);
-        let mut txn = self.txns.begin();
+        let txn = self.txns.begin();
         match txn.commit_at(&mut self.txns, read_ts).await {
             Ok(apply) => {
                 self.tidy.merge(apply.apply(&mut self.txns).await);

--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -441,7 +441,7 @@ pub(crate) async fn empty_caa<S, F, K, V, T, D>(
 #[instrument(level = "debug", fields(shard=%data_write.shard_id(), ts=?commit_ts))]
 async fn apply_caa<K, V, T, D>(
     data_write: &mut WriteHandle<K, V, T, D>,
-    batch_raws: &Vec<&[u8]>,
+    batch_raw: &[u8],
     commit_ts: T,
 ) where
     K: Debug + Codec,
@@ -449,17 +449,12 @@ async fn apply_caa<K, V, T, D>(
     T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
     D: Semigroup + Codec64 + Send + Sync,
 {
-    let mut batches = batch_raws
-        .into_iter()
-        .map(|batch| ProtoIdBatch::parse(batch))
-        .map(|batch| data_write.batch_from_transmittable_batch(batch))
-        .collect::<Vec<_>>();
+    let batch = ProtoIdBatch::parse(batch_raw);
+    let mut batch = data_write.batch_from_transmittable_batch(batch);
     let Some(mut upper) = data_write.shared_upper().into_option() else {
         // Shard is closed, which means the upper must be past init_ts.
-        // Mark the batches as consumed, so we don't get warnings in the logs.
-        for batch in batches {
-            batch.into_hollow_batch();
-        }
+        // Mark the batch as consumed, so we don't get warnings in the logs.
+        batch.into_hollow_batch();
         return;
     };
     loop {
@@ -469,27 +464,24 @@ async fn apply_caa<K, V, T, D>(
                 data_write.shard_id().to_string(),
                 commit_ts
             );
-            // Mark the batches as consumed, so we don't get warnings in the logs.
-            for batch in batches {
-                batch.into_hollow_batch();
-            }
+            // Mark the batch as consumed, so we don't get warnings in the logs.
+            batch.into_hollow_batch();
             return;
         }
         debug!(
-            "CaA data {:.9} apply b={:?} t={:?} [{:?},{:?})",
+            "CaA data {:.9} apply b={} t={:?} [{:?},{:?})",
             data_write.shard_id().to_string(),
-            batch_raws
-                .iter()
-                .map(|batch_raw| batch_raw.hashed())
-                .collect::<Vec<_>>(),
+            batch_raw.hashed(),
             commit_ts,
             upper,
             commit_ts.step_forward(),
         );
-        let mut batches = batches.iter_mut().collect::<Vec<_>>();
+        // If we both spill to s3 in `Txn::write`` _and_ add the ability to
+        // merge two `Txn`s and then commit them together, then we need to do
+        // all the batches for a given `(shard, ts)` at once.
         let res = data_write
             .compare_and_append_batch(
-                batches.as_mut_slice(),
+                &mut [&mut batch],
                 Antichain::from_elem(upper.clone()),
                 Antichain::from_elem(commit_ts.step_forward()),
             )
@@ -551,7 +543,6 @@ pub(crate) async fn cads<T, O, C>(
 
 #[cfg(test)]
 pub mod tests {
-    use std::collections::BTreeMap;
     use std::sync::Arc;
     use std::sync::Mutex;
 
@@ -563,88 +554,9 @@ pub mod tests {
     use prost::Message;
 
     use crate::operator::DataSubscribe;
-    use crate::txn_write::{Txn, TxnApply};
-    use crate::txns::{Tidy, TxnsHandle};
+    use crate::txn_write::Txn;
 
     use super::*;
-
-    impl<K, V, T, D, O, C> TxnsHandle<K, V, T, D, O, C>
-    where
-        K: Debug + Codec + Clone,
-        V: Debug + Codec + Clone,
-        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
-        D: Semigroup + Codec64 + Send + Sync + Clone,
-        O: Opaque + Debug + Codec64,
-        C: TxnsCodec,
-    {
-        /// Returns a new, empty test transaction that can involve the data shards
-        /// registered with this handle.
-        pub(crate) fn begin_test(&self) -> TestTxn<K, V, T, D> {
-            TestTxn::new()
-        }
-    }
-
-    /// A [`Txn`] wrapper that exposes extra functionality for tests.
-    #[derive(Debug)]
-    pub struct TestTxn<K, V, T, D>
-    where
-        T: Timestamp + Lattice + Codec64,
-    {
-        txn: Txn<K, V, T, D>,
-        /// A copy of every write to use in tests.
-        writes: BTreeMap<ShardId, Vec<(K, V, D)>>,
-    }
-
-    impl<K, V, T, D> TestTxn<K, V, T, D>
-    where
-        K: Debug + Codec + Clone,
-        V: Debug + Codec + Clone,
-        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
-        D: Semigroup + Codec64 + Send + Sync + Clone,
-    {
-        pub(crate) fn new() -> Self {
-            Self {
-                txn: Txn::new(),
-                writes: BTreeMap::default(),
-            }
-        }
-
-        pub(crate) async fn write(&mut self, data_id: &ShardId, key: K, val: V, diff: D) {
-            self.writes
-                .entry(*data_id)
-                .or_default()
-                .push((key.clone(), val.clone(), diff.clone()));
-            self.txn.write(data_id, key, val, diff).await
-        }
-
-        pub(crate) async fn commit_at<O, C>(
-            &mut self,
-            handle: &mut TxnsHandle<K, V, T, D, O, C>,
-            commit_ts: T,
-        ) -> Result<TxnApply<T>, T>
-        where
-            O: Opaque + Debug + Codec64,
-            C: TxnsCodec,
-        {
-            self.txn.commit_at(handle, commit_ts).await
-        }
-
-        pub(crate) fn merge(&mut self, other: Self) {
-            for (data_id, writes) in other.writes {
-                self.writes.entry(data_id).or_default().extend(writes);
-            }
-            self.txn.merge(other.txn)
-        }
-
-        pub(crate) fn tidy(&mut self, tidy: Tidy) {
-            self.txn.tidy(tidy)
-        }
-
-        #[allow(dead_code)]
-        fn take_tidy(&mut self) -> Tidy {
-            self.txn.take_tidy()
-        }
-    }
 
     /// A test helper for collecting committed writes and later comparing them
     /// to reads for correctness.
@@ -673,7 +585,7 @@ pub mod tests {
             let () = self.tx.send(update).unwrap();
         }
 
-        pub fn record_txn(&self, commit_ts: u64, txn: &TestTxn<String, (), u64, i64>) {
+        pub fn record_txn(&self, commit_ts: u64, txn: &Txn<String, (), i64>) {
             for (data_id, writes) in txn.writes.iter() {
                 for (k, (), d) in writes.iter() {
                     self.record((*data_id, k.clone(), commit_ts, *d));

--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -327,15 +327,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64> TxnsCacheState
         let batches = self
             .unapplied_batches
             .values()
-            .fold(
-                BTreeMap::new(),
-                |mut accum: BTreeMap<_, Vec<_>>, (data_id, batch, ts)| {
-                    accum.entry((ts, data_id)).or_default().push(batch);
-                    accum
-                },
-            )
-            .into_iter()
-            .map(|((ts, data_id), batches)| (data_id, Unapplied::Batch(batches), ts));
+            .map(|(data_id, batch, ts)| (data_id, Unapplied::Batch(batch), ts));
         // This will emit registers and forgets before batches at the same timestamp. Currently,
         // this is fine because for a single data shard you can't combine registers, forgets, and
         // batches at the same timestamp. In the future if we allow combining these operations in
@@ -991,7 +983,7 @@ impl<T: Timestamp + TotalOrder> DataTimes<T> {
 #[derive(Debug)]
 pub(crate) enum Unapplied<'a> {
     RegisterForget,
-    Batch(Vec<&'a Vec<u8>>),
+    Batch(&'a Vec<u8>),
 }
 
 #[cfg(test)]

--- a/src/persist-txn/src/txn_write.rs
+++ b/src/persist-txn/src/txn_write.rs
@@ -20,7 +20,6 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use mz_ore::cast::CastFrom;
 use mz_ore::instrument;
-use mz_persist_client::batch::Batch;
 use mz_persist_client::ShardId;
 use mz_persist_types::txn::{TxnsCodec, TxnsEntry};
 use mz_persist_types::{Codec, Codec64, Opaque, StepForward};
@@ -32,54 +31,17 @@ use tracing::debug;
 use crate::proto::ProtoIdBatch;
 use crate::txns::{Tidy, TxnsHandle};
 
-/// Pending writes to a shard for an in-progress transaction.
-#[derive(Debug)]
-pub(crate) struct TxnWrite<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
-    pub(crate) batches: Vec<Batch<K, V, T, D>>,
-    pub(crate) writes: Vec<(K, V, D)>,
-}
-
-impl<K, V, T, D> TxnWrite<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
-    /// Merges the staged writes in `other` into this.
-    pub fn merge(&mut self, other: Self) {
-        self.batches.extend(other.batches);
-        self.writes.extend(other.writes);
-    }
-}
-
-impl<K, V, T, D> Default for TxnWrite<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
-    fn default() -> Self {
-        Self {
-            batches: Vec::default(),
-            writes: Vec::default(),
-        }
-    }
-}
-
 /// An in-progress transaction.
 #[derive(Debug)]
-pub struct Txn<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
-    pub(crate) writes: BTreeMap<ShardId, TxnWrite<K, V, T, D>>,
+pub struct Txn<K, V, D> {
+    pub(crate) writes: BTreeMap<ShardId, Vec<(K, V, D)>>,
     tidy: Tidy,
 }
 
-impl<K, V, T, D> Txn<K, V, T, D>
+impl<K, V, D> Txn<K, V, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
-    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
     D: Semigroup + Codec64 + Send + Sync,
 {
     pub(crate) fn new() -> Self {
@@ -100,7 +62,6 @@ where
         self.writes
             .entry(*data_id)
             .or_default()
-            .writes
             .push((key, val, diff))
     }
 
@@ -118,12 +79,13 @@ where
     ///
     /// Panics if any involved data shards were not registered before commit ts.
     #[instrument(level = "debug", fields(ts = ?commit_ts))]
-    pub async fn commit_at<O, C>(
-        &mut self,
+    pub async fn commit_at<T, O, C>(
+        &self,
         handle: &mut TxnsHandle<K, V, T, D, O, C>,
         commit_ts: T,
     ) -> Result<TxnApply<T>, T>
     where
+        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
         O: Opaque + Debug + Codec64,
         C: TxnsCodec,
     {
@@ -166,72 +128,50 @@ where
                 );
 
                 let txn_batches_updates = FuturesUnordered::new();
-                while let Some((data_id, updates)) = self.writes.pop_first() {
-                    let mut data_write = handle.datas.take_write(&data_id).await;
+                for (data_id, updates) in self.writes.iter() {
+                    let mut data_write = handle.datas.take_write(data_id).await;
                     let commit_ts = commit_ts.clone();
                     txn_batches_updates.push(async move {
-                        let mut batches = updates
-                            .batches
-                            .into_iter()
-                            .map(|mut batch| {
-                                batch
-                                    .rewrite_ts(
-                                        &Antichain::from_elem(commit_ts.clone()),
-                                        Antichain::from_elem(commit_ts.step_forward()),
-                                    )
-                                    .expect("invalid usage");
-                                batch.into_transmittable_batch()
-                            })
-                            .collect::<Vec<_>>();
-                        if !updates.writes.is_empty() {
-                            let mut batch = data_write.builder(Antichain::from_elem(T::minimum()));
-                            for (k, v, d) in updates.writes.iter() {
-                                batch.add(k, v, &commit_ts, d).await.expect("valid usage");
-                            }
-                            let batch = batch
-                                .finish(Antichain::from_elem(commit_ts.step_forward()))
-                                .await
-                                .expect("valid usage");
-                            let batch = batch.into_transmittable_batch();
-                            batches.push(batch);
+                        let mut batch = data_write.builder(Antichain::from_elem(T::minimum()));
+                        for (k, v, d) in updates.iter() {
+                            batch.add(k, v, &commit_ts, d).await.expect("valid usage");
                         }
-
-                        let batch_updates = batches
-                            .into_iter()
-                            .map(|batch| {
-                                // The code to handle retracting applied batches assumes
-                                // that the encoded representation of each is unique (it
-                                // works by retracting and cancelling out the raw
-                                // bytes). It's possible to make that code handle any
-                                // diff value but the complexity isn't worth it.
-                                //
-                                // So ensure that every committed batch has a unique
-                                // serialization. Technically, I'm pretty sure that
-                                // they're naturally unique but the justification is
-                                // long, subtle, and brittle. Instead, just slap a
-                                // random uuid on it.
-                                let batch_raw = ProtoIdBatch::new(batch.clone()).encode_to_vec();
-                                debug!(
-                                    "wrote {:.9} batch {}",
-                                    data_id.to_string(),
-                                    batch_raw.hashed(),
-                                );
-                                let update = C::encode(TxnsEntry::Append(
-                                    data_id,
-                                    T::encode(&commit_ts),
-                                    batch_raw,
-                                ));
-                                (batch, update)
-                            })
-                            .collect::<Vec<_>>();
-                        (data_write, batch_updates)
+                        let batch = batch
+                            .finish(Antichain::from_elem(commit_ts.step_forward()))
+                            .await
+                            .expect("valid usage");
+                        let batch = batch.into_transmittable_batch();
+                        // The code to handle retracting applied batches assumes
+                        // that the encoded representation of each is unique (it
+                        // works by retracting and cancelling out the raw
+                        // bytes). It's possible to make that code handle any
+                        // diff value but the complexity isn't worth it.
+                        //
+                        // So ensure that every committed batch has a unique
+                        // serialization. Technically, I'm pretty sure that
+                        // they're naturally unique but the justification is
+                        // long, subtle, and brittle. Instead, just slap a
+                        // random uuid on it.
+                        let batch_raw = ProtoIdBatch::new(batch.clone()).encode_to_vec();
+                        debug!(
+                            "wrote {:.9} batch {} len={}",
+                            data_id.to_string(),
+                            batch_raw.hashed(),
+                            updates.len()
+                        );
+                        let update = C::encode(TxnsEntry::Append(
+                            *data_id,
+                            T::encode(&commit_ts),
+                            batch_raw,
+                        ));
+                        (data_write, batch, update)
                     })
                 }
                 let txn_batches_updates = txn_batches_updates.collect::<Vec<_>>().await;
+
                 let mut txns_updates = txn_batches_updates
                     .iter()
-                    .flat_map(|(_, batch_updates)| batch_updates.iter().map(|(_, updates)| updates))
-                    .map(|(key, val)| ((key, val), &commit_ts, 1))
+                    .map(|(_, _, (key, val))| ((key, val), &commit_ts, 1))
                     .collect::<Vec<_>>();
                 let apply_is_empty = txns_updates.is_empty();
 
@@ -271,16 +211,14 @@ where
                         );
                         // The batch we wrote at commit_ts did commit. Mark it as
                         // such to avoid a WARN in the logs.
-                        for (data_write, batch_updates) in txn_batches_updates {
-                            for (batch, _) in batch_updates {
-                                let batch = data_write
-                                    .batch_from_transmittable_batch(batch)
-                                    .into_hollow_batch();
-                                handle.metrics.batches.commit_count.inc();
-                                let commit_bytes = &handle.metrics.batches.commit_bytes;
-                                for part in batch.parts.iter() {
-                                    commit_bytes.inc_by(u64::cast_from(part.encoded_size_bytes));
-                                }
+                        for (data_write, batch, _) in txn_batches_updates {
+                            let batch = data_write
+                                .batch_from_transmittable_batch(batch)
+                                .into_hollow_batch();
+                            handle.metrics.batches.commit_count.inc();
+                            let commit_bytes = &handle.metrics.batches.commit_bytes;
+                            for part in batch.parts.iter() {
+                                commit_bytes.inc_by(u64::cast_from(part.encoded_size_bytes));
                             }
                             handle.datas.put_write(data_write);
                         }
@@ -293,18 +231,16 @@ where
                         handle.metrics.commit.retry_count.inc();
                         assert!(txns_upper < new_txns_upper);
                         txns_upper = new_txns_upper;
-                        for (data_write, batch_updates) in txn_batches_updates {
-                            let batches = batch_updates
-                                .into_iter()
-                                .map(|(batch, _)| {
-                                    data_write.batch_from_transmittable_batch(batch.clone())
-                                })
-                                .collect();
-                            let txn_write = TxnWrite {
-                                writes: Vec::new(),
-                                batches,
-                            };
-                            self.writes.insert(data_write.shard_id(), txn_write);
+                        // The batch we wrote at commit_ts didn't commit. At the
+                        // moment, we'll try writing it out again at some higher
+                        // commit_ts on the next loop around, so we're free to go
+                        // ahead and delete this one. When we do the TODO to
+                        // efficiently re-timestamp batches, this must be removed.
+                        for (data_write, batch, _) in txn_batches_updates {
+                            let () = data_write
+                                .batch_from_transmittable_batch(batch)
+                                .delete()
+                                .await;
                             handle.datas.put_write(data_write);
                         }
                         let () = handle.txns_cache.update_ge(&txns_upper).await;
@@ -319,7 +255,7 @@ where
     /// Merges the staged writes in the other txn into this one.
     pub fn merge(&mut self, other: Self) {
         for (data_id, writes) in other.writes {
-            self.writes.entry(data_id).or_default().merge(writes);
+            self.writes.entry(data_id).or_default().extend(writes);
         }
         self.tidy.merge(other.tidy);
     }
@@ -447,7 +383,7 @@ mod tests {
 
         // Non-empty txn means non-empty apply. Min unapplied ts is the commit
         // ts.
-        let mut txn = txns.begin_test();
+        let mut txn = txns.begin();
         txn.write(&d0, "2".into(), (), 1).await;
         let apply_2 = txn.commit_at(&mut txns, 2).await.unwrap();
         log.record_txn(2, &txn);
@@ -475,10 +411,10 @@ mod tests {
         let tidy_4 = txns.expect_commit_at(4, d0, &["4"], &log).await;
         cache.update_gt(&4).await;
         assert_eq!(cache.min_unapplied_ts(), &4);
-        let mut txn0 = txns.begin_test();
+        let mut txn0 = txns.begin();
         txn0.write(&d0, "5".into(), (), 1).await;
         txn0.tidy(tidy_4);
-        let mut txn1 = txns.begin_test();
+        let mut txn1 = txns.begin();
         txn1.merge(txn0);
         let apply_5 = txn1.commit_at(&mut txns, 5).await.unwrap();
         log.record_txn(5, &txn1);
@@ -534,7 +470,7 @@ mod tests {
         const NUM_WRITES: usize = 25;
         let tasks = FuturesUnordered::new();
         for idx in 0..NUM_WRITES {
-            let mut txn = txns.begin_test();
+            let mut txn = txns.begin();
             txn.write(&d0, format!("{:05}", idx), (), 1).await;
             let (txns_id, client, log) = (txns.txns_id(), client.clone(), log.clone());
 
@@ -675,33 +611,5 @@ mod tests {
             }
         });
         assert!(commit.await.is_err());
-    }
-
-    #[mz_ore::test(tokio::test)]
-    #[cfg_attr(miri, ignore)] // too slow
-    async fn commit_retry() {
-        let client = PersistClient::new_for_tests().await;
-        let mut txns = TxnsHandle::expect_open(client.clone()).await;
-        let mut cache = TxnsCache::expect_open(0, &txns).await;
-        let d0 = txns.expect_register(1).await;
-        let d1 = txns.expect_register(2).await;
-
-        // `txn` commit is interrupted by `other` commit.
-        let mut txn = txns.begin();
-        txn.write(&d0, "0".into(), (), 1).await;
-        let mut other = txns.begin();
-        other.write(&d1, "42".into(), (), 1).await;
-        other.commit_at(&mut txns, 3).await.unwrap();
-        let upper = txn.commit_at(&mut txns, 3).await.unwrap_err();
-        assert_eq!(upper, 4);
-
-        // Add more writes to `txn` and try again.
-        txn.write(&d0, "1".into(), (), 1).await;
-        txn.commit_at(&mut txns, 4).await.unwrap();
-        txns.apply_le(&4).await;
-
-        let expected_d0 = vec!["0".to_owned(), "1".to_owned()];
-        let actual_d0 = cache.expect_snapshot(&client, d0, 4).await;
-        assert_eq!(actual_d0, expected_d0);
     }
 }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2182,7 +2182,7 @@ where
             //   timestamp given to us by the coordinator).
             // - That all txn writes through `init_ts` have been applied
             //   (materialized physically in the data shards).
-            let mut empty_txn = txns.begin();
+            let empty_txn = txns.begin();
             let apply = empty_txn
                 .commit_at(&mut txns, init_ts.clone())
                 .await


### PR DESCRIPTION
This reverts commit a15eb601dd1fef43b7435ff0777dfa18e82f2e5d.

The code in this commit is correct, but we found a flaw in rewrite_ts. Reverting this usage before it gets out to staging/prod so that we don't have to worry about backward compatibility in the fix. I'll revert the revert once things are settled again.

Touches #26384

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
