### PR TITLE
catalog: Listen to audit log updates

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -253,6 +253,10 @@ impl CatalogState {
                 self.apply_comment_update(comment, diff);
                 Ok(None)
             }
+            StateUpdateKind::AuditLog(_audit_log) => {
+                // Audit logs are not stored in-memory.
+                Ok(None)
+            }
             StateUpdateKind::StorageCollectionMetadata(storage_collection_metadata) => {
                 self.apply_storage_collection_metadata_update(storage_collection_metadata, diff);
                 Ok(None)
@@ -1023,6 +1027,12 @@ impl CatalogState {
                 &comment.comment,
                 diff,
             )],
+            StateUpdateKind::AuditLog(audit_log) => {
+                assert_eq!(diff, 1, "audit log is append only");
+                vec![self
+                    .pack_audit_log_update(&audit_log.event)
+                    .expect("could not pack audit log update")]
+            }
             StateUpdateKind::StorageCollectionMetadata(_)
             | StateUpdateKind::UnfinalizedShard(_) => Vec::new(),
         }

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -305,8 +305,9 @@ impl Catalog {
                     StateUpdateKind::SystemObjectMapping(system_object_mapping) => builtin_item_updates.push((system_object_mapping, update.diff)),
                     StateUpdateKind::Item(_) => item_updates.push(update),
                     StateUpdateKind::Comment(_)
+                    | StateUpdateKind::AuditLog(_)
                     | StateUpdateKind::StorageCollectionMetadata(_)
-                    | StateUpdateKind::UnfinalizedShard(_)=> post_item_updates.push(update),
+                    | StateUpdateKind::UnfinalizedShard(_) => post_item_updates.push(update),
                 }
             }
 
@@ -510,10 +511,20 @@ impl Catalog {
                     _ => unreachable!("all operators must be scalar functions"),
                 }
             }
-            let audit_logs = catalog.storage().await.get_audit_logs().await?;
-            for event in audit_logs {
-                builtin_table_updates.push(catalog.state.pack_audit_log_update(&event)?);
-            }
+            let audit_logs = catalog
+                .storage()
+                .await
+                .get_audit_logs()
+                .await?
+                .into_iter()
+                .map(|event| StateUpdate {
+                    kind: StateUpdateKind::AuditLog(mz_catalog::durable::objects::AuditLog {
+                        event,
+                    }),
+                    diff: 1,
+                })
+                .collect();
+            builtin_table_updates.extend(catalog.state.generate_builtin_table_updates(audit_logs));
 
             // To avoid reading over storage_usage events multiple times, do both
             // the table updates and delete calculations in a single read over the

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -681,6 +681,21 @@ impl DurableType<SystemPrivilegesKey, SystemPrivilegesValue> for MzAclItem {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditLog {
+    pub event: VersionedEvent,
+}
+
+impl DurableType<AuditLogKey, ()> for AuditLog {
+    fn into_key_value(self) -> (AuditLogKey, ()) {
+        (AuditLogKey { event: self.event }, ())
+    }
+
+    fn from_key_value(key: AuditLogKey, _value: ()) -> Self {
+        Self { event: key.event }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StorageCollectionMetadata {
     pub id: GlobalId,
     pub shard: String,

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -759,6 +759,10 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
         }
 
         Ok(match kind {
+            StateUpdateKind::AuditLog(key, value) => {
+                let audit_log = into_durable(key, value)?;
+                Some(memory::objects::StateUpdateKind::AuditLog(audit_log))
+            }
             StateUpdateKind::Cluster(key, value) => {
                 let cluster = into_durable(key, value)?;
                 Some(memory::objects::StateUpdateKind::Cluster(cluster))
@@ -801,6 +805,12 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
                 let schema = into_durable(key, value)?;
                 Some(memory::objects::StateUpdateKind::Schema(schema))
             }
+            StateUpdateKind::StorageCollectionMetadata(key, value) => {
+                let storage_collection_metadata = into_durable(key, value)?;
+                Some(memory::objects::StateUpdateKind::StorageCollectionMetadata(
+                    storage_collection_metadata,
+                ))
+            }
             StateUpdateKind::SystemConfiguration(key, value) => {
                 let system_configuration = into_durable(key, value)?;
                 Some(memory::objects::StateUpdateKind::SystemConfiguration(
@@ -819,12 +829,6 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
                     system_privilege,
                 ))
             }
-            StateUpdateKind::StorageCollectionMetadata(key, value) => {
-                let storage_collection_metadata = into_durable(key, value)?;
-                Some(memory::objects::StateUpdateKind::StorageCollectionMetadata(
-                    storage_collection_metadata,
-                ))
-            }
             StateUpdateKind::UnfinalizedShard(key, value) => {
                 let unfinalized_shard = into_durable(key, value)?;
                 Some(memory::objects::StateUpdateKind::UnfinalizedShard(
@@ -832,8 +836,7 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
                 ))
             }
             // TODO(jkosh44) Add conversions for valid variants.
-            StateUpdateKind::AuditLog(_, _)
-            | StateUpdateKind::Config(_, _)
+            StateUpdateKind::Config(_, _)
             | StateUpdateKind::Epoch(_)
             | StateUpdateKind::IdAllocator(_, _)
             | StateUpdateKind::Setting(_, _)

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -2290,6 +2290,7 @@ pub enum StateUpdateKind {
     SystemObjectMapping(durable::objects::SystemObjectMapping),
     Item(durable::objects::Item),
     Comment(durable::objects::Comment),
+    AuditLog(durable::objects::AuditLog),
     // TODO(jkosh44) Add all other object variants.
     // Storage updates.
     StorageCollectionMetadata(durable::objects::StorageCollectionMetadata),


### PR DESCRIPTION
This commit teaches the in-memory catalog how to listen to audit log
updates.

Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
