### PR TITLE
storage: evenly distribute values produced by SourceRender

### DIFF
--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -404,8 +404,11 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
         })
     });
 
-    // Distribute the raw slot data to all workers and turn it into a collection
-    let raw_collection = data_stream.distribute().as_collection();
+    // Distribute the raw slot data to all workers and turn it into a collection.
+    //
+    // This is required by the `SourceRender` contract, as well as the for efficient
+    // decoding.
+    let raw_collection = data_stream.distribute_values().as_collection();
 
     // We now process the slot updates and apply the cast expressions
     let mut final_row = Row::default();

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -507,7 +507,10 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
     });
 
     // Distribute the raw COPY data to all workers and turn it into a collection
-    let raw_collection = raw_data.distribute().as_collection();
+    //
+    // This is required by the `SourceRender` contract, as well as the for efficient
+    // decoding.
+    let raw_collection = raw_data.distribute_values().as_collection();
 
     // We now decode the COPY protocol and apply the cast expressions
     let mut text_row = Row::default();

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -62,7 +62,9 @@ pub trait SourceRender {
     /// Rendering a source is expected to return four things.
     ///
     /// First, a source must produce a collection that is produced by the rendered dataflow and
-    /// must contain *definite*[^1] data for all times beyond the resumption frontier.
+    /// must contain *definite*[^1] data for all times beyond the resumption frontier. This
+    /// collection must be spread evenly across the workers for efficient resource utilization
+    /// later on.
     ///
     /// Second, a source may produce an optional progress stream that will be used to drive
     /// reclocking. This is useful for sources that can query the highest offsets of the external
@@ -92,7 +94,7 @@ pub trait SourceRender {
 
 /// Source-agnostic wrapper for messages. Each source must implement a
 /// conversion to Message.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SourceMessage {
     /// The message key
     pub key: Row,
@@ -103,7 +105,7 @@ pub struct SourceMessage {
 }
 
 /// A record produced by a source
-#[derive(Clone, Serialize, Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SourceOutput<FromTime> {
     /// The record's key (or some empty/default value for sources without the concept of key)
     pub key: Row,

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -152,8 +152,13 @@ where
     /// into the operator is dropped.
     fn with_token(&self, token: Weak<()>) -> Stream<G, D1>;
 
-    /// Distributes the data of the stream to all workers in a round-robin fashion.
+    /// Distributes the containers of data of the stream to all workers in a round-robin fashion.
     fn distribute(&self) -> Stream<G, D1>
+    where
+        D1: ExchangeData;
+
+    /// Distributes the individual pieces of data of the stream to all workers in a round-robin fashion.
+    fn distribute_values(&self) -> Stream<G, D1>
     where
         D1: ExchangeData;
 }
@@ -453,6 +458,29 @@ where
                 });
             }
         })
+    }
+
+    fn distribute_values(&self) -> Stream<G, D1>
+    where
+        D1: ExchangeData,
+    {
+        let mut vector = Vec::new();
+        let mut next: u64 = 0;
+        self.unary(
+            Exchange::new(move |_| {
+                next = next.wrapping_add(1);
+                next
+            }),
+            "DistributeValues",
+            move |_, _| {
+                move |input, output| {
+                    input.for_each(|time, data| {
+                        data.swap(&mut vector);
+                        output.session(&time).give_vec(&mut vector);
+                    });
+                }
+            },
+        )
     }
 }
 


### PR DESCRIPTION
Currently `SourceRender` implementations are inconsistent about what workers they produce values on. This pr changes that contract, requiring users to produce _values_ (not just containers of values) evenly on workers. This effectively spreads reclocking across the workers evenly, at the cost of additional exchanges occurring between workers. It also ensures that data is processed evenly in later stages (like decode), even if those stages are altered to use `Pipeline`'s (instead of the mix of `Pipeline` and `Exchange` used today. This change will also be required to prototype feedback-based hydration flow control, and we should enforce this constraint now.

The performance of this is actually BETTER than #26414 (which used hashing, and also double-distributed things from pg), so it should not be a problem.

### Motivation
  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
