### PR TITLE
storage: allow dynamically enriching Kafka client IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6080,6 +6080,7 @@ dependencies = [
  "protobuf-src",
  "rand",
  "rdkafka",
+ "regex",
  "serde",
  "serde_json",
  "thiserror",

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -57,6 +57,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -32,9 +32,26 @@ pub const STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION: Config<bool> = Config::ne
     during shard finalization",
 );
 
+/// Rules for enriching the `client.id` property of Kafka clients with
+/// additional data.
+///
+/// The configuration value must be a JSON array of objects containing keys
+/// named `pattern` and `payload`, both of type string. Rules are checked in the
+/// order they are defined. The rule's pattern must be a regular expression
+/// understood by the Rust `regex` crate. If the rule's pattern matches the
+/// address of any broker in the connection, then the payload is appended to the
+/// client ID. A rule's payload is always prefixed with `-`, to separate it from
+/// the preceding data in the client ID.
+pub const KAFKA_CLIENT_ID_ENRICHMENT_RULES: Config<String> = Config::new(
+    "kafka_client_id_enrichment_rules",
+    "[]",
+    "Rules for enriching the `client.id` property of Kafka clients with additional data.",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&DELAY_SOURCES_PAST_REHYDRATION)
         .add(&STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION)
+        .add(&KAFKA_CLIENT_ID_ENRICHMENT_RULES)
 }

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -234,7 +234,11 @@ impl TransactionalProducer {
         metrics: Arc<KafkaSinkMetrics>,
         statistics: SinkStatistics,
     ) -> Result<Self, ContextCreationError> {
-        let client_id = connection.client_id(&storage_configuration.connection_context, sink_id);
+        let client_id = connection.client_id(
+            storage_configuration.config_set(),
+            &storage_configuration.connection_context,
+            sink_id,
+        );
         let transactional_id =
             connection.transactional_id(&storage_configuration.connection_context, sink_id);
 
@@ -753,7 +757,11 @@ async fn determine_sink_resume_upper(
         ..
     } = storage_configuration.parameters.kafka_timeout_config;
 
-    let client_id = connection.client_id(&storage_configuration.connection_context, sink_id);
+    let client_id = connection.client_id(
+        storage_configuration.config_set(),
+        &storage_configuration.connection_context,
+        sink_id,
+    );
     let group_id = connection.progress_group_id(&storage_configuration.connection_context, sink_id);
     let progress_topic = connection
         .progress_topic(&storage_configuration.connection_context)

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -173,7 +173,11 @@ impl SourceRender for KafkaSourceConnection {
             let [mut data_cap, mut progress_cap, health_cap, stats_cap]: [_; 4] =
                 caps.try_into().unwrap();
 
-            let client_id = self.client_id(&config.config.connection_context, config.id);
+            let client_id = self.client_id(
+                config.config.config_set(),
+                &config.config.connection_context,
+                config.id,
+            );
             let group_id = self.group_id(&config.config.connection_context, config.id);
             let KafkaSourceConnection {
                 connection,


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/cloud/issues/8316.

I've tested this manually and it works as expected. It's hard to write an automated test for this, though, as Kafka brokers don't readily expose the `client.id`s of connected clients. I think that's fine, given that this feature is purely for analytics, and has no bearing on the Materialize's observable behavior.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Skip the first two commits. Those are #26470.

See LaunchDarkly to preview the enrichment rule we plan to enable in production: https://app.launchdarkly.com/default/production/features/kafka_client_id_enrichment_rules/variations.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
