### PR TITLE
frontegg-auth: avoid caching error responses

### DIFF
--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -2537,8 +2537,7 @@ async fn test_transient_auth_failures() {
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
-            // Make the refresh window very large so it's easy to test.
-            refresh_drop_factor: 1.0,
+            refresh_drop_factor: DEFAULT_REFRESH_DROP_FACTOR,
         },
         mz_frontegg_auth::Client::default(),
         &metrics_registry,
@@ -2649,8 +2648,7 @@ async fn test_transient_auth_failure_on_refresh() {
             now: SYSTEM_TIME.clone(),
             admin_role: "mzadmin".to_string(),
             refresh_drop_lru_size: DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
-            // Make the refresh window very large so it's easy to test.
-            refresh_drop_factor: 1.0,
+            refresh_drop_factor: DEFAULT_REFRESH_DROP_FACTOR,
         },
         mz_frontegg_auth::Client::default(),
         &metrics_registry,


### PR DESCRIPTION
Handing this one off to @ParkMyCar. We need to add a test to validate the new behavior here.

----

Discovered during part of incident 103.

Fix https://github.com/MaterializeInc/materialize/issues/26477.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
