### PR TITLE
persist: Write structured columnar data to S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5239,7 +5239,6 @@ dependencies = [
  "mz-persist-types",
  "mz-postgres-client",
  "mz-proto",
- "mz-repr",
  "once_cell",
  "openssl",
  "openssl-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5239,6 +5239,7 @@ dependencies = [
  "mz-persist-types",
  "mz-postgres-client",
  "mz-proto",
+ "mz-repr",
  "once_cell",
  "openssl",
  "openssl-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5281,6 +5281,7 @@ dependencies = [
  "futures-util",
  "h2",
  "hex",
+ "itertools",
  "mz-build-info",
  "mz-build-tools",
  "mz-dyncfg",

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -249,6 +249,21 @@ steps:
               composition: testdrive
               args: [--default-size=8]
 
+      - id: testdrive-structured-persist
+        label: ":racing_car: testdrive with Structured Persist"
+        depends_on: build-aarch64
+        timeout_in_minutes: 180
+        agents:
+          queue: linux-aarch64-large
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+          - ./ci/plugins/mzcompose:
+              composition: testdrive
+              args: [
+                --system-param=persist_part_decode_format=row_with_validate,
+                --system-param=persist_batch_columnar_format=both,
+              ]
+
       - id: testdrive-in-cloudtest
         label: Full Testdrive in Cloudtest (K8s)
         depends_on: build-aarch64
@@ -810,6 +825,17 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=TogglePersistRoundtripSpine, "--seed=$BUILDKITE_JOB_ID"]
+
+      - id: checks-toggle-persist-batch-columnar-format
+        label: "Checks toggling persist batch columnar format"
+        depends_on: build-aarch64
+        timeout_in_minutes: 45
+        agents:
+          queue: linux-aarch64-large
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=TogglePersistBatchColumnarFormat, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-migrate-aarch64-x86-64
         label: "Checks migrate from aarch64 to x86-64"

--- a/deny.toml
+++ b/deny.toml
@@ -148,7 +148,6 @@ name = "rustls"
 [[bans.deny]]
 name = "lazy_static"
 wrappers = [
-  "arrow-csv",
   "bindgen",
   "bstr",
   "console",

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -337,3 +337,19 @@ class TogglePersistRoundtripSpine(SystemVarChange):
                 )
             ],
         )
+
+
+class TogglePersistBatchColumnarFormat(SystemVarChange):
+    def __init__(self, checks: list[type[Check]], executor: Executor, seed: str | None):
+        super().__init__(
+            checks,
+            executor,
+            seed,
+            [
+                SystemVarChangeEntry(
+                    name="persist_batch_columnar_format",
+                    value_for_manipulate_phase_1="row",
+                    value_for_manipulate_phase_2="both",
+                )
+            ],
+        )

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -96,6 +96,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_use_critical_since_snapshot": "true",
     # TODO: change to true when #27219 is resolved
     "persist_use_critical_since_source": "false",
+    "persist_part_decode_format": "row_with_validate",
     "statement_logging_default_sample_rate": "0.01",
     "statement_logging_max_sample_rate": "0.01",
     "storage_persist_sink_minimum_batch_updates": "100",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -917,6 +917,7 @@ class FlipFlagsAction(Action):
             "enable_variadic_left_join_lowering"
         ] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["persist_batch_columnar_format"] = ["row", "both"]
 
     def run(self, exe: Executor) -> bool:
         flag_name = self.rng.choice(list(self.flags_with_values.keys()))

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -220,6 +220,16 @@ macro_rules! soft_panic_or_log {
     }}
 }
 
+/// Panics if soft assertions are enabled.
+#[macro_export]
+macro_rules! soft_panic_no_log {
+    ($($arg:tt)+) => {{
+        if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
+            panic!($($arg)+);
+        }
+    }}
+}
+
 /// Asserts that the left expression contains the right expression.
 ///
 /// Containment is determined by the `contains` method on the left type. If the

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -39,6 +39,7 @@ futures = "0.3.25"
 futures-util = "0.3"
 h2 = "0.3.13"
 hex = "0.4.3"
+itertools = "0.10.5"
 mz-build-info = { path = "../build-info" }
 mz-dyncfg = { path = "../dyncfg" }
 mz-ore = { path = "../ore", features = ["bytes_", "test", "tracing_"] }

--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -198,7 +198,9 @@ pub fn bench_encode_batch(name: &str, throughput: bool, c: &mut Criterion, data:
             Antichain::from_elem(0u64),
         ),
         index: 0,
