### PR TITLE
RBAC: Make system object privileges more robust

### DIFF
--- a/src/catalog/src/memory/error.rs
+++ b/src/catalog/src/memory/error.rs
@@ -43,6 +43,8 @@ pub enum ErrorKind {
     ReservedReplicaName(String),
     #[error("system cluster '{0}' cannot be modified")]
     ReadOnlyCluster(String),
+    #[error("system cluster replica '{0}' cannot be modified")]
+    ReadOnlyClusterReplica(String),
     #[error("system database '{0}' cannot be modified")]
     ReadOnlyDatabase(String),
     #[error("system schema '{0}' cannot be modified")]

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -30,6 +30,16 @@ ALTER TABLE mz_tables RENAME TO foo;
 query error must be owner of SOURCE mz_internal.mz_storage_shards
 ALTER SOURCE mz_internal.mz_storage_shards RENAME TO foo;
 
+simple conn=mz_system,user=mz_system
+ALTER TABLE mz_tables RENAME TO foo;
+----
+db error: db error: ERROR: system item 'mz_catalog.mz_tables' cannot be modified
+
+simple conn=mz_system,user=mz_system
+ALTER SOURCE mz_internal.mz_storage_shards RENAME TO foo;
+----
+db error: ERROR: system item 'mz_internal.mz_storage_shards' cannot be modified
+
 query error Expected one of IGNORE or TIMELINE or TIMESTAMP or RETAIN, found SIZE
 ALTER SOURCE mz_internal.mz_storage_shards RESET (size);
 

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -24,10 +24,10 @@ ALTER SYSTEM SET enable_rbac_checks TO false;
 ----
 COMPLETE 0
 
-query error system schema 'mz_catalog' cannot be modified
+query error must be owner of TABLE mz_catalog.mz_tables
 ALTER TABLE mz_tables RENAME TO foo;
 
-query error system schema 'mz_internal' cannot be modified
+query error must be owner of SOURCE mz_internal.mz_storage_shards
 ALTER SOURCE mz_internal.mz_storage_shards RENAME TO foo;
 
 query error Expected one of IGNORE or TIMELINE or TIMESTAMP or RETAIN, found SIZE

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -33,7 +33,7 @@ ALTER SOURCE mz_internal.mz_storage_shards RENAME TO foo;
 simple conn=mz_system,user=mz_system
 ALTER TABLE mz_tables RENAME TO foo;
 ----
-db error: db error: ERROR: system item 'mz_catalog.mz_tables' cannot be modified
+db error: ERROR: system item 'mz_catalog.mz_tables' cannot be modified
 
 simple conn=mz_system,user=mz_system
 ALTER SOURCE mz_internal.mz_storage_shards RENAME TO foo;

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -39,7 +39,7 @@ ALTER SYSTEM SET enable_rbac_checks TO false;
 ----
 COMPLETE 0
 
-statement error db error: ERROR: system cluster 'mz_introspection' cannot be modified
+statement error db error: ERROR: must be owner of CLUSTER mz_introspection
 ALTER CLUSTER mz_introspection RENAME TO foo
 
 simple conn=mz_system,user=mz_system
@@ -839,20 +839,5 @@ simple conn=mz_system,user=mz_system
 DROP CLUSTER t1
 ----
 COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER CLUSTER mz_system SET (SIZE = '2')
-----
-COMPLETE 0
-
-query I
-SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'mz_system') AND id LIKE 's%';
-----
-1
-
-query I
-SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'mz_system') AND id LIKE 'u%';
-----
-0
 
 reset-server

--- a/test/sqllogictest/default_privileges.slt
+++ b/test/sqllogictest/default_privileges.slt
@@ -5147,8 +5147,7 @@ db error: ERROR: unknown role 'mz_introspection'
 simple conn=mz_system,user=mz_system
 ALTER DEFAULT PRIVILEGES FOR ROLE mz_support GRANT SELECT ON TABLES TO PUBLIC
 ----
-db error: ERROR: role name "mz_support" is reserved
-DETAIL: The role prefixes "mz_" and "pg_" are reserved for system roles.
+db error: ERROR: must be a member of "mz_support"
 
 statement error system schema 'mz_catalog' cannot be modified
 ALTER DEFAULT PRIVILEGES FOR ROLE materialize IN SCHEMA mz_catalog GRANT INSERT ON TABLES TO PUBLIC

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -490,11 +490,46 @@ ALTER SYSTEM SET enable_rbac_checks TO false;
 ----
 COMPLETE 0
 
-statement error system cluster 'mz_introspection' cannot be modified
+statement error permission denied for CLUSTER "mz_introspection"
 CREATE MATERIALIZED VIEW live_keys AS ( SELECT key FROM bar );
 
