### PR TITLE
storage/copy-to-s3: parquet format option & upload implementation stub

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -107,7 +107,6 @@ use mz_ore::thread::JoinHandleExt;
 use mz_ore::tracing::{OpenTelemetryContext, TracingHandle};
 use mz_ore::{soft_assert_or_log, soft_panic_or_log, stack};
 use mz_persist_client::usage::{ShardsUsageReferenced, StorageUsageClient};
-use mz_pgcopy::CopyFormatParams;
 use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::role_id::RoleId;
 use mz_repr::{GlobalId, RelationDesc, Timestamp};
@@ -127,6 +126,7 @@ use mz_storage_types::connections::inline::{IntoInlineConnection, ReferencedConn
 use mz_storage_types::connections::Connection as StorageConnection;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::controller::PersistTxnTablesImpl;
+use mz_storage_types::sinks::S3SinkFormat;
 use mz_storage_types::sources::Timeline;
 use mz_timestamp_oracle::WriteTimestamp;
 use mz_transform::dataflow::DataflowMetainfo;
@@ -444,7 +444,7 @@ pub struct CopyToContext {
     /// The ID of the CONNECTION object to be used for copying the data.
     pub connection_id: GlobalId,
     /// Format params to format the data.
-    pub format_params: CopyFormatParams<'static>,
+    pub format: S3SinkFormat,
     /// Approximate max file size of each uploaded file.
     pub max_file_size: u64,
     /// Number of batches the output of the COPY TO will be partitioned into

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -106,7 +106,7 @@ impl Coordinator {
             to,
             connection,
             connection_id,
-            format_params,
+            format,
             max_file_size,
         }: plan::CopyToPlan,
         target_cluster: TargetCluster,
@@ -149,7 +149,7 @@ impl Coordinator {
                     uri,
                     connection,
                     connection_id,
-                    format_params,
+                    format,
                     max_file_size,
                     // This will be set in `peek_stage_validate` stage below.
                     output_batch_count: None,

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -238,7 +238,7 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
                         uri: self.copy_to_context.uri.to_string(),
                         max_file_size: self.copy_to_context.max_file_size,
                         desc: self.copy_to_context.desc.clone(),
-                        format: self.copy_to_context.format_params.clone(),
+                        format: self.copy_to_context.format.clone(),
                     },
                     aws_connection: aws_connection.clone(),
                     connection_id: self.copy_to_context.connection_id,

--- a/src/aws-util/src/s3_uploader.rs
+++ b/src/aws-util/src/s3_uploader.rs
@@ -82,6 +82,8 @@ pub struct CompletedUpload {
     pub part_count: u32,
     /// The total number of bytes uploaded in the multi part upload.
     pub total_bytes_uploaded: u64,
+    pub bucket: String,
+    pub key: String,
 }
 
 /// Configuration object to configure the behaviour of the `S3MultiPartUploader`.
@@ -255,6 +257,8 @@ impl S3MultiPartUploader {
         Ok(CompletedUpload {
             part_count: self.part_count.try_into().expect("i32 to u32"),
             total_bytes_uploaded: self.total_bytes_uploaded,
+            bucket: self.bucket,
+            key: self.key,
         })
     }
 
@@ -403,6 +407,8 @@ mod tests {
         let CompletedUpload {
             part_count,
             total_bytes_uploaded,
+            bucket: _,
+            key: _,
         } = uploader.finish().await?;
 
         // Getting the uploaded object from s3 and validating the contents.
@@ -463,6 +469,8 @@ mod tests {
         let CompletedUpload {
             part_count,
             total_bytes_uploaded,
+            bucket: _,
+            key: _,
         } = uploader.finish().await?;
 
         // Getting the uploaded object from s3 and validating the contents.

--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -51,14 +51,14 @@ breaking:
     - compute-types/src/sinks.proto
     # reason: Ignore because plans are currently not persisted.
     - expr/src/relation.proto
-    # reason: not yet released
-    - mysql-util/src/desc.proto
     # reason: does currently not require backward-compatibility
     - storage-client/src/client.proto
     # reason: does currently not require backward-compatibility
     - storage-client/src/statistics.proto
     # reason: currently does not require backward-compatibility
     - storage-types/src/connections/aws.proto
+    # reason: copy-to-s3 not yet released
+    - storage-types/src/sinks.proto
 lint:
   use:
     - DEFAULT

--- a/src/mysql-util/src/desc.proto
+++ b/src/mysql-util/src/desc.proto
@@ -13,11 +13,6 @@ package mz_mysql_util;
 
 import "repr/src/relation_and_scalar.proto";
 
-// TODO: Remove this ignore after MySQL Private Preview begins
-// This was to allow converting ProtoMySqlColumnDesc.column_type to an optional field
-// which should be wire compatible but is not generated-bindings-compatible.
-// buf breaking: ignore (not yet released)
-
 message ProtoMySqlTableDesc {
     string name = 1;
     string schema_name = 2;

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1915,6 +1915,13 @@ where
                 CopyFormatParams::Csv(CopyCsvFormatParams::default()),
                 Format::Text,
             ),
+            CopyFormat::Parquet => {
+                let text = "Parquet format is not supported".to_string();
+                return self
+                    .error(ErrorResponse::error(SqlState::INTERNAL_ERROR, text.clone()))
+                    .await
+                    .map(|state| (state, SendRowsEndedReason::Errored { error: text }));
+            }
         };
 
         let encode_fn = |row: &Row, typ: &RelationType, out: &mut Vec<u8>| {

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -63,6 +63,11 @@ COPY t TO STDOUT WITH (FORMAT = csv)
 Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }] })
 
 parse-statement
