### PR TITLE
[persist] Delete from blob with the full key

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -379,7 +379,11 @@ where
                             part_deletes.add(&part);
                         }
                         let () = part_deletes
-                            .delete(&blob, &metrics.retries.external.compaction_noop_delete)
+                            .delete(
+                                &blob,
+                                machine.shard_id(),
+                                &metrics.retries.external.compaction_noop_delete,
+                            )
                             .await;
                         Ok(apply_merge_result)
                     }

--- a/src/persist-client/src/internal/paths.rs
+++ b/src/persist-client/src/internal/paths.rs
@@ -149,14 +149,6 @@ impl std::fmt::Display for PartialBatchKey {
     }
 }
 
-impl Deref for PartialBatchKey {
-    type Target = String;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 /// An opaque identifier for an individual blob of a persist durable TVC (aka shard).
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct RollupId(pub(crate) [u8; 16]);


### PR DESCRIPTION
### Motivation

Noticed an uptick in noop deletes in our staging environment. This would cause an increase in the number of unreferenced blobs that would need to be cleaned up out of band.

### Tips for reviewer

It turns out that this bug was the only user of the `Deref` impl on partial keys, and I feel like that impl is probably kind of a footgun since it makes it very easy to use the partial key as a blob key... so I've deleted that too. Let me know if that sounds wrong!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
