### PR TITLE
Support for FORMAT CSV in COPY TO STDOUT

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -377,6 +377,14 @@ fn test_copy() {
             .read_to_string(&mut buf)
             .unwrap();
         assert_eq!(buf, "");
+
+        let mut buf = String::new();
+        client
+            .copy_out("COPY (SELECT 1 WHERE FALSE) TO STDOUT (FORMAT CSV)")
+            .unwrap()
+            .read_to_string(&mut buf)
+            .unwrap();
+        assert_eq!(buf, "");
     }
 
     // Test basic, non-empty COPY.
@@ -400,6 +408,14 @@ fn test_copy() {
             .read_to_string(&mut buf)
             .unwrap();
         assert_eq!(buf, "\\N\t2\n\\t\t4\n");
+
+        let mut buf = String::new();
+        client
+            .copy_out("COPY (VALUES (NULL, '21', 2), (E'\t', 'my,str', 4)) TO STDOUT (FORMAT CSV)")
+            .unwrap()
+            .read_to_string(&mut buf)
+            .unwrap();
+        assert_eq!(buf, ",21,2\n\t,\"my,str\",4\n");
     }
 }
 

--- a/src/pgcopy/src/copy.proto
+++ b/src/pgcopy/src/copy.proto
@@ -11,10 +11,13 @@ syntax = "proto3";
 
 package mz_pgcopy.copy;
 
+import "google/protobuf/empty.proto";
+
 message ProtoCopyFormatParams {
     oneof kind {
         ProtoCopyTextFormatParams text = 1;
         ProtoCopyCsvFormatParams csv = 2;
+        google.protobuf.Empty binary = 3;
     }
 }
 

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -14,8 +14,7 @@ use bytes::BytesMut;
 use csv::{ByteRecord, ReaderBuilder};
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Datum, RelationType, Row, RowArena};
-use proptest::prelude::any;
-use proptest::prelude::Arbitrary;
+use proptest::prelude::{any, Arbitrary, Just};
 use proptest::strategy::{BoxedStrategy, Strategy, Union};
 use serde::Deserialize;
 use serde::Serialize;
@@ -24,7 +23,7 @@ static END_OF_COPY_MARKER: &[u8] = b"\\.";
 
 include!(concat!(env!("OUT_DIR"), "/mz_pgcopy.copy.rs"));
 
