### PR TITLE
ci: Retry testdrive tests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -187,6 +187,11 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: testdrive
               args: [--redpanda]
+        # TODO(def-) Remove when #19097 is fixed
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 1
 
       - id: redpanda-testdrive-aarch64
         label: ":panda_face: :racing_car: testdrive aarch64"
@@ -212,6 +217,11 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: testdrive
               args: [--kafka-default-partitions=5]
+        # TODO(def-) Remove when #19097 is fixed
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 1
 
       - id: testdrive-replicas-4
         label: ":racing_car: testdrive 4 replicas"
@@ -224,6 +234,11 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: testdrive
               args: [--replicas=4]
+        # TODO(def-) Remove when #19097 is fixed
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 1
 
       - id: testdrive-size-1
         label: ":racing_car: testdrive with SIZE 1"
@@ -236,6 +251,11 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: testdrive
               args: [--default-size=1]
+        # TODO(def-) Remove when #19097 is fixed
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 1
 
       - id: testdrive-size-8
         label: ":racing_car: testdrive with SIZE 8"
@@ -248,6 +268,11 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: testdrive
               args: [--default-size=8]
+        # TODO(def-) Remove when #19097 is fixed
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 1
 
       - id: testdrive-in-cloudtest
         label: Full Testdrive in Cloudtest (K8s)
@@ -260,6 +285,11 @@ steps:
           - ./ci/plugins/cloudtest:
               args: [-m=long, test/cloudtest/test_full_testdrive.py]
         sanitizer: skip
+        # TODO(def-) Remove when #19097 is fixed
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 1
 
       - id: persistence-testdrive
         label: ":racing_car: testdrive with --persistent-user-tables"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -247,6 +247,11 @@ steps:
           composition: testdrive
     agents:
       queue: linux-aarch64
+    # TODO(def-) Remove when #19097 is fixed
+    retry:
+      automatic:
+        - exit_status: 1
+          limit: 1
 
   - id: cluster-tests
     label: Cluster tests %N


### PR DESCRIPTION
I'm really not happy with this. Is there a better way to avoid https://github.com/MaterializeInc/materialize/issues/19097 without cutting out lots of tests? CC @aljoscha 

But this is failing in every Nightly run, and many Test pipeline runs.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
