### PR TITLE
compute: unify frontier logging

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -59,7 +59,7 @@ use uuid::Uuid;
 
 use crate::arrangement::manager::{SpecializedTraceHandle, TraceBundle, TraceManager};
 use crate::logging;
-use crate::logging::compute::ComputeEvent;
+use crate::logging::compute::{CollectionLogging, ComputeEvent};
 use crate::metrics::ComputeMetrics;
 use crate::render::{LinearJoinSpec, StartSignal};
 use crate::server::{ComputeInstanceContext, ResponseSender};
@@ -360,9 +360,14 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         for object_id in dataflow.export_ids() {
             let mut collection = CollectionState::new();
 
-            collection.reported_frontier = ReportedFrontier::NotReported {
+            if let Some(logger) = self.compute_state.compute_logger.clone() {
+                let logging = CollectionLogging::new(object_id, logger, dataflow_index);
+                collection.logging = Some(logging);
+            }
+
+            collection.set_reported_frontier(ReportedFrontier::NotReported {
                 lower: as_of.clone(),
-            };
+            });
 
             let existing = self.compute_state.collections.insert(object_id, collection);
             if existing.is_some() {
@@ -370,19 +375,6 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                     id = ?object_id,
                     "existing collection for newly created dataflow",
                 );
-            }
-
-            // Log dataflow construction and frontier construction.
-            if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-                logger.log(ComputeEvent::Export {
-                    id: object_id,
-                    dataflow_index,
-                });
-                logger.log(ComputeEvent::Frontier {
-                    id: object_id,
-                    time: timely::progress::Timestamp::minimum(),
-                    diff: 1,
-                });
             }
         }
 
@@ -473,14 +465,6 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         // If the collection is unscheduled, remove it from the list of waiting collections.
         self.compute_state.suspended_collections.remove(&id);
 
-        // Remove frontier logging.
-        if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-            logger.log(ComputeEvent::ExportDropped { id });
-            if let Some(time) = collection.reported_frontier.logging_time() {
-                logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
-            }
-        }
-
         // We need to emit a final response reporting the dropping of this collection,
         // unless:
         //  * The collection is a subscribe, in which case we will emit a
@@ -488,7 +472,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         //  * The collection has already advanced to the empty frontier, in which case
         //    the final `FrontierUpper` response already serves the purpose of reporting
         //    the end of the dataflow.
-        if !collection.is_subscribe() && !collection.reported_frontier.is_empty() {
+        if !collection.is_subscribe() && !collection.reported_frontier().is_empty() {
             self.compute_state.dropped_collections.push(id);
         }
     }
@@ -510,7 +494,11 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             self.compute_state.traces.set(id, trace);
 
             // Initialize compute and logging state for the logging index.
-            let collection = CollectionState::new();
+            let mut collection = CollectionState::new();
+
+            let logging = CollectionLogging::new(id, logger.clone(), dataflow_index);
+            collection.logging = Some(logging);
+
             let existing = self.compute_state.collections.insert(id, collection);
             if existing.is_some() {
                 error!(
@@ -518,13 +506,6 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                     "existing collection for newly initialized logging export",
                 );
             }
-
-            logger.log(ComputeEvent::Export { id, dataflow_index });
-            logger.log(ComputeEvent::Frontier {
-                id,
-                time: timely::progress::Timestamp::minimum(),
-                diff: 1,
-            });
         }
 
         // Sanity check.
@@ -561,7 +542,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                 continue;
             }
 
-            match &collection.reported_frontier {
+            match collection.reported_frontier() {
                 ReportedFrontier::Reported(old_frontier) => {
                     // In steady state it is not expected for `old_frontier` to be beyond
                     // `new_frontier`. However, during reconcilation this can happen as we
@@ -578,19 +559,8 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                 }
             }
 
-            let new_reported_frontier = ReportedFrontier::Reported(new_frontier.clone());
-
-            if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-                if let Some(time) = collection.reported_frontier.logging_time() {
-                    logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
-                }
-                if let Some(time) = new_reported_frontier.logging_time() {
-                    logger.log(ComputeEvent::Frontier { id, time, diff: 1 });
-                }
-            }
-
             new_uppers.push((id, new_frontier.clone()));
