### PR TITLE
slt: Adapt unstable.slt to new reality

### DIFF
--- a/test/sqllogictest/introspection/unstable.slt
+++ b/test/sqllogictest/introspection/unstable.slt
@@ -19,8 +19,16 @@ ALTER SYSTEM SET enable_rbac_checks TO false
 ----
 COMPLETE 0
 
-statement error cannot create index with unstable dependencies
+# Following #26434, this still goes through RBAC now
+statement error must be owner of VIEW mz_internal.mz_active_peeks
 CREATE DEFAULT INDEX ON mz_internal.mz_active_peeks
+
+simple conn=mz_system,user=mz_system
+CREATE DEFAULT INDEX ON mz_internal.mz_active_peeks
+----
+db error: ERROR: cannot create index with unstable dependencies
+DETAIL: The object depends on the following unstable objects:
+    mz_active_peeks
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM RESET enable_rbac_checks


### PR DESCRIPTION
Following https://github.com/MaterializeInc/materialize/pull/26434

Fixes https://github.com/MaterializeInc/materialize/issues/26522

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
