### PR TITLE
[explain] Support materialized views in `explain filter pushdown`

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2121,7 +2121,9 @@ impl Coordinator {
     ///
     /// This method expects all dataflow plans to be available, so it must run after
     /// [`Coordinator::bootstrap_dataflow_plans`].
-    fn collect_dataflow_storage_constraints(&self) -> BTreeMap<GlobalId, StorageConstraints> {
+    pub(self) fn collect_dataflow_storage_constraints(
+        &self,
+    ) -> BTreeMap<GlobalId, StorageConstraints> {
         let is_storage_collection =
             |id: &GlobalId| self.controller.storage.check_exists(*id).is_ok();
 
@@ -2203,7 +2205,7 @@ impl Coordinator {
     /// # Panics
     ///
     /// Panics if the given dataflow exports neither an index nor a materialized view.
-    fn bootstrap_dataflow_as_of(
+    pub(self) fn bootstrap_dataflow_as_of(
         &mut self,
         dataflow: &DataflowDescription<Plan>,
         cluster_id: ComputeInstanceId,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2345,11 +2345,12 @@ impl Coordinator {
             mz_ore::soft_panic_or_log!(
                 "error bootstrapping dataflow `as_of`: \
                  `min_as_of` {:?} greater than `max_as_of` {:?} \
-                 (import_ids={}, export_ids={}, storage_constraints={:?})",
+                 (import_ids={}, export_ids={}, name={}, storage_constraints={:?})",
                 min_as_of.elements(),
                 max_as_of.elements(),
                 dataflow.display_import_ids(),
                 dataflow.display_export_ids(),
+                dataflow.debug_name,
                 storage_constraints,
             );
             min_as_of.clone()

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2121,9 +2121,7 @@ impl Coordinator {
     ///
     /// This method expects all dataflow plans to be available, so it must run after
     /// [`Coordinator::bootstrap_dataflow_plans`].
-    pub(self) fn collect_dataflow_storage_constraints(
-        &self,
-    ) -> BTreeMap<GlobalId, StorageConstraints> {
+    fn collect_dataflow_storage_constraints(&self) -> BTreeMap<GlobalId, StorageConstraints> {
         let is_storage_collection =
             |id: &GlobalId| self.controller.storage.check_exists(*id).is_ok();
 
@@ -2205,7 +2203,7 @@ impl Coordinator {
     /// # Panics
     ///
     /// Panics if the given dataflow exports neither an index nor a materialized view.
-    pub(self) fn bootstrap_dataflow_as_of(
+    fn bootstrap_dataflow_as_of(
         &mut self,
         dataflow: &DataflowDescription<Plan>,
         cluster_id: ComputeInstanceId,
@@ -2345,12 +2343,11 @@ impl Coordinator {
             mz_ore::soft_panic_or_log!(
                 "error bootstrapping dataflow `as_of`: \
                  `min_as_of` {:?} greater than `max_as_of` {:?} \
-                 (import_ids={}, export_ids={}, name={}, storage_constraints={:?})",
+                 (import_ids={}, export_ids={}, storage_constraints={:?})",
                 min_as_of.elements(),
                 max_as_of.elements(),
                 dataflow.display_import_ids(),
                 dataflow.display_export_ids(),
-                dataflow.debug_name,
                 storage_constraints,
             );
             min_as_of.clone()

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2202,6 +2202,9 @@ impl Coordinator {
                 )
                 .await;
             }
+            Explainee::MaterializedView(gid) => {
+                self.explain_pushdown_materialized_view(ctx, gid).await;
+            }
             _ => {
                 ctx.retire(Err(AdapterError::Unsupported(
                     "EXPLAIN FILTER PUSHDOWN queries for this explainee type",

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -890,7 +890,7 @@ impl Coordinator {
             .collect_dataflow_storage_constraints()
             .remove(&gid)
             .expect("all dataflow storage constraints were collected");
-        let (as_of, _read_holds) = self.bootstrap_dataflow_as_of(
+        let (as_of, read_holds) = self.bootstrap_dataflow_as_of(
             &plan,
             mview.cluster_id,
             storage_constraints,
@@ -915,6 +915,7 @@ impl Coordinator {
             ctx,
             as_of,
             mz_now,
+            Some(read_holds),
             plan.source_imports
                 .into_iter()
                 .filter_map(|(id, (source, _))| source.arguments.operators.map(|mfp| (id, mfp))),

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -1025,7 +1025,7 @@ impl Coordinator {
             .map(|t| ResultSpec::value(Datum::MzTimestamp(*t)))
             .unwrap_or_else(ResultSpec::value_all);
 
-        self.render_explain_pushdown(ctx, as_of, mz_now, stage.imports)
+        self.render_explain_pushdown(ctx, as_of, mz_now, None, stage.imports)
             .await
     }
 

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -298,3 +298,10 @@ EXPLAIN PLAN INSIGHTS FOR SELECT 1
 EXPLAIN PLAN INSIGHTS FOR SELECT 1
 =>
 ExplainPlan(ExplainPlanStatement { stage: Some(PlanInsights), with_options: [], format: None, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+
+parse-statement
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW whatever
+----
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW whatever
+=>
+ExplainPushdown(ExplainPushdownStatement { explainee: MaterializedView(Name(UnresolvedItemName([Ident("whatever")]))) })

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1192,15 +1192,15 @@ where
         // here.
         let read_handle = self.read_handle_for_snapshot(&metadata, id).await;
 
-        let data_snapshot = match metadata {
-            CollectionMetadata {
-                txns_shard: Some(txns_id),
-                data_shard,
-                ..
-            } => {
-                let as_of = as_of
-                    .as_option()
-                    .expect("cannot read as_of the empty antichain");
+        let data_snapshot = match (metadata, as_of.as_option()) {
+            (
+                CollectionMetadata {
+                    txns_shard: Some(txns_id),
+                    data_shard,
+                    ..
+                },
+                Some(as_of),
+            ) => {
                 let txns_read = self.txns.expect_enabled_lazy(&txns_id);
                 txns_read.update_gt(as_of.clone()).await;
                 let data_snapshot = txns_read.data_snapshot(data_shard, as_of.clone()).await;

--- a/test/sqllogictest/explain/pushdown.slt
+++ b/test/sqllogictest/explain/pushdown.slt
@@ -111,6 +111,16 @@ materialize.public.jsonb_fields  1859  0  2  0
 # Cleanup
 # ----------------------------------------
 
+# EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW is also supported
+
+statement ok
+CREATE MATERIALIZED VIEW big_numbers AS SELECT * FROM numbers WHERE value > 10000;
+
+query TIIII
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW big_numbers
+----
+materialize.public.numbers  0  0  0  0
+
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_explain_pushdown = false
 ----

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1630,10 +1630,8 @@ COMPLETE 0
 # Pulling stats for refresh-every and similar MVs can time out,
 # since data may not yet be available...
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET statement_timeout = '1s'
-----
-COMPLETE 0
+statement ok
+SET statement_timeout = '1s'
 
 statement ok
 EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW const_mv;

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1619,3 +1619,118 @@ create  cluster-replica  "c_schedule_1"  "schedule"  false  {"decision":"on","ob
 create  cluster-replica  "c_schedule_3"  "schedule"  false  {"decision":"on","objects_needing_refresh":["uXXX"],"rehydration_time_estimate":"00:00:00"}
 create  cluster-replica  "c_schedule_4"  "schedule"  false  {"decision":"on","objects_needing_refresh":["uXXX"],"rehydration_time_estimate":"00:00:00"}
 create  cluster-replica  "c_schedule_rehydration_time_estimate"  "schedule"  false  {"decision":"on","objects_needing_refresh":["uXXX"],"rehydration_time_estimate":"00:16:35"}
+
+# Materialized views in this file can be explained
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_explain_pushdown = true
+----
+COMPLETE 0
+
+# Pulling stats for refresh-every and similar MVs can time out,
+# since data may not yet be available...
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET statement_timeout = '1s'
+----
+COMPLETE 0
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW const_mv;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW const_mv2;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv3;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv5;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv8;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv9;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv12;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_aligned_to_future;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_aligned_to_past;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_assertion_at_begin;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_assertion_at_end;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_assertion_plus_refresh_every;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_desugar1;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_desugar2;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_good_assertion_on_renamed_column;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_greatest;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_misordered_assertions;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_multiple_refresh_options;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_multiple_refresh_options;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_no_assertions;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_no_creation_refresh;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_on_commit;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv_two_assertions;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mvi1;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mvi2;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mvi3;
+
+statement ok
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mvi3;
+
+# Attempting to explain MVs which are not readable at the current time can block
+
+statement error db error: ERROR: canceling statement due to statement timeout
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv4;
+
+statement error db error: ERROR: canceling statement due to statement timeout
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv10;
+
+statement error db error: ERROR: canceling statement due to statement timeout
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW mv11;
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_explain_pushdown = false
+----
+COMPLETE 0


### PR DESCRIPTION
### Motivation

#24498

In particular, it can be helpful to see the statistics for an existing materialized view -- to know what the level of pushdown would be like if the view was re-bootstrapping now.

### Tips for reviewer

I think the diciest part of this PR is the timestamp selection code... please check my work!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
