### PR TITLE
environmentd: detect malformed rows

### DIFF
--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -72,6 +72,7 @@ pub use crate::coord::ExecuteContextExtra;
 pub use crate::coord::{load_remote_system_parameters, serve, Config};
 pub use crate::error::AdapterError;
 pub use crate::notice::AdapterNotice;
+pub use crate::util::verify_datum_desc;
 pub use crate::webhook::{
     AppendWebhookError, AppendWebhookResponse, AppendWebhookValidator, WebhookAppenderCache,
 };

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -16,7 +16,7 @@ use mz_compute_client::controller::error::{
 use mz_controller_types::ClusterId;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{halt, soft_assert_no_log};
-use mz_repr::{RelationDesc, ScalarType};
+use mz_repr::{RelationDesc, Row, ScalarType};
 use mz_sql::names::FullItemName;
 use mz_sql::plan::StatementDesc;
 use mz_sql::session::metadata::SessionMetadata;
@@ -445,4 +445,33 @@ pub(crate) fn viewable_variables<'a>(
             v.visible(session.user(), Some(catalog.system_config()))
                 .is_ok()
         })
+}
+
+/// Verify that the row datums match the expected desc.
+pub fn verify_datum_desc(desc: &RelationDesc, rows: &[Row]) -> Result<(), AdapterError> {
+    // Verify the first row is of the expected type. This is often good enough to
+    // find problems. Notably it failed to find #6304 when "FETCH 2" was used in a
+    // test, instead we had to use "FETCH 1" twice.
+    if let [row, ..] = rows {
+        let datums = row.unpack();
+        let col_types = &desc.typ().column_types;
+        if datums.len() != col_types.len() {
+            let msg = format!(
+                "internal error: row descriptor has {} columns but row has {} columns",
+                col_types.len(),
+                datums.len(),
+            );
+            return Err(AdapterError::Internal(msg));
+        }
+        for (i, (d, t)) in datums.iter().zip(col_types).enumerate() {
+            if !d.is_instance_of(t) {
+                let msg = format!(
+                    "internal error: column {} is not of expected type {:?}: {:?}",
+                    i, t, d
+                );
+                return Err(AdapterError::Internal(msg));
+            }
+        }
+    }
+    Ok(())
 }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -27,14 +27,14 @@ use mz_adapter::client::RecordFirstRowStream;
 use mz_adapter::session::{EndTransactionAction, TransactionStatus};
 use mz_adapter::statement_logging::{StatementEndedExecutionReason, StatementExecutionStrategy};
 use mz_adapter::{
-    AdapterError, AdapterNotice, ExecuteContextExtra, ExecuteResponse, ExecuteResponseKind,
-    PeekResponseUnary, SessionClient,
+    verify_datum_desc, AdapterError, AdapterNotice, ExecuteContextExtra, ExecuteResponse,
+    ExecuteResponseKind, PeekResponseUnary, SessionClient,
 };
 use mz_interchange::encode::TypedDatum;
 use mz_interchange::json::{JsonNumberPolicy, ToJson};
 use mz_ore::cast::CastFrom;
 use mz_ore::result::ResultExt;
-use mz_repr::{Datum, RelationDesc, RowArena};
+use mz_repr::{Datum, RelationDesc, Row, RowArena};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{Raw, Statement, StatementKind};
 use mz_sql::parse::StatementParseResult;
