### PR TITLE
[persist] Split up runs that might not truly be consolidated

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -326,6 +326,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER)
         .add(&crate::internal::state::ROLLUP_THRESHOLD)
         .add(&crate::internal::apply::ROUNDTRIP_SPINE)
+        .add(&crate::iter::SPLIT_OLD_RUNS)
         .add(&crate::operators::PERSIST_SINK_MINIMUM_BATCH_UPDATES)
         .add(&crate::operators::STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
         .add(&crate::operators::STORAGE_SOURCE_DECODE_FUEL)

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -40,7 +40,7 @@ use crate::internal::machine::Machine;
 use crate::internal::metrics::ShardMetrics;
 use crate::internal::state::{BatchPart, HollowBatch};
 use crate::internal::trace::{ApplyMergeResult, FueledMergeRes};
-use crate::iter::Consolidator;
+use crate::iter::{Consolidator, SPLIT_OLD_RUNS};
 use crate::{Metrics, PersistConfig, ShardId, WriterId};
 
 /// A request for compaction.
@@ -72,6 +72,7 @@ pub struct CompactRes<T> {
 pub struct CompactConfig {
     pub(crate) compaction_memory_bound_bytes: usize,
     pub(crate) compaction_yield_after_n_updates: usize,
+    pub(crate) split_old_runs: bool,
     pub(crate) version: semver::Version,
     pub(crate) batch: BatchBuilderConfig,
 }
@@ -82,6 +83,7 @@ impl CompactConfig {
         let mut ret = CompactConfig {
             compaction_memory_bound_bytes: value.dynamic.compaction_memory_bound_bytes(),
             compaction_yield_after_n_updates: value.compaction_yield_after_n_updates,
+            split_old_runs: SPLIT_OLD_RUNS.get(&value.configs),
             version: value.build_version.clone(),
             batch: BatchBuilderConfig::new(value, writer_id),
         };
@@ -715,6 +717,7 @@ where
                 since: desc.since().clone(),
             },
             prefetch_budget_bytes,
+            cfg.split_old_runs,
         );
 
         for (desc, parts) in runs {

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -704,6 +704,12 @@ where
         );
 
         let mut consolidator = Consolidator::new(
+            format!(
+                "{}[lower={:?},upper={:?}]",
+                shard_id,
+                desc.lower().elements(),
+                desc.upper().elements()
+            ),
             Arc::clone(&metrics),
             FetchBatchFilter::Compaction {
                 since: desc.since().clone(),

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -242,6 +242,7 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidation
 /// but it's also free to abandon the instance at any time if it eg. only needs a few entries.
 #[derive(Debug)]
 pub(crate) struct Consolidator<T, D> {
+    context: String,
     metrics: Arc<Metrics>,
     runs: Vec<VecDeque<(ConsolidationPart<T, D>, usize)>>,
     filter: FetchBatchFilter<T>,
@@ -263,11 +264,13 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
     /// on the size of the parts that the consolidator will fetch... we'll try and stay below the
     /// limit, but may burst above it if that's necessary to make progress.
     pub fn new(
+        context: String,
         metrics: Arc<Metrics>,
         filter: FetchBatchFilter<T>,
         prefetch_budget_bytes: usize,
     ) -> Self {
         Self {
+            context,
             metrics,
             runs: vec![],
             filter,
@@ -407,6 +410,7 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
         }
 
         let mut iter = ConsolidatingIter::new(
+            &self.context,
             self.initial_state.as_ref().map(borrow_tuple),
             &mut self.drop_stash,
         );
@@ -752,6 +756,7 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> PartRef<'a, T
 
 #[derive(Debug)]
 pub(crate) struct ConsolidatingIter<'a, T: Timestamp, D> {
+    context: &'a str,
     parts: Vec<ConsolidationPartIter<'a, T, D>>,
     heap: BinaryHeap<PartRef<'a, T, D>>,
     upper_bound: Option<(&'a [u8], &'a [u8], T)>,
@@ -765,10 +770,12 @@ where
     D: Codec64 + Semigroup,
 {
     pub fn new(
+        context: &'a str,
         init_state: Option<TupleRef<'a, T, D>>,
         drop_stash: &'a mut Option<Tuple<T, D>>,
     ) -> Self {
         Self {
+            context,
             parts: vec![],
             heap: BinaryHeap::new(),
             upper_bound: None,
@@ -816,7 +823,8 @@ where
                             // Don't want to log the entire KV, but it's interesting to know
                             // whether it's KVs going backwards or 'just' timestamps.
                             panic!(
-                                "data arrived at the consolidator out of order (kvs equal? {})",
+                                "data arrived at the consolidator out of order ({}, kvs equal? {})",
+                                self.context,
                                 (*k0, *v0) == (*k1, *v1)
                             );
                         }
@@ -918,6 +926,7 @@ mod tests {
             let streaming = {
                 // Toy compaction loop!
                 let mut consolidator = Consolidator {
+                    context: "test".to_string(),
                     metrics: Arc::clone(metrics),
                     // Generated runs of data that are sorted, but not necessarily consolidated.
                     // This is because timestamp-advancement may cause us to have duplicate KVTs,
@@ -999,6 +1008,7 @@ mod tests {
             let shard_metrics = metrics.shards.shard(&shard_id, "");
 
             let mut consolidator: Consolidator<u64, i64> = Consolidator::new(
+                "test".to_string(),
                 Arc::clone(&metrics),
                 FetchBatchFilter::Compaction {
                     since: desc.since().clone(),

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1070,6 +1070,7 @@ where
         let batches = self.machine.snapshot(&as_of).await?;
 
         let mut consolidator = Consolidator::new(
+            format!("{}[as_of={:?}]", self.shard_id(), as_of.elements()),
             Arc::clone(&self.metrics),
             FetchBatchFilter::Snapshot {
                 as_of: as_of.clone(),

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -43,7 +43,7 @@ use crate::internal::machine::Machine;
 use crate::internal::metrics::Metrics;
 use crate::internal::state::{BatchPart, HollowBatch};
 use crate::internal::watch::StateWatch;
-use crate::iter::Consolidator;
+use crate::iter::{Consolidator, SPLIT_OLD_RUNS};
 use crate::{parse_id, GarbageCollector, PersistConfig, ShardId};
 
 pub use crate::internal::encoding::LazyPartStats;
@@ -1076,6 +1076,7 @@ where
                 as_of: as_of.clone(),
             },
             self.cfg.dynamic.compaction_memory_bound_bytes(),
+            SPLIT_OLD_RUNS.get(&self.cfg.configs),
         );
 
         let filter = FetchBatchFilter::Snapshot { as_of };


### PR DESCRIPTION
In the distant past, we wrote some >1-length runs that aren't actually consolidated: due to bugs or to ordering changes. This is annoying because the Consolidator requires its inputs to be consolidated to produce consolidated output. So: we have code that will re-sort parts that it discovers were written by old versions of Materialize.

However, even if all parts are consolidated, runs might not be! (Oops!) So it's safest to treat runs written using these old versions as though they were a bunch of single-part runs instead.

### Motivation

Known bug: #26170 

This assert has only fired once ever in production, and we didn't have enough debugging info enabled at the time to know for sure that this is the exact issue we hit.

### Tips for reviewer

I started work on a unit test for this, but it is tedious to write because it requires generating batches that aren't correct, which involves a fair bit of low-level code. Let me know if that seems worthwhile!

I've also added some additional context to the log, with hopefully enough information to start an investigation if this assert fires again. Happy to take suggestions on format / content / etc.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
