### PR TITLE
sql: Don't panic in statment logigng with COPY FROM

### DIFF
--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -2041,8 +2041,10 @@ where
                     },
                 );
             }
-            _ => {
-                assert!(ctx_extra.is_trivial())
+            other => {
+                tracing::warn!(?other, "aborting COPY FROM");
+                self.adapter_client
+                    .retire_execute(ctx_extra, StatementEndedExecutionReason::Aborted);
             }
         }
         res


### PR DESCRIPTION
This PR changes the handling for statement logging in `COPY FROM`. Previously we asserted the returned statement logging context was trivial (i.e. no statement UUID) but this isn't the case if statement logging is enabled.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/26432

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes a panic with COPY FROM