-pub fn encode_copy_row_binary(
+fn encode_copy_row_binary(
     row: &Row,
     typ: &RelationType,
     out: &mut Vec<u8>,
@@ -68,8 +67,8 @@ pub fn encode_copy_row_binary(
     Ok(())
 }
 
-pub fn encode_copy_row_text(
-    CopyTextFormatParams { null, delimiter }: CopyTextFormatParams,
+fn encode_copy_row_text(
+    CopyTextFormatParams { null, delimiter }: &CopyTextFormatParams,
     row: &Row,
     typ: &RelationType,
     out: &mut Vec<u8>,
@@ -78,7 +77,7 @@ pub fn encode_copy_row_text(
     let mut buf = BytesMut::new();
     for (idx, field) in mz_pgrepr::values_from_row(row, typ).into_iter().enumerate() {
         if idx > 0 {
-            out.push(delimiter);
+            out.push(*delimiter);
         }
         match field {
             None => out.extend(null),
@@ -101,24 +100,24 @@ pub fn encode_copy_row_text(
     Ok(())
 }
 
-pub fn encode_copy_row_csv(
+fn encode_copy_row_csv(
     CopyCsvFormatParams {
         delimiter: delim,
         quote,
         escape,
         header: _,
         null,
-    }: CopyCsvFormatParams,
+    }: &CopyCsvFormatParams,
     row: &Row,
     typ: &RelationType,
     out: &mut Vec<u8>,
 ) -> Result<(), io::Error> {
     let null = null.as_bytes();
-    let is_special = |c: &u8| *c == delim || *c == quote || *c == b'\r' || *c == b'\n';
+    let is_special = |c: &u8| *c == *delim || *c == *quote || *c == b'\r' || *c == b'\n';
     let mut buf = BytesMut::new();
     for (idx, field) in mz_pgrepr::values_from_row(row, typ).into_iter().enumerate() {
         if idx > 0 {
-            out.push(delim);
+            out.push(*delim);
         }
         match field {
             None => out.extend(null),
@@ -137,14 +136,14 @@ pub fn encode_copy_row_csv(
                     // Quote the value by wrapping it in the quote character and
                     // emitting the escape character before any quote or escape
                     // characters within.
-                    out.push(quote);
+                    out.push(*quote);
                     for b in &buf {
-                        if *b == quote || *b == escape {
-                            out.push(escape);
+                        if *b == *quote || *b == *escape {
+                            out.push(*escape);
                         }
                         out.push(*b);
                     }
-                    out.push(quote);
+                    out.push(*quote);
                 } else {
                     // The value does not need quoting and can be emitted
                     // directly.
@@ -436,6 +435,7 @@ impl<'a> RawIterator<'a> {
 pub enum CopyFormatParams<'a> {
     Text(CopyTextFormatParams<'a>),
     Csv(CopyCsvFormatParams<'a>),
+    Binary,
 }
 
 impl RustType<ProtoCopyFormatParams> for CopyFormatParams<'static> {
@@ -445,6 +445,7 @@ impl RustType<ProtoCopyFormatParams> for CopyFormatParams<'static> {
             kind: Some(match self {
                 Self::Text(f) => Kind::Text(f.into_proto()),
                 Self::Csv(f) => Kind::Csv(f.into_proto()),
+                Self::Binary => Kind::Binary(()),
             }),
         }
     }
@@ -454,6 +455,7 @@ impl RustType<ProtoCopyFormatParams> for CopyFormatParams<'static> {
         match proto.kind {
             Some(Kind::Text(f)) => Ok(Self::Text(f.into_rust()?)),
             Some(Kind::Csv(f)) => Ok(Self::Csv(f.into_rust()?)),
+            Some(Kind::Binary(())) => Ok(Self::Binary),
             None => Err(TryFromProtoError::missing_field(
                 "ProtoCopyFormatParams::kind",
             )),
@@ -469,6 +471,7 @@ impl Arbitrary for CopyFormatParams<'static> {
         Union::new(vec![
             any::<CopyTextFormatParams>().prop_map(Self::Text).boxed(),
             any::<CopyCsvFormatParams>().prop_map(Self::Csv).boxed(),
+            Just(Self::Binary).boxed(),
         ])
     }
 }
@@ -482,12 +485,16 @@ pub fn decode_copy_format<'a>(
     match params {
         CopyFormatParams::Text(params) => decode_copy_format_text(data, column_types, params),
         CopyFormatParams::Csv(params) => decode_copy_format_csv(data, column_types, params),
+        CopyFormatParams::Binary => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "cannot decode as binary format",
+        )),
     }
 }
 
 /// Encodes the given `Row` into bytes based on the given `CopyFormatParams`.
 pub fn encode_copy_format<'a>(
-    params: CopyFormatParams<'a>,
+    params: &CopyFormatParams<'a>,
     row: &Row,
     typ: &RelationType,
     out: &mut Vec<u8>,
@@ -495,7 +502,7 @@ pub fn encode_copy_format<'a>(
     match params {
         CopyFormatParams::Text(params) => encode_copy_row_text(params, row, typ, out),
         CopyFormatParams::Csv(params) => encode_copy_row_csv(params, row, typ, out),
-        // TODO (mouli): Handle Binary format here as well?
+        CopyFormatParams::Binary => encode_copy_row_binary(row, typ, out),
     }
 }
 
@@ -1024,7 +1031,7 @@ mod tests {
         for TestCase { params, expected } in tests {
             out.clear();
             let params = CopyFormatParams::Csv(params);
-            let _ = encode_copy_format(params.clone(), &row, &typ, &mut out);
+            let _ = encode_copy_format(&params, &row, &typ, &mut out);
             let output = std::str::from_utf8(&out);
             assert_eq!(output, std::str::from_utf8(expected));
         }

--- a/src/pgcopy/src/lib.rs
+++ b/src/pgcopy/src/lib.rs
@@ -16,7 +16,7 @@
 mod copy;
 
 pub use copy::{
-    decode_copy_format, encode_copy_format, encode_copy_row_binary, encode_copy_row_text,
-    CopyCsvFormatParams, CopyFormatParams, CopyTextFormatParams, CopyTextFormatParser,
-    ProtoCopyCsvFormatParams, ProtoCopyFormatParams, ProtoCopyTextFormatParams,
+    decode_copy_format, encode_copy_format, CopyCsvFormatParams, CopyFormatParams,
+    CopyTextFormatParams, CopyTextFormatParser, ProtoCopyCsvFormatParams, ProtoCopyFormatParams,
+    ProtoCopyTextFormatParams,
 };

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -31,7 +31,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::instrument;
 use mz_ore::netio::AsyncReady;
 use mz_ore::str::StrExt;
-use mz_pgcopy::{CopyFormatParams, CopyTextFormatParams};
+use mz_pgcopy::{CopyCsvFormatParams, CopyFormatParams, CopyTextFormatParams};
 use mz_pgwire_common::{ErrorResponse, Format, FrontendMessage, Severity, VERSIONS, VERSION_3};
 use mz_repr::{Datum, GlobalId, RelationDesc, RelationType, Row, RowArena, ScalarType};
 use mz_server_core::TlsMode;
@@ -1905,29 +1905,20 @@ where
         row_desc: RelationDesc,
         mut stream: RecordFirstRowStream,
     ) -> Result<(State, SendRowsEndedReason), io::Error> {
-        let (encode_fn, encode_format): (
-            fn(&Row, &RelationType, &mut Vec<u8>) -> Result<(), std::io::Error>,
-            Format,
-        ) = match format {
-            // TODO (mouli): refactor to use `mz_pgcopy::encode_copy_format` and
-            // handle `Binary` there as well.
-            CopyFormat::Text => {
-                let encode_fn = |row: &Row, typ: &RelationType, out: &mut Vec<u8>| {
-                    mz_pgcopy::encode_copy_row_text(CopyTextFormatParams::default(), row, typ, out)
-                };
-                (encode_fn, Format::Text)
-            }
-            CopyFormat::Binary => (mz_pgcopy::encode_copy_row_binary, Format::Binary),
-            _ => {
-                let msg = format!("COPY TO format {:?} not supported", format);
-                return self
-                    .error(ErrorResponse::error(
-                        SqlState::FEATURE_NOT_SUPPORTED,
-                        msg.clone(),
-                    ))
-                    .await
-                    .map(|state| (state, SendRowsEndedReason::Errored { error: msg }));
-            }
+        let (row_format, encode_format) = match format {
+            CopyFormat::Text => (
+                CopyFormatParams::Text(CopyTextFormatParams::default()),
+                Format::Text,
+            ),
+            CopyFormat::Binary => (CopyFormatParams::Binary, Format::Binary),
+            CopyFormat::Csv => (
+                CopyFormatParams::Csv(CopyCsvFormatParams::default()),
+                Format::Text,
+            ),
+        };
+
+        let encode_fn = |row: &Row, typ: &RelationType, out: &mut Vec<u8>| {
+            mz_pgcopy::encode_copy_format(&row_format, row, typ, out)
         };
 
         let typ = row_desc.typ();

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -56,6 +56,13 @@ COPY t TO STDOUT WITH (FORMAT = text)
 Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("text")]))) }] })
 
 parse-statement
+COPY t TO STDOUT WITH (FORMAT CSV)
+----
+COPY t TO STDOUT WITH (FORMAT = csv)
+=>
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }] })
+
+parse-statement
 COPY t FROM STDIN WITH (FORMAT CSV, DELIMITER '|', NULL 'NULL', QUOTE '"', ESCAPE '\\', HEADER false)
 ----
 COPY t FROM STDIN WITH (FORMAT = csv, DELIMITER = '|', NULL = 'NULL', QUOTE = '"', ESCAPE = '\\', HEADER = false)

