### PR TITLE
limits test: Reduce size in FilterSubqueries scenario

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1241,7 +1241,7 @@ class FilterSubqueries(Generator):
     because of excessive memory allocations in the `RedundantJoin` transform.
     """
 
-    COUNT = 100
+    COUNT = 50
 
     @classmethod
     def body(cls) -> None:
@@ -1252,13 +1252,7 @@ class FilterSubqueries(Generator):
             > INSERT INTO t1 VALUES (1);
 
             # Increase SQL timeout to 10 minutes (~5 should be enough).
-            #
-            # Update: Now 15 minutes, not 10. This query appears to scale
-            # super-linear with COUNT. Here are timings for the first few
-            # multiples of 10 on a fresh staging env.
-            #
-            # 10: 200ms, 20: 375ms, 30: 1.5s, 40: 5.5s, 50: 16s, 60: 45s
-            $ set-sql-timeout duration=900s
+            $ set-sql-timeout duration=600s
 
             > SELECT * FROM t1 AS a1 WHERE {
                 " AND ".join(


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/7281#018ebec3-9f8a-4bb8-99fe-67a506c406bd

I'm in parallel trying to bisect where this came from.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
