### PR TITLE
canary-environment: Adapt to v2 dbt sources

### DIFF
--- a/test/canary-environment/macros/create_loadgen_source.sql
+++ b/test/canary-environment/macros/create_loadgen_source.sql
@@ -8,8 +8,6 @@
 -- by the Apache License, Version 2.0.
 
 {% macro create_loadgen_source(name) %}
-CREATE SOURCE IF NOT EXISTS "{{ name.schema }}"."{{ name.table }}"
-IN CLUSTER qa_canary_environment_storage
 FROM KAFKA CONNECTION kafka_connection (TOPIC 'datagen_demo_snowflakeschema_{{ name.table }}')
 KEY FORMAT BYTES
 VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection

--- a/test/canary-environment/models/loadgen/customer.sql
+++ b/test/canary-environment/models/loadgen/customer.sql
@@ -7,6 +7,5 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
-
+{{ config(materialized='source', cluster='qa_canary_environment_storage', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/loadgen/product.sql
+++ b/test/canary-environment/models/loadgen/product.sql
@@ -7,6 +7,5 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
-
+{{ config(materialized='source', cluster='qa_canary_environment_storage', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/loadgen/product_category.sql
+++ b/test/canary-environment/models/loadgen/product_category.sql
@@ -7,6 +7,5 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
-
+{{ config(materialized='source', cluster='qa_canary_environment_storage', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/loadgen/region.sql
+++ b/test/canary-environment/models/loadgen/region.sql
@@ -7,6 +7,5 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
-
+{{ config(materialized='source', cluster='qa_canary_environment_storage', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/loadgen/sales.sql
+++ b/test/canary-environment/models/loadgen/sales.sql
@@ -7,6 +7,5 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
-
+{{ config(materialized='source', cluster='qa_canary_environment_storage', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/loadgen/store.sql
+++ b/test/canary-environment/models/loadgen/store.sql
@@ -7,6 +7,5 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
-
+{{ config(materialized='source', cluster='qa_canary_environment_storage', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/loadgen/supplier.sql
+++ b/test/canary-environment/models/loadgen/supplier.sql
@@ -7,6 +7,5 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
-
+{{ config(materialized='source', cluster='qa_canary_environment_storage', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/mysql_cdc/mysql_cdc.sql
+++ b/test/canary-environment/models/mysql_cdc/mysql_cdc.sql
@@ -7,9 +7,6 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source') }}
-
-CREATE SOURCE {{ this }}
-IN CLUSTER qa_canary_environment_storage
+{{ config(materialized='source', cluster='qa_canary_environment_storage') }}
 FROM MYSQL CONNECTION mysql
 FOR TABLES (public.people, public.relationships)

--- a/test/canary-environment/models/pg_cdc/pg_cdc.sql
+++ b/test/canary-environment/models/pg_cdc/pg_cdc.sql
@@ -7,10 +7,7 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source') }}
-
-CREATE SOURCE {{ this }}
-IN CLUSTER qa_canary_environment_storage
+{{ config(materialized='source', cluster='qa_canary_environment_storage') }}
 FROM POSTGRES
 CONNECTION pg (PUBLICATION 'mz_source')
 FOR TABLES (people, relationships)

--- a/test/canary-environment/models/tpch/tpch.sql
+++ b/test/canary-environment/models/tpch/tpch.sql
@@ -7,11 +7,7 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source') }}
-
-CREATE SOURCE {{ this }}
-  IN CLUSTER qa_canary_environment_storage
-  FROM LOAD GENERATOR
-  TPCH (SCALE FACTOR 1, TICK INTERVAL '0.1s')
-  FOR ALL TABLES
-;
+{{ config(materialized='source', cluster='qa_canary_environment_storage') }}
+FROM LOAD GENERATOR
+TPCH (SCALE FACTOR 1, TICK INTERVAL '0.1s')
+FOR ALL TABLES


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/25405

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
