### PR TITLE
fivetran-destination: Start separate `COPY FROM` sinks for each file

### DIFF
--- a/test/testdrive/fivetran-destination.td
+++ b/test/testdrive/fivetran-destination.td
@@ -93,7 +93,11 @@ $ fivetran-destination action=write_batch
         }
     }
 }
-{}
+{
+    "response": {
+        "Success": true
+    }
+}
 
 > SELECT a, b FROM foo.bar ORDER BY a DESC;
 100 world
@@ -164,13 +168,74 @@ $ fivetran-destination action=write_batch
         }
     }
 }
-{}
+{
+    "response": {
+        "Success": true
+    }
+}
 
 > SELECT COUNT(*) FROM foo.large;
 2600000
 
 > SELECT * FROM foo.large LIMIT 1;
 5000 "I am a large log line, <- can this comma mess us up?" foo_bar_baz 10
+
+# Try copying a file that is over the limit.
+
+$ file-append container=fivetran path=too_large.csv compression=gzip header=a,b,c,d repeat=2000000
+5000,"I am a large log line, <- can this comma mess us up?",foo_bar_baz,10
+
+$ fivetran-destination action=write_batch
+{
+    "schema_name": "foo",
+    "table_name": "large",
+    "table": {
+        "name": "large",
+        "columns": [
+            {
+                "name": "a",
+                "type": 3,
+                "primary_key": true
+            },
+            {
+                "name": "b",
+                "type": 13,
+                "primary_key": false
+            },
+            {
+                "name": "c",
+                "type": 13,
+                "primary_key": false
+            },
+            {
+                "name": "d",
+                "type": 3,
+                "primary_key": false
+            }
+        ]
+    },
+    "keys": {},
+    "replace_files": ["${testdrive.fivetran-destination-files-path}/too_large.csv"],
+    "update_files": [],
+    "delete_files": [],
+    "file_params": {
+        "Csv": {
+            "compression": 2,
+            "encryption": 0,
+            "null_string": "null-123",
+            "unmodified_string": "unmodified-123"
+        }
+    }
+}
+{
+    "response": {
+        "Failure": "error when calling Materialize: Error { kind: Db, cause: Some(DbError { severity: \"ERROR\", parsed_severity: None, code: SqlState(E53000), message: \"COPY FROM STDIN too large\", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: None, line: None, routine: None }) }: closing sink: replace_files: replace files: write_batch"
+    }
+}
+
+# No new data should have been inserted.
+> SELECT COUNT(*) FROM foo.large;
+2600000
 
 # Cleanup.
 > DROP SCHEMA foo CASCADE;
@@ -179,3 +244,4 @@ $ file-delete container=fivetran path=a.csv
 $ file-delete container=fivetran path=b.csv
 $ file-delete container=fivetran path=c.csv
 $ file-delete container=fivetran path=d.csv
+$ file-delete container=fivetran path=too_large.csv

--- a/test/testdrive/fivetran-destination.td
+++ b/test/testdrive/fivetran-destination.td
@@ -105,9 +105,19 @@ $ fivetran-destination action=write_batch
 
 > CREATE TABLE foo.large (a int, b text, c text, d int)
 
-# Repeating this line 1,400,000 times should get us close to 100MiB
-$ file-append container=fivetran path=c.csv compression=gzip header=a,b,c,d repeat=1400000
+# Set the max copy from size to 100MiB.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET max_copy_from_size = 104857600;
+
+# Repeating this line 1,300,000 times should get us close to 100MiB.
+$ file-append container=fivetran path=c.csv compression=gzip header=a,b,c,d repeat=1300000
 5000,"I am a large log line, <- can this comma mess us up?",foo_bar_baz,10
+
+$ file-append container=fivetran path=d.csv compression=gzip header=a,b,c,d repeat=1300000
+5000,"I am a large log line, <- can this comma mess us up?",foo_bar_baz,10
+
+# Note: Both 'c.csv' and 'd.csv' are individually under the 'max_copy_from_size', but together
+# they exceed it. We want to make sure the write_batch still succeeds in this case.
 
 $ fivetran-destination action=write_batch
 {
@@ -139,7 +149,10 @@ $ fivetran-destination action=write_batch
         ]
     },
     "keys": {},
-    "replace_files": ["${testdrive.fivetran-destination-files-path}/c.csv"],
+    "replace_files": [
+        "${testdrive.fivetran-destination-files-path}/c.csv",
+        "${testdrive.fivetran-destination-files-path}/d.csv"
+    ],
     "update_files": [],
     "delete_files": [],
     "file_params": {
@@ -154,7 +167,7 @@ $ fivetran-destination action=write_batch
 {}
 
 > SELECT COUNT(*) FROM foo.large;
-1400000
+2600000
 
 > SELECT * FROM foo.large LIMIT 1;
 5000 "I am a large log line, <- can this comma mess us up?" foo_bar_baz 10
@@ -165,3 +178,4 @@ $ fivetran-destination action=write_batch
 $ file-delete container=fivetran path=a.csv
 $ file-delete container=fivetran path=b.csv
 $ file-delete container=fivetran path=c.csv
+$ file-delete container=fivetran path=d.csv


### PR DESCRIPTION
This PR updates the Fivetran Destination to change how it copies data into temporary tables within Materialize.

### Motivation

* Fixes an unspecified bug

Previously we would copy all CSV files via a single `COPY ... FROM` statement. This was sub-optimal because Materialize has a maximum buffer size when copying files. For example, if the maximum buffer size is 100MiB, you should be able to copy 2 80MiB files, you just need to use an individual `COPY ... FROM` for each. We were not doing this though so we would fail when trying to sync a large enough volume of data.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improves the amount of data that can be synced with the Fivetran Destination
