### PR TITLE
compute: fix `DataflowDescription::is_imported`

### DIFF
--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -208,6 +208,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
     /// Returns true iff `id` is already imported.
     pub fn is_imported(&self, id: &GlobalId) -> bool {
         self.objects_to_build.iter().any(|bd| &bd.id == id)
+            || self.index_imports.keys().any(|i| i == id)
             || self.source_imports.keys().any(|i| i == id)
     }
 


### PR DESCRIPTION
`DataflowDescription::is_imported` was failing to check if the given ID was exported as an index, so it would only detect imported views and sources. Fixed by checking for membership in `index_imports` as well.

### Motivation

  * This PR fixes a previously unreported bug.

`DataflowDescription::is_imported` always returns `false` for index imports.

This is no big deal since `is_imported` is currently only used in `DataflowBuilder::import_into_dataflow` where it allows us to avoid redundant work. Importing an index twice only makes the new import overwrite the old one and does no harm.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
