### PR TITLE
postgres-consistency test: Ignore translate function

### DIFF
--- a/misc/python/materialize/output_consistency/expression/expression_characteristics.py
+++ b/misc/python/materialize/output_consistency/expression/expression_characteristics.py
@@ -36,6 +36,7 @@ class ExpressionCharacteristics(Enum):
     TEXT_WITH_SPECIAL_SPACE_CHARS = 141
     """Lines with tabulators, newlines, and further whitespace types"""
     TEXT_WITH_BACKSLASH_CHAR = 142
+    TEXT_WITH_SPECIAL_NON_SPACE_CHARS = 143
 
     JSON_EMPTY = 150
     JSON_ARRAY = 151

--- a/misc/python/materialize/output_consistency/input_data/values/bytea_values_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/values/bytea_values_provider.py
@@ -24,6 +24,13 @@ BYTEA_DATA_TYPE_WITH_VALUES.add_raw_value(
     "EMPTY",
     {ExpressionCharacteristics.TEXT_EMPTY},
 )
+# space character
 BYTEA_DATA_TYPE_WITH_VALUES.add_raw_value("'\\x20'", "VAL_SPACE", set())
+# text 'hello'
 BYTEA_DATA_TYPE_WITH_VALUES.add_raw_value("'\\x68656c6c6f'", "VAL_1", set())
-BYTEA_DATA_TYPE_WITH_VALUES.add_raw_value("'\\x68656c6c6f20f09f918b'", "VAL_2", set())
+# text 'hello' with space and emoticon
+BYTEA_DATA_TYPE_WITH_VALUES.add_raw_value(
+    "'\\x68656c6c6f20f09f918b'",
+    "VAL_2",
+    {ExpressionCharacteristics.TEXT_WITH_SPECIAL_NON_SPACE_CHARS},
+)

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -180,8 +180,12 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("#25937 (base64 decode with new line and tab)")
 
-        if db_function.function_name_in_lower_case == "translate":
-            return YesIgnore("#26553: translate")
+        if db_function.function_name_in_lower_case == "translate" and expression.args[
+            1
+        ].has_any_characteristic(
+            {ExpressionCharacteristics.TEXT_WITH_SPECIAL_NON_SPACE_CHARS}
+        ):
+            return YesIgnore("#26553 (translate with special characters)")
 
         return NoIgnore()
 

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -180,6 +180,9 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("#25937 (base64 decode with new line and tab)")
 
+        if db_function.function_name_in_lower_case == "translate":
+            return YesIgnore("#26553: translate")
+
         return NoIgnore()
 
     def _matches_problematic_operation_invocation(


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
