### PR TITLE
[persist] Minor fixups

### DIFF
--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -263,14 +263,7 @@ where
     pub fn all_batches(&self) -> Vec<HollowBatch<T>> {
         self.state
             .read_lock(&self.metrics.locks.applier_read_noncacheable, |state| {
-                state
-                    .state
-                    .collections
-                    .trace
-                    .batches()
-                    .into_iter()
-                    .cloned()
-                    .collect()
+                state.state.collections.trace.batches().cloned().collect()
             })
     }
 

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -263,7 +263,7 @@ where
         // writer that generated the compaction request / maintenance. this machine has a
         // spine structure that generated the request, so it has a much better chance of
         // merging and committing the result than a machine kept up-to-date through state
-        // diffs, which may have a different spine structure less amendable to merging.
+        // diffs, which may have a different spine structure less amenable to merging.
         let send = new_compaction_sender.try_send((
             Instant::now(),
             req,

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1357,24 +1357,25 @@ pub mod datadriven {
             if x.seqno < from {
                 continue;
             }
-            let mut batches = vec![];
             let rollups: Vec<_> = x
                 .collections
                 .rollups
                 .keys()
                 .map(|seqno| seqno.to_string())
                 .collect();
-            x.collections.trace.map_batches(|b| {
-                if b.parts.is_empty() {
-                    return;
-                }
-                for (batch_name, original_batch) in &datadriven.batches {
-                    if original_batch.parts == b.parts {
-                        batches.push(batch_name.to_owned());
-                        break;
-                    }
-                }
-            });
+            let batches: Vec<_> = x
+                .collections
+                .trace
+                .batches()
+                .filter(|b| !b.parts.is_empty())
+                .filter_map(|b| {
+                    datadriven
+                        .batches
+                        .iter()
+                        .find(|(_, original_batch)| original_batch.parts == b.parts)
+                        .map(|(batch_name, _)| batch_name.to_owned())
+                })
+                .collect();
             write!(
                 s,
                 "seqno={} batches={} rollups={}\n",

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1508,13 +1508,13 @@ where
             ));
         }
 
-        let mut batches = Vec::new();
-        self.collections.trace.map_batches(|b| {
-            if PartialOrder::less_than(as_of, b.desc.lower()) {
-                return;
-            }
-            batches.push(b.clone());
-        });
+        let batches = self
+            .collections
+            .trace
+            .batches()
+            .filter(|b| !PartialOrder::less_than(as_of, b.desc.lower()))
+            .cloned()
+            .collect();
         Ok(batches)
     }
 
@@ -1533,18 +1533,15 @@ where
     pub fn next_listen_batch(&self, frontier: &Antichain<T>) -> Result<HollowBatch<T>, SeqNo> {
         // TODO: Avoid the O(n^2) here: `next_listen_batch` is called once per
         // batch and this iterates through all batches to find the next one.
-        let mut ret = Err(self.seqno);
-        self.collections.trace.map_batches(|b| {
-            if ret.is_ok() {
-                return;
-            }
-            if PartialOrder::less_equal(b.desc.lower(), frontier)
-                && PartialOrder::less_than(frontier, b.desc.upper())
-            {
-                ret = Ok(b.clone());
-            }
-        });
-        ret
+        self.collections
+            .trace
+            .batches()
+            .find(|b| {
+                PartialOrder::less_equal(b.desc.lower(), frontier)
+                    && PartialOrder::less_than(frontier, b.desc.upper())
+            })
+            .cloned()
+            .ok_or(self.seqno)
     }
 
     pub fn need_rollup(&self, threshold: usize) -> Option<SeqNo> {

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -984,16 +984,17 @@ struct Spine<T> {
 
 impl<T> Spine<T> {
     pub fn map_batches<'a, F: FnMut(&'a SpineBatch<T>)>(&'a self, mut f: F) {
-        for batch in self.merging.iter().rev() {
-            match batch {
-                MergeState::Double(batch1, batch2, _) => {
-                    f(batch1);
-                    f(batch2);
-                }
-                MergeState::Single(batch) => f(batch),
-                _ => {}
-            }
+        for batch in self.spine_batches() {
+            f(batch);
         }
+    }
+
+    pub fn spine_batches(&self) -> impl Iterator<Item = &SpineBatch<T>> {
+        self.merging.iter().rev().flat_map(|m| match m {
+            MergeState::Vacant => None.into_iter().chain(None.into_iter()),
+            MergeState::Single(a) => Some(a).into_iter().chain(None.into_iter()),
+            MergeState::Double(a, b, _) => Some(a).into_iter().chain(Some(b).into_iter()),
+        })
     }
 }
 

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -971,12 +971,6 @@ struct Spine<T> {
 }
 
 impl<T> Spine<T> {
-    pub fn map_batches<'a, F: FnMut(&'a SpineBatch<T>)>(&'a self, mut f: F) {
-        for batch in self.spine_batches() {
-            f(batch);
-        }
-    }
-
     pub fn spine_batches(&self) -> impl Iterator<Item = &SpineBatch<T>> {
         self.merging.iter().rev().flat_map(|m| match m {
             MergeState::Vacant => None.into_iter().chain(None.into_iter()),

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -100,11 +100,7 @@ impl<T: PartialEq> PartialEq for Trace<T> {
 
         // Intentionally use HollowBatches for this comparison so we ignore
         // differences in spine layers.
-        let (mut self_batches, mut other_batches) = (Vec::new(), Vec::new());
-        self.map_batches(|b| self_batches.push(b));
-        other.map_batches(|b| other_batches.push(b));
-
-        self_batches == other_batches
+        self.batches().eq(other.batches())
     }
 }
 
@@ -385,23 +381,17 @@ impl<T> Trace<T> {
     }
 
     pub fn num_spine_batches(&self) -> usize {
-        let mut ret = 0;
-        self.spine.map_batches(|_| ret += 1);
-        ret
+        self.spine.spine_batches().count()
     }
 
     #[cfg(test)]
     pub fn num_hollow_batches(&self) -> usize {
-        let mut ret = 0;
-        self.map_batches(|_| ret += 1);
-        ret
+        self.batches().count()
     }
 
     #[cfg(test)]
     pub fn num_updates(&self) -> usize {
-        let mut ret = 0;
-        self.map_batches(|b| ret += b.len);
-        ret
+        self.batches().map(|b| b.len).sum()
     }
 }
 


### PR DESCRIPTION
Primarily providing more-efficient iterators over batches, plus some other odds & ends.

### Motivation

Previously-unspecified refactoring. (I think most of these are valuable on their own, but efficiently iterating over spine batches looks like it will be useful for some upcoming changes.)

### Tips for reviewer

Unsolicited refactoring PR, so feel free to push back on whatever. In particular, I wasn't sure how far to go with migrating `map_batches`; all of the usages can be easily ported to a for loop, so I just picked the ones that either seemed simpler with iterator methods or got to save a little work.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
