### PR TITLE
parallel-workload: Simpler fix for copy-to-s3 contention

### DIFF
--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -32,7 +32,7 @@ from materialize.data_ingest.transaction import Transaction
 from materialize.mzcompose.services.mysql import MySql
 
 
-class DataIngestExecutor:
+class Executor:
     num_transactions: int
     ports: dict[str, int]
     mz_conn: pg8000.Connection
@@ -112,7 +112,7 @@ class DataIngestExecutor:
                     time.sleep(wait_time_in_sec)
 
 
-class PrintExecutor(DataIngestExecutor):
+class PrintExecutor(Executor):
     def create(self, logging_exe: Any | None = None) -> None:
         pass
 
@@ -125,7 +125,7 @@ def delivery_report(err: str, msg: Any) -> None:
     assert err is None, f"Delivery failed for User record {msg.key()}: {err}"
 
 
-class KafkaExecutor(DataIngestExecutor):
+class KafkaExecutor(Executor):
     producer: confluent_kafka.Producer
     avro_serializer: AvroSerializer
     key_avro_serializer: AvroSerializer
@@ -288,7 +288,7 @@ class KafkaExecutor(DataIngestExecutor):
         self.producer.flush()
 
 
-class MySqlExecutor(DataIngestExecutor):
+class MySqlExecutor(Executor):
     mysql_conn: pymysql.Connection
     table: str
     source: str
@@ -413,7 +413,7 @@ class MySqlExecutor(DataIngestExecutor):
         self.mysql_conn.commit()
 
 
-class PgExecutor(DataIngestExecutor):
+class PgExecutor(Executor):
     pg_conn: pg8000.Connection
     table: str
     source: str
@@ -537,7 +537,7 @@ class PgExecutor(DataIngestExecutor):
         self.pg_conn.commit()
 
 
-class KafkaRoundtripExecutor(DataIngestExecutor):
+class KafkaRoundtripExecutor(Executor):
     table: str
     table_original: str
     topic: str

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -402,7 +402,10 @@ class CopyToS3Action(Action):
     def run(self, exe: Executor) -> bool:
         obj = self.rng.choice(exe.db.db_objects())
         obj_name = str(obj)
-        query = f"COPY (SELECT * FROM {obj_name}) TO 's3://copytos3/{self.rng.randrange(100)}' WITH (AWS CONNECTION = aws_conn, FORMAT = 'csv')"
+        with exe.db.lock:
+            location = exe.db.s3_path
+            exe.db.s3_path += 1
+        query = f"COPY (SELECT * FROM {obj_name}) TO 's3://copytos3/{location}' WITH (AWS CONNECTION = aws_conn, FORMAT = 'csv')"
 
         exe.execute(query, explainable=False)
         return True

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -57,7 +57,7 @@ from materialize.parallel_workload.database import (
     View,
     WebhookSource,
 )
-from materialize.parallel_workload.executor import ParallelWorkloadExecutor
+from materialize.parallel_workload.executor import Executor
 from materialize.parallel_workload.settings import Complexity, Scenario
 from materialize.sqlsmith import known_errors
 
