### PR TITLE
drop vpc endpoint in task

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -875,6 +875,9 @@ impl Coordinator {
                     let _ = Retry::default()
                         .max_duration(Duration::from_secs(60))
                         .retry_async(|_state| async {
+                            fail_point!("drop_vpc_endpoint", |r| {
+                                Err(anyhow::anyhow!("Fail point error {:?}", r))
+                            });
                             match cloud_resource_controller
                                 .delete_vpc_endpoint(vpc_endpoint)
                                 .await

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -550,7 +550,7 @@ impl Coordinator {
                 self.drop_secrets(secrets_to_drop).await;
             }
             if !vpc_endpoints_to_drop.is_empty() {
-                self.drop_vpc_endpoints(vpc_endpoints_to_drop).await;
+                self.drop_vpc_endpoints_in_background(vpc_endpoints_to_drop)
             }
             if !cluster_replicas_to_drop.is_empty() {
                 fail::fail_point!("after_catalog_drop_replica");
@@ -856,20 +856,43 @@ impl Coordinator {
         }
     }
 
-    async fn drop_vpc_endpoints(&mut self, vpc_endpoints: Vec<GlobalId>) {
-        for vpc_endpoint in vpc_endpoints {
-            if let Err(e) = self
-                .cloud_resource_controller
-                .as_ref()
-                .ok_or(AdapterError::Unsupported("AWS PrivateLink connections"))
-                .expect("vpc endpoints should only be dropped in CLOUD, where `cloud_resource_controller` is `Some`")
-                .delete_vpc_endpoint(vpc_endpoint)
-                .await
-            {
-                warn!("Dropping VPC Endpoints has encountered an error: {}", e);
-                // TODO reschedule this https://github.com/MaterializeInc/cloud/issues/4407
+    fn drop_vpc_endpoints_in_background(&mut self, vpc_endpoints: Vec<GlobalId>) {
+        let cloud_resource_controller = Arc::clone(self.cloud_resource_controller
+            .as_ref()
+            .ok_or(AdapterError::Unsupported("AWS PrivateLink connections"))
+            .expect("vpc endpoints should only be dropped in CLOUD, where `cloud_resource_controller` is `Some`"));
+        // We don't want to block the coordinator on an external delete api
+        // calls, so move the drop vpc_endpoint to a separate task. This does
+        // mean that a failed drop won't bubble up to the user as an error
+        // message. However, even if it did (and how the code previously
+        // worked), mz has already dropped it from our catalog, and so we
+        // wouldn't be able to retry anyway. Any orphaned vpc_endpoints will
+        // eventually be cleaned during restart via coord bootstrap.
+        task::spawn(
+            || "drop_vpc_endpoints",
+            async move {
+                for vpc_endpoint in vpc_endpoints {
+                    let _ = Retry::default()
+                        .max_duration(Duration::from_secs(60))
+                        .retry_async(|_state| async {
+                            match cloud_resource_controller
+                                .delete_vpc_endpoint(vpc_endpoint)
+                                .await
+                            {
+                                Ok(_) => Ok(()),
+                                Err(e) => {
+                                    warn!("Dropping VPC Endpoints has encountered an error: {}", e);
+                                    Err(e)
+                                }
+                            }
+                        })
+                        .await;
+                }
             }
-        }
+            .instrument(info_span!(
+                "coord::catalog_transact_inner::drop_vpc_endpoints"
+            )),
+        );
     }
 
     /// Removes all temporary items created by the specified connection, though


### PR DESCRIPTION
use run_in_task_if for vpc endpoint drop
and add span to task

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Drop vpc is an external call that should be moved to a task rather than blocking the coordinator. This particular call has been known to lead to a stall and envd crash. 
inspiration from https://github.com/MaterializeInc/materialize/pull/25795
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
