### PR TITLE
GA COMMENT ON: update docs, remove feature flag from code

### DIFF
--- a/doc/user/content/sql/comment-on.md
+++ b/doc/user/content/sql/comment-on.md
@@ -6,8 +6,6 @@ menu:
     parent: 'commands'
 ---
 
-{{< public-preview />}}
-
 `COMMENT ON ...` adds or updates the comment of an object.
 
 ## Syntax

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -64,7 +64,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_assert_not_null": "true",
     "enable_aws_connection": "true",
     "enable_columnation_lgalloc": "true",
-    "enable_comment": "true",
     "enable_compute_chunked_stack": "true",
     "enable_connection_validation_syntax": "true",
     "enable_copy_to_expr": "true",

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5867,8 +5867,6 @@ pub fn plan_comment(
 ) -> Result<Plan, PlanError> {
     const MAX_COMMENT_LENGTH: usize = 1024;
 
-    scx.require_feature_flag(&vars::ENABLE_COMMENT)?;
-
     let CommentStatement { object, comment } = stmt;
 
     // TODO(parkmycar): Make max comment length configurable.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1934,13 +1934,6 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_comment,
-        desc: "the COMMENT ON feature for objects",
-        default: true,
-        internal: false,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_sink_doc_on_option,
         desc: "DOC ON option for sinks",
         default: false,

--- a/test/legacy-upgrade/create-in-v0.68.0-comment.td
+++ b/test/legacy-upgrade/create-in-v0.68.0-comment.td
@@ -10,7 +10,6 @@
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET enable_comment = true;
 
 > CREATE TABLE comment_table ( x int8, y text );
 > CREATE VIEW comment_view AS SELECT x FROM comment_table;

--- a/test/sqllogictest/comment.slt
+++ b/test/sqllogictest/comment.slt
@@ -12,12 +12,6 @@ mode cockroach
 # Start from a pristine server
 reset-server
 
-# Enable comments.
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_comment TO true;
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE a ( x int8, y text, z jsonb );
 

--- a/test/testdrive/kafka-avro-sinks-doc-comments.td
+++ b/test/testdrive/kafka-avro-sinks-doc-comments.td
@@ -13,7 +13,6 @@ $ set-arg-default single-replica-cluster=quickstart
 # Test Avro UPSERT sinks doc comments
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_comment = true;
 ALTER SYSTEM SET enable_sink_doc_on_option = true;
 
 > CREATE TYPE point AS (x integer, y integer);

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -29,7 +29,6 @@ emit_introspection_query_notice     on                      "Whether to print a 
 emit_timestamp_notice               off                     "Boolean flag indicating whether to send a NOTICE with timestamp explanations of queries (Materialize)."
 emit_trace_id_notice                off                     "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize)."
 enable_alter_swap                   on                      "Whether the ALTER SWAP feature for objects is allowed (Materialize)."
-enable_comment                      on                      "Whether the COMMENT ON feature for objects is allowed (Materialize)."
 enable_rbac_checks                  on                      "User facing global boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
 enable_session_rbac_checks          off                     "User facing session boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
 extra_float_digits                  3                       "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."


### PR DESCRIPTION
Flag was already defaulted to true in the code & LaunchDarkly, and customers are already using it in production.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
