### PR TITLE
parallel-workload: Support ddl-only complexity

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1306,6 +1306,18 @@ steps:
               composition: parallel-workload
               args: [--runtime=1500]
 
+      - id: parallel-workload-ddl-only
+        label: "Parallel Workload (DDL Only)"
+        depends_on: build-aarch64
+        artifact_paths: [parallel-workload-queries.log.zst]
+        timeout_in_minutes: 60
+        agents:
+          queue: linux-aarch64-small
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: parallel-workload
+              args: [--runtime=1500, --complexity=ddl-only, --threads=2]
+
       - id: parallel-workload-100-threads
         label: "Parallel Workload (100 threads)"
         depends_on: build-aarch64

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -82,7 +82,7 @@ class Action:
             "must be owner of",
             "network error",  # #21954, remove when fixed when fixed
         ]
-        if exe.db.complexity == Complexity.DDL:
+        if exe.db.complexity in (Complexity.DDL, Complexity.DDLOnly):
             result.extend(
                 [
                     "query could not complete",

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -154,6 +154,8 @@ def run(
             weights = [60, 30, 30, 30, 0]
         elif complexity == Complexity.Read:
             weights = [60, 30, 0, 0, 0]
+        elif complexity == Complexity.DDLOnly:
+            weights = [0, 0, 0, 0, 100]
         else:
             raise ValueError(f"Unknown complexity {complexity}")
         worker_rng = random.Random(rng.randrange(SEED_RANGE))

--- a/misc/python/materialize/parallel_workload/settings.py
+++ b/misc/python/materialize/parallel_workload/settings.py
@@ -15,6 +15,7 @@ class Complexity(Enum):
     Read = "read"
     DML = "dml"
     DDL = "ddl"
+    DDLOnly = "ddl-only"
 
     @classmethod
     def _missing_(cls, value):


### PR DESCRIPTION


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
