### PR TITLE
cloud-push: use aarch64 images

### DIFF
--- a/bin/cloud-push
+++ b/bin/cloud-push
@@ -26,8 +26,8 @@ tag=$1
 shift
 
 for image in environmentd clusterd; do
-    bin/mzimage acquire --arch=x86_64 "$image" "$@"
-    docker tag "$(bin/mzimage spec --arch=x86_64 "$image" "$@")" "$username/$image:$tag"
+    bin/mzimage acquire --arch=aarch64 "$image" "$@"
+    docker tag "$(bin/mzimage spec --arch=aarch64 "$image" "$@")" "$username/$image:$tag"
     docker push "$username/$image:$tag"
 done
 


### PR DESCRIPTION
Both envd and clusterd run on ARM in staging nowadays, so images pushed without this change will not be deployable in staging.

### Motivation

  * This PR fixes a utility script.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A