### PR TITLE
parallel-workload: UUID types, ENVELOPE subscribes, Allow HTTP for most actions, Support websockets, Disable SQLsmith, faster startup always

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -66,3 +66,4 @@ typing-extensions==4.7.0
 yamllint==1.33.0
 confluent-kafka==2.1.1
 fastavro==1.8.2
+websocket-client==1.7.0

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1318,11 +1318,11 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-aarch64-small
+          queue: linux-aarch64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --complexity=dml, --threads=8]
+              args: [--runtime=1500, --complexity=dml, --threads=16]
 
       - id: parallel-workload-ddl
         label: "Parallel Workload (DDL)"
@@ -1330,11 +1330,11 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-aarch64-small
+          queue: linux-aarch64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500]
+              args: [--runtime=1500, --threads=16]
 
       - id: parallel-workload-ddl-only
         label: "Parallel Workload (DDL Only)"
@@ -1354,7 +1354,6 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          # OOMs with linux-aarch64-small
           queue: linux-aarch64
         plugins:
           - ./ci/plugins/mzcompose:
@@ -1367,11 +1366,11 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-aarch64-small
+          queue: linux-aarch64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=rename, --naughty-identifiers]
+              args: [--runtime=1500, --scenario=rename, --naughty-identifiers, --threads=16]
 
       - id: parallel-workload-rename
         label: "Parallel Workload (rename)"
@@ -1379,11 +1378,11 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-aarch64-small
+          queue: linux-aarch64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=rename]
+              args: [--runtime=1500, --scenario=rename, --threads=16]
 
       - id: parallel-workload-cancel
         label: "Parallel Workload (cancel)"
@@ -1392,11 +1391,11 @@ steps:
         timeout_in_minutes: 60
         skip: "TODO(def-): Reenable when #2392 is fixed"
         agents:
-          queue: linux-aarch64-small
+          queue: linux-aarch64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=cancel]
+              args: [--runtime=1500, --scenario=cancel, --threads=16]
 
       - id: parallel-workload-kill
         label: "Parallel Workload (kill)"
@@ -1404,12 +1403,11 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          # OOMs with linux-aarch64-small
-          queue: linux-aarch64-small
+          queue: linux-aarch64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=kill]
+              args: [--runtime=1500, --scenario=kill, --threads=16]
 
       - id: parallel-workload-backup-restore
         label: "Parallel Workload (backup & restore)"
@@ -1418,11 +1416,11 @@ steps:
         timeout_in_minutes: 60
         skip: "TODO(def-): Properly stop all db actions during backup & restore"
         agents:
-          queue: linux-aarch64-small
+          queue: linux-aarch64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers]
+              args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers, --threads=16]
 
       - id: parallel-workload-persist-txn
         label: "Parallel Workload (toggle persist-txn)"
@@ -1430,11 +1428,11 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 60
         agents:
-          queue: linux-aarch64-small
+          queue: linux-aarch64
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=toggle-persist-txn]
+              args: [--runtime=1500, --scenario=toggle-persist-txn, --threads=16]
 
   - id: incident-70
     label: "Test for incident 70"

--- a/misc/python/materialize/data_ingest/data_type.py
+++ b/misc/python/materialize/data_ingest/data_type.py
@@ -293,7 +293,7 @@ class UUID(DataType):
                 "6f5eec33-a3c9-40b2-ae06-58f53aca6e7d",
                 "00000000-0000-0000-0000-000000000000",
                 "ffffffff-ffff-ffff-ffff-ffffffffffff",
-                uuid.uuid4(),
+                uuid.UUID(int=rng.getrandbits(128), version=4),
             ]
         )
         return f"'{result}'::uuid" if in_query else str(result)

--- a/misc/python/materialize/data_ingest/data_type.py
+++ b/misc/python/materialize/data_ingest/data_type.py
@@ -10,6 +10,7 @@
 import json
 import random
 import string
+import uuid
 from enum import Enum
 from typing import Any
 
@@ -279,6 +280,34 @@ class Bytea(Text):
             return "bytea"
 
 
