### PR TITLE
storage: add sink metric for number of partitions

### DIFF
--- a/src/storage/src/metrics/sink/kafka.rs
+++ b/src/storage/src/metrics/sink/kafka.rs
@@ -51,6 +51,8 @@ pub(crate) struct KafkaSinkMetricDefs {
     pub rdkafka_disconnects: IntGaugeVec,
     /// The number of outstanding progress records that need to be read before the sink can resume.
     pub outstanding_progress_records: UIntGaugeVec,
+    /// The number of partitions this sink is publishing to.
+    pub partition_count: UIntGaugeVec,
 }
 
 impl KafkaSinkMetricDefs {
@@ -140,6 +142,11 @@ impl KafkaSinkMetricDefs {
                 help: "The number of outstanding progress records that need to be read before the sink can resume.",
                 var_labels: ["sink_id"],
             )),
+            partition_count: registry.register(metric!(
+                name: "mz_sink_partition_count",
+                help: "The number of partitions this sink is publishing to.",
+                var_labels: ["sink_id"],
+            )),
         }
     }
 }
@@ -180,6 +187,8 @@ pub(crate) struct KafkaSinkMetrics {
     pub rdkafka_disconnects: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
     /// The number of outstanding progress records that need to be read before the sink can resume.
     pub outstanding_progress_records: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    /// The number of partitions this sink is publishing to.
+    pub partition_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
 }
 
 impl KafkaSinkMetrics {
@@ -232,6 +241,9 @@ impl KafkaSinkMetrics {
                 .get_delete_on_drop_gauge(labels.to_vec()),
             outstanding_progress_records: defs
                 .outstanding_progress_records
+                .get_delete_on_drop_gauge(labels.to_vec()),
+            partition_count: defs
+                .partition_count
                 .get_delete_on_drop_gauge(labels.to_vec()),
         }
     }

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -445,7 +445,7 @@ disruptions: list[Disruption] = [
     KafkaSinkDisruption(
         name="delete-sink-topic-delete-progress-fix",
         breakage=lambda c, seed: delete_sink_topic(c, seed),
-        expected_error="sink progress data exists, but sink data topic is missing",
+        expected_error="sink data topic is missing",
         # If we delete the progress topic, we will re-create the sink as if it is new.
         fixage=lambda c, seed: c.exec(
             "redpanda", "rpk", "topic", "delete", f"testdrive-progress-topic-{seed}"
@@ -454,7 +454,7 @@ disruptions: list[Disruption] = [
     KafkaSinkDisruption(
         name="delete-sink-topic-recreate-topic-fix",
         breakage=lambda c, seed: delete_sink_topic(c, seed),
-        expected_error="sink progress data exists, but sink data topic is missing",
+        expected_error="sink data topic is missing",
         # If we recreate the sink topic, the sink will work but will likely be inconsistent.
         fixage=lambda c, seed: c.exec(
             "redpanda", "rpk", "topic", "create", f"testdrive-sink-topic-{seed}"


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
