### PR TITLE
expr: correctly support multibyte chars in translate

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -185,13 +185,6 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("#25937 (base64 decode with new line and tab)")
 
-        if db_function.function_name_in_lower_case == "translate" and expression.args[
-            1
-        ].has_any_characteristic(
-            {ExpressionCharacteristics.TEXT_WITH_SPECIAL_NON_SPACE_CHARS}
-        ):
-            return YesIgnore("#26553 (translate with special characters)")
-
         return NoIgnore()
 
     def _matches_problematic_operation_invocation(

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -6420,14 +6420,17 @@ fn replace<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a> {
 
 fn translate<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a> {
     let string = datums[0].unwrap_str();
-    let from = datums[1].unwrap_str();
-    let to = datums[2].unwrap_str();
+    let from = datums[1].unwrap_str().chars().collect::<Vec<_>>();
+    let to = datums[2].unwrap_str().chars().collect::<Vec<_>>();
 
     Datum::String(
         temp_storage.push_string(
             string
                 .chars()
-                .filter_map(|c| from.find(c).map_or(Some(c), |m| to.chars().nth(m)))
+                .filter_map(|c| match from.iter().position(|f| f == &c) {
+                    Some(idx) => to.get(idx).copied(),
+                    None => Some(c),
+                })
                 .collect(),
         ),
     )

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -1620,6 +1620,16 @@ SELECT translate('hello', 'fl', 'tx')
 ----
 hexxo
 
+query T
+SELECT translate('12345', '143', 'ax')
+----
+a2x5
+
+query T
+SELECT translate('a', '👋a', E'xy')
+----
+y
+
 # constant_time_eq for string
 
 statement ok


### PR DESCRIPTION
Fixes #26553

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix `translate` when used with multibyte chars.