--- a/src/storage-operators/src/s3_oneshot_sink.rs
+++ b/src/storage-operators/src/s3_oneshot_sink.rs
@@ -366,7 +366,7 @@ impl CopyToS3Uploader {
     async fn append_row(&mut self, row: &Row) -> Result<(), anyhow::Error> {
         self.buf.clear();
         // encode the row and write to temp buffer.
-        encode_copy_format(self.format.clone(), row, self.desc.typ(), &mut self.buf)
+        encode_copy_format(&self.format, row, self.desc.typ(), &mut self.buf)
             .map_err(|_| anyhow!("error encoding row"))?;
 
         if self.current_file_uploader.is_none() {

--- a/test/pgtest/copy.pt
+++ b/test/pgtest/copy.pt
@@ -57,3 +57,20 @@ CopyData "[255, 255]"
 CopyDone
 CommandComplete {"tag":"COPY 4"}
 ReadyForQuery {"status":"I"}
+
+# Verify CSV output.
+send
+Query {"query": "COPY (VALUES (1, '2'), (3, '4'), (5, '\\\t\n\rte,st\\N'), (6, NULL) ORDER BY column1) TO STDOUT WITH (FORMAT csv)"}
+----
+
+until
+ReadyForQuery
+----
+CopyOut {"format":"text","column_formats":["text","text"]}
+CopyData "1,2\n"
+CopyData "3,4\n"
+CopyData "5,\"\\\t\n\rte,st\\N\"\n"
+CopyData "6,\n"
+CopyDone
+CommandComplete {"tag":"COPY 4"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/4982

Somewhat of a side-quest to the copy-to-s3 work, this completes some `TODO`s that were enabled by the work in https://github.com/MaterializeInc/materialize/pull/25521 which gave us the pieces to implement `COPY .. TO STDOUT (FORMAT CSV)`.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
