### PR TITLE
persist: Delete unused code

### DIFF
--- a/src/persist/src/indexed/columnar/arrow.rs
+++ b/src/persist/src/indexed/columnar/arrow.rs
@@ -11,27 +11,16 @@
 
 use std::collections::BTreeMap;
 use std::convert;
-use std::io::{Read, Seek, Write};
 use std::sync::Arc;
 
 use arrow2::array::{Array, BinaryArray, PrimitiveArray};
 use arrow2::chunk::Chunk;
 use arrow2::datatypes::{DataType, Field, Schema};
-use arrow2::io::ipc::read::{read_file_metadata, FileMetadata, FileReader};
-use arrow2::io::ipc::write::{FileWriter, WriteOptions};
-use differential_dataflow::trace::Description;
 use mz_dyncfg::Config;
 use mz_ore::lgbytes::MetricsRegion;
-use mz_persist_types::Codec64;
 use once_cell::sync::Lazy;
-use timely::progress::{Antichain, Timestamp};
 
-use crate::error::Error;
-use crate::gen::persist::ProtoBatchFormat;
 use crate::indexed::columnar::ColumnarRecords;
-use crate::indexed::encoding::{
-    decode_trace_inline_meta, encode_trace_inline_meta, BlobTraceBatchPart,
-};
 use crate::metrics::ColumnarMetrics;
 
 /// The Arrow schema we use to encode ((K, V), T, D) tuples.
@@ -77,94 +66,6 @@ pub static SCHEMA_ARROW_KVTD: Lazy<Arc<Schema>> = Lazy::new(|| {
         },
     ]))
 });
-
-const INLINE_METADATA_KEY: &str = "MZ:inline";
-
-/// Encodes an BlobTraceBatchPart into the Arrow file format.
-///
-/// NB: This is currently unused, but it's here because we may want to use it
-/// for the local cache and so we can easily compare arrow vs parquet.
-pub fn encode_trace_arrow<W: Write, T: Timestamp + Codec64>(
-    w: &mut W,
-    batch: &BlobTraceBatchPart<T>,
-) -> Result<(), Error> {
-    let mut metadata = BTreeMap::new();
-    metadata.insert(
-        INLINE_METADATA_KEY.into(),
-        encode_trace_inline_meta(batch, ProtoBatchFormat::ArrowKvtd),
-    );
-    let schema = Schema::from(SCHEMA_ARROW_KVTD.fields.clone()).with_metadata(metadata);
-    let options = WriteOptions { compression: None };
-    let mut writer = FileWriter::try_new(w, schema, None, options)?;
-    for records in batch.updates.iter() {
-        writer.write(&encode_arrow_batch_kvtd(records), None)?;
-    }
-    writer.finish()?;
-    Ok(())
-}
-
-/// Decodes a BlobTraceBatchPart from the Arrow file format.
-///
-/// NB: This is currently unused, but it's here because we may want to use it
-/// for the local cache and so we can easily compare arrow vs parquet.
-pub fn decode_trace_arrow<R: Read + Seek, T: Timestamp + Codec64>(
-    r: &mut R,
-    metrics: &ColumnarMetrics,
-) -> Result<BlobTraceBatchPart<T>, Error> {
-    let file_meta = read_file_metadata(r)?;
-    let (format, meta) =
-        decode_trace_inline_meta(file_meta.schema.metadata.get(INLINE_METADATA_KEY))?;
-
-    let updates = match format {
-        ProtoBatchFormat::Unknown => return Err("unknown format".into()),
-        ProtoBatchFormat::ArrowKvtd => decode_arrow_file_kvtd(r, file_meta, metrics)?,
-        ProtoBatchFormat::ParquetKvtd => {
-            return Err("ParquetKvtd format not supported in arrow".into())
-        }
-    };
-
-    let ret = BlobTraceBatchPart {
-        desc: meta.desc.map_or_else(
-            || {
-                Description::new(
-                    Antichain::from_elem(T::minimum()),
-                    Antichain::from_elem(T::minimum()),
-                    Antichain::from_elem(T::minimum()),
-                )
-            },
-            |x| x.into(),
-        ),
-        index: meta.index,
-        updates,
-    };
-    ret.validate()?;
-    Ok(ret)
-}
-
-fn decode_arrow_file_kvtd<R: Read + Seek>(
-    r: &mut R,
-    file_meta: FileMetadata,
-    metrics: &ColumnarMetrics,
-) -> Result<Vec<ColumnarRecords>, Error> {
-    let projection = None;
-    let file_reader = FileReader::new(r, file_meta, projection, None);
-
-    let file_schema = file_reader.schema().fields.as_slice();
-    // We're not trying to accept any sort of user created data, so be strict.
-    if file_schema != SCHEMA_ARROW_KVTD.fields {
-        return Err(format!(
-            "expected arrow schema {:?} got: {:?}",
-            SCHEMA_ARROW_KVTD.fields, file_schema
-        )
-        .into());
-    }
-
-    let mut ret = Vec::new();
-    for chunk in file_reader {
-        ret.push(decode_arrow_batch_kvtd(&chunk?, metrics)?);
-    }
-    Ok(ret)
-}
 
 /// Converts a ColumnarRecords into an arrow [(K, V, T, D)] Chunk.
 pub fn encode_arrow_batch_kvtd(x: &ColumnarRecords) -> Chunk<Box<dyn Array>> {

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -621,7 +621,7 @@ pub mod tests {
     >(
         new_fn: NewFn,
     ) -> Result<(), ExternalError> {
-        let values = vec!["v0".as_bytes().to_vec(), "v1".as_bytes().to_vec()];
+        let values = ["v0".as_bytes().to_vec(), "v1".as_bytes().to_vec()];
 
         let blob0 = new_fn("path0").await?;
 


### PR DESCRIPTION
This PR deletes some unused code for an Arrow-based columnar encoding that theoretically could be used for a local blob file cache. If we want to re-add this format in the future I'll be more than happy to do so :)

### Motivation

AFAICT this code hasn't been touched in a couple years and is currently unused, as we make changes to the Parquet columnar format it makes things a bit easier to reason about if we don't need to handle this currently unused case. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
