### PR TITLE
*: set opentelemetry-filter default to 'info'

### DIFF
--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -172,7 +172,7 @@ pub struct TracingCliArgs {
         long,
         env = "STARTUP_OPENTELEMETRY_FILTER",
         requires = "opentelemetry-endpoint",
-        default_value = "off"
+        default_value = "info"
     )]
     pub startup_opentelemetry_filter: CloneableEnvFilter,
     /// Additional key-value pairs to send with all opentelemetry traces.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -838,7 +838,7 @@ pub static LOGGING_FILTER: VarDefinition = VarDefinition::new_lazy(
 
 pub static OPENTELEMETRY_FILTER: VarDefinition = VarDefinition::new_lazy(
     "opentelemetry_filter",
-    lazy_value!(CloneableEnvFilter; || CloneableEnvFilter::from_str("off").expect("valid EnvFilter")),
+    lazy_value!(CloneableEnvFilter; || CloneableEnvFilter::from_str("info").expect("valid EnvFilter")),
     "Sets the filter to apply to OpenTelemetry-backed distributed tracing.",
     true,
 );


### PR DESCRIPTION
We've now rolled out "info" to all of staging and prod. Change the default in code so that we pick it up in things in bin/environmentd.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
