### PR TITLE
persist: more context on stats decode errors

### DIFF
--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1289,10 +1289,29 @@ impl LazyPartStats {
     /// This does not cache the returned value, it decodes each time it's
     /// called.
     pub fn decode(&self) -> PartStats {
-        let key = self.key.decode().expect("valid proto");
-        PartStats {
-            key: key.into_rust().expect("valid stats"),
-        }
+        // These clones are not ideal, but we're only doing it while debugging a
+        // pesky panic.
+        let key_cloned = self.key.clone();
+        let key = self.key.decode();
+        let key = match key {
+            Ok(key) => key,
+            Err(e) => {
+                panic!(
+                    "cannot decode {:?} as ProtoStructStats: {:?}",
+                    key_cloned, e
+                );
+            }
+        };
+
+        let key_cloned = key.clone();
+        let key_decoded = key.into_rust();
+        let key_decoded = match key_decoded {
+            Ok(key_decoded) => key_decoded,
+            Err(e) => {
+                panic!("cannot convert {:?} into StructStats: {:?}", key_cloned, e);
+            }
+        };
+        PartStats { key: key_decoded }
     }
 }
 


### PR DESCRIPTION
In the hopes of sussing out what's going on in:
https://github.com/MaterializeInc/materialize/issues/26474

The cloning feels heavy handed, but it would give us more context on what we're trying to decode here.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
