### PR TITLE
catalog: Listen to cluster updates

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -276,7 +276,7 @@ impl Catalog {
                     };
                     add_new_builtin_clusters_migration(&mut txn, &cluster_sizes)?;
                     add_new_builtin_introspection_source_migration(&mut txn)?;
-                    add_new_builtin_cluster_replicas_migration(&state, &mut txn, &cluster_sizes)?;
+                    add_new_builtin_cluster_replicas_migration(&mut txn, &cluster_sizes)?;
                     add_new_builtin_roles_migration(&mut txn)?;
                 }
                 builtin_item_ids

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1487,7 +1487,6 @@ fn add_new_builtin_roles_migration(
 }
 
 fn add_new_builtin_cluster_replicas_migration(
-    state: &CatalogState,
     txn: &mut Transaction<'_>,
     builtin_cluster_sizes: &BuiltinBootstrapClusterSizes,
 ) -> Result<(), AdapterError> {
@@ -1522,10 +1521,7 @@ fn add_new_builtin_cluster_replicas_migration(
 
             let replica_id = txn.get_and_increment_id(SYSTEM_REPLICA_ID_ALLOC_KEY.to_string())?;
             let replica_id = ReplicaId::System(replica_id);
-            let mut config = builtin_cluster_replica_config(replica_size);
-            let azs = cluster.availability_zones();
-            let location = state.concretize_replica_location(config.location, &Vec::new(), azs)?;
-            config.location = location.into();
+            let config = builtin_cluster_replica_config(replica_size);
             txn.insert_cluster_replica(
                 cluster.id,
                 replica_id,

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -24,6 +24,7 @@
 
 pub mod notice;
 
+use std::collections::BTreeMap;
 use std::hash::Hash;
 use std::string::ToString;
 use std::sync::Mutex;
@@ -7211,6 +7212,9 @@ pub mod BUILTINS {
         BUILTINS_STATIC.iter()
     }
 }
+
+pub static BUILTIN_LOG_LOOKUP: Lazy<BTreeMap<&'static str, &'static BuiltinLog>> =
+    Lazy::new(|| BUILTINS::logs().map(|log| (log.name, log)).collect());
 
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -32,8 +32,8 @@ pub use crate::durable::metrics::Metrics;
 use crate::durable::objects::Snapshot;
 pub use crate::durable::objects::{
     Cluster, ClusterConfig, ClusterReplica, ClusterVariant, ClusterVariantManaged, Comment,
-    Database, DefaultPrivilege, Item, ReplicaConfig, ReplicaLocation, Role, Schema,
-    SystemConfiguration, SystemObjectMapping,
+    Database, DefaultPrivilege, IntrospectionSourceIndex, Item, ReplicaConfig, ReplicaLocation,
+    Role, Schema, SystemConfiguration, SystemObjectMapping,
 };
 use crate::durable::persist::UnopenedPersistCatalogState;
 pub use crate::durable::transaction::Transaction;

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -183,6 +183,16 @@ pub struct Cluster {
     pub config: ClusterConfig,
 }
 
+impl Cluster {
+    /// Returns the availability zones of this cluster, if they exist.
+    pub fn availability_zones(&self) -> Option<&[String]> {
+        match &self.config.variant {
+            ClusterVariant::Managed(managed) => Some(&managed.availability_zones),
+            ClusterVariant::Unmanaged => None,
+        }
+    }
+}
+
 impl DurableType<ClusterKey, ClusterValue> for Cluster {
     fn into_key_value(self) -> (ClusterKey, ClusterValue) {
         (

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -183,16 +183,6 @@ pub struct Cluster {
     pub config: ClusterConfig,
 }
 
-impl Cluster {
-    /// Returns the availability zones of this cluster, if they exist.
-    pub fn availability_zones(&self) -> Option<&[String]> {
-        match &self.config.variant {
-            ClusterVariant::Managed(managed) => Some(&managed.availability_zones),
-            ClusterVariant::Unmanaged => None,
-        }
-    }
-}
-
 impl DurableType<ClusterKey, ClusterValue> for Cluster {
     fn into_key_value(self) -> (ClusterKey, ClusterValue) {
         (

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -759,6 +759,16 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
         }
 
         Ok(match kind {
+            StateUpdateKind::Cluster(key, value) => {
+                let cluster = into_durable(key, value)?;
+                Some(memory::objects::StateUpdateKind::Cluster(cluster))
+            }
+            StateUpdateKind::ClusterReplica(key, value) => {
+                let cluster_replica = into_durable(key, value)?;
+                Some(memory::objects::StateUpdateKind::ClusterReplica(
+                    cluster_replica,
+                ))
+            }
             StateUpdateKind::Comment(key, value) => {
                 let comment = into_durable(key, value)?;
                 Some(memory::objects::StateUpdateKind::Comment(comment))
@@ -771,6 +781,12 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
                 let default_privilege = into_durable(key, value)?;
                 Some(memory::objects::StateUpdateKind::DefaultPrivilege(
                     default_privilege,
+                ))
+            }
+            StateUpdateKind::IntrospectionSourceIndex(key, value) => {
+                let introspection_source_index = into_durable(key, value)?;
+                Some(memory::objects::StateUpdateKind::IntrospectionSourceIndex(
+                    introspection_source_index,
                 ))
             }
             StateUpdateKind::Role(key, value) => {
@@ -795,12 +811,9 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
             }
             // TODO(jkosh44) Add conversions for valid variants.
             StateUpdateKind::AuditLog(_, _)
-            | StateUpdateKind::Cluster(_, _)
-            | StateUpdateKind::ClusterReplica(_, _)
             | StateUpdateKind::Config(_, _)
             | StateUpdateKind::Epoch(_)
             | StateUpdateKind::IdAllocator(_, _)
-            | StateUpdateKind::IntrospectionSourceIndex(_, _)
             | StateUpdateKind::Item(_, _)
             | StateUpdateKind::Setting(_, _)
             | StateUpdateKind::StorageUsage(_, _)

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -1456,6 +1456,18 @@ impl<'a> Transaction<'a> {
                 StateUpdateKind::SystemConfiguration,
             ))
             .chain(get_collection_updates(
+                &self.clusters,
+                StateUpdateKind::Cluster,
+            ))
+            .chain(get_collection_updates(
+                &self.introspection_sources,
+                StateUpdateKind::IntrospectionSourceIndex,
+            ))
+            .chain(get_collection_updates(
+                &self.cluster_replicas,
+                StateUpdateKind::ClusterReplica,
+            ))
+            .chain(get_collection_updates(
                 &self.comments,
                 StateUpdateKind::Comment,
             ))

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -146,7 +146,7 @@ impl From<Role> for durable::Role {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct Cluster {
     pub name: String,
     pub id: ClusterId,
@@ -250,6 +250,14 @@ impl Cluster {
             .insert(to_name, replica_id)
             .is_none());
     }
+
+    /// Returns the availability zones of this cluster, if they exist.
+    pub fn availability_zones(&self) -> Option<&[String]> {
+        match &self.config.variant {
+            ClusterVariant::Managed(managed) => Some(&managed.availability_zones),
+            ClusterVariant::Unmanaged => None,
+        }
+    }
 }
 
 impl From<Cluster> for durable::Cluster {
@@ -264,7 +272,7 @@ impl From<Cluster> for durable::Cluster {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct ClusterReplica {
     pub name: String,
     pub cluster_id: ClusterId,
@@ -310,7 +318,7 @@ impl From<ClusterReplica> for durable::ClusterReplica {
     }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct ClusterReplicaProcessStatus {
     pub status: ClusterStatus,
     pub time: DateTime<Utc>,
@@ -2270,6 +2278,9 @@ pub enum StateUpdateKind {
     DefaultPrivilege(durable::objects::DefaultPrivilege),
     SystemPrivilege(MzAclItem),
     SystemConfiguration(durable::objects::SystemConfiguration),
+    Cluster(durable::objects::Cluster),
+    IntrospectionSourceIndex(durable::objects::IntrospectionSourceIndex),
+    ClusterReplica(durable::objects::ClusterReplica),
     Comment(durable::objects::Comment),
     // TODO(jkosh44) Add all other object variants.
 }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -105,7 +105,7 @@ pub enum ComputeControllerResponse<T> {
 }
 
 /// Replica configuration
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ComputeReplicaConfig {
     /// TODO(#25239): Add documentation.
     pub logging: ComputeReplicaLogging,

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -53,7 +53,7 @@ pub struct ClusterConfig {
 pub type ClusterStatus = mz_orchestrator::ServiceStatus;
 
 /// Configures a cluster replica.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct ReplicaConfig {
     /// The location of the replica.
     pub location: ReplicaLocation,
@@ -161,7 +161,7 @@ fn test_replica_allocation_deserialization() {
 }
 
 /// Configures the location of a cluster replica.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, PartialEq)]
 pub enum ReplicaLocation {
     /// An unmanaged replica.
     Unmanaged(UnmanagedReplicaLocation),
@@ -225,7 +225,7 @@ pub enum ClusterRole {
 }
 
 /// The location of an unmanaged replica.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnmanagedReplicaLocation {
     /// The network addresses of the storagectl endpoints for each process in
     /// the replica.
@@ -244,7 +244,7 @@ pub struct UnmanagedReplicaLocation {
 }
 
 /// Information about availability zone constraints for replicas.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ManagedReplicaAvailabilityZones {
     /// Specified if the `Replica` is from `MANAGED` cluster,
     /// and specifies if there is an `AVAILABILITY ZONES`
@@ -256,7 +256,7 @@ pub enum ManagedReplicaAvailabilityZones {
 }
 
 /// The location of a managed replica.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct ManagedReplicaLocation {
     /// The resource allocation for the replica.
     pub allocation: ReplicaAllocation,


### PR DESCRIPTION
This commit teaches the in-memory catalog how to listen to all cluster related updates. This includes clusters, cluster replicas, and introspection source indexes.

Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
