### PR TITLE
catalog: Listen and generate builtin table update

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -28,8 +28,8 @@ use mz_catalog::builtin::{
 use mz_catalog::config::AwsPrincipalContext;
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
-    CatalogItem, ClusterVariant, Connection, DataSourceDesc, Database, Func, Index,
-    MaterializedView, Sink, Table, Type, View,
+    CatalogItem, ClusterVariant, Connection, DataSourceDesc, Func, Index, MaterializedView, Sink,
+    Table, Type, View,
 };
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_controller::clusters::{
@@ -52,7 +52,9 @@ use mz_sql::catalog::{
     TypeCategory,
 };
 use mz_sql::func::FuncImplCatalogDetails;
-use mz_sql::names::{CommentObjectId, ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier};
+use mz_sql::names::{
+    CommentObjectId, DatabaseId, ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier,
+};
 use mz_sql::session::user::SYSTEM_USER;
 use mz_sql::session::vars::SessionVars;
 use mz_sql_parser::ast::display::AstDisplay;
@@ -99,9 +101,10 @@ impl CatalogState {
 
     pub(super) fn pack_database_update(
         &self,
-        database: &Database,
+        database_id: &DatabaseId,
         diff: Diff,
     ) -> BuiltinTableUpdate {
+        let database = self.get_database(database_id);
         let row = self.pack_privilege_array_row(database.privileges());
         let privileges = row.unpack_first();
         BuiltinTableUpdate {

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -545,8 +545,7 @@ impl Catalog {
                     state
                         .database_by_name
                         .insert(name.clone(), database_id.clone());
-                    builtin_table_updates
-                        .push(state.pack_database_update(&state.database_by_id[&database_id], 1));
+                    builtin_table_updates.push(state.pack_database_update(&database_id, 1));
 
                     state.add_to_audit_log(
                         oracle_write_ts,
@@ -1006,7 +1005,7 @@ impl Catalog {
                                 )));
                             }
                             tx.remove_database(&id)?;
-                            builtin_table_updates.push(state.pack_database_update(database, -1));
+                            builtin_table_updates.push(state.pack_database_update(&id, -1));
                             state.add_to_audit_log(
                                 oracle_write_ts,
                                 session,
@@ -1335,14 +1334,12 @@ impl Catalog {
                                     .push(state.pack_cluster_update(&cluster_name, 1));
                             }
                             ObjectId::Database(id) => {
-                                let database = state.get_database(id);
-                                builtin_table_updates
-                                    .push(state.pack_database_update(database, -1));
+                                builtin_table_updates.push(state.pack_database_update(id, -1));
                                 let database = state.get_database_mut(id);
                                 update_privilege_fn(&mut database.privileges);
                                 let database = state.get_database(id);
                                 tx.update_database(*id, database.clone().into())?;
-                                builtin_table_updates.push(state.pack_database_update(database, 1));
+                                builtin_table_updates.push(state.pack_database_update(id, 1));
                             }
                             ObjectId::Schema((database_spec, schema_spec)) => {
                                 let schema_id = schema_spec.clone().into();
@@ -1899,7 +1896,7 @@ impl Catalog {
                                     ErrorKind::ReadOnlyDatabase(database.name().to_string()),
                                 )));
                             }
-                            builtin_table_updates.push(state.pack_database_update(database, -1));
+                            builtin_table_updates.push(state.pack_database_update(id, -1));
                             let database = state.get_database_mut(id);
                             Self::update_privilege_owners(
                                 &mut database.privileges,
@@ -1909,7 +1906,7 @@ impl Catalog {
                             database.owner_id = new_owner;
                             let database = state.get_database(id);
                             tx.update_database(*id, database.clone().into())?;
-                            builtin_table_updates.push(state.pack_database_update(database, 1));
+                            builtin_table_updates.push(state.pack_database_update(id, 1));
                         }
                         ObjectId::Schema((database_spec, schema_spec)) => {
                             let schema_id: SchemaId = schema_spec.clone().into();


### PR DESCRIPTION
This commit teaches the in-memory catalog how to generate builtin table
updates from changes to the durable catalog state.

Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
