### PR TITLE
ci: set timeout of bounded-memory to a reasonable value

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -304,7 +304,7 @@ steps:
       - id: bounded-memory
         label: "Bounded Memory"
         depends_on: build-aarch64
-        timeout_in_minutes: 3600
+        timeout_in_minutes: 90
         parallelism: 2
         agents:
           queue: linux-aarch64


### PR DESCRIPTION
A successful build passes within 30 minutes.