### PR TITLE
compute: remove `enable_persist_sink_stash` config

### DIFF
--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -59,16 +59,6 @@ pub const ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING: Config<bool> = Config::new(
     "Enable logging of the hydration status of compute operators.",
 );
 
-/// Enable usage of a pre-correction stash in the `persist_sink`.
-///
-/// Introduced to derisk the rollout of the `persist_sink` stash.
-/// TODO(teskje): remove after successful validation in prod
-pub const ENABLE_PERSIST_SINK_STASH: Config<bool> = Config::new(
-    "enable_compute_persist_sink_stash",
-    true,
-    "Enable usage of a pre-correction stash in the compute `persist_sink`.",
-);
-
 /// Enable controller-controlled dataflow scheduling.
 ///
 /// Introduced to derisk the rollout of the `Schedule` compute command.
@@ -128,7 +118,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
         .add(&ENABLE_CHUNKED_STACK)
         .add(&ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING)
-        .add(&ENABLE_PERSIST_SINK_STASH)
         .add(&ENABLE_CONTROLLER_DATAFLOW_SCHEDULING)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)


### PR DESCRIPTION
This config was added as a failsafe to derisk the introduction of the `UpdateStash` in the `persist_sink`. The `UpdateStash` has been deployed in production without issues, so the failsafe is not needed anymore.

### Motivation

   * This PR removes a feature flag.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A