### PR TITLE
Testdrive auto-rewriting

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -227,6 +227,10 @@ Max number of tests to run before terminating. This is useful in conjunction wit
 
 Shuffle the list of tests before running them (using the value from --seed, if any). This is useful when attempting to use `testdrive` in randomized scenarios or when applying background workload to the database.
 
+#### `--rewrite-results`
+
+Automatically rewrite the testdrive file with the correct results when they are not as expected. Consider setting a lower `--default-max-tries` value too to get a result faster.
+
 ## Other options
 
 #### `--consistency-checks=<file, statement, disable>`

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -2118,7 +2118,7 @@ pub async fn rewrite_file(runner: &mut Runner<'_>, filename: &Path) -> Result<()
 /// Provides a means to rewrite the `.slt` file while iterating over it.
 ///
 /// This struct takes the slt file as its `input`, tracks a cursor into it
-/// (`input_offset`), and provides a buffe (`output`) to store the rewritten
+/// (`input_offset`), and provides a buffer (`output`) to store the rewritten
 /// results.
 ///
 /// Functions that modify the file will lazily move `input` into `output` using


### PR DESCRIPTION
See also https://github.com/MaterializeInc/materialize/pull/6404 for previous attempt

Fixes: #17223

Only supports rewriting basic SQL commands. We'll have to see if
extending it beyond this is worth it. Some commands will be impossible
to rewrite of course.

Easy way to test is break something in get-started.td, then run: `cargo run --bin testdrive -- --default-max-tries 10 --rewrite-results test/testdrive/get-started.td`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
