### PR TITLE
storage/copy-to-s3: Rework error handling in copy-to-s3 operator, add assert for assumption about timely FIFO semantics

### DIFF
--- a/src/compute/src/sink/copy_to_s3_oneshot.rs
+++ b/src/compute/src/sink/copy_to_s3_oneshot.rs
@@ -19,7 +19,8 @@ use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::consolidate_pact;
-use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use timely::dataflow::operators::Operator;
 use timely::dataflow::Scope;
 use timely::progress::Antichain;
 
@@ -66,8 +67,10 @@ where
         // files based on the user provided `MAX_FILE_SIZE`.
         let batch_count = self.output_batch_count;
 
-        // TODO(#25835): Note, even though we do get deterministic output currently
-        // after the exchange below, it's not explicitly supported and we should change it.
+        // This relies on an assumption the output order after the Exchange is deterministic, which
+        // is necessary to ensure the files written from each compute replica are identical.
+        // While this is not technically guaranteed, the current implementation uses a FIFO channel.
+        // In the storage copy_to operator we assert the ordering of rows to detect any regressions.
         let input = consolidate_pact::<KeyBatcher<_, _, _>, _, _, _, _, _>(
             &sinked_collection.map(move |row| {
                 let batch = row.hashed() % batch_count;
@@ -77,18 +80,40 @@ where
             "Consolidated COPY TO S3 input",
         );
 
+        // We need to consolidate the error collection to ensure we don't act on retracted errors.
         let error = consolidate_pact::<KeyBatcher<_, _, _>, _, _, _, _, _>(
             &err_collection.map(move |row| {
                 let batch = row.hashed() % batch_count;
                 ((row, batch), ())
             }),
             Exchange::new(move |(((_, batch), _), _, _)| *batch),
-            "Consolidated COPY TO S3 error",
+            "Consolidated COPY TO S3 errors",
         );
+        // We can only propagate the one error back to the client, so filter the error
+        // collection to the first error that is before the sink 'up_to' to avoid
+        // sending the full error collection to the next operator. We ensure we find the
+        // first error before the 'up_to' to avoid accidentally sending an irrelevant error.
+        let error_stream =
+            error
+                .inner
+                .unary_frontier(Pipeline, "COPY TO S3 error filtering", |_cap, _info| {
+                    let up_to = sink.up_to.clone();
+                    let mut vector = Vec::new();
+                    let mut received_one = false;
+                    move |input, output| {
+                        while let Some((time, data)) = input.next() {
+                            if !up_to.less_equal(time.time()) && !received_one {
+                                received_one = true;
+                                data.swap(&mut vector);
+                                output.session(&time).give_iterator(vector.drain(..1));
+                            }
+                        }
+                    }
+                });
 
         mz_storage_operators::s3_oneshot_sink::copy_to(
             input,
-            error,
+            error_stream,
             sink.up_to.clone(),
             self.upload_info.clone(),
             connection_context,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Addresses feedback from @antiguru on some copy-to-s3 timely usage:

1. I originally addressed the timely ordering assumption this operator contains in https://github.com/MaterializeInc/materialize/pull/26340 but we decided that the performance cost of that PR was not desirable so it was closed.
  The current PR instead notes the ordering assumption and adds an `assert` to detect if the ordering of rows received by the storage operator is unsorted, which would indicate a potential regression in the behavior. Fixes https://github.com/MaterializeInc/materialize/issues/25835


2. We are currently distributing errors across all workers such that some workers might proceed to start their uploads even if another worker receives an error in its error stream. This is undesirable since we end up uploading incomplete data unnecessarily and take longer to respond to the client. We also send the full (potentially large) error stream across a timely exchange even though we only ever return the first error to the client.
 This PR now filters the error stream for each worker to just 1 error before it's sent to the storage operator. We then read these errors in the `initialization_operator` rather than the `upload_operator` and broadcast them to all workers to ensure we don't do any unnecessary work in the `upload_operator`.


<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
