### PR TITLE
Revert "storage: more descriptive logging for persist_source/shard_source"

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -219,7 +219,6 @@ pub fn build_compute_dataflow<A: Allocate>(
                     // `dataflow.as_of`. `persist_source` is documented to provide this guarantee.
                     let (mut ok_stream, err_stream, token) = persist_source::persist_source(
                         inner,
-                        "compute".to_string(),
                         *source_id,
                         Arc::clone(&compute_state.persist_clients),
                         source.storage_metadata.clone(),

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -107,7 +107,6 @@ where
     let source_as_of = None;
     let (ok_stream, err_stream, token) = mz_storage_operators::persist_source::persist_source(
         &mut desired_collection.scope(),
-        "persist_sink".to_string(),
         sink_id,
         Arc::clone(&compute_state.persist_clients),
         target.clone(),

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -130,7 +130,6 @@ impl Subtime {
 /// [advanced by]: differential_dataflow::lattice::Lattice::advance_by
 pub fn persist_source<G>(
     scope: &mut G,
-    reason: String,
     source_id: GlobalId,
     persist_clients: Arc<PersistClientCache>,
     metadata: CollectionMetadata,
@@ -193,7 +192,6 @@ where
 
         let (stream, source_tokens) = persist_source_core(
             scope,
-            format!("persist_source({}, {})", source_id, reason),
             source_id,
             Arc::clone(&persist_clients),
             metadata.clone(),
@@ -261,7 +259,6 @@ type RefinedScope<'g, G> = Child<'g, G, (<G as ScopeParent>::Timestamp, Subtime)
 #[allow(clippy::needless_borrow)]
 pub fn persist_source_core<'g, G>(
     scope: &RefinedScope<'g, G>,
-    name: String,
     source_id: GlobalId,
     persist_clients: Arc<PersistClientCache>,
     metadata: CollectionMetadata,
@@ -288,6 +285,7 @@ where
     G: Scope<Timestamp = mz_repr::Timestamp>,
 {
     let cfg = persist_clients.cfg().clone();
+    let name = source_id.to_string();
     let desc = metadata.relation_desc.clone();
     let filter_plan = map_filter_project.as_ref().map(|p| (*p).clone());
 

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -53,7 +53,6 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
     };
     let (ok_collection, err_collection, persist_tokens) = persist_source::persist_source(
         scope,
-        "render_storage_sink".to_string(),
         sink.from,
         Arc::clone(&storage_state.persist_clients),
         sink.from_storage_metadata.clone(),

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -308,7 +308,6 @@ where
                                 };
                             let (stream, tok) = persist_source::persist_source_core(
                                 scope,
-                                format!("upsert_rehydration({})", id),
                                 id,
                                 persist_clients,
                                 description.ingestion_metadata,


### PR DESCRIPTION

This reverts commit 718224fd2b63449cdafe4cb7b96aadf046137bd1.

Turns out this changes the name in more places than I expected: https://github.com/MaterializeInc/materialize/pull/26402#issuecomment-2035246080


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
