### PR TITLE
persist: impl Codec64 for Product<u32, u32>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5469,6 +5469,7 @@ dependencies = [
  "prost-build",
  "serde",
  "serde_json",
+ "timely",
  "uuid",
  "workspace-hack",
 ]

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1192,10 +1192,11 @@ impl Deref for PartDeletes {
 #[cfg(test)]
 mod tests {
     use mz_dyncfg::ConfigUpdates;
+    use timely::order::Product;
 
     use crate::cache::PersistClientCache;
     use crate::internal::paths::{BlobKey, PartialBlobKey};
-    use crate::tests::{all_ok, new_test_client, CodecProduct};
+    use crate::tests::{all_ok, new_test_client};
     use crate::PersistLocation;
 
     use super::*;
@@ -1345,25 +1346,17 @@ mod tests {
             .expect("client construction failed");
         let shard_id = ShardId::new();
         let (mut write, _) = client
-            .expect_open::<String, String, CodecProduct, i64>(shard_id)
+            .expect_open::<String, String, Product<u32, u32>, i64>(shard_id)
             .await;
 
         let batch = write
             .batch(
                 &[
-                    (
-                        ("1".to_owned(), "one".to_owned()),
-                        CodecProduct::new(0, 10),
-                        1,
-                    ),
-                    (
-                        ("2".to_owned(), "two".to_owned()),
-                        CodecProduct::new(10, 0),
-                        1,
-                    ),
+                    (("1".to_owned(), "one".to_owned()), Product::new(0, 10), 1),
+                    (("2".to_owned(), "two".to_owned()), Product::new(10, 0), 1),
                 ],
-                Antichain::from_elem(CodecProduct::new(0, 0)),
-                Antichain::from_iter([CodecProduct::new(0, 11), CodecProduct::new(10, 1)]),
+                Antichain::from_elem(Product::new(0, 0)),
+                Antichain::from_iter([Product::new(0, 11), Product::new(10, 1)]),
             )
             .await
             .expect("invalid usage");

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -675,9 +675,7 @@ mod tests {
     use mz_persist_types::codec_impls::{StringSchema, VecU8Schema};
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
-    use serde::{Deserialize, Serialize};
-    use timely::order::{PartialOrder, Product};
-    use timely::progress::timestamp::PathSummary;
+    use timely::order::PartialOrder;
     use timely::progress::Antichain;
 
     use crate::batch::BLOB_TARGET_SIZE;
@@ -687,68 +685,6 @@ mod tests {
     use crate::read::ListenEvent;
 
     use super::*;
-
-    /// A product type that fits in Codec64. Used to test persist on partial orders
-    #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
-    pub(crate) struct CodecProduct(Product<u32, u32>);
-
-    impl CodecProduct {
-        pub(crate) fn new(outer: u32, inner: u32) -> Self {
-            Self(Product::new(outer, inner))
-        }
-    }
-
-    impl Timestamp for CodecProduct {
-        type Summary = <Product<u32, u32> as Timestamp>::Summary;
-
-        fn minimum() -> Self {
-            Self(Product::minimum())
-        }
-    }
-
-    impl PathSummary<CodecProduct> for <Product<u32, u32> as Timestamp>::Summary {
-        fn results_in(&self, src: &CodecProduct) -> Option<CodecProduct> {
-            self.results_in(&src.0).map(CodecProduct)
-        }
-
-        fn followed_by(&self, other: &Self) -> Option<Self> {
-            PathSummary::<Product<u32, u32>>::followed_by(self, other)
-        }
-    }
-
-    impl PartialOrder for CodecProduct {
-        fn less_equal(&self, other: &Self) -> bool {
-            self.0.less_equal(&other.0)
-        }
-    }
-
-    impl Codec64 for CodecProduct {
-        fn codec_name() -> String {
-            "CodecProduct".to_owned()
-        }
-
-        fn encode(&self) -> [u8; 8] {
-            let [a, b, c, d] = u32::to_le_bytes(self.0.outer);
-            let [e, f, g, h] = u32::to_le_bytes(self.0.inner);
-            [a, b, c, d, e, f, g, h]
-        }
-
-        fn decode([a, b, c, d, e, f, g, h]: [u8; 8]) -> Self {
-            let outer = u32::from_le_bytes([a, b, c, d]);
-            let inner = u32::from_le_bytes([e, f, g, h]);
-            Self(Product::new(outer, inner))
-        }
-    }
-
-    impl Lattice for CodecProduct {
-        fn join(&self, other: &Self) -> Self {
-            Self(self.0.join(&other.0))
-        }
-
-        fn meet(&self, other: &Self) -> Self {
-            Self(self.0.meet(&other.0))
-        }
-    }
 
     pub fn new_test_client_cache(dyncfgs: &ConfigUpdates) -> PersistClientCache {
         // Configure an aggressively small blob_target_size so we get some

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -25,6 +25,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
+timely = { version = "0.12.0", default-features = false, features = ["bincode", "getopts"] }
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 


### PR DESCRIPTION
Given that we've been talking about persist's handling of partial orders recently, seems like a reasonable thing to have around for tests and such.

All credit to Petros for the idea and impl.
https://github.com/petrosagg/materialize/commit/0145c428f59b4888b5370c531e256458310dfc70


### Motivation

  * This PR adds a feature that has not yet been specified.


### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
