### PR TITLE
tests: bounded memory: enable mysql-cdc-large-tx

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -463,29 +463,28 @@ SCENARIOS = [
             [
                 dedent(
                     f"""
-                    INSERT INTO t1 (f3) SELECT CONCAT('{i}', REPEAT('a', {PAD_LEN})) FROM series_helper LIMIT {int(REPEAT / 24)};
+                    INSERT INTO t1 (f3) SELECT CONCAT('{i}', REPEAT('a', {PAD_LEN})) FROM series_helper LIMIT {int(REPEAT / 128)};
                     """
                 )
-                for i in range(0, ITERATIONS * 20)
+                for i in range(0, ITERATIONS * 10)
             ]
         )
         + "COMMIT;\n"
         + dedent(
             f"""
-            > SELECT * FROM v1; /* expect {int(ITERATIONS * 20) * int(REPEAT / 24)} */
-            {int(ITERATIONS * 20) * int(REPEAT / 24)}
+            > SELECT * FROM v1; /* expect {int(ITERATIONS * 10) * int(REPEAT / 128)} */
+            {int(ITERATIONS * 10) * int(REPEAT / 128)}
             """
         ),
         post_restart=dedent(
             f"""
             # We do not do DELETE post-restart, as it will cause OOM for clusterd
-            > SELECT * FROM v1; /* expect {int(ITERATIONS * 20) * int(REPEAT / 24)} */
-            {int(ITERATIONS * 20) * int(REPEAT / 24)}
+            > SELECT * FROM v1; /* expect {int(ITERATIONS * 10) * int(REPEAT / 128)} */
+            {int(ITERATIONS * 10) * int(REPEAT / 128)}
             """
         ),
-        materialized_memory="4.5Gb",
-        clusterd_memory="8.0Gb",
-        disabled=True,
+        materialized_memory="3.5Gb",
+        clusterd_memory="8.5Gb",
     ),
     KafkaScenario(
         name="upsert-snapshot",


### PR DESCRIPTION
Nightly: https://buildkite.com/materialize/nightly/builds?branch=nrainer-materialize%3Atests%2Fbounded-memory-mysql-tx

If the nightly build fails, the merge will need to await the merge of https://github.com/MaterializeInc/materialize/pull/26382.