### PR TITLE
[persist] Add the new spine info to the serde representation

### DIFF
--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1667,7 +1667,7 @@ fn serialize_part_stats<S: Serializer>(
 // compatibility guarantees, but still probably best to be thoughtful about
 // making unnecessary changes. Additionally, it's nice to make the output as
 // nice to use as possible without tying our hands for the actual code usages.
-impl<T: Serialize> Serialize for State<T> {
+impl<T: Serialize + Timestamp + Lattice> Serialize for State<T> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         let State {
             applier_version,
@@ -1698,7 +1698,11 @@ impl<T: Serialize> Serialize for State<T> {
         let () = s.serialize_field("writers", writers)?;
         let () = s.serialize_field("since", &trace.since().elements())?;
         let () = s.serialize_field("upper", &trace.upper().elements())?;
-        let () = s.serialize_field("batches", &trace.batches().into_iter().collect::<Vec<_>>())?;
+        let trace = trace.flatten();
+        let () = s.serialize_field("batches", &trace.legacy_batches.keys().collect::<Vec<_>>())?;
+        let () = s.serialize_field("hollow_batches", &trace.hollow_batches)?;
+        let () = s.serialize_field("spine_batches", &trace.spine_batches)?;
+        let () = s.serialize_field("fueling_merges", &trace.fueling_merges)?;
         s.end()
     }
 }

--- a/src/persist-client/src/internal/state_serde.json
+++ b/src/persist-client/src/internal/state_serde.json
@@ -384,6 +384,56 @@
     }
   ],
   "hollow_batches": {},
-  "spine_batches": {},
+  "spine_batches": {
+    "0-4": {
+      "level": 5,
+      "desc": {
+        "lower": {
+          "elements": [
+            0
+          ]
+        },
+        "upper": {
+          "elements": [
+            17715365949975899502
+          ]
+        },
+        "since": {
+          "elements": [
+            16259358130896200968
+          ]
+        }
+      },
+      "parts": [
+        "0-1",
+        "1-2",
+        "2-3",
+        "3-4"
+      ]
+    },
+    "4-5": {
+      "level": 4,
+      "desc": {
+        "lower": {
+          "elements": [
+            17715365949975899502
+          ]
+        },
+        "upper": {
+          "elements": [
+            18440881202665513003
+          ]
+        },
+        "since": {
+          "elements": [
+            626979934278723597
+          ]
+        }
+      },
+      "parts": [
+        "4-5"
+      ]
+    }
+  },
   "fueling_merges": {}
 }

--- a/src/persist-client/src/internal/state_serde.json
+++ b/src/persist-client/src/internal/state_serde.json
@@ -382,5 +382,8 @@
         ]
       ]
     }
-  ]
+  ],
+  "hollow_batches": {},
+  "spine_batches": {},
+  "fueling_merges": {}
 }

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -57,6 +57,7 @@ use differential_dataflow::trace::Description;
 use mz_ore::cast::CastFrom;
 #[allow(unused_imports)] // False positive.
 use mz_ore::fmt::FormatBuffer;
+use serde::{Serialize, Serializer};
 use timely::progress::frontier::AntichainRef;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -113,7 +114,7 @@ impl<T: Timestamp + Lattice> Default for Trace<T> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ThinSpineBatch<T> {
     pub(crate) level: usize,
     pub(crate) desc: Description<T>,
@@ -516,6 +517,16 @@ enum SpineLog<'a, T> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SpineId(pub usize, pub usize);
 
+impl Serialize for SpineId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let SpineId(lo, hi) = self;
+        serializer.serialize_str(&format!("{lo}-{hi}"))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct IdHollowBatch<T> {
     pub id: SpineId,
@@ -800,7 +811,7 @@ impl<T: Timestamp + Lattice> SpineBatch<T> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct FuelingMerge<T> {
     pub(crate) since: Antichain<T>,
     pub(crate) remaining_work: usize,

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -1628,8 +1628,9 @@ pub(crate) mod tests {
             (
                 any::<Option<T>>(),
                 proptest::collection::vec(any_hollow_batch::<T>(), num_batches),
+                any::<bool>(),
             ),
-            |(since, mut batches)| {
+            |(since, mut batches, roundtrip_structure)| {
                 let mut trace = Trace::<T>::default();
                 trace.downgrade_since(&since.map_or_else(Antichain::new, Antichain::from_elem));
 
@@ -1650,6 +1651,7 @@ pub(crate) mod tests {
                     lower = batch.desc.upper().clone();
                     let _merge_req = trace.push_batch(batch);
                 }
+                trace.roundtrip_structure = roundtrip_structure;
                 trace
             },
         )


### PR DESCRIPTION
### Motivation

In service of #16607 - this makes it easier to visually inspect the state.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
