### PR TITLE
lint: More reliably detect if cargo tools are available

### DIFF
--- a/ci/test/lint-main/checks/check-cargo.sh
+++ b/ci/test/lint-main/checks/check-cargo.sh
@@ -17,19 +17,17 @@ cd "$(dirname "$0")/../../../.."
 
 . misc/shlib/shlib.bash
 
-INSTALLED_CARGO_PACKAGES=$(cargo install --list)
-
-if ! echo "$INSTALLED_CARGO_PACKAGES" | grep --silent "cargo-about"; then
+if ! cargo about --version > /dev/null 2>&1; then
   echo "lint: cargo-about is not installed"
   echo "hint: install it with: cargo install cargo-about"
 fi
 
-if ! echo "$INSTALLED_CARGO_PACKAGES" | grep --silent "cargo-hakari"; then
+if ! cargo hakari --version > /dev/null 2>&1; then
   echo "lint: cargo-hakari is not installed"
   echo "hint: install it with: cargo install cargo-hakari"
 fi
 
-if ! echo "$INSTALLED_CARGO_PACKAGES" | grep --silent "cargo-deplint"; then
+if ! cargo --list | grep --quiet deplint; then
   echo "lint: cargo-deplint is not installed"
   echo "hint: install it with: cargo install cargo-deplint"
 fi


### PR DESCRIPTION
`cargo install --list` does not work in ci-builder.

Previous output:
```
lint: cargo-about is not installed
hint: install it with: cargo install cargo-about
lint: cargo-hakari is not installed
hint: install it with: cargo install cargo-hakari
lint: cargo-deplint is not installed
hint: install it with: cargo install cargo-deplint
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