@@ -73,14 +73,14 @@ class Action:
         self.rng = rng
         self.composition = composition
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         raise NotImplementedError
 
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = [
             "permission denied for",
             "must be owner of",
-            "network error",  # #21954, remove when fixed
+            "network error",  # #21954, remove when fixed when fixed
         ]
         if exe.db.complexity == Complexity.DDL:
             result.extend(
@@ -125,7 +125,7 @@ class Action:
 
 
 class FetchAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
         if exe.db.complexity == Complexity.DDL:
             result.extend(
@@ -136,7 +136,7 @@ class FetchAction(Action):
             )
         return result
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         obj = self.rng.choice(exe.db.db_objects())
         # See https://github.com/MaterializeInc/materialize/issues/20474
         exe.rollback() if self.rng.choice([True, False]) else exe.commit()
@@ -155,14 +155,14 @@ class FetchAction(Action):
 
 
 class SelectOneAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         exe.execute("SELECT 1", explainable=True)
         exe.cur.fetchall()
         return True
 
 
 class SelectAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
         result.extend(
             [
@@ -178,7 +178,7 @@ class SelectAction(Action):
             )
         return result
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         obj = self.rng.choice(exe.db.db_objects())
         column = self.rng.choice(obj.columns)
         obj2 = self.rng.choice(exe.db.db_objects_without_views())
@@ -238,7 +238,7 @@ class SQLsmithAction(Action):
         self.queries = []
         assert self.composition
 
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
         result.extend(known_errors)
         result.extend(
@@ -255,7 +255,7 @@ class SQLsmithAction(Action):
             )
         return result
 
-    def refill_sqlsmith(self, exe: ParallelWorkloadExecutor) -> None:
+    def refill_sqlsmith(self, exe: Executor) -> None:
         self.composition.silent = True
         seed = self.rng.randrange(2**31)
         try:
@@ -296,7 +296,7 @@ class SQLsmithAction(Action):
         finally:
             self.composition.silent = False
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         if exe.db.fast_startup:
             return False
 
@@ -309,7 +309,7 @@ class SQLsmithAction(Action):
 
 
 class HttpSelectAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         obj = self.rng.choice(exe.db.db_objects())
         column = self.rng.choice(obj.columns)
         obj2 = self.rng.choice(exe.db.db_objects_without_views())
@@ -382,7 +382,7 @@ class HttpSelectAction(Action):
 
 
 class CopyToS3Action(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
         result.extend(
             [
@@ -399,7 +399,7 @@ class CopyToS3Action(Action):
             )
         return result
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         obj = self.rng.choice(exe.db.db_objects())
         obj_name = str(obj)
         query = f"COPY (SELECT * FROM {obj_name}) TO 's3://copytos3/{self.rng.randrange(100)}' WITH (AWS CONNECTION = aws_conn, FORMAT = 'csv')"
@@ -409,12 +409,12 @@ class CopyToS3Action(Action):
 
 
 class InsertAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "cannot be run inside a transaction block",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         table = None
         if exe.insert_table is not None:
             for t in exe.db.tables:
@@ -460,7 +460,7 @@ class InsertAction(Action):
 
 
 class SourceInsertAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             sources = [
                 source
@@ -486,12 +486,12 @@ class SourceInsertAction(Action):
 
 
 class UpdateAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "canceling statement due to statement timeout",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         table = None
         if exe.insert_table is not None:
             for t in exe.db.tables:
@@ -514,12 +514,12 @@ class UpdateAction(Action):
 
 
 class DeleteAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "canceling statement due to statement timeout",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         table = self.rng.choice(exe.db.tables)
         query = f"DELETE FROM {table}"
         if self.rng.random() < 0.95:
@@ -540,7 +540,7 @@ class DeleteAction(Action):
 
 
 class CommentAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         table = self.rng.choice(exe.db.tables)
 
         if self.rng.choice([True, False]):
@@ -554,12 +554,12 @@ class CommentAction(Action):
 
 
 class CreateIndexAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "already exists",  # TODO: Investigate
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         if len(exe.db.indexes) >= MAX_INDEXES:
             return False
 
@@ -581,7 +581,7 @@ class CreateIndexAction(Action):
 
 
 class DropIndexAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if not exe.db.indexes:
                 return False
@@ -597,7 +597,7 @@ class DropIndexAction(Action):
 
 
 class CreateTableAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         if len(exe.db.tables) >= MAX_TABLES:
             return False
         table_id = exe.db.table_id
@@ -613,12 +613,12 @@ class CreateTableAction(Action):
 
 
 class DropTableAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "still depended upon by",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.tables) <= 2:
                 return False
@@ -635,7 +635,7 @@ class DropTableAction(Action):
 
 
 class RenameTableAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         if exe.db.scenario != Scenario.Rename:
             return False
         with exe.db.lock:
@@ -656,7 +656,7 @@ class RenameTableAction(Action):
 
 
 class RenameViewAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         if exe.db.scenario != Scenario.Rename:
             return False
         with exe.db.lock:
@@ -680,7 +680,7 @@ class RenameViewAction(Action):
 
 
 class RenameSinkAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         if exe.db.scenario != Scenario.Rename:
             return False
         with exe.db.lock:
@@ -704,7 +704,7 @@ class RenameSinkAction(Action):
 
 
 class CreateDatabaseAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.dbs) >= MAX_DBS:
                 return False
@@ -717,12 +717,12 @@ class CreateDatabaseAction(Action):
 
 
 class DropDatabaseAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "cannot be dropped with RESTRICT while it contains schemas",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.dbs) <= 1:
                 return False
@@ -739,7 +739,7 @@ class DropDatabaseAction(Action):
 
 
 class CreateSchemaAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.schemas) >= MAX_SCHEMAS:
                 return False
@@ -752,12 +752,12 @@ class CreateSchemaAction(Action):
 
 
 class DropSchemaAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "cannot be dropped without CASCADE while it contains objects",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.schemas) <= 1:
                 return False
