### PR TITLE
platform-checks: Increase timeout for validation

### DIFF
--- a/misc/python/materialize/checks/all_checks/pg_cdc.py
+++ b/misc/python/materialize/checks/all_checks/pg_cdc.py
@@ -163,6 +163,9 @@ class PgCdcBase:
             GRANT SELECT ON postgres_source_tableB{self.suffix} TO materialize
             GRANT SELECT ON postgres_source_tableC{self.suffix} TO materialize
 
+            # Can take longer after a restart
+            $ set-sql-timeout duration=600s
+
             > SELECT f1, max(f2), SUM(LENGTH(f3)) FROM postgres_source_tableA{self.suffix} GROUP BY f1;
             A 800 {self.expects}
             B 800 {self.expects}


### PR DESCRIPTION
See https://materializeinc.slack.com/archives/C01LKF361MZ/p1712759792742669 for context

I'm not sure if this is the proper fix. But I couldn't find anything suspicious in services.log

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