+COPY t TO STDOUT WITH (FORMAT PARQUET)
+----
+error: Parquet unsupported
+
+parse-statement
 COPY t FROM STDIN WITH (FORMAT CSV, DELIMITER '|', NULL 'NULL', QUOTE '"', ESCAPE '\\', HEADER false)
 ----
 COPY t FROM STDIN WITH (FORMAT = csv, DELIMITER = '|', NULL = 'NULL', QUOTE = '"', ESCAPE = '\\', HEADER = false)
@@ -120,6 +125,13 @@ COPY t TO 's3://path/' || mz_now() WITH (FORMAT = csv, MAX FILE SIZE = '100MB', 
 COPY t TO 's3://path/' || mz_now() WITH (FORMAT = csv, MAX FILE SIZE = '100MB', AWS CONNECTION = aws_conn)
 =>
 Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("s3://path/")), expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("mz_now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) }), options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }, CopyOption { name: MaxFileSize, value: Some(Value(String("100MB"))) }, CopyOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("aws_conn")])))) }] })
+
+parse-statement
+COPY t TO 's3://path/' || mz_now() WITH (FORMAT = parquet, MAX FILE SIZE = '100MB', AWS CONNECTION = aws_conn)
+----
+COPY t TO 's3://path/' || mz_now() WITH (FORMAT = parquet, MAX FILE SIZE = '100MB', AWS CONNECTION = aws_conn)
+=>
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("s3://path/")), expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("mz_now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) }), options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("parquet")]))) }, CopyOption { name: MaxFileSize, value: Some(Value(String("100MB"))) }, CopyOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("aws_conn")])))) }] })
 
 parse-statement
 COPY t TO 's3://path/' || repeat('1', 2)

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -63,11 +63,6 @@ COPY t TO STDOUT WITH (FORMAT = csv)
 Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }] })
 
 parse-statement