@@ -774,12 +774,12 @@ class DropSchemaAction(Action):
 
 
 class RenameSchemaAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "ambiguous reference to schema named"  # see https://github.com/MaterializeInc/materialize/pull/22551#pullrequestreview-1691876923
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         if exe.db.scenario != Scenario.Rename:
             return False
         with exe.db.lock:
@@ -800,12 +800,12 @@ class RenameSchemaAction(Action):
 
 
 class SwapSchemaAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "object state changed while transaction was in progress",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         if exe.db.scenario != Scenario.Rename:
             return False
         with exe.db.lock:
@@ -844,14 +844,14 @@ class SwapSchemaAction(Action):
 
 
 class TransactionIsolationAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         level = self.rng.choice(["SERIALIZABLE", "STRICT SERIALIZABLE"])
         exe.set_isolation(level)
         return True
 
 
 class CommitRollbackAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         if not exe.action_run_since_last_commit_rollback:
             return False
 
@@ -864,7 +864,7 @@ class CommitRollbackAction(Action):
 
 
 class CreateViewAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.views) >= MAX_VIEWS:
                 return False
@@ -895,12 +895,12 @@ class CreateViewAction(Action):
 
 
 class DropViewAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "still depended upon by",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if not exe.db.views:
                 return False
@@ -920,7 +920,7 @@ class DropViewAction(Action):
 
 
 class CreateRoleAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.roles) >= MAX_ROLES:
                 return False
@@ -933,13 +933,13 @@ class CreateRoleAction(Action):
 
 
 class DropRoleAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "cannot be dropped because some objects depend on it",
             "current role cannot be dropped",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if not exe.db.roles:
                 return False
@@ -964,7 +964,7 @@ class DropRoleAction(Action):
 
 
 class CreateClusterAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.clusters) >= MAX_CLUSTERS:
                 return False
@@ -983,13 +983,13 @@ class CreateClusterAction(Action):
 
 
 class DropClusterAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             # cannot drop cluster "..." because other objects depend on it
             "because other objects depend on it",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.clusters) <= 1:
                 return False
@@ -1016,12 +1016,12 @@ class DropClusterAction(Action):
 
 
 class SwapClusterAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "object state changed while transaction was in progress",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         if exe.db.scenario != Scenario.Rename:
             return False
         with exe.db.lock:
@@ -1060,12 +1060,12 @@ class SwapClusterAction(Action):
 
 
 class SetClusterAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "SET cluster cannot be called in an active transaction",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if not exe.db.clusters:
                 return False
@@ -1076,14 +1076,14 @@ class SetClusterAction(Action):
 
 
 class CreateClusterReplicaAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = [
             "cannot create more than one replica of a cluster containing sources or sinks",
         ] + super().errors_to_ignore(exe)
 
         return result
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             # Keep cluster 0 with 1 replica for sources/sinks
             unmanaged_clusters = [c for c in exe.db.clusters[1:] if not c.managed]
@@ -1108,7 +1108,7 @@ class CreateClusterReplicaAction(Action):
 
 
 class DropClusterReplicaAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             # Keep cluster 0 with 1 replica for sources/sinks
             unmanaged_clusters = [c for c in exe.db.clusters[1:] if not c.managed]
