### PR TITLE
ci-builder: Pass through new canary loadtest passwords

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -204,6 +204,8 @@ case "$cmd" in
             --env AWS_SECRET_ACCESS_KEY
             --env AWS_SESSION_TOKEN
             --env BUILDKITE_CI_API_KEY
+            --env CANARY_LOADTEST_APP_PASSWORD
+            --env CANARY_LOADTEST_PASSWORD
             --env CI
             --env CI_SANITIZER
             --env CI_COVERAGE_ENABLED


### PR DESCRIPTION
Forgotten in https://github.com/MaterializeInc/materialize/pull/26277
Test run: https://buildkite.com/materialize/qa-canary-environment-base-load/builds/65

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
