### PR TITLE
persist: preparation for inline writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,6 +5041,7 @@ dependencies = [
  "mz-dyncfg",
  "mz-ore",
  "mz-persist",
+ "mz-persist-proc",
  "mz-persist-types",
  "mz-postgres-client",
  "mz-proto",
@@ -5067,6 +5068,16 @@ dependencies = [
  "tonic-build",
  "tracing",
  "uuid",
+ "workspace-hack",
+]
+
+[[package]]
+name = "mz-persist-proc"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
  "workspace-hack",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "src/persist",
     "src/persist-cli",
     "src/persist-client",
+    "src/persist-proc",
     "src/persist-txn",
     "src/persist-types",
     "src/pgcopy",

--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -49,8 +49,8 @@ breaking:
     - expr/src/relation.proto
     # reason: not yet released
     - mysql-util/src/desc.proto
-    # reason: still under active development
-    - persist-types/src/stats.proto
+    # reason: working around a false positive in buf's breaking change lint
+    - persist-client/src/internal/state.proto
     # reason: does currently not require backward-compatibility
     - storage-client/src/client.proto
     # reason: does currently not require backward-compatibility

--- a/src/dyncfg/src/lib.rs
+++ b/src/dyncfg/src/lib.rs
@@ -359,7 +359,7 @@ impl ConfigUpdates {
     ///
     /// If a value of the same config has previously been added to these
     /// updates, replaces it.
-    pub fn add_dynamic(&mut self, name: &'static str, val: ConfigVal) {
+    pub fn add_dynamic(&mut self, name: &str, val: ConfigVal) {
         self.updates.insert(
             name.to_owned(),
             ProtoConfigVal {

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -42,6 +42,7 @@ mz-build-info = { path = "../build-info" }
 mz-dyncfg = { path = "../dyncfg" }
 mz-ore = { path = "../ore", features = ["bytes_", "test", "tracing_"] }
 mz-persist = { path = "../persist" }
+mz-persist-proc = { path = "../persist-proc" }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
 mz-timely-util = { path = "../timely-util" }

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1018,6 +1018,8 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
 
 #[cfg(test)]
 mod tests {
+    use mz_dyncfg::ConfigUpdates;
+
     use crate::cache::PersistClientCache;
     use crate::internal::paths::{BlobKey, PartialBlobKey};
     use crate::tests::{all_ok, new_test_client, CodecProduct};
@@ -1231,10 +1233,10 @@ mod tests {
     }
 
     // NB: Most edge cases are exercised in datadriven tests.
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // too slow
-    async fn rewrite_ts_example() {
-        let client = new_test_client().await;
+    async fn rewrite_ts_example(dyncfgs: ConfigUpdates) {
+        let client = new_test_client(&dyncfgs).await;
         let (mut write, read) = client
             .expect_open::<String, (), u64, i64>(ShardId::new())
             .await;

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -10,10 +10,10 @@
 //! A handle to a batch of updates
 
 use std::borrow::Cow;
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 use std::fmt::Debug;
 use std::marker::PhantomData;
-use std::ops::Range;
+use std::ops::{Deref, Range};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -45,9 +45,9 @@ use crate::cfg::MiB;
 use crate::error::InvalidUsage;
 use crate::internal::encoding::{LazyPartStats, Schemas};
 use crate::internal::machine::retry_external;
-use crate::internal::metrics::{BatchWriteMetrics, Metrics, ShardMetrics};
+use crate::internal::metrics::{BatchWriteMetrics, Metrics, RetryMetrics, ShardMetrics};
 use crate::internal::paths::{PartId, PartialBatchKey, WriterKey};
-use crate::internal::state::{HollowBatch, HollowBatchPart};
+use crate::internal::state::{BatchPart, HollowBatch, HollowBatchPart};
 use crate::stats::{
     part_stats_for_legacy_part, untrimmable_columns, STATS_BUDGET_BYTES, STATS_COLLECTION_ENABLED,
 };
@@ -91,12 +91,12 @@ where
     fn drop(&mut self) {
         if self.batch.parts.len() > 0 {
             warn!(
-                "un-consumed Batch, with {} dangling blob keys: {:?}",
+                "un-consumed Batch, with {} parts and dangling blob keys: {:?}",
                 self.batch.parts.len(),
                 self.batch
                     .parts
                     .iter()
-                    .map(|x| &x.key.0)
+                    .map(|x| x.printable_name())
                     .collect::<Vec<_>>(),
             );
         }
@@ -192,18 +192,13 @@ where
         if !self.batch_delete_enabled {
             return;
         }
-        let deletes = FuturesUnordered::new();
+        let mut deletes = PartDeletes::default();
         for part in self.batch.parts.iter() {
-            let metrics = Arc::clone(&self.metrics);
-            let blob = Arc::clone(&self.blob);
-            deletes.push(async move {
-                retry_external(&metrics.retries.external.batch_delete, || async {
-                    blob.delete(&part.key).await
-                })
-                .await;
-            });
+            deletes.add(part);
         }
-        let () = deletes.collect().await;
+        let () = deletes
+            .delete(&self.blob, &self.metrics.retries.external.batch_delete)
+            .await;
     }
 
     /// Turns this [`Batch`] into a `HollowBatch`.
@@ -803,8 +798,8 @@ pub(crate) struct BatchParts<T> {
     lower: Antichain<T>,
     blob: Arc<dyn Blob + Send + Sync>,
     isolated_runtime: Arc<IsolatedRuntime>,
-    writing_parts: VecDeque<JoinHandle<HollowBatchPart<T>>>,
-    finished_parts: Vec<HollowBatchPart<T>>,
+    writing_parts: VecDeque<JoinHandle<BatchPart<T>>>,
+    finished_parts: Vec<BatchPart<T>>,
     batch_metrics: BatchWriteMetrics,
 }
 
@@ -933,13 +928,13 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
                     stats
                 });
 
-                HollowBatchPart {
+                BatchPart::Hollow(HollowBatchPart {
                     key: partial_key,
                     encoded_size_bytes: payload_len,
                     key_lower,
                     stats,
                     ts_rewrite: None,
-                }
+                })
             }
             .instrument(write_span),
         );
@@ -960,7 +955,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
     }
 
     #[instrument(level = "debug", name = "batch::finish_upload", fields(shard = %self.shard_id))]
-    pub(crate) async fn finish(self) -> Vec<HollowBatchPart<T>> {
+    pub(crate) async fn finish(self) -> Vec<BatchPart<T>> {
         let mut parts = self.finished_parts;
         for handle in self.writing_parts {
             let part = handle.wait_and_assert_finished().await;
@@ -992,7 +987,7 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
         // To prove that there is no data to truncate below the lower, require
         // that the lower is <= the rewrite ts.
         for part in batch.parts.iter() {
-            let part_lower_bound = part.ts_rewrite.as_ref().unwrap_or(batch.desc.lower());
+            let part_lower_bound = part.ts_rewrite().unwrap_or(batch.desc.lower());
             if !PartialOrder::less_equal(truncate.lower(), part_lower_bound) {
                 return Err(InvalidUsage::InvalidRewrite(format!(
                     "rewritten batch might have data below {:?} at {:?}",
@@ -1015,6 +1010,38 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
         });
     }
     Ok(())
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PartDeletes(BTreeSet<PartialBatchKey>);
+
+impl PartDeletes {
+    // Adds the part to the set to be deleted and returns true if it was already
+    // present.
+    pub fn add<T>(&mut self, part: &BatchPart<T>) -> bool {
+        match part {
+            BatchPart::Hollow(x) => self.0.insert(x.key.clone()),
+        }
+    }
+
+    pub async fn delete(self, blob: &Arc<dyn Blob + Send + Sync>, metrics: &Arc<RetryMetrics>) {
+        let deletes = FuturesUnordered::new();
+        for key in self.0 {
+            let metrics = Arc::clone(metrics);
+            let blob = Arc::clone(blob);
+            deletes.push(async move {
+                retry_external(&metrics, || blob.delete(&key)).await;
+            });
+        }
+        let () = deletes.collect().await;
+    }
+}
+
+impl Deref for PartDeletes {
+    type Target = BTreeSet<PartialBatchKey>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 #[cfg(test)]
@@ -1147,6 +1174,9 @@ mod tests {
 
         assert_eq!(batch.batch.parts.len(), 3);
         for part in &batch.batch.parts {
+            let part = match part {
+                BatchPart::Hollow(x) => x,
+            };
             match BlobKey::parse_ids(&part.key.complete(&shard_id)) {
                 Ok((shard, PartialBlobKey::Batch(writer, _))) => {
                     assert_eq!(shard.to_string(), shard_id.to_string());
@@ -1194,6 +1224,9 @@ mod tests {
 
         assert_eq!(batch.batch.parts.len(), 2);
         for part in &batch.batch.parts {
+            let part = match part {
+                BatchPart::Hollow(x) => x,
+            };
             match BlobKey::parse_ids(&part.key.complete(&shard_id)) {
                 Ok((shard, PartialBlobKey::Batch(writer, _))) => {
                     assert_eq!(shard.to_string(), shard_id.to_string());

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -314,7 +314,7 @@ where
             let bytes = req
                 .inputs
                 .iter()
-                .flat_map(|x| x.parts.iter().map(|x| x.encoded_size_bytes))
+                .flat_map(|x| x.parts.iter().map(|x| x.encoded_size_bytes()))
                 .sum::<usize>();
             let start = Instant::now();
             info!(
@@ -355,7 +355,7 @@ where
                 res.output
                     .parts
                     .iter()
-                    .map(|x| x.encoded_size_bytes)
+                    .map(|x| x.encoded_size_bytes())
                     .sum::<usize>(),
                 start.elapsed(),
             );

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -343,6 +343,7 @@ where
 mod tests {
     use std::str::FromStr;
 
+    use mz_dyncfg::ConfigUpdates;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
@@ -384,10 +385,10 @@ mod tests {
         assert_eq!(container.reader_id, id);
     }
 
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn rate_limit() {
-        let client = crate::tests::new_test_client().await;
+    async fn rate_limit(dyncfgs: ConfigUpdates) {
+        let client = crate::tests::new_test_client(&dyncfgs).await;
 
         let shard_id = crate::ShardId::new();
 
@@ -416,10 +417,10 @@ mod tests {
     }
 
     // Verifies that the handle updates its view of the opaque token correctly
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn handle_opaque_token() {
-        let client = new_test_client().await;
+    async fn handle_opaque_token(dyncfgs: ConfigUpdates) {
+        let client = new_test_client(&dyncfgs).await;
         let shard_id = ShardId::new();
 
         let mut since = client

--- a/src/persist-client/src/error.rs
+++ b/src/persist-client/src/error.rs
@@ -13,7 +13,6 @@ use std::fmt::Debug;
 
 use timely::progress::{Antichain, Timestamp};
 
-use crate::internal::paths::PartialBatchKey;
 use crate::ShardId;
 
 /// An error resulting from invalid usage of the API.
@@ -34,7 +33,7 @@ pub enum InvalidUsage<T> {
         /// The given upper bound
         upper: Antichain<T>,
         /// Set of keys containing updates.
-        keys: Vec<PartialBatchKey>,
+        keys: Vec<String>,
     },
     /// Bounds of a [crate::batch::Batch] are not valid for the attempted append call
     InvalidBatchBounds {

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -144,6 +144,8 @@ impl<'a> DirectiveArgs<'a> {
 }
 
 mod tests {
+    use mz_dyncfg::ConfigUpdates;
+
     use super::*;
 
     #[mz_ore::test]
@@ -176,13 +178,13 @@ mod tests {
         });
     }
 
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // too slow
-    async fn machine() {
+    async fn machine(dyncfgs: ConfigUpdates) {
         use crate::internal::machine::datadriven as machine_dd;
 
         ::datadriven::walk_async("tests/machine", |mut f| {
-            let initial_state_fut = machine_dd::MachineState::new();
+            let initial_state_fut = machine_dd::MachineState::new(&dyncfgs);
             async move {
                 println!("running datadriven file: {}", f.filename);
                 let state = Arc::new(Mutex::new(initial_state_fut.await));

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -222,6 +222,7 @@ mod tests {
                             "downgrade-since" => {
                                 machine_dd::downgrade_since(&mut state, args).await
                             }
+                            "dyncfg" => machine_dd::dyncfg(&mut state, args).await,
                             "expire-critical-reader" => {
                                 machine_dd::expire_critical_reader(&mut state, args).await
                             }

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -17,7 +17,7 @@ use timely::progress::Antichain;
 use tokio::sync::Mutex;
 
 use crate::internal::paths::PartialBatchKey;
-use crate::internal::state::{HollowBatch, HollowBatchPart};
+use crate::internal::state::{BatchPart, HollowBatch, HollowBatchPart};
 
 /// A [datadriven::TestCase] wrapper with helpers for parsing.
 #[derive(Debug)]
@@ -103,12 +103,14 @@ impl<'a> DirectiveArgs<'a> {
             len,
             parts: keys
                 .iter()
-                .map(|x| HollowBatchPart {
-                    key: PartialBatchKey((*x).to_owned()),
-                    encoded_size_bytes: 0,
-                    key_lower: vec![],
-                    stats: None,
-                    ts_rewrite: None,
+                .map(|x| {
+                    BatchPart::Hollow(HollowBatchPart {
+                        key: PartialBatchKey((*x).to_owned()),
+                        encoded_size_bytes: 0,
+                        key_lower: vec![],
+                        stats: None,
+                        ts_rewrite: None,
+                    })
                 })
                 .collect(),
             runs: vec![],

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1379,6 +1379,7 @@ impl<T: Timestamp + Codec64> RustType<ProtoU64Antichain> for Antichain<T> {
 mod tests {
     use bytes::Bytes;
     use mz_build_info::DUMMY_BUILD_INFO;
+    use mz_dyncfg::ConfigUpdates;
     use mz_persist::location::SeqNo;
     use proptest::prelude::*;
 
@@ -1583,9 +1584,9 @@ mod tests {
         );
     }
 
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn state_diff_migration_rollups() {
+    async fn state_diff_migration_rollups(dyncfgs: ConfigUpdates) {
         let r1_rollup = HollowRollup {
             key: PartialRollupKey("foo".to_owned()),
             encoded_size_bytes: None,
@@ -1660,7 +1661,7 @@ mod tests {
         let state: Rollup<u64> = rollup.into_rust().unwrap();
         let state = state.state;
         let mut state = state.check_codecs::<(), (), i64>(&shard_id).unwrap();
-        let cache = new_test_client_cache();
+        let cache = new_test_client_cache(&dyncfgs);
         let encoded_diff = VersionedData {
             seqno: SeqNo(5),
             data: diff_proto.encode_to_vec().into(),

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -2030,7 +2030,11 @@ pub mod datadriven {
                     true,
                     Arc::clone(&datadriven.client.metrics),
                     Arc::clone(&datadriven.client.blob),
-                    datadriven.shard_id,
+                    datadriven
+                        .client
+                        .metrics
+                        .shards
+                        .shard(&datadriven.shard_id, "test"),
                     datadriven.client.cfg.build_version.clone(),
                     hollow,
                 )

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -220,7 +220,7 @@ where
         writer_id: &WriterId,
         debug_info: &HandleDebugState,
         heartbeat_timestamp_ms: u64,
-    ) -> Result<Result<(SeqNo, WriterMaintenance<T>), InvalidUsage<T>>, Upper<T>> {
+    ) -> CompareAndAppendRes<T> {
         let idempotency_token = IdempotencyToken::new();
         loop {
             let res = self
@@ -234,8 +234,13 @@ where
                 )
                 .await;
             match res {
-                Ok(x) => return Ok(x),
-                Err((seqno, _current_upper)) => {
+                CompareAndAppendRes::Success(seqno, maintenance) => {
+                    return CompareAndAppendRes::Success(seqno, maintenance)
+                }
+                CompareAndAppendRes::InvalidUsage(x) => {
+                    return CompareAndAppendRes::InvalidUsage(x)
+                }
+                CompareAndAppendRes::UpperMismatch(seqno, _current_upper) => {
                     // If the state machine thinks that the shard upper is not
                     // far enough along, it could be because the caller of this
                     // method has found out that it advanced via some some
@@ -243,12 +248,13 @@ where
                     // machine state. So, fetch the latest state and try again
                     // if we indeed get something different.
                     self.applier.fetch_and_update_state(Some(seqno)).await;
-                    let current_upper = self.applier.clone_upper();
+                    let (current_seqno, current_upper) =
+                        self.applier.upper(|seqno, upper| (seqno, upper.clone()));
 
                     // We tried to to a compare_and_append with the wrong
                     // expected upper, that won't work.
                     if &current_upper != batch.desc.lower() {
-                        return Err(Upper(current_upper));
+                        return CompareAndAppendRes::UpperMismatch(current_seqno, current_upper);
                     } else {
                         // The upper stored in state was outdated. Retry after
                         // updating.
@@ -269,7 +275,7 @@ where
         // making it a parameter allows us to simulate hitting an indeterminate
         // error on the first attempt in tests.
         mut indeterminate: Option<Indeterminate>,
-    ) -> Result<Result<(SeqNo, WriterMaintenance<T>), InvalidUsage<T>>, (SeqNo, Upper<T>)> {
+    ) -> CompareAndAppendRes<T> {
         let metrics = Arc::clone(&self.applier.metrics);
         let lease_duration_ms = self
             .applier
@@ -424,7 +430,7 @@ where
                     if !writer_was_present {
                         metrics.state.writer_added.inc();
                     }
-                    return Ok(Ok((seqno, writer_maintenance)));
+                    return CompareAndAppendRes::Success(seqno, writer_maintenance);
                 }
                 Err(CompareAndAppendBreak::AlreadyCommitted) => {
                     // A previous iteration through this loop got an
@@ -435,7 +441,7 @@ where
                     if !writer_was_present {
                         metrics.state.writer_added.inc();
                     }
-                    return Ok(Ok((seqno, WriterMaintenance::default())));
+                    return CompareAndAppendRes::Success(seqno, WriterMaintenance::default());
                 }
                 Err(CompareAndAppendBreak::InvalidUsage(err)) => {
                     // InvalidUsage is (or should be) a deterministic function
@@ -443,7 +449,7 @@ where
                     // state. It's handed back via a Break, so we never even try
                     // to commit it. No network, no Indeterminate.
                     assert!(indeterminate.is_none());
-                    return Ok(Err(err));
+                    return CompareAndAppendRes::InvalidUsage(err);
                 }
                 Err(CompareAndAppendBreak::Upper {
                     shard_upper,
@@ -463,14 +469,14 @@ where
                         // No way this could have committed in some previous
                         // attempt of this loop: the upper of the writer is
                         // strictly less than the proposed new upper.
-                        return Err((seqno, Upper(shard_upper)));
+                        return CompareAndAppendRes::UpperMismatch(seqno, shard_upper);
                     }
                     if indeterminate.is_none() {
                         // No way this could have committed in some previous
                         // attempt of this loop: we never saw an indeterminate
                         // error (thus there was no previous iteration of the
                         // loop).
-                        return Err((seqno, Upper(shard_upper)));
+                        return CompareAndAppendRes::UpperMismatch(seqno, shard_upper);
                     }
                     // This is the bad case. We can't distinguish if some
                     // previous attempt that got an Indeterminate error
@@ -993,6 +999,23 @@ where
                     continue;
                 }
             }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum CompareAndAppendRes<T> {
+    Success(SeqNo, WriterMaintenance<T>),
+    InvalidUsage(InvalidUsage<T>),
+    UpperMismatch(SeqNo, Antichain<T>),
+}
+
+#[cfg(test)]
+impl<T: Debug> CompareAndAppendRes<T> {
+    fn unwrap(self) -> (SeqNo, WriterMaintenance<T>) {
+        match self {
+            CompareAndAppendRes::Success(seqno, maintenance) => (seqno, maintenance),
+            x => panic!("{:?}", x),
         }
     }
 }
@@ -2080,7 +2103,7 @@ pub mod datadriven {
             .optional::<String>("prev_indeterminate")
             .map(|x| Indeterminate::new(anyhow::Error::msg(x)));
         let now = (datadriven.client.cfg.now)();
-        let (_, maintenance) = datadriven
+        let res = datadriven
             .machine
             .compare_and_append_idempotent(
                 &batch,
@@ -2090,9 +2113,14 @@ pub mod datadriven {
                 &HandleDebugState::default(),
                 indeterminate,
             )
-            .await
-            .map_err(|(_seqno, upper)| anyhow!("{:?}", upper))?
-            .expect("invalid usage");
+            .await;
+        let maintenance = match res {
+            CompareAndAppendRes::Success(_, x) => x,
+            CompareAndAppendRes::UpperMismatch(_seqno, upper) => {
+                return Err(anyhow!("{:?}", Upper(upper)))
+            }
+            _ => panic!("{:?}", res),
+        };
         // TODO: Don't throw away writer maintenance. It's slightly tricky
         // because we need a WriterId for Compactor.
         datadriven.routine.push(maintenance.routine);
@@ -2190,8 +2218,7 @@ pub mod tests {
                     (write.cfg.now)(),
                 )
                 .await
-                .expect("invalid usage")
-                .expect("unexpected upper");
+                .unwrap();
             writer_maintenance
                 .perform(&write.machine, &write.gc, write.compact.as_ref())
                 .await;

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -427,10 +427,10 @@ impl MetricsVecs {
                 apply_unbatched_cmd_cas: self.retry_metrics("apply_unbatched_cmd::cas"),
             },
             external: RetryExternal {
-                batch_delete: self.retry_metrics("batch::delete"),
+                batch_delete: Arc::new(self.retry_metrics("batch::delete")),
                 batch_set: self.retry_metrics("batch::set"),
                 blob_open: self.retry_metrics("blob::open"),
-                compaction_noop_delete: self.retry_metrics("compaction_noop::delete"),
+                compaction_noop_delete: Arc::new(self.retry_metrics("compaction_noop::delete")),
                 consensus_open: self.retry_metrics("consensus::open"),
                 fetch_batch_get: self.retry_metrics("fetch_batch::get"),
                 fetch_state_scan: self.retry_metrics("fetch_state::scan"),
@@ -634,10 +634,10 @@ pub struct RetryDeterminate {
 
 #[derive(Debug)]
 pub struct RetryExternal {
-    pub(crate) batch_delete: RetryMetrics,
+    pub(crate) batch_delete: Arc<RetryMetrics>,
     pub(crate) batch_set: RetryMetrics,
     pub(crate) blob_open: RetryMetrics,
-    pub(crate) compaction_noop_delete: RetryMetrics,
+    pub(crate) compaction_noop_delete: Arc<RetryMetrics>,
     pub(crate) consensus_open: RetryMetrics,
     pub(crate) fetch_batch_get: RetryMetrics,
     pub(crate) fetch_state_scan: RetryMetrics,

--- a/src/persist-client/src/internal/restore.rs
+++ b/src/persist-client/src/internal/restore.rs
@@ -11,7 +11,7 @@
 
 use crate::internal::encoding::UntypedState;
 use crate::internal::paths::BlobKey;
-use crate::internal::state::State;
+use crate::internal::state::{BatchPart, State};
 use crate::internal::state_diff::{StateDiff, StateFieldValDiff};
 use crate::internal::state_versions::StateVersions;
 use crate::ShardId;
@@ -86,7 +86,9 @@ pub(crate) async fn restore_blob(
             }
             for batch in rollup_state.collections.trace.batches() {
                 for part in &batch.parts {
-                    let key = part.key.complete(&shard_id);
+                    let key = match part {
+                        BatchPart::Hollow(x) => x.key.complete(&shard_id),
+                    };
                     check_restored(&key, blob.restore(&key).await);
                 }
             }
@@ -94,7 +96,9 @@ pub(crate) async fn restore_blob(
         for diff in diff.referenced_batches() {
             if let Some(after) = after(diff) {
                 for part in &after.parts {
-                    let key = part.key.complete(&shard_id);
+                    let key = match part {
+                        BatchPart::Hollow(x) => x.key.complete(&shard_id),
+                    };
                     check_restored(&key, blob.restore(&key).await);
                 }
             }

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+// buf breaking: ignore (working around a false positive in buf's breaking change lint)
+
 syntax = "proto3";
 
 package mz_persist_client.internal.state;
@@ -22,7 +24,9 @@ message ProtoU64Description {
 }
 
 message ProtoHollowBatchPart {
-    string key = 1;
+   oneof kind {
+        string key = 1;
+    }
     uint64 encoded_size_bytes = 2;
 
     bytes key_lower = 3;

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1613,6 +1613,7 @@ pub(crate) mod tests {
     use std::ops::Range;
 
     use mz_build_info::DUMMY_BUILD_INFO;
+    use mz_dyncfg::ConfigUpdates;
     use mz_ore::now::SYSTEM_TIME;
     use proptest::prelude::*;
     use proptest::strategy::ValueTree;
@@ -2530,10 +2531,10 @@ pub(crate) mod tests {
         );
     }
 
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // too slow
-    async fn sneaky_downgrades() {
-        let mut clients = new_test_client_cache();
+    async fn sneaky_downgrades(dyncfgs: ConfigUpdates) {
+        let mut clients = new_test_client_cache(&dyncfgs);
         let shard_id = ShardId::new();
 
         async fn open_and_write(

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -169,6 +169,63 @@ pub struct HandleDebugState {
     pub purpose: String,
 }
 
+/// Part of the updates in a Batch.
+///
+/// Either a pointer to ones stored in Blob or the updates themselves inlined.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(tag = "type")]
+pub enum BatchPart<T> {
+    Hollow(HollowBatchPart<T>),
+}
+
+impl<T> BatchPart<T> {
+    pub fn encoded_size_bytes(&self) -> usize {
+        match self {
+            BatchPart::Hollow(x) => x.encoded_size_bytes,
+        }
+    }
+
+    // A user-interpretable identifier or description of the part (for logs and
+    // such).
+    pub fn printable_name(&self) -> &str {
+        match self {
+            BatchPart::Hollow(x) => x.key.0.as_str(),
+        }
+    }
+
+    pub fn stats(&self) -> Option<&LazyPartStats> {
+        match self {
+            BatchPart::Hollow(x) => x.stats.as_ref(),
+        }
+    }
+
+    pub fn key_lower(&self) -> &[u8] {
+        match self {
+            BatchPart::Hollow(x) => x.key_lower.as_slice(),
+        }
+    }
+
+    pub fn ts_rewrite(&self) -> Option<&Antichain<T>> {
+        match self {
+            BatchPart::Hollow(x) => x.ts_rewrite.as_ref(),
+        }
+    }
+}
+
+impl<T: Ord> PartialOrd for BatchPart<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: Ord> Ord for BatchPart<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (BatchPart::Hollow(s), BatchPart::Hollow(o)) => s.cmp(o),
+        }
+    }
+}
+
 /// A subset of a [HollowBatch] corresponding 1:1 to a blob.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct HollowBatchPart<T> {
@@ -201,7 +258,7 @@ pub struct HollowBatch<T> {
     /// Describes the times of the updates in the batch.
     pub desc: Description<T>,
     /// Pointers usable to retrieve the updates.
-    pub parts: Vec<HollowBatchPart<T>>,
+    pub parts: Vec<BatchPart<T>>,
     /// The number of updates in the batch.
     pub len: usize,
     /// Runs of sequential sorted batch parts, stored as indices into `parts`.
@@ -315,7 +372,7 @@ pub(crate) struct HollowBatchRunIter<'a, T> {
 }
 
 impl<'a, T> Iterator for HollowBatchRunIter<'a, T> {
-    type Item = &'a [HollowBatchPart<T>];
+    type Item = &'a [BatchPart<T>];
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.batch.parts.is_empty() {
@@ -379,7 +436,7 @@ impl<T: Timestamp> HollowBatch<T> {
             ));
         }
         for part in self.parts.iter() {
-            let Some(ts_rewrite) = part.ts_rewrite.as_ref() else {
+            let Some(ts_rewrite) = part.ts_rewrite() else {
                 continue;
             };
             if PartialOrder::less_than(frontier, ts_rewrite) {
@@ -397,7 +454,9 @@ impl<T: Timestamp> HollowBatch<T> {
             self.desc.since().clone(),
         );
         for part in &mut self.parts {
-            part.ts_rewrite = Some(frontier.clone());
+            match part {
+                BatchPart::Hollow(part) => part.ts_rewrite = Some(frontier.clone()),
+            }
         }
         Ok(())
     }
@@ -684,7 +743,11 @@ where
                 InvalidUsage::InvalidEmptyTimeInterval {
                     lower: batch.desc.lower().clone(),
                     upper: batch.desc.upper().clone(),
-                    keys: batch.parts.iter().map(|x| x.key.clone()).collect(),
+                    keys: batch
+                        .parts
+                        .iter()
+                        .map(|x| x.printable_name().to_owned())
+                        .collect(),
                 },
             ));
         }
@@ -1324,8 +1387,8 @@ where
 
                 let mut batch_size = 0;
                 for x in x.parts.iter() {
-                    batch_size += x.encoded_size_bytes;
-                    if x.ts_rewrite.is_some() {
+                    batch_size += x.encoded_size_bytes();
+                    if x.ts_rewrite().is_some() {
                         ret.rewrite_part_count += 1;
                     }
                 }
@@ -1653,6 +1716,7 @@ pub(crate) mod tests {
                     (Antichain::from_elem(t1), Antichain::from_elem(t0))
                 };
                 let since = Antichain::from_elem(since);
+                let parts = parts.into_iter().map(BatchPart::Hollow).collect::<Vec<_>>();
                 let runs = if runs { vec![parts.len()] } else { vec![] };
                 HollowBatch {
                     desc: Description::new(lower, upper, since),
@@ -1817,12 +1881,14 @@ pub(crate) mod tests {
             ),
             parts: keys
                 .iter()
-                .map(|x| HollowBatchPart {
-                    key: PartialBatchKey((*x).to_owned()),
-                    encoded_size_bytes: 0,
-                    key_lower: vec![],
-                    stats: None,
-                    ts_rewrite: None,
+                .map(|x| {
+                    BatchPart::Hollow(HollowBatchPart {
+                        key: PartialBatchKey((*x).to_owned()),
+                        encoded_size_bytes: 0,
+                        key_lower: vec![],
+                        stats: None,
+                        ts_rewrite: None,
+                    })
                 })
                 .collect(),
             len,
@@ -2056,7 +2122,7 @@ pub(crate) mod tests {
                 InvalidEmptyTimeInterval {
                     lower: Antichain::from_elem(5),
                     upper: Antichain::from_elem(5),
-                    keys: vec![PartialBatchKey("key1".to_owned())],
+                    keys: vec!["key1".to_owned()],
                 }
             ))
         );

--- a/src/persist-client/src/internal/state_serde.json
+++ b/src/persist-client/src/internal/state_serde.json
@@ -118,6 +118,7 @@
       "part_runs": [
         [
           {
+            "type": "Hollow",
             "key": "𝕏`𑜈Ⱥ5:<",
             "encoded_size_bytes": 16872256722443379164,
             "key_lower": "009abac79278769a8279207fb05f71d6fa9de6df3a3175e60606a6f4b7e471b019f49aaf03c0ca34281ee4c943fb5497062565268d24444fd890cab724176dca822cc29101aef59d92d9093e",
@@ -173,6 +174,7 @@
       "part_runs": [
         [
           {
+            "type": "Hollow",
             "key": "P'𞹇X",
             "encoded_size_bytes": 4013661555173142149,
             "key_lower": "35d1ee28deb0ea5a05c513d1b26ae687666abc8b8ea9a47627533da6db6fd9029cb6b1f6ef776782fd090908c30bfe5d179bfe733d77b4ce7845c54bbd961881",

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -1138,16 +1138,18 @@ impl<T: Timestamp + Lattice + Codec64> ReferencedBlobValidator<T> {
 
 #[cfg(test)]
 mod tests {
+    use mz_dyncfg::ConfigUpdates;
+
     use crate::tests::new_test_client;
 
     use super::*;
 
     /// Regression test for (part of) #17752, where an interrupted
     /// `bin/environmentd --reset` resulted in panic in persist usage code.
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn fetch_all_live_states_regression_uninitialized() {
-        let client = new_test_client().await;
+    async fn fetch_all_live_states_regression_uninitialized(dyncfgs: ConfigUpdates) {
+        let client = new_test_client(&dyncfgs).await;
         let state_versions = StateVersions::new(
             client.cfg.clone(),
             Arc::clone(&client.consensus),

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -38,7 +38,9 @@ use crate::internal::metrics::ShardMetrics;
 use crate::internal::paths::{BlobKey, PartialBlobKey, PartialRollupKey, RollupId};
 #[cfg(debug_assertions)]
 use crate::internal::state::HollowBatch;
-use crate::internal::state::{HollowBlobRef, HollowRollup, NoOpStateTransition, State, TypedState};
+use crate::internal::state::{
+    BatchPart, HollowBlobRef, HollowRollup, NoOpStateTransition, State, TypedState,
+};
 use crate::internal::state_diff::{StateDiff, StateFieldValDiff};
 use crate::{Metrics, PersistConfig, ShardId};
 
@@ -1121,13 +1123,17 @@ impl<T: Timestamp + Lattice + Codec64> ReferencedBlobValidator<T> {
             .inc_batches
             .iter()
             .flat_map(|x| x.parts.iter())
-            .map(|x| &*x.key)
+            .map(|x| match x {
+                BatchPart::Hollow(x) => &x.key,
+            })
             .collect();
         let full_parts = self
             .full_batches
             .iter()
             .flat_map(|x| x.parts.iter())
-            .map(|x| &*x.key)
+            .map(|x| match x {
+                BatchPart::Hollow(x) => &x.key,
+            })
             .collect();
         assert_eq!(inc_parts, full_parts);
 

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -778,7 +778,7 @@ impl<T: Timestamp + Lattice> SpineBatch<T> {
                 b.batch
                     .parts
                     .iter()
-                    .map(|x| format!(" {}", x.key))
+                    .map(|x| format!(" {}", x.printable_name()))
                     .collect::<Vec<_>>()
                     .join(""),
             ),
@@ -803,7 +803,7 @@ impl<T: Timestamp + Lattice> SpineBatch<T> {
                     parts
                         .iter()
                         .flat_map(|x| x.batch.parts.iter())
-                        .map(|x| format!(" {}", x.key))
+                        .map(|x| format!(" {}", x.printable_name()))
                         .collect::<Vec<_>>()
                         .join("")
                 )
@@ -1592,7 +1592,7 @@ pub mod datadriven {
                     .inputs
                     .iter()
                     .flat_map(|x| x.batch.parts.iter())
-                    .map(|x| x.key.0.clone())
+                    .map(|x| x.printable_name())
                     .collect::<Vec<_>>()
                     .join(" ")
             );

--- a/src/persist-client/src/internal/watch.rs
+++ b/src/persist-client/src/internal/watch.rs
@@ -142,6 +142,7 @@ mod tests {
     use futures::FutureExt;
     use futures_task::noop_waker;
     use mz_build_info::DUMMY_BUILD_INFO;
+    use mz_dyncfg::ConfigUpdates;
     use mz_ore::cast::CastFrom;
     use mz_ore::metrics::MetricsRegistry;
     use timely::progress::Antichain;
@@ -277,14 +278,14 @@ mod tests {
         }
     }
 
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn state_watch_listen_snapshot() {
+    async fn state_watch_listen_snapshot(dyncfgs: ConfigUpdates) {
         mz_ore::test::init_logging();
         let waker = noop_waker();
         let mut cx = Context::from_waker(&waker);
 
-        let client = new_test_client().await;
+        let client = new_test_client(&dyncfgs).await;
         // Override the listen poll so that it's useless.
         client.cfg.set_config(
             &NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF,

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -43,6 +43,7 @@ use tracing::{debug, trace};
 use crate::batch::BLOB_TARGET_SIZE;
 use crate::cfg::RetryParameters;
 use crate::fetch::{FetchedBlob, SerdeLeasedBatchPart};
+use crate::internal::state::BatchPart;
 use crate::read::SubscriptionLeaseReturner;
 use crate::stats::{STATS_AUDIT_PERCENT, STATS_FILTER_ENABLED};
 use crate::{Diagnostics, PersistClient, ShardId};
@@ -382,32 +383,35 @@ where
             for mut part_desc in parts {
                 // TODO: Push the filter down into the Subscribe?
                 if STATS_FILTER_ENABLED.get(&cfg) {
-                    let should_fetch = part_desc.part.stats.as_ref().map_or(true, |stats| {
+                    let should_fetch = part_desc.part.stats().map_or(true, |stats| {
                         should_fetch_part(&stats.decode(), current_frontier.borrow())
                     });
-                    let bytes = u64::cast_from(part_desc.part.encoded_size_bytes);
+                    let bytes = u64::cast_from(part_desc.part.encoded_size_bytes());
                     if should_fetch {
                         audit_budget_bytes =
-                            audit_budget_bytes.saturating_add(part_desc.part.encoded_size_bytes);
+                            audit_budget_bytes.saturating_add(part_desc.part.encoded_size_bytes());
                         metrics.pushdown.parts_fetched_count.inc();
                         metrics.pushdown.parts_fetched_bytes.inc_by(bytes);
                     } else {
                         metrics.pushdown.parts_filtered_count.inc();
                         metrics.pushdown.parts_filtered_bytes.inc_by(bytes);
-                        let should_audit = {
-                            let mut h = DefaultHasher::new();
-                            part_desc.part.key.hash(&mut h);
-                            usize::cast_from(h.finish()) % 100 < STATS_AUDIT_PERCENT.get(&cfg)
+                        let should_audit = match &part_desc.part {
+                            BatchPart::Hollow(x) => {
+                                let mut h = DefaultHasher::new();
+                                x.key.hash(&mut h);
+                                usize::cast_from(h.finish()) % 100 < STATS_AUDIT_PERCENT.get(&cfg)
+                            }
                         };
-                        if should_audit && part_desc.part.encoded_size_bytes < audit_budget_bytes {
-                            audit_budget_bytes -= part_desc.part.encoded_size_bytes;
+                        if should_audit && part_desc.part.encoded_size_bytes() < audit_budget_bytes
+                        {
+                            audit_budget_bytes -= part_desc.part.encoded_size_bytes();
                             metrics.pushdown.parts_audited_count.inc();
                             metrics.pushdown.parts_audited_bytes.inc_by(bytes);
                             part_desc.request_filter_pushdown_audit();
                         } else {
                             debug!(
                                 "skipping part because of stats filter {:?}",
-                                part_desc.part.stats
+                                part_desc.part.stats()
                             );
                             lease_returner.return_leased_part(part_desc);
                             continue;

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1218,6 +1218,7 @@ mod tests {
     use std::pin;
     use std::str::FromStr;
 
+    use mz_dyncfg::ConfigUpdates;
     use mz_ore::cast::CastFrom;
     use mz_ore::metrics::MetricsRegistry;
     use mz_persist::mem::{MemBlob, MemBlobConfig, MemConsensus};
@@ -1237,16 +1238,16 @@ mod tests {
     use super::*;
 
     // Verifies `Subscribe` can be dropped while holding snapshot batches.
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn drop_unused_subscribe() {
+    async fn drop_unused_subscribe(dyncfgs: ConfigUpdates) {
         let data = vec![
             (("0".to_owned(), "zero".to_owned()), 0, 1),
             (("1".to_owned(), "one".to_owned()), 1, 1),
             (("2".to_owned(), "two".to_owned()), 2, 1),
         ];
 
-        let (mut write, read) = new_test_client()
+        let (mut write, read) = new_test_client(&dyncfgs)
             .await
             .expect_open::<String, String, u64, i64>(crate::ShardId::new())
             .await;
@@ -1267,9 +1268,9 @@ mod tests {
     }
 
     // Verifies that we streaming-consolidate away identical key-values in the same batch.
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn streaming_consolidate() {
+    async fn streaming_consolidate(dyncfgs: ConfigUpdates) {
         let data = &[
             // Identical records should sum together...
             (("k".to_owned(), "v".to_owned()), 0, 1),
@@ -1281,7 +1282,7 @@ mod tests {
         ];
 
         let (mut write, read) = {
-            let client = new_test_client().await;
+            let client = new_test_client(&dyncfgs).await;
             client.cfg.set_config(&BLOB_TARGET_SIZE, 1000); // So our batch stays together!
             client
                 .expect_open::<String, String, u64, i64>(crate::ShardId::new())
@@ -1316,9 +1317,9 @@ mod tests {
         )
     }
 
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn snapshot_and_stream() {
+    async fn snapshot_and_stream(dyncfgs: ConfigUpdates) {
         let data = &mut [
             (("k1".to_owned(), "v1".to_owned()), 0, 1),
             (("k2".to_owned(), "v2".to_owned()), 1, 1),
@@ -1328,7 +1329,7 @@ mod tests {
         ];
 
         let (mut write, mut read) = {
-            let client = new_test_client().await;
+            let client = new_test_client(&dyncfgs).await;
             client.cfg.set_config(&BLOB_TARGET_SIZE, 0); // split batches across multiple parts
             client
                 .expect_open::<String, String, u64, i64>(crate::ShardId::new())
@@ -1355,9 +1356,9 @@ mod tests {
     }
 
     // Verifies the semantics of `SeqNo` leases + checks dropping `LeasedBatchPart` semantics.
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // https://github.com/MaterializeInc/materialize/issues/19983
-    async fn seqno_leases() {
+    async fn seqno_leases(dyncfgs: ConfigUpdates) {
         let mut data = vec![];
         for i in 0..20 {
             data.push(((i.to_string(), i.to_string()), i, 1))
@@ -1365,7 +1366,7 @@ mod tests {
 
         let shard_id = ShardId::new();
 
-        let client = new_test_client().await;
+        let client = new_test_client(&dyncfgs).await;
         let (mut write, read) = client
             .expect_open::<String, String, u64, i64>(shard_id)
             .await;

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -728,21 +728,22 @@ impl std::fmt::Display for HumanBytes {
 
 #[cfg(test)]
 mod tests {
-    use crate::batch::BLOB_TARGET_SIZE;
     use bytes::Bytes;
+    use mz_dyncfg::ConfigUpdates;
     use mz_persist::location::SeqNo;
     use semver::Version;
     use timely::progress::Antichain;
 
+    use crate::batch::BLOB_TARGET_SIZE;
     use crate::internal::paths::{PartialRollupKey, RollupId};
     use crate::tests::new_test_client;
     use crate::ShardId;
 
     use super::*;
 
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn size() {
+    async fn size(dyncfgs: ConfigUpdates) {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
             (("2".to_owned(), "two".to_owned()), 2, 1),
@@ -750,7 +751,7 @@ mod tests {
             (("4".to_owned(), "four".to_owned()), 4, 1),
         ];
 
-        let client = new_test_client().await;
+        let client = new_test_client(&dyncfgs).await;
         let build_version = client.cfg.build_version.clone();
         let shard_id_one = ShardId::new();
         let shard_id_two = ShardId::new();
@@ -847,9 +848,9 @@ mod tests {
 
     /// This is just a sanity check for the overall flow of computing ShardUsage.
     /// The edge cases are exercised in separate tests.
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn usage_sanity() {
+    async fn usage_sanity(dyncfgs: ConfigUpdates) {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
             (("2".to_owned(), "two".to_owned()), 2, 1),
@@ -858,7 +859,7 @@ mod tests {
         ];
 
         let shard_id = ShardId::new();
-        let mut client = new_test_client().await;
+        let mut client = new_test_client(&dyncfgs).await;
 
         let (mut write0, _) = client
             .expect_open::<String, String, u64, i64>(shard_id)
@@ -911,9 +912,9 @@ mod tests {
         assert!(shard_usage_audit.leaked_bytes > 0);
     }
 
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn usage_referenced() {
+    async fn usage_referenced(dyncfgs: ConfigUpdates) {
         mz_ore::test::init_logging();
 
         let data = vec![
@@ -924,7 +925,7 @@ mod tests {
         ];
 
         let shard_id = ShardId::new();
-        let mut client = new_test_client().await;
+        let mut client = new_test_client(&dyncfgs).await;
         // make our bookkeeping simple by skipping compaction blobs writes
         client.cfg.compaction_enabled = false;
         // make things interesting and create multiple parts per batch
@@ -1227,10 +1228,10 @@ mod tests {
     /// This also tests a (hypothesized) race that's possible in prod where an
     /// initial rollup is written for a shard, but the initial CaS hasn't yet
     /// succeeded.
-    #[mz_ore::test(tokio::test)]
+    #[mz_persist_proc::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn usage_regression_shard_in_blob_not_consensus() {
-        let client = new_test_client().await;
+    async fn usage_regression_shard_in_blob_not_consensus(dyncfgs: ConfigUpdates) {
+        let client = new_test_client(&dyncfgs).await;
         let shard_id = ShardId::new();
 
         // Somewhat unsatisfying, we manually construct a rollup blob key.

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -480,7 +480,7 @@ where
 
         let any_batch_rewrite = batches
             .iter()
-            .any(|x| x.batch.parts.iter().any(|x| x.ts_rewrite.is_some()));
+            .any(|x| x.batch.parts.iter().any(|x| x.ts_rewrite().is_some()));
         let (mut parts, mut num_updates, mut runs) = (vec![], 0, vec![]);
         for batch in batches.iter() {
             let () = validate_truncate_batch(&batch.batch, &desc, any_batch_rewrite)?;

--- a/src/persist-proc/Cargo.toml
+++ b/src/persist-proc/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "mz-persist-proc"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license = "Apache-2.0"
+
+[lints]
+workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = { version = "1.0" }
+syn = { version = "1.0", features = ["extra-traits", "full"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
+
+[features]
+default = ["workspace-hack"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["workspace-hack"]

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -1,0 +1,86 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Internal utility proc-macros for persist.
+//!
+//! Note: This is separate from the `mz_persist_client` crate because
+//! `proc-macro` crates are only allowed to export procedural macros and nothing
+//! else.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn, ReturnType};
+
+/// Persist wrapper around the `test` macro.
+///
+/// The wrapper automatically runs the test with various interesting
+/// configurations.
+#[proc_macro_attribute]
+pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    test_impl(attr, item)
+}
+
+/// Implementation for the `#[mz_persist_proc::test]` macro.
+fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = TokenStream2::from(attr);
+    let item = parse_macro_input!(item as ItemFn);
+
+    let attrs = &item.attrs;
+    let async_ = &item.sig.asyncness;
+    let await_ = if async_.is_some() {
+        quote! {.await}
+    } else {
+        quote! {}
+    };
+    let inputs = &item.sig.inputs;
+    let body = &item.block;
+    let test_name = &item.sig.ident;
+
+    // Note that Rust does not allow us to have a test function with
+    // #[should_panic] that has a non-unit return value.
+    let ret = match &item.sig.output {
+        ReturnType::Default => quote! {},
+        ReturnType::Type(_, type_) => quote! {-> #type_},
+    };
+
+    quote! {
+        #[::mz_ore::test(
+            #args
+        )]
+        #(#attrs)*
+        #async_ fn #test_name() #ret {
+            #async_ fn test_impl(#inputs) #ret {
+              #body
+            }
+
+            let dyncfgs = [
+                {
+                    // Placeholder default configuration until inline writes PR.
+                    mz_dyncfg::ConfigUpdates::default()
+                },
+            ];
+
+            for (idx, dyncfgs) in dyncfgs.into_iter().enumerate() {
+                let debug = dyncfgs.updates.iter().map(|(name, val)| {
+                    format!(" {}={:?}", name, val.val.clone().unwrap())
+                }).collect::<String>();
+                eprintln!("mz_persist_proc::test {}{}", idx, debug);
+                test_impl(dyncfgs)#await_
+            }
+          }
+    }
+    .into()
+}

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -160,7 +160,7 @@ impl<T: Timestamp + Lattice + TotalOrder + Codec64> DataSnapshot<T> {
     pub async fn snapshot_cursor<K, V, D>(
         &self,
         data_read: &mut ReadHandle<K, V, T, D>,
-        should_fetch_part: impl for<'a> Fn(&'a Option<LazyPartStats>) -> bool,
+        should_fetch_part: impl for<'a> Fn(Option<&'a LazyPartStats>) -> bool,
     ) -> Result<Cursor<K, V, T, D>, Since<T>>
     where
         K: Debug + Codec + Ord,

--- a/src/persist-txn/src/txn_write.rs
+++ b/src/persist-txn/src/txn_write.rs
@@ -218,7 +218,7 @@ where
                             handle.metrics.batches.commit_count.inc();
                             let commit_bytes = &handle.metrics.batches.commit_bytes;
                             for part in batch.parts.iter() {
-                                commit_bytes.inc_by(u64::cast_from(part.encoded_size_bytes));
+                                commit_bytes.inc_by(u64::cast_from(part.encoded_size_bytes()));
                             }
                             handle.datas.put_write(data_write);
                         }

--- a/src/persist-types/src/stats.proto
+++ b/src/persist-types/src/stats.proto
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// buf breaking: ignore (still under active development)
-
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";

--- a/src/storage-operators/src/stats.rs
+++ b/src/storage-operators/src/stats.rs
@@ -43,7 +43,7 @@ impl StatsCursor {
         as_of: Antichain<Timestamp>,
     ) -> Result<StatsCursor, Since<Timestamp>> {
         let should_fetch = |name: &'static str, count: fn(&RelationPartStats) -> Option<usize>| {
-            move |stats: &Option<LazyPartStats>| {
+            move |stats: Option<&LazyPartStats>| {
                 let Some(stats) = stats else { return true };
                 let stats = stats.decode();
                 let metrics = &metrics.pushdown.part_stats;


### PR DESCRIPTION
There are a number of mechanical bits in #19383 that can easily be separated out. Do so in a separate PR to keep that one focused on the interesting diffs (as much as possible).

See individual commits for details. This PR is not terribly motivated on its own, definitely look at the other one for the context of why these things are happening.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Intended to be no behavior change.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