@@ -1145,7 +1145,7 @@ class DropClusterReplicaAction(Action):
 
 
 class GrantPrivilegesAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if not exe.db.roles:
                 return False
@@ -1174,7 +1174,7 @@ class GrantPrivilegesAction(Action):
 
 
 class RevokePrivilegesAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if not exe.db.roles:
                 return False
@@ -1213,7 +1213,7 @@ class ReconnectAction(Action):
         super().__init__(rng, composition)
         self.random_role = random_role
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         autocommit = exe.cur._c.autocommit
         host = exe.db.host
         port = exe.db.ports["materialized"]
@@ -1264,7 +1264,7 @@ class ReconnectAction(Action):
 class CancelAction(Action):
     workers: list["Worker"]
 
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "must be a member of",
         ] + super().errors_to_ignore(exe)
@@ -1278,7 +1278,7 @@ class CancelAction(Action):
         super().__init__(rng, composition)
         self.workers = workers
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         pid = self.rng.choice(
             [worker.exe.pg_pid for worker in self.workers if worker.exe and worker.exe.pg_pid != -1]  # type: ignore
         )
@@ -1310,7 +1310,7 @@ class KillAction(Action):
         self.system_parameters = {}
         self.sanity_restart = sanity_restart
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         assert self.composition
         self.composition.kill("materialized")
         # Otherwise getting failure on "up" locally
@@ -1345,7 +1345,7 @@ class BackupRestoreAction(Action):
         self.num = 0
         assert self.composition
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         self.num += 1
         time.sleep(self.rng.uniform(10, 240))
 
@@ -1392,7 +1392,7 @@ class BackupRestoreAction(Action):
 
 
 class CreateWebhookSourceAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
         if exe.db.scenario in (Scenario.Kill, Scenario.TogglePersistTxn):
             result.extend(
@@ -1400,7 +1400,7 @@ class CreateWebhookSourceAction(Action):
             )
         return result
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.webhook_sources) >= MAX_WEBHOOK_SOURCES:
                 return False
@@ -1422,12 +1422,12 @@ class CreateWebhookSourceAction(Action):
 
 
 class DropWebhookSourceAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "still depended upon by",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if not exe.db.webhook_sources:
                 return False
@@ -1444,7 +1444,7 @@ class DropWebhookSourceAction(Action):
 
 
 class CreateKafkaSourceAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
         if exe.db.scenario in (Scenario.Kill, Scenario.TogglePersistTxn):
             result.extend(
@@ -1452,7 +1452,7 @@ class CreateKafkaSourceAction(Action):
             )
         return result
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.kafka_sources) >= MAX_KAFKA_SOURCES:
                 return False
@@ -1484,12 +1484,12 @@ class CreateKafkaSourceAction(Action):
 
 
 class DropKafkaSourceAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "still depended upon by",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if not exe.db.kafka_sources:
                 return False
@@ -1507,7 +1507,7 @@ class DropKafkaSourceAction(Action):
 
 
 class CreateMySqlSourceAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
         if exe.db.scenario in (Scenario.Kill, Scenario.TogglePersistTxn):
             result.extend(
@@ -1515,7 +1515,7 @@ class CreateMySqlSourceAction(Action):
             )
         return result
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         # TODO: Reenable when #22770 is fixed
         if exe.db.scenario == Scenario.BackupRestore:
             return False
@@ -1551,12 +1551,12 @@ class CreateMySqlSourceAction(Action):
 
 
 class DropMySqlSourceAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "still depended upon by",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if not exe.db.mysql_sources:
                 return False
@@ -1574,7 +1574,7 @@ class DropMySqlSourceAction(Action):
 
 
 class CreatePostgresSourceAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
         if exe.db.scenario in (Scenario.Kill, Scenario.TogglePersistTxn):
             result.extend(
@@ -1582,7 +1582,7 @@ class CreatePostgresSourceAction(Action):
             )
         return result
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         # TODO: Reenable when #22770 is fixed
         if exe.db.scenario == Scenario.BackupRestore:
             return False
