### PR TITLE
compute: reconcile dataflows with transient IDs

### DIFF
--- a/src/compute-types/src/plan/flat_plan.rs
+++ b/src/compute-types/src/plan/flat_plan.rs
@@ -655,6 +655,21 @@ impl<T> FlatPlan<T> {
     pub fn destruct(self) -> (BTreeMap<LirId, FlatPlanNode<T>>, LirId, Vec<LirId>) {
         (self.nodes, self.root, self.topological_order)
     }
+
+    /// Replace references to global IDs by the result of `func`.
+    pub fn replace_ids<F>(&mut self, mut func: F)
+    where
+        F: FnMut(GlobalId) -> GlobalId,
+    {
+        for node in self.nodes.values_mut() {
+            if let FlatPlanNode::Get {
+                id: Id::Global(id), ..
+            } = node
+            {
+                *id = func(*id);
+            }
+        }
+    }
 }
 
 impl<T: Clone> FlatPlan<T> {

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1764,6 +1764,11 @@ def workflow_test_compute_reconciliation_reuse(c: Composition) -> None:
 
         return reused, replaced
 
+    # Run a slow-path SELECT to allocate a transient ID. This ensures that
+    # after the restart dataflows get different internal transient IDs
+    # assigned, which is something we want reconciliation to be able to handle.
+    c.sql("SELECT * FROM mz_views JOIN mz_indexes USING (id)")
+
     # Set up a cluster and a number of dataflows that can be reconciled.
     c.sql(
         """


### PR DESCRIPTION
When the optimizer produces a `DataflowDescription` it sometimes needs to allocate transient `GlobalId`s to make objects referenceable internally. The IDs it receives when doing so depend on which commands have previously been run against the Mz instance since its last restart, so they are not deterministic. Compute reconciliation that compares `DataflowDescription`s as-is may thus fail and unnecessarily recreate dataflows because the compared `DataflowDescription`s contain different internal transient IDs, even though they might be semantically equivalent.

This PR fixes the described defect by normalizing internal transient IDs before comparing `DataflowDescription`s during reconciliation.

### Motivation

  * This PR fixes a recognized bug.

Fixes #26155

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
