### PR TITLE
persist: include size in blob::set and consensus:cas tracing spans

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -2488,7 +2488,7 @@ impl Blob for MetricsBlob {
         res
     }
 
-    #[instrument(name = "blob::set", fields(shard=blob_key_shard_id(key)))]
+    #[instrument(name = "blob::set", fields(shard=blob_key_shard_id(key),size_bytes=value.len()))]
     async fn set(&self, key: &str, value: Bytes) -> Result<(), ExternalError> {
         let bytes = value.len();
         let res = self
@@ -2590,7 +2590,7 @@ impl Consensus for MetricsConsensus {
         res
     }
 
-    #[instrument(name = "consensus::compare_and_set", fields(shard=key))]
+    #[instrument(name = "consensus::compare_and_set", fields(shard=key,size_bytes=new.data.len()))]
     async fn compare_and_set(
         &self,
         key: &str,


### PR DESCRIPTION
Seems useful to have in traces.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
