### PR TITLE
 adapter: clearer distinction between TimelineReadHolds and ephemeral ReadHolds

### DIFF
--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -13,19 +13,6 @@
 //! This module contains the API for read holds on collections. A "read hold" prevents
 //! the controller from compacting the associated collections, and ensures that they
 //! remain "readable" at a specific time, as long as the hold is held.
-//!
-//! The split into [InternalReadHolds] and [ReadHolds] makes a historically
-//! grown distinction explicit. The former is for use internal to the
-//! Coordinator: for each timeline we keep a [TimelineState], and when creating
-//! a collection a hold for it is added to that timeline-global
-//! [InternalReadHolds]. Likewise, when a collection is dropped its entry is
-//! removed from that [InternalReadHolds]. The timeline-global
-//! [InternalReadHolds] is never released, but it is continually downgraded
-//! using [Coordinator::update_read_holds].
-//!
-//! [ReadHolds] are used for short-lived read holds. For example, when
-//! processing peeks or rendering dataflows. These are never downgraded but they
-//! _are_ released automatically when being dropped.
 
 //! Allow usage of `std::collections::HashMap`.
 //! The code in this module deals with `Antichain`-keyed maps. `Antichain` does not implement
@@ -51,27 +38,38 @@ use timely::progress::Antichain;
 
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::timeline::{TimelineContext, TimelineState};
+use crate::coord::Coordinator;
 use crate::session::Session;
 use crate::util::ResultExt;
 
-/// Relevant information for acquiring or releasing a bundle of read holds.
+/// For each timeline, we hold one [TimelineReadHolds] as the root read holds
+/// for that timeline. Even if there are no other read holds ([ReadHolds] and/or
+/// [ReadHoldsInner]), it acts as a backstop that makes sure that collections
+/// remain readable at the read timestamp (according to the
+/// timestamp oracle) of that timeline.
 ///
-/// See module-level documentation about the split between [InternalReadHolds]
-/// and [ReadHolds].
+/// When creating a collection in a timeline, it is added to the one
+/// [TimelineReadHolds] of that timeline and when a collection is dropped it is
+/// removed.
+///
+/// A [TimelineReadHolds] is never released, it is only dropped when the
+/// corresponding timeline is dropped, which only happens when all collections
+/// in it have been dropped. We only add collections, remove collections, and
+/// downgrade (update, yes!) the read holds.
 #[derive(Debug, Serialize)]
