### PR TITLE
storage/copy-to-s3: Implement a sentinel file to indicate whether copy is completed

### DIFF
--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -235,7 +235,7 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
             Connection::Aws(aws_connection) => {
                 ComputeSinkConnection::CopyToS3Oneshot(CopyToS3OneshotSinkConnection {
                     upload_info: S3UploadInfo {
-                        prefix: self.copy_to_context.uri.to_string(),
+                        uri: self.copy_to_context.uri.to_string(),
                         max_file_size: self.copy_to_context.max_file_size,
                         desc: self.copy_to_context.desc.clone(),
                         format: self.copy_to_context.format_params.clone(),

--- a/src/aws-util/src/s3.rs
+++ b/src/aws-util/src/s3.rs
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0.
 
 use aws_sdk_s3::config::Builder;
-use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client;
 use aws_types::sdk_config::SdkConfig;
 
@@ -47,37 +46,4 @@ pub async fn list_bucket_path(
                 .collect::<Result<Vec<String>, _>>()
         })
         .transpose()?)
-}
-
-/// Upload an object to an S3 bucket. `mz_aws_util::s3_uploader::S3MultiPartUploader`
-/// should be used instead for large files.
-pub async fn upload_object<T: Into<ByteStream>>(
-    client: &Client,
-    bucket: &str,
-    key: &str,
-    body: T,
-) -> Result<(), aws_sdk_s3::Error> {
-    client
-        .put_object()
-        .bucket(bucket)
-        .key(key)
-        .body(body.into())
-        .send()
-        .await?;
-    Ok(())
-}
-
-/// Delete an object by key from an S3 bucket.
-pub async fn delete_object(
-    client: &Client,
-    bucket: &str,
-    key: &str,
-) -> Result<(), aws_sdk_s3::Error> {
-    client
-        .delete_object()
-        .bucket(bucket)
-        .key(key)
-        .send()
-        .await?;
-    Ok(())
 }

--- a/src/aws-util/src/s3.rs
+++ b/src/aws-util/src/s3.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use aws_sdk_s3::config::Builder;
+use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client;
 use aws_types::sdk_config::SdkConfig;
 
@@ -46,4 +47,36 @@ pub async fn list_bucket_path(
                 .collect::<Result<Vec<String>, _>>()
         })
         .transpose()?)
+}
+
+/// Upload an object to an S3 bucket. `mz_aws_util::s3_uploader::S3MultiPartUploader`
+/// should be used instead for large files.
+pub async fn upload_object<T: Into<ByteStream>>(
+    client: &Client,
+    bucket: &str,
+    key: &str,
+    body: T,
+) -> Result<(), aws_sdk_s3::Error> {
+    client
+        .put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(body.into())
+        .send()
+        .await?;
+    Ok(())
+}
+
+pub async fn delete_object(
+    client: &Client,
+    bucket: &str,
+    key: &str,
+) -> Result<(), aws_sdk_s3::Error> {
+    client
+        .delete_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await?;
+    Ok(())
 }

--- a/src/aws-util/src/s3.rs
+++ b/src/aws-util/src/s3.rs
@@ -67,6 +67,7 @@ pub async fn upload_object<T: Into<ByteStream>>(
     Ok(())
 }
 
+/// Delete an object by key from an S3 bucket.
 pub async fn delete_object(
     client: &Client,
     bucket: &str,

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -481,6 +481,7 @@ impl CopyFormatParams<'static> {
         match self {
             &CopyFormatParams::Text(_) => "txt",
             &CopyFormatParams::Csv(_) => "csv",
+            &CopyFormatParams::Binary => "bin",
         }
     }
 }

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -476,6 +476,15 @@ impl Arbitrary for CopyFormatParams<'static> {
     }
 }
 