-            collection.reported_frontier = new_reported_frontier;
+            collection.set_reported_frontier(ReportedFrontier::Reported(new_frontier.clone()));
         }
 
         for (id, upper) in new_uppers {
@@ -626,7 +596,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             // The compute protocol forbids reporting `Status` about collections that have advanced
             // to the empty frontier, so we ignore updates for those.
             let collection = self.compute_state.collections.get(&event.export_id);
-            if collection.map_or(true, |c| c.reported_frontier.is_empty()) {
+            if collection.map_or(true, |c| c.reported_frontier().is_empty()) {
                 continue;
             }
 
@@ -705,7 +675,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                     SubscribeResponse::DroppedAt(_) => Antichain::new(),
                 };
 
-                match &collection.reported_frontier {
+                match collection.reported_frontier() {
                     ReportedFrontier::Reported(old_frontier) => {
                         assert!(
                             PartialOrder::less_than(old_frontier, &new_frontier),
@@ -721,26 +691,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                     }
                 }
 
-                let new_reported_frontier = ReportedFrontier::Reported(new_frontier);
-
-                if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-                    if let Some(time) = collection.reported_frontier.logging_time() {
-                        logger.log(ComputeEvent::Frontier {
-                            id: sink_id,
-                            time,
-                            diff: -1,
-                        });
-                    }
-                    if let Some(time) = new_reported_frontier.logging_time() {
-                        logger.log(ComputeEvent::Frontier {
-                            id: sink_id,
-                            time,
-                            diff: 1,
-                        });
-                    }
-                }
-
-                collection.reported_frontier = new_reported_frontier;
+                collection.set_reported_frontier(ReportedFrontier::Reported(new_frontier));
             } else {
                 // Presumably tracking state for this subscribe was already dropped by
                 // `drop_collection`. There is nothing left to do for logging.
@@ -1335,20 +1286,12 @@ impl ReportedFrontier {
             Self::NotReported { .. } => false,
         }
     }
-
-    /// Return a timestamp suitable for logging the reported frontier.
-    pub fn logging_time(&self) -> Option<Timestamp> {
-        match self {
-            Self::Reported(frontier) => frontier.get(0).copied(),
-            Self::NotReported { .. } => Some(timely::progress::Timestamp::minimum()),
-        }
-    }
 }
 
 /// State maintained for a compute collection.
 pub struct CollectionState {
     /// Tracks the frontier that has been reported to the controller.
-    pub reported_frontier: ReportedFrontier,
+    reported_frontier: ReportedFrontier,
     /// A token that should be dropped when this collection is dropped to clean up associated
     /// sink state.
     ///
@@ -1358,6 +1301,8 @@ pub struct CollectionState {
     ///
     /// Only `Some` if the collection is a sink and *not* a subscribe.
     pub sink_write_frontier: Option<Rc<RefCell<Antichain<Timestamp>>>>,
+    /// Logging state maintained for this collection.
+    logging: Option<CollectionLogging>,
 }
 
 impl CollectionState {
@@ -1366,11 +1311,30 @@ impl CollectionState {
             reported_frontier: ReportedFrontier::new(),
             sink_token: None,
             sink_write_frontier: None,
+            logging: None,
         }
     }
 
     fn is_subscribe(&self) -> bool {
         self.sink_token.is_some() && self.sink_write_frontier.is_none()
+    }
+
+    /// Return the frontier that has been reported to the controller.
+    pub fn reported_frontier(&self) -> &ReportedFrontier {
+        &self.reported_frontier
+    }
+
+    /// Set the frontier that has been reported to the controller.
+    pub fn set_reported_frontier(&mut self, frontier: ReportedFrontier) {
+        if let Some(logging) = &mut self.logging {
+            let time = match &frontier {
+                ReportedFrontier::Reported(frontier) => frontier.get(0).copied(),
+                ReportedFrontier::NotReported { .. } => Some(Timestamp::MIN),
+            };
+            logging.set_frontier(time);
+        }
+
+        self.reported_frontier = frontier;
     }
 }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -459,6 +459,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             // Report frontier information back the coordinator.
             if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {
                 compute_state.report_compute_frontiers();
+                compute_state.log_input_frontiers();
                 compute_state.report_dropped_collections();
                 compute_state.report_operator_hydration();
             }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -42,7 +42,6 @@ use tokio::sync::mpsc::error::SendError;
 use tracing::{info, trace, warn};
 
 use crate::compute_state::{ActiveComputeState, ComputeState, ReportedFrontier};
-use crate::logging::compute::ComputeEvent;
 use crate::metrics::ComputeMetrics;
 
 /// Caller-provided configuration for compute.
@@ -750,17 +749,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                     }
                 };
 
-                // Compensate what already was sent to logging sources.
-                if let Some(logger) = &compute_state.compute_logger {
-                    if let Some(time) = collection.reported_frontier.logging_time() {
-                        logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
-                    }
-                    if let Some(time) = new_reported_frontier.logging_time() {
-                        logger.log(ComputeEvent::Frontier { id, time, diff: 1 });
-                    }
-                }
-
-                collection.reported_frontier = new_reported_frontier;
+                collection.set_reported_frontier(new_reported_frontier);
 
                 // Sink tokens should be retained for retained dataflows, and dropped for dropped
                 // dataflows.


### PR DESCRIPTION
This PR unifies compute logging of both output and input frontiers.

It first introduces a `CollectionLogging` type which emits per-collection `ComputeEvent`s and takes care of producing retraction events as necessary when frontiers update or collections are dropped.

It then moves input frontier logging to use the `CollectionLogging` type as well. For this, the purpose-built input frontier logging operators are replaced by probes, which are then queried between worker steps to receive updated frontiers to be logged.

Overall, this change has two benefits:
* It introduces more structure to the frontier logging, making it easier to reason about.
* It makes input frontiers available to the `ComputeState`, which is a precondition for [reporting them to the controller](https://github.com/MaterializeInc/materialize/pull/26594) as part of #16275.

### Motivation

   * This PR refactors existing code.

Part of #16275

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
