### PR TITLE
ci: Upload metadata about shard lists

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from string import ascii_lowercase
 from textwrap import dedent
 
-from materialize.buildkite import accepted_by_shard
+from materialize.buildkite import shard_list
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.cockroach import Cockroach
@@ -799,7 +799,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument("--clusterd-memory-search-step", default=0.2, type=float)
     args = parser.parse_args()
 
-    for scenario in SCENARIOS:
+    for scenario in shard_list(SCENARIOS, lambda scenario: scenario.name):
         if (
             args.scenarios is not None
             and len(args.scenarios) > 0
@@ -809,8 +809,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         if scenario.disabled:
             print(f"+++ Scenario {scenario.name} is disabled, skipping.")
-            continue
-        if not accepted_by_shard(scenario.name):
             continue
 
         if args.find_minimal_memory:

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -64,7 +64,9 @@ SERVICES = [
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    for i, name in enumerate(c.workflows):
+    for name in buildkite.shard_list(
+        list(c.workflows.keys()), lambda workflow: workflow
+    ):
         # incident-70 requires more memory, runs in separate CI step
         # concurrent-connections is too flaky
         # refresh-mv-restart: Reenable when #25821 is fixed
@@ -77,9 +79,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "test-index-source-stuck",
         ):
             continue
-        if buildkite.accepted_by_shard(name):
-            with c.test_case(name):
-                c.workflow(name)
+        with c.test_case(name):
+            c.workflow(name)
 
 
 def workflow_test_smoke(c: Composition, parser: WorkflowArgumentParser) -> None:

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -415,11 +415,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     c.up(*dependencies)
 
-    scenarios_to_run = [
-        scenario
-        for scenario in selected_scenarios
-        if buildkite.accepted_by_shard(scenario.__name__)
-    ]
+    scenarios_to_run = buildkite.shard_list(
+        selected_scenarios, lambda scenario: scenario.__name__
+    )
 
     scenarios_with_regressions = []
     for cycle in range(0, args.max_retries):


### PR DESCRIPTION
Based on discussion in https://materializeinc.slack.com/archives/C057X0NG91B/p1712739384730909

Usage is then through command line:
```bash
$ curl --silent -H "Authorization: Bearer $BUILDKITE_TOKEN" "https://api.buildkite.com/v2/organizations/materialize/pipelines/test/builds/80456" | jq ".meta_data"
{
  "buildkite:git:commit": "commit 9d6f79d657580573f6dc8a80f364112d98de868c\nabbrev-commit 9d6f79d657\nAuthor: Dennis Felsing <dennis@felsing.org>\n\n    ci: Upload metadata about shard lists",
  "Shard for Cluster tests 1": "test-compute-controller-metrics, test-compute-reconciliation-reuse, test-concurrent-connections, test-github-23246, test-github-26215, test-incident-70, test-replica-metrics, test-replica-targeted-subscribe-abort, test-single-time-monotonicity-enforcers, test-smoke, test-system-table-indexes",
  "Shard for Cluster tests 2": "cluster-drop-concurrent, pg-snapshot-resumption, test-github-15799, test-github-17510, test-http-race-condition, test-mv-source-sink, test-profile-fetch, test-refresh-mv-warmup, test-remote-storage",
  "Shard for Cluster tests 3": "default, statement-logging, test-compute-reconciliation-no-errors, test-drop-quickstart-cluster, test-gh-25633, test-github-12251, test-github-15496, test-github-15531, test-github-15535, test-metrics-retention-across-restart, test-query-without-default-cluster, test-refresh-mv-restart, test-resource-limits",
  "Shard for Cluster tests 4": "blue-green-deployment, pg-snapshot-partial-failure, sink-failure, test-bootstrap-vars, test-clusterd-death-detection, test-github-15930, test-github-17177, test-github-17509, test-github-19610, test-github-cloud-7998, test-index-source-stuck, test-invalid-compute-reuse, test-mz-subscriptions, test-optimizer-metrics, test-replica-targeted-select-abort, test-subscribe-hydration-status, test-upsert",
  "Shard for MySQL CDC tests 1": "cdc, default, many-inserts",
  "Shard for MySQL CDC tests 2": "replica-connection, schema-change-restart",
  "Shard for MySQL CDC resumption tests 1": "default, disruptions, switch-to-lagging-replica, switch-to-replica-and-kill-master",
  "Shard for MySQL CDC resumption tests 2": "backup-restore, bin-log-manipulations, master-changes, short-bin-log-retention",
  "Shard for Source/Sink Error Reporting 1": "delete-sink-topic-recreate-topic-fix, kill-redpanda, kill-postgres, drop-publication-postgres, alter-postgres, bad-kafka-sink",
  "Shard for Source/Sink Error Reporting 2": "delete-sink-topic-delete-progress-fix, delete-source-topic, sigstop-redpanda, unsupported-postgres",
  "Shard for Postgres CDC resumption tests 1": "disconnect_pg_during_snapshot, disconnect_pg_during_replication, restart_pg_during_snapshot, restart_mz_during_snapshot, fix_pg_schema_while_mz_restarts, verify_no_snapshot_reingestion",
  "Shard for Postgres CDC resumption tests 2": "pg_out_of_disk_space, restart_pg_during_replication, restart_mz_during_replication",
  "Shard for Checks without restart or upgrade 1": "AlterConnectionHost, AlterConnectionSshChangeBase, AlterIndex, BasicTopK, BooleanType, BuiltinRoles, Cast, CheckDatabaseCreate, CheckSchemas, Comment, Commit, DataflowErrorRetraction, DecodeErrorUpsertValue, DefaultPrivileges, Delete, DeltaJoin, DropManagedCluster, DropRole, DropSubsource, ExplainCatalogItem, Identifiers, JoinTypes, KafkaFormats, Like, MaterializedViewsAssertNotNull, MaterializedViewsRefresh, MonotonicTopK, MySqlCdc, NestedTypes, Owners, RealType, RenameTable, SshKafka, SshPg, String, Threshold, UnifiedCluster, UpsertManyUpdates, UpsertUpdateGrow, UpsertUpdateShrink, Webhook",
  "Shard for Checks without restart or upgrade 2": "AwsConnection, CheckDatabaseDrop, CopyToS3, CreateRole, Having, KafkaProtocols, MySqlCdcNoWait, OptimizerNotices, ParseError, PeekCancellation, Range, RenameReplica, ReplicaAnnotations, RetainHistoryOnMv, Rollback, SinkNullDefaults, StatementLogging, SwapCluster, UpsertManyKeyColumns, UpsertManyValueColumns, WideRows, WindowFunctions",
  "Shard for Checks without restart or upgrade 3": "AlterConnectionToNonSsh, ConstantPlan, CreateCluster, CreateManagedCluster, DebeziumPostgres, DecodeError, DecodeErrorUpsertKey, DoubleType, DropReplica, InsertSelect, JsonSource, LinearJoin, ManyRows, MaterializeType, NullValue, ParseHexError, PgCdc, RenameIndex, RenameSchema, RenameView, SinkUpsert, TemporalPrecisionTypes, UUID, Update, UpsertEnrichValue, UpsertManyRows",
  "Shard for Checks without restart or upgrade 4": "Aggregation, AlterConnectionToSsh, ArrayType, CreateIndex, CreateReplica, CreateTable, DropCluster, DropIndex, DropTable, JsonbType, MaterializedViews, MonotonicTop1, MultiplePartitions, MySqlCdcMzNow, NumericTypes, PeekPersist, PgCdcMzNow, PgCdcNoWait, Privileges, Regex, RegexpExtract, RenameCluster, RenameSource, RetainHistoryOnKafkaSource, SinkComments, SinkTables, SourceErrors, SwapSchema, TemporalTypes, TextByteaTypes, UpsertDelete, UpsertInsert, UpsertUpdate, UpsertWideKey, UpsertWideValue, WithMutuallyRecursive",
  "Shard for Checks + restart of environmentd & storage clusterd 1": "AlterConnectionSshChangeBase, AlterIndex, BasicTopK, Cast, ConstantPlan, DebeziumPostgres, DefaultPrivileges, Delete, DropReplica, DropSubsource, Identifiers, JoinTypes, JsonSource, MonotonicTopK, RenameIndex, RenameSchema, RenameView, SshKafka, SshPg, String, TemporalPrecisionTypes, UpsertManyRows, UpsertManyUpdates, UpsertUpdateShrink",
  "Shard for Checks + restart of environmentd & storage clusterd 2": "AlterConnectionToSsh, ArrayType, DropTable, Having, KafkaProtocols, MultiplePartitions, NumericTypes, ParseError, PeekPersist, PgCdcMzNow, Privileges, RenameSource, RetainHistoryOnKafkaSource, Rollback, SinkComments, SinkNullDefaults, StatementLogging, TemporalTypes, TextByteaTypes, UpsertDelete, UpsertWideKey",
  "Shard for Checks + restart of environmentd & storage clusterd 3": "AlterConnectionToNonSsh, BooleanType, BuiltinRoles, CreateCluster, CreateManagedCluster, DataflowErrorRetraction, DecodeError, DecodeErrorUpsertKey, DecodeErrorUpsertValue, DeltaJoin, DropManagedCluster, MaterializeType, MaterializedViewsAssertNotNull, MySqlCdc, ParseHexError, RealType, SinkUpsert, UpsertEnrichValue, Webhook",
  "Shard for Checks + restart of environmentd & storage clusterd 4": "Aggregation, CreateReplica, CreateTable, DropCluster, DropIndex, JsonbType, MonotonicTop1, MySqlCdcNoWait, PgCdcNoWait, Range, Regex, RenameCluster, RenameReplica, SourceErrors, UpsertManyKeyColumns, WithMutuallyRecursive",
  "Shard for Checks + restart of environmentd & storage clusterd 5": "AlterConnectionHost, CheckDatabaseCreate, CheckSchemas, Comment, Commit, DoubleType, DropRole, ExplainCatalogItem, InsertSelect, KafkaFormats, Like, LinearJoin, ManyRows, MaterializedViewsRefresh, NestedTypes, NullValue, Owners, PgCdc, RenameTable, Threshold, UUID, UnifiedCluster, Update, UpsertUpdateGrow",
  "Shard for Checks + restart of environmentd & storage clusterd 6": "AwsConnection, CheckDatabaseDrop, CopyToS3, CreateIndex, CreateRole, MaterializedViews, MySqlCdcMzNow, OptimizerNotices, PeekCancellation, RegexpExtract, ReplicaAnnotations, RetainHistoryOnMv, SinkTables, SwapCluster, SwapSchema, UpsertInsert, UpsertManyValueColumns, UpsertUpdate, UpsertWideValue, WideRows, WindowFunctions"
}
```
Is this good enough for you @nrainer-materialize ?
The metadata is unfortunately not exposed in the Buildkite UI, so we'd have to implement that ourselves as an extra step if we want.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