@@ -1618,12 +1618,12 @@ class CreatePostgresSourceAction(Action):
 
 
 class DropPostgresSourceAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "still depended upon by",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if not exe.db.postgres_sources:
                 return False
@@ -1641,13 +1641,13 @@ class DropPostgresSourceAction(Action):
 
 
 class CreateKafkaSinkAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             # Another replica can be created in parallel
             "cannot create sink in cluster with more than one replica",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if len(exe.db.kafka_sinks) >= MAX_KAFKA_SINKS:
                 return False
@@ -1675,12 +1675,12 @@ class CreateKafkaSinkAction(Action):
 
 
 class DropKafkaSinkAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
             "still depended upon by",
         ] + super().errors_to_ignore(exe)
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if not exe.db.kafka_sinks:
                 return False
@@ -1697,13 +1697,13 @@ class DropKafkaSinkAction(Action):
 
 
 class HttpPostAction(Action):
-    def errors_to_ignore(self, exe: ParallelWorkloadExecutor) -> list[str]:
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
         if exe.db.scenario == Scenario.Rename:
             result.extend(["404: no object was found at the path"])
         return result
 
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         with exe.db.lock:
             if not exe.db.webhook_sources:
                 return False
@@ -1765,7 +1765,7 @@ class HttpPostAction(Action):
 
 
 class StatisticsAction(Action):
