### PR TITLE
*: remove the internal `idle_arrangement_merge_effort` option

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -57,7 +57,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "cluster_always_use_disk": "true",
     "compute_dataflow_max_inflight_bytes": "134217728",  # 128 MiB
     "compute_hydration_concurrency": 2,
-    "default_arrangement_exert_proportionality": "16",
     "disk_cluster_replicas_default": "true",
     "enable_alter_swap": "true",
     "enable_assert_not_null": "true",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -58,7 +58,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "compute_dataflow_max_inflight_bytes": "134217728",  # 128 MiB
     "compute_hydration_concurrency": 2,
     "default_arrangement_exert_proportionality": "16",
-    "default_idle_arrangement_merge_effort": "0",
     "disk_cluster_replicas_default": "true",
     "enable_alter_swap": "true",
     "enable_assert_not_null": "true",

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1411,14 +1411,11 @@ impl Coordinator {
         let compute_config = flags::compute_config(system_config);
         let storage_config = flags::storage_config(system_config);
         let scheduling_config = flags::orchestrator_scheduling_config(system_config);
-        let merge_effort = system_config.default_idle_arrangement_merge_effort();
         let exert_prop = system_config.default_arrangement_exert_proportionality();
         self.controller.compute.update_configuration(compute_config);
         self.controller.storage.update_parameters(storage_config);
         self.controller
             .update_orchestrator_scheduling_config(scheduling_config);
-        self.controller
-            .set_default_idle_arrangement_merge_effort(merge_effort);
         self.controller
             .set_default_arrangement_exert_proportionality(exert_prop);
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1411,13 +1411,13 @@ impl Coordinator {
         let compute_config = flags::compute_config(system_config);
         let storage_config = flags::storage_config(system_config);
         let scheduling_config = flags::orchestrator_scheduling_config(system_config);
-        let exert_prop = system_config.default_arrangement_exert_proportionality();
+        let exert_prop = system_config.arrangement_exert_proportionality();
         self.controller.compute.update_configuration(compute_config);
         self.controller.storage.update_parameters(storage_config);
         self.controller
             .update_orchestrator_scheduling_config(scheduling_config);
         self.controller
-            .set_default_arrangement_exert_proportionality(exert_prop);
+            .set_arrangement_exert_proportionality(exert_prop);
 
         let mut policies_to_set: BTreeMap<CompactionWindow, CollectionIdBundle> =
             Default::default();

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -206,7 +206,7 @@ impl Coordinator {
         let mut update_metrics_retention = false;
         let mut update_secrets_caching_config = false;
         let mut update_cluster_scheduling_config = false;
-        let mut update_default_arrangement_merge_options = false;
+        let mut update_arrangement_exert_proportionality = false;
         let mut update_http_config = false;
         let mut log_indexes_to_drop = Vec::new();
 
@@ -312,8 +312,8 @@ impl Coordinator {
                     update_metrics_retention |= name == vars::METRICS_RETENTION.name();
                     update_secrets_caching_config |= vars::is_secrets_caching_var(name);
                     update_cluster_scheduling_config |= vars::is_cluster_scheduling_var(name);
-                    update_default_arrangement_merge_options |=
-                        name == vars::DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY.name();
+                    update_arrangement_exert_proportionality |=
+                        name == vars::ARRANGEMENT_EXERT_PROPORTIONALITY.name();
                     update_http_config |= vars::is_http_config_var(name);
                 }
                 catalog::Op::ResetAllSystemConfiguration => {
@@ -327,7 +327,7 @@ impl Coordinator {
                     update_metrics_retention = true;
                     update_secrets_caching_config = true;
                     update_cluster_scheduling_config = true;
-                    update_default_arrangement_merge_options = true;
+                    update_arrangement_exert_proportionality = true;
                     update_http_config = true;
                 }
                 catalog::Op::RenameItem { id, .. } => {
@@ -616,8 +616,8 @@ impl Coordinator {
             if update_cluster_scheduling_config {
                 self.update_cluster_scheduling_config();
             }
-            if update_default_arrangement_merge_options {
-                self.update_default_arrangement_merge_options();
+            if update_arrangement_exert_proportionality {
+                self.update_arrangement_exert_proportionality();
             }
             if update_http_config {
                 self.update_http_config();
@@ -953,14 +953,14 @@ impl Coordinator {
         self.update_compute_base_read_policies(compute_policies);
     }
 
-    fn update_default_arrangement_merge_options(&mut self) {
+    fn update_arrangement_exert_proportionality(&mut self) {
         let prop = self
             .catalog()
             .system_config()
-            .default_arrangement_exert_proportionality();
+            .arrangement_exert_proportionality();
         self.controller
             .compute
-            .set_default_arrangement_exert_proportionality(prop);
+            .set_arrangement_exert_proportionality(prop);
     }
 
     fn update_http_config(&mut self) {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -313,8 +313,6 @@ impl Coordinator {
                     update_secrets_caching_config |= vars::is_secrets_caching_var(name);
                     update_cluster_scheduling_config |= vars::is_cluster_scheduling_var(name);
                     update_default_arrangement_merge_options |=
-                        name == vars::DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT.name();
-                    update_default_arrangement_merge_options |=
                         name == vars::DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY.name();
                     update_http_config |= vars::is_http_config_var(name);
                 }
@@ -956,14 +954,6 @@ impl Coordinator {
     }
 
     fn update_default_arrangement_merge_options(&mut self) {
-        let effort = self
-            .catalog()
-            .system_config()
-            .default_idle_arrangement_merge_effort();
-        self.controller
-            .compute
-            .set_default_idle_arrangement_merge_effort(effort);
-
         let prop = self
             .catalog()
             .system_config()

--- a/src/cluster-client/src/client.proto
+++ b/src/cluster-client/src/client.proto
@@ -22,6 +22,5 @@ message ProtoTimelyConfig {
     uint64 workers = 1;
     uint64 process = 2;
     repeated string addresses = 3;
-    uint32 idle_arrangement_merge_effort = 4;
     uint32 arrangement_exert_proportionality = 5;
 }

--- a/src/cluster-client/src/client.rs
+++ b/src/cluster-client/src/client.rs
@@ -135,10 +135,6 @@ pub struct TimelyConfig {
     pub process: usize,
     /// Addresses of all processes
     pub addresses: Vec<String>,
-    /// The amount of effort to be spent on arrangement compaction during idle times.
-    ///
-    /// See `differential_dataflow::Config::idle_merge_effort`.
-    pub idle_arrangement_merge_effort: u32,
     /// Proportionality value that decides whether to exert additional arrangement merge effort.
     ///
     /// Specifically, additional merge effort is exerted when the size of the second-largest batch
@@ -156,7 +152,6 @@ impl RustType<ProtoTimelyConfig> for TimelyConfig {
             workers: self.workers.into_proto(),
             addresses: self.addresses.into_proto(),
             process: self.process.into_proto(),
-            idle_arrangement_merge_effort: self.idle_arrangement_merge_effort,
             arrangement_exert_proportionality: self.arrangement_exert_proportionality,
         }
     }
@@ -166,7 +161,6 @@ impl RustType<ProtoTimelyConfig> for TimelyConfig {
             process: proto.process.into_rust()?,
             workers: proto.workers.into_rust()?,
             addresses: proto.addresses.into_rust()?,
-            idle_arrangement_merge_effort: proto.idle_arrangement_merge_effort,
             arrangement_exert_proportionality: proto.arrangement_exert_proportionality,
         })
     }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -134,8 +134,8 @@ pub struct ComputeController<T> {
     initialized: bool,
     /// Compute configuration to apply to new instances.
     config: ComputeParameters,
-    /// Default value for `arrangement_exert_proportionality`.
-    default_arrangement_exert_proportionality: u32,
+    /// `arrangement_exert_proportionality` value passed to new replicas.
+    arrangement_exert_proportionality: u32,
     /// A replica response to be handled by the corresponding `Instance` on a subsequent call to
     /// `ActiveComputeController::process`.
     stashed_replica_response: Option<(ComputeInstanceId, ReplicaId, ComputeResponse<T>)>,
@@ -178,7 +178,7 @@ impl<T: Timestamp> ComputeController<T> {
             build_info,
             initialized: false,
             config: Default::default(),
-            default_arrangement_exert_proportionality: 16,
+            arrangement_exert_proportionality: 16,
             stashed_replica_response: None,
             envd_epoch,
             metrics: ComputeControllerMetrics::new(metrics_registry),
@@ -261,9 +261,9 @@ impl<T: Timestamp> ComputeController<T> {
             .collection_reverse_dependencies(id))
     }
 
-    /// TODO(#25239): Add documentation.
-    pub fn set_default_arrangement_exert_proportionality(&mut self, value: u32) {
-        self.default_arrangement_exert_proportionality = value;
+    /// Set the `arrangement_exert_proportionality` value to be passed to new replicas.
+    pub fn set_arrangement_exert_proportionality(&mut self, value: u32) {
+        self.arrangement_exert_proportionality = value;
     }
 
     /// Returns the read and write frontiers for each collection.
@@ -305,7 +305,7 @@ impl<T: Timestamp> ComputeController<T> {
             build_info: _,
             initialized,
             config: _,
-            default_arrangement_exert_proportionality,
+            arrangement_exert_proportionality,
             stashed_replica_response,
             envd_epoch,
             metrics: _,
@@ -334,8 +334,8 @@ impl<T: Timestamp> ComputeController<T> {
             field("instances", instances)?,
             field("initialized", initialized)?,
             field(
-                "default_arrangement_exert_proportionality",
-                default_arrangement_exert_proportionality,
+                "arrangement_exert_proportionality",
+                arrangement_exert_proportionality,
             )?,
             field(
                 "stashed_replica_response",
@@ -533,9 +533,6 @@ where
             None => (false, Duration::from_secs(1)),
         };
 
-        let arrangement_exert_proportionality =
-            self.compute.default_arrangement_exert_proportionality;
-
         let replica_config = ReplicaConfig {
             location,
             logging: LoggingConfig {
@@ -544,7 +541,7 @@ where
                 log_logging: config.logging.log_logging,
                 index_logs: Default::default(),
             },
-            arrangement_exert_proportionality,
+            arrangement_exert_proportionality: self.compute.arrangement_exert_proportionality,
             grpc_client: self.compute.config.grpc_client.clone(),
         };
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -134,8 +134,6 @@ pub struct ComputeController<T> {
     initialized: bool,
     /// Compute configuration to apply to new instances.
     config: ComputeParameters,
-    /// Default value for `idle_arrangement_merge_effort`.
-    default_idle_arrangement_merge_effort: u32,
     /// Default value for `arrangement_exert_proportionality`.
     default_arrangement_exert_proportionality: u32,
     /// A replica response to be handled by the corresponding `Instance` on a subsequent call to
@@ -180,7 +178,6 @@ impl<T: Timestamp> ComputeController<T> {
             build_info,
             initialized: false,
             config: Default::default(),
-            default_idle_arrangement_merge_effort: 1000,
             default_arrangement_exert_proportionality: 16,
             stashed_replica_response: None,
             envd_epoch,
@@ -265,11 +262,6 @@ impl<T: Timestamp> ComputeController<T> {
     }
 
     /// TODO(#25239): Add documentation.
-    pub fn set_default_idle_arrangement_merge_effort(&mut self, value: u32) {
-        self.default_idle_arrangement_merge_effort = value;
-    }
-
-    /// TODO(#25239): Add documentation.
     pub fn set_default_arrangement_exert_proportionality(&mut self, value: u32) {
         self.default_arrangement_exert_proportionality = value;
     }
@@ -313,7 +305,6 @@ impl<T: Timestamp> ComputeController<T> {
             build_info: _,
             initialized,
             config: _,
-            default_idle_arrangement_merge_effort,
             default_arrangement_exert_proportionality,
             stashed_replica_response,
             envd_epoch,
@@ -342,10 +333,6 @@ impl<T: Timestamp> ComputeController<T> {
         let map = serde_json::Map::from_iter([
             field("instances", instances)?,
             field("initialized", initialized)?,
-            field(
-                "default_idle_arrangement_merge_effort",
-                default_idle_arrangement_merge_effort,
-            )?,
             field(
                 "default_arrangement_exert_proportionality",
                 default_arrangement_exert_proportionality,
@@ -546,8 +533,6 @@ where
             None => (false, Duration::from_secs(1)),
         };
 
-        let idle_arrangement_merge_effort = self.compute.default_idle_arrangement_merge_effort;
-
         let arrangement_exert_proportionality =
             self.compute.default_arrangement_exert_proportionality;
 
@@ -559,7 +544,6 @@ where
                 log_logging: config.logging.log_logging,
                 index_logs: Default::default(),
             },
-            idle_arrangement_merge_effort,
             arrangement_exert_proportionality,
             grpc_client: self.compute.config.grpc_client.clone(),
         };

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -39,7 +39,6 @@ type Client<T> = Partitioned<ComputeGrpcClient, ComputeCommand<T>, ComputeRespon
 pub(super) struct ReplicaConfig {
     pub location: ClusterReplicaLocation,
     pub logging: LoggingConfig,
-    pub idle_arrangement_merge_effort: u32,
     pub arrangement_exert_proportionality: u32,
     pub grpc_client: GrpcClientParameters,
 }
@@ -261,7 +260,6 @@ where
                 workers: self.config.location.workers,
                 process: 0,
                 addresses: self.config.location.dataflow_addrs.clone(),
-                idle_arrangement_merge_effort: self.config.idle_arrangement_merge_effort,
                 arrangement_exert_proportionality: self.config.arrangement_exert_proportionality,
             };
             *epoch = self.epoch;

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -198,11 +198,6 @@ impl<T: Timestamp> Controller<T> {
         self.compute.activate(&mut *self.storage)
     }
 
-    pub fn set_default_idle_arrangement_merge_effort(&mut self, value: u32) {
-        self.compute
-            .set_default_idle_arrangement_merge_effort(value);
-    }
-
     pub fn set_default_arrangement_exert_proportionality(&mut self, value: u32) {
         self.compute
             .set_default_arrangement_exert_proportionality(value);

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -198,9 +198,8 @@ impl<T: Timestamp> Controller<T> {
         self.compute.activate(&mut *self.storage)
     }
 
-    pub fn set_default_arrangement_exert_proportionality(&mut self, value: u32) {
-        self.compute
-            .set_default_arrangement_exert_proportionality(value);
+    pub fn set_arrangement_exert_proportionality(&mut self, value: u32) {
+        self.compute.set_arrangement_exert_proportionality(value);
     }
 
     /// Returns the connection context installed in the controller.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1155,7 +1155,7 @@ impl SystemVars {
             &KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES,
             &KEEP_N_SINK_STATUS_HISTORY_ENTRIES,
             &KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES,
-            &DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY,
+            &ARRANGEMENT_EXERT_PROPORTIONALITY,
             &ENABLE_STORAGE_SHARD_FINALIZATION,
             &ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE,
             &ENABLE_DEFAULT_CONNECTION_VALIDATION,
@@ -1894,9 +1894,9 @@ impl SystemVars {
         *self.expect_value(&KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES)
     }
 
-    /// Returns the `default_arrangement_exert_proportionality` configuration parameter.
-    pub fn default_arrangement_exert_proportionality(&self) -> u32 {
-        *self.expect_value(&DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY)
+    /// Returns the `arrangement_exert_proportionality` configuration parameter.
+    pub fn arrangement_exert_proportionality(&self) -> u32 {
+        *self.expect_value(&ARRANGEMENT_EXERT_PROPORTIONALITY)
     }
 
     /// Returns the `enable_storage_shard_finalization` configuration parameter.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1155,7 +1155,6 @@ impl SystemVars {
             &KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES,
             &KEEP_N_SINK_STATUS_HISTORY_ENTRIES,
             &KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES,
-            &DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT,
             &DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY,
             &ENABLE_STORAGE_SHARD_FINALIZATION,
             &ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE,
@@ -1893,11 +1892,6 @@ impl SystemVars {
 
     pub fn keep_n_privatelink_status_history_entries(&self) -> usize {
         *self.expect_value(&KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES)
-    }
-
-    /// Returns the `default_idle_arrangement_merge_effort` configuration parameter.
-    pub fn default_idle_arrangement_merge_effort(&self) -> u32 {
-        *self.expect_value(&DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT)
     }
 
     /// Returns the `default_arrangement_exert_proportionality` configuration parameter.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1291,10 +1291,10 @@ pub static STATEMENT_LOGGING_SAMPLE_RATE: VarDefinition = VarDefinition::new_laz
     false,
 ).with_constraint(&NUMERIC_BOUNDED_0_1_INCLUSIVE);
 
-pub static DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY: VarDefinition = VarDefinition::new(
-    "default_arrangement_exert_proportionality",
+pub static ARRANGEMENT_EXERT_PROPORTIONALITY: VarDefinition = VarDefinition::new(
+    "arrangement_exert_proportionality",
     value!(u32; 16),
-    "The default value to use for the `ARRANGEMENT EXERT PROPORTIONALITY` cluster/replica option.",
+    "Value that controls how much merge effort to exert on arrangements.",
     true,
 );
 

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1291,13 +1291,6 @@ pub static STATEMENT_LOGGING_SAMPLE_RATE: VarDefinition = VarDefinition::new_laz
     false,
 ).with_constraint(&NUMERIC_BOUNDED_0_1_INCLUSIVE);
 
-pub static DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT: VarDefinition = VarDefinition::new(
-    "default_idle_arrangement_merge_effort",
-    value!(u32; 0),
-    "The default value to use for the `IDLE ARRANGEMENT MERGE EFFORT` cluster/replica option.",
-    true,
-);
-
 pub static DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY: VarDefinition = VarDefinition::new(
     "default_arrangement_exert_proportionality",
     value!(u32; 16),

--- a/src/storage-controller/src/rehydration.rs
+++ b/src/storage-controller/src/rehydration.rs
@@ -272,12 +272,11 @@ where
                 // Overridden by the storage `PartitionedState` implementation.
                 process: 0,
                 addresses: location.dataflow_addrs.clone(),
-                // These values are not currently used by storage, so we just choose
+                // This value is not currently used by storage, so we just choose
                 // some identifiable value.
                 //
                 // TODO(guswynn): cluster-unification: ensure this is cleaned up when
                 // the compute and storage command streams are merged.
-                idle_arrangement_merge_effort: 1337,
                 arrangement_exert_proportionality: 1337,
             };
             let dests = location


### PR DESCRIPTION
This PR removes the internal `idle_arrangement_merge_effort` option, which has been supplanted by `arrangement_exert_proportionality`. The SQL-level cluster/replica option has been removed previously in #26319, so this option was only accessible through a feature flag and has been switched off everywhere for months now.

This PR also renames the feature flag `default_arrangement_exert_proportionality` to just `arrangement_exert_proportionality`, stripping the misleading "default" prefix. It was added when we were still planning to have a cluster/replica option that could override the feature flag, but we are not planning this now.

### Motivation

  * This PR adds a known-desirable feature.

Follow-up to https://github.com/MaterializeInc/materialize/issues/17002

### Tips for reviewer

Once we have wired up the compute controller to dyncfg (#26131) we can consider making `arrangement_exert_proportionality` a dyncfg, removing the adapter boilerplate that supports it currently.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
