### PR TITLE
compute,storage: cleanup `SinkRender` trait

### DIFF
--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -129,7 +129,7 @@ where
             .region_named(&region_name, |inner| {
                 let sink_render = get_sink_render_for::<_>(&sink.connection);
 
-                let sink_token = sink_render.render_continuous_sink(
+                let sink_token = sink_render.render_sink(
                     compute_state,
                     sink,
                     sink_id,
@@ -154,7 +154,7 @@ pub(crate) trait SinkRender<G>
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
 {
-    fn render_continuous_sink(
+    fn render_sink(
         &self,
         compute_state: &mut crate::compute_state::ComputeState,
         sink: &ComputeSinkDesc<CollectionMetadata>,
@@ -163,9 +163,7 @@ where
         start_signal: StartSignal,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
-    ) -> Option<Rc<dyn Any>>
-    where
-        G: Scope<Timestamp = mz_repr::Timestamp>;
+    ) -> Option<Rc<dyn Any>>;
 }
 
 fn get_sink_render_for<G>(

--- a/src/compute/src/sink/copy_to_s3_oneshot.rs
+++ b/src/compute/src/sink/copy_to_s3_oneshot.rs
@@ -31,7 +31,7 @@ impl<G> SinkRender<G> for CopyToS3OneshotSinkConnection
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    fn render_continuous_sink(
+    fn render_sink(
         &self,
         compute_state: &mut crate::compute_state::ComputeState,
         sink: &ComputeSinkDesc<CollectionMetadata>,
@@ -40,10 +40,7 @@ where
         _start_signal: StartSignal,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
-    ) -> Option<Rc<dyn Any>>
-    where
-        G: Scope<Timestamp = Timestamp>,
-    {
+    ) -> Option<Rc<dyn Any>> {
         // An encapsulation of the copy to response protocol.
         // Used to send rows and errors if this fails.
         let response_protocol_handle = Rc::new(RefCell::new(Some(ResponseProtocol {

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -52,7 +52,7 @@ impl<G> SinkRender<G> for PersistSinkConnection<CollectionMetadata>
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    fn render_continuous_sink(
+    fn render_sink(
         &self,
         compute_state: &mut ComputeState,
         sink: &ComputeSinkDesc<CollectionMetadata>,
@@ -61,10 +61,7 @@ where
         start_signal: StartSignal,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
-    ) -> Option<Rc<dyn Any>>
-    where
-        G: Scope<Timestamp = Timestamp>,
-    {
+    ) -> Option<Rc<dyn Any>> {
         let mut desired_collection = sinked_collection.map(Ok).concat(&err_collection.map(Err));
 
         // If a `RefreshSchedule` was specified, round up timestamps.

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -33,7 +33,7 @@ impl<G> SinkRender<G> for SubscribeSinkConnection
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    fn render_continuous_sink(
+    fn render_sink(
         &self,
         compute_state: &mut crate::compute_state::ComputeState,
         sink: &ComputeSinkDesc<CollectionMetadata>,
@@ -42,10 +42,7 @@ where
         _start_signal: StartSignal,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
-    ) -> Option<Rc<dyn Any>>
-    where
-        G: Scope<Timestamp = Timestamp>,
-    {
+    ) -> Option<Rc<dyn Any>> {
         // An encapsulation of the Subscribe response protocol.
         // Used to send rows and progress messages,
         // and alert if the dataflow was dropped before completing.

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -68,7 +68,7 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
     let ok_collection =
         apply_sink_envelope(sink_id, sink, &sink_render, ok_collection.as_collection());
 
-    let (health, sink_tokens) = sink_render.render_continuous_sink(
+    let (health, sink_tokens) = sink_render.render_sink(
         storage_state,
         sink,
         sink_id,
@@ -227,16 +227,14 @@ where
     /// TODO
     fn get_relation_key_indices(&self) -> Option<&[usize]>;
     /// TODO
-    fn render_continuous_sink(
+    fn render_sink(
         &self,
         storage_state: &mut StorageState,
         sink: &StorageSinkDesc<MetadataFilled, Timestamp>,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
-    ) -> (Stream<G, HealthStatusMessage>, Vec<PressOnDropButton>)
-    where
-        G: Scope<Timestamp = Timestamp>;
+    ) -> (Stream<G, HealthStatusMessage>, Vec<PressOnDropButton>);
 }
 
 fn get_sink_render_for<G>(connection: &StorageSinkConnection) -> Box<dyn SinkRender<G>>

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -141,7 +141,7 @@ impl<G: Scope<Timestamp = Timestamp>> SinkRender<G> for KafkaSinkConnection {
         self.relation_key_indices.as_deref()
     }
 
-    fn render_continuous_sink(
+    fn render_sink(
         &self,
         storage_state: &mut StorageState,
         sink: &StorageSinkDesc<MetadataFilled, Timestamp>,


### PR DESCRIPTION
This PR makes two minor changes to the `SinkRender` traits:

 * Removes a redundant trait bound.
 * Renames `render_continuous_sink` to just `render_sink`.

### Motivation

   * This PR refactors existing code.

Just something I stumble over from time to time.

### Tips for reviewer

I have done my research to find out why the method was called `render_continuous_sink` in the first place:
![Screenshot 2024-04-12 at 13 55 26](https://github.com/MaterializeInc/materialize/assets/4521314/2a79e6d0-9443-4ede-909c-ab552a147a7a)

Meanwhile we have the `copy_to_s3` sink which _is_ a one-shot sink and uses the same render method, so that reasoning doesn't apply anymore.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A