### PR TITLE
catalog: Listen to storage usage updates

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -257,6 +257,10 @@ impl CatalogState {
                 // Audit logs are not stored in-memory.
                 Ok(None)
             }
+            StateUpdateKind::StorageUsage(_storage_usage) => {
+                // Storage usage events are not stored in-memory.
+                Ok(None)
+            }
             StateUpdateKind::StorageCollectionMetadata(storage_collection_metadata) => {
                 self.apply_storage_collection_metadata_update(storage_collection_metadata, diff);
                 Ok(None)
@@ -1027,10 +1031,12 @@ impl CatalogState {
                 diff,
             )],
             StateUpdateKind::AuditLog(audit_log) => {
-                assert_eq!(diff, 1, "audit log is append only");
                 vec![self
-                    .pack_audit_log_update(&audit_log.event)
+                    .pack_audit_log_update(&audit_log.event, diff)
                     .expect("could not pack audit log update")]
+            }
+            StateUpdateKind::StorageUsage(storage_usage) => {
+                vec![self.pack_storage_usage_update(&storage_usage.metric, diff)]
             }
             StateUpdateKind::StorageCollectionMetadata(_)
             | StateUpdateKind::UnfinalizedShard(_) => Vec::new(),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1333,6 +1333,7 @@ impl CatalogState {
     pub fn pack_audit_log_update(
         &self,
         event: &VersionedEvent,
+        diff: Diff,
     ) -> Result<BuiltinTableUpdate, Error> {
         let (event_type, object_type, details, user, occurred_at): (
             &EventType,
@@ -1376,14 +1377,15 @@ impl CatalogState {
                 },
                 Datum::TimestampTz(dt.try_into().expect("must fit")),
             ]),
-            diff: 1,
+            diff,
         })
     }
 
     pub fn pack_storage_usage_update(
         &self,
         VersionedStorageUsage::V1(event): &VersionedStorageUsage,
-    ) -> Result<BuiltinTableUpdate, Error> {
+        diff: Diff,
+    ) -> BuiltinTableUpdate {
         let id = self.resolve_builtin_table(&MZ_STORAGE_USAGE_BY_SHARD);
         let row = Row::pack_slice(&[
             Datum::UInt64(event.id),
@@ -1395,7 +1397,7 @@ impl CatalogState {
                     .expect("must fit"),
             ),
         ]);
-        Ok(BuiltinTableUpdate { id, row, diff: 1 })
+        BuiltinTableUpdate { id, row, diff }
     }
 
     pub fn pack_egress_ip_update(&self, ip: &Ipv4Addr) -> Result<BuiltinTableUpdate, Error> {

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -2291,7 +2291,7 @@ impl CatalogState {
         };
         let id = tx.allocate_audit_log_id()?;
         let event = VersionedEvent::new(id, event_type, object_type, details, user, occurred_at);
-        builtin_table_updates.push(self.pack_audit_log_update(&event)?);
+        builtin_table_updates.push(self.pack_audit_log_update(&event, 1)?);
         audit_events.push(event.clone());
         tx.insert_audit_log_event(event);
         Ok(())
@@ -2309,7 +2309,7 @@ impl CatalogState {
             tx.get_and_increment_id(mz_catalog::durable::STORAGE_USAGE_ID_ALLOC_KEY.to_string())?;
 
         let details = VersionedStorageUsage::new(id, shard_id, size_bytes, collection_timestamp);
-        builtin_table_updates.push(self.pack_storage_usage_update(&details)?);
+        builtin_table_updates.push(self.pack_storage_usage_update(&details, 1));
         tx.insert_storage_usage_event(details);
         Ok(())
     }

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -696,6 +696,26 @@ impl DurableType<AuditLogKey, ()> for AuditLog {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorageUsage {
+    pub metric: VersionedStorageUsage,
+}
+
+impl DurableType<StorageUsageKey, ()> for StorageUsage {
+    fn into_key_value(self) -> (StorageUsageKey, ()) {
+        (
+            StorageUsageKey {
+                metric: self.metric,
+            },
+            (),
+        )
+    }
+
+    fn from_key_value(key: StorageUsageKey, _value: ()) -> Self {
+        Self { metric: key.metric }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StorageCollectionMetadata {
     pub id: GlobalId,
     pub shard: String,

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -811,6 +811,12 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
                     storage_collection_metadata,
                 ))
             }
+            StateUpdateKind::StorageUsage(key, value) => {
+                let storage_usage = into_durable(key, value)?;
+                Some(memory::objects::StateUpdateKind::StorageUsage(
+                    storage_usage,
+                ))
+            }
             StateUpdateKind::SystemConfiguration(key, value) => {
                 let system_configuration = into_durable(key, value)?;
                 Some(memory::objects::StateUpdateKind::SystemConfiguration(
@@ -835,12 +841,11 @@ impl TryFrom<StateUpdateKind> for Option<memory::objects::StateUpdateKind> {
                     unfinalized_shard,
                 ))
             }
-            // TODO(jkosh44) Add conversions for valid variants.
+            // Not exposed to higher layers.
             StateUpdateKind::Config(_, _)
             | StateUpdateKind::Epoch(_)
             | StateUpdateKind::IdAllocator(_, _)
             | StateUpdateKind::Setting(_, _)
-            | StateUpdateKind::StorageUsage(_, _)
             | StateUpdateKind::PersistTxnShard(_, _) => None,
         })
     }

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -2291,7 +2291,7 @@ pub enum StateUpdateKind {
     Item(durable::objects::Item),
     Comment(durable::objects::Comment),
     AuditLog(durable::objects::AuditLog),
-    // TODO(jkosh44) Add all other object variants.
+    StorageUsage(durable::objects::StorageUsage),
     // Storage updates.
     StorageCollectionMetadata(durable::objects::StorageCollectionMetadata),
     UnfinalizedShard(durable::objects::UnfinalizedShard),


### PR DESCRIPTION
This commit teaches the in-memory catalog how to listen to storage
usage updates.

Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