-pub struct InternalReadHolds<T> {
+pub struct TimelineReadHolds<T> {
     pub holds: HashMap<Antichain<T>, CollectionIdBundle>,
 }
 
-impl<T: Eq + Hash + Ord> InternalReadHolds<T> {
+impl<T: Eq + Hash + Ord> TimelineReadHolds<T> {
     /// Return empty `ReadHolds`.
     pub fn new() -> Self {
-        InternalReadHolds {
+        TimelineReadHolds {
             holds: HashMap::new(),
         }
     }
 
-    /// Returns whether the [InternalReadHolds] is empty.
+    /// Returns whether the [TimelineReadHolds] is empty.
     pub fn is_empty(&self) -> bool {
         self.holds.is_empty()
     }
@@ -82,7 +80,7 @@ impl<T: Eq + Hash + Ord> InternalReadHolds<T> {
     }
 
     /// Return a `CollectionIdBundle` containing all the IDs in the
-    /// [InternalReadHolds].
+    /// [TimelineReadHolds].
     pub fn id_bundle(&self) -> CollectionIdBundle {
         self.holds
             .values()
@@ -93,6 +91,7 @@ impl<T: Eq + Hash + Ord> InternalReadHolds<T> {
     }
 
     /// Returns an iterator over all storage ids and the time at which their read hold exists.
+    #[allow(unused)]
     pub fn storage_ids(&self) -> impl Iterator<Item = (&Antichain<T>, &GlobalId)> {
         self.holds
             .iter()
@@ -130,10 +129,11 @@ impl<T: Eq + Hash + Ord> InternalReadHolds<T> {
         })
     }
 
-    /// Extends a [InternalReadHolds] with the contents of another
-    /// [InternalReadHolds].
+    /// Extends a [TimelineReadHolds] with the contents of another
+    /// [TimelineReadHolds].
+    ///
     /// Asserts that the newly added read holds don't coincide with any of the existing read holds in self.
-    pub fn extend_with_new(&mut self, mut other: InternalReadHolds<T>) {
+    pub fn extend_with_new(&mut self, mut other: TimelineReadHolds<T>) {
         for (time, other_id_bundle) in other.holds.drain() {
             let self_id_bundle = self.holds.entry(time).or_default();
             assert!(
@@ -168,28 +168,19 @@ impl<T: Eq + Hash + Ord> InternalReadHolds<T> {
     }
 }
 
-impl<T> Default for InternalReadHolds<T> {
-    fn default() -> Self {
-        InternalReadHolds {
-            holds: Default::default(),
-        }
-    }
-}
-
-/// A wrapper around [InternalReadHolds] that will release it's holds when dropped.
-///
-/// See module-level documentation about the split between [InternalReadHolds]
-/// and [ReadHolds].
+/// [ReadHolds] are used for short-lived read holds. For example, when
+/// processing peeks or rendering dataflows. These are never downgraded but they
+/// _are_ released automatically when being dropped.
 pub struct ReadHolds<T> {
-    pub inner: InternalReadHolds<T>,
-    dropped_read_holds_tx: tokio::sync::mpsc::UnboundedSender<InternalReadHolds<T>>,
+    pub inner: ReadHoldsInner<T>,
+    dropped_read_holds_tx: tokio::sync::mpsc::UnboundedSender<ReadHoldsInner<T>>,
 }
 
 impl<T: Eq + Hash + Ord> ReadHolds<T> {
     /// Return empty `ReadHolds`.
     pub fn new(
-        read_holds: InternalReadHolds<T>,
-        dropped_read_holds_tx: tokio::sync::mpsc::UnboundedSender<InternalReadHolds<T>>,
+        read_holds: ReadHoldsInner<T>,
+        dropped_read_holds_tx: tokio::sync::mpsc::UnboundedSender<ReadHoldsInner<T>>,
     ) -> Self {
         ReadHolds {
             inner: read_holds,
@@ -199,9 +190,9 @@ impl<T: Eq + Hash + Ord> ReadHolds<T> {
 }
 
 impl<T> Deref for ReadHolds<T> {
-    type Target = InternalReadHolds<T>;
+    type Target = ReadHoldsInner<T>;
 
-    fn deref(&self) -> &InternalReadHolds<T> {
+    fn deref(&self) -> &ReadHoldsInner<T> {
         &self.inner
     }
 }
@@ -223,6 +214,79 @@ impl<T> Drop for ReadHolds<T> {
         let res = self.dropped_read_holds_tx.send(inner_holds);
         if let Err(e) = res {
             tracing::warn!("error when trying to drop ReadHold: {:?}", e)
+        }
+    }
+}
+
+/// Inner state of [ReadHolds]. We have this separate so that we can send the
+/// inner state along a channel, for releasing when dropped.
+#[derive(Debug)]
+pub struct ReadHoldsInner<T> {
+    pub holds: HashMap<Antichain<T>, CollectionIdBundle>,
+}
+
+impl<T: Eq + Hash + Ord> ReadHoldsInner<T> {
+    /// Return empty `ReadHolds`.
+    pub fn new() -> Self {
+        ReadHoldsInner {
+            holds: HashMap::new(),
+        }
+    }
+
+    /// Return a `CollectionIdBundle` containing all the IDs in the
+    /// [ReadHoldsInner].
+    pub fn id_bundle(&self) -> CollectionIdBundle {
+        self.holds
+            .values()
+            .fold(CollectionIdBundle::default(), |mut accum, id_bundle| {
+                accum.extend(id_bundle);
+                accum
+            })
+    }
+
+    /// Returns an iterator over all storage ids and the time at which their read hold exists.
+    fn storage_ids(&self) -> impl Iterator<Item = (&Antichain<T>, &GlobalId)> {
+        self.holds
+            .iter()
+            .flat_map(|(time, id_bundle)| std::iter::repeat(time).zip(id_bundle.storage_ids.iter()))
+    }
+
+    /// Returns an iterator over all compute ids by compute instance and the time at which their
+    /// read hold exists.
+    fn compute_ids(
+        &self,
+    ) -> impl Iterator<
+        Item = (
+            &ComputeInstanceId,
+            impl Iterator<Item = (&Antichain<T>, &GlobalId)>,
+        ),
+    > {
+        let compute_instances: BTreeSet<_> = self
+            .holds
+            .iter()
+            .flat_map(|(_, id_bundle)| id_bundle.compute_ids.keys())
+            .collect();
+
+        compute_instances.into_iter().map(|compute_instance| {
+            let inner_iter = self
+                .holds
+                .iter()
+                .filter_map(|(time, id_bundle)| {
+                    id_bundle
+                        .compute_ids
+                        .get(compute_instance)
+                        .map(|ids| std::iter::repeat(time).zip(ids.iter()))
+                })
+                .flatten();
+            (compute_instance, inner_iter)
+        })
+    }
+}
+
+impl<T> Default for ReadHoldsInner<T> {
+    fn default() -> Self {
+        ReadHoldsInner {
+            holds: Default::default(),
         }
     }
 }
@@ -282,6 +346,57 @@ impl crate::coord::Coordinator {
         id_bundle: &CollectionIdBundle,
         compaction_window: CompactionWindow,
     ) {
+        // Creates a `ReadHolds` struct that contains a read hold for each id in
+        // `id_bundle`. The time of each read holds is at `time`, if possible
+        // otherwise it is at the lowest possible time, meaning the implied
+        // capability of the collection.
+        //
+        // This does not apply the read holds in STORAGE or COMPUTE. The code
+        // below applies those, after ensuring that read capabilities exist.
+        let initialize_read_holds = |coord: &mut Coordinator,
+                                     time: mz_repr::Timestamp,
+                                     id_bundle: &CollectionIdBundle|
+         -> TimelineReadHolds<mz_repr::Timestamp> {
+            let mut read_holds = TimelineReadHolds::new();
+            let time = Antichain::from_elem(time);
+
+            for id in id_bundle.storage_ids.iter() {
+                let collection = coord
+                    .controller
+                    .storage
+                    .collection(*id)
+                    .expect("collection does not exist");
+                let read_frontier = collection.implied_capability.clone();
+                let time = time.join(&read_frontier);
+                read_holds
+                    .holds
+                    .entry(time)
+                    .or_default()
+                    .storage_ids
+                    .insert(*id);
+            }
+            for (compute_instance, compute_ids) in id_bundle.compute_ids.iter() {
+                let compute = coord.controller.active_compute();
+                for id in compute_ids.iter() {
+                    let collection = compute
+                        .collection(*compute_instance, *id)
+                        .expect("collection does not exist");
+                    let read_frontier = collection.read_capability().clone();
+                    let time = time.join(&read_frontier);
+                    read_holds
+                        .holds
+                        .entry(time)
+                        .or_default()
+                        .compute_ids
+                        .entry(*compute_instance)
+                        .or_default()
+                        .insert(*id);
+                }
+            }
+
+            read_holds
+        };
+
         let mut compute_policy_updates: BTreeMap<ComputeInstanceId, Vec<_>> = BTreeMap::new();
         let mut storage_policy_updates = Vec::new();
         let mut id_bundles: HashMap<_, CollectionIdBundle> = HashMap::new();
@@ -292,7 +407,7 @@ impl crate::coord::Coordinator {
                 TimelineContext::TimelineDependent(timeline) => {
                     let TimelineState { oracle, .. } = self.ensure_timeline_state(&timeline).await;
                     let read_ts = oracle.read_ts().await;
-                    let new_read_holds = self.initialize_read_holds(read_ts, &id_bundle);
+                    let new_read_holds = initialize_read_holds(self, read_ts, &id_bundle);
                     let TimelineState { read_holds, .. } =
                         self.ensure_timeline_state(&timeline).await;
                     for (time, id_bundle) in &new_read_holds.holds {
@@ -503,57 +618,6 @@ impl crate::coord::Coordinator {
         self.compute_read_capabilities.remove(id).is_some()
     }
 
-    /// Creates a `ReadHolds` struct that creates a read hold for each id in
-    /// `id_bundle`. The time of each read holds is at `time`, if possible
-    /// otherwise it is at the lowest possible time.
-    ///
-    /// This does not apply the read holds in STORAGE or COMPUTE. It is up
-    /// to the caller to apply the read holds.
-    fn initialize_read_holds(
-        &mut self,
-        time: mz_repr::Timestamp,
-        id_bundle: &CollectionIdBundle,
-    ) -> InternalReadHolds<mz_repr::Timestamp> {
-        let mut read_holds = InternalReadHolds::new();
-        let time = Antichain::from_elem(time);
-
-        for id in id_bundle.storage_ids.iter() {
-            let collection = self
-                .controller
-                .storage
-                .collection(*id)
-                .expect("collection does not exist");
-            let read_frontier = collection.implied_capability.clone();
-            let time = time.join(&read_frontier);
-            read_holds
-                .holds
-                .entry(time)
-                .or_default()
-                .storage_ids
-                .insert(*id);
-        }
-        for (compute_instance, compute_ids) in id_bundle.compute_ids.iter() {
-            let compute = self.controller.active_compute();
-            for id in compute_ids.iter() {
-                let collection = compute
-                    .collection(*compute_instance, *id)
-                    .expect("collection does not exist");
-                let read_frontier = collection.read_capability().clone();
-                let time = time.join(&read_frontier);
-                read_holds
-                    .holds
-                    .entry(time)
-                    .or_default()
-                    .compute_ids
-                    .entry(*compute_instance)
-                    .or_default()
-                    .insert(*id);
-            }
-        }
-
-        read_holds
-    }
-
     /// Attempt to acquire read holds on the indicated collections at the indicated `time`.
     ///
     /// If we are unable to acquire a read hold at the provided `time` for a specific id, then
@@ -566,7 +630,48 @@ impl crate::coord::Coordinator {
         id_bundle: &CollectionIdBundle,
         precise: bool,
     ) -> Result<ReadHolds<Timestamp>, Vec<(Antichain<Timestamp>, CollectionIdBundle)>> {
-        let read_holds = self.initialize_read_holds(time, id_bundle);
+        // Create a `ReadHoldsInner` that contains a read hold for each id in
+        // `id_bundle`. The time of each read holds is at `time`, if possible
+        // otherwise it is at the lowest possible time.
+        //
+        // This does not apply the read holds in STORAGE or COMPUTE. The code
+        // below applies those in the correct read capability.
+        let mut read_holds = ReadHoldsInner::new();
+        let time_antichain = Antichain::from_elem(time);
+
+        for id in id_bundle.storage_ids.iter() {
+            let collection = self
+                .controller
+                .storage
+                .collection(*id)
+                .expect("collection does not exist");
+            let read_frontier = collection.implied_capability.clone();
+            let time_antichain = time_antichain.join(&read_frontier);
+            read_holds
+                .holds
+                .entry(time_antichain)
+                .or_default()
+                .storage_ids
+                .insert(*id);
+        }
+        for (compute_instance, compute_ids) in id_bundle.compute_ids.iter() {
+            let compute = self.controller.active_compute();
+            for id in compute_ids.iter() {
+                let collection = compute
+                    .collection(*compute_instance, *id)
+                    .expect("collection does not exist");
+                let read_frontier = collection.read_capability().clone();
+                let time_antichain = time_antichain.join(&read_frontier);
+                read_holds
+                    .holds
+                    .entry(time_antichain)
+                    .or_default()
+                    .compute_ids
+                    .entry(*compute_instance)
+                    .or_default()
+                    .insert(*id);
+            }
+        }
 
         if precise {
             // If we are not able to acquire read holds precisely at the specified time (only later), then error out.
@@ -646,9 +751,9 @@ impl crate::coord::Coordinator {
     /// `read_holds`, and its behavior will be erratic if called on anything else.
     pub(super) fn update_read_holds(
         &mut self,
-        mut read_holds: InternalReadHolds<mz_repr::Timestamp>,
+        mut read_holds: TimelineReadHolds<mz_repr::Timestamp>,
         new_time: mz_repr::Timestamp,
-    ) -> InternalReadHolds<mz_repr::Timestamp> {
+    ) -> TimelineReadHolds<mz_repr::Timestamp> {
         // After this, read_holds.holds is initialized to an empty HashMap.
         let old_holds = std::mem::take(&mut read_holds.holds);
 
@@ -751,7 +856,7 @@ impl crate::coord::Coordinator {
     /// `initialize_read_holds`, `acquire_read_holds`, or `update_read_hold` that returned
     /// `ReadHolds`, and its behavior will be erratic if called on anything else,
     /// or if called more than once on the same bundle of read holds.
-    pub(super) fn release_read_holds(&mut self, read_holdses: Vec<InternalReadHolds<Timestamp>>) {
+    pub(super) fn release_read_holds(&mut self, read_holdses: Vec<ReadHoldsInner<Timestamp>>) {
         // Update STORAGE read policies.
         let mut storage_policy_changes = Vec::new();
         for read_holds in read_holdses.iter() {

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -38,7 +38,7 @@ use timely::progress::Timestamp as TimelyTimestamp;
 use tracing::{debug, error, info, Instrument};
 
 use crate::coord::id_bundle::CollectionIdBundle;
-use crate::coord::read_policy::InternalReadHolds;
+use crate::coord::read_policy::TimelineReadHolds;
 use crate::coord::timestamp_selection::TimestampProvider;
 use crate::coord::Coordinator;
 use crate::AdapterError;
@@ -79,7 +79,7 @@ impl TimelineContext {
 /// guarantee that those read timestamps are valid.
 pub(crate) struct TimelineState<T> {
     pub(crate) oracle: Arc<dyn TimestampOracle<T> + Send + Sync>,
-    pub(crate) read_holds: InternalReadHolds<T>,
+    pub(crate) read_holds: TimelineReadHolds<T>,
 }
 
 impl<T: fmt::Debug> fmt::Debug for TimelineState<T> {
@@ -240,7 +240,7 @@ impl Coordinator {
                 timeline.clone(),
                 TimelineState {
                     oracle,
-                    read_holds: InternalReadHolds::new(),
+                    read_holds: TimelineReadHolds::new(),
                 },
             );
         }

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -649,7 +649,7 @@ impl Coordinator {
             };
             let read_ts = oracle.read_ts().await;
             if read_holds.times().any(|time| time.less_than(&read_ts)) {
-                read_holds = self.update_read_holds(read_holds, read_ts);
+                self.update_timeline_read_holds(&mut read_holds, read_ts);
             }
             self.global_timelines
                 .insert(timeline, TimelineState { oracle, read_holds });

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -61,8 +61,8 @@ pub use crate::client::{Client, Handle, SessionClient};
 pub use crate::command::{ExecuteResponse, ExecuteResponseKind, RowsFuture, StartupResponse};
 pub use crate::coord::id_bundle::CollectionIdBundle;
 pub use crate::coord::peek::PeekResponseUnary;
-pub use crate::coord::read_policy::InternalReadHolds;
 pub use crate::coord::read_policy::ReadHolds;
+pub use crate::coord::read_policy::ReadHoldsInner;
 pub use crate::coord::timeline::TimelineContext;
 pub use crate::coord::timestamp_selection::{
     TimestampContext, TimestampExplanation, TimestampProvider,

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -26,8 +26,8 @@ use mz_storage_types::sources::Timeline;
 use serde::{Deserialize, Serialize};
 use timely::progress::Antichain;
 
-use mz_adapter::InternalReadHolds;
 use mz_adapter::ReadHolds;
+use mz_adapter::ReadHoldsInner;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(transparent)]
@@ -131,7 +131,7 @@ impl TimestampProvider for Frontiers {
     }
 
     fn acquire_read_holds(&mut self, id_bundle: &CollectionIdBundle) -> ReadHolds<Timestamp> {
-        let mut read_holds = InternalReadHolds::new();
+        let mut read_holds = ReadHoldsInner::new();
 
         for (instance_id, ids) in id_bundle.compute_ids.iter() {
             for id in ids.iter() {


### PR DESCRIPTION
Preparatory work for https://github.com/MaterializeInc/materialize/issues/24845, where we
want to introduce more concurrency to the Coordinator and Controllers.

The code/comments/docs explain the motivation and how/why they are used.
The overarching motivation is that future work around introducing more
concurrency in the adapter/Coordinator will make this necessary, but it
also feels correct to make this distinction that has always been there
explicit in the code and interfaces. A previous refactoring was not
going far enough.

It's nice to see how the previous
acquire_read_holds/update_read_holds/release_read_holds were actually
used for disjoint purposes, we don't have to duplicate those methods
now.

Also, this moves initialize_read_holds inside the methods where it's
used because its semantics were confusing and because it was really only
used in two places: for the thing we now call TimelineReadHolds and what
we now call ephemeral ReadHolds.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
