### PR TITLE
fivetran: Enable the `native-tls-vendored` feature for reqwest

### DIFF
--- a/src/fivetran-destination/Cargo.toml
+++ b/src/fivetran-destination/Cargo.toml
@@ -45,7 +45,7 @@ insta = "1.32"
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = { version = "1.1.0", optional = true }
-reqwest = { version = "0.11.13", features = ["blocking"] }
+reqwest = { version = "0.11.13", features = ["blocking", "native-tls-vendored"] }
 tonic-build = "0.9.2"
 
 [features]


### PR DESCRIPTION
As it says in the title, enable the `native-tls-vendored` feature.

### Motivation

Prevent the build process from trying to link openSSL

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
