### PR TITLE
ci: Make Release Qualification green again

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1091,7 +1091,8 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlsmith
-              args: [--max-joins=2, --runtime=1500]
+              # TODO(def-) Increase number of joins when #23451 is fixed
+              args: [--max-joins=1, --runtime=1500]
 
       - id: sqlsmith-explain
         label: "SQLsmith explain"
@@ -1102,7 +1103,8 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlsmith
-              args: [--max-joins=15, --explain-only, --runtime=1500]
+              # TODO(def-) Increase number of joins when #23451 is fixed
+              args: [--max-joins=5, --explain-only, --runtime=1500]
 
   - group: SQLancer
     key: sqlancer

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -31,7 +31,7 @@ steps:
       # 48h
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-large
+        queue: builder-linux-aarch64
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -54,7 +54,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-large
+        queue: builder-linux-aarch64
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -65,7 +65,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-large
+        queue: builder-linux-aarch64
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -99,7 +99,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64
+        queue: linux-aarch64-large
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -122,11 +122,12 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-large
+        queue: builder-linux-aarch64
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
             args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=100000, --max-execution-time=8h]
+      skip: "Reenable when #19999 is fixed"
 
   - id: feature-benchmark-scale-plus-one
     label: "Feature benchmark against 'common-ancestor' with --scale=+1 %N"
@@ -153,6 +154,7 @@ steps:
         - ./ci/plugins/mzcompose:
             composition: sqlsmith
             args: [--max-joins=2, --runtime=6000]
+      skip: "Reenable when #23451 is fixed"
 
     - id: sqlsmith-explain-long
       label: "Longer SQLsmith explain"
@@ -164,6 +166,7 @@ steps:
         - ./ci/plugins/mzcompose:
             composition: sqlsmith
             args: [--max-joins=15, --explain-only, --runtime=6000]
+      skip: "Reenable when #23451 is fixed"
 
   - id: tests-preflight-check-rollback
     label: Tests with preflight check and rollback

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -1439,6 +1439,8 @@ class MySqlInitialLoad(MySqlCdc):
     """Measure the time it takes to read 1M existing records from MySQL
     when creating a materialized source"""
 
+    FIXED_SCALE = True  # TODO: Remove when #25323 is fixed
+
     def shared(self) -> Action:
         return TdAction(
             f"""

--- a/misc/python/materialize/feature_benchmark/scenarios/concurrency.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/concurrency.py
@@ -20,6 +20,7 @@ class ParallelIngestion(Concurrency):
     """Measure the time it takes to ingest multiple sources concurrently."""
 
     SOURCES = 10
+    FIXED_SCALE = True  # Disk slowness in CRDB leading to CRDB going down
 
     def shared(self) -> Action:
         return TdAction(

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -339,7 +339,8 @@ class KafkaSourcesLarge(Scenario):
             CreateViewParameterized(
                 max_views=50, expensive_aggregates=False, max_inputs=1
             ): 5,
-            CreateSinkParameterized(max_sinks=25): 10,
+            # TODO(def-) Reenable when #26511 is fixed
+            # CreateSinkParameterized(max_sinks=25): 10,
             ValidateView: 10,
             Ingest: 100,
             PeekCancellation: 5,


### PR DESCRIPTION
Trial run (of an older state, I already disabled the three failing tests): https://buildkite.com/materialize/release-qualification/builds/467#_

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
