### PR TITLE
fivetran: Make dependency on `protobuf-src` optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4532,7 +4532,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
- "workspace-hack",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4532,6 +4532,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+ "workspace-hack",
 ]
 
 [[package]]

--- a/src/fivetran-destination/Cargo.toml
+++ b/src/fivetran-destination/Cargo.toml
@@ -16,9 +16,9 @@ clap = { version = "3.2.24", features = ["derive", "env"] }
 csv-async = { version = "1.2.6", default-features = false, features = ["tokio"] }
 futures = "0.3.25"
 itertools = "0.10.5"
-mz-ore = { path = "../ore", features = ["cli", "id_gen"] }
-mz-pgrepr = { path = "../pgrepr" }
-mz-sql-parser = { path = "../sql-parser" }
+mz-ore = { path = "../ore", features = ["cli", "id_gen"], default-features = false }
+mz-pgrepr = { path = "../pgrepr", default-features = false }
+mz-sql-parser = { path = "../sql-parser", default-features = false }
 openssl = { version = "0.10.48", features = ["vendored"] }
 postgres-openssl = "0.5.0"
 postgres-protocol = { version = "0.6.5" }
@@ -37,16 +37,12 @@ tokio-util = { version = "0.7.4", features = ["io"] }
 tracing = "0.1.37"
 tracing-core = "0.1.30"
 tracing-subscriber = "0.3.16"
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 insta = "1.32"
 
 [build-dependencies]
 prost-build = "0.11.2"
-protobuf-src = "1.1.0"
-reqwest = "0.11.13"
+protobuf-src = { version = "1.1.0", optional = true }
+reqwest = { version = "0.11.13", features = ["blocking"] }
 tonic-build = "0.9.2"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["workspace-hack"]

--- a/src/fivetran-destination/Cargo.toml
+++ b/src/fivetran-destination/Cargo.toml
@@ -37,6 +37,7 @@ tokio-util = { version = "0.7.4", features = ["io"] }
 tracing = "0.1.37"
 tracing-core = "0.1.30"
 tracing-subscriber = "0.3.16"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
 insta = "1.32"
@@ -46,3 +47,6 @@ prost-build = "0.11.2"
 protobuf-src = { version = "1.1.0", optional = true }
 reqwest = { version = "0.11.13", features = ["blocking"] }
 tonic-build = "0.9.2"
+
+[features]
+default = ["protobuf-src"]

--- a/src/fivetran-destination/README.md
+++ b/src/fivetran-destination/README.md
@@ -21,17 +21,24 @@ for instructions.
 ### Binary distribution
 
 To build the destination into a static Rust binary for distribution, first make sure you have
-updated the `misc/fivetran_sdk` submodule, this is how we include the protobuf definitions for the
+updated the `misc/fivetran-sdk` submodule, this is how we include the protobuf definitions for the
 SDK. From the root of the Materialize repository run:
 
 ```shell
-git submodule update --init --recursive misc/fivetran_sdk
+git submodule update --init --recursive misc/fivetran-sdk
 ```
 