-    def run(self, exe: ParallelWorkloadExecutor) -> bool:
+    def run(self, exe: Executor) -> bool:
         for typ, objs in [
             ("tables", exe.db.tables),
             ("views", exe.db.views),

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -402,7 +402,7 @@ class CopyToS3Action(Action):
     def run(self, exe: ParallelWorkloadExecutor) -> bool:
         obj = self.rng.choice(exe.db.db_objects())
         obj_name = str(obj)
-        query = f"COPY (SELECT * FROM {obj_name}) TO 's3://copytos3/{exe.executor_id}_{exe.next_counter_value()}' WITH (AWS CONNECTION = aws_conn, FORMAT = 'csv')"
+        query = f"COPY (SELECT * FROM {obj_name}) TO 's3://copytos3/{self.rng.randrange(100)}' WITH (AWS CONNECTION = aws_conn, FORMAT = 'csv')"
 
         exe.execute(query, explainable=False)
         return True

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -865,6 +865,7 @@ class Database:
     postgres_source_id: int
     kafka_sinks: list[KafkaSink]
     kafka_sink_id: int
+    s3_path: int
     lock: threading.Lock
     seed: str
     sqlsmith_state: str
@@ -890,6 +891,7 @@ class Database:
         NAUGHTY_IDENTIFIERS = naughty_identifiers
         self.fast_startup = fast_startup
 
+        self.s3_path = 0
         self.dbs = [DB(seed, i) for i in range(rng.randint(1, MAX_INITIAL_DBS))]
         self.db_id = len(self.dbs)
         self.schemas = [

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -41,9 +41,8 @@ class ParallelWorkloadExecutor:
     action_run_since_last_commit_rollback: bool
 
     def __init__(
-        self, executor_id: int, rng: random.Random, cur: pg8000.Cursor, db: "Database"
+        self, rng: random.Random, cur: pg8000.Cursor, db: "Database"
     ):
-        self.executor_id = executor_id
         self.rng = rng
         self.cur = cur
         self.db = db

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -28,7 +28,7 @@ def initialize_logging() -> None:
     lock = threading.Lock()
 
 
-class ParallelWorkloadExecutor:
+class Executor:
     rng: random.Random
     cur: pg8000.Cursor
     pg_pid: int
@@ -40,9 +40,7 @@ class ParallelWorkloadExecutor:
     last_log: str
     action_run_since_last_commit_rollback: bool
 
-    def __init__(
-        self, rng: random.Random, cur: pg8000.Cursor, db: "Database"
-    ):
+    def __init__(self, rng: random.Random, cur: pg8000.Cursor, db: "Database"):
         self.rng = rng
         self.cur = cur
         self.db = db

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -53,7 +53,6 @@ class ParallelWorkloadExecutor:
         self.rollback_next = True
         self.last_log = ""
         self.action_run_since_last_commit_rollback = False
-        self._atomic_counter = 0
 
     def set_isolation(self, level: str) -> None:
         self.execute(f"SET TRANSACTION_ISOLATION TO '{level}'")
@@ -86,13 +85,6 @@ class ParallelWorkloadExecutor:
         with lock:
             print(f"[{thread_name}] {msg}", file=logging)
             logging.flush()
-
-    def next_counter_value(self) -> int:
-        with self.db.lock:
-            value = self._atomic_counter
-            self._atomic_counter = self._atomic_counter + 1
-
-        return value
 
     def execute(
         self, query: str, extra_info: str = "", explainable: bool = False

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -47,10 +47,7 @@ from materialize.parallel_workload.database import (
     MAX_WEBHOOK_SOURCES,
     Database,
 )
-from materialize.parallel_workload.executor import (
-    ParallelWorkloadExecutor,
-    initialize_logging,
-)
+from materialize.parallel_workload.executor import Executor, initialize_logging
 from materialize.parallel_workload.settings import Complexity, Scenario
 from materialize.parallel_workload.worker import Worker
 from materialize.parallel_workload.worker_exception import WorkerFailedException
@@ -94,7 +91,7 @@ def run(
     )
     system_conn.autocommit = True
     with system_conn.cursor() as system_cur:
-        system_exe = ParallelWorkloadExecutor(rng, system_cur, database)
+        system_exe = Executor(rng, system_cur, database)
         system_exe.execute(
             f"ALTER SYSTEM SET max_schemas_per_database = {MAX_SCHEMAS * 10 + num_threads}"
         )
@@ -144,7 +141,7 @@ def run(
         conn.autocommit = True
         with conn.cursor() as cur:
             assert composition
-            database.create(ParallelWorkloadExecutor(rng, cur, database), composition)
+            database.create(Executor(rng, cur, database), composition)
         conn.close()
 
     workers = []
@@ -367,7 +364,7 @@ def run(
     with conn.cursor() as cur:
         # Dropping the database also releases the long running connections
         # used by database objects.
-        database.drop(ParallelWorkloadExecutor(rng, cur, database))
+        database.drop(Executor(rng, cur, database))
 
         # Make sure all unreachable connections are closed too
         gc.collect()

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -94,7 +94,7 @@ def run(
     )
     system_conn.autocommit = True
     with system_conn.cursor() as system_cur:
-        system_exe = ParallelWorkloadExecutor(-1, rng, system_cur, database)
+        system_exe = ParallelWorkloadExecutor(rng, system_cur, database)
         system_exe.execute(
             f"ALTER SYSTEM SET max_schemas_per_database = {MAX_SCHEMAS * 10 + num_threads}"
         )
@@ -144,9 +144,7 @@ def run(
         conn.autocommit = True
         with conn.cursor() as cur:
             assert composition
-            database.create(
-                ParallelWorkloadExecutor(-1, rng, cur, database), composition
-            )
+            database.create(ParallelWorkloadExecutor(rng, cur, database), composition)
         conn.close()
 
     workers = []
@@ -177,7 +175,6 @@ def run(
             for action_class in action_list.action_classes
         ]
         worker = Worker(
-            i,
             worker_rng,
             actions,
             action_list.weights,
@@ -204,7 +201,6 @@ def run(
     if scenario == Scenario.Cancel:
         worker_rng = random.Random(rng.randrange(SEED_RANGE))
         worker = Worker(
-            num_threads + 1,
             worker_rng,
             [CancelAction(worker_rng, composition, workers)],
             [1],
@@ -225,7 +221,6 @@ def run(
         worker_rng = random.Random(rng.randrange(SEED_RANGE))
         assert composition, "Kill scenario only works in mzcompose"
         worker = Worker(
-            num_threads + 2,
             worker_rng,
             [KillAction(worker_rng, composition, sanity_restart)],
             [1],
@@ -251,7 +246,6 @@ def run(
         worker_rng = random.Random(rng.randrange(SEED_RANGE))
         assert composition, "TogglePersistTxn scenario only works in mzcompose"
         worker = Worker(
-            num_threads + 3,
             worker_rng,
             [
                 KillAction(
@@ -279,7 +273,6 @@ def run(
         worker_rng = random.Random(rng.randrange(SEED_RANGE))
         assert composition, "Backup & Restore scenario only works in mzcompose"
         worker = Worker(
-            num_threads + 4,
             worker_rng,
             [BackupRestoreAction(worker_rng, composition, database)],
             [1],
@@ -304,7 +297,6 @@ def run(
     if False:  # sanity check for debugging
         worker_rng = random.Random(rng.randrange(SEED_RANGE))
         worker = Worker(
-            num_threads + 5,
             worker_rng,
             [StatisticsAction(worker_rng, composition)],
             [1],
@@ -375,7 +367,7 @@ def run(
     with conn.cursor() as cur:
         # Dropping the database also releases the long running connections
         # used by database objects.
-        database.drop(ParallelWorkloadExecutor(-1, rng, cur, database))
+        database.drop(ParallelWorkloadExecutor(rng, cur, database))
 
         # Make sure all unreachable connections are closed too
         gc.collect()

--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -18,7 +18,7 @@ from materialize.data_ingest.query_error import QueryError
 from materialize.mzcompose.composition import Composition
 from materialize.parallel_workload.action import Action, ActionList, ReconnectAction
 from materialize.parallel_workload.database import Database
-from materialize.parallel_workload.executor import ParallelWorkloadExecutor
+from materialize.parallel_workload.executor import Executor
 
 
 class Worker:
@@ -30,7 +30,7 @@ class Worker:
     num_queries: Counter[type[Action]]
     autocommit: bool
     system: bool
-    exe: ParallelWorkloadExecutor | None
+    exe: Executor | None
     ignored_errors: defaultdict[str, Counter[type[Action]]]
     composition: Composition | None
     failed_query_error: QueryError | None
@@ -65,7 +65,7 @@ class Worker:
         )
         self.conn.autocommit = self.autocommit
         cur = self.conn.cursor()
-        self.exe = ParallelWorkloadExecutor(self.rng, cur, database)
+        self.exe = Executor(self.rng, cur, database)
         self.exe.set_isolation("SERIALIZABLE")
         cur.execute("SET auto_route_introspection_queries TO false")
         cur.execute("SELECT pg_backend_pid()")

--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -37,7 +37,6 @@ class Worker:
 
     def __init__(
         self,
-        worker_id: int,
         rng: random.Random,
         actions: list[Action],
         weights: list[float],
@@ -47,7 +46,6 @@ class Worker:
         composition: Composition | None,
         action_list: ActionList | None = None,
     ):
-        self.worker_id = worker_id
         self.rng = rng
         self.action_list = action_list
         self.actions = actions
@@ -67,7 +65,7 @@ class Worker:
         )
         self.conn.autocommit = self.autocommit
         cur = self.conn.cursor()
-        self.exe = ParallelWorkloadExecutor(self.worker_id, self.rng, cur, database)
+        self.exe = ParallelWorkloadExecutor(self.rng, cur, database)
         self.exe.set_isolation("SERIALIZABLE")
         cur.execute("SET auto_route_introspection_queries TO false")
         cur.execute("SELECT pg_backend_pid()")


### PR DESCRIPTION
Fixes #26422

@nrainer-materialize I reverted your previous fix, I hope that's ok for you. I think your fix was too complex, we don't require having the worker id since the parallel-workload.log will already contain the command and which worker copied to each s3 path. The renaming of the executors I didn't understand, did they conflict in some file? If so they can be imported under a different name in that file. Otherwise I don't want to add the name of the testing framework to each class, otherwise we'll have a lot of `FeatureBenchmarkAction`, `ParallelWorkloadAction`, `ZippyAction`, etc.. Since they don't usually interact with each other I think each of them just being called `Action` is fine.

Tip for reviewers: Only the last commit does anything, the rest is just a revert.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