-        updates: data.batches().collect::<Vec<_>>(),
+        updates: mz_persist::indexed::encoding::BlobTraceUpdates::Row(
+            data.batches().collect::<Vec<_>>(),
+        ),
     };
 
     g.bench_function(BenchmarkId::new("trace", data.goodput_pretty()), |b| {

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -27,8 +27,10 @@ use mz_dyncfg::Config;
 use mz_ore::cast::CastFrom;
 use mz_ore::instrument;
 use mz_ore::task::{JoinHandle, JoinHandleExt};
-use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsBuilder};
-use mz_persist::indexed::encoding::BlobTraceBatchPart;
+use mz_persist::indexed::columnar::{
+    ColumnarRecords, ColumnarRecordsBuilder, ColumnarRecordsStructuredExt,
+};
+use mz_persist::indexed::encoding::{BatchColumnarFormat, BlobTraceBatchPart, BlobTraceUpdates};
 use mz_persist::location::Blob;
 use mz_persist_types::stats::{trim_to_budget, truncate_bytes, TruncateBound, TRUNCATE_LEN};
 use mz_persist_types::{Codec, Codec64};
@@ -39,7 +41,7 @@ use semver::Version;
 use timely::order::TotalOrder;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
-use tracing::{debug_span, error, trace_span, warn, Instrument};
+use tracing::{debug_span, trace_span, warn, Instrument};
 
 use crate::async_runtime::IsolatedRuntime;
 use crate::cfg::MiB;
@@ -52,7 +54,7 @@ use crate::internal::state::{
     BatchPart, HollowBatch, HollowBatchPart, ProtoInlineBatchPart, WRITE_DIFFS_SUM,
 };
 use crate::stats::{
-    part_stats_for_legacy_part, untrimmable_columns, STATS_BUDGET_BYTES, STATS_COLLECTION_ENABLED,
+    encode_updates, untrimmable_columns, STATS_BUDGET_BYTES, STATS_COLLECTION_ENABLED,
 };
 use crate::write::WriterId;
 use crate::{PersistConfig, ShardId};
@@ -232,7 +234,8 @@ where
                 .decode::<T>(&self.metrics.columnar)
                 .expect("valid inline part");
             let key_lower = updates.key_lower().to_vec();
-            let diffs_sum = diffs_sum::<D>(&updates.updates).expect("inline parts are not empty");
+            let diffs_sum =
+                diffs_sum::<D>(updates.updates.iter()).expect("inline parts are not empty");
 
             let write_span =
                 debug_span!("batch::flush_to_blob", shard = %self.shard_metrics.shard_id)
@@ -330,6 +333,7 @@ pub struct BatchBuilderConfig {
     pub(crate) blob_target_size: usize,
     pub(crate) batch_delete_enabled: bool,
     pub(crate) batch_builder_max_outstanding_parts: usize,
+    pub(crate) batch_columnar_format: BatchColumnarFormat,
     pub(crate) inline_writes_single_max_bytes: usize,
     pub(crate) stats_collection_enabled: bool,
     pub(crate) stats_budget: usize,
@@ -342,6 +346,12 @@ pub(crate) const BATCH_DELETE_ENABLED: Config<bool> = Config::new(
     "persist_batch_delete_enabled",
     false,
     "Whether to actually delete blobs when batch delete is called (Materialize).",
+);
+
+pub(crate) const BATCH_COLUMNAR_FORMAT: Config<&'static str> = Config::new(
+    "persist_batch_columnar_format",
+    BatchColumnarFormat::default().as_str(),
+    "Columnar format for a batch written to Persist, either 'row' or 'both' (Materialize).",
 );
 
 /// A target maximum size of blob payloads in bytes. If a logical "batch" is
@@ -381,6 +391,7 @@ impl BatchBuilderConfig {
             batch_builder_max_outstanding_parts: value
                 .dynamic
                 .batch_builder_max_outstanding_parts(),
+            batch_columnar_format: BatchColumnarFormat::from_str(&BATCH_COLUMNAR_FORMAT.get(value)),
             inline_writes_single_max_bytes: INLINE_WRITES_SINGLE_MAX_BYTES.get(value),
             stats_collection_enabled: STATS_COLLECTION_ENABLED.get(value),
             stats_budget: STATS_BUDGET_BYTES.get(value),
@@ -963,7 +974,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         } else {
             let part = BlobTraceBatchPart {
                 desc,
-                updates: vec![updates],
+                updates: BlobTraceUpdates::Row(vec![updates]),
                 index,
             };
             let write_span =
@@ -1009,7 +1020,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         shard_metrics: Arc<ShardMetrics>,
         batch_metrics: BatchWriteMetrics,
         isolated_runtime: Arc<IsolatedRuntime>,
-        updates: BlobTraceBatchPart<T>,
+        mut updates: BlobTraceBatchPart<T>,
         key_lower: Vec<u8>,
         ts_rewrite: Option<Antichain<T>>,
         diffs_sum: [u8; 8],
@@ -1022,22 +1033,54 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
 
         let (stats, (buf, encode_time)) = isolated_runtime
             .spawn_named(|| "batch::encode_part", async move {
-                let stats = if cfg.stats_collection_enabled {
-                    let stats_start = Instant::now();
-                    match part_stats_for_legacy_part(&schemas, &updates.updates) {
-                        Ok(x) => {
-                            let mut trimmed_bytes = 0;
-                            let x = LazyPartStats::encode(&x, |s| {
-                                trimmed_bytes = trim_to_budget(s, cfg.stats_budget, |s| {
-                                    cfg.stats_untrimmable_columns.should_retain(s)
-                                });
-                            });
-                            Some((x, stats_start.elapsed(), trimmed_bytes))
-                        }
+                // Only encode our updates in a structured format if required, it's expensive.
+                let s = if cfg.stats_collection_enabled || cfg.batch_columnar_format.is_structured()
+                {
+                    let result = metrics_
+                        .columnar
+                        .arrow()
+                        .measure_part_build(|| encode_updates(&schemas, &updates.updates));
+                    match result {
                         Err(err) => {
-                            error!("failed to construct part stats: {}", err);
+                            tracing::error!(?err, "failed to encode in columnar format!");
                             None
                         }
+                        Ok(s) => Some(s),
+                    }
+                } else {
+                    None
+                };
+
+                let stats = if let Some((part, stats)) = s {
+                    // Only change the updates to use the structured format, if our updates had a
+                    // single batch.
+                    match updates.updates {
+                        BlobTraceUpdates::Row(mut records)
+                            if records.len() == 1 && cfg.batch_columnar_format.is_structured() =>
+                        {
+                            let record = records.pop().expect("checked length above");
+                            let record_ext = ColumnarRecordsStructuredExt {
+                                key: part.to_key_arrow().map(|(_, array)| array),
+                                val: part.to_val_arrow().map(|(_, array)| array),
+                            };
+                            updates.updates = BlobTraceUpdates::Both((record, record_ext))
+                        }
+                        _ => (),
+                    }
+
+                    if cfg.stats_collection_enabled {
+                        let trimmed_start = Instant::now();
+                        let mut trimmed_bytes = 0;
+                        let trimmed_stats = LazyPartStats::encode(&stats, |s| {
+                            trimmed_bytes = trim_to_budget(s, cfg.stats_budget, |s| {
+                                cfg.stats_untrimmable_columns.should_retain(s)
+                            })
+                        });
+                        let trimmed_duration = trimmed_start.elapsed();
+
+                        Some((trimmed_stats, trimmed_duration, trimmed_bytes))
+                    } else {
+                        None
                     }
                 } else {
                     None

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -363,6 +363,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::stats::STATS_UNTRIMMABLE_COLUMNS_EQUALS)
         .add(&crate::stats::STATS_UNTRIMMABLE_COLUMNS_PREFIX)
         .add(&crate::stats::STATS_UNTRIMMABLE_COLUMNS_SUFFIX)
+        .add(&crate::fetch::PART_DECODE_FORMAT)
 }
 
 impl PersistConfig {

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -323,6 +323,7 @@ pub(crate) const MiB: usize = 1024 * 1024;
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     mz_persist::cfg::all_dyn_configs(configs)
         .add(&crate::batch::BATCH_DELETE_ENABLED)
+        .add(&crate::batch::BATCH_COLUMNAR_FORMAT)
         .add(&crate::batch::BLOB_TARGET_SIZE)
         .add(&crate::batch::INLINE_WRITES_TOTAL_MAX_BYTES)
         .add(&crate::batch::INLINE_WRITES_SINGLE_MAX_BYTES)

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -680,11 +680,11 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
 /// return static Codec names, and rebind the names if/when we get a CodecMismatch, so we can convince
 /// the type system and our safety checks that we really can read the data.
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct K;
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct V;
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 struct T;
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 struct D(i64);

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -359,7 +359,7 @@ pub async fn blob_batch_part(
         updates: Vec::new(),
     };
     let mut cursor = Cursor::default();
-    while let Some((k, v, t, d)) = cursor.pop(&encoded_part) {
+    while let Some(((k, v, t, d), _)) = cursor.pop(&encoded_part) {
         if out.updates.len() > limit {
             break;
         }
@@ -404,7 +404,7 @@ async fn consolidated_size(args: &StateArgs) -> Result<(), anyhow::Error> {
             .await
             .expect("part exists");
             let mut cursor = Cursor::default();
-            while let Some((k, v, mut t, d)) = cursor.pop(&encoded_part) {
+            while let Some(((k, v, mut t, d), _)) = cursor.pop(&encoded_part) {
                 t.advance_by(as_of);
                 let d = <i64 as Codec64>::decode(d);
                 updates.push(((k.to_owned(), v.to_owned()), t, d));

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -748,7 +748,7 @@ impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedPart<K, V, 
             // Only downcast and create decoders if we have structured data AND
             // an audit of the data is requested.
             (
-                BlobTraceUpdates::Both((_codec, structured)),
+                BlobTraceUpdates::Both(_codec, structured),
                 PartDecodeFormat::Row {
                     validate_structured: true,
                 },
@@ -921,7 +921,7 @@ where
                     // Purposefully do not trace to prevent blowing up Sentry.
                     let is_valid = val_metrics.report_valid(|| Ok(v_s) == v);
                     if !is_valid {
-                        soft_panic_no_log!("structured key did not match");
+                        soft_panic_no_log!("structured val did not match");
                     }
                 }
 

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -9,7 +9,7 @@
 
 //! Fetching batches of data from persist's backing store
 
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Instant;
@@ -18,11 +18,14 @@ use anyhow::anyhow;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
-use mz_dyncfg::{Config, ConfigSet};
+use mz_dyncfg::{Config, ConfigSet, ConfigValHandle};
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastFrom;
-use mz_persist::indexed::encoding::BlobTraceBatchPart;
+use mz_ore::{soft_panic_no_log, soft_panic_or_log};
+use mz_persist::indexed::encoding::{BlobTraceBatchPart, BlobTraceUpdates};
 use mz_persist::location::{Blob, SeqNo};
+use mz_persist_types::columnar::{PartDecoder, Schema};
+use mz_persist_types::dyn_struct::DynStructCol;
 use mz_persist_types::stats::PartStats;
 use mz_persist_types::{Codec, Codec64};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
@@ -36,6 +39,7 @@ use crate::batch::{
     proto_fetch_batch_filter, ProtoFetchBatchFilter, ProtoFetchBatchFilterListen, ProtoLease,
     ProtoLeasedBatchPart,
 };
+use crate::cfg::PersistConfig;
 use crate::error::InvalidUsage;
 use crate::internal::encoding::{LazyInlineBatchPart, LazyPartStats, LazyProto, Schemas};
 use crate::internal::machine::retry_external;
@@ -67,6 +71,29 @@ pub(crate) const FETCH_SEMAPHORE_PERMIT_ADJUSTMENT: Config<f64> = Config::new(
     replicas.",
 );
 
+pub(crate) const PART_DECODE_FORMAT: Config<&'static str> = Config::new(
+    "persist_part_decode_format",
+    PartDecodeFormat::default().as_str(),
+    "Format we'll use to decode a Persist Part, either 'row' or 'row_with_validate' (Materialize).",
+);
+
+#[derive(Debug, Clone)]
+pub(crate) struct BatchFetcherConfig {
+    pub(crate) part_decode_format: ConfigValHandle<String>,
+}
+
+impl BatchFetcherConfig {
+    pub fn new(value: &PersistConfig) -> Self {
+        BatchFetcherConfig {
+            part_decode_format: PART_DECODE_FORMAT.handle(value),
+        }
+    }
+
+    pub fn part_decode_format(&self) -> PartDecodeFormat {
+        PartDecodeFormat::from_str(self.part_decode_format.get().as_str())
+    }
+}
+
 /// Capable of fetching [`LeasedBatchPart`] while not holding any capabilities.
 #[derive(Debug)]
 pub struct BatchFetcher<K, V, T, D>
@@ -77,6 +104,7 @@ where
     V: Debug + Codec,
     D: Semigroup + Codec64 + Send + Sync,
 {
+    pub(crate) cfg: BatchFetcherConfig,
     pub(crate) blob: Arc<dyn Blob>,
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) shard_metrics: Arc<ShardMetrics>,
@@ -169,6 +197,7 @@ where
             schemas: self.schemas.clone(),
             filter: part.filter.clone(),
             filter_pushdown_audit: part.filter_pushdown_audit,
+            structured_part_audit: self.cfg.part_decode_format(),
             fetch_permit,
             _phantom: PhantomData,
         };
@@ -268,6 +297,7 @@ impl<T: Timestamp + Codec64> RustType<ProtoFetchBatchFilter> for FetchBatchFilte
 /// Note to check the `LeasedBatchPart` documentation for how to handle the
 /// returned value.
 pub(crate) async fn fetch_leased_part<K, V, T, D>(
+    cfg: &PersistConfig,
     part: &LeasedBatchPart<T>,
     blob: &dyn Blob,
     metrics: Arc<Metrics>,
@@ -303,12 +333,14 @@ where
         // process.
         panic!("{} could not fetch batch part: {}", reader_id, blob_key)
     });
+    let part_cfg = BatchFetcherConfig::new(cfg);
     FetchedPart::new(
         metrics,
         encoded_part,
         schemas,
         part.filter.clone(),
         part.filter_pushdown_audit,
+        part_cfg.part_decode_format(),
         part.part.stats(),
     )
 }
@@ -530,6 +562,7 @@ pub struct FetchedBlob<K: Codec, V: Codec, T, D> {
     schemas: Schemas<K, V>,
     filter: FetchBatchFilter<T>,
     filter_pushdown_audit: bool,
+    structured_part_audit: PartDecodeFormat,
     fetch_permit: Option<Arc<MetricsPermits>>,
     _phantom: PhantomData<fn() -> D>,
 }
@@ -558,6 +591,7 @@ impl<K: Codec, V: Codec, T: Clone, D> Clone for FetchedBlob<K, V, T, D> {
             filter: self.filter.clone(),
             filter_pushdown_audit: self.filter_pushdown_audit.clone(),
             fetch_permit: self.fetch_permit.clone(),
+            structured_part_audit: self.structured_part_audit.clone(),
             _phantom: self._phantom.clone(),
         }
     }
@@ -631,6 +665,7 @@ impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedBlob<K, V, 
             self.schemas.clone(),
             self.filter.clone(),
             self.filter_pushdown_audit,
+            self.structured_part_audit,
             stats,
         );
         ShardSourcePart {
@@ -657,6 +692,10 @@ pub struct FetchedPart<K: Codec, V: Codec, T, D> {
     metrics: Arc<Metrics>,
     ts_filter: FetchBatchFilter<T>,
     part: EncodedPart<T>,
+    structured_part: (
+        Option<Arc<<K::Schema as Schema<K>>::Decoder>>,
+        Option<Arc<<V::Schema as Schema<V>>::Decoder>>,
+    ),
     schemas: Schemas<K, V>,
     filter_pushdown_audit: Option<LazyPartStats>,
     part_cursor: Cursor,
@@ -672,6 +711,7 @@ impl<K: Codec, V: Codec, T: Clone, D> Clone for FetchedPart<K, V, T, D> {
             metrics: Arc::clone(&self.metrics),
             ts_filter: self.ts_filter.clone(),
             part: self.part.clone(),
+            structured_part: self.structured_part.clone(),
             schemas: self.schemas.clone(),
             filter_pushdown_audit: self.filter_pushdown_audit.clone(),
             part_cursor: self.part_cursor.clone(),
@@ -689,6 +729,7 @@ impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedPart<K, V, 
         schemas: Schemas<K, V>,
         ts_filter: FetchBatchFilter<T>,
         filter_pushdown_audit: bool,
+        structured_part_audit: PartDecodeFormat,
         stats: Option<&LazyPartStats>,
     ) -> Self {
         let filter_pushdown_audit = if filter_pushdown_audit {
@@ -696,10 +737,66 @@ impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedPart<K, V, 
         } else {
             None
         };
+
+        // TODO(parkmycar): We should probably refactor this since these columns are duplicated
+        // (via a smart pointer) in EncodedPart.
+        //
+        // For structured columnar data we need to downcast from `dyn Array`s to concrete types.
+        // Downcasting is relatively expensive so we want to do this once, which is why we do it
+        // when creating a FetchedPart.
+        let structured_part = match (&part.part.updates, structured_part_audit) {
+            // Only downcast and create decoders if we have structured data AND
+            // an audit of the data is requested.
+            (
+                BlobTraceUpdates::Both((_codec, structured)),
+                PartDecodeFormat::Row {
+                    validate_structured: true,
+                },
+            ) => {
+                let maybe_key = structured
+                    .key
+                    .as_ref()
+                    .map(|col| {
+                        let col = DynStructCol::from_arrow(schemas.key.columns(), col)?;
+                        let decoder = schemas.key.decoder(col.as_ref())?;
+                        Ok::<_, String>(Arc::new(decoder))
+                    })
+                    .transpose();
+                let key = match maybe_key {
+                    Ok(key) => key,
+                    Err(err) => {
+                        tracing::error!(?err, "failed to create key decoder");
+                        None
+                    }
+                };
+
+                let maybe_val = structured
+                    .val
+                    .as_ref()
+                    .map(|col| {
+                        let col = DynStructCol::from_arrow(schemas.val.columns(), col)?;
+                        let decoder = schemas.val.decoder(col.as_ref())?;
+                        Ok::<_, String>(Arc::new(decoder))
+                    })
+                    .transpose();
+                let val = match maybe_val {
+                    Ok(val) => val,
+                    Err(err) => {
+                        tracing::error!(?err, "failed to create val decoder");
+                        None
+                    }
+                };
+
+                (key, val)
+            }
+            _ => (None, None),
+        };
+
         FetchedPart {
             metrics,
             ts_filter,
             part,
+            structured_part,
             schemas,
             filter_pushdown_audit,
             part_cursor: Cursor::default(),
@@ -751,6 +848,9 @@ where
             if !self.ts_filter.filter_ts(&mut t) {
                 continue;
             }
+            // Record the index at which we popped this element, incase we want to do structured
+            // validation below.
+            let popped_idx = self.part_cursor.idx - 1;
 
             let mut d = D::decode(d);
 
@@ -796,6 +896,35 @@ where
                     },
                     None => V::decode(v),
                 });
+
+                // Note: We only provide structured columns, if they were originally written, and a
+                // dyncfg was specified to run validation.
+                if let Some(key_structured) = self.structured_part.0.as_ref() {
+                    let key_metrics = self.metrics.columnar.arrow().key();
+
+                    let mut k_s = K::default();
+                    key_metrics.measure_decoding(|| key_structured.decode(popped_idx, &mut k_s));
+
+                    // Purposefully do not trace to prevent blowing up Sentry.
+                    let is_valid = key_metrics.report_valid(|| Ok(k_s) == k);
+                    if !is_valid {
+                        soft_panic_no_log!("structured key did not match");
+                    }
+                }
+
+                if let Some(val_structured) = self.structured_part.1.as_ref() {
+                    let val_metrics = self.metrics.columnar.arrow().val();
+
+                    let mut v_s = V::default();
+                    val_metrics.measure_decoding(|| val_structured.decode(popped_idx, &mut v_s));
+
+                    // Purposefully do not trace to prevent blowing up Sentry.
+                    let is_valid = val_metrics.report_valid(|| Ok(v_s) == v);
+                    if !is_valid {
+                        soft_panic_no_log!("structured key did not match");
+                    }
+                }
+
                 return Some(((k, v), t, d));
             }
         }
@@ -1132,6 +1261,65 @@ impl<T: Timestamp + Codec64> RustType<(ProtoLeasedBatchPart, Arc<Metrics>)> for 
             lease: None,
             filter_pushdown_audit: proto.filter_pushdown_audit,
         })
+    }
+}
+
+/// Format we'll use when decoding a [`Part`].
+///
+/// [`Part`]: mz_persist_types::part::Part
+#[derive(Debug, Copy, Clone)]
+pub enum PartDecodeFormat {
+    /// Decode from opaque `Codec` data.
+    Row {
+        /// Will also decode the structured data, and validate it matches.
+        validate_structured: bool,
+    },
+}
+
+impl PartDecodeFormat {
+    /// Returns a default value for [`PartDecodeFormat`].
+    pub const fn default() -> Self {
+        // IMPORTANT: By default we will not decode or validate our structured format until it's
+        // more stable.
+        PartDecodeFormat::Row {
+            validate_structured: false,
+        }
+    }
+
+    /// Parses a [`PartDecodeFormat`] from the provided string, falling back to the default if the
+    /// provided value is unrecognized.
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "row" => PartDecodeFormat::Row {
+                validate_structured: false,
+            },
+            "row_with_validate" => PartDecodeFormat::Row {
+                validate_structured: true,
+            },
+            x => {
+                let default = PartDecodeFormat::default();
+                soft_panic_or_log!("Invalid part decode format: '{x}', falling back to {default}");
+                default
+            }
+        }
+    }
+
+    /// Returns a string representation of [`PartDecodeFormat`].
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            PartDecodeFormat::Row {
+                validate_structured: false,
+            } => "row",
+            PartDecodeFormat::Row {
+                validate_structured: true,
+            } => "row_with_validate",
+        }
+    }
+}
+
+impl fmt::Display for PartDecodeFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -1175,7 +1175,7 @@ impl Cursor {
 
     /// Returns true if the cursor is past the end of the part data.
     pub fn is_exhausted<T: Timestamp + Codec64>(&self, part: &EncodedPart<T>) -> bool {
-        self.part_idx >= part.part.updates.len()
+        self.part_idx >= part.part.updates.num_row_groups()
     }
 
     /// Advance the cursor just past the end of the most recent update, if there is one.

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -19,7 +19,7 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use mz_ore::halt;
 use mz_persist::indexed::columnar::ColumnarRecords;
-use mz_persist::indexed::encoding::BlobTraceBatchPart;
+use mz_persist::indexed::encoding::{BlobTraceBatchPart, BlobTraceUpdates};
 use mz_persist::location::{SeqNo, VersionedData};
 use mz_persist::metrics::ColumnarMetrics;
 use mz_persist_types::stats::{PartStats, ProtoStructStats};
@@ -1392,7 +1392,7 @@ impl ProtoInlineBatchPart {
         Ok(BlobTraceBatchPart {
             desc: proto.desc.into_rust_if_some("ProtoInlineBatchPart::desc")?,
             index: proto.index.into_rust()?,
-            updates: vec![updates],
+            updates: BlobTraceUpdates::Row(vec![updates]),
         })
     }
 }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1727,7 +1727,7 @@ pub mod datadriven {
             .await
             .expect("invalid batch part");
             let mut cursor = Cursor::default();
-            while let Some((k, _v, t, d)) = cursor.pop(&part) {
+            while let Some(((k, _v, t, d), _)) = cursor.pop(&part) {
                 let (k, d) = (String::decode(k).unwrap(), i64::decode(d));
                 write!(s, "{k} {t} {d}\n");
             }
@@ -1974,7 +1974,7 @@ pub mod datadriven {
 
                     let mut updates = Vec::new();
                     let mut cursor = Cursor::default();
-                    while let Some((k, _v, mut t, d)) = cursor.pop(&part) {
+                    while let Some(((k, _v, mut t, d), _)) = cursor.pop(&part) {
                         t.advance_by(as_of.borrow());
                         updates.push((String::decode(k).unwrap(), t, i64::decode(d)));
                     }

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -919,7 +919,7 @@ mod tests {
     use differential_dataflow::trace::Description;
     use mz_ore::metrics::MetricsRegistry;
     use mz_persist::indexed::columnar::ColumnarRecordsBuilder;
-    use mz_persist::indexed::encoding::BlobTraceBatchPart;
+    use mz_persist::indexed::encoding::{BlobTraceBatchPart, BlobTraceUpdates};
     use mz_persist::location::Blob;
     use mz_persist::mem::{MemBlob, MemBlobConfig};
     use proptest::collection::vec;
@@ -986,7 +986,9 @@ mod tests {
                                         BlobTraceBatchPart {
                                             desc: desc.clone(),
                                             index: 0,
-                                            updates: vec![records.finish(&metrics.columnar)],
+                                            updates: BlobTraceUpdates::Row(vec![
+                                                records.finish(&metrics.columnar)
+                                            ]),
                                         },
                                     );
                                     (ConsolidationPart::from_encoded(part, &filter, true), 0)

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -34,7 +34,7 @@ use crate::cache::{PersistClientCache, StateCache};
 use crate::cfg::PersistConfig;
 use crate::critical::{CriticalReaderId, SinceHandle};
 use crate::error::InvalidUsage;
-use crate::fetch::BatchFetcher;
+use crate::fetch::{BatchFetcher, BatchFetcherConfig};
 use crate::internal::compact::Compactor;
 use crate::internal::encoding::{parse_id, Schemas};
 use crate::internal::gc::GarbageCollector;
@@ -422,6 +422,7 @@ impl PersistClient {
             val: val_schema,
         };
         let fetcher = BatchFetcher {
+            cfg: BatchFetcherConfig::new(&self.cfg),
             blob: Arc::clone(&self.blob),
             metrics: Arc::clone(&self.metrics),
             shard_metrics,

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -455,6 +455,7 @@ where
     /// [`Subscribe`], which contains a [`Listen`], to fetch batches.
     async fn fetch_batch_part(&mut self, part: LeasedBatchPart<T>) -> FetchedPart<K, V, T, D> {
         let fetched_part = fetch_leased_part(
+            &self.handle.cfg,
             &part,
             self.handle.blob.as_ref(),
             Arc::clone(&self.handle.metrics),
@@ -1077,9 +1078,11 @@ where
         let shard_metrics = Arc::clone(&self.machine.applier.shard_metrics);
         let reader_id = self.reader_id.clone();
         let schemas = self.schemas.clone();
+        let persist_cfg = self.cfg.clone();
         let stream = async_stream::stream! {
             for part in snap {
                 let mut fetched_part = fetch_leased_part(
+                    &persist_cfg,
                     &part,
                     blob.as_ref(),
                     Arc::clone(&metrics),

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -137,7 +137,7 @@ where
 {
     let updates = match updates {
         BlobTraceUpdates::Row(updates) => itertools::Either::Left(updates.into_iter()),
-        BlobTraceUpdates::Both((codec, _structured)) => {
+        BlobTraceUpdates::Both(codec, _structured) => {
             // This is super unexpected, but not worthy of a panic.
             soft_panic_or_log!("re-encoding structured data?");
             itertools::Either::Right(std::iter::once(codec))

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -629,10 +629,6 @@ impl ColumnRef<()> for BooleanBuffer {
             .as_any()
             .downcast_ref::<BooleanArray>()
             .ok_or_else(|| format!("expected BooleanArray but was {:?}", array.data_type()))?;
-        if array.logical_nulls().is_some() {
-            return Err("unexpected validity for non-optional bool".to_owned());
-        }
-
         Ok(array.values().clone())
     }
 }

--- a/src/persist-types/src/dyn_struct.rs
+++ b/src/persist-types/src/dyn_struct.rs
@@ -218,17 +218,25 @@ impl DynStructCol {
         let (mut fields, mut arrays) = (Vec::new(), Vec::new());
         for (name, _stats_fn, col) in self.cols() {
             let (array, is_nullable) = col.to_arrow();
+            if array.len() == 0 && self.len != 0 {
+                continue;
+            }
+
             fields.push(Field::new(name, array.data_type().clone(), is_nullable));
             arrays.push(array);
         }
         if fields.is_empty() {
             return None;
         }
-        // TODO(parkmycar): We need to pass the validity bitmap here.
-        Some(StructArray::new(Fields::from(fields), arrays, None))
+        Some(StructArray::new(
+            Fields::from(fields),
+            arrays,
+            self.validity.clone(),
+        ))
     }
 
-    pub(crate) fn from_arrow(cfg: DynStructCfg, array: &dyn Array) -> Result<Self, String> {
+    /// Create a [`DynStructCol`] from an [`arrow::array::Array`].
+    pub fn from_arrow(cfg: DynStructCfg, array: &dyn Array) -> Result<Self, String> {
         let array = array
             .as_any()
             .downcast_ref::<StructArray>()

--- a/src/persist-types/src/dyn_struct.rs
+++ b/src/persist-types/src/dyn_struct.rs
@@ -218,10 +218,6 @@ impl DynStructCol {
         let (mut fields, mut arrays) = (Vec::new(), Vec::new());
         for (name, _stats_fn, col) in self.cols() {
             let (array, is_nullable) = col.to_arrow();
-            if array.len() == 0 && self.len != 0 {
-                continue;
-            }
-
             fields.push(Field::new(name, array.data_type().clone(), is_nullable));
             arrays.push(array);
         }

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -36,7 +36,7 @@ pub mod txn;
 
 /// Encoding and decoding operations for a type usable as a persisted key or
 /// value.
-pub trait Codec: Sized + 'static {
+pub trait Codec: Sized + PartialEq + 'static {
     /// The type of the associated schema for [Self].
     ///
     /// This is a separate type because Row is not self-describing. For Row, you

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -56,7 +56,7 @@ impl Part {
         Ok(stats.some)
     }
 
-    /// Returns an [`arrow2`] array representing the `key` column.
+    /// Returns an [`arrow`] array representing the `key` column.
     pub fn to_key_arrow(&self) -> Option<(Field, StructArray)> {
         self.key.to_arrow_struct().map(|array| {
             let field = Field::new("k_s", array.data_type().clone(), false);
@@ -64,7 +64,7 @@ impl Part {
         })
     }
 
-    /// Returns an [`arrow2`] array representing the `val` column.
+    /// Returns an [`arrow`] array representing the `val` column.
     pub fn to_val_arrow(&self) -> Option<(Field, StructArray)> {
         self.val.to_arrow_struct().map(|array| {
             let field = Field::new("v_s", array.data_type().clone(), false);
@@ -72,7 +72,7 @@ impl Part {
         })
     }
 
-    /// Returns [`arrow2`] types representing this [`Part`].
+    /// Returns [`arrow`] types representing this [`Part`].
     pub fn to_arrow(&self) -> (Vec<Field>, Vec<Arc<dyn Array>>) {
         let (mut fields, mut arrays) = (Vec::new(), Vec::<Arc<dyn Array>>::new());
 

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -11,7 +11,7 @@
 
 use std::sync::Arc;
 
-use arrow::array::{Array, Int64Array, PrimitiveArray};
+use arrow::array::{Array, Int64Array, PrimitiveArray, StructArray};
 use arrow::buffer::ScalarBuffer;
 use arrow::datatypes::{Field, Int64Type};
 use mz_ore::iter::IteratorExt;
@@ -56,7 +56,24 @@ impl Part {
         Ok(stats.some)
     }
 
-    pub(crate) fn to_arrow(&self) -> (Vec<Field>, Vec<Arc<dyn Array>>) {
+    /// Returns an [`arrow2`] array representing the `key` column.
+    pub fn to_key_arrow(&self) -> Option<(Field, StructArray)> {
+        self.key.to_arrow_struct().map(|array| {
+            let field = Field::new("k_s", array.data_type().clone(), false);
+            (field, array)
+        })
+    }
+
+    /// Returns an [`arrow2`] array representing the `val` column.
+    pub fn to_val_arrow(&self) -> Option<(Field, StructArray)> {
+        self.val.to_arrow_struct().map(|array| {
+            let field = Field::new("v_s", array.data_type().clone(), false);
+            (field, array)
+        })
+    }
+
+    /// Returns [`arrow2`] types representing this [`Part`].
+    pub fn to_arrow(&self) -> (Vec<Field>, Vec<Arc<dyn Array>>) {
         let (mut fields, mut arrays) = (Vec::new(), Vec::<Arc<dyn Array>>::new());
 
         {
@@ -65,8 +82,8 @@ impl Part {
             // model this as a missing column (rather than something like
             // NullArray). This also matches how we'd do the same for nested
             // structs.
-            if let Some(key_array) = self.key.to_arrow_struct() {
-                fields.push(Field::new("k", key_array.data_type().clone(), false));
+            if let Some((field, key_array)) = self.to_key_arrow() {
+                fields.push(field);
                 arrays.push(Arc::new(key_array));
             }
         }
@@ -77,8 +94,8 @@ impl Part {
             // model this as a missing column (rather than something like
             // NullArray). This also matches how we'd do the same for nested
             // structs.
-            if let Some(val_array) = self.val.to_arrow_struct() {
-                fields.push(Field::new("v", val_array.data_type().clone(), false));
+            if let Some((field, val_array)) = self.to_val_arrow() {
+                fields.push(field);
                 arrays.push(Arc::new(val_array));
             }
         }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -64,7 +64,6 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
-mz-repr = { path = "../repr" }
 serde_json = "1.0.89"
 tempfile = "3.8.1"
 

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -64,6 +64,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
+mz-repr = { path = "../repr" }
 serde_json = "1.0.89"
 tempfile = "3.8.1"
 

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -14,6 +14,7 @@ use std::mem::size_of;
 use std::sync::Arc;
 use std::{cmp, fmt};
 
+use ::arrow::array::StructArray;
 use ::arrow::datatypes::ArrowNativeType;
 use bytes::Bytes;
 use mz_ore::bytes::MaybeLgBytes;
@@ -542,6 +543,26 @@ impl ColumnarRecords {
             .map_err(TryFromProtoError::InvalidPersistState)?;
         Ok(ret)
     }
+}
+
+/// An "extension" to [`ColumnarRecords`] that duplicates the "key" (`K`) and "val" (`V`) columns
+/// as structured Arrow data.
+///
+/// [`ColumnarRecords`] stores the key and value columns as binary blobs encoded with the [`Codec`]
+/// trait. We're migrating to instead store the key and value columns as structured Parquet data,
+/// which we interface with via Arrow.
+///
+/// [`Codec`]: mz_persist_types::Codec
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnarRecordsStructuredExt {
+    /// The structured `k` column.
+    ///
+    /// [`arrow`] does not allow empty [`StructArray`]s so we model an empty `key` column as None.
+    pub key: Option<StructArray>,
+    /// The structured `v` column.
+    ///
+    /// [`arrow`] does not allow empty [`StructArray`]s so we model an empty `val` column as None.
+    pub val: Option<StructArray>,
 }
 
 #[cfg(test)]

--- a/src/persist/src/indexed/columnar/arrow.rs
+++ b/src/persist/src/indexed/columnar/arrow.rs
@@ -77,7 +77,7 @@ pub fn encode_arrow_batch_kvtd(x: &ColumnarRecords) -> Vec<arrow::array::ArrayRe
 }
 
 /// Converts a [`ColumnarRecords`] and [`ColumnarRecordsStructuredExt`] pair
-/// (aka [`BlobTraceUpdates::Both`]) into an [`arrow2::chunk::Chunk`] with columns
+/// (aka [`BlobTraceUpdates::Both`]) into [`arrow::array::Array`]s with columns
 /// [(K, V, T, D, K_S, V_S)].
 ///
 /// [`BlobTraceUpdates::Both`]: crate::indexed::encoding::BlobTraceUpdates::Both

--- a/src/persist/src/indexed/columnar/arrow.rs
+++ b/src/persist/src/indexed/columnar/arrow.rs
@@ -16,10 +16,11 @@ use arrow::buffer::{Buffer, OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{DataType, Field, Schema};
 use mz_dyncfg::Config;
 use mz_ore::bytes::MaybeLgBytes;
+use mz_ore::iter::IteratorExt;
 use mz_ore::lgbytes::{LgBytes, MetricsRegion};
 use once_cell::sync::Lazy;
 
-use crate::indexed::columnar::ColumnarRecords;
+use crate::indexed::columnar::{ColumnarRecords, ColumnarRecordsStructuredExt};
 use crate::metrics::ColumnarMetrics;
 
 /// The Arrow schema we use to encode ((K, V), T, D) tuples.
@@ -75,6 +76,35 @@ pub fn encode_arrow_batch_kvtd(x: &ColumnarRecords) -> Vec<arrow::array::ArrayRe
     vec![Arc::new(key), Arc::new(val), Arc::new(ts), Arc::new(diff)]
 }
 
+/// Converts a [`ColumnarRecords`] and [`ColumnarRecordsStructuredExt`] pair
+/// (aka [`BlobTraceUpdates::Both`]) into an [`arrow2::chunk::Chunk`] with columns
+/// [(K, V, T, D, K_S, V_S)].
+///
+/// [`BlobTraceUpdates::Both`]: crate::indexed::encoding::BlobTraceUpdates::Both
+pub fn encode_arrow_batch_kvtd_ks_vs(
+    records: &ColumnarRecords,
+    structured: &ColumnarRecordsStructuredExt,
+) -> (Vec<Arc<Field>>, Vec<Arc<dyn Array>>) {
+    let mut fields: Vec<_> = (*SCHEMA_ARROW_RS_KVTD).fields().iter().cloned().collect();
+    let mut arrays = encode_arrow_batch_kvtd(records);
+
+    if let Some(key_array) = &structured.key {
+        let key_field = Field::new("k_s", key_array.data_type().clone(), false);
+
+        fields.push(Arc::new(key_field));
+        arrays.push(Arc::new(key_array.clone()));
+    }
+
+    if let Some(val_array) = &structured.val {
+        let val_field = Field::new("v_s", val_array.data_type().clone(), false);
+
+        fields.push(Arc::new(val_field));
+        arrays.push(Arc::new(val_array.clone()));
+    }
+
+    (fields, arrays)
+}
+
 pub(crate) const ENABLE_ARROW_LGALLOC_CC_SIZES: Config<bool> = Config::new(
     "persist_enable_arrow_lgalloc_cc_sizes",
     true,
@@ -91,33 +121,37 @@ pub(crate) const ENABLE_ARROW_LGALLOC_NONCC_SIZES: Config<bool> = Config::new(
 ///
 /// [`RecordBatch`]: `arrow::array::RecordBatch`
 pub fn decode_arrow_batch_kvtd(
-    batch: &arrow::array::RecordBatch,
+    columns: &[Arc<dyn Array>],
     metrics: &ColumnarMetrics,
 ) -> Result<ColumnarRecords, String> {
-    if batch.columns().len() != 4 {
-        return Err(format!(
-            "got wrong number of columns! {}",
-            batch.columns().len()
-        ));
-    }
+    let (key_col, val_col, ts_col, diff_col) = match &columns {
+        x @ &[k, v, t, d] => {
+            // The columns need to all have the same logical length.
+            if !x.iter().map(|col| col.len()).all_equal() {
+                return Err(format!(
+                    "columns don't all have equal length {k_len}, {v_len}, {t_len}, {d_len}",
+                    k_len = k.len(),
+                    v_len = v.len(),
+                    t_len = t.len(),
+                    d_len = d.len()
+                ));
+            }
 
-    let columns = batch.columns();
+            (k, v, t, d)
+        }
+        _ => return Err(format!("expected 4 columns got {}", columns.len())),
+    };
 
-    let key = &columns[0];
-    let val = &columns[1];
-    let time = &columns[2];
-    let diff = &columns[3];
-
-    let key = key
+    let key = key_col
         .as_binary_opt::<i32>()
         .ok_or_else(|| "key column is wrong type".to_string())?;
-    let val = val
+    let val = val_col
         .as_binary_opt::<i32>()
         .ok_or_else(|| "val column is wrong type".to_string())?;
-    let time = time
+    let time = ts_col
         .as_primitive_opt::<arrow::datatypes::Int64Type>()
         .ok_or_else(|| "time column is wrong type".to_string())?;
-    let diff = diff
+    let diff = diff_col
         .as_primitive_opt::<arrow::datatypes::Int64Type>()
         .ok_or_else(|| "diff column is wrong type".to_string())?;
 
@@ -143,6 +177,48 @@ pub fn decode_arrow_batch_kvtd(
     ret.borrow().validate()?;
 
     Ok(ret)
+}
+
+/// Converts an arrow [(K, V, T, D)] Chunk into a ColumnarRecords.
+pub fn decode_arrow_batch_kvtd_ks_vs(
+    cols: &[Arc<dyn Array>],
+    maybe_key_col: Option<&dyn Array>,
+    maybe_val_col: Option<&dyn Array>,
+    metrics: &ColumnarMetrics,
+) -> Result<(ColumnarRecords, ColumnarRecordsStructuredExt), String> {
+    let same_length = cols
+        .iter()
+        .map(|col| col.as_ref())
+        .chain(maybe_key_col.as_deref().into_iter())
+        .chain(maybe_val_col.as_deref().into_iter())
+        .map(|col| col.len())
+        .all_equal();
+    if !same_length {
+        return Err("not all columns (included structured) have the same length".to_string());
+    }
+
+    // We always have (K, V, T, D) columns.
+    let primary_records = decode_arrow_batch_kvtd(cols, metrics)?;
+
+    // Optionally we might have 'K_S' and/or 'V_S' columns.
+    let key = maybe_key_col
+        .map(|col| {
+            col.as_any()
+                .downcast_ref::<arrow::array::StructArray>()
+                .ok_or_else(|| format!("k_s column doesn't match schema"))
+        })
+        .transpose()?
+        .cloned();
+    let val = maybe_val_col
+        .map(|col| {
+            col.as_any()
+                .downcast_ref::<arrow::array::StructArray>()
+                .ok_or_else(|| format!("v_s column doesn't match schema"))
+        })
+        .transpose()?
+        .cloned();
+
+    Ok((primary_records, ColumnarRecordsStructuredExt { key, val }))
 }
 
 /// Copies a slice of data into a possibly disk-backed lgalloc region.

--- a/src/persist/src/indexed/columnar/parquet.rs
+++ b/src/persist/src/indexed/columnar/parquet.rs
@@ -249,6 +249,7 @@ fn report_parquet_metrics(
     metrics
         .parquet()
         .encoded_size
+        .with_label_values(&[format])
         .inc_by(u64::cast_from(bytes_written));
 
     let report_column_size = |col_name: &str, metrics: &ParquetColumnMetrics| {

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -167,7 +167,7 @@ pub enum BlobTraceUpdates {
     /// an Apache Arrow columnar format.
     ///
     /// [`Codec`]: mz_persist_types::Codec
-    Both((ColumnarRecords, ColumnarRecordsStructuredExt)),
+    Both(ColumnarRecords, ColumnarRecordsStructuredExt),
     // TODO(parkmycar): Write only columnar/Arrow data.
 }
 
@@ -176,7 +176,7 @@ impl BlobTraceUpdates {
     pub fn get(&self, idx: usize) -> Option<&ColumnarRecords> {
         match self {
             BlobTraceUpdates::Row(updates) => updates.get(idx),
-            BlobTraceUpdates::Both((codec, _structured)) => match idx {
+            BlobTraceUpdates::Both(codec, _structured) => match idx {
                 0 => Some(codec),
                 _ => None,
             },
@@ -187,7 +187,7 @@ impl BlobTraceUpdates {
     pub fn num_row_groups(&self) -> usize {
         match self {
             BlobTraceUpdates::Row(updates) => updates.len(),
-            BlobTraceUpdates::Both(_) => 1,
+            BlobTraceUpdates::Both(..) => 1,
         }
     }
 
@@ -195,7 +195,7 @@ impl BlobTraceUpdates {
     pub fn iter(&self) -> impl Iterator<Item = &'_ ColumnarRecords> {
         let updates: Box<dyn Iterator<Item = _>> = match self {
             BlobTraceUpdates::Row(updates) => Box::new(updates.iter()),
-            BlobTraceUpdates::Both((codec, _s)) => Box::new(std::iter::once(codec)),
+            BlobTraceUpdates::Both(codec, _s) => Box::new(std::iter::once(codec)),
         };
         updates
     }
@@ -204,7 +204,7 @@ impl BlobTraceUpdates {
     pub fn goodbytes(&self) -> usize {
         match self {
             BlobTraceUpdates::Row(updates) => updates.iter().map(|u| u.goodbytes()).sum(),
-            BlobTraceUpdates::Both((codec, _s)) => codec.goodbytes(),
+            BlobTraceUpdates::Both(codec, _s) => codec.goodbytes(),
         }
     }
 }

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -20,19 +20,77 @@ use bytes::BufMut;
 use differential_dataflow::trace::Description;
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastFrom;
+use mz_ore::soft_panic_or_log;
 use mz_persist_types::Codec64;
 use prost::Message;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 
 use crate::error::Error;
+use crate::gen::persist::proto_batch_part_inline::FormatMetadata as ProtoFormatMetadata;
 use crate::gen::persist::{
     ProtoBatchFormat, ProtoBatchPartInline, ProtoU64Antichain, ProtoU64Description,
 };
 use crate::indexed::columnar::parquet::{decode_trace_parquet, encode_trace_parquet};
-use crate::indexed::columnar::ColumnarRecords;
+use crate::indexed::columnar::{ColumnarRecords, ColumnarRecordsStructuredExt};
 use crate::location::Blob;
 use crate::metrics::ColumnarMetrics;
+
+/// Column format of a batch.
+#[derive(Debug, Copy, Clone)]
+pub enum BatchColumnarFormat {
+    /// Rows are encoded to `ProtoRow` and then a batch is written down as a Parquet with a schema
+    /// of `(k, v, t, d)`, where `k` are the serialized bytes.
+    Row,
+    /// Rows are encoded to `ProtoRow` and a columnar struct. The batch is written down as Parquet
+    /// with a schema of `(k, k_c, v, v_c, t, d)`, where `k` are the serialized bytes and `k_c` is
+    /// nested columnar data.
+    Both,
+}
+
+impl BatchColumnarFormat {
+    /// Returns a default value for [`BatchColumnarFormat`].
+    pub const fn default() -> Self {
+        // IMPORTANT: Default to only writing Row data and not our newer structured format.
+        BatchColumnarFormat::Row
+    }
+
+    /// Returns a [`BatchColumnarFormat`] for a given `&str`, falling back to a default value if
+    /// provided `&str` is invalid.
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "row" => BatchColumnarFormat::Row,
+            "both" => BatchColumnarFormat::Both,
+            x => {
+                let default = BatchColumnarFormat::default();
+                soft_panic_or_log!("Invalid batch columnar type: {x}, falling back to {default}");
+                default
+            }
+        }
+    }
+
+    /// Returns a string representation for the [`BatchColumnarFormat`].
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            BatchColumnarFormat::Row => "row",
+            BatchColumnarFormat::Both => "both",
+        }
+    }
+
+    /// Returns if we should encode a Batch in a structured format.
+    pub const fn is_structured(&self) -> bool {
+        match self {
+            BatchColumnarFormat::Row => false,
+            BatchColumnarFormat::Both => true,
+        }
+    }
+}
+
+impl fmt::Display for BatchColumnarFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// The metadata necessary to reconstruct a list of [BlobTraceBatchPart]s.
 ///
@@ -94,7 +152,61 @@ pub struct BlobTraceBatchPart<T> {
     /// Index of this part in the list of parts that form the batch.
     pub index: u64,
     /// The updates themselves.
-    pub updates: Vec<ColumnarRecords>,
+    pub updates: BlobTraceUpdates,
+}
+
+/// The set of updates that are part of a [`BlobTraceBatchPart`].
+#[derive(Clone, Debug, PartialEq)]
+pub enum BlobTraceUpdates {
+    /// Legacy format. Keys and Values are encoded into bytes via [`Codec`], then stored in our own
+    /// columnar-esque struct.
+    ///
+    /// [`Codec`]: mz_persist_types::Codec
+    Row(Vec<ColumnarRecords>),
+    /// Migration format. Keys and Values are encoded into bytes via [`Codec`] and structured into
+    /// an Apache Arrow columnar format.
+    ///
+    /// [`Codec`]: mz_persist_types::Codec
+    Both((ColumnarRecords, ColumnarRecordsStructuredExt)),
+    // TODO(parkmycar): Write only columnar/Arrow data.
+}
+
+impl BlobTraceUpdates {
+    /// Return the [`ColumnarRecords`], if one exists for the provided `idx`.
+    pub fn get(&self, idx: usize) -> Option<&ColumnarRecords> {
+        match self {
+            BlobTraceUpdates::Row(updates) => updates.get(idx),
+            BlobTraceUpdates::Both((codec, _structured)) => match idx {
+                0 => Some(codec),
+                _ => None,
+            },
+        }
+    }
+
+    /// Returns the number of row groups.
+    pub fn num_row_groups(&self) -> usize {
+        match self {
+            BlobTraceUpdates::Row(updates) => updates.len(),
+            BlobTraceUpdates::Both(_) => 1,
+        }
+    }
+
+    /// Returns an iterator over the [`ColumnarRecords`] in this update.
+    pub fn iter(&self) -> impl Iterator<Item = &'_ ColumnarRecords> {
+        let updates: Box<dyn Iterator<Item = _>> = match self {
+            BlobTraceUpdates::Row(updates) => Box::new(updates.iter()),
+            BlobTraceUpdates::Both((codec, _s)) => Box::new(std::iter::once(codec)),
+        };
+        updates
+    }
+
+    /// Returns the total number of logical bytes in the represented data.
+    pub fn goodbytes(&self) -> usize {
+        match self {
+            BlobTraceUpdates::Row(updates) => updates.iter().map(|u| u.goodbytes()).sum(),
+            BlobTraceUpdates::Both((codec, _s)) => codec.goodbytes(),
+        }
+    }
 }
 
 impl TraceBatchMeta {
@@ -402,12 +514,13 @@ mod tests {
         )
     }
 
-    fn columnar_records(updates: Vec<((Vec<u8>, Vec<u8>), u64, i64)>) -> Vec<ColumnarRecords> {
+    fn columnar_records(updates: Vec<((Vec<u8>, Vec<u8>), u64, i64)>) -> BlobTraceUpdates {
         let mut builder = ColumnarRecordsBuilder::default();
         for ((k, v), t, d) in updates {
             assert!(builder.push(((&k, &v), Codec64::encode(&t), Codec64::encode(&d))));
         }
-        vec![builder.finish(&ColumnarMetrics::disconnected())]
+        let updates = vec![builder.finish(&ColumnarMetrics::disconnected())];
+        BlobTraceUpdates::Row(updates)
     }
 
     #[mz_ore::test]
@@ -629,6 +742,8 @@ mod tests {
     fn encoded_batch_sizes() {
         fn sizes(data: DataGenerator) -> usize {
             let metrics = ColumnarMetrics::disconnected();
+            let updates = data.batches().collect();
+            let updates = BlobTraceUpdates::Row(updates);
             let trace = BlobTraceBatchPart {
                 desc: Description::new(
                     Antichain::from_elem(0u64),
@@ -636,7 +751,7 @@ mod tests {
                     Antichain::from_elem(0u64),
                 ),
                 index: 0,
-                updates: data.batches().collect(),
+                updates,
             };
             let mut trace_buf = Vec::new();
             trace.encode(&mut trace_buf, &metrics);

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -100,11 +100,11 @@ impl ArrowMetrics {
             var_labels: ["op", "column"],
         ));
 
-        let part_build_duration: CounterVec = registry.register(metric!(
+        let part_build_seconds: Counter = registry.register(metric!(
             name: "mz_persist_columnar_part_build_seconds",
             help: "number of seconds we've spent encoding our structured columnar format",
         ));
-        let part_build_count: IntCounterVec = registry.register(metric!(
+        let part_build_count: IntCounter = registry.register(metric!(
             name: "mz_persist_columnar_part_build_count",
             help: "number of times we've encoded our structured columnar format",
         ));
@@ -112,8 +112,8 @@ impl ArrowMetrics {
         ArrowMetrics {
             key: ArrowColumnMetrics::new(&op_count, &op_seconds, "key"),
             val: ArrowColumnMetrics::new(&op_count, &op_seconds, "val"),
-            part_build_seconds: part_build_duration.with_label_values(&[]),
-            part_build_count: part_build_count.with_label_values(&[]),
+            part_build_seconds,
+            part_build_count,
         }
     }
 

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -9,11 +9,13 @@
 
 //! Implementation-specific metrics for persist blobs and consensus
 
+use std::time::Instant;
+
 use mz_dyncfg::ConfigSet;
 use mz_ore::lgbytes::{LgBytesMetrics, LgBytesOpMetrics};
 use mz_ore::metric;
-use mz_ore::metrics::{IntCounter, MetricsRegistry};
-use prometheus::IntCounterVec;
+use mz_ore::metrics::{Counter, IntCounter, MetricsRegistry};
+use prometheus::{CounterVec, IntCounterVec};
 
 /// Metrics specific to S3Blob's internal workings.
 #[derive(Debug, Clone)]
@@ -78,13 +80,171 @@ impl S3BlobMetrics {
 /// Metrics specific to our usage of Arrow and Parquet.
 #[derive(Debug, Clone)]
 pub struct ArrowMetrics {
-    // TODO(parkmycar): Add some metrics here.
+    pub(crate) key: ArrowColumnMetrics,
+    pub(crate) val: ArrowColumnMetrics,
+    pub(crate) part_build_seconds: Counter,
+    pub(crate) part_build_count: IntCounter,
 }
 
 impl ArrowMetrics {
     /// Returns a new [ArrowMetrics] instance connected to the given registry.
-    pub fn new(_registry: &MetricsRegistry) -> Self {
-        ArrowMetrics {}
+    pub fn new(registry: &MetricsRegistry) -> Self {
+        let op_count: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_columnar_op_count",
+            help: "number of rows we've run the specified op on in our structured columnar format",
+            var_labels: ["op", "column", "result"],
+        ));
+        let op_seconds: CounterVec = registry.register(metric!(
+            name: "mz_persist_columnar_op_seconds",
+            help: "numer of seconds we've spent running the specified op on our structured columnar format",
+            var_labels: ["op", "column"],
+        ));
+
+        let part_build_duration: CounterVec = registry.register(metric!(
+            name: "mz_persist_columnar_part_build_seconds",
+            help: "number of seconds we've spent encoding our structured columnar format",
+        ));
+        let part_build_count: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_columnar_part_build_count",
+            help: "number of times we've encoded our structured columnar format",
+        ));
+
+        ArrowMetrics {
+            key: ArrowColumnMetrics::new(&op_count, &op_seconds, "key"),
+            val: ArrowColumnMetrics::new(&op_count, &op_seconds, "val"),
+            part_build_seconds: part_build_duration.with_label_values(&[]),
+            part_build_count: part_build_count.with_label_values(&[]),
+        }
+    }
+
+    /// Metrics for the top-level 'k_s' column.
+    pub fn key(&self) -> &ArrowColumnMetrics {
+        &self.key
+    }
+
+    /// Metrics for the top-level 'v_s' column.
+    pub fn val(&self) -> &ArrowColumnMetrics {
+        &self.val
+    }
+
+    /// Measure and report how long building a Part takes.
+    pub fn measure_part_build<R, F: FnOnce() -> R>(&self, f: F) -> R {
+        let start = Instant::now();
+        let r = f();
+        let duration = start.elapsed();
+
+        self.part_build_count.inc();
+        self.part_build_seconds.inc_by(duration.as_secs_f64());
+
+        r
+    }
+}
+
+/// Metrics for a top-level [`arrow`] column in our structured representation.
+#[derive(Debug, Clone)]
+pub struct ArrowColumnMetrics {
+    decoding_count: IntCounter,
+    decoding_seconds: Counter,
+    correct_count: IntCounter,
+    invalid_count: IntCounter,
+}
+
+impl ArrowColumnMetrics {
+    fn new(count: &IntCounterVec, duration: &CounterVec, col: &'static str) -> Self {
+        ArrowColumnMetrics {
+            decoding_count: count.with_label_values(&["decode", col, "success"]),
+            decoding_seconds: duration.with_label_values(&["decode", col]),
+            correct_count: count.with_label_values(&["validation", col, "correct"]),
+            invalid_count: count.with_label_values(&["validation", col, "invalid"]),
+        }
+    }
+
+    /// Measure and report how long decoding takes.
+    pub fn measure_decoding<R, F: FnOnce() -> R>(&self, decode: F) -> R {
+        let start = Instant::now();
+        let result = decode();
+        let duration = start.elapsed();
+
+        self.decoding_count.inc();
+        self.decoding_seconds.inc_by(duration.as_secs_f64());
+
+        result
+    }
+
+    /// Measure and report statistics for validation.
+    pub fn report_valid<F: FnOnce() -> bool>(&self, f: F) -> bool {
+        let is_valid = f();
+        if is_valid {
+            self.correct_count.inc();
+        } else {
+            self.invalid_count.inc();
+        }
+        is_valid
+    }
+}
+
+/// Metrics for a Parquet file that we write to S3.
+#[derive(Debug, Clone)]
+pub struct ParquetMetrics {
+    pub(crate) encoded_size: IntCounter,
+    pub(crate) num_row_groups: IntCounterVec,
+    pub(crate) k_metrics: ParquetColumnMetrics,
+    pub(crate) v_metrics: ParquetColumnMetrics,
+    pub(crate) t_metrics: ParquetColumnMetrics,
+    pub(crate) d_metrics: ParquetColumnMetrics,
+    pub(crate) k_s_metrics: ParquetColumnMetrics,
+    pub(crate) v_s_metrics: ParquetColumnMetrics,
+}
+
+impl ParquetMetrics {
+    pub(crate) fn new(registry: &MetricsRegistry) -> Self {
+        let encoded_size: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_parquet_encoded_size",
+            help: "encoded size of a parquet file that we write to S3",
+        ));
+        let num_row_groups: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_parquet_row_group_count",
+            help: "count of row groups in a parquet file",
+            var_labels: ["format"],
+        ));
+
+        let column_size: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_parquet_column_size",
+            help: "size in bytes of a column within a parquet file",
+            var_labels: ["col", "compressed"],
+        ));
+
+        ParquetMetrics {
+            encoded_size: encoded_size.with_label_values(&[]),
+            num_row_groups,
+            k_metrics: ParquetColumnMetrics::new("k", &column_size),
+            v_metrics: ParquetColumnMetrics::new("v", &column_size),
+            t_metrics: ParquetColumnMetrics::new("t", &column_size),
+            d_metrics: ParquetColumnMetrics::new("d", &column_size),
+            k_s_metrics: ParquetColumnMetrics::new("k_s", &column_size),
+            v_s_metrics: ParquetColumnMetrics::new("v_s", &column_size),
+        }
+    }
+}
+
+/// Metrics for a column within a Parquet file that we write to S3.
+#[derive(Debug, Clone)]
+pub struct ParquetColumnMetrics {
+    pub(crate) uncompressed_size: IntCounter,
+    pub(crate) compressed_size: IntCounter,
+}
+
+impl ParquetColumnMetrics {
+    pub(crate) fn new(col: &'static str, size: &IntCounterVec) -> Self {
+        ParquetColumnMetrics {
+            uncompressed_size: size.with_label_values(&[col, "uncompressed"]),
+            compressed_size: size.with_label_values(&[col, "compressed"]),
+        }
+    }
+
+    pub(crate) fn report_sizes(&self, uncompressed: u64, compressed: u64) {
+        self.uncompressed_size.inc_by(uncompressed);
+        self.compressed_size.inc_by(compressed);
     }
 }
 
@@ -92,8 +252,8 @@ impl ArrowMetrics {
 #[derive(Debug)]
 pub struct ColumnarMetrics {
     pub(crate) lgbytes_arrow: LgBytesOpMetrics,
-    #[allow(dead_code)] // TODO(parkmycar): In a follow up PR I'll be adding metrics.
-    pub(crate) arrow_metrics: ArrowMetrics,
+    pub(crate) parquet: ParquetMetrics,
+    pub(crate) arrow: ArrowMetrics,
     // TODO: Having these two here isn't quite the right thing to do, but it
     // saves a LOT of plumbing.
     pub(crate) cfg: ConfigSet,
@@ -109,11 +269,22 @@ impl ColumnarMetrics {
         is_cc_active: bool,
     ) -> Self {
         ColumnarMetrics {
+            parquet: ParquetMetrics::new(registry),
+            arrow: ArrowMetrics::new(registry),
             lgbytes_arrow: lgbytes.persist_arrow.clone(),
-            arrow_metrics: ArrowMetrics::new(registry),
             cfg,
             is_cc_active,
         }
+    }
+
+    /// Returns a reference to the [`arrow`] metrics for our structured data representation.
+    pub fn arrow(&self) -> &ArrowMetrics {
+        &self.arrow
+    }
+
+    /// Returns a reference to the [`parquet`] metrics for our structured data representation.
+    pub fn parquet(&self) -> &ParquetMetrics {
+        &self.parquet
     }
 
     /// Returns a [ColumnarMetrics] disconnected from any metrics registry.

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -186,7 +186,7 @@ impl ArrowColumnMetrics {
 /// Metrics for a Parquet file that we write to S3.
 #[derive(Debug, Clone)]
 pub struct ParquetMetrics {
-    pub(crate) encoded_size: IntCounter,
+    pub(crate) encoded_size: IntCounterVec,
     pub(crate) num_row_groups: IntCounterVec,
     pub(crate) k_metrics: ParquetColumnMetrics,
     pub(crate) v_metrics: ParquetColumnMetrics,
@@ -201,6 +201,7 @@ impl ParquetMetrics {
         let encoded_size: IntCounterVec = registry.register(metric!(
             name: "mz_persist_parquet_encoded_size",
             help: "encoded size of a parquet file that we write to S3",
+            var_labels: ["format"],
         ));
         let num_row_groups: IntCounterVec = registry.register(metric!(
             name: "mz_persist_parquet_row_group_count",
@@ -215,7 +216,7 @@ impl ParquetMetrics {
         ));
 
         ParquetMetrics {
-            encoded_size: encoded_size.with_label_values(&[]),
+            encoded_size,
             num_row_groups,
             k_metrics: ParquetColumnMetrics::new("k", &column_size),
             v_metrics: ParquetColumnMetrics::new("v", &column_size),

--- a/src/persist/src/persist.proto
+++ b/src/persist/src/persist.proto
@@ -32,6 +32,12 @@ message ProtoBatchPartInline {
     // be only one trace batch with the same description and index.
     ProtoU64Description desc = 2;
     uint64 index = 3;
+
+    // Optional metadata for the `format`.
+    oneof format_metadata {
+        // Metadata for the structured format with `[(K, V, T, D, K_S, V_S)]`.
+        uint64 structured_migration = 4;
+    }
 }
 
 enum ProtoBatchFormat {
@@ -63,6 +69,15 @@ enum ProtoBatchFormat {
     // compression, and I'd like to exhaust that direction first before dealing
     // with a trie-like column structure.
     ParquetKvtd = 2;
+    // Parquet format that understands the structure of the inner data. See the
+    // `metadata` field on `ProtoBatchPartInline` for more information about
+    // how this data is structured in Parquet.
+    //
+    // For example, the initial use of this format will contain the columns
+    // `[(K, V, T, D, K_S, V_S)]` where `K_S` and `V_S` are structured versions
+    // of the opaque data stored in `K` and `V`, respectively. Eventually we'll
+    // stop writing `K` and `V` and migrate entirely to `K_S` and `V_S`.
+    ParquetStructured = 3;
 }
 
 message ProtoColumnarRecords {

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -638,7 +638,7 @@ impl RowEncoder {
 
 impl PartEncoder<Row> for RowEncoder {
     fn encode(&mut self, val: &Row) {
-        self.len += 1;
+        self.inc_len();
         for (encoder, datum) in self.col_encoders.iter_mut().zip(val.iter()) {
             encoder.encode(datum);
         }

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1281,8 +1281,8 @@ impl PartDecoder<SourceData> for SourceDataDecoder {
                     .expect("error should be valid");
                 val.0 = Err(err);
             }
-            x @ (true, Some(_)) | x @ (false, None) => {
-                panic!("SourceData should have exactly one of ok or err, {idx} @ {x:?}\n{self:?}")
+            (true, Some(_)) | (false, None) => {
+                panic!("SourceData should have exactly one of ok or err")
             }
         };
     }
@@ -1584,7 +1584,7 @@ mod tests {
 
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // too slow
-    fn all_scalar_types_columnar_roundtrip() {
+    fn all_scalar_types_parquet_roundtrip() {
         proptest!(|(scalar_type in any::<ScalarType>())| {
             // The proptest! macro interferes with rustfmt.
             let datums = scalar_type.interesting_datums();
@@ -1594,7 +1594,7 @@ mod tests {
 
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // too slow
-    fn all_datums_columnar_roundtrip() {
+    fn all_datums_parquet_roundtrip() {
         let datums = any::<ScalarType>().prop_flat_map(|ty| {
             prop::collection::vec(arb_datum_for_scalar(&ty), 0..128)
                 .prop_map(move |datums| (ty.clone(), datums))

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1232,9 +1232,11 @@ impl PartEncoder<SourceData> for SourceDataEncoder {
 
     fn finish(self) -> (usize, Vec<DynColumnMut>) {
         // Collect all of the columns from the inner RowEncoder to a single 'ok' column.
-        let (_, ok_validity) = self.ok_validity.into_parts();
-        let (ok_len, ok_cols) = self.ok.finish();
-        let ok_col = DynStructMut::from_parts(self.ok_cfg, ok_len, ok_validity, ok_cols);
+        let (ok_len_1, ok_validity) = self.ok_validity.into_parts();
+        let (ok_len_2, ok_cols) = self.ok.finish();
+        let ok_col = DynStructMut::from_parts(self.ok_cfg, ok_len_1, ok_validity, ok_cols);
+
+        assert_eq!(ok_len_1, ok_len_2, "mismatched length for 'ok' column");
 
         let ok_col = DynColumnMut::new::<Option<DynStruct>>(Box::new(ok_col));
         let err_col = DynColumnMut::new::<Option<Vec<u8>>>(self.err);
@@ -1279,8 +1281,8 @@ impl PartDecoder<SourceData> for SourceDataDecoder {
                     .expect("error should be valid");
                 val.0 = Err(err);
             }
-            (true, Some(_)) | (false, None) => {
-                panic!("SourceData should have exactly one of ok or err")
+            x @ (true, Some(_)) | x @ (false, None) => {
+                panic!("SourceData should have exactly one of ok or err, {idx} @ {x:?}\n{self:?}")
             }
         };
     }
@@ -1532,7 +1534,7 @@ impl<'a> SubsourceResolver {
 
 #[cfg(test)]
 mod tests {
-    use mz_repr::ScalarType;
+    use mz_repr::{arb_datum_for_scalar, ScalarType};
     use proptest::prelude::*;
     use proptest::strategy::ValueTree;
 
@@ -1553,11 +1555,16 @@ mod tests {
         assert!("".parse::<Timeline>().is_err());
     }
 
-    fn scalar_type_columnar_roundtrip(scalar_type: ScalarType) {
-        use mz_persist_types::columnar::validate_roundtrip;
+    #[track_caller]
+    fn scalar_type_parquet_roundtrip<'a>(
+        scalar_type: ScalarType,
+        datums: impl IntoIterator<Item = Datum<'a>>,
+    ) {
+        use mz_persist_types::parquet::validate_roundtrip;
+
         let mut rows = Vec::new();
-        for datum in scalar_type.interesting_datums() {
-            rows.push(SourceData(Ok(Row::pack(std::iter::once(datum)))));
+        for datum in datums {
+            rows.push(SourceData(Ok(Row::pack_slice(&[datum]))));
         }
         rows.push(SourceData(Err(EnvelopeError::Flat("foo".into()).into())));
 
@@ -1569,7 +1576,7 @@ mod tests {
 
         // Nullable version of the column.
         let schema = RelationDesc::empty().with_column("col", scalar_type.nullable(true));
-        rows.push(SourceData(Ok(Row::pack(std::iter::once(Datum::Null)))));
+        rows.push(SourceData(Ok(Row::pack_slice(&[Datum::Null]))));
         for row in rows.iter() {
             assert_eq!(validate_roundtrip(&schema, row), Ok(()));
         }
@@ -1580,7 +1587,23 @@ mod tests {
     fn all_scalar_types_columnar_roundtrip() {
         proptest!(|(scalar_type in any::<ScalarType>())| {
             // The proptest! macro interferes with rustfmt.
-            scalar_type_columnar_roundtrip(scalar_type)
+            let datums = scalar_type.interesting_datums();
+            scalar_type_parquet_roundtrip(scalar_type, datums);
+        });
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // too slow
+    fn all_datums_columnar_roundtrip() {
+        let datums = any::<ScalarType>().prop_flat_map(|ty| {
+            prop::collection::vec(arb_datum_for_scalar(&ty), 0..128)
+                .prop_map(move |datums| (ty.clone(), datums))
+        });
+
+        proptest!(|((ty, datums) in datums)| {
+            // The proptest! macro interferes with rustfmt.
+            let datums = datums.iter().map(Datum::from);
+            scalar_type_parquet_roundtrip(ty, datums);
         });
     }
 

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -55,6 +55,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         default=Materialized.Size.DEFAULT_SIZE,
         help="Use SIZE 'N-N' for replicas and SIZE 'N' for sources",
     )
+    parser.add_argument(
+        "--system-param",
+        type=str,
+        action="append",
+        nargs="*",
+        help="System parameters to set in Materialize, i.e. what you would set with `ALTER SYSTEM SET`",
+    )
 
     parser.add_argument("--replicas", type=int, default=1, help="use multiple replicas")
 
@@ -90,9 +97,23 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         fivetran_destination_files_path="/share/tmp",
     )
 
+    sysparams = args.system_param
+    if not args.system_param:
+        sysparams = []
+
+    additional_system_parameter_defaults = {}
+    for val in sysparams:
+        x = val[0].split("=")
+        assert len(x) == 2, f"--system-param '{val}' should be the format <key>=<val>"
+        key = x[0]
+        val = x[1]
+
+        additional_system_parameter_defaults[key] = val
+
     materialized = Materialized(
         default_size=args.default_size,
         external_minio=True,
+        additional_system_parameter_defaults=additional_system_parameter_defaults,
     )
 
     with c.override(testdrive, materialized):

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -103,7 +103,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     additional_system_parameter_defaults = {}
     for val in sysparams:
-        x = val[0].split("=")
+        x = val[0].split("=", maxsplit=1)
         assert len(x) == 2, f"--system-param '{val}' should be the format <key>=<val>"
         key = x[0]
         val = x[1]


### PR DESCRIPTION
This PR adds a V0 implementation of writing structured columnar data to S3.

To start it introduces two `dyncfg`s to control this:
1. `persist_batch_columnar_format` - controls the format we'll use to write batches, either `Row` which is the same as the current behavior, or `Both` which writes row data and structured columnar format.
2. `persist_part_decode_Format` - controls how we decode parts, current options are `Row { validate_structured: bool }`. We will always decode `Row` data, but we will optionally decode and validate the structured data.

Using these two `dyncfg`s we update the Arrow/Parquet handling to optionally encode and decode two new `k_s` and `v_s` columns which are structured versions of the existing `k` and `v` columns.

If structured encoding is turned on, we use the columnar `Part` we create for collecting statistics and instead of throwing it away we write it to S3. So the write path shouldn't become any more expensive. If structured decoding is enabled then we will optionally decode a `K` and `V` from our structured data, check that it matches what we decode from the Row data, and record the result of that check in a prometheus metric for monitoring.

#### Tests

I extended some existing tests that validate round-tripping `ScalarType`s/`Datum`s to go through Parquet. Also updated the `testdrive` mzcompose framework to support setting dyncfgs and addded a new nightly test slug that runs all of testdrive with structured data enabled.

#### Metrics

Added a few new metrics to track the encoding speed and size of the structured format.

Arrow related metrics

(for `k_s` and `v_s` columns)
* `decode_count`
* `decode_seconds`
* `correct_count`
* `incorrect_count`

(for a `Part`)
* `part_build_count`
* `part_build_seconds`

Parquet Related metrics

(for `k`, `v`, `t`, `d`, `k_s`, `v_s` columns)
* `uncompressed_size`
* `compressed_size`

(for a Parquet file)
* `encoded_size`
* `num_row_groups`

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/24830

### Tips for reviewer

This PR is split up into logical commits that can be reviewed independently:

1. Changes to our existing Columnar code that is necessary to support round-tripping through Parquet.
2. Add relevant Arrow and Parquet methods for encoding the new `k_s` and `v_s` structured columns.
3. Changes to the `Batch` encoding path to optionally write structured data
4. Changes to the `Batch` decoding path to optionally read structured data
5. Test related changes.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds a feature gated ability to write structured columnar data.
