### PR TITLE
mzexplore: compute maximum depth of ASTs in the wild

### DIFF
--- a/misc/mzexplore/defs.jq
+++ b/misc/mzexplore/defs.jq
@@ -39,7 +39,7 @@ def ast_node_names:
     ((if type == "object"
       then [keys[] | select(test("[A-Z][a-z]*"))]
       else []
-      end) 
+      end)
      + [.[]? | ast_node_names]) | flatten | unique
 ;
 

--- a/misc/mzexplore/defs.jq
+++ b/misc/mzexplore/defs.jq
@@ -37,7 +37,7 @@ def is_mir_relexpr:
 
 def ast_node_names:
     ((if type == "object"
-      then [keys[] | select(test("[A-Z][a-z]*"))]
+      then [keys[] | select(test("^[A-Z][A-Za-z]*$"))]
       else []
       end)
      + [.[]? | ast_node_names]) | flatten | unique

--- a/misc/mzexplore/defs.jq
+++ b/misc/mzexplore/defs.jq
@@ -16,6 +16,33 @@ def typename(expr):
     end
 ;
 
+def is_mir_relexpr:
+  type == "object" and
+  (   has("Get")
+   or has("Constant")
+   or has("Let")
+   or has("LetRec")
+   or has("Project")
+   or has("Map")
+   or has("FlatMap")
+   or has("Filter")
+   or has("Join")
+   or has("Reduce")
+   or has("TopK")
+   or has("Negate")
+   or has("Threshold")
+   or has("Union")
+   or has("ArrangeBy"))
+;
+
+def ast_node_names:
+    ((if type == "object"
+      then [keys[] | select(test("[A-Z][a-z]*"))]
+      else []
+      end) 
+     + [.[]? | ast_node_names]) | flatten | unique
+;
+
 def iscall(expr):
     expr | type == "object" and (has("CallVariadic") or has("CallBinary") or has("CallUnary"))
 ;

--- a/misc/mzexplore/depth.jq
+++ b/misc/mzexplore/depth.jq
@@ -12,10 +12,10 @@
 include "defs";
 
 def depth:
-    [if is_mir_relexpr then 1 else 0 end + 
+    [if is_mir_relexpr then 1 else 0 end +
      (if type == "object" or type == "array"
-      then .[]? | depth 
-      else 0 
+      then .[]? | depth
+      else 0
       end)
     ] | max
 ;

--- a/misc/mzexplore/depth.jq
+++ b/misc/mzexplore/depth.jq
@@ -1,0 +1,23 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# depth.jq — calculating depth of an AST
+
+include "defs";
+
+def depth:
+    [if is_mir_relexpr then 1 else 0 end + 
+     (if type == "object" or type == "array"
+      then .[]? | depth 
+      else 0 
+      end)
+    ] | max
+;
+
+depth


### PR DESCRIPTION
Some `jq` hacking for computing AST depth.

### Motivation

  * This PR adds a feature that has not yet been specified.

  New analysis of customer queries, as part of optimizer work.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
