### PR TITLE
catalog: Listen to storage metadata updates

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -33,7 +33,8 @@ use crate::durable::objects::Snapshot;
 pub use crate::durable::objects::{
     Cluster, ClusterConfig, ClusterReplica, ClusterVariant, ClusterVariantManaged, Comment,
     Database, DefaultPrivilege, IntrospectionSourceIndex, Item, ReplicaConfig, ReplicaLocation,
-    Role, Schema, SystemConfiguration, SystemObjectMapping,
+    Role, Schema, StorageCollectionMetadata, SystemConfiguration, SystemObjectMapping,
+    UnfinalizedShard,
 };
 use crate::durable::persist::UnopenedPersistCatalogState;
 pub use crate::durable::transaction::Transaction;

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -680,6 +680,48 @@ impl DurableType<SystemPrivilegesKey, SystemPrivilegesValue> for MzAclItem {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorageCollectionMetadata {
+    pub id: GlobalId,
+    pub shard: String,
+}
+
+impl DurableType<StorageCollectionMetadataKey, StorageCollectionMetadataValue>
+    for StorageCollectionMetadata
+{
+    fn into_key_value(self) -> (StorageCollectionMetadataKey, StorageCollectionMetadataValue) {
+        (
+            StorageCollectionMetadataKey { id: self.id },
+            StorageCollectionMetadataValue { shard: self.shard },
+        )
+    }
+
+    fn from_key_value(
+        key: StorageCollectionMetadataKey,
+        value: StorageCollectionMetadataValue,
+    ) -> Self {
+        Self {
+            id: key.id,
+            shard: value.shard,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnfinalizedShard {
+    pub shard: String,
+}
+
+impl DurableType<UnfinalizedShardKey, ()> for UnfinalizedShard {
+    fn into_key_value(self) -> (UnfinalizedShardKey, ()) {
+        (UnfinalizedShardKey { shard: self.shard }, ())
+    }
+
+    fn from_key_value(key: UnfinalizedShardKey, _value: ()) -> Self {
+        Self { shard: key.shard }
+    }
+}
+
 // Structs used internally to represent on-disk state.
 
 /// A snapshot of the current on-disk state.

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -819,6 +819,18 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
                     system_privilege,
                 ))
             }
+            StateUpdateKind::StorageCollectionMetadata(key, value) => {
+                let storage_collection_metadata = into_durable(key, value)?;
+                Some(memory::objects::StateUpdateKind::StorageCollectionMetadata(
+                    storage_collection_metadata,
+                ))
+            }
+            StateUpdateKind::UnfinalizedShard(key, value) => {
+                let unfinalized_shard = into_durable(key, value)?;
+                Some(memory::objects::StateUpdateKind::UnfinalizedShard(
+                    unfinalized_shard,
+                ))
+            }
             // TODO(jkosh44) Add conversions for valid variants.
             StateUpdateKind::AuditLog(_, _)
             | StateUpdateKind::Config(_, _)
@@ -826,8 +838,6 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
             | StateUpdateKind::IdAllocator(_, _)
             | StateUpdateKind::Setting(_, _)
             | StateUpdateKind::StorageUsage(_, _)
-            | StateUpdateKind::StorageCollectionMetadata(_, _)
-            | StateUpdateKind::UnfinalizedShard(_, _)
             | StateUpdateKind::PersistTxnShard(_, _) => None,
         })
     }

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -1488,14 +1488,22 @@ impl<'a> Transaction<'a> {
                 StateUpdateKind::ClusterReplica,
             ))
             .chain(get_collection_updates(
-                &self.comments,
-                StateUpdateKind::Comment,
-            ))
-            .chain(get_collection_updates(
                 &self.system_gid_mapping,
                 StateUpdateKind::SystemObjectMapping,
             ))
             .chain(get_collection_updates(&self.items, StateUpdateKind::Item))
+            .chain(get_collection_updates(
+                &self.comments,
+                StateUpdateKind::Comment,
+            ))
+            .chain(get_collection_updates(
+                &self.storage_collection_metadata,
+                StateUpdateKind::StorageCollectionMetadata,
+            ))
+            .chain(get_collection_updates(
+                &self.unfinalized_shards,
+                StateUpdateKind::UnfinalizedShard,
+            ))
             .map(|kind| StateUpdate { kind, diff: 1 })
     }
 

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -2291,4 +2291,7 @@ pub enum StateUpdateKind {
     Item(durable::objects::Item),
     Comment(durable::objects::Comment),
     // TODO(jkosh44) Add all other object variants.
+    // Storage updates.
+    StorageCollectionMetadata(durable::objects::StorageCollectionMetadata),
+    UnfinalizedShard(durable::objects::UnfinalizedShard),
 }


### PR DESCRIPTION
This commit teaches the in-memory catalog how to listen to storage
metadata updates.

Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