+class UUID(DataType):
+    @staticmethod
+    def random_value(
+        rng: random.Random,
+        record_size: RecordSize = RecordSize.LARGE,
+        in_query: bool = False,
+    ) -> Any:
+        result = rng.choice(
+            [
+                "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+                "6f5eec33-a3c9-40b2-ae06-58f53aca6e7d",
+                "00000000-0000-0000-0000-000000000000",
+                "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                uuid.uuid4(),
+            ]
+        )
+        return f"'{result}'::uuid" if in_query else str(result)
+
+    @staticmethod
+    def numeric_value(num: int, in_query: bool = False) -> Any:
+        result = uuid.uuid1(clock_seq=num)
+        return f"'{result}'::uuid" if in_query else str(result)
+
+    @staticmethod
+    def name(backend: Backend = Backend.POSTGRES) -> str:
+        return "uuid"
+
+
 class Jsonb(DataType):
     @staticmethod
     def name(backend: Backend = Backend.POSTGRES) -> str:
@@ -363,7 +392,7 @@ DATA_TYPES = sorted(list(all_subclasses(DataType)), key=repr)
 # fastavro._schema_common.UnknownType: record
 # bytea requires Python bytes type instead of str
 DATA_TYPES_FOR_AVRO = sorted(
-    list(set(DATA_TYPES) - {TextTextMap, Jsonb, Bytea, Boolean}), key=repr
+    list(set(DATA_TYPES) - {TextTextMap, Jsonb, Bytea, Boolean, UUID}), key=repr
 )
 
 # MySQL doesn't support keys of unlimited size

--- a/misc/python/materialize/data_ingest/query_error.py
+++ b/misc/python/materialize/data_ingest/query_error.py
@@ -15,11 +15,3 @@ class QueryError(Exception):
     def __init__(self, msg: str, query: str):
         self.msg = msg
         self.query = query
-
-class WSQueryError(Exception):
-    msg: str
-    query: str
-
-    def __init__(self, msg: str, query: str):
-        self.msg = msg
-        self.query = query

--- a/misc/python/materialize/data_ingest/query_error.py
+++ b/misc/python/materialize/data_ingest/query_error.py
@@ -15,3 +15,11 @@ class QueryError(Exception):
     def __init__(self, msg: str, query: str):
         self.msg = msg
         self.query = query
+
+class WSQueryError(Exception):
+    msg: str
+    query: str
+
+    def __init__(self, msg: str, query: str):
+        self.msg = msg
+        self.query = query

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -68,6 +68,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_copy_to_expr": "true",
     "enable_disk_cluster_replicas": "true",
     "enable_eager_delta_joins": "true",
+    "enable_envelope_debezium_in_subscribe": "true",
     "enable_equivalence_propagation": "true",
     "enable_explain_broken": "true",
     "enable_expressions_in_limit_syntax": "true",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -312,9 +312,6 @@ class SQLsmithAction(Action):
             self.composition.silent = False
 
     def run(self, exe: Executor) -> bool:
-        if exe.db.fast_startup:
-            return False
-
         while not self.queries:
             self.refill_sqlsmith(exe)
         query = self.queries.pop()
