### PR TITLE
adapter: Fix description of subscribe using envelope upsert with multiple keys

### DIFF
--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -392,8 +392,8 @@ column. Each progress row will have a `NULL` key and a `NULL` value.
 {{< private-preview />}}
 
 To modify the output of `SUBSCRIBE` to support upserts using a
-[Debezium-style diff envelope](https://materialize.com/docs/sql/create-sink/#debezium-envelope)
-, use`ENVELOPE DEBEZIUM`. This clause allows you to specify a `KEY` that
+[Debezium-style diff envelope](https://materialize.com/docs/sql/create-sink/#debezium-envelope),
+use `ENVELOPE DEBEZIUM`. This clause allows you to specify a `KEY` that
 Materialize uses to interpret the rows as a series of inserts, updates and
 deletes within each distinct timestamp. Unlike `ENVELOPE UPSERT`, the output
 includes the state of the row before and after the upsert operation.

--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -392,7 +392,7 @@ column. Each progress row will have a `NULL` key and a `NULL` value.
 {{< private-preview />}}
 
 To modify the output of `SUBSCRIBE` to support upserts using a
-[Debezium-style diff envelope](/sql/create-sink/#debezium-envelope),
+[Debezium-style diff envelope](/sql/create-sink/kafka/#debezium-envelope),
 use `ENVELOPE DEBEZIUM`. This clause allows you to specify a `KEY` that
 Materialize uses to interpret the rows as a series of inserts, updates and
 deletes within each distinct timestamp. Unlike `ENVELOPE UPSERT`, the output

--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -392,7 +392,7 @@ column. Each progress row will have a `NULL` key and a `NULL` value.
 {{< private-preview />}}
 
 To modify the output of `SUBSCRIBE` to support upserts using a
-[Debezium-style diff envelope](https://materialize.com/docs/sql/create-sink/#debezium-envelope),
+[Debezium-style diff envelope](/sql/create-sink/#debezium-envelope),
 use `ENVELOPE DEBEZIUM`. This clause allows you to specify a `KEY` that
 Materialize uses to interpret the rows as a series of inserts, updates and
 deletes within each distinct timestamp. Unlike `ENVELOPE UPSERT`, the output

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -750,7 +750,8 @@ pub fn describe_subscribe(
                 desc = desc.with_column(column_name, column_ty);
             }
 
-            // Then add the remaining columns in the order from the original table.
+            // Then add the remaining columns in the order from the original
+            // table, filtering out the key columns since we added those above.
             for (mut name, mut ty) in relation_desc
                 .into_iter()
                 .filter(|(name, _ty)| !key_columns.contains(name))

--- a/test/testdrive/subscribe-output.td
+++ b/test/testdrive/subscribe-output.td
@@ -422,9 +422,43 @@ contains: column "invalid_key" does not exist
 > INSERT INTO t4 VALUES (1, 'foo', '30a7947e-4b38-46a4-b7c2-602ba62ce20b');
 
 > BEGIN;
-> DECLARE c4 CURSOR FOR SUBSCRIBE t4 ENVELOPE UPSERT (KEY (c, a));
+> DECLARE c4u CURSOR FOR SUBSCRIBE t4 ENVELOPE UPSERT (KEY (c, a));
 
-> FETCH 1 c4;
+> FETCH 1 c4u;
 <TIMESTAMP> upsert 30a7947e-4b38-46a4-b7c2-602ba62ce20b 1 foo
+
+$ postgres-execute connection=mz_system
+UPDATE t4 SET b = 'bar' WHERE a = 1
+
+> FETCH 1 c4u;
+<TIMESTAMP> upsert 30a7947e-4b38-46a4-b7c2-602ba62ce20b 1 bar
+
+$ postgres-execute connection=mz_system
+DELETE FROM t4 WHERE b = 'bar'
+
+> FETCH 1 c4u;
+<TIMESTAMP> delete 30a7947e-4b38-46a4-b7c2-602ba62ce20b 1 <null>
+
+> COMMIT;
+
+> INSERT INTO t4 VALUES (1, 'foo', '30a7947e-4b38-46a4-b7c2-602ba62ce20b');
+
+> BEGIN;
+> DECLARE c4d CURSOR FOR SUBSCRIBE t4 ENVELOPE DEBEZIUM (KEY (c, a));
+
+> FETCH 1 c4d;
+<TIMESTAMP> insert 30a7947e-4b38-46a4-b7c2-602ba62ce20b 1 <null> foo
+
+$ postgres-execute connection=mz_system
+UPDATE t4 SET b = 'bar' WHERE a = 1
+
+> FETCH 1 c4d;
+<TIMESTAMP> upsert 30a7947e-4b38-46a4-b7c2-602ba62ce20b 1 foo bar
+
+$ postgres-execute connection=mz_system
+DELETE FROM t4 WHERE b = 'bar'
+
+> FETCH 1 c4d;
+<TIMESTAMP> delete 30a7947e-4b38-46a4-b7c2-602ba62ce20b 1 bar <null>
 
 > COMMIT;

--- a/test/testdrive/subscribe-output.td
+++ b/test/testdrive/subscribe-output.td
@@ -414,3 +414,17 @@ contains: column "invalid_key" does not exist
 <TIMESTAMP> 1 3 4
 
 > COMMIT;
+
+# Subscribe with a query that uses two columns for upsert key.
+
+> CREATE TABLE t4 (a int, b text, c uuid);
+
+> INSERT INTO t4 VALUES (1, 'foo', '30a7947e-4b38-46a4-b7c2-602ba62ce20b');
+
+> BEGIN;
+> DECLARE c4 CURSOR FOR SUBSCRIBE t4 ENVELOPE UPSERT (KEY (c, a));
+
+> FETCH 1 c4;
+<TIMESTAMP> upsert 30a7947e-4b38-46a4-b7c2-602ba62ce20b 1 foo
+
+> COMMIT;


### PR DESCRIPTION
This PR fixes the description of a subscribe using envelope upsert with multiple keys. 

For example, consider the following scenario:
```
CREATE TABLE t1 (a int, b text, c uuid);
SUBSCRIBE TO t1 ENVELOPE UPSERT (KEY (c, a));
```

We pack the [keys into the returned `Row`](https://github.com/MaterializeInc/materialize/blob/main/src/adapter/src/active_compute_sink.rs#L243-L246) in the order in which they're specified in the `SUBSCRIBE` statement, e.g. `[c, a]`. But the `describe_subscribe` function was creating the returned `RelationDesc` with the order that they're specified on the source, e.g. `[a, c]`.

### Motivation

Fixes a panic that would occur when sending a `Row` because we assumed the wrong `Datum` type.

Fixes https://github.com/MaterializeInc/cloud/issues/9139

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes a panic related to `ENVELOPE UPSERT` in `SUBSCRIBE`
