### PR TITLE
tests: bounded memory: stabilize pg-cdc-large-tx by increasing clusterd memory

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -306,6 +306,7 @@ SCENARIOS = [
             """
         ),
         materialized_memory="4.5Gb",
+        clusterd_memory="4.5Gb",
     ),
     MySqlCdcScenario(
         name="mysql-cdc-snapshot",


### PR DESCRIPTION
It failed in the nightly build of the release: https://buildkite.com/materialize/nightlies/builds/7249#018eabb1-4abd-4b10-957e-6229981f5a6d

See also: https://github.com/MaterializeInc/materialize/pull/26267#issuecomment-2039085008