### PR TITLE
dyncfg: support JSON-valued configuration variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4264,6 +4264,7 @@ dependencies = [
  "prost-build",
  "protobuf-src",
  "serde",
+ "serde_json",
  "tracing",
  "workspace-hack",
 ]

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -22,7 +22,7 @@ pub const ENABLE_MZ_JOIN_CORE: Config<bool> = Config::new(
 );
 
 /// The yielding behavior with which linear joins should be rendered.
-pub const LINEAR_JOIN_YIELDING: Config<String> = Config::new(
+pub const LINEAR_JOIN_YIELDING: Config<&str> = Config::new(
     "linear_join_yielding",
     "work:1000000,time:100",
     "The yielding behavior compute rendering should apply for linear join operators. Either \

--- a/src/dyncfg/Cargo.toml
+++ b/src/dyncfg/Cargo.toml
@@ -17,6 +17,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
+serde_json = "1.0.99"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/dyncfg/src/dyncfg.proto
+++ b/src/dyncfg/src/dyncfg.proto
@@ -37,6 +37,10 @@ message ProtoConfigVal {
         ProtoOptionU64 opt_usize = 7;
         string string = 4;
         mz_proto.ProtoDuration duration = 5;
+        // Switch to Protobuf's native JSON representation,
+        // google.protobuf.Value, once prost supports it.
+        // See: https://github.com/tokio-rs/prost/issues/404
+        string json = 8;
     }
     reserved 1;
 }

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -67,38 +67,41 @@ pub(crate) const STATS_BUDGET_BYTES: Config<usize> = Config::new(
     "The budget (in bytes) of how many stats to maintain per batch part.",
 );
 
-pub(crate) const STATS_UNTRIMMABLE_COLUMNS_EQUALS: Config<String> = Config::new(
+pub(crate) const STATS_UNTRIMMABLE_COLUMNS_EQUALS: Config<fn() -> String> = Config::new(
     "persist_stats_untrimmable_columns_equals",
-    concat!(
-        // If we trim the "err" column, then we can't ever use pushdown on a
-        // part (because it could have >0 errors).
-        "err,",
-        "ts,",
-        "receivedat,",
-        "createdat,",
-        // Fivetran created tables track deleted rows by setting this column.
-        //
-        // See <https://fivetran.com/docs/using-fivetran/features#capturedeletes>.
-        "_fivetran_deleted,",
-    ),
+    || {
+        [
+            // If we trim the "err" column, then we can't ever use pushdown on a
+            // part (because it could have >0 errors).
+            "err",
+            "ts",
+            "receivedat",
+            "createdat",
+            // Fivetran created tables track deleted rows by setting this column.
+            //
+            // See <https://fivetran.com/docs/using-fivetran/features#capturedeletes>.
+            "_fivetran_deleted",
+        ]
+        .join(",")
+    },
     "\
     Which columns to always retain during persist stats trimming. Any column \
     with a name exactly equal (case-insensitive) to one of these will be kept. \
     Comma separated list.",
 );
 
-pub(crate) const STATS_UNTRIMMABLE_COLUMNS_PREFIX: Config<String> = Config::new(
+pub(crate) const STATS_UNTRIMMABLE_COLUMNS_PREFIX: Config<fn() -> String> = Config::new(
     "persist_stats_untrimmable_columns_prefix",
-    concat!("last_,",),
+    || ["last_"].join(","),
     "\
     Which columns to always retain during persist stats trimming. Any column \
     with a name starting with (case-insensitive) one of these will be kept. \
     Comma separated list.",
 );
 
-pub(crate) const STATS_UNTRIMMABLE_COLUMNS_SUFFIX: Config<String> = Config::new(
+pub(crate) const STATS_UNTRIMMABLE_COLUMNS_SUFFIX: Config<fn() -> String> = Config::new(
     "persist_stats_untrimmable_columns_suffix",
-    concat!("timestamp,", "time,", "_at,", "_tstamp,"),
+    || ["timestamp", "time", "_at", "_tstamp"].join(","),
     "\
     Which columns to always retain during persist stats trimming. Any column \
     with a name ending with (case-insensitive) one of these will be kept. \

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1227,6 +1227,9 @@ impl SystemVars {
                 ConfigVal::Duration(default) => {
                     VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), true)
                 }
+                ConfigVal::Json(default) => {
+                    VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), true)
+                }
             })
             .collect();
 
@@ -1856,6 +1859,9 @@ impl SystemVars {
                 }
                 ConfigVal::Duration(_) => {
                     ConfigVal::from(*self.expect_config_value::<Duration>(name))
+                }
+                ConfigVal::Json(_) => {
+                    ConfigVal::from(self.expect_config_value::<serde_json::Value>(name).clone())
                 }
             };
             updates.add_dynamic(entry.name(), val);

--- a/src/sql/src/session/vars/value.rs
+++ b/src/sql/src/session/vars/value.rs
@@ -354,6 +354,31 @@ impl Value for Duration {
     }
 }
 
+impl Value for serde_json::Value {
+    fn type_name() -> Cow<'static, str>
+    where
+        Self: Sized,
+    {
+        "jsonb".into()
+    }
+
+    fn parse(input: VarInput<'_>) -> Result<Self, VarParseError>
+    where
+        Self: Sized,
+    {
+        let s = extract_single_value(input)?;
+        serde_json::from_str(s).map_err(|_| VarParseError::InvalidParameterType)
+    }
+
+    fn box_clone(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
 /// This style should actually be some more complex struct, but we only support this configuration
 /// of it, so this is fine for the time being.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -552,7 +552,7 @@ impl KafkaConnection {
         }
 
         let rules = KAFKA_CLIENT_ID_ENRICHMENT_RULES.get(configs);
-        let rules = match serde_json::from_str::<Vec<EnrichmentRule>>(&rules) {
+        let rules = match serde_json::from_value::<Vec<EnrichmentRule>>(rules) {
             Ok(rules) => rules,
             Err(e) => {
                 warn!(%e, "failed to decode kafka_client_id_enrichment_rules");

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -42,9 +42,9 @@ pub const STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION: Config<bool> = Config::ne
 /// address of any broker in the connection, then the payload is appended to the
 /// client ID. A rule's payload is always prefixed with `-`, to separate it from
 /// the preceding data in the client ID.
-pub const KAFKA_CLIENT_ID_ENRICHMENT_RULES: Config<String> = Config::new(
+pub const KAFKA_CLIENT_ID_ENRICHMENT_RULES: Config<fn() -> serde_json::Value> = Config::new(
     "kafka_client_id_enrichment_rules",
-    "[]",
+    || serde_json::json!([]),
     "Rules for enriching the `client.id` property of Kafka clients with additional data.",
 );
 


### PR DESCRIPTION
These will be used in a forthcoming commit to support a particularly complex feature flag.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

@danhhz I need a JSON-valued configuration flag to support https://github.com/MaterializeInc/cloud/issues/8316. Turned out to be a rabbit hole to allow `json!({})` as a default value, but it didn't end up being too deep, thankfully.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
