### PR TITLE
persist: remove unconditionally enabled configs

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -80,7 +80,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_sink_doc_on_option": "true",
     "enable_statement_lifecycle_logging": "true",
     "enable_table_keys": "true",
-    "enable_try_parse_monotonic_iso8601_timestamp": "true",
     "enable_variadic_left_join_lowering": "true",
     "enable_worker_core_affinity": "true",
     "persist_batch_delete_enabled": "true",

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3801,8 +3801,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
             params!(String, TimestampTz) => BinaryFunc::TimezoneOffset => RecordAny, oid::FUNC_TIMEZONE_OFFSET;
         },
         "try_parse_monotonic_iso8601_timestamp" => Scalar {
-            params!(String) => Operation::unary(move |ecx, e| {
-                ecx.require_feature_flag(&crate::session::vars::ENABLE_TRY_PARSE_MONOTONIC_ISO8601_TIMESTAMP)?;
+            params!(String) => Operation::unary(move |_ecx, e| {
                 Ok(e.call_unary(UnaryFunc::TryParseMonotonicIso8601Timestamp(func::TryParseMonotonicIso8601Timestamp)))
             }) => Timestamp, oid::FUNC_TRY_PARSE_MONOTONIC_ISO8601_TIMESTAMP;
         },

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -549,7 +549,6 @@ pub fn plan_explain_plan(
         let mut with_options = ExplainPlanOptionExtracted::try_from(with_options)?;
 
         if with_options.filter_pushdown {
-            scx.require_feature_flag(&vars::ENABLE_MFP_PUSHDOWN_EXPLAIN)?;
             // If filtering is disabled, explain plans should not include pushdown info.
             with_options.filter_pushdown = scx.catalog.system_vars().persist_stats_filter_enabled();
         }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1759,13 +1759,6 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_mfp_pushdown_explain,
-        desc: "`filter_pushdown` explain",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_multi_worker_storage_persist_sink,
         desc: "multi-worker storage persist sink",
         default: true,
@@ -1859,13 +1852,6 @@ feature_flags!(
     {
         name: enable_connection_validation_syntax,
         desc: "CREATE CONNECTION .. WITH (VALIDATE) and VALIDATE CONNECTION syntax",
-        default: true,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
-        name: enable_try_parse_monotonic_iso8601_timestamp,
-        desc: "the try_parse_monotonic_iso8601_timestamp function",
         default: true,
         internal: true,
         enable_for_item_parsing: true,

--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -10,11 +10,6 @@
 mode cockroach
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_mfp_pushdown_explain = true
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET persist_stats_filter_enabled = true
 ----
 COMPLETE 0
@@ -217,11 +212,6 @@ EOF
 
 # Verify that try_parse_monotonic_iso8601_timestamp gets pushdown (the whole
 # point of that func)
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_try_parse_monotonic_iso8601_timestamp = true;
-----
-COMPLETE 0
 
 query T multiline
 EXPLAIN WITH(humanized expressions, filter pushdown)

--- a/test/sqllogictest/try_parse_monotonic_iso8601_timestamp.slt
+++ b/test/sqllogictest/try_parse_monotonic_iso8601_timestamp.slt
@@ -9,19 +9,6 @@
 
 mode cockroach
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_try_parse_monotonic_iso8601_timestamp = false;
-----
-COMPLETE 0
-
-statement error the try_parse_monotonic_iso8601_timestamp function is not supported
-select try_parse_monotonic_iso8601_timestamp('2015-09-18T23:56:04.123Z');
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_try_parse_monotonic_iso8601_timestamp = true;
-----
-COMPLETE 0
-
 # Real-world example
 query T
 select try_parse_monotonic_iso8601_timestamp('2015-09-18T23:56:04.123Z');


### PR DESCRIPTION
These are now in GA and on everywhere. Remove the flags.

Touches #26545

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
