### PR TITLE
data-ingest test: Print comparator that fails

### DIFF
--- a/misc/python/materialize/data_ingest/workload.py
+++ b/misc/python/materialize/data_ingest/workload.py
@@ -203,7 +203,11 @@ def execute_workload(
         while sleep_time < 60:
             conn.autocommit = True
             with conn.cursor() as cur:
-                cur.execute(f"SELECT * FROM {executor.table} ORDER BY {order_str}")
+                try:
+                    cur.execute(f"SELECT * FROM {executor.table} ORDER BY {order_str}")
+                except:
+                    print(f"Comparing against {type(executor).__name__} failed")
+                    raise
                 actual_result = cur.fetchall()
             conn.autocommit = False
             if actual_result == expected_result:


### PR DESCRIPTION
As noticed in https://materializeinc.slack.com/archives/C01LKF361MZ/p1712759442116639

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
