### PR TITLE
build: Update h2 0.3.24 -> 0.3.26, unsafe-libyaml 0.2.9 -> 0.2.11, openssl-src

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,9 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -6675,9 +6675,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.25.0+1.1.1t"
+version = "111.28.1+1.1.1w"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+checksum = "4bf7e82ffd6d3d6e6524216a0bfd85509f68b5b28354e8e7800057e44cefa9b4"
 dependencies = [
  "cc",
 ]
@@ -9680,9 +9680,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/deny.toml
+++ b/deny.toml
@@ -179,6 +179,18 @@ wrappers = [
     "pulldown-cmark",
 ]
 
+[advisories]
+ignore = [
+    # Consider switching `yaml-rust` to the actively maintained `yaml-rust2` fork of the original project
+    "RUSTSEC-2024-0320",
+    # Consider `std::io::IsTerminal` or `is-terminal` instead of `atty` (unmaintained)
+    "RUSTSEC-2021-0145",
+    # Consider `encoding_rs` instead of `encoding` (unmaintained)
+    "RUSTSEC-2021-0153",
+    # Upgrading openssl will increase the shared library we depend on
+    "RUSTSEC-2023-0072",
+]
+
 # Must be manually kept in sync with about.toml.
 # See: https://github.com/EmbarkStudios/cargo-about/issues/201
 [licenses]

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -345,7 +345,7 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.h2]]
-version = "0.3.24"
+version = "0.3.26"
 when = "2024-01-17"
 user-id = 359
 user-login = "seanmonstar"
@@ -505,7 +505,7 @@ user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.openssl-src]]
-version = "111.25.0+1.1.1t"
+version = "111.28.1+1.1.1w"
 when = "2023-02-07"
 user-id = 1
 user-login = "alexcrichton"
@@ -834,7 +834,7 @@ user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
 [[publisher.unsafe-libyaml]]
-version = "0.2.9"
+version = "0.2.11"
 when = "2023-07-15"
 user-id = 3618
 user-login = "dtolnay"


### PR DESCRIPTION
and mark not-so-easy to upgrade dependencies to be ignored. As seen in https://buildkite.com/materialize/security/builds/1179#018e99f9-79d7-4b6d-926e-1697e87d4c7e This started failing following the Rust 1.77 upgrade.

These are not new warnings, they were previously just ignored as warnings, and are now considered errors.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
