### PR TITLE
columnar: Refactor `PartDecorder`

### DIFF
--- a/src/persist-cli/src/maelstrom/txn_list_append_single.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_single.rs
@@ -751,13 +751,13 @@ mod codec_impls {
     impl Schema<MaelstromKey> for MaelstromKeySchema {
         type Encoder<'a> = SimpleEncoder<'a, MaelstromKey, u64>;
 
-        type Decoder<'a> = SimpleDecoder<'a, MaelstromKey, u64>;
+        type Decoder = SimpleDecoder<MaelstromKey, u64>;
 
         fn columns(&self) -> DynStructCfg {
             SimpleSchema::<MaelstromKey, u64>::columns(&())
         }
 
-        fn decoder<'a>(&self, cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
+        fn decoder(&self, cols: ColumnsRef) -> Result<Self::Decoder, String> {
             SimpleSchema::<MaelstromKey, u64>::decoder(cols, |val, ret| ret.0 = val)
         }
 
@@ -795,13 +795,13 @@ mod codec_impls {
     impl Schema<MaelstromVal> for MaelstromValSchema {
         type Encoder<'a> = SimpleEncoder<'a, MaelstromVal, Vec<u8>>;
 
-        type Decoder<'a> = SimpleDecoder<'a, MaelstromVal, Vec<u8>>;
+        type Decoder = SimpleDecoder<MaelstromVal, Vec<u8>>;
 
         fn columns(&self) -> DynStructCfg {
             SimpleSchema::<MaelstromVal, Vec<u8>>::columns(&())
         }
 
-        fn decoder<'a>(&self, cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
+        fn decoder(&self, cols: ColumnsRef) -> Result<Self::Decoder, String> {
             SimpleSchema::<MaelstromVal, Vec<u8>>::decoder(cols, |val, ret| {
                 *ret = MaelstromVal::decode(val).expect("should be valid MaelstromVal")
             })

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -17,7 +17,7 @@ arrow2 = { version = "0.16.0", features = ["compute_aggregate", "io_ipc", "io_pa
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 hex = "0.4.3"
-mz-ore = { path = "../ore", features = ["test"], default-features = false }
+mz-ore = { path = "../ore", features = ["metrics", "test"], default-features = false }
 mz-proto = { path = "../proto", default-features = false }
 parquet2 = { version = "0.17.1", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -239,7 +239,7 @@ pub trait PartEncoder<'a, T> {
 ///
 /// This allows us to amortize the cost of downcasting columns into concrete
 /// types.
-pub trait PartDecoder<'a, T> {
+pub trait PartDecoder<T> {
     /// Decodes the value at the given index.
     ///
     /// Implementations of this should reuse allocations within the passed value
@@ -252,13 +252,13 @@ pub trait Schema<T>: Debug + Send + Sync {
     /// The associated [PartEncoder] implementor.
     type Encoder<'a>: PartEncoder<'a, T>;
     /// The associated [PartDecoder] implementor.
-    type Decoder<'a>: PartDecoder<'a, T>;
+    type Decoder: PartDecoder<T> + Debug;
 
     /// Returns the name and types of the columns in this type.
     fn columns(&self) -> DynStructCfg;
 
-    /// Returns a [Self::Decoder<'a>] for the given columns.
-    fn decoder<'a>(&self, cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String>;
+    /// Returns a [`Self::Decoder`] for the given columns.
+    fn decoder(&self, cols: ColumnsRef) -> Result<Self::Decoder, String>;
 
     /// Returns a [Self::Encoder<'a>] for the given columns.
     fn encoder<'a>(&self, cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String>;

--- a/src/persist-types/src/dyn_col.rs
+++ b/src/persist-types/src/dyn_col.rs
@@ -21,7 +21,7 @@ use crate::dyn_struct::{DynStruct, ValidityRef};
 use crate::stats::{DynStats, StatsFrom};
 
 /// A type-erased [crate::columnar::Data::Col].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DynColumnRef(DataType, Arc<dyn Any + Send + Sync>);
 
 impl DynColumnRef {
@@ -34,9 +34,18 @@ impl DynColumnRef {
         &self.0
     }
 
+    /// Returns the inner value if it is a column of type `T`, or an Err if it isn't.
+    pub fn downcast<T: Data>(self) -> Result<Arc<T::Col>, String> {
+        let col = self
+            .1
+            .downcast::<T::Col>()
+            .map_err(|_| format!("expected {} col", std::any::type_name::<T::Col>()))?;
+        Ok(col)
+    }
+
     /// Returns a typed, shared reference to the inner value if it is a column
     /// of type `T`, or an Err if it isn't.
-    pub fn downcast<T: Data>(&self) -> Result<&T::Col, String> {
+    pub fn downcast_ref<T: Data>(&self) -> Result<&T::Col, String> {
         let col = self
             .1
             .downcast_ref::<T::Col>()
@@ -49,7 +58,7 @@ impl DynColumnRef {
         struct LenDataFn<'a>(&'a DynColumnRef);
         impl DataFn<Result<usize, String>> for LenDataFn<'_> {
             fn call<T: Data>(self, _cfg: &T::Cfg) -> Result<usize, String> {
-                self.0.downcast::<T>().map(|x| x.len())
+                self.0.downcast_ref::<T>().map(|x| x.len())
             }
         }
         self.0
@@ -59,12 +68,12 @@ impl DynColumnRef {
 
     /// Computes statistics on this column using the default implementation of
     /// `T::Stats::From`.
-    pub fn stats_default(&self, validity: ValidityRef<'_>) -> Box<dyn DynStats> {
-        struct StatsDataFn<'a>(&'a DynColumnRef, ValidityRef<'a>);
+    pub fn stats_default(&self, validity: ValidityRef) -> Box<dyn DynStats> {
+        struct StatsDataFn<'a>(&'a DynColumnRef, ValidityRef);
         impl DataFn<Result<Box<dyn DynStats>, String>> for StatsDataFn<'_> {
             fn call<T: Data>(self, _cfg: &T::Cfg) -> Result<Box<dyn DynStats>, String> {
                 let StatsDataFn(col, validity) = self;
-                let col = col.downcast::<T>()?;
+                let col = col.downcast_ref::<T>()?;
                 Ok(Box::new(T::Stats::stats_from(col, validity)))
             }
         }
@@ -96,7 +105,7 @@ impl DynColumnRef {
         struct ToArrowDataFn<'a>(&'a DynColumnRef);
         impl DataFn<Result<(Encoding, Box<dyn Array>), String>> for ToArrowDataFn<'_> {
             fn call<T: Data>(self, _cfg: &T::Cfg) -> Result<(Encoding, Box<dyn Array>), String> {
-                Ok(self.0.downcast::<T>()?.to_arrow())
+                Ok(self.0.downcast_ref::<T>()?.to_arrow())
             }
         }
         let (encoding, array) = self
@@ -164,7 +173,7 @@ impl DynColumnMut {
                     .downcast::<T>()
                     .expect("DynColumnMut DataType should have internally consistent");
                 let src = src
-                    .downcast::<T>()
+                    .downcast_ref::<T>()
                     .expect("push_from src type should match dst");
                 ColumnPush::<T>::push(dst, ColumnGet::<T>::get(src, idx));
             }

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -41,12 +41,12 @@ impl Part {
     }
 
     /// Returns a [ColumnsRef] for the key columns.
-    pub fn key_ref<'a>(&'a self) -> ColumnsRef<'a> {
+    pub fn key_ref(&self) -> ColumnsRef {
         self.key.as_ref()
     }
 
     /// Returns a [ColumnsRef] for the val columns.
-    pub fn val_ref<'a>(&'a self) -> ColumnsRef<'a> {
+    pub fn val_ref(&self) -> ColumnsRef {
         self.val.as_ref()
     }
 

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -39,7 +39,7 @@ fn as_optional_datum<'a>(row: &'a Row) -> Option<Datum<'a>> {
 /// because the non-option version won't generate any Nulls.
 pub(crate) fn proto_datum_min_max_nulls(
     col: &<Option<Vec<u8>> as Data>::Col,
-    validity: ValidityRef<'_>,
+    validity: ValidityRef,
 ) -> (Vec<u8>, Vec<u8>, usize) {
     let (mut min, mut max) = (Row::default(), Row::default());
     let mut null_count = 0;
@@ -81,7 +81,7 @@ pub(crate) fn proto_datum_min_max_nulls(
 /// because the non-option version won't generate any Nulls.
 pub(crate) fn jsonb_stats_nulls(
     col: &<Option<Vec<u8>> as Data>::Col,
-    validity: ValidityRef<'_>,
+    validity: ValidityRef,
 ) -> Result<(JsonStats, usize), String> {
     let mut datums = JsonDatums::default();
     let mut null_count = 0;


### PR DESCRIPTION
This PR refactored `PartDecoder` to have owned values, instead of references to the columns in a `Part`. This is required for efficiently working with structured columnar data.

Note: this PR originally included a change for `PartEncoder` as well, but it was split out into a separate PR.

### Motivation

A `Part` is our structured columnar representation of data. Currently to decode a `Part` we take references to the contained columns and downcast them from a `dyn Array` trait object, to a concrete column type. This downcasting is relatively expensive so we want to do it as infrequently as possible, ideally once per-`Part`.

The problem is when iterating over a `Part` (i.e. with `FetchedPart`) we own the underlying data, and the lexical scope for which we would be able to borrow is a single iteration. This means we would need to create a `PartDecoder` for every `Row` we decode, which means repeatedly downcasting our trait objects, something we need to avoid for performance reasons. The problem we're running into is a classical Rust issue, to prevent downcasting on every iteration what we'd need is something like:

```
struct FetchedPart {
  part: Part,
  decoder: PartDecoder<'self>,
  // ...
}
```

where the lifetime of the `PartDecoder` is tied to `FetchedPart`, but this requires self references and isn't easily done in Rust. (Note: the `Pin` type exists to achieve self-referential structs, but I wanted to avoid using that here).

#### Performance

This is a performance sensitive code path, but there shouldn't be any noticeable change with this refactor. Instead of passing `&T` we now pass `Arc<T>`. All of these types are the same size (one word) so they should all get passed via registers in function calls. There is a bit of overhead with de-referencing an `Arc`, you need to do some pointer arithmetic to get the address of the inner value, but that is simply something we can't avoid.

### Tips for reviewer

The PR is split into three separate commits which can be reviewed independently:

1. Refactor of `PartDecoder`
2. Refactor of benchmarks

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
