### PR TITLE
catalog: Convert soft_asserts to asserts

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -2300,16 +2300,15 @@ impl CatalogState {
         {
             if diff == 1 {
                 let prev = map.insert(key, value());
-                soft_assert_eq_or_log!(
-                    prev,
-                    None,
+                assert_eq!(
+                    prev, None,
                     "values must be explicitly retracted before inserting a new value"
                 );
             } else if diff == -1 {
                 let prev = map.remove(&key);
                 // We can't assert the exact contents of the previous value, since we don't know
                 // what it should look like.
-                soft_assert_or_log!(
+                assert!(
                     prev.is_some(),
                     "retraction does not match existing value: {key:?}"
                 );
@@ -2441,9 +2440,8 @@ impl CatalogState {
                         comment.sub_component,
                         Some(comment.comment),
                     );
-                    soft_assert_eq_or_log!(
-                        prev,
-                        None,
+                    assert_eq!(
+                        prev, None,
                         "values must be explicitly retracted before inserting a new value"
                     );
                 }
@@ -2453,7 +2451,7 @@ impl CatalogState {
                         comment.sub_component,
                         None,
                     );
-                    soft_assert_eq_or_log!(
+                    assert_eq!(
                         prev,
                         Some(comment.comment),
                         "retraction does not match existing value: ({:?}, {:?})",

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -516,14 +516,13 @@ impl<U: ApplyUpdate<StateUpdateKind>> PersistHandle<StateUpdateKind, U> {
             let value = value.clone();
             if diff == 1 {
                 let prev = map.insert(key, value);
-                soft_assert_eq_or_log!(
-                    prev,
-                    None,
+                assert_eq!(
+                    prev, None,
                     "values must be explicitly retracted before inserting a new value"
                 );
             } else if diff == -1 {
                 let prev = map.remove(&key);
-                soft_assert_eq_or_log!(
+                assert_eq!(
                     prev,
                     Some(value),
                     "retraction does not match existing value"
@@ -660,15 +659,14 @@ impl ApplyUpdate<StateUpdateKindRaw> for UnopenedCatalogStateInner {
             match (kind, update.diff) {
                 (StateUpdateKind::Config(key, value), 1) => {
                     let prev = self.configs.insert(key.key, value.value);
-                    soft_assert_eq_or_log!(
-                        prev,
-                        None,
+                    assert_eq!(
+                        prev, None,
                         "values must be explicitly retracted before inserting a new value"
                     );
                 }
                 (StateUpdateKind::Config(key, value), -1) => {
                     let prev = self.configs.remove(&key.key);
-                    soft_assert_eq_or_log!(
+                    assert_eq!(
                         prev,
                         Some(value.value),
                         "retraction does not match existing value"


### PR DESCRIPTION
This commit converts some soft assert statements to normal assert statements. The reason is that if the assert doesn't hold, the catalog is in an inconsistent state, and we shouldn't continue.

### Motivation

This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