@@ -1777,7 +1774,7 @@ read_action_list = ActionList(
     [
         (SelectAction, 100),
         (SelectOneAction, 1),
-        (SQLsmithAction, 30),
+        # (SQLsmithAction, 30),  # Questionable use
         (CopyToS3Action, 100),
         # (SetClusterAction, 1),  # SET cluster cannot be called in an active transaction
         (CommitRollbackAction, 30),

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -985,6 +985,8 @@ class Database:
         for row in exe.cur.fetchall():
             exe.execute(f"DROP ROLE {identifier(row[0])} CASCADE")
 
+        print("Creating connections")
+
         exe.execute(
             "CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER 'kafka:9092', SECURITY PROTOCOL PLAINTEXT"
         )
@@ -1007,7 +1009,7 @@ class Database:
             "CREATE CONNECTION IF NOT EXISTS aws_conn TO AWS (ENDPOINT 'http://minio:9000/', REGION 'minio', ACCESS KEY ID 'minioadmin', SECRET ACCESS KEY SECRET minio)"
         )
 
-        print("Created connections")
+        print("Creating relations")
 
         for relation in self:
             relation.create(exe)

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, TextIO
 
 import pg8000
 import requests
+import websocket
 
 from materialize.data_ingest.query_error import QueryError
 from materialize.parallel_workload.settings import Scenario
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
 
 logging: TextIO | None
 lock: threading.Lock
+websocket.enableTrace(True)
 
 
 def initialize_logging() -> None:
@@ -41,6 +43,7 @@ class Http(Enum):
 class Executor:
     rng: random.Random
     cur: pg8000.Cursor
+    ws: websocket.WebSocket | None
     pg_pid: int
     # Used by INSERT action to prevent writing into different tables in the same transaction
     insert_table: int | None
@@ -50,9 +53,16 @@ class Executor:
     last_log: str
     action_run_since_last_commit_rollback: bool
 
-    def __init__(self, rng: random.Random, cur: pg8000.Cursor, db: "Database"):
+    def __init__(
+        self,
+        rng: random.Random,
+        cur: pg8000.Cursor,
+        ws: websocket.WebSocket | None,
+        db: "Database",
+    ):
         self.rng = rng
         self.cur = cur
+        self.ws = ws
         self.db = db
         self.pg_pid = -1
         self.insert_table = None
@@ -60,6 +70,7 @@ class Executor:
         self.rollback_next = True
         self.last_log = ""
         self.action_run_since_last_commit_rollback = False
+        self.use_ws = self.rng.choice([True, False]) if self.ws else False
 
     def set_isolation(self, level: str) -> None:
         self.execute(f"SET TRANSACTION_ISOLATION TO '{level}'")
@@ -68,17 +79,25 @@ class Executor:
         self.insert_table = None
         try:
             self.log("commit")
-            self.cur._c.commit()
+            if self.use_ws:
+                self.execute("commit")
+            else:
+                self.cur._c.commit()
         except Exception as e:
             raise QueryError(str(e), "commit")
+        self.use_ws = self.rng.choice([True, False]) if self.ws else False
 
     def rollback(self) -> None:
         self.insert_table = None
         try:
             self.log("rollback")
-            self.cur._c.rollback()
+            if self.use_ws:
+                self.execute("rollback")
+            else:
+                self.cur._c.rollback()
         except Exception as e:
             raise QueryError(str(e), "rollback")
+        self.use_ws = self.rng.choice([True, False]) if self.ws else False
 
     def log(self, msg: str) -> None:
         global logging, lock
@@ -112,14 +131,20 @@ class Executor:
         self.log(f"{query}{extra_info_str}{http_str}")
         if not is_http:
             try:
-                self.cur.execute(query)
+                if self.use_ws and self.ws:
+                    self.ws.send(json.dumps({"queries": [{"query": query}]}))
+                else:
+                    self.cur.execute(query)
             except Exception as e:
                 raise QueryError(str(e), query)
 
             self.action_run_since_last_commit_rollback = True
 
             if fetch:
-                self.cur.fetchall()
+                if self.use_ws and self.ws:
+                    self.ws.recv()
+                else:
+                    self.cur.fetchall()
 
             return
 

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -91,7 +91,7 @@ def run(
     )
     system_conn.autocommit = True
     with system_conn.cursor() as system_cur:
-        system_exe = Executor(rng, system_cur, database)
+        system_exe = Executor(rng, system_cur, None, database)
         system_exe.execute(
             f"ALTER SYSTEM SET max_schemas_per_database = {MAX_SCHEMAS * 10 + num_threads}"
         )
@@ -141,7 +141,7 @@ def run(
         conn.autocommit = True
         with conn.cursor() as cur:
             assert composition
-            database.create(Executor(rng, cur, database), composition)
+            database.create(Executor(rng, cur, None, database), composition)
         conn.close()
 
     workers = []
@@ -192,7 +192,7 @@ def run(
         thread = threading.Thread(
             name=thread_name,
             target=worker.run,
-            args=(host, ports["materialized"], "materialize", database),
+            args=(host, ports["materialized"], ports["http"], "materialize", database),
         )
         thread.start()
         threads.append(thread)
@@ -366,7 +366,7 @@ def run(
     with conn.cursor() as cur:
         # Dropping the database also releases the long running connections
         # used by database objects.
-        database.drop(Executor(rng, cur, database))
+        database.drop(Executor(rng, cur, None, database))
 
         # Make sure all unreachable connections are closed too
         gc.collect()

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -65,7 +65,6 @@ def run(
     scenario: Scenario,
     num_threads: int | None,
     naughty_identifiers: bool,
-    fast_startup: bool,
     composition: Composition | None,
     sanity_restart: bool,
 ) -> None:
@@ -74,7 +73,7 @@ def run(
     rng = random.Random(random.randrange(SEED_RANGE))
 
     print(
-        f"+++ Running with: --seed={seed} --threads={num_threads} --runtime={runtime} --complexity={complexity.value} --scenario={scenario.value} {'--naughty-identifiers ' if naughty_identifiers else ''} {'--fast-startup' if fast_startup else ''}(--host={host})"
+        f"+++ Running with: --seed={seed} --threads={num_threads} --runtime={runtime} --complexity={complexity.value} --scenario={scenario.value} {'--naughty-identifiers ' if naughty_identifiers else ''} (--host={host})"
     )
     initialize_logging()
 
@@ -83,7 +82,7 @@ def run(
     ).timestamp()
 
     database = Database(
-        rng, seed, host, ports, complexity, scenario, naughty_identifiers, fast_startup
+        rng, seed, host, ports, complexity, scenario, naughty_identifiers
     )
 
     system_conn = pg8000.connect(
@@ -496,7 +495,6 @@ def main() -> int:
         Scenario(args.scenario),
         args.threads,
         args.naughty_identifiers,
-        args.fast_startup,
         composition=None,  # only works in mzcompose
         sanity_restart=False,  # only works in mzcompose
     )

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -211,7 +211,7 @@ def run(
         thread = threading.Thread(
             name="cancel",
             target=worker.run,
-            args=(host, ports["mz_system"], "mz_system", database),
+            args=(host, ports["mz_system"], ports["http"], "mz_system", database),
         )
         thread.start()
         threads.append(thread)
@@ -231,7 +231,7 @@ def run(
         thread = threading.Thread(
             name="kill",
             target=worker.run,
-            args=(host, ports["materialized"], "materialize", database),
+            args=(host, ports["materialized"], ports["http"], "materialize", database),
         )
         thread.start()
         threads.append(thread)
@@ -263,7 +263,7 @@ def run(
         thread = threading.Thread(
             name="toggle-persist-txn",
             target=worker.run,
-            args=(host, ports["materialized"], "materialize", database),
+            args=(host, ports["materialized"], ports["http"], "materialize", database),
         )
         thread.start()
         threads.append(thread)
@@ -283,7 +283,7 @@ def run(
         thread = threading.Thread(
             name="kill",
             target=worker.run,
-            args=(host, ports["materialized"], "materialize", database),
+            args=(host, ports["materialized"], ports["http"], "materialize", database),
         )
         thread.start()
         threads.append(thread)
@@ -307,7 +307,7 @@ def run(
         thread = threading.Thread(
             name="statistics",
             target=worker.run,
-            args=(host, ports["mz_system"], "mz_system", database),
+            args=(host, ports["mz_system"], ports["http"], "mz_system", database),
         )
         thread.start()
         threads.append(thread)

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -112,7 +112,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             scenario,
             args.threads,
             args.naughty_identifiers,
-            args.fast_startup,
             c,
             sanity_restart,
         )


### PR DESCRIPTION
To be able to catch #26549 and similar issues in the future. Works to reproduce: https://buildkite.com/materialize/nightly/builds/7326
```
+++ [worker_0] Query failed: FETCH 554 c WITH (timeout='6s'); {'S': 'ERROR', 'C': 'XX000', 'M': 'internal error: column 2 is not of expected type ColumnType { scalar_type: Bytes, nullable: false }: Map({"accept": String("*/*"), "accept-encoding": String("gzip, deflate"), "connection": String("keep-alive"), "content-length": String("100"), "host": String("localhost:6976"), "signature": String("\\"4QLnAMIyXDs3m0vIjhGfKWiVclfu300OPlsvSsdbMxvopvhWLfzr8V5H4yuJL6sF1T677tk9gfwkACjo8vZmtwmNlmlZCxDUN5Ie\\""), "user-agent": String("python-requests/2.28.1"), "x-event-type": String("\\"1oRuv0KljwxiOpvyMZXyxEWyqeQVvJwu8zhxDYxP5PqRoBlBBHR3cMVx6Fi8avEA4M5gAp8kXxPhtT5DRParaylxxfbTCWgXhkBp\\""), "x-mz-api-key": String("\\"8bnZI8u455ncDt5Vbw8WK36jM7xSPc3nEzL6cEtTgD5cQpnQ7Mt42ihvmdyPv0q6CIE6MKvXHRfy69RLK6SKemwPmTWJo58PHuiQ\\"")})'}
+++ [worker_0] Query failed: FETCH ALL c WITH (timeout='3s'); {'S': 'ERROR', 'C': 'XX000', 'M': 'internal error: column 3 is not of expected type ColumnType { scalar_type: String, nullable: false }: Float64(OrderedFloat(81.97457423573255))'}
+++ [worker_43] Query failed: FETCH ALL c WITH (timeout='8s'); {'S': 'ERROR', 'C': 'XX000', 'M': 'internal error: column 2 is not of expected type ColumnType { scalar_type: String, nullable: false }: Float64(OrderedFloat(56.306350172714275))'}
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
