### PR TITLE
Expect matching parens around cluster options

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3700,7 +3700,7 @@ impl<'a> Parser<'a> {
         let paren = self.consume_token(&Token::LParen);
         let options = self.parse_comma_separated(Parser::parse_cluster_option)?;
         if paren {
-            let _ = self.consume_token(&Token::RParen);
+            self.expect_token(&Token::RParen)?;
         }
 
         let features = if self.parse_keywords(&[FEATURES]) {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1611,6 +1611,20 @@ CREATE CLUSTER cluster (MANAGED, DISK = true)
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Managed, value: None }, ClusterOption { name: Disk, value: Some(Value(Boolean(true))) }], features: [] })
 
 parse-statement
+CREATE CLUSTER cluster (MANAGED, DISK = true
+----
+error: Expected right parenthesis, found EOF
+CREATE CLUSTER cluster (MANAGED, DISK = true
+                                            ^
+
+parse-statement
+CREATE CLUSTER cluster MANAGED, DISK = true)
+----
+error: Expected end of statement, found right parenthesis
+CREATE CLUSTER cluster MANAGED, DISK = true)
+                                           ^
+
+parse-statement
 CREATE CLUSTER cluster INTROSPECTION INTERVAL '1'
 ----
 CREATE CLUSTER cluster (INTROSPECTION INTERVAL = '1')


### PR DESCRIPTION
The following is currently accepted in the Console:
```
CREATE CLUSTER c1 (SIZE = '3xsmall';
```
(In psql, this is prevented due to some psql-specific mechanism.)

This PR makes it so that if the `(` is there, then we also expect the `)`. (But still allows for leaving out both `(` and `)` at the same time, for historical reasons.)

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
