### PR TITLE
fix merge skew

### DIFF
--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -1069,7 +1069,7 @@ mod tests {
                 let params = CopyFormatParams::Csv(csv_params);
 
                 // Roundtrip the Row through our CSV format.
-                encode_copy_format(params.clone(), &row, &typ, &mut buf)?;
+                encode_copy_format(&params, &row, &typ, &mut buf)?;
                 let column_types = typ
                     .column_types
                     .iter()


### PR DESCRIPTION
Looks like some PRs raced and `pgcopy` fails to build on main

### Motivation

Fix main

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
