### PR TITLE
adapter: Validate off-thread purification

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -331,7 +331,7 @@ pub struct BackgroundWorkResult<T> {
     pub ctx: ExecuteContext,
     pub result: Result<T, AdapterError>,
     pub params: Params,
-    pub resolved_ids: ResolvedIds,
+    pub plan_validity: PlanValidity,
     pub original_stmt: Arc<Statement<Raw>>,
     pub otel_ctx: OpenTelemetryContext,
 }


### PR DESCRIPTION
Certain statements must be purified off thread before they are planned. Previously, after purification we were correctly checking that the statement's `GlobalId` dependencies were still valid, but we were not checking other dependencies, such as cluster dependencies. This commit fixes the described issue by using the existing `PlanValidity` struct to track and re-validate the statement's dependencies.

Fixes #26538

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
