### PR TITLE
catalog: Listen to role and comment updates

### DIFF
--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -759,6 +759,10 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
         }
 
         Ok(match kind {
+            StateUpdateKind::Comment(key, value) => {
+                let comment = into_durable(key, value)?;
+                Some(memory::objects::StateUpdateKind::Comment(comment))
+            }
             StateUpdateKind::Database(key, value) => {
                 let database = into_durable(key, value)?;
                 Some(memory::objects::StateUpdateKind::Database(database))
@@ -768,6 +772,10 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
                 Some(memory::objects::StateUpdateKind::DefaultPrivilege(
                     default_privilege,
                 ))
+            }
+            StateUpdateKind::Role(key, value) => {
+                let role = into_durable(key, value)?;
+                Some(memory::objects::StateUpdateKind::Role(role))
             }
             StateUpdateKind::Schema(key, value) => {
                 let schema = into_durable(key, value)?;
@@ -789,13 +797,11 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
             StateUpdateKind::AuditLog(_, _)
             | StateUpdateKind::Cluster(_, _)
             | StateUpdateKind::ClusterReplica(_, _)
-            | StateUpdateKind::Comment(_, _)
             | StateUpdateKind::Config(_, _)
             | StateUpdateKind::Epoch(_)
             | StateUpdateKind::IdAllocator(_, _)
             | StateUpdateKind::IntrospectionSourceIndex(_, _)
             | StateUpdateKind::Item(_, _)
-            | StateUpdateKind::Role(_, _)
             | StateUpdateKind::Setting(_, _)
             | StateUpdateKind::StorageUsage(_, _)
             | StateUpdateKind::SystemObjectMapping(_, _)

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -1437,6 +1437,7 @@ impl<'a> Transaction<'a> {
         }
 
         std::iter::empty()
+            .chain(get_collection_updates(&self.roles, StateUpdateKind::Role))
             .chain(get_collection_updates(
                 &self.databases,
                 StateUpdateKind::Database,
@@ -1456,6 +1457,10 @@ impl<'a> Transaction<'a> {
             .chain(get_collection_updates(
                 &self.system_configurations,
                 StateUpdateKind::SystemConfiguration,
+            ))
+            .chain(get_collection_updates(
+                &self.comments,
+                StateUpdateKind::Comment,
             ))
             .map(|kind| StateUpdate { kind, diff: 1 })
     }

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -113,7 +113,7 @@ impl Schema {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct Role {
     pub name: String,
     pub id: RoleId,
@@ -2267,10 +2267,12 @@ pub struct StateUpdate {
 /// Variants are listed in dependency order.
 #[derive(Debug)]
 pub enum StateUpdateKind {
+    Role(durable::objects::Role),
     Database(durable::objects::Database),
     Schema(durable::objects::Schema),
     DefaultPrivilege(durable::objects::DefaultPrivilege),
     SystemPrivilege(MzAclItem),
     SystemConfiguration(durable::objects::SystemConfiguration),
+    Comment(durable::objects::Comment),
     // TODO(jkosh44) Add all other object variants.
 }


### PR DESCRIPTION
This commit teaches the in-memory catalog how to listen to role and
comment updates.

Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