+impl CopyFormatParams<'static> {
+    pub fn file_extension(&self) -> &str {
+        match self {
+            &CopyFormatParams::Text(_) => "txt",
+            &CopyFormatParams::Csv(_) => "csv",
+        }
+    }
+}
+
 /// Decodes the given bytes into `Row`-s based on the given `CopyFormatParams`.
 pub fn decode_copy_format<'a>(
     data: &[u8],

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -109,7 +109,7 @@ message ProtoPersistSinkConnection {
 }
 
 message ProtoS3UploadInfo {
-    string prefix = 1;
+    string uri = 1;
     uint64 max_file_size = 2;
     mz_repr.relation_and_scalar.ProtoRelationDesc desc = 3;
     mz_pgcopy.copy.ProtoCopyFormatParams format = 4;

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -783,8 +783,8 @@ impl RustType<ProtoKafkaSinkFormat> for KafkaSinkFormat {
 /// Info required to copy the data to s3.
 #[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct S3UploadInfo {
-    /// The s3 prefix path to write the data to.
-    pub prefix: String,
+    /// The s3 uri path to write the data to.
+    pub uri: String,
     /// The max file size of each file uploaded to S3.
     pub max_file_size: u64,
     /// The relation desc of the data to be uploaded to S3.
@@ -796,7 +796,7 @@ pub struct S3UploadInfo {
 impl RustType<ProtoS3UploadInfo> for S3UploadInfo {
     fn into_proto(&self) -> ProtoS3UploadInfo {
         ProtoS3UploadInfo {
-            prefix: self.prefix.clone(),
+            uri: self.uri.clone(),
             max_file_size: self.max_file_size,
             desc: Some(self.desc.into_proto()),
             format: Some(self.format.into_proto()),
@@ -805,7 +805,7 @@ impl RustType<ProtoS3UploadInfo> for S3UploadInfo {
 
     fn from_proto(proto: ProtoS3UploadInfo) -> Result<Self, TryFromProtoError> {
         Ok(S3UploadInfo {
-            prefix: proto.prefix,
+            uri: proto.uri,
             max_file_size: proto.max_file_size,
             desc: proto.desc.into_rust_if_some("ProtoS3UploadInfo::desc")?,
             format: proto

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -730,6 +730,7 @@ impl Run for PosCommand {
                     }
                     "psql-execute" => psql::run_execute(builtin, state).await,
                     "s3-verify-data" => s3::run_verify_data(builtin, state).await,
+                    "s3-verify-keys" => s3::run_verify_keys(builtin, state).await,
                     "schema-registry-publish" => schema_registry::run_publish(builtin, state).await,
                     "schema-registry-verify" => schema_registry::run_verify(builtin, state).await,
                     "schema-registry-wait" => schema_registry::run_wait(builtin, state).await,

--- a/src/testdrive/src/action/postgres/execute.rs
+++ b/src/testdrive/src/action/postgres/execute.rs
@@ -7,37 +7,55 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, bail, Context};
+use mz_ore::task;
+use tokio_postgres::Client;
 
 use crate::action::{ControlFlow, State};
 use crate::parser::BuiltinCommand;
 use crate::util::postgres::postgres_client;
 
-pub async fn run_execute(
-    mut cmd: BuiltinCommand,
-    state: &State,
-) -> Result<ControlFlow, anyhow::Error> {
-    let connection = cmd.args.string("connection")?;
-    cmd.args.done()?;
-
-    let client;
-    let client = if connection.starts_with("postgres://") {
-        let (client_inner, _) = postgres_client(&connection, state.default_timeout).await?;
-        client = client_inner;
-        &client
-    } else {
-        state
-            .postgres_clients
-            .get(&connection)
-            .ok_or_else(|| anyhow!("connection '{}' not found", &connection))?
-    };
-
+async fn execute_input(cmd: BuiltinCommand, client: &Client) -> Result<(), anyhow::Error> {
     for query in cmd.input {
         println!(">> {}", query);
         client
             .batch_execute(&query)
             .await
             .context("executing postgres query")?;
+    }
+    Ok(())
+}
+
+pub async fn run_execute(
+    mut cmd: BuiltinCommand,
+    state: &State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let connection = cmd.args.string("connection")?;
+    let background = cmd.args.opt_bool("background")?.unwrap_or(false);
+    cmd.args.done()?;
+
+    match (connection.starts_with("postgres://"), background) {
+        (true, true) => {
+            let (client_inner, _) = postgres_client(&connection, state.default_timeout).await?;
+            task::spawn(|| "postgres-execute", async move {
+                match execute_input(cmd, &client_inner).await {
+                    Ok(_) => {}
+                    Err(e) => println!("Error in backgrounded postgres-execute query: {e}"),
+                }
+            });
+        }
+        (false, true) => bail!("cannot use 'background' arg with referenced connection"),
+        (true, false) => {
+            let (client_inner, _) = postgres_client(&connection, state.default_timeout).await?;
+            execute_input(cmd, &client_inner).await?;
+        }
+        (false, false) => {
+            let client = state
+                .postgres_clients
+                .get(&connection)
+                .ok_or_else(|| anyhow!("connection '{}' not found", &connection))?;
+            execute_input(cmd, client).await?;
+        }
     }
 
     Ok(ControlFlow::Continue)

--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -138,3 +138,12 @@ $ s3-verify-data bucket=copytos3 key=test/2
 
 $ s3-verify-data bucket=copytos3 key=test/3
 "{1,2}",f,Infinity,"{""s"":""abc""}",1,32767,2147483647,9223372036854775807,12345678901234567890123.4567890123456789,2010-10-10,10:10:10,2010-10-10 10:10:10,00:00:00,aaaa,\x5c7841414141,това е,\xd182d0b5d0bad181d182
+
+
+# Copy a large amount of data in the background and check to see that the INCOMPLETE
+# sentinel object is written during the copy
+
+$ postgres-execute background=true connection=postgres://materialize:materialize@${testdrive.materialize-sql-addr}
+COPY (SELECT * FROM generate_series(1, 5000000)) TO 's3://copytos3/test/5' WITH (AWS CONNECTION = aws_conn, MAX FILE SIZE = "100MB", FORMAT = 'csv');
+
+$ s3-verify-keys bucket=copytos3 prefix-path=test/5 key-pattern=INCOMPLETE


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/26403

I've left a TODO for implementing a manifest file -- this just implements the INCOMPLETE sentinel such that it's possible to know when the copy is done.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

The diff is large since I refactored the s3 sink operator to extract most of the upload logic into a separate function (`handle_inputs_and_upload`) that returns a `Result` to allow use of `?` and simplify the error handling verbosity.

I also centralized the logic on how we create keys for the s3 objects we're uploading since it was otherwise spread around in a few places. I also renamed a few misleading fields related to S3 URIs and paths/object-keys.


<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
