### PR TITLE
[persist] Generalize some spine internals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "arrow"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5367,6 +5373,7 @@ name = "mz-persist-client"
 version = "0.99.0-dev"
 dependencies = [
  "anyhow",
+ "arrayvec 0.7.4",
  "async-stream",
  "async-trait",
  "bytes",
@@ -7567,7 +7574,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55c4d17d994b637e2f4daf6e5dc5d660d209d5642377d675d7a1c3ab69fa579"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "typed-arena",
  "unicode-width",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,8 @@ multiple-versions = "deny"
 # Materialize-maintained fork that avoids the duplicated transitive
 # dependencies.
 skip = [
+    # arrayvec had a significant API change in 0.7
+    { name = "arrayvec", version = "0.5.2" },
     # One-time exception for base64 due to its prevalence in the crate graph.
     { name = "base64", version = "0.13.1" },
     { name = "base64", version = "0.21.5" },

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -15,6 +15,12 @@ who = "Matt Arthur <matthewleearthur@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.5.2"
 
+[[audits.arrayvec]]
+who = "Ben Kirwin <bkirwi@materialize.com>"
+criteria = "maintained-and-necessary"
+version = "0.7.4"
+notes = "We need collections with a known-small maximum size in contexts like Persist's spine, and arrayvec is a popular and actively-maintained implementation."
+
 [[audits.arrow]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -29,6 +29,7 @@ harness = false
 
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
+arrayvec = "0.7.4"
 async-stream = "0.3.3"
 async-trait = "0.1.68"
 bytes = { version = "1.3.0", features = ["serde"] }

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -47,9 +47,11 @@
 //! [Batch]: differential_dataflow::trace::Batch
 //! [Batch::Merger]: differential_dataflow::trace::Batch::Merger
 
+use arrayvec::ArrayVec;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::mem;
 use std::sync::Arc;
 
 use differential_dataflow::lattice::Lattice;
@@ -210,15 +212,11 @@ impl<T: Timestamp + Lattice> Trace<T> {
         };
 
         for (level, state) in self.spine.merging.iter().enumerate() {
-            match state {
-                MergeState::Vacant => {}
-                MergeState::Single(batch) => push_spine_batch(level, batch),
-                MergeState::Double(left, right, merge) => {
-                    push_spine_batch(level, left);
-                    push_spine_batch(level, right);
-                    let merge_id = SpineId(left.id().0, right.id().1);
-                    fueling_merges.insert(merge_id, merge.clone());
-                }
+            for batch in &state.batches {
+                push_spine_batch(level, batch);
+            }
+            if let Some((id, merge)) = state.id().zip(state.merge.as_ref()) {
+                fueling_merges.insert(id, merge.clone());
             }
         }
 
@@ -353,7 +351,7 @@ impl<T: Timestamp + Lattice> Trace<T> {
             .first_key_value()
             .map(|(_, batch)| batch.level + 1)
             .unwrap_or(0);
-        let mut merging = vec![MergeState::Vacant; levels];
+        let mut merging = vec![MergeState::default(); levels];
         for (id, mut batch) in spine_batches {
             let level = batch.level;
             let batch = if batch.parts.len() == 1 {
@@ -375,20 +373,12 @@ impl<T: Timestamp + Lattice> Trace<T> {
                 }
             };
 
-            let state = std::mem::replace(&mut merging[level], MergeState::Vacant);
-            let state = match state {
-                MergeState::Vacant => MergeState::Single(batch),
-                MergeState::Single(single) => {
-                    let merge_id = SpineId(single.id().0, batch.id().1);
-                    let merge = fueling_merges
-                        .remove(&merge_id)
-                        .ok_or_else(|| format!("Expected merge at level {level}"))?;
-                    MergeState::Double(single, batch, merge)
-                }
-                _ => Err(format!("Too many batches at level {level}"))?,
-            };
+            let state = &mut merging[level];
 
-            merging[level] = state;
+            state.push_batch(batch);
+            if let Some(merge_id) = state.id() {
+                state.merge = fueling_merges.remove(&merge_id);
+            }
         }
 
         let mut trace = Trace {
@@ -513,24 +503,11 @@ impl<T: Timestamp + Lattice> Trace<T> {
 
     pub fn apply_merge_res(&mut self, res: &FueledMergeRes<T>) -> ApplyMergeResult {
         for batch in self.spine.merging.iter_mut().rev() {
-            match batch {
-                MergeState::Double(batch1, batch2, _) => {
-                    let result = batch1.maybe_replace(res);
-                    if result.matched() {
-                        return result;
-                    }
-                    let result = batch2.maybe_replace(res);
-                    if result.matched() {
-                        return result;
-                    }
+            for batch in &mut batch.batches {
+                let result = batch.maybe_replace(res);
+                if result.matched() {
+                    return result;
                 }
-                MergeState::Single(batch) => {
-                    let result = batch.maybe_replace(res);
-                    if result.matched() {
-                        return result;
-                    }
-                }
-                _ => {}
             }
         }
         ApplyMergeResult::NotAppliedNoMatch
@@ -1000,6 +977,12 @@ impl<T: Timestamp + Lattice> FuelingMerge<T> {
     }
 }
 
+/// The maximum number of batches per level in the spine.
+/// In practice, we probably want a larger max and a configurable soft cap, but using a
+/// stack-friendly data structure and keeping this number low makes this safer during the
+/// initial rollout.
+const BATCHES_PER_LEVEL: usize = 2;
+
 /// An append-only collection of update batches.
 ///
 /// The `Spine` is a general-purpose trace implementation based on collection
@@ -1093,11 +1076,7 @@ struct Spine<T> {
 
 impl<T> Spine<T> {
     pub fn spine_batches(&self) -> impl Iterator<Item = &SpineBatch<T>> {
-        self.merging.iter().rev().flat_map(|m| match m {
-            MergeState::Vacant => None.into_iter().chain(None.into_iter()),
-            MergeState::Single(a) => Some(a).into_iter().chain(None.into_iter()),
-            MergeState::Double(a, b, _) => Some(a).into_iter().chain(Some(b).into_iter()),
-        })
+        self.merging.iter().rev().flat_map(|m| &m.batches)
     }
 }
 
@@ -1146,7 +1125,7 @@ impl<T: Timestamp + Lattice> Spine<T> {
                     // Since we just inserted a batch, we should always have work to complete...
                     // but otherwise we just leave this layer vacant.
                     if let Some(merged) = self.complete_at(position, log) {
-                        self.merging[position] = MergeState::Single(merged);
+                        self.merging[position] = MergeState::single(merged);
                     }
                     return;
                 }
@@ -1165,11 +1144,7 @@ impl<T: Timestamp + Lattice> Spine<T> {
     fn describe(&self) -> Vec<(usize, usize)> {
         self.merging
             .iter()
-            .map(|b| match b {
-                MergeState::Vacant => (0, 0),
-                x @ MergeState::Single(_) => (1, x.len()),
-                x @ MergeState::Double(..) => (2, x.len()),
-            })
+            .map(|b| (b.batches.len(), b.len()))
             .collect()
     }
 
@@ -1272,7 +1247,7 @@ impl<T: Timestamp + Lattice> Spine<T> {
     fn roll_up(&mut self, index: usize, log: &mut SpineLog<'_, T>) {
         // Ensure entries sufficient for `index`.
         while self.merging.len() <= index {
-            self.merging.push(MergeState::Vacant);
+            self.merging.push(MergeState::default());
         }
 
         // We only need to roll up if there are non-vacant layers.
@@ -1296,7 +1271,7 @@ impl<T: Timestamp + Lattice> Spine<T> {
 
             // If the insertion results in a merge, we should complete it to
             // ensure the upcoming insertion at `index` does not panic.
-            if self.merging[index].is_double() {
+            if self.merging[index].is_full() {
                 let merged = self.complete_at(index, log).expect("double batch");
                 self.insert_at(merged, index + 1);
             }
@@ -1348,22 +1323,21 @@ impl<T: Timestamp + Lattice> Spine<T> {
     fn insert_at(&mut self, batch: SpineBatch<T>, index: usize) {
         // Ensure the spine is large enough.
         while self.merging.len() <= index {
-            self.merging.push(MergeState::Vacant);
+            self.merging.push(MergeState::default());
         }
 
         // Insert the batch at the location.
-        match self.merging[index].take() {
-            MergeState::Vacant => {
-                self.merging[index] = MergeState::Single(batch);
-            }
-            MergeState::Single(old) => {
-                let compaction_frontier = Some(self.since.borrow());
-                self.merging[index] = MergeState::begin_merge(old, batch, compaction_frontier);
-            }
-            MergeState::Double(..) => {
-                panic!("Attempted to insert batch into incomplete merge!")
-            }
-        };
+        let merging = &mut self.merging[index];
+        merging.push_batch(batch);
+        if merging.batches.is_full() {
+            let compaction_frontier = Some(self.since.borrow());
+            let fueling_merge = SpineBatch::begin_merge(
+                &merging.batches[0],
+                &merging.batches[1],
+                compaction_frontier,
+            );
+            merging.merge = Some(fueling_merge)
+        }
     }
 
     /// Completes and extracts what ever is at layer `index`, leaving this layer vacant.
@@ -1383,7 +1357,6 @@ impl<T: Timestamp + Lattice> Spine<T> {
                 // To move a batch down, we require that it contain few enough
                 // records that the lower level is appropriate, and that moving
                 // the batch would not create a merge violating our invariant.
-
                 let appropriate_level = usize::cast_from(
                     self.merging[length - 1]
                         .len()
@@ -1393,45 +1366,36 @@ impl<T: Timestamp + Lattice> Spine<T> {
 
                 // Continue only as far as is appropriate
                 while appropriate_level < length - 1 {
-                    match self.merging[length - 2].take() {
+                    let current = &mut self.merging[length - 2];
+                    if current.is_vacant() {
                         // Vacant batches can be absorbed.
-                        MergeState::Vacant => {
-                            self.merging.remove(length - 2);
-                            length = self.merging.len();
-                        }
-                        // Single batches may initiate a merge, if sizes are
-                        // within bounds, but terminate the loop either way.
-                        MergeState::Single(batch) => {
+                        self.merging.remove(length - 2);
+                        length = self.merging.len();
+                    } else {
+                        if !current.is_full() {
+                            // Single batches may initiate a merge, if sizes are
+                            // within bounds, but terminate the loop either way.
+
                             // Determine the number of records that might lead
                             // to a merge. Importantly, this is not the number
                             // of actual records, but the sum of upper bounds
                             // based on indices.
                             let mut smaller = 0;
                             for (index, batch) in self.merging[..(length - 2)].iter().enumerate() {
-                                match batch {
-                                    MergeState::Vacant => {}
-                                    MergeState::Single(_) => {
-                                        smaller += 1 << index;
-                                    }
-                                    MergeState::Double(..) => {
-                                        smaller += 2 << index;
-                                    }
-                                }
+                                smaller += batch.batches.len() << index;
                             }
 
                             if smaller <= (1 << length) / 8 {
-                                self.merging.remove(length - 2);
-                                self.insert_at(batch, length - 2);
-                            } else {
-                                self.merging[length - 2] = MergeState::Single(batch);
+                                // Remove the batch under consideration (shifting the deeper batches up a level),
+                                // then merge in the single batch at the current level.
+                                let state = self.merging.remove(length - 2);
+                                assert_eq!(state.batches.len(), 1);
+                                for batch in state.batches {
+                                    self.insert_at(batch, length - 2);
+                                }
                             }
-                            return;
                         }
-                        // If a merge is in progress there is nothing to do.
-                        MergeState::Double(a, b, fuel) => {
-                            self.merging[length - 2] = MergeState::Double(a, b, fuel);
-                            return;
-                        }
+                        break;
                     }
                 }
             }
@@ -1449,20 +1413,11 @@ impl<T: Timestamp + Lattice> Spine<T> {
         let mut id = SpineId(0, 0);
         let mut frontier = Antichain::from_elem(T::minimum());
         for x in self.merging.iter().rev() {
-            let batches = match x {
-                MergeState::Vacant => vec![],
-                MergeState::Single(x) => {
-                    vec![x]
-                }
-                MergeState::Double(x0, x1, _m) => {
-                    // TODO: Anything we can validate about remaining_work? It'd
-                    // be nice to assert that it's bigger than the len of the
-                    // two batches, but apply_merge_res might swap those lengths
-                    // out from under us.
-                    vec![x0, x1]
-                }
-            };
-            for batch in batches {
+            // TODO: Anything we can validate about x.merge? It'd
+            // be nice to assert that it's bigger than the len of the
+            // two batches, but apply_merge_res might swap those lengths
+            // out from under us.
+            for batch in &x.batches {
                 if batch.id().0 != id.1 {
                     return Err(format!(
                         "batch id {:?} does not match the previous id {:?}: {:?}",
@@ -1512,59 +1467,76 @@ impl<T: Timestamp + Lattice> Spine<T> {
 /// A layer can be empty, contain a single batch, or contain a pair of batches
 /// that are in the process of merging into a batch for the next layer.
 #[derive(Debug, Clone)]
-enum MergeState<T> {
-    /// An empty layer, containing no updates.
-    Vacant,
-    /// A layer containing a single batch.
-    Single(SpineBatch<T>),
-    /// A layer containing two batches, in the process of merging.
-    Double(SpineBatch<T>, SpineBatch<T>, FuelingMerge<T>),
+struct MergeState<T> {
+    batches: ArrayVec<SpineBatch<T>, BATCHES_PER_LEVEL>,
+    merge: Option<FuelingMerge<T>>,
+}
+
+impl<T> Default for MergeState<T> {
+    fn default() -> Self {
+        Self {
+            batches: ArrayVec::new(),
+            merge: None,
+        }
+    }
 }
 
 impl<T: Timestamp + Lattice> MergeState<T> {
+    /// An id that covers all the batches in the given merge state, assuming there are any.
+    fn id(&self) -> Option<SpineId> {
+        if let (Some(first), Some(last)) = (self.batches.first(), self.batches.last()) {
+            Some(SpineId(first.id().0, last.id().1))
+        } else {
+            None
+        }
+    }
+
+    /// A new single-batch merge state.
+    fn single(batch: SpineBatch<T>) -> Self {
+        let mut state = Self::default();
+        state.push_batch(batch);
+        state
+    }
+
+    /// Push a new batch at this level, checking invariants.
+    fn push_batch(&mut self, batch: SpineBatch<T>) {
+        if let Some(last) = self.batches.last() {
+            assert_eq!(last.id().1, batch.id().0);
+            assert_eq!(last.upper(), batch.lower());
+        }
+        assert!(
+            self.merge.is_none(),
+            "Attempted to insert batch into incomplete merge!"
+        );
+        self.batches
+            .try_push(batch)
+            .expect("Attempted to insert batch into full layer!");
+    }
+
     /// The number of actual updates contained in the level.
     fn len(&self) -> usize {
-        match self {
-            MergeState::Single(b) => b.len(),
-            MergeState::Double(b1, b2, _) => b1.len() + b2.len(),
-            _ => 0,
-        }
+        self.batches.iter().map(SpineBatch::len).sum()
     }
 
     /// True if this merge state contains no updates.
     fn is_empty(&self) -> bool {
-        match self {
-            MergeState::Single(b) => b.is_empty(),
-            MergeState::Double(b1, b2, _) => b1.is_empty() && b2.is_empty(),
-            _ => true,
-        }
+        self.batches.iter().all(SpineBatch::is_empty)
     }
 
-    /// True only for the MergeState::Vacant variant.
+    /// True if this level contains no batches.
     fn is_vacant(&self) -> bool {
-        if let MergeState::Vacant = self {
-            true
-        } else {
-            false
-        }
+        self.batches.is_empty()
     }
 
-    /// True only for the MergeState::Single variant.
+    /// True only for a single-batch state.
     fn is_single(&self) -> bool {
-        if let MergeState::Single(_) = self {
-            true
-        } else {
-            false
-        }
+        self.batches.len() == 1
     }
 
-    /// True only for the MergeState::Double variant.
-    fn is_double(&self) -> bool {
-        if let MergeState::Double(_, _, _) = self {
-            true
-        } else {
-            false
-        }
+    /// True if this merge cannot hold any more batches.
+    /// (i.e. for a binary merge tree, true if this layer holds two batches.)
+    fn is_full(&self) -> bool {
+        self.batches.is_full()
     }
 
     /// Immediately complete any merge.
@@ -1574,48 +1546,33 @@ impl<T: Timestamp + Lattice> MergeState<T> {
     ///
     /// There is the additional option of input batches.
     fn complete(&mut self, log: &mut SpineLog<'_, T>) -> Option<SpineBatch<T>> {
-        match std::mem::replace(self, MergeState::Vacant) {
-            MergeState::Vacant => None,
-            MergeState::Single(batch) => Some(batch),
-            MergeState::Double(a, b, merge) => Some(merge.done(a, b, log)),
+        let mut this = mem::take(self);
+        if let Some(merge) = this.merge {
+            let [a, b] = this.batches.into_inner().expect("full batch");
+            Some(merge.done(a, b, log))
+        } else {
+            assert!(
+                this.batches.len() <= 1,
+                "Multi-batch runs should have an in-progress merge!"
+            );
+            this.batches.pop()
         }
     }
 
     /// True iff the layer is a complete merge, ready for extraction.
     fn is_complete(&self) -> bool {
-        match self {
-            MergeState::Double(_, _, work) => work.remaining_work == 0,
-            _ => false,
+        match &self.merge {
+            Some(m) => m.remaining_work == 0,
+            None => false,
         }
     }
 
     /// Performs a bounded amount of work towards a merge.
     fn work(&mut self, fuel: &mut isize) {
         // We only perform work for merges in progress.
-        if let MergeState::Double(b1, b2, merge) = self {
-            merge.work(b1, b2, fuel);
+        if let Some(merge) = &mut self.merge {
+            merge.work(&self.batches[0], &self.batches[1], fuel)
         }
-    }
-
-    /// Extract the merge state, typically temporarily.
-    fn take(&mut self) -> Self {
-        std::mem::replace(self, MergeState::Vacant)
-    }
-
-    /// Initiates the merge of an "old" batch with a "new" batch.
-    ///
-    /// The upper frontier of the old batch should match the lower frontier of
-    /// the new batch, with the resulting batch describing their composed
-    /// interval, from the lower frontier of the old batch to the upper frontier
-    /// of the new batch.
-    fn begin_merge(
-        batch1: SpineBatch<T>,
-        batch2: SpineBatch<T>,
-        compaction_frontier: Option<AntichainRef<T>>,
-    ) -> MergeState<T> {
-        assert_eq!(batch1.upper(), batch2.lower());
-        let begin_merge = SpineBatch::begin_merge(&batch1, &batch2, compaction_frontier);
-        MergeState::Double(batch1, batch2, begin_merge)
     }
 }
 

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -1426,6 +1426,24 @@ impl<T: Timestamp + Lattice> Spine<T> {
         let mut id = SpineId(0, 0);
         let mut frontier = Antichain::from_elem(T::minimum());
         for x in self.merging.iter().rev() {
+            if x.is_full() != x.merge.is_some() {
+                return Err(format!(
+                    "all (and only) full batches should have fueling merges (full={}, merge={:?})",
+                    x.is_full(),
+                    x.merge,
+                ));
+            }
+
+            if let Some(m) = &x.merge {
+                if x.id() != Some(m.id) {
+                    return Err(format!(
+                        "merge id should match the range of the batch ids (batch={:?}, merge={:?})",
+                        x.id(),
+                        m.id,
+                    ));
+                }
+            }
+
             // TODO: Anything we can validate about x.merge? It'd
             // be nice to assert that it's bigger than the len of the
             // two batches, but apply_merge_res might swap those lengths


### PR DESCRIPTION
This changes Persist's spine implementation from a binary tree to an N-ary tree where N=2.

Obviously this should have no actual impact on its behaviour -- but it sets us up to vary N more easily in the future.

### Motivation

#16607 

### Tips for reviewer

I pulled in `arrayvec` here - a new dep, but I think it's a good one, and it's tailor-made for this sort of case.

I think this is correct for N=2; while I've made some effort to make it more likely to work for N>2, I haven't tested it, and would prefer to take that as a followup. (Though if you notice anything obviously wrong here I'm happy to shake that out early of course!)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