-Once you have the `fivetran_sdk` submodule updated, run:
+Once you have the `fivetran-sdk` submodule updated you can build the binary. If you already have 
+[`protoc`](https://grpc.io/docs/protoc-installation/) installed and part of your PATH run:
 
 ```shell
 cargo build --release -p mz-fivetran-destination
+```
+
+Otherwise you can enable the `protobuf-src` feature to build `protoc` from the vendored source:
+
+```shell
+cargo build --release -p mz-fivetran-destination --features protobuf-src
 ```
 
 Cargo will emit the built binary at

--- a/src/fivetran-destination/README.md
+++ b/src/fivetran-destination/README.md
@@ -28,17 +28,17 @@ SDK. From the root of the Materialize repository run:
 git submodule update --init --recursive misc/fivetran-sdk
 ```
 
-Once you have the `fivetran-sdk` submodule updated you can build the binary. If you already have 
-[`protoc`](https://grpc.io/docs/protoc-installation/) installed and part of your PATH run:
+Once you have the `fivetran-sdk` submodule updated you can build the binary with:
 
 ```shell
 cargo build --release -p mz-fivetran-destination
 ```
 
-Otherwise you can enable the `protobuf-src` feature to build `protoc` from the vendored source:
+> **Note:** If you already have [`protoc`](https://grpc.io/docs/protoc-installation/) installed
+and in your PATH, you can skip building the vendored version with:
 
 ```shell
-cargo build --release -p mz-fivetran-destination --features protobuf-src
+cargo build --release -p mz-fivetran-destination --no-default-features
 ```
 
 Cargo will emit the built binary at

--- a/src/fivetran-destination/build.rs
+++ b/src/fivetran-destination/build.rs
@@ -20,6 +20,7 @@ fn main() {
 
     // Build protobufs.
     {
+        #[cfg(feature = "protobuf-src")]
         env::set_var("PROTOC", protobuf_src::protoc());
 
         let mut config = prost_build::Config::new();

--- a/src/lowertest-derive/Cargo.toml
+++ b/src/lowertest-derive/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 proc-macro2 = "1.0.60"
 quote = "1.0.23"
 syn = { version = "1.0.107", features = ["extra-traits", "printing"] }
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/lowertest/Cargo.toml
+++ b/src/lowertest/Cargo.toml
@@ -11,11 +11,11 @@ workspace = true
 
 [dependencies]
 mz-lowertest-derive = { path = "../lowertest-derive" }
-mz-ore = { path = "../ore", features = ["test"] }
+mz-ore = { path = "../ore", features = ["test"], default-features = false }
 proc-macro2 = "1.0.60"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.66"

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -17,8 +17,8 @@ arrow2 = { version = "0.16.0", features = ["compute_aggregate", "io_ipc", "io_pa
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 hex = "0.4.3"
-mz-ore = { path = "../ore", features = ["test"] }
-mz-proto = { path = "../proto" }
+mz-ore = { path = "../ore", features = ["test"], default-features = false }
+mz-proto = { path = "../proto", default-features = false }
 parquet2 = { version = "0.17.1", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
@@ -26,14 +26,18 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 uuid = { version = "1.7.0", features = ["v4"] }
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 
 [build-dependencies]
 prost-build = "0.11.2"
-protobuf-src = "1.1.0"
+protobuf-src = { version = "1.1.0", optional = true }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
+
+[features]
+default = ["protobuf-src", "workspace-hack"]
+protobuf-src = ["dep:protobuf-src", "mz-proto/protobuf-src"]

--- a/src/persist-types/build.rs
+++ b/src/persist-types/build.rs
@@ -7,10 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::env;
-
 fn main() {
-    env::set_var("PROTOC", protobuf_src::protoc());
+    #[cfg(feature = "protobuf-src")]
+    std::env::set_var("PROTOC", protobuf_src::protoc());
 
     prost_build::Config::new()
         .type_attribute(".", "#[derive(serde::Serialize)]")

--- a/src/pgrepr-consts/Cargo.toml
+++ b/src/pgrepr-consts/Cargo.toml
@@ -14,3 +14,6 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
+
+[features]
+default = ["workspace-hack"]

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -15,16 +15,19 @@ bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 dec = "0.4.8"
 once_cell = "1.16.0"
-mz-ore = { path = "../ore" }
-mz-pgrepr-consts = { path = "../pgrepr-consts" }
-mz-pgwire-common = { path = "../pgwire-common" }
-mz-repr = { path = "../repr" }
+mz-ore = { path = "../ore", default-features = false }
+mz-pgrepr-consts = { path = "../pgrepr-consts", default-features = false }
+mz-pgwire-common = { path = "../pgwire-common", default-features = false }
+mz-repr = { path = "../repr", default-features = false }
 postgres-types = { version = "0.2.5", features = [
   "with-chrono-0_4",
   "with-uuid-1",
 ] }
 uuid = "1.2.2"
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
+
+[features]
+default = ["workspace-hack"]

--- a/src/pgtz/Cargo.toml
+++ b/src/pgtz/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 chrono = { version = "0.4.35", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
 mz-lowertest = { path = "../lowertest" }
-mz-ore = { path = "../ore", features = ["test"] }
-mz-proto = { path = "../proto", features = ["chrono"] }
+mz-ore = { path = "../ore", features = ["test"], default-features = false }
+mz-proto = { path = "../proto", features = ["chrono"], default-features = false }
 phf = { version = "0.11.1", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
@@ -26,11 +26,15 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 [build-dependencies]
 anyhow = "1.0.66"
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", default-features = false }
 phf_codegen = "0.11.1"
 prost-build = "0.11.2"
-protobuf-src = "1.1.0"
+protobuf-src = { version = "1.1.0", optional = true }
 uncased = "0.9.7"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
+
+[features]
+default = ["protobuf-src", "workspace-hack"]
+protobuf-src = ["dep:protobuf-src", "mz-proto/protobuf-src"]

--- a/src/pgtz/build.rs
+++ b/src/pgtz/build.rs
@@ -34,6 +34,7 @@ fn main() -> Result<()> {
 
     // Build protobufs.
     {
+        #[cfg(feature = "protobuf-src")]
         env::set_var("PROTOC", protobuf_src::protoc());
 
         prost_build::Config::new()

--- a/src/pgwire-common/Cargo.toml
+++ b/src/pgwire-common/Cargo.toml
@@ -15,13 +15,16 @@ async-trait = "0.1.68"
 byteorder = "1.4.3"
 bytes = "1.3.0"
 bytesize = "1.1.0"
-mz-ore = { path = "../ore", features = ["network"] }
-mz-server-core = { path = "../server-core" }
+mz-ore = { path = "../ore", features = ["network"], default-features = false }
+mz-server-core = { path = "../server-core", default-features = false }
 tokio = "1.24.2"
 tokio-openssl = "0.6.3"
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
+
+[features]
+default = ["workspace-hack"]

--- a/src/proto/Cargo.toml
+++ b/src/proto/Cargo.toml
@@ -27,14 +27,17 @@ serde_json = { version = "1.0.89", features = ["arbitrary_precision"] }
 tokio-postgres = { version = "0.7.8", optional = true }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = "1.2.2"
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [features]
+default = ["protobuf-src", "workspace-hack"]
+
 chrono = ["dep:chrono", "dep:chrono-tz"]
+protobuf-src = ["dep:protobuf-src"]
 
 [build-dependencies]
 prost-build = "0.11.2"
-protobuf-src = "1.1.0"
+protobuf-src = { version = "1.1.0", optional = true }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/proto/build.rs
+++ b/src/proto/build.rs
@@ -7,10 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::env;
-
 fn main() {
-    env::set_var("PROTOC", protobuf_src::protoc());
+    #[cfg(feature = "protobuf-src")]
+    std::env::set_var("PROTOC", protobuf_src::protoc());
 
     prost_build::Config::new()
         .btree_map(["."])

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -35,11 +35,11 @@ hex = "0.4.3"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 mz-lowertest = { path = "../lowertest" }
-mz-ore = { path = "../ore", features = ["bytes_", "smallvec", "region", "stack", "test"] }
-mz-persist-types = { path = "../persist-types" }
-mz-pgtz = { path = "../pgtz" }
-mz-proto = { path = "../proto", features = ["chrono"] }
-mz-sql-parser = { path = "../sql-parser" }
+mz-ore = { path = "../ore", features = ["bytes_", "smallvec", "region", "stack", "test"], default-features = false }
+mz-persist-types = { path = "../persist-types", default-features = false }
+mz-pgtz = { path = "../pgtz", default-features = false }
+mz-proto = { path = "../proto", features = ["chrono"], default-features = false }
+mz-sql-parser = { path = "../sql-parser", default-features = false }
 num-traits = "0.2.15"
 num_enum = "0.5.7"
 ordered-float = { version = "4.2.0", features = ["serde"] }
@@ -64,7 +64,7 @@ thiserror = "1.0.37"
 # for the tracing_ feature
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.16", default-features = false, optional = true }
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4.0" }
@@ -73,10 +73,18 @@ rand = "0.8.5"
 
 [build-dependencies]
 prost-build = "0.11.2"
-protobuf-src = "1.1.0"
+protobuf-src = { version = "1.1.0", optional = true }
 
 [features]
+default = ["protobuf-src", "workspace-hack"]
+
 tracing_ = ["tracing", "tracing-subscriber"]
+protobuf-src = [
+    "dep:protobuf-src",
+    "mz-persist-types/protobuf-src",
+    "mz-pgtz/protobuf-src",
+    "mz-proto/protobuf-src",
+]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -7,10 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::env;
-
 fn main() {
-    env::set_var("PROTOC", protobuf_src::protoc());
+    #[cfg(feature = "protobuf-src")]
+    std::env::set_var("PROTOC", protobuf_src::protoc());
 
     prost_build::Config::new()
         .btree_map(["."])

--- a/src/server-core/Cargo.toml
+++ b/src/server-core/Cargo.toml
@@ -19,7 +19,10 @@ tracing = "0.1.37"
 futures = "0.3.25"
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 tokio = "1.24.2"
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
+
+[features]
+default = ["workspace-hack"]


### PR DESCRIPTION
This PR aims to make the dependency of `protobuf-src` optional for the Fivetran Destination, it also has the benefit of reducing the number of dependencies by removing the dependency on `workspace-hack`. Mostly this entailed hunting down the transitive dependencies that also used `protobuf-src` and making `protobuf-src` optional their too, but enabled by default. Relevant [Slack convo](https://materializeinc.slack.com/archives/CMH6PG4CW/p1712153228671109) with how we landed on this approach.

Fivetran hit some issues when building related to compiling `protoc` and to work around them we don't build the vendored version of `protoc` and rely on the version present in their path.

### Motivation

Fix build issues for Fivetran, reduce the time required to build.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
