### PR TITLE
postgres consistency: extend timezone ignores

### DIFF
--- a/misc/python/materialize/postgres_consistency/custom/predefined_pg_queries.py
+++ b/misc/python/materialize/postgres_consistency/custom/predefined_pg_queries.py
@@ -104,6 +104,17 @@ def create_pg_timezone_names_query() -> QueryTemplate:
         "Europe/Volgograd",
     ]
 
+    # further time zones that differ in CI (due to the used libtz version)
+    excluded_timezones.extend(
+        [
+            "America/Scoresbysund",
+            "Antarctica/Casey",
+            "Antarctica/Vostok",
+            "Asia/Almaty",
+            "Asia/Qostanay",
+        ]
+    )
+
     # do not exist in mz
     excluded_timezones.extend(
         [


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightly/builds/7344#018ec8aa-5406-4fdb-a4df-8b83b6e20d22.

Nightly: https://buildkite.com/materialize/nightly/builds/7363 ✅ 