-statement error  cannot modify managed cluster mz_introspection
-CREATE CLUSTER REPLICA mz_introspection.backup SIZE '1';
+statement error must be owner of CLUSTER mz_introspection
+ALTER CLUSTER mz_introspection SET (REPLICATION FACTOR 2);
 
-statement error system cluster 'mz_introspection' cannot be modified
+statement error permission denied for CLUSTER "mz_introspection"
 CREATE INDEX i_keys ON bar (key);
+
+statement error must be owner of CLUSTER mz_system
+ALTER CLUSTER mz_system SET (MANAGED = false)
+
+simple conn=mz_system,user=mz_system
+ALTER CLUSTER mz_system SET (REPLICATION FACTOR 0)
+----
+COMPLETE 0
+
+statement error must be owner of CLUSTER mz_system
+ALTER CLUSTER mz_system SET (REPLICATION FACTOR 1)
+
+simple conn=mz_system,user=mz_system
+ALTER CLUSTER mz_system SET (REPLICATION FACTOR 1)
+----
+COMPLETE 0
+
+# Replicas in system clusters should system IDs.
+
+simple conn=mz_system,user=mz_system
+ALTER CLUSTER mz_system SET (SIZE = '2')
+----
+COMPLETE 0
+
+query I
+SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'mz_system') AND id LIKE 's%';
+----
+1
+
+query I
+SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'mz_system') AND id LIKE 'u%';
+----
+0
+
+reset-server

--- a/test/sqllogictest/unstable.slt
+++ b/test/sqllogictest/unstable.slt
@@ -9,7 +9,7 @@
 
 mode cockroach
 
-# Objects in the mz_internal schema are.
+# Objects in the mz_internal schema are unstable.
 
 statement error cannot create view with unstable dependencies
 CREATE VIEW v AS SELECT id, object_type, comment FROM mz_internal.mz_comments
@@ -19,7 +19,8 @@ ALTER SYSTEM SET enable_rbac_checks TO false;
 ----
 COMPLETE 0
 
-statement error cannot create index with unstable dependencies
+# RBAC stops us from creating the index before we get the unstable error.
+statement error must be owner of TABLE mz_internal.mz_comments
 CREATE DEFAULT INDEX ON mz_internal.mz_comments
 
 simple conn=mz_system,user=mz_system

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -35,10 +35,10 @@ $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-inter
 ALTER SYSTEM SET enable_rbac_checks TO false
 
 ! DROP CLUSTER mz_system CASCADE
-contains:system cluster 'mz_system' cannot be modified
+contains:must be owner of CLUSTER mz_system
 
 ! DROP CLUSTER mz_introspection CASCADE
-contains:system cluster 'mz_introspection' cannot be modified
+contains:must be owner of CLUSTER mz_introspection
 
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_rbac_checks TO true
@@ -56,10 +56,10 @@ ALTER SYSTEM SET enable_rbac_checks TO false
 contains: cannot modify managed cluster mz_system
 
 ! DROP CLUSTER REPLICA mz_system.r1;
-contains:cannot drop replica of managed cluster
+contains:must be owner of CLUSTER REPLICA mz_system.r1
 
 ! ALTER CLUSTER mz_system SET (SIZE='2');
-contains: system cluster 'mz_system' cannot be modified
+contains: must be owner of CLUSTER mz_system
 
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_rbac_checks TO true
@@ -81,7 +81,7 @@ mv quickstart
 mv quickstart
 
 #! CREATE MATERIALIZED VIEW mv1 AS SELECT MIN(1)
-#contains:system cluster 'mz_system' cannot be modified
+#contains:must be owner of CLUSTER mz_system
 
 > SET CLUSTER TO quickstart
 


### PR DESCRIPTION
The system relies on many system objects not being modified by users,
even superusers and even when RBAC is turned off. This has required us
to layer additional checks for system objects on top of RBAC, since
it's possible for superusers (and users with RBAC turned off) to skip
RBAC checks on system objects. This commit updates RBAC checks so that
even if RBAC is turned off or the caller is a superuser, checks against
system objects are still performed, so that we can remove many of the
additional checks against system objects.

Unfortunately, there are some modifications that even `mz_system`
shouldn't make, such as deleting a catalog table, or else the system
will break. So, we need to keep additional checks that prevent those
modifications to safeguard `mz_system` from accidentally breaking a
Materialize instance.

Additionally, we currently make an exception for reading from system
objects. Superusers and users with RBAC turned off can always read from
any system object. This allows, for example, superusers to read from
`mz_statement_execution_history` without membership to the `mz_monitor`
role.

Resolves #25134

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
