### PR TITLE
compute: `ReadCapability` responses to fix per-replica read holds

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -829,6 +829,8 @@ pub struct CollectionState<T> {
     write_frontier: Antichain<T>,
     /// The write frontiers reported by individual replicas.
     replica_write_frontiers: BTreeMap<ReplicaId, Antichain<T>>,
+    /// The read capabilities reported by individual replicas.
+    replica_read_capabilities: BTreeMap<ReplicaId, Antichain<T>>,
 }
 
 impl<T> CollectionState<T> {
@@ -887,6 +889,7 @@ impl<T: Timestamp> CollectionState<T> {
             compute_dependencies,
             write_frontier: upper,
             replica_write_frontiers: BTreeMap::new(),
+            replica_read_capabilities: BTreeMap::new(),
         }
     }
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1715,6 +1715,7 @@ where
             ComputeResponse::FrontierUpper { id, upper } => {
                 self.handle_frontier_upper(id, upper, replica_id)
             }
+            ComputeResponse::ReadCapability { id, frontier } => None, // TODO
             ComputeResponse::PeekResponse(uuid, peek_response, otel_ctx) => {
                 self.handle_peek_response(uuid, peek_response, otel_ctx, replica_id)
             }

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -515,6 +515,7 @@ impl<M> CommandMetrics<M> {
 #[derive(Debug)]
 struct ResponseMetrics<M> {
     frontier_upper: M,
+    read_capability: M,
     peek_response: M,
     subscribe_response: M,
     copy_to_response: M,
@@ -528,6 +529,7 @@ impl<M> ResponseMetrics<M> {
     {
         Self {
             frontier_upper: build_metric("frontier_upper"),
+            read_capability: build_metric("read_capability"),
             peek_response: build_metric("peek_response"),
             subscribe_response: build_metric("subscribe_response"),
             copy_to_response: build_metric("copy_to_response"),
@@ -540,6 +542,7 @@ impl<M> ResponseMetrics<M> {
 
         match proto.kind.as_ref().unwrap() {
             FrontierUpper(_) => &self.frontier_upper,
+            ReadCapability(_) => &self.read_capability,
             PeekResponse(_) => &self.peek_response,
             SubscribeResponse(_) => &self.subscribe_response,
             CopyToResponse(_) => &self.copy_to_response,

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -185,10 +185,10 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     ///
     /// A replica that receives an `AllowCompaction` command with the empty frontier must
     /// eventually respond with a [`FrontierUpper`] response reporting the empty frontier for the
-    /// same collection. ([#16275])
+    /// same collection. ([#16271])
     ///
     /// [`FrontierUpper`]: super::response::ComputeResponse::FrontierUpper
-    /// [#16275]: https://github.com/MaterializeInc/materialize/issues/16275
+    /// [#16271]: https://github.com/MaterializeInc/materialize/issues/16271
     AllowCompaction {
         /// TODO(#25239): Add documentation.
         id: GlobalId,

--- a/src/compute-client/src/protocol/response.proto
+++ b/src/compute-client/src/protocol/response.proto
@@ -38,12 +38,18 @@ message ProtoComputeResponse {
         ProtoCopyToResponse resp = 2;
     }
 
+    message ProtoReadCapabilityKind {
+        mz_repr.global_id.ProtoGlobalId id = 1;
+        mz_repr.antichain.ProtoU64Antichain frontier = 2;
+    }
+
     oneof kind {
         mz_storage_client.client.ProtoTrace frontier_upper = 1;
         ProtoPeekResponseKind peek_response = 2;
         ProtoSubscribeResponseKind subscribe_response = 3;
         ProtoCopyToResponseKind copy_to_response = 4;
         ProtoStatusResponse status = 5;
+        ProtoReadCapabilityKind read_capability = 6;
     }
 }
 

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -326,6 +326,7 @@ where
 
                 result
             }
+            ComputeResponse::ReadCapability { id, frontier } => None, // TODO
             ComputeResponse::PeekResponse(uuid, response, otel_ctx) => {
                 // Incorporate new peek responses; awaiting all responses.
                 let entry = self

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -256,6 +256,9 @@ where
             return;
         }
 
+        // Wait for the start signal before doing any work.
+        let () = start_signal.await;
+
         // Internally, the `open_leased_reader` call registers a new LeasedReaderId and then fires
         // up a background tokio task to heartbeat it. It is possible that we might get a
         // particularly adversarial scheduling where the CRDB query to register the id is sent and
@@ -285,13 +288,6 @@ where
         .await
         .expect("reader creation shouldn't panic")
         .expect("could not open persist shard");
-
-        // Wait for the start signal only after having obtained a read handle and therefore a read
-        // hold on the source shard. The compute controller is currently not able to correctly
-        // maintain read holds for inputs to REFRESH MVs, so it needs a little help.
-        //
-        // TODO(#16275): move this await before the reader initialization
-        let () = start_signal.await;
 
         let cfg = read.cfg.clone();
         let metrics = Arc::clone(&read.metrics);


### PR DESCRIPTION
This PR introduces a new `ReadCapability` compute response that reports for each compute collection the least time that the replica still needs to read from the collection inputs. The controller then uses this new information to maintain the per-replica read holds. Doing so fixes a bug where the controller would release read holds too early because they were based on the reported `FrontierUpper`s, which can jump into the future for `REFRESH` materialized views. 



### Motivation

  * This PR fixes a recognized bug.

Fixes #16275 

### Tips for reviewer

Commits can be reviewed separately.

Note that replicas only report a single `ReadCapability` for each compute collection, rather than one per input. This is mostly to simplify the implementation, though it also reduces network traffic. There are no fundamental reasons against reporting capabilities per input, if it turns out that doing so would be beneficial. 

Also note that unfortunately introducing the `ReadCapability` response does not allow us to remove the workaround of sending a `FrontierUpper([])` response for each dropped collection. As it turns out, the `ComputeClient`s (at least `PartitionedState`) rely on that response to know when to clean up their frontier tracking state for a dropped collection. So removing the final `FrontierUpper([])` response is still blocked by #16271, after which the `ComputeClient`s will be able to drop their state based on observed `ComputeCommand`s instead.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
