### PR TITLE
testdrive: fix query timeout

### DIFF
--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -138,11 +138,8 @@ async fn try_run_sql(
         .await
         .context("preparing query failed")?;
 
-    let query_with_timeout = tokio::time::timeout(
-        state.default_timeout.clone(),
-        state.pgclient.query(&stmt, &[]),
-    )
-    .await;
+    let query_with_timeout =
+        tokio::time::timeout(state.timeout.clone(), state.pgclient.query(&stmt, &[])).await;
 
     if query_with_timeout.is_err() {
         bail!("query timed out")


### PR DESCRIPTION
This applies a fix to https://github.com/MaterializeInc/materialize/pull/26496.

Use the `timeout` instead of `default_timeout`, which takes `set-sql-timeout` into account.