@@ -409,16 +409,36 @@ pub enum SqlResult {
 }
 
 impl SqlResult {
-    fn rows(
-        client: &mut SessionClient,
-        tag: String,
-        rows: Vec<Vec<serde_json::Value>>,
-        desc: RelationDesc,
-    ) -> SqlResult {
+    /// Convert adapter Row results into the web row result format. Error if the row format does not
+    /// match the expected descriptor.
+    fn rows(client: &mut SessionClient, sql_rows: Vec<Row>, desc: &RelationDesc) -> SqlResult {
+        if let Err(err) = verify_datum_desc(desc, &sql_rows) {
+            return SqlResult::Err {
+                error: err.into(),
+                notices: make_notices(client),
+            };
+        }
+        let mut rows: Vec<Vec<serde_json::Value>> = vec![];
+        let mut datum_vec = mz_repr::DatumVec::new();
+        let types = &desc.typ().column_types;
+        for row in sql_rows {
+            let datums = datum_vec.borrow_with(&row);
+            rows.push(
+                datums
+                    .iter()
+                    .enumerate()
+                    .map(|(i, d)| {
+                        TypedDatum::new(*d, &types[i])
+                            .json(&JsonNumberPolicy::ConvertNumberToString)
+                    })
+                    .collect(),
+            );
+        }
+        let tag = format!("SELECT {}", rows.len());
         SqlResult::Rows {
             tag,
             rows,
-            desc: Description::from(&desc),
+            desc: Description::from(desc),
             notices: make_notices(client),
         }
     }
@@ -642,13 +662,11 @@ impl ResultSender for SqlResponse {
 impl ResultSender for WebSocket {
     const SUPPORTS_STREAMING_NOTICES: bool = true;
 
-    // The first component of the return value is
-    // Err if sending to the client
-    // produced an error and the server should disconnect. It is Ok(Err) if the statement
-    // produced an error and should error the transaction, but remain connected. It is Ok(Ok(()))
-    // if the statement succeeded.
-    // The second component of the return value is `Some` if execution still
-    // needs to be retired for statement logging purposes.
+    // The first component of the return value is Err if sending to the client produced an error and
+    // the server should disconnect. It is Ok(Err) if the statement produced an error and should
+    // error the transaction, but remain connected. It is Ok(Ok(())) if the statement succeeded. The
+    // second component of the return value is `Some` if execution still needs to be retired for
+    // statement logging purposes.
     async fn add_result(
         &mut self,
         client: &mut SessionClient,
@@ -738,6 +756,17 @@ impl ResultSender for WebSocket {
                     };
                     match res {
                         Some(PeekResponseUnary::Rows(rows)) => {
+                            if let Err(err) = verify_datum_desc(desc, &rows) {
+                                let error = err.to_string();
+                                break (
+                                    true,
+                                    vec![WebSocketResponse::Error(err.into())],
+                                    Some((
+                                        StatementEndedExecutionReason::Errored { error },
+                                        ctx_extra,
+                                    )),
+                                );
+                            }
                             rows_returned += rows.len();
                             for row in rows {
                                 let datums = datum_vec.borrow_with(&row);
@@ -1240,46 +1269,10 @@ async fn execute_stmt<S: ResultSender>(
                     return Ok(SqlResult::err(client, AdapterError::Canceled).into());
                 }
             };
-            let mut sql_rows: Vec<Vec<serde_json::Value>> = vec![];
-            let mut datum_vec = mz_repr::DatumVec::new();
-            let desc = desc.relation_desc.expect("RelationDesc must exist");
-            let types = &desc.typ().column_types;
-            for row in rows {
-                let datums = datum_vec.borrow_with(&row);
-                sql_rows.push(
-                    datums
-                        .iter()
-                        .enumerate()
-                        .map(|(i, d)| {
-                            TypedDatum::new(*d, &types[i])
-                                .json(&JsonNumberPolicy::ConvertNumberToString)
-                        })
-                        .collect(),
-                );
-            }
-            let tag = format!("SELECT {}", sql_rows.len());
-            SqlResult::rows(client, tag, sql_rows, desc).into()
+            SqlResult::rows(client, rows, &desc.relation_desc.expect("RelationDesc must exist")).into()
         }
         ExecuteResponse::SendingRowsImmediate { rows } => {
-            let mut sql_rows: Vec<Vec<serde_json::Value>> = vec![];
-            let mut datum_vec = mz_repr::DatumVec::new();
-            let desc = desc.relation_desc.expect("RelationDesc must exist");
-            let types = &desc.typ().column_types;
-            for row in rows {
-                let datums = datum_vec.borrow_with(&row);
-                sql_rows.push(
-                    datums
-                        .iter()
-                        .enumerate()
-                        .map(|(i, d)| {
-                            TypedDatum::new(*d, &types[i])
-                                .json(&JsonNumberPolicy::ConvertNumberToString)
-                        })
-                        .collect(),
-                );
-            }
-            let tag = format!("SELECT {}", sql_rows.len());
-            SqlResult::rows(client, tag, sql_rows, desc).into()
+            SqlResult::rows(client, rows, &desc.relation_desc.expect("RelationDesc must exist")).into()
         }
         ExecuteResponse::Subscribing { rx, ctx_extra } => StatementResult::Subscribe {
             tag: "SUBSCRIBE".into(),


### PR DESCRIPTION
pgwire had runtime protection against mismatching desc and rows. Extend that to http and websocket. This would have protected against the panic in the linked issue. Adding a test for this results in panic without this patch, and an error output with it. Not adding the test because the underlying issue is getting fixed which will prevent the test from working.

See #26549

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a