### PR TITLE
postgres-consistency: Also ignore equality operators

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -40,6 +40,7 @@ from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter im
     PreExecutionInconsistencyIgnoreFilterBase,
 )
 from materialize.output_consistency.input_data.operations.equality_operations_provider import (
+    TAG_EQUALITY,
     TAG_EQUALITY_ORDERING,
 )
 from materialize.output_consistency.input_data.operations.generic_operations_provider import (
@@ -213,7 +214,10 @@ class PgPreExecutionInconsistencyIgnoreFilter(
             )
 
         if (
-            db_operation.is_tagged(TAG_EQUALITY_ORDERING)
+            (
+                db_operation.is_tagged(TAG_EQUALITY_ORDERING)
+                or db_operation.is_tagged(TAG_EQUALITY)
+            )
             and expression.args[0].resolve_return_type_category()
             == DataTypeCategory.NUMERIC
             and expression.args[1].resolve_return_type_category()


### PR DESCRIPTION
As noticed in https://github.com/MaterializeInc/materialize/issues/26323#issuecomment-2044133655

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