-COPY t TO STDOUT WITH (FORMAT PARQUET)
-----
-error: Parquet unsupported
-
-parse-statement
 COPY t FROM STDIN WITH (FORMAT CSV, DELIMITER '|', NULL 'NULL', QUOTE '"', ESCAPE '\\', HEADER false)
 ----
 COPY t FROM STDIN WITH (FORMAT = csv, DELIMITER = '|', NULL = 'NULL', QUOTE = '"', ESCAPE = '\\', HEADER = false)

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1529,6 +1529,7 @@ pub enum CopyFormat {
     Text,
     Csv,
     Binary,
+    Parquet,
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -49,7 +49,7 @@ use mz_sql_parser::ast::{
     TransactionIsolationLevel, TransactionMode, Value, WithOptionValue,
 };
 use mz_storage_types::connections::inline::ReferencedConnection;
-use mz_storage_types::sinks::{SinkEnvelope, StorageSinkConnection};
+use mz_storage_types::sinks::{S3SinkFormat, SinkEnvelope, StorageSinkConnection};
 use mz_storage_types::sources::{SourceDesc, Timeline};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -810,7 +810,7 @@ pub struct CopyToPlan {
     pub connection: mz_storage_types::connections::Connection<ReferencedConnection>,
     /// The ID of the connection.
     pub connection_id: GlobalId,
-    pub format_params: CopyFormatParams<'static>,
+    pub format: S3SinkFormat,
     pub max_file_size: u64,
 }
 

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -782,7 +782,7 @@ fn generate_rbac_requirements(
             to: _,
             connection: _,
             connection_id: _,
-            format_params: _,
+            format: _,
             max_file_size: _,
         }) => {
             let mut privileges = generate_read_privileges(

--- a/src/storage-operators/src/s3_oneshot_sink.rs
+++ b/src/storage-operators/src/s3_oneshot_sink.rs
@@ -13,10 +13,10 @@ use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
+use anyhow::anyhow;
 use aws_types::sdk_config::SdkConfig;
 use differential_dataflow::{Collection, Hashable};
 use http::Uri;
-
 use mz_ore::cast::CastFrom;
 use mz_ore::future::InTask;
 use mz_ore::task::JoinHandleExt;

--- a/src/storage-operators/src/s3_oneshot_sink.rs
+++ b/src/storage-operators/src/s3_oneshot_sink.rs
@@ -9,22 +9,18 @@
 
 //! Uploads a consolidated collection to S3
 
+use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
-use anyhow::anyhow;
 use aws_types::sdk_config::SdkConfig;
-use bytesize::ByteSize;
 use differential_dataflow::{Collection, Hashable};
 use http::Uri;
-use mz_aws_util::s3_uploader::{
-    CompletedUpload, S3MultiPartUploadError, S3MultiPartUploader, S3MultiPartUploaderConfig,
-};
+
 use mz_ore::cast::CastFrom;
 use mz_ore::future::InTask;
 use mz_ore::task::JoinHandleExt;
-use mz_pgcopy::encode_copy_format;
-use mz_repr::{Diff, GlobalId, RelationDesc, Row, Timestamp};
+use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_types::connections::aws::AwsConnection;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::errors::DataflowError;
@@ -35,6 +31,9 @@ use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 use timely::PartialOrder;
 use tracing::{debug, info};
+
+mod parquet;
+mod pgcopy;
 
 /// Copy the rows from the input collection to s3.
 /// `worker_callback` is used to send the final count of rows uploaded to s3,
@@ -74,18 +73,32 @@ pub fn copy_to<G, F>(
         s3_key_manager.clone(),
     );
 
-    let completion_stream = render_upload_operator(
-        scope.clone(),
-        connection_context.clone(),
-        aws_connection.clone(),
-        connection_id,
-        connection_details,
-        sink_id,
-        input_collection,
-        err_collection,
-        up_to,
-        start_stream,
-    );
+    let completion_stream = match connection_details.format {
+        S3SinkFormat::PgCopy(_) => render_upload_operator::<G, pgcopy::PgCopyUploader>(
+            scope.clone(),
+            connection_context.clone(),
+            aws_connection.clone(),
+            connection_id,
+            connection_details,
+            sink_id,
+            input_collection,
+            err_collection,
+            up_to,
+            start_stream,
+        ),
+        S3SinkFormat::Parquet => render_upload_operator::<G, parquet::ParquetUploader>(
+            scope.clone(),
+            connection_context.clone(),
+            aws_connection.clone(),
+            connection_id,
+            connection_details,
+            sink_id,
+            input_collection,
+            err_collection,
+            up_to,
+            start_stream,
+        ),
+    };
 
     render_completion_operator(
         scope,
@@ -289,7 +302,7 @@ fn render_completion_operator<G, F>(
 /// Returns a `completion_stream` which contains 1 event per worker of
 /// the result of the upload operation, either an error or the number of rows
 /// uploaded by the worker.
-fn render_upload_operator<G>(
+fn render_upload_operator<G, T>(
     scope: G,
     connection_context: ConnectionContext,
     aws_connection: AwsConnection,
@@ -303,6 +316,7 @@ fn render_upload_operator<G>(
 ) -> Stream<G, Result<u64, String>>
 where
     G: Scope<Timestamp = Timestamp>,
+    T: CopyToS3Uploader,
 {
     let worker_id = scope.index();
     let mut builder = AsyncOperatorBuilder::new("CopyToS3-uploader".to_string(), scope.clone());
@@ -362,7 +376,7 @@ where
                 .await?;
 
             // Map of an uploader per batch.
-            let mut s3_uploaders: BTreeMap<u64, CopyToS3Uploader> = BTreeMap::new();
+            let mut s3_uploaders: BTreeMap<u64, T> = BTreeMap::new();
             let mut row_count = 0;
             while let Some(event) = input_handle.next().await {
                 match event {
@@ -377,15 +391,18 @@ where
                                     )
                                 }
                                 row_count += u64::try_from(diff).unwrap();
-                                let uploader = s3_uploaders.entry(batch).or_insert_with(|| {
-                                    debug!(%sink_id, %worker_id, "handling batch: {}", batch);
-                                    CopyToS3Uploader::new(
-                                        sdk_config.clone(),
-                                        connection_details.clone(),
-                                        &sink_id,
-                                        batch,
-                                    )
-                                });
+                                let uploader = match s3_uploaders.entry(batch) {
+                                    Entry::Occupied(entry) => entry.into_mut(),
+                                    Entry::Vacant(entry) => {
+                                        debug!(%sink_id, %worker_id, "handling batch: {}", batch);
+                                        entry.insert(T::new(
+                                            sdk_config.clone(),
+                                            connection_details.clone(),
+                                            &sink_id,
+                                            batch,
+                                        )?)
+                                    }
+                                };
                                 for _ in 0..diff {
                                     uploader.append_row(&row).await?;
                                 }
@@ -469,285 +486,20 @@ impl S3KeyManager {
     }
 }
 
-/// Required state to upload batches to S3
-struct CopyToS3Uploader {
-    /// The output description.
-    desc: RelationDesc,
-    /// Params to format the data.
-    format: S3SinkFormat,
-    /// The index of the current file within the batch.
-    file_index: usize,
-    /// Provides the appropriate bucket and object keys to use for uploads
-    key_manager: S3KeyManager,
-    /// Identifies the batch that files uploaded by this uploader belong to
-    batch: u64,
-    /// The desired file size. A new file upload will be started
-    /// when the size exceeds this amount.
-    max_file_size: u64,
-    /// The aws sdk config.
-    /// This is an option so that we can get an owned value later to move to a
-    /// spawned tokio task.
-    sdk_config: Option<SdkConfig>,
-    /// Multi-part uploader for the current file.
-    /// Keeping the uploader in an `Option` to later take owned value.
-    current_file_uploader: Option<S3MultiPartUploader>,
-    /// Temporary buffer to store the encoded bytes.
-    /// Currently at a time this will only store one single encoded row
-    /// before getting added to the `current_file_uploader`'s buffer.
-    buf: Vec<u8>,
-}
-
-impl CopyToS3Uploader {
+/// This trait is used to abstract over the upload details for different file formats.
+/// Each format has its own buffering semantics and upload logic, since some can be
+/// written in a streaming fashion row-by-row, whereas others use a columnar-based
+/// format that requires buffering a batch of rows before writing to S3.
+trait CopyToS3Uploader: Sized {
     fn new(
         sdk_config: SdkConfig,
         connection_details: S3UploadInfo,
         sink_id: &GlobalId,
         batch: u64,
-    ) -> CopyToS3Uploader {
-        CopyToS3Uploader {
-            desc: connection_details.desc,
-            sdk_config: Some(sdk_config),
-            format: connection_details.format,
-            key_manager: S3KeyManager::new(sink_id, &connection_details.uri),
-            batch,
-            max_file_size: connection_details.max_file_size,
-            file_index: 0,
-            current_file_uploader: None,
-            buf: Vec::new(),
-        }
-    }
-
-    /// Creates the uploader for the next file and starts the multi part upload.
-    async fn start_new_file_upload(&mut self) -> Result<(), anyhow::Error> {
-        self.flush().await?;
-        assert!(self.current_file_uploader.is_none());
-
-        self.file_index += 1;
-        let object_key = self.key_manager.data_key(
-            self.batch,
-            self.file_index,
-            match &self.format {
-                S3SinkFormat::PgCopy(params) => params.file_extension(),
-                S3SinkFormat::Parquet => "parquet",
-            },
-        );
-        let bucket = self.key_manager.bucket.clone();
-        info!("starting upload: bucket {}, key {}", &bucket, &object_key);
-        let sdk_config = self
-            .sdk_config
-            .take()
-            .expect("sdk_config should always be present");
-        let max_file_size = self.max_file_size;
-        // Moving the aws s3 calls onto tokio tasks instead of using timely runtime.
-        let handle = mz_ore::task::spawn(|| "s3_uploader::try_new", async move {
-            let uploader = S3MultiPartUploader::try_new(
-                &sdk_config,
-                bucket,
-                object_key,
-                S3MultiPartUploaderConfig {
-                    part_size_limit: ByteSize::mib(10).as_u64(),
-                    file_size_limit: max_file_size,
-                },
-            )
-            .await;
-            (uploader, sdk_config)
-        });
-        let (uploader, sdk_config) = handle.wait_and_assert_finished().await;
-        self.sdk_config = Some(sdk_config);
-        self.current_file_uploader = Some(uploader?);
-        Ok(())
-    }
-
-    /// Finishes any remaining in-progress upload.
-    async fn flush(&mut self) -> Result<(), anyhow::Error> {
-        if let Some(uploader) = self.current_file_uploader.take() {
-            // Moving the aws s3 calls onto tokio tasks instead of using timely runtime.
-            let handle =
-                mz_ore::task::spawn(|| "s3_uploader::finish", async { uploader.finish().await });
-            let CompletedUpload {
-                part_count,
-                total_bytes_uploaded,
-                bucket,
-                key,
-            } = handle.wait_and_assert_finished().await?;
-            info!(
-                "finished upload: bucket {}, key {}, bytes_uploaded {}, parts_uploaded {}",
-                bucket, key, total_bytes_uploaded, part_count
-            );
-        }
-        Ok(())
-    }
-
-    async fn upload_buffer(&mut self) -> Result<(), S3MultiPartUploadError> {
-        assert!(!self.buf.is_empty());
-        assert!(self.current_file_uploader.is_some());
-
-        let mut uploader = self.current_file_uploader.take().unwrap();
-        // TODO: Make buf a Bytes so it can be cheaply cloned.
-        let buf = std::mem::take(&mut self.buf);
-        // Moving the aws s3 calls onto tokio tasks instead of using timely runtime.
-        let handle = mz_ore::task::spawn(|| "s3_uploader::buffer_chunk", async move {
-            let result = uploader.buffer_chunk(&buf).await;
-            (uploader, buf, result)
-        });
-        let (uploader, buf, result) = handle.wait_and_assert_finished().await;
-        self.current_file_uploader = Some(uploader);
-        self.buf = buf;
-
-        let _ = result?;
-        Ok(())
-    }
-
-    /// Appends the row to the in-progress upload where it is buffered till it reaches the configured
-    /// `part_size_limit` after which the `S3MultiPartUploader` will upload that part. In case it will
-    /// exceed the max file size of the ongoing upload, then a new `S3MultiPartUploader` for a new file will
-    /// be created and the row data will be appended there.
-    async fn append_row(&mut self, row: &Row) -> Result<(), anyhow::Error> {
-        self.buf.clear();
-        match &self.format {
-            S3SinkFormat::PgCopy(fmt_params) => {
-                // encode the row and write to temp buffer.
-                encode_copy_format(fmt_params, row, self.desc.typ(), &mut self.buf)
-                    .map_err(|_| anyhow!("error encoding row"))?;
-            }
-            S3SinkFormat::Parquet => unimplemented!("Parquet format not supported yet"),
-        }
-
-        if self.current_file_uploader.is_none() {
-            self.start_new_file_upload().await?;
-        }
-
-        match self.upload_buffer().await {
-            Ok(_) => Ok(()),
-            Err(S3MultiPartUploadError::UploadExceedsMaxFileLimit(_)) => {
-                // Start a multi part upload of next file.
-                self.start_new_file_upload().await?;
-                // Upload data for the new part.
-                self.upload_buffer().await?;
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }?;
-
-        Ok(())
-    }
-}
-
-/// On CI, these tests are enabled by adding the scratch-aws-access plugin
-/// to the `cargo-test` step in `ci/test/pipeline.template.yml` and setting
-/// `MZ_S3_UPLOADER_TEST_S3_BUCKET` in
-/// `ci/test/cargo-test/mzcompose.py`.
-///
-/// For a Materialize developer, to opt in to these tests locally for
-/// development, follow the AWS access guide:
-///
-/// ```text
-/// https://www.notion.so/materialize/AWS-access-5fbd9513dcdc4e11a7591e8caa5f63fe
-/// ```
-///
-/// then running `source src/aws-util/src/setup_test_env_mz.sh`. You will also have
-/// to run `aws sso login` if you haven't recently.
-#[cfg(test)]
-mod tests {
-    use bytesize::ByteSize;
-    use mz_pgcopy::CopyFormatParams;
-    use mz_repr::{ColumnName, ColumnType, Datum, RelationType};
-    use uuid::Uuid;
-
-    use super::*;
-
-    fn s3_bucket_path_for_test() -> Option<(String, String)> {
-        let bucket = match std::env::var("MZ_S3_UPLOADER_TEST_S3_BUCKET") {
-            Ok(bucket) => bucket,
-            Err(_) => {
-                if mz_ore::env::is_var_truthy("CI") {
-                    panic!("CI is supposed to run this test but something has gone wrong!");
-                }
-                return None;
-            }
-        };
-
-        let prefix = Uuid::new_v4().to_string();
-        let path = format!("cargo_test/{}/file", prefix);
-        Some((bucket, path))
-    }
-
-    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
-    #[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/materialize/issues/18898
-    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `TLS_method` on OS `linux`
-    async fn test_multiple_files() -> Result<(), anyhow::Error> {
-        let sdk_config = mz_aws_util::defaults().load().await;
-        let (bucket, path) = match s3_bucket_path_for_test() {
-            Some(tuple) => tuple,
-            None => return Ok(()),
-        };
-        let sink_id = GlobalId::User(123);
-        let batch = 456;
-        let typ: RelationType = RelationType::new(vec![ColumnType {
-            scalar_type: mz_repr::ScalarType::String,
-            nullable: true,
-        }]);
-        let column_names = vec![ColumnName::from("col1")];
-        let desc = RelationDesc::new(typ, column_names.into_iter());
-        let mut uploader = CopyToS3Uploader::new(
-            sdk_config.clone(),
-            S3UploadInfo {
-                uri: format!("s3://{}/{}", bucket, path),
-                // this is only for testing, users will not be able to set value smaller than 16MB.
-                max_file_size: ByteSize::b(6).as_u64(),
-                desc,
-                format: S3SinkFormat::PgCopy(CopyFormatParams::Csv(Default::default())),
-            },
-            &sink_id,
-            batch,
-        );
-        let mut row = Row::default();
-        // Even though this will exceed max_file_size, it should be successfully uploaded in a single file.
-        row.packer().push(Datum::from("1234567"));
-        uploader.append_row(&row).await?;
-
-        // Since the max_file_size is 6B, this row will be uploaded to a new file.
-        row.packer().push(Datum::Null);
-        uploader.append_row(&row).await?;
-
-        row.packer().push(Datum::from("5678"));
-        uploader.append_row(&row).await?;
-
-        uploader.flush().await?;
-
-        // Based on the max_file_size, the uploader should have uploaded two
-        // files, part-0001.csv and part-0002.csv
-        let s3_client = mz_aws_util::s3::new_client(&sdk_config);
-        let first_file = s3_client
-            .get_object()
-            .bucket(bucket.clone())
-            .key(format!(
-                "{}/mz-{}-batch-{:04}-0001.csv",
-                path, sink_id, batch
-            ))
-            .send()
-            .await
-            .unwrap();
-
-        let body = first_file.body.collect().await.unwrap().into_bytes();
-        let expected_body: &[u8] = b"1234567\n";
-        assert_eq!(body, *expected_body);
-
-        let second_file = s3_client
-            .get_object()
-            .bucket(bucket)
-            .key(format!(
-                "{}/mz-{}-batch-{:04}-0002.csv",
-                path, sink_id, batch
-            ))
-            .send()
-            .await
-            .unwrap();
-
-        let body = second_file.body.collect().await.unwrap().into_bytes();
-        let expected_body: &[u8] = b"\n5678\n";
-        assert_eq!(body, *expected_body);
-
-        Ok(())
-    }
+    ) -> Result<Self, anyhow::Error>;
+    /// Append a row to the internal buffer, and optionally flush the buffer to S3.
+    async fn append_row(&mut self, row: &Row) -> Result<(), anyhow::Error>;
+    /// Flush the full remaining internal buffer to S3, and close all open resources.
+    /// This will be called when the input stream is finished.
+    async fn flush(&mut self) -> Result<(), anyhow::Error>;
 }

--- a/src/storage-operators/src/s3_oneshot_sink/parquet.rs
+++ b/src/storage-operators/src/s3_oneshot_sink/parquet.rs
@@ -1,0 +1,34 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use aws_types::sdk_config::SdkConfig;
+
+use mz_repr::{GlobalId, Row};
+use mz_storage_types::sinks::S3UploadInfo;
+
+use super::CopyToS3Uploader;
+
+pub(super) struct ParquetUploader {}
+
+impl CopyToS3Uploader for ParquetUploader {
+    fn new(
+        _sdk_config: SdkConfig,
+        _connection_details: S3UploadInfo,
+        _sink_id: &GlobalId,
+        _batch: u64,
+    ) -> Result<ParquetUploader, anyhow::Error> {
+        anyhow::bail!("Parquet uploading is not yet implemented")
+    }
+    async fn append_row(&mut self, _row: &Row) -> Result<(), anyhow::Error> {
+        anyhow::bail!("Parquet uploading is not yet implemented")
+    }
+    async fn flush(&mut self) -> Result<(), anyhow::Error> {
+        anyhow::bail!("Parquet uploading is not yet implemented")
+    }
+}

--- a/src/storage-operators/src/s3_oneshot_sink/pgcopy.rs
+++ b/src/storage-operators/src/s3_oneshot_sink/pgcopy.rs
@@ -1,0 +1,300 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::anyhow;
+use aws_types::sdk_config::SdkConfig;
+use bytesize::ByteSize;
+use mz_aws_util::s3_uploader::{
+    CompletedUpload, S3MultiPartUploadError, S3MultiPartUploader, S3MultiPartUploaderConfig,
+};
+use mz_ore::task::JoinHandleExt;
+use mz_pgcopy::{encode_copy_format, CopyFormatParams};
+use mz_repr::{GlobalId, RelationDesc, Row};
+use mz_storage_types::sinks::{S3SinkFormat, S3UploadInfo};
+use tracing::info;
+
+use super::{CopyToS3Uploader, S3KeyManager};
+
+/// Required state to upload batches to S3
+pub(super) struct PgCopyUploader {
+    /// The output description.
+    desc: RelationDesc,
+    /// Params to format the data.
+    format: CopyFormatParams<'static>,
+    /// The index of the current file within the batch.
+    file_index: usize,
+    /// Provides the appropriate bucket and object keys to use for uploads
+    key_manager: S3KeyManager,
+    /// Identifies the batch that files uploaded by this uploader belong to
+    batch: u64,
+    /// The desired file size. A new file upload will be started
+    /// when the size exceeds this amount.
+    max_file_size: u64,
+    /// The aws sdk config.
+    /// This is an option so that we can get an owned value later to move to a
+    /// spawned tokio task.
+    sdk_config: Option<SdkConfig>,
+    /// Multi-part uploader for the current file.
+    /// Keeping the uploader in an `Option` to later take owned value.
+    current_file_uploader: Option<S3MultiPartUploader>,
+    /// Temporary buffer to store the encoded bytes.
+    /// Currently at a time this will only store one single encoded row
+    /// before getting added to the `current_file_uploader`'s buffer.
+    buf: Vec<u8>,
+}
+
+impl CopyToS3Uploader for PgCopyUploader {
+    fn new(
+        sdk_config: SdkConfig,
+        connection_details: S3UploadInfo,
+        sink_id: &GlobalId,
+        batch: u64,
+    ) -> Result<PgCopyUploader, anyhow::Error> {
+        match connection_details.format {
+            S3SinkFormat::PgCopy(format_params) => Ok(PgCopyUploader {
+                desc: connection_details.desc,
+                sdk_config: Some(sdk_config),
+                format: format_params,
+                key_manager: S3KeyManager::new(sink_id, &connection_details.uri),
+                batch,
+                max_file_size: connection_details.max_file_size,
+                file_index: 0,
+                current_file_uploader: None,
+                buf: Vec::new(),
+            }),
+            _ => anyhow::bail!("Expected PgCopy format"),
+        }
+    }
+
+    /// Finishes any remaining in-progress upload.
+    async fn flush(&mut self) -> Result<(), anyhow::Error> {
+        if let Some(uploader) = self.current_file_uploader.take() {
+            // Moving the aws s3 calls onto tokio tasks instead of using timely runtime.
+            let handle =
+                mz_ore::task::spawn(|| "s3_uploader::finish", async { uploader.finish().await });
+            let CompletedUpload {
+                part_count,
+                total_bytes_uploaded,
+                bucket,
+                key,
+            } = handle.wait_and_assert_finished().await?;
+            info!(
+                "finished upload: bucket {}, key {}, bytes_uploaded {}, parts_uploaded {}",
+                bucket, key, total_bytes_uploaded, part_count
+            );
+        }
+        Ok(())
+    }
+
+    /// Appends the row to the in-progress upload where it is buffered till it reaches the configured
+    /// `part_size_limit` after which the `S3MultiPartUploader` will upload that part. In case it will
+    /// exceed the max file size of the ongoing upload, then a new `S3MultiPartUploader` for a new file will
+    /// be created and the row data will be appended there.
+    async fn append_row(&mut self, row: &Row) -> Result<(), anyhow::Error> {
+        self.buf.clear();
+        // encode the row and write to temp buffer.
+        encode_copy_format(&self.format, row, self.desc.typ(), &mut self.buf)
+            .map_err(|_| anyhow!("error encoding row"))?;
+
+        if self.current_file_uploader.is_none() {
+            self.start_new_file_upload().await?;
+        }
+
+        match self.upload_buffer().await {
+            Ok(_) => Ok(()),
+            Err(S3MultiPartUploadError::UploadExceedsMaxFileLimit(_)) => {
+                // Start a multi part upload of next file.
+                self.start_new_file_upload().await?;
+                // Upload data for the new part.
+                self.upload_buffer().await?;
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }?;
+
+        Ok(())
+    }
+}
+
+impl PgCopyUploader {
+    /// Creates the uploader for the next file and starts the multi part upload.
+    async fn start_new_file_upload(&mut self) -> Result<(), anyhow::Error> {
+        self.flush().await?;
+        assert!(self.current_file_uploader.is_none());
+
+        self.file_index += 1;
+        let object_key =
+            self.key_manager
+                .data_key(self.batch, self.file_index, self.format.file_extension());
+        let bucket = self.key_manager.bucket.clone();
+        info!("starting upload: bucket {}, key {}", &bucket, &object_key);
+        let sdk_config = self
+            .sdk_config
+            .take()
+            .expect("sdk_config should always be present");
+        let max_file_size = self.max_file_size;
+        // Moving the aws s3 calls onto tokio tasks instead of using timely runtime.
+        let handle = mz_ore::task::spawn(|| "s3_uploader::try_new", async move {
+            let uploader = S3MultiPartUploader::try_new(
+                &sdk_config,
+                bucket,
+                object_key,
+                S3MultiPartUploaderConfig {
+                    part_size_limit: ByteSize::mib(10).as_u64(),
+                    file_size_limit: max_file_size,
+                },
+            )
+            .await;
+            (uploader, sdk_config)
+        });
+        let (uploader, sdk_config) = handle.wait_and_assert_finished().await;
+        self.sdk_config = Some(sdk_config);
+        self.current_file_uploader = Some(uploader?);
+        Ok(())
+    }
+
+    async fn upload_buffer(&mut self) -> Result<(), S3MultiPartUploadError> {
+        assert!(!self.buf.is_empty());
+        assert!(self.current_file_uploader.is_some());
+
+        let mut uploader = self.current_file_uploader.take().unwrap();
+        // TODO: Make buf a Bytes so it can be cheaply cloned.
+        let buf = std::mem::take(&mut self.buf);
+        // Moving the aws s3 calls onto tokio tasks instead of using timely runtime.
+        let handle = mz_ore::task::spawn(|| "s3_uploader::buffer_chunk", async move {
+            let result = uploader.buffer_chunk(&buf).await;
+            (uploader, buf, result)
+        });
+        let (uploader, buf, result) = handle.wait_and_assert_finished().await;
+        self.current_file_uploader = Some(uploader);
+        self.buf = buf;
+
+        let _ = result?;
+        Ok(())
+    }
+}
+
+/// On CI, these tests are enabled by adding the scratch-aws-access plugin
+/// to the `cargo-test` step in `ci/test/pipeline.template.yml` and setting
+/// `MZ_S3_UPLOADER_TEST_S3_BUCKET` in
+/// `ci/test/cargo-test/mzcompose.py`.
+///
+/// For a Materialize developer, to opt in to these tests locally for
+/// development, follow the AWS access guide:
+///
+/// ```text
+/// https://www.notion.so/materialize/AWS-access-5fbd9513dcdc4e11a7591e8caa5f63fe
+/// ```
+///
+/// then running `source src/aws-util/src/setup_test_env_mz.sh`. You will also have
+/// to run `aws sso login` if you haven't recently.
+#[cfg(test)]
+mod tests {
+    use bytesize::ByteSize;
+    use mz_pgcopy::CopyFormatParams;
+    use mz_repr::{ColumnName, ColumnType, Datum, RelationType};
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn s3_bucket_path_for_test() -> Option<(String, String)> {
+        let bucket = match std::env::var("MZ_S3_UPLOADER_TEST_S3_BUCKET") {
+            Ok(bucket) => bucket,
+            Err(_) => {
+                if mz_ore::env::is_var_truthy("CI") {
+                    panic!("CI is supposed to run this test but something has gone wrong!");
+                }
+                return None;
+            }
+        };
+
+        let prefix = Uuid::new_v4().to_string();
+        let path = format!("cargo_test/{}/file", prefix);
+        Some((bucket, path))
+    }
+
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/materialize/issues/18898
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `TLS_method` on OS `linux`
+    async fn test_multiple_files() -> Result<(), anyhow::Error> {
+        let sdk_config = mz_aws_util::defaults().load().await;
+        let (bucket, path) = match s3_bucket_path_for_test() {
+            Some(tuple) => tuple,
+            None => return Ok(()),
+        };
+        let sink_id = GlobalId::User(123);
+        let batch = 456;
+        let typ: RelationType = RelationType::new(vec![ColumnType {
+            scalar_type: mz_repr::ScalarType::String,
+            nullable: true,
+        }]);
+        let column_names = vec![ColumnName::from("col1")];
+        let desc = RelationDesc::new(typ, column_names.into_iter());
+        let mut uploader = PgCopyUploader::new(
+            sdk_config.clone(),
+            S3UploadInfo {
+                uri: format!("s3://{}/{}", bucket, path),
+                // this is only for testing, users will not be able to set value smaller than 16MB.
+                max_file_size: ByteSize::b(6).as_u64(),
+                desc,
+                format: S3SinkFormat::PgCopy(CopyFormatParams::Csv(Default::default())),
+            },
+            &sink_id,
+            batch,
+        )?;
+        let mut row = Row::default();
+        // Even though this will exceed max_file_size, it should be successfully uploaded in a single file.
+        row.packer().push(Datum::from("1234567"));
+        uploader.append_row(&row).await?;
+
+        // Since the max_file_size is 6B, this row will be uploaded to a new file.
+        row.packer().push(Datum::Null);
+        uploader.append_row(&row).await?;
+
+        row.packer().push(Datum::from("5678"));
+        uploader.append_row(&row).await?;
+
+        uploader.flush().await?;
+
+        // Based on the max_file_size, the uploader should have uploaded two
+        // files, part-0001.csv and part-0002.csv
+        let s3_client = mz_aws_util::s3::new_client(&sdk_config);
+        let first_file = s3_client
+            .get_object()
+            .bucket(bucket.clone())
+            .key(format!(
+                "{}/mz-{}-batch-{:04}-0001.csv",
+                path, sink_id, batch
+            ))
+            .send()
+            .await
+            .unwrap();
+
+        let body = first_file.body.collect().await.unwrap().into_bytes();
+        let expected_body: &[u8] = b"1234567\n";
+        assert_eq!(body, *expected_body);
+
+        let second_file = s3_client
+            .get_object()
+            .bucket(bucket)
+            .key(format!(
+                "{}/mz-{}-batch-{:04}-0002.csv",
+                path, sink_id, batch
+            ))
+            .send()
+            .await
+            .unwrap();
+
+        let body = second_file.body.collect().await.unwrap().into_bytes();
+        let expected_body: &[u8] = b"\n5678\n";
+        assert_eq!(body, *expected_body);
+
+        Ok(())
+    }
+}

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -20,6 +20,10 @@ import "storage-types/src/connections.proto";
 
 package mz_storage_types.sinks;
 
+// TODO: Remove this after https://github.com/MaterializeInc/materialize/pull/26495 merges
+// buf breaking: ignore (copy-to-s3 not yet released)
+
+
 message ProtoStorageSinkDesc {
     reserved 5, 8, 9, 10;
     mz_repr.global_id.ProtoGlobalId from = 1;

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -108,9 +108,16 @@ message ProtoPersistSinkConnection {
     mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 2;
 }
 
+message ProtoS3SinkFormat {
+    oneof kind {
+        mz_pgcopy.copy.ProtoCopyFormatParams pg_copy = 1;
+        google.protobuf.Empty parquet = 2;
+    }
+}
+
 message ProtoS3UploadInfo {
     string uri = 1;
     uint64 max_file_size = 2;
     mz_repr.relation_and_scalar.ProtoRelationDesc desc = 3;
-    mz_pgcopy.copy.ProtoCopyFormatParams format = 4;
+    ProtoS3SinkFormat format = 4;
 }

--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -35,14 +35,14 @@ contains:AWS CONNECTION is required for COPY ... TO <expr>
   WITH (
     AWS CONNECTION = aws_conn
   );
-contains:only CSV format is supported for COPY ... TO <expr>
+contains:FORMAT TEXT not yet supported
 
 ! COPY t TO 's3://path/to/dir'
   WITH (
     AWS CONNECTION = aws_conn,
     FORMAT = 'binary'
   );
-contains:only CSV format is supported for COPY ... TO <expr>
+contains:FORMAT BINARY not yet supported
 
 ! COPY t TO '/path/'
   WITH (


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/26491

This adds support for `COPY <> TO 's3://path/' WITH (FORMAT = parquet)` in sql parsing / planning.

It also splits out the logic for uploading CSV formatted files into a trait implementation to allow different logic for the arrow/parquet implementation, which will be fairly different since we need to translate rows into a columnar format.

This PR is mostly just preparation for the actual parquet format implementation - taking care of all the boilerplate, etc.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

The diff looks large but it's mostly just moving code out of `s3_oneshot_sink.rs` into a submodule

All of this is currently behind a feature flag (`enable_copy_to_expr`) so will not be available to users

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
