### PR TITLE
Doc: Add tests for the datagen webhook js docs widget

### DIFF
--- a/ci/test/docs-widgets/webhooks-datagen.test.js
+++ b/ci/test/docs-widgets/webhooks-datagen.test.js
@@ -1,0 +1,156 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { JSDOM } from "jsdom";
+import fs from "fs";
+import path from "path";
+
+describe("Webhooks Data Generator", async () => {
+  let window, document;
+  let isGenerating = false;
+
+  beforeEach(() => {
+    const htmlPath = path.join(
+      __dirname,
+      "../../../doc/user/layouts/shortcodes/plugins/webhooks-datagen.html"
+    );
+    const htmlContent = fs.readFileSync(htmlPath, "utf-8");
+    const dom = new JSDOM(htmlContent, {
+      runScripts: "dangerously",
+      resources: "usable",
+      url: "http://localhost",
+    });
+
+    window = dom.window;
+    document = window.document;
+
+    // Wait for all the scripts and content to load
+    return new Promise((resolve) => {
+      document.addEventListener("DOMContentLoaded", resolve);
+    });
+  });
+
+  it("should initialize the DOM elements correctly", async () => {
+    const webhookURLInput = window.document.getElementById("webhookURL");
+    const authPasswordInput = window.document.getElementById("authPassword");
+    const jsonSchemaTextarea = window.document.getElementById("jsonSchema");
+    const startButton = window.document.getElementById("startButton");
+    const stopButton = window.document.getElementById("stopButton");
+
+    await new Promise((r) => setTimeout(r, 650));
+
+    expect(webhookURLInput).not.toBeNull();
+    expect(authPasswordInput).not.toBeNull();
+    expect(jsonSchemaTextarea).not.toBeNull();
+    expect(startButton).not.toBeNull();
+    expect(stopButton).not.toBeNull();
+  });
+
+  it("should not start generation without valid URL and password", async () => {
+    const startButton = window.document.getElementById("startButton");
+    const webhookURLInput = window.document.getElementById("webhookURL");
+    const authPasswordInput = window.document.getElementById("authPassword");
+
+    // Leave the URL and password empty
+    webhookURLInput.value = "";
+    authPasswordInput.value = "";
+
+    startButton.click();
+
+    expect(startButton.style.display).not.toBe("none");
+  });
+
+  it("should enable the stop button when generation starts", async () => {
+    const startButton = window.document.getElementById("startButton");
+    const stopButton = window.document.getElementById("stopButton");
+    const webhookURLInput = window.document.getElementById("webhookURL");
+    const authPasswordInput = window.document.getElementById("authPassword");
+
+    webhookURLInput.value = "http://localhost";
+    authPasswordInput.value = "password";
+
+    startButton.click();
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(stopButton.disabled).toBe(false);
+  });
+
+  it("should populate JSON schema based on selected use case", async () => {
+    const jsonSchemaTextarea = window.document.getElementById("jsonSchema");
+    const useCaseSelect = window.document.getElementById("useCaseSelect");
+
+    // Select a use case
+    useCaseSelect.value = "sensorData";
+    useCaseSelect.dispatchEvent(new window.Event("change"));
+
+    expect(jsonSchemaTextarea.value.trim()).not.toBe("");
+  });
+
+  it("should clear logs when the stop button is clicked", async () => {
+    const stopButton = window.document.getElementById("stopButton");
+    const logOutputDiv = window.document.getElementById("logOutput");
+
+    logOutputDiv.innerHTML = "<p>Log message</p>";
+
+    stopButton.click();
+
+    expect(logOutputDiv.innerHTML).toBe(logOutputDiv.innerHTML);
+  });
+
+  it("should remove the error message if the JSON schema is corrected", async () => {
+    const jsonSchemaTextarea = window.document.getElementById("jsonSchema");
+    const jsonErrorDiv = window.document.getElementById("jsonError");
+
+    // Input invalid JSON and then correct it
+    jsonSchemaTextarea.value = "invalid json";
+    jsonSchemaTextarea.dispatchEvent(new window.Event("blur"));
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    jsonSchemaTextarea.value = '{"valid": "json"}';
+    jsonSchemaTextarea.dispatchEvent(new window.Event("blur"));
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(jsonErrorDiv.style.display).toBe("none");
+  });
+
+  it("should have empty webhook URL and auth password inputs initially", async () => {
+    const webhookURLInput = window.document.getElementById("webhookURL");
+    const authPasswordInput = window.document.getElementById("authPassword");
+    await new Promise((r) => setTimeout(r, 50));
+    expect(webhookURLInput.value).toBe("");
+    expect(authPasswordInput.value).toBe("");
+  });
+
+  it("should not start generation with empty webhook URL and auth password", async () => {
+    const startButton = window.document.getElementById("startButton");
+    const webhookURLInput = window.document.getElementById("webhookURL");
+    const authPasswordInput = window.document.getElementById("authPassword");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    webhookURLInput.value = "";
+    authPasswordInput.value = "";
+
+    startButton.click();
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(isGenerating).toBe(false);
+  });
+
+  it("should stop data generation and enable start button when stop button is clicked", async () => {
+    const startButton = window.document.getElementById("startButton");
+    const stopButton = window.document.getElementById("stopButton");
+
+    // Trigger generation
+    startButton.click();
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    stopButton.click();
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(isGenerating).toBe(false);
+    expect(startButton.style.display).not.toBe("none");
+  });
+});


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Adding some basic tests for the webhooks datagen docs JS widget.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
