### PR TITLE
REFRESH's automated cluster scheduling

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -77,6 +77,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_rbac_checks": "true",
     "enable_reduce_mfp_fusion": "true",
     "enable_refresh_every_mvs": "true",
+    "enable_cluster_schedule_refresh": "true",
     "enable_sink_doc_on_option": "true",
     "enable_statement_lifecycle_logging": "true",
     "enable_table_keys": "true",

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -137,6 +137,7 @@ use timely::PartialOrder;
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, OwnedMutexGuard};
+use tokio::time::MissedTickBehavior;
 use tracing::{debug, info, info_span, span, warn, Instrument, Level, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
@@ -182,6 +183,7 @@ pub(crate) mod timeline;
 pub(crate) mod timestamp_selection;
 
 mod appends;
+mod cluster_scheduling;
 mod command_handler;
 pub mod consistency;
 mod ddl;
@@ -270,6 +272,13 @@ pub enum Message<T = mz_repr::Timestamp> {
     },
     DrainStatementLog,
     PrivateLinkVpcEndpointEvents(Vec<VpcEndpointEvent>),
+    CheckSchedulingPolicies,
+
+    /// Scheduling policy decisions about turning clusters On/Off.
+    /// `Vec<(policy name, Vec of decisions by the policy)>`
+    /// A cluster will be On if and only if there is at least one On decision for it.
+    /// Scheduling decisions for clusters that have `SCHEDULE = MANUAL` are ignored.
+    SchedulingDecisions(Vec<(&'static str, Vec<(ClusterId, bool)>)>),
 }
 
 impl Message {
@@ -320,6 +329,8 @@ impl Message {
             Message::DrainStatementLog => "drain_statement_log",
             Message::AlterConnectionValidationReady(..) => "alter_connection_validation_ready",
             Message::PrivateLinkVpcEndpointEvents(_) => "private_link_vpc_endpoint_events",
+            Message::CheckSchedulingPolicies => "check_scheduling_policies",
+            Message::SchedulingDecisions { .. } => "scheduling_decision",
         }
     }
 }
@@ -1389,13 +1400,21 @@ pub struct Coordinator {
     /// Data used by the statement logging feature.
     statement_logging: StatementLogging,
 
-    /// Limit for how many conncurrent webhook requests we allow.
+    /// Limit for how many concurrent webhook requests we allow.
     webhook_concurrency_limit: WebhookConcurrencyLimiter,
 
     /// Optional config for the Postgres-backed timestamp oracle. This is
     /// _required_ when `postgres` is configured using the `timestamp_oracle`
     /// system variable.
     pg_timestamp_oracle_config: Option<PostgresTimestampOracleConfig>,
+
+    /// Periodically asks cluster scheduling policies to make their decisions.
+    check_cluster_scheduling_policies_interval: tokio::time::Interval,
+
+    /// This keeps the last On/Off decision for each cluster and each scheduling policy.
+    /// (Clusters that have been dropped or are otherwise out of scope for automatic scheduling are
+    /// periodically cleaned up from this Map.)
+    cluster_scheduling_decisions: BTreeMap<ClusterId, BTreeMap<&'static str, bool>>,
 }
 
 impl Coordinator {
@@ -2547,6 +2566,11 @@ impl Coordinator {
                         span.follows_from(Span::current());
                         Message::GroupCommitInitiate(span, None)
                     },
+                    // `tick()` on `Interval` is cancel-safe:
+                    // https://docs.rs/tokio/1.19.2/tokio/time/struct.Interval.html#cancel-safety
+                    _ = self.check_cluster_scheduling_policies_interval.tick() => {
+                        Message::CheckSchedulingPolicies
+                    },
 
                     // Process the idle metric at the lowest priority to sample queue non-idle time.
                     // `recv()` on `Receiver` is cancellation safe:
@@ -3030,6 +3054,12 @@ pub fn serve(
         let segment_client_clone = segment_client.clone();
         let coord_now = now.clone();
         let advance_timelines_interval = tokio::time::interval(catalog.config().timestamp_interval);
+        let mut check_scheduling_policies_interval = tokio::time::interval(
+            catalog
+                .system_config()
+                .cluster_check_scheduling_policies_interval(),
+        );
+        check_scheduling_policies_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         if let Some(config) = pg_timestamp_oracle_config.as_ref() {
             // Apply settings from system vars as early as possible because some
@@ -3099,6 +3129,8 @@ pub fn serve(
                     statement_logging: StatementLogging::new(coord_now.clone()),
                     webhook_concurrency_limit,
                     pg_timestamp_oracle_config,
+                    check_cluster_scheduling_policies_interval: check_scheduling_policies_interval,
+                    cluster_scheduling_decisions: BTreeMap::new(),
                 };
                 let bootstrap = handle.block_on(async {
                     coord

--- a/src/adapter/src/coord/cluster_scheduling.rs
+++ b/src/adapter/src/coord/cluster_scheduling.rs
@@ -1,0 +1,245 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::coord::{Coordinator, Message};
+use differential_dataflow::lattice::Lattice;
+use itertools::Itertools;
+use mz_catalog::memory::objects::{CatalogItem, ClusterVariant, ClusterVariantManaged};
+use mz_controller_types::ClusterId;
+use mz_ore::soft_panic_or_log;
+use mz_sql::catalog::CatalogCluster;
+use mz_sql_parser::ast::ClusterScheduleOptionValue;
+use std::time::Instant;
+use timely::progress::Antichain;
+use tracing::{debug, warn};
+
+const POLICIES: &[&str] = &[REFRESH_POLICY_NAME];
+
+const REFRESH_POLICY_NAME: &str = "refresh";
+
+impl Coordinator {
+    #[mz_ore::instrument(level = "debug")]
+    /// Call each scheduling policy.
+    pub(crate) async fn check_scheduling_policies(&mut self) {
+        // (So far, we have only this one policy.)
+        self.check_refresh_policy();
+    }
+
+    /// Runs the `SCHEDULE = ON REFRESH` cluster scheduling policy, which makes cluster On/Off
+    /// decisions based on REFRESH materialized view write frontiers and the current time (the local
+    /// oracle read ts), and sends `Message::SchedulingDecisions` with these decisions.
+    /// (Queries the timestamp oracle on a background task.)
+    fn check_refresh_policy(&mut self) {
+        let start_time = Instant::now();
+
+        // Collect the smallest REFRESH MV write frontiers per cluster.
+        let mut min_refresh_mv_write_frontiers = Vec::new();
+        for cluster in self.catalog().clusters() {
+            if let ClusterVariant::Managed(ref config) = cluster.config.variant {
+                match config.schedule {
+                    ClusterScheduleOptionValue::Manual => {
+                        // Nothing to do, user manages this cluster manually.
+                    }
+                    ClusterScheduleOptionValue::Refresh => {
+                        let refresh_mv_write_frontiers = cluster
+                            .bound_objects()
+                            .iter()
+                            .filter_map(|id| {
+                                if let CatalogItem::MaterializedView(mv) =
+                                    self.catalog().get_entry(id).item()
+                                {
+                                    if mv.refresh_schedule.is_some() {
+                                        Some(&self
+                                            .controller
+                                            .storage
+                                            .collection(*id)
+                                            .expect("the storage controller should know about MVs that exist in the catalog")
+                                            .write_frontier)
+                                    } else {
+                                        None
+                                    }
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect_vec();
+                        debug!(%cluster.id, ?refresh_mv_write_frontiers, "check_refresh_policy");
+                        min_refresh_mv_write_frontiers.push((
+                            cluster.id,
+                            refresh_mv_write_frontiers
+                                .into_iter()
+                                .fold(Antichain::new(), |ac1, ac2| Lattice::meet(&ac1, ac2)),
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Spawn a background task that queries the timestamp oracle for the current read timestamp,
+        // compares this ts with the REFRESH MV write frontiers, thus making On/Off decisions per
+        // cluster, and sends a `Message::SchedulingDecisions` with these decisions.
+        let ts_oracle = self.get_local_timestamp_oracle();
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
+        let check_scheduling_policies_seconds_cloned =
+            self.metrics.check_scheduling_policies_seconds.clone();
+        mz_ore::task::spawn(|| "refresh policy get ts and make decisions", async move {
+            let task_start_time = Instant::now();
+            let local_read_ts = ts_oracle.read_ts().await;
+            debug!(%local_read_ts, ?min_refresh_mv_write_frontiers, "check_refresh_policy background task");
+            let decisions = min_refresh_mv_write_frontiers
+                .into_iter()
+                .map(|(cluster_id, min_refresh_mv_write_frontier)| {
+                    (
+                        cluster_id,
+                        min_refresh_mv_write_frontier.less_than(&local_read_ts),
+                    )
+                })
+                .collect();
+            if let Err(e) = internal_cmd_tx.send(Message::SchedulingDecisions(vec![(
+                REFRESH_POLICY_NAME,
+                decisions,
+            )])) {
+                // It is not an error for this task to be running after `internal_cmd_rx` is dropped.
+                warn!("internal_cmd_rx dropped before we could send: {:?}", e);
+            }
+            check_scheduling_policies_seconds_cloned
+                .with_label_values(&[REFRESH_POLICY_NAME, "background"])
+                .observe((Instant::now() - task_start_time).as_secs_f64());
+        });
+
+        self.metrics
+            .check_scheduling_policies_seconds
+            .with_label_values(&[REFRESH_POLICY_NAME, "main"])
+            .observe((Instant::now() - start_time).as_secs_f64());
+    }
+
+    /// Handles `SchedulingDecisions`:
+    /// 1. Adds the newly made decisions to `cluster_scheduling_decisions`.
+    /// 2. Cleans up old decisions that are for clusters no longer in scope of automated scheduling
+    ///   decisions.
+    /// 3. For each cluster, it sums up `cluster_scheduling_decisions`, checks the summed up decision
+    ///   against the cluster state, and turns cluster On/Off if needed.
+    #[mz_ore::instrument(level = "debug")]
+    pub(crate) async fn handle_scheduling_decisions(
+        &mut self,
+        decisions: Vec<(&'static str, Vec<(ClusterId, bool)>)>,
+    ) {
+        let start_time = Instant::now();
+
+        // 1. Add the received decisions to `cluster_scheduling_decisions`.
+        for (policy_name, decisions) in decisions.iter() {
+            for (cluster_id, decision) in decisions {
+                self.cluster_scheduling_decisions
+                    .entry(*cluster_id)
+                    .or_insert_with(Default::default)
+                    .insert(policy_name, *decision);
+            }
+        }
+
+        // 2. Clean up those clusters from `scheduling_decisions` that
+        // - have been dropped, or
+        // - were switched to unmanaged, or
+        // - were switched to `SCHEDULE = MANUAL`.
+        for cluster_id in self
+            .cluster_scheduling_decisions
+            .keys()
+            .cloned()
+            .collect_vec()
+        {
+            match self.get_managed_cluster_config(cluster_id) {
+                None => {
+                    // Cluster have been dropped or switched to unmanaged.
+                    debug!(
+                        "handle_scheduling_decisions: \
+                        Removing cluster {} from cluster_scheduling_decisions, \
+                        because get_managed_cluster_config returned None",
+                        cluster_id
+                    );
+                    self.cluster_scheduling_decisions.remove(&cluster_id);
+                }
+                Some(managed_config) => {
+                    if matches!(managed_config.schedule, ClusterScheduleOptionValue::Manual) {
+                        debug!(
+                            "handle_scheduling_decisions: \
+                            Removing cluster {} from cluster_scheduling_decisions, \
+                            because schedule is Manual",
+                            cluster_id
+                        );
+                        self.cluster_scheduling_decisions.remove(&cluster_id);
+                    }
+                }
+            }
+        }
+
+        // 3. Act on `scheduling_decisions` where needed.
+        let mut altered_a_cluster = false;
+        for (cluster_id, decisions) in self.cluster_scheduling_decisions.clone() {
+            // We touch a cluster only when all policies have made a decision about it. This is
+            // to ensure that after an envd restart all policies have a chance to run at least once
+            // before we turn off a cluster, to avoid spuriously turning off a cluster and possibly
+            // losing a hydrated state.
+            if POLICIES.iter().all(|policy| decisions.contains_key(policy)) {
+                // Check whether the cluster's state matches the needed state.
+                let needs_replica = decisions.values().contains(&true);
+                let cluster_config = self
+                    .get_managed_cluster_config(cluster_id)
+                    .expect("cleaned up non-existing and unmanaged clusters above");
+                let has_replica = cluster_config.replication_factor > 0; // Is it On?
+                if needs_replica != has_replica {
+                    // Turn the cluster On or Off.
+                    altered_a_cluster = true;
+                    let mut new_config = cluster_config.clone();
+                    new_config.replication_factor = if needs_replica { 1 } else { 0 };
+                    if let Err(e) = self
+                        .sequence_alter_cluster_managed_to_managed(
+                            None,
+                            cluster_id,
+                            &cluster_config,
+                            new_config.clone(),
+                        )
+                        .await
+                    {
+                        soft_panic_or_log!(
+                            "handle_scheduling_decisions couldn't alter cluster {}. \
+                             Old config: {:?}, \
+                             New config: {:?}, \
+                             Error: {}",
+                            cluster_id,
+                            cluster_config,
+                            new_config,
+                            e
+                        );
+                    }
+                }
+            } else {
+                debug!(
+                    "handle_scheduling_decisions: \
+                    Not all policies have made a decision about cluster {}. decisions: {:?}",
+                    cluster_id, decisions,
+                );
+            }
+        }
+
+        self.metrics
+            .handle_scheduling_decisions_seconds
+            .with_label_values(&[altered_a_cluster.to_string().as_str()])
+            .observe((Instant::now() - start_time).as_secs_f64());
+    }
+
+    /// Returns the managed config for a cluster. Returns None if the cluster doesn't exist or if
+    /// it's an unmanaged cluster.
+    fn get_managed_cluster_config(&self, cluster_id: ClusterId) -> Option<ClusterVariantManaged> {
+        let cluster = self.catalog().try_get_cluster(cluster_id)?;
+        if let ClusterVariant::Managed(managed_config) = cluster.config.variant.clone() {
+            Some(managed_config)
+        } else {
+            None
+        }
+    }
+}

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -211,6 +211,12 @@ impl Coordinator {
                         )
                         .await;
                 }
+                Message::CheckSchedulingPolicies => {
+                    self.check_scheduling_policies().await;
+                }
+                Message::SchedulingDecisions(decisions) => {
+                    self.handle_scheduling_decisions(decisions).await;
+                }
             }
         }
         .instrument(span)

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -113,7 +113,9 @@ impl Coordinator {
     }
 
     /// Returns a [`TimestampOracle`] used for reads and writes from/to a local input.
-    fn get_local_timestamp_oracle(&self) -> Arc<dyn TimestampOracle<Timestamp> + Send + Sync> {
+    pub(crate) fn get_local_timestamp_oracle(
+        &self,
+    ) -> Arc<dyn TimestampOracle<Timestamp> + Send + Sync> {
         self.get_timestamp_oracle(&Timeline::EpochMilliseconds)
     }
 

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -37,6 +37,8 @@ pub struct Metrics {
     pub append_table_duration_seconds: HistogramVec,
     pub webhook_validation_reduce_failures: IntCounterVec,
     pub webhook_get_appender: IntCounter,
+    pub check_scheduling_policies_seconds: HistogramVec,
+    pub handle_scheduling_decisions_seconds: HistogramVec,
 }
 
 impl Metrics {
@@ -141,6 +143,18 @@ impl Metrics {
             webhook_get_appender: registry.register(metric!(
                 name: "mz_webhook_get_appender_count",
                 help: "Count of getting a webhook appender from the Coordinator.",
+            )),
+            check_scheduling_policies_seconds: registry.register(metric!(
+                name: "mz_check_scheduling_policies_seconds",
+                help: "The time each policy in `check_scheduling_policies` takes.",
+                var_labels: ["policy", "thread"],
+                buckets: histogram_seconds_buckets(0.000_128, 8.0),
+            )),
+            handle_scheduling_decisions_seconds: registry.register(metric!(
+                name: "mz_handle_scheduling_decisions_seconds",
+                help: "The time `handle_scheduling_decisions` takes.",
+                var_labels: ["altered_a_cluster"],
+                buckets: histogram_seconds_buckets(0.000_128, 8.0),
             )),
         }
     }

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -2100,6 +2100,13 @@ impl mz_sql::catalog::CatalogCluster<'_> for Cluster {
             _ => None,
         }
     }
+
+    fn schedule(&self) -> Option<&ClusterScheduleOptionValue> {
+        match &self.config.variant {
+            ClusterVariant::Managed(ClusterVariantManaged { schedule, .. }) => Some(schedule),
+            _ => None,
+        }
+    }
 }
 
 impl mz_sql::catalog::CatalogClusterReplica<'_> for ClusterReplica {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -30,7 +30,9 @@ use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap};
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::role_id::RoleId;
 use mz_repr::{ColumnName, GlobalId, RelationDesc};
-use mz_sql_parser::ast::{Expr, Ident, QualifiedReplica, UnresolvedItemName};
+use mz_sql_parser::ast::{
+    ClusterScheduleOptionValue, Expr, Ident, QualifiedReplica, UnresolvedItemName,
+};
 use mz_storage_types::connections::inline::{ConnectionResolver, ReferencedConnection};
 use mz_storage_types::connections::{Connection, ConnectionContext};
 use mz_storage_types::sources::SourceDesc;
@@ -533,6 +535,9 @@ pub trait CatalogCluster<'a> {
 
     /// Returns the size of the cluster, if the cluster is a managed cluster.
     fn managed_size(&self) -> Option<&str>;
+
+    /// Returns the schedule of the cluster, if the cluster is a managed cluster.
+    fn schedule(&self) -> Option<&ClusterScheduleOptionValue>;
 }
 
 /// A cluster replica in a [`SessionCatalog`]

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1181,6 +1181,7 @@ impl SystemVars {
             &cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY,
             &cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT,
             &cluster_scheduling::CLUSTER_ALWAYS_USE_DISK,
+            &cluster_scheduling::CLUSTER_CHECK_SCHEDULING_POLICIES_INTERVAL,
             &grpc_client::HTTP2_KEEP_ALIVE_TIMEOUT,
             &STATEMENT_LOGGING_MAX_SAMPLE_RATE,
             &STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE,
@@ -2005,6 +2006,10 @@ impl SystemVars {
 
     pub fn cluster_always_use_disk(&self) -> bool {
         *self.expect_value(&cluster_scheduling::CLUSTER_ALWAYS_USE_DISK)
+    }
+
+    pub fn cluster_check_scheduling_policies_interval(&self) -> Duration {
+        *self.expect_value(&cluster_scheduling::CLUSTER_CHECK_SCHEDULING_POLICIES_INTERVAL)
     }
 
     /// Returns the `privatelink_status_update_quota_per_minute` configuration parameter.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1538,6 +1538,16 @@ pub mod cluster_scheduling {
         "Always provisions a replica with disk, regardless of `DISK` DDL option.",
         true,
     );
+
+    const DEFAULT_CHECK_SCHEDULING_POLICIES_INTERVAL: Duration = Duration::from_secs(3);
+
+    pub static CLUSTER_CHECK_SCHEDULING_POLICIES_INTERVAL: VarDefinition = VarDefinition::new(
+        "cluster_check_scheduling_policies_interval",
+        value!(Duration; DEFAULT_CHECK_SCHEDULING_POLICIES_INTERVAL),
+        "How often policies are invoked to automatically start/stop clusters, e.g., \
+            for REFRESH EVERY materialized views.",
+        true,
+    );
 }
 
 /// Macro to simplify creating feature flags, i.e. boolean flags that we use to toggle the
@@ -2006,7 +2016,14 @@ feature_flags!(
     },
     {
         name: enable_refresh_every_mvs,
-        desc: "REFRESH EVERY materialized views",
+        desc: "REFRESH EVERY and REFRESH AT materialized views",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
+    {
+        name: enable_cluster_schedule_refresh,
+        desc: "`SCHEDULE = ON REFRESH` cluster option",
         default: false,
         internal: true,
         enable_for_item_parsing: true,

--- a/src/sql/src/session/vars/value.rs
+++ b/src/sql/src/session/vars/value.rs
@@ -1122,6 +1122,7 @@ macro_rules! impl_value_for_simple {
 
 impl_value_for_simple!(i32, "integer");
 impl_value_for_simple!(u32, "unsigned integer");
+impl_value_for_simple!(u64, "64-bit unsigned integer");
 impl_value_for_simple!(usize, "unsigned integer");
 impl_value_for_simple!(f64, "double-precision floating-point number");
 

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -657,7 +657,7 @@ ALTER SYSTEM SET enable_refresh_every_mvs = false
 COMPLETE 0
 
 # Should be disabled
-query error db error: ERROR: REFRESH EVERY materialized views is not supported
+query error db error: ERROR: REFRESH EVERY and REFRESH AT materialized views is not supported
 CREATE MATERIALIZED VIEW mv_bad WITH (ASSERT NOT NULL x, REFRESH EVERY '8 seconds') AS SELECT * FROM t2;
 
 simple conn=mz_system,user=mz_system
@@ -1102,6 +1102,20 @@ EXPLAIN REPLAN MATERIALIZED VIEW mv8;
 # Automated cluster scheduling for REFRESH
 # ----------------------------------------
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_cluster_schedule_refresh = false
+----
+COMPLETE 0
+
+# Should be disabled
+query error db error: ERROR: `SCHEDULE = ON REFRESH` cluster option is not supported
+CREATE CLUSTER c_schedule_0 (SIZE = '1', SCHEDULE = ON REFRESH);
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_cluster_schedule_refresh = true
+----
+COMPLETE 0
+
 statement error db error: ERROR: Expected one of MANUAL or ON, found identifier "aaaaaaaa"
 CREATE CLUSTER c_schedule_0 (SIZE = '1', SCHEDULE = AAAAAAAA);
 
@@ -1111,23 +1125,70 @@ CREATE CLUSTER c_schedule_0 (SIZE = '1', SCHEDULE = 42);
 statement error db error: ERROR: Expected one of MANUAL or ON, found REFRESH
 CREATE CLUSTER c_schedule_0 (SIZE = '1', SCHEDULE = REFRESH);
 
+statement error db error: ERROR: REPLICATION FACTOR cannot be given together with any SCHEDULE other than MANUAL
+CREATE CLUSTER c_schedule_0 (SIZE = '1', SCHEDULE = ON REFRESH, REPLICATION FACTOR = 1);
+
 statement ok
 CREATE CLUSTER c_schedule_1 (SIZE = '1', SCHEDULE = MANUAL);
 
 statement ok
 CREATE CLUSTER c_schedule_2 (SIZE = '1', SCHEDULE MANUAL);
 
-statement error db error: ERROR: cluster schedules other than MANUAL are not supported
+statement ok
 CREATE CLUSTER c_schedule_3 (SIZE = '1', SCHEDULE = ON REFRESH);
 
-statement ok
-ALTER cluster c_schedule_1 RESET (SCHEDULE);
+statement error db error: ERROR: REPLICATION FACTOR cannot be set if the cluster SCHEDULE is anything other than MANUAL
+ALTER CLUSTER c_schedule_3 SET (REPLICATION FACTOR = 1);
 
 statement ok
-ALTER cluster c_schedule_1 SET (SCHEDULE = MANUAL);
+ALTER CLUSTER c_schedule_1 RESET (SCHEDULE);
 
-statement error db error: ERROR: cluster schedules other than MANUAL are not supported
-ALTER cluster c_schedule_1 SET (SCHEDULE = ON REFRESH);
+statement error db error: ERROR: REPLICATION FACTOR cannot be given together with any SCHEDULE other than MANUAL
+ALTER CLUSTER c_schedule_1 SET (REPLICATION FACTOR = 1, SCHEDULE = ON REFRESH);
+
+statement ok
+ALTER CLUSTER c_schedule_1 SET (SCHEDULE = MANUAL);
+
+statement ok
+ALTER CLUSTER c_schedule_1 SET (SCHEDULE = ON REFRESH);
+
+statement ok
+SELECT mz_unsafe.mz_sleep(3+2);
+
+# Should turn off.
+query I
+SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'c_schedule_1';
+----
+0
+
+statement error db error: ERROR: cluster schedules other than MANUAL are not supported for unmanaged clusters
+ALTER CLUSTER c_schedule_1 SET (MANAGED = false, SCHEDULE = ON REFRESH);
+
+# The SCHEDULE shouldn't simply "fall off" when switching to unmanaged,
+statement error db error: ERROR: when switching a cluster to unmanaged, if the managed cluster's SCHEDULE is anything other than MANUAL, you have to explicitly set the SCHEDULE to MANUAL
+ALTER CLUSTER c_schedule_1 SET (MANAGED = false);
+
+# ... but can be explicitly set to MANUAL in the same command.
+statement ok
+ALTER CLUSTER c_schedule_1 SET (MANAGED = false, SCHEDULE = MANUAL);
+
+statement ok
+ALTER CLUSTER c_schedule_1 SET (MANAGED = true, SIZE = '1');
+
+statement ok
+ALTER CLUSTER c_schedule_1 SET (SCHEDULE = ON REFRESH);
+
+# Setting some other cluster option in ALTER CLUSTER shouldn't change the SCHEDULE.
+# (The sleep is needed so that if the following ALTER erroneously sets the SCHEDULE to MANUAL, then we should be in a
+# turned off state at that moment to trigger errors in later tests.)
+statement ok
+SELECT mz_unsafe.mz_sleep(3);
+
+statement ok
+ALTER CLUSTER c_schedule_1 SET (INTROSPECTION DEBUGGING = TRUE);
+
+statement ok
+ALTER CLUSTER c_schedule_1 RESET (INTROSPECTION DEBUGGING);
 
 statement ok
 CREATE CLUSTER unmanaged1 (SCHEDULE = MANUAL, REPLICAS (r1 (SIZE '1')))
@@ -1138,5 +1199,105 @@ ALTER cluster unmanaged1 SET (SCHEDULE = MANUAL);
 statement error db error: ERROR: cluster schedules other than MANUAL are not supported for unmanaged clusters
 ALTER cluster unmanaged1 SET (SCHEDULE = ON REFRESH);
 
+statement error db error: ERROR: REPLICATION FACTOR cannot be given together with any SCHEDULE other than MANUAL
+ALTER cluster unmanaged1 SET (managed = true, SCHEDULE = ON REFRESH, REPLICATION FACTOR = 1, SIZE = '1');
+
 statement error db error: ERROR: cluster schedules other than MANUAL are not supported for unmanaged clusters
 CREATE CLUSTER unmanaged2 (SCHEDULE = ON REFRESH, REPLICAS (r1 (SIZE '1')))
+
+statement ok
+CREATE CLUSTER c_schedule_5 (SIZE = '1');
+
+statement error db error: ERROR: Expected one of OWNER or RENAME or RESET or SET or SWAP, found left parenthesis
+ALTER CLUSTER c_schedule_5 (MANAGED = false, SCHEDULE = REFRESH);
+
+statement ok
+CREATE MATERIALIZED VIEW mv9
+IN CLUSTER c_schedule_1
+WITH (REFRESH = EVERY '8 sec')
+AS SELECT sum(x*y*z) + count(*) FROM t2;
+
+query I
+SELECT * FROM mv9;
+----
+1371335
+
+statement ok
+INSERT INTO t2 VALUES (1, 0, 1);
+
+statement ok
+SELECT mz_unsafe.mz_sleep(8+1);
+
+query I
+SELECT * FROM mv9;
+----
+1371336
+
+statement ok
+CREATE MATERIALIZED VIEW mv10
+IN CLUSTER c_schedule_1
+WITH (REFRESH AT CREATION)
+AS SELECT count(*) FROM t2;
+
+query I
+SELECT * FROM mv10
+----
+10
+
+# The other refresh cluster should be off, because there is no refresh MV on it yet.
+query I
+SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'c_schedule_3';
+----
+0
+
+# A `REFRESH AT CREATION` MV alone on a cluster should make the cluster turn on.
+statement ok
+CREATE MATERIALIZED VIEW mv11
+IN CLUSTER c_schedule_3
+WITH (REFRESH AT CREATION)
+AS SELECT count(*) FROM t2;
+
+query I
+SELECT * FROM mv11
+----
+10
+
+## Very short refresh interval.
+
+statement ok
+CREATE CLUSTER c_schedule_4 (SIZE = '1', SCHEDULE = ON REFRESH);
+
+statement ok
+CREATE MATERIALIZED VIEW mv12
+IN CLUSTER c_schedule_4
+WITH (REFRESH EVERY '1 millisecond')
+AS SELECT count(*) FROM t2;
+
+query I
+SELECT * FROM mv12
+----
+10
+
+statement ok
+INSERT INTO t2 VALUES (1, 1, 10);
+
+query I
+SELECT * FROM mv12
+----
+11
+
+# This should set the schedule back to manual.
+statement ok
+ALTER CLUSTER c_schedule_4 RESET (SCHEDULE);
+
+statement ok
+ALTER CLUSTER c_schedule_4 SET (REPLICATION FACTOR = 0);
+
+statement ok
+SELECT mz_unsafe.mz_sleep(3);
+
+# Should stay off, because it was reset to manual.
+query I
+SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'c_schedule_3';
+----
+0

--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -10,6 +10,9 @@
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_refresh_every_mvs = true
 
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET enable_cluster_schedule_refresh = true
+
 > CREATE DATABASE materialized_view_refresh_options;
 > SET DATABASE = materialized_view_refresh_options;
 
@@ -383,4 +386,143 @@ true
   WHERE name = 'mv10';
 true
 
+# ----------------------------------------
+# Automated cluster scheduling for REFRESH
+# ----------------------------------------
+
+> CREATE CLUSTER scheduled_cluster (SIZE = '1', SCHEDULE = ON REFRESH);
+
+# No MV yet, so the cluster should be turned off.
+> SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'scheduled_cluster';
+0
+
+> CREATE MATERIALIZED VIEW mv11
+  IN CLUSTER scheduled_cluster
+  WITH (REFRESH = EVERY '8 sec')
+  AS SELECT count(*) FROM t2;
+
+# The cluster should be turned on at some point.
+> SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'scheduled_cluster';
+1
+
+# And then the cluster should compute MV results.
+> SELECT * FROM mv11;
+4
+
+# The cluster should be turned off at some point.
+> SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'scheduled_cluster';
+0
+
+# We should have a "drop" in `mz_audit_events`
+> SELECT count(*) > 0
+  FROM mz_audit_events
+  WHERE
+    event_type = 'drop' AND
+    object_type = 'cluster-replica' AND
+    (details->'cluster_name')::text = '"scheduled_cluster"' AND
+    user IS NULL;
+true
+
+> DELETE FROM t2;
+
+# The cluster should be turned on at some point again.
+> SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'scheduled_cluster';
+1
+
+# And then the cluster should compute MV results again.
+> SELECT * FROM mv11;
+0
+
+# We should have a "create" in `mz_audit_events`
+> SELECT count(*) > 0
+  FROM mz_audit_events
+  WHERE
+    event_type = 'create' AND
+    object_type = 'cluster-replica' AND
+    (details->'cluster_name')::text = '"scheduled_cluster"' AND
+    user IS NULL;
+true
+
+# Things should keep working if we switch from managed to unmanaged cluster and then back.
+> ALTER CLUSTER scheduled_cluster SET (MANAGED = false, SCHEDULE = MANUAL);
+> ALTER CLUSTER scheduled_cluster SET (MANAGED = true, SIZE = '1', SCHEDULE = ON REFRESH);
+
+> INSERT INTO t2 VALUES (64);
+
+> SELECT * FROM mv11;
+1
+
+## When we create an MV whose first refresh is in the far future, we should immediately turn on the cluster briefly, so
+## that the Persist shard's write frontier moves from 0 to the first refresh time.
+
+> CREATE CLUSTER scheduled_cluster_2 (SIZE = '1', SCHEDULE = ON REFRESH);
+> SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'scheduled_cluster_2';
+0
+
+> CREATE MATERIALIZED VIEW mv12
+  IN CLUSTER scheduled_cluster_2
+  WITH (REFRESH AT '3000-01-01 23:59')
+  AS SELECT sum(y) FROM t2;
+
+# The MV's write frontier should move away from 0.
+> SELECT f.write_frontier > 0
+  FROM mz_internal.mz_frontiers f
+  JOIN mz_materialized_views m ON (m.id = f.object_id)
+  WHERE m.name = 'mv12'
+true
+
+# But then the cluster should turn off.
+> SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'scheduled_cluster_2';
+0
+
+## Unbilled replicas.
+## - The auto scheduling won't create or drop unbilled replicas.
+## - But unbilled replicas can affect the auto scheduling: If a cluster has an unbilled replica at the moment when a
+##   refresh should happen, the unbilled replica might complete the refresh before the auto scheduling has a chance to
+##   create a replica. (However, it's not guaranteed that an unbilled replica will prevent the auto scheduling from
+##   creating a replica.)
+
+# Creating an unbilled replica on a `SCHEDULE = ON REFRESH` cluster shouldn't blow things up.
+
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+$ postgres-execute connection=mz_system
+CREATE CLUSTER REPLICA scheduled_cluster.unbilled SIZE '2-2', BILLED AS 'free', INTERNAL;
+
+> INSERT INTO t2 VALUES (200);
+
+> SELECT * FROM mv11;
+2
+
+# Unbilled is not auto-dropped.
+
+> SELECT r.name
+  FROM mz_catalog.mz_cluster_replicas r, mz_catalog.mz_clusters c
+  WHERE c.id = r.cluster_id AND c.name = 'scheduled_cluster';
+unbilled
+
+> SELECT mz_unsafe.mz_sleep(3);
+<null>
+
+> SELECT r.name
+  FROM mz_catalog.mz_cluster_replicas r, mz_catalog.mz_clusters c
+  WHERE c.id = r.cluster_id AND c.name = 'scheduled_cluster';
+unbilled
+
+# Things continue normally after the unbilled is (manually) dropped.
+
+$ postgres-execute connection=mz_system
+DROP CLUSTER REPLICA scheduled_cluster.unbilled;
+
+> INSERT INTO t2 VALUES (99);
+
+> SELECT * FROM mv11;
+3
+
+# ----------------------------------------
+# Cleanup
+# ----------------------------------------
+
 > DROP DATABASE materialized_view_refresh_options;
+> DROP CLUSTER refresh_cluster;
+> DROP CLUSTER scheduled_cluster;
+> DROP CLUSTER scheduled_cluster_2;


### PR DESCRIPTION
This is the main PR of implementing the automated cluster scheduling for REFRESH MVs (https://github.com/MaterializeInc/materialize/issues/25712), i.e., automatically turning on clusters when the time comes for a refresh. (Earlier PRs: https://github.com/MaterializeInc/materialize/pull/25998, https://github.com/MaterializeInc/materialize/pull/26242.) 

I've tagged @ParkMyCar and @benesch, because I had some design discussions with both of you.

[Meeting notes](https://www.notion.so/materialize/Compute-meeting-on-automatic-cluster-scheduling-ce353b8af52e449d8784241c4a1c0585) where we sketched some aspects of the design.

I've put most of the implementation in a separate file: `src/adapter/src/coord/cluster_scheduling.rs` (rather than e.g., `message_handler.rs` or `coord.rs`); I hope that's ok.

Note that I'm using the term "scheduling", which might be confused with [replica placement](https://github.com/MaterializeInc/materialize/blob/abdefa840dee47ac61885d8ceb9437f1038f020b/src/sql/src/session/vars/definitions.rs#L1472), which is also termed `cluster_scheduling`. I'm open to suggestions on how to make the terminology clearer. Maybe we could rename `cluster_scheduling` to `replica_placement`?

Note that currently there is only one policy (`SCHEDULE = REFRESH`), but we made the decision in the above meeting with @benesch to already have a separation of policies and the mechanism of acting on policy decisions (discussed [here](https://www.notion.so/materialize/Compute-meeting-on-automatic-cluster-scheduling-ce353b8af52e449d8784241c4a1c0585?pvs=4#1515f35684eb46488651f46b2413e84a)). For the Policy-Mechanism separation, I made some further design decisions not mentioned in the design meeting:
- We wait for all policies to make a decision about a cluster before acting on policy decisions. This is because certain future policies might be called not just together with all the other policies periodically with `check_scheduling_policies_interval.tick()`, but also in isolation, in response to certain events. For example, we might create a policy for turning on clusters in response to peeks, where the `SchedulingDecisions` msg could be sent from the peek handling code, with a decision only from this one policy.
- `SCHEDULE = MANUAL` clusters are explicitly ignored by both `check_scheduling_policies` and `handle_scheduling_decisions`. Note that we couldn't make these clusters blend into the scheduling by having policies make always On or always Off decisions for them, because these would override the manual decisions of users.

@MaterializeInc/testing, I've added various tests, including restart tests, but let me know if you can think of further tests to add.

(This is the penultimate PR for automated cluster scheduling for REFRESH MVs. The last PR will add a user-configurable warmup time: `CREATE MATERIALIZED VIEW` will get a `WARMUP` option, which will specify that the cluster should be turned on not exactly at the refresh time, but a bit earlier, by a fixed time interval. This is to allow the cluster to complete rehydration before the refresh time, so that the refresh can be instantaneously performed, without MV downtime.)

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/materialize/issues/25